### PR TITLE
refactor: Harden Phase 1 foundation — 7 architectural review items

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,9 +71,13 @@ This separation is the most important architectural property of Urd. Do not bypa
 
 These formats MUST be preserved exactly (the existing bash backup system and monitoring depend on them):
 
-1. **Snapshot naming:** `YYYYMMDD-<short_name>` (e.g., `20260322-opptak`)
+1. **Snapshot naming:**
+   - **Legacy (read-only):** `YYYYMMDD-<short_name>` (e.g., `20260322-opptak`) — parsed as midnight. Existing snapshots in this format are recognized and handled correctly by `SnapshotName::parse()`.
+   - **Current (write):** `YYYYMMDD-HHMM-<short_name>` (e.g., `20260322-1430-opptak`) — all new snapshots use this format to support sub-daily snapshot intervals (e.g., 15-minute intervals on htpc-home).
+   - **Coexistence:** Both formats may exist in the same snapshot directory. Retention, send, and display logic handle both transparently. Ordering is by datetime, not string comparison.
+   - **Phase 3 note:** During parallel running, the bash script may not recognize HHMM-format names. This is acceptable — the bash script only manages snapshots it created (matched by its own naming convention). Urd manages all snapshots in the directory regardless of format.
 2. **Snapshot directories:** `<snapshot_root>/<subvolume_name>/` (e.g., `.snapshots/subvol3-opptak/`)
-3. **Pin files:** `.last-external-parent-<DRIVE_LABEL>` in the subvolume's local snapshot directory
+3. **Pin files:** `.last-external-parent-<DRIVE_LABEL>` in the subvolume's local snapshot directory. May contain either legacy or current snapshot name format.
 4. **Prometheus metrics:** exact metric names, labels, and value semantics (see `docs/PLAN.md` for full list)
 
 ### BTRFS Commands

--- a/docs/99-reports/2026-03-22-phase1-arch-review-v3.md
+++ b/docs/99-reports/2026-03-22-phase1-arch-review-v3.md
@@ -1,0 +1,260 @@
+# Urd Phase 1 Architectural Review
+
+**Project:** Urd -- BTRFS Time Machine for Linux
+**Date:** 2026-03-22
+**Scope:** PR #1, commit `afec570` -- full Phase 1 implementation (config, types, retention, planner, `urd plan` CLI)
+**Reviewer:** Architectural Adversary (Claude Opus 4.6)
+**Files reviewed:** All source files in `src/`, `config/urd.toml.example`, `docs/PLAN.md`, `CLAUDE.md`, `Cargo.toml`
+
+---
+
+## 1. Executive Summary
+
+Phase 1 is a strong foundation. The planner/executor separation is the right architecture for a backup tool -- it makes the most dangerous logic (what to delete) fully testable without touching the filesystem. The code is clean, the types are thoughtful, and the test coverage targets the right things. There are two findings that matter for Phase 2: the planner emits a pin operation *before* the send it depends on has succeeded, and the snapshot name format has quietly diverged from the backward-compatibility contract. Everything else is either a genuine trade-off made correctly or a minor issue.
+
+---
+
+## 2. What Kills You
+
+The catastrophic failure mode for Urd is **silent data loss**: deleting the last copy of irreplaceable data (recordings in `subvol3-opptak`) without the operator knowing until they need to restore.
+
+This can happen through three channels:
+
+1. **Retention deletes a pinned snapshot.** The pin file is the only thing protecting the incremental chain parent. If the pin is stale, corrupt, or not read, retention can delete the parent, breaking the chain. The next send would silently fall back to full -- not data loss per se, but the operator loses the incremental chain and may not notice until the external drive fills up.
+
+2. **A partial send leaves the external drive in an inconsistent state.** Phase 2's executor must clean up partial receives. If it doesn't, the next incremental send will have the wrong parent. This is a Phase 2 concern, but the planner's flat operation list doesn't encode the dependency: "only pin if send succeeds." More on this below.
+
+3. **Retention deletes snapshots that haven't been sent to any external drive.** Currently, local retention runs independently of external send status. A snapshot could be the only unsent copy and still be eligible for deletion by graduated retention. The pinned set only contains the *last sent* snapshot per drive -- not *all unsent* snapshots.
+
+**Current distance from catastrophe:** Two bugs away. The planner correctly reads pin files and protects pinned snapshots. But it does not protect *unsent* snapshots from local retention, and the pin operation is emitted optimistically. Neither of these is a bug today (Phase 1 is plan-only), but they become live risks the moment the executor starts deleting.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | Retention and planning logic are well-tested. Snapshot name format divergence is the main gap. |
+| Security | 3 | No path validation on config-sourced values that will reach `sudo btrfs`. Acceptable for Phase 1 (no execution), must be addressed in Phase 2. |
+| Architectural Excellence | 5 | Planner/executor separation, `FileSystemState` trait for testing, pure-function planner -- textbook correct for this domain. |
+| Systems Design | 3 | Pin-before-send ordering, no unsent-snapshot protection, and no idempotency consideration for the plan itself. |
+| Rust Idioms | 4 | Good use of newtypes, derives, `#[must_use]`. A few `#[allow(dead_code)]` and `#[allow(clippy::too_many_arguments)]` that deserve scrutiny. |
+| Code Quality | 4 | Clean, readable, well-tested where it matters. Test coverage is proportional to risk (retention has the most tests). |
+
+---
+
+## 4. Design Tensions
+
+### 4.1 Flat operation list vs. dependency graph
+
+The planner produces a `Vec<PlannedOperation>` -- a flat, ordered list. This is simple: iterate and execute. But it cannot express "pin only if send succeeds" or "skip external retention if send failed." The implicit contract is that the executor will handle these dependencies through control flow.
+
+**Why it was probably chosen:** Simplicity. A flat list is dead easy to test, print, and reason about. A dependency graph adds complexity that may not pay for itself.
+
+**Verdict:** Right call for Phase 1. But the current code emits `PinParent` immediately after `SendIncremental`/`SendFull` in the operation list (lines 315-334 of `plan.rs`). The executor *must* understand that pin is conditional on send success. This ordering dependency exists only in the author's head. Before Phase 2, either: (a) document it as a contract on the executor, (b) group send+pin into a compound operation, or (c) make pin a post-condition on the send operation itself. Option (b) is simplest.
+
+### 4.2 `FileSystemState` trait vs. direct filesystem access
+
+The planner takes a `&dyn FileSystemState` trait object, allowing the mock in tests and the real filesystem in production. This adds a trait and a mock struct.
+
+**Why:** Testability. The planner is the most dangerous module -- it decides what to delete. Testing it without the real filesystem is essential.
+
+**Verdict:** Emphatically correct. This is the single most important design decision in the codebase. The `FileSystemState` trait lets you test all of retention + planning logic with zero filesystem interaction. It paid for itself immediately in the 14 planner tests.
+
+### 4.3 Graduated retention windows as durations vs. calendar boundaries
+
+Retention windows are computed as `now - Duration::hours(hourly)`, not as calendar boundaries. This means "daily = 30" means "30 * 24 hours from the end of the hourly window," not "30 calendar days."
+
+**Why:** Simpler to implement. Duration arithmetic avoids calendar edge cases (month boundaries, DST).
+
+**Verdict:** Mostly right, but creates a subtle issue. The hourly window ends at `now - 24h`, and the daily window starts there. A snapshot taken at 14:00 yesterday will be in the hourly window at 13:59 today but in the daily window at 14:01 today. At that boundary, it transitions from "keep everything" to "keep one per day" -- meaning same-day siblings get deleted. This is fine in steady state but could surprise an operator who expects "the last 24 hours of snapshots" to mean "snapshots from today and yesterday." This is a trade-off, not a bug, but worth documenting.
+
+### 4.4 New snapshot format (YYYYMMDD-HHMM-name) vs. legacy (YYYYMMDD-name)
+
+`SnapshotName::new()` always produces the new format with hours and minutes. But CLAUDE.md and PLAN.md both specify the backward-compatible format as `YYYYMMDD-shortname`. This is a real tension -- see finding 5.1 below.
+
+---
+
+## 5. Findings by Dimension
+
+### 5.1 Correctness
+
+**[Significant] Snapshot name format divergence from backward-compatibility contract.**
+
+CLAUDE.md states: "Snapshot naming: `YYYYMMDD-<short_name>` (e.g., `20260322-opptak`)". The `SnapshotName::new()` function produces `YYYYMMDD-HHMM-shortname` (e.g., `20260322-1430-opptak`). The parser correctly handles both formats, but new snapshots will use the new format.
+
+This matters because: (a) the bash script is still running and must coexist during Phase 3 parallel operation, (b) pin files written by the bash script use the legacy format, (c) any external tooling parsing snapshot directory names will break on the new format.
+
+If this is intentional -- the new format is the future and the bash script will be retired -- then CLAUDE.md's backward-compatibility section needs updating. If it's unintentional, `SnapshotName::new()` should produce the legacy format and the new format should be opt-in.
+
+**Consequence:** During parallel run (Phase 3), the bash script may not recognize Urd's snapshots. Pin files could reference snapshots the other system can't find. This is recoverable but would cause confusion and possibly redundant full sends.
+
+**[Significant] Planner emits PinParent before send execution confirms success.**
+
+In `plan_external_send()` (plan.rs:329-334), the `PinParent` operation is appended to the operations list immediately after the send operation. But the planner doesn't know whether the send will succeed. If the executor runs operations sequentially and one fails, it needs to know not to execute the pin.
+
+**Consequence:** If the executor naively iterates the operation list and the send fails but the pin still executes, the pin file will point to a snapshot that doesn't exist on the external drive. The next send will attempt an incremental with a parent that's only on the local side, which will fail. The fallback to full send exists, but the error path is noisy and wastes bandwidth.
+
+**Fix:** Group `Send` + `Pin` into a single compound operation, or tag the pin with a dependency on the preceding send. Alternatively, document explicitly that the executor must skip pin operations when the preceding send failed.
+
+**[Moderate] `unwrap()` in `plan_local_snapshot` on `newest` (plan.rs:200).**
+
+Line 200: `now.signed_duration_since(newest.unwrap().datetime())`. This `unwrap()` is safe because the `else` branch only executes when `should_create` is false, which requires `newest` to be `Some`. But the safety depends on control flow that could be refactored away. A future change to the `should_create` logic could make this panic.
+
+**Fix:** Use `let Some(newest) = newest else { unreachable!() }` or restructure to avoid the separate `unwrap()`.
+
+**[Commendation] Retention logic is well-structured and thoroughly tested.**
+
+The graduated retention function handles the window cascade correctly: hourly -> daily -> weekly -> monthly -> beyond. Pinned snapshots are protected at every level. Space pressure triggers hourly thinning without breaking the cascade. The 14 retention tests cover the important cases: empty input, all-within-window, daily thinning, weekly thinning, pinned protection, space pressure, and count-based retention.
+
+This is the most critical code in the system and it has proportional test coverage. Good instinct.
+
+**[Commendation] `SnapshotName::parse()` handles both formats correctly, including compound short names.**
+
+The parser correctly distinguishes `20260322-htpc-home` (legacy, short_name = "htpc-home") from `20260322-0930-htpc-home` (new format, short_name = "htpc-home"). The heuristic -- check if positions 0-1 and 2-3 after the first dash are valid hour/minute digits followed by a dash -- is sound and handles edge cases like short names that start with digits. The tests cover compound names explicitly.
+
+### 5.2 Security
+
+**[Significant] No path validation on config-sourced values.**
+
+`DriveConfig.mount_path`, `SubvolumeConfig.source`, `SnapshotRoot.path` -- these are all read from TOML and used to construct paths that will eventually be passed to `sudo btrfs subvolume delete` and `sudo btrfs send`. A malicious or malformed config could inject paths outside the expected scope.
+
+In Phase 1 this is theoretical -- the planner doesn't execute anything. But in Phase 2, these paths reach `std::process::Command` with sudo. The config file is user-owned and user-edited, so it's a low-trust boundary (the user is attacking themselves). But a config parsing bug or tilde-expansion edge case could construct an unexpected path.
+
+**Fix for Phase 2:** Validate that all paths are absolute after expansion, contain no `..` components, and fall within expected prefixes (snapshot roots, drive mount points). Do this in `Config::validate()`.
+
+**[Moderate] `expand_tilde` converts paths through `to_string_lossy`.**
+
+In `Config::expand_paths()`, paths are expanded and then converted back to strings via `to_string_lossy()`. If a path contains non-UTF-8 bytes (unlikely on this system, but possible), the lossy conversion silently corrupts it. The corrupted path would then be used for filesystem operations.
+
+**Consequence:** A silently wrong path passed to `sudo btrfs delete` could delete the wrong thing. Extremely unlikely in practice (paths are authored in a TOML file, which is UTF-8), but the code doesn't enforce this assumption.
+
+**Fix:** Store paths as `PathBuf` throughout, not `String`. This eliminates the lossy round-trip entirely.
+
+### 5.3 Architectural Excellence
+
+**[Commendation] Planner/executor separation is exemplary.**
+
+The `plan()` function is a pure function of `(Config, NaiveDateTime, PlanFilters, &dyn FileSystemState)`. It produces a `BackupPlan` with no side effects. This means:
+
+- All backup logic is testable without a filesystem.
+- `urd plan` and `urd backup --dry-run` are trivially correct (they just print the plan).
+- The executor (Phase 2) can be developed and tested independently.
+- A bug in the executor cannot corrupt the planning logic.
+
+This is the right architecture for a tool that deletes data with sudo privileges. The planner tests prove the backup logic is correct without ever touching a real snapshot.
+
+**[Commendation] `FileSystemState` trait is the right testing seam.**
+
+The trait has exactly the methods the planner needs: list snapshots, check mounts, read pin files, get free space. The mock implementation is straightforward -- just `HashMap`s. This is the kind of abstraction that pays for itself on the first test.
+
+**[Minor] `op_belongs_to` in `plan_cmd.rs` uses path heuristics instead of data.**
+
+The function determines which subvolume an operation belongs to by inspecting the parent directory of the path. This works but is fragile -- it depends on the convention that snapshot paths are `{root}/{subvol_name}/{snapshot_name}`. If a `PlannedOperation` carried a `subvolume_name` field on all variants, this function could be a simple field comparison.
+
+Currently only `CreateSnapshot` carries `subvolume_name`. Adding it to the other variants would make grouping reliable and eliminate the path-parsing heuristic.
+
+### 5.4 Systems Design
+
+**[Significant] Local retention can delete unsent snapshots.**
+
+The planner runs local retention independently of external send status. A snapshot that has never been sent to any external drive can be deleted by graduated retention if it falls outside the hourly window and a newer snapshot exists for that calendar day.
+
+Example: snapshot created at 10:00, external drive not mounted all day. At 11:00, a new snapshot is created. At 10:01 the next day (25 hours later), the 10:00 snapshot exits the hourly window and enters the daily window. If the 11:00 snapshot is already the daily representative, the 10:00 snapshot is eligible for deletion. If neither has been sent externally, both copies exist only locally.
+
+This is acceptable if the operator understands the risk. But for `subvol3-opptak` (irreplaceable recordings), deleting the only copy of a snapshot that was never backed up externally is concerning.
+
+**Fix:** Either (a) add unsent snapshots to the pinned set (conservative), (b) add a `min_local_keep` floor that ensures N snapshots always survive regardless of retention (simple), or (c) add a warning to the plan output when a snapshot would be deleted that has never been sent (informative).
+
+**[Moderate] No consideration for clock skew or NTP jumps.**
+
+The planner computes intervals using `now.signed_duration_since(snapshot.datetime())`. If the system clock jumps backward (NTP correction, manual adjustment), a snapshot from the future will have a negative elapsed time, which will always be less than the interval -- so no new snapshot will be created until the clock catches up.
+
+The retention code handles future snapshots correctly (line 68-70 of retention.rs: "Future snapshot -- keep it (clock skew protection)"). Good.
+
+But the snapshot creation logic doesn't warn when the newest snapshot appears to be in the future. An operator who accidentally creates a snapshot dated 2027 would silently suppress all automatic snapshots for a year.
+
+**Fix:** Log a warning when the newest snapshot's datetime is more than a few minutes ahead of `now`.
+
+### 5.5 Rust Idioms
+
+**[Minor] `#[allow(dead_code)]` on structs with publicly useful methods.**
+
+`GeneralConfig` and `BackupPlan` have `#[allow(dead_code)]` annotations. These fields and methods will be used in Phase 2. The allows are fine for now, but they should be tracked and removed as the code fills out. Dead code allows that survive past their intended phase accumulate into a norm of suppressing warnings.
+
+**[Minor] `#[allow(clippy::too_many_arguments)]` on three functions in `plan.rs`.**
+
+`plan_local_snapshot` (7 args), `plan_local_retention` (8 args), and `plan_external_send` (9 args) all suppress this clippy warning. Nine arguments is a code smell, but the alternative (a context struct) would add ceremony without adding clarity -- these are internal helper functions called from one place each.
+
+**Verdict:** Acceptable for internal functions. If any of these grow more callers, introduce a context struct then.
+
+**[Commendation] Strong typing for domain concepts.**
+
+`SnapshotName`, `Interval`, `ByteSize`, `DriveRole`, `GraduatedRetention` -- these types prevent mixing up strings, numbers, and durations. `SnapshotName` encapsulates parsing and formatting, making it impossible to construct an invalid name through the public API. `Interval` prevents negative durations. This is Rust used well.
+
+### 5.6 Code Quality
+
+**[Minor] Test for parsing example config file reads the file but doesn't assert strongly.**
+
+`parse_example_config` (config.rs:342-420) reads the example config as a string but doesn't use it -- the test parses an inline string instead. The comment says "The example config hasn't been updated yet, so this may fail." But `parse_example_config_file` (line 423) does parse the real file. The first test's comment is stale and the `let _ = toml_str` suppression is a smell. Clean up or remove the inline-config test.
+
+**[Commendation] Test coverage is proportional to risk.**
+
+Retention: 10 tests. Planner: 11 tests. Chain/pin files: 8 tests. Types/parsing: 12 tests. Config: 6 tests. The most dangerous code (retention, planning) has the most tests. The tests verify behavior ("creates snapshot when interval elapsed") not implementation details. They will survive refactoring. This is disciplined test design.
+
+---
+
+## 6. The Simplicity Question
+
+**What's earning its keep:**
+
+- `FileSystemState` trait: enables all planner testing. Essential.
+- `SnapshotName` type: parsing, ordering, display all in one place. Essential.
+- `GraduatedRetention` / `ResolvedGraduatedRetention` split: cleanly separates "what was configured" from "what is the resolved policy." Prevents null-handling bugs. Worth it.
+- `PlannedOperation` enum: makes the plan printable, testable, and inspectable. The Display impl gives free `urd plan` output. Essential.
+
+**What could be simpler:**
+
+- `ByteSize` is 50 lines of parsing code for a type used in two config fields. A crate like `bytesize` or `humansize` could replace it. Trade-off: one fewer dependency vs. 50 lines of straightforward code. Given the project's conservative dependency stance, keeping it is reasonable.
+- `DriveRole` is an enum with three variants, used in one field, not matched on anywhere in Phase 1. It could be a plain string for now. But it will be matched on when udev rules distinguish drive roles (Phase 5), so the enum is a reasonable bet.
+- `count_retention` is unused (`#[allow(dead_code)]`). It's 20 lines and well-tested, so the cost of carrying it is near zero. Keep it -- external retention will likely use it.
+
+**What to delete:** Nothing. Every module has a clear purpose and the code is tight. The dead-code items (`count_retention`, some `GeneralConfig` fields) are small and will be used soon. This is a codebase where nothing is wasted.
+
+---
+
+## 7. Priority Action Items
+
+Ordered by proximity to the catastrophic failure mode (silent data loss):
+
+1. **Protect unsent snapshots from local retention.** A snapshot that has never been sent to any external drive should not be deleted by automated retention. At minimum, add a `min_local_keep` floor. At best, treat unsent snapshots as implicitly pinned. (Significant -- one executor bug away from data loss.)
+
+2. **Resolve the pin-before-send dependency.** Either group send+pin into a compound operation, or document the executor contract that pin must not execute on send failure. This must be resolved before Phase 2 ships. (Significant -- one executor bug away from broken chains.)
+
+3. **Decide on snapshot name format and update documentation.** If `YYYYMMDD-HHMM-shortname` is the new format, update CLAUDE.md's backward-compatibility section and document the migration plan. If legacy format must be preserved during parallel run, change `SnapshotName::new()` to produce it. (Significant -- affects Phase 3 coexistence.)
+
+4. **Add path validation in `Config::validate()` before Phase 2.** All paths that will reach `sudo btrfs` must be absolute, contain no `..`, and fall within expected prefixes. (Significant for Phase 2 security.)
+
+5. **Store config paths as `PathBuf` instead of `String`.** Eliminates the `to_string_lossy()` round-trip in `expand_paths()`. Low effort, prevents a class of silent corruption. (Moderate.)
+
+6. **Warn on future-dated snapshots in the planner.** A clock-skew snapshot from the future will silently suppress automatic snapshots until the clock catches up. A log warning makes this diagnosable. (Moderate.)
+
+7. **Add `subvolume_name` to all `PlannedOperation` variants.** Eliminates the path-heuristic grouping in `plan_cmd.rs` and makes the operation self-describing. (Minor, but prevents a fragile pattern from spreading.)
+
+---
+
+## 8. Open Questions
+
+1. **Is the new snapshot format intentional?** The divergence between CLAUDE.md (`YYYYMMDD-shortname`) and `SnapshotName::new()` (`YYYYMMDD-HHMM-shortname`) may be a deliberate evolution or an oversight. The answer changes item #3's priority.
+
+2. **What happens when the bash script encounters Urd's snapshots?** During Phase 3 parallel operation, will the bash script's pin file reader handle the HHMM format? Will it try to send snapshots it didn't create?
+
+3. **Is there a maximum number of snapshots per subvolume directory?** With 15-minute intervals and 24-hour hourly retention, that's ~96 snapshots per day per subvolume. Over 30 days of daily retention, that's ~126 entries. BTRFS handles this fine, but `read_dir()` ordering is not guaranteed -- the sort in the planner is important.
+
+4. **What's the expected behavior when two instances of Urd run concurrently?** The planner is pure and produces the same plan for the same inputs, but two executors running the same plan would create duplicate snapshots (or fail on the second). Is there a lockfile planned?
+
+5. **`max_usage_percent` is validated (<=100) but never used in retention.** Is this deferred to Phase 2, or is `min_free_bytes` the preferred space-pressure mechanism?
+
+---
+
+*Metadata: Reviewed commit `afec570`. All source files in `src/`, `config/urd.toml.example`, `docs/PLAN.md`, and `CLAUDE.md` were read in full. No areas excluded. Test suite not executed as part of this review (plan-only code, no integration test prerequisites).*

--- a/docs/99-reports/2026-03-22-phase1-arch-review.md
+++ b/docs/99-reports/2026-03-22-phase1-arch-review.md
@@ -1,0 +1,330 @@
+# Urd Phase 1 Architectural Review
+
+**Project:** Urd -- BTRFS Time Machine for Linux
+**Date:** 2026-03-22
+**Scope:** PR #1 (commit `afec570`), full Phase 1 implementation
+**Reviewer:** Architectural adversary (Claude Opus 4.6)
+**Coverage:** All 11 source files, config example, design plan (PLAN.md, CLAUDE.md)
+**Excluded:** No source files excluded. Phase 2+ modules (executor, btrfs, state, metrics) not yet written.
+
+---
+
+## Executive Summary
+
+Phase 1 is a strong foundation. The planner/executor separation is genuinely well-executed -- the planner is a pure function of config + filesystem state + time, with no side effects, and the `FileSystemState` trait makes it fully testable without touching disk. The retention logic is sound and well-tested. However, the snapshot naming format has quietly drifted from the backward-compatibility contract (the plan says `YYYYMMDD-shortname`, the code generates `YYYYMMDD-HHMM-shortname`), which will break coexistence with the bash script. There are also several places where the retention algorithm can silently delete more than intended under edge conditions.
+
+---
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Architectural Excellence | 4 | Clean module boundaries, well-justified `FileSystemState` trait, planner purity maintained throughout |
+| Correctness | 3 | Retention window math has edge cases; snapshot format breaks backward compat contract; `op_belongs_to` is fragile |
+| Systems Design Best Practices | 3 | Good TOCTOU awareness for Phase 1 scope, but pin-before-send ordering and /proc/mounts parsing have gaps |
+| Security | 4 | No command injection surface in Phase 1 (no shell-outs yet); path construction is safe; `std::process::Command` planned correctly |
+| Rust Best Practices and Idioms | 4 | Idiomatic ownership, good use of newtypes, proper `thiserror`/`anyhow` split; minor issues with `#[allow]` accumulation |
+| Code Quality | 4 | Comprehensive tests (59 passing), clear naming, consistent style; `op_belongs_to` and `#[allow(clippy::too_many_arguments)]` are debt markers |
+
+---
+
+## Findings by Dimension
+
+### 1. Architectural Excellence
+
+#### Commendation: Planner purity via `FileSystemState` trait
+
+`plan.rs` lines 14-45 define a `FileSystemState` trait that abstracts all filesystem interaction. The planner function (`plan()` at line 60) accepts `&dyn FileSystemState`, meaning the entire planning algorithm is testable with `MockFileSystemState` -- no temp directories, no real mounts, no sudo. This is exactly the right abstraction: it has two real implementations (real + mock), it captures a genuine polymorphism boundary, and it keeps the core logic pure.
+
+The `MockFileSystemState` (lines 460-528) is well-designed too -- it uses `HashMap`s keyed on the right identifiers, making test setup readable and intention-revealing.
+
+#### Commendation: Module responsibility boundaries
+
+Each module does one thing. `retention.rs` computes what to keep/delete but never touches disk. `chain.rs` reads pin files but doesn't know about retention. `config.rs` parses and validates but doesn't know about plans. `drives.rs` checks mounts and space but doesn't know about snapshots. The dependency graph is clean and unidirectional: `plan.rs` depends on `config`, `types`, `retention`, `chain`, and `drives`, but none of those depend on `plan`. This is textbook.
+
+#### Moderate: `plan_cmd.rs` re-derives subvolume grouping from path structure
+
+`plan_cmd.rs` function `op_belongs_to()` (lines 76-95) determines which subvolume an operation belongs to by inspecting the parent directory of file paths in the operation. For `SendIncremental`, `SendFull`, `DeleteSnapshot`, and `PinParent`, it walks up the path and checks directory names. This is fragile -- it couples display logic to path construction conventions in the planner.
+
+The `CreateSnapshot` variant already carries `subvolume_name`. The other variants should too. Adding `subvolume_name: String` to every `PlannedOperation` variant would make `op_belongs_to` a trivial string comparison and eliminate a class of display bugs if path structures ever change.
+
+#### Minor: `PlanFilters` could validate mutual exclusivity
+
+`PlanFilters` allows `local_only` and `external_only` to both be `true` simultaneously. The planner would produce an empty plan (local operations skipped by `external_only`, external operations skipped by `local_only`), which is confusing but not incorrect. A validation at the CLI layer would be better UX. Clap supports `conflicts_with` for this.
+
+### 2. Correctness
+
+#### Significant: Snapshot naming format breaks backward compatibility contract
+
+CLAUDE.md section "Backward Compatibility" and PLAN.md section "Architecture: Key Design Principles" both state:
+
+> Snapshot naming: `YYYYMMDD-<short_name>` (e.g., `20260322-opptak`)
+
+But `SnapshotName::new()` (types.rs line 122) generates `YYYYMMDD-HHMM-shortname`:
+
+```rust
+let raw = format!(
+    "{}-{:02}{:02}-{}",
+    datetime.format("%Y%m%d"),
+    datetime.time().hour(),
+    datetime.time().minute(),
+    short_name
+);
+```
+
+This means `urd plan` will generate `CreateSnapshot` operations with destinations like `20260322-1500-opptak` instead of the `20260322-opptak` format the bash script uses. During the parallel run phase (Phase 3), both systems would create snapshots with different naming conventions in the same directory. Retention logic would treat them as different snapshots. Pin files written by one system would not match snapshot names from the other.
+
+The new format with HHMM is arguably better (supports sub-daily snapshots), but the migration needs to be explicit. Either:
+1. Keep generating legacy format during coexistence, switch to HHMM format only after cutover.
+2. Document the format change as intentional and update CLAUDE.md/PLAN.md.
+3. Make `SnapshotName::new()` accept a format parameter.
+
+#### Significant: Retention window calculation uses fixed 30-day months
+
+`retention.rs` line 53:
+
+```rust
+Some(weekly_cutoff - chrono::Duration::days(i64::from(config.monthly) * 30))
+```
+
+Using 30 days per month is an approximation. With `monthly = 12`, the monthly window extends 360 days (not 365/366). This means snapshots from days 360-365 of the past year are outside all windows and will be deleted. For a backup system protecting irreplaceable data, losing the oldest monthly snapshot due to a 5-day rounding error is a real risk.
+
+Worse, the windows are chained: hourly ends, then daily starts from where hourly ended, then weekly, then monthly. If the user sets `hourly = 24, daily = 30`, the daily window starts 24 hours ago and extends 30 *days* further. But `daily_cutoff` is computed as `hourly_cutoff - Duration::days(daily)` -- this means the daily window is 30 days *after* the hourly window ends, which is correct in intent but the naming is misleading (it's a cutoff, not a count of calendar days).
+
+The deeper issue: with `monthly = 12` and 30-day approximation, the total retention window is `24h + 30d + 26w + 360d = ~1.97 years`. With proper month calculation it would be `~2 years`. The 18-day gap means some monthly snapshots will be deleted early.
+
+**Suggested fix:** Compute the monthly cutoff using chrono's `Months` type or subtract actual calendar months from the weekly cutoff date. Alternatively, document that "monthly = 12" means "360 days" and let users set monthly = 13 if they want a full year.
+
+#### Significant: `space_governed_retention` can delete down to 1 snapshot
+
+`retention.rs` lines 170-183: when under space pressure, `space_governed_retention` deletes oldest unpinned survivors until only 1 remains. But it doesn't know snapshot sizes, so it deletes everything it can. The comment says "The executor will stop deleting once space is recovered" -- but the *plan* still lists all those deletions. If the executor faithfully executes every `DeleteSnapshot` in the plan, it will delete down to 1 snapshot regardless of whether space was recovered after the first deletion.
+
+This is a design tension between planner purity and executor intelligence. The planner cannot know sizes, so it over-deletes in the plan. The executor needs to check space between deletions. This should be documented explicitly as a Phase 2 requirement, and the `PlannedOperation::DeleteSnapshot` should perhaps carry a `conditional: bool` or `reason_category` enum so the executor knows which deletions to re-evaluate at execution time.
+
+#### Moderate: `op_belongs_to` produces wrong results for external operations
+
+`plan_cmd.rs` line 82-85:
+
+```rust
+PlannedOperation::SendIncremental { snapshot, .. }
+| PlannedOperation::SendFull { snapshot, .. } => snapshot
+    .parent()
+    .and_then(|p| p.file_name())
+    .is_some_and(|dir| dir.to_string_lossy() == subvol_name),
+```
+
+For a send operation, `snapshot` is a local path like `/snap/sv1/20260322-1500-one`. The parent is `/snap/sv1`, and `file_name()` returns `sv1`. This works.
+
+But for a `DeleteSnapshot` on an external drive, `path` is something like `/mnt/d1/.snapshots/sv1/20260322-1500-one`. The parent's file_name is `sv1` -- this also works. However, if the external `snapshot_root` config value were empty or `.`, the path would be `/mnt/d1/sv1/20260322-...` and this would still work. If `snapshot_root` contained a nested path like `backups/.snapshots`, it would still work because the subvol_name directory is always the immediate parent.
+
+This is actually correct for all current cases, but it's correct by accident of path construction, not by design. Adding `subvolume_name` to all variants (as suggested above) would make this robust.
+
+#### Moderate: SnapshotName parsing ambiguity with numeric short names
+
+`SnapshotName::parse()` (types.rs lines 161-183) tries to detect the new `HHMM` format by checking if positions 9-12 are digits and position 13 is `-`. Consider a legacy snapshot named `20260322-1234test`. Positions 9-12 are `1234`, position 13 is `t` (not `-`), so it falls through to legacy format. Good.
+
+But consider `20260322-1234-test`. This is ambiguous -- it could be legacy with short_name `1234-test` or new format with time 12:34 and short_name `test`. The parser interprets it as new format (time 12:34, name `test`). If the bash script created a snapshot with short_name `1234-test` in legacy format, Urd would misparse it.
+
+In practice, the configured short names (`opptak`, `htpc-home`, `docs`, etc.) don't start with 4 digits, so this is unlikely to bite. But it's a latent ambiguity worth documenting, especially since the system must coexist with the bash script's output.
+
+#### Minor: `NaiveTime::from_hms_opt(0, 0, 0)` cannot fail
+
+`types.rs` line 191: `NaiveTime::from_hms_opt(0, 0, 0).ok_or_else(...)` -- midnight is always a valid time. The error path is unreachable. This is harmless but could be simplified to `.unwrap()` with a comment, or use a const.
+
+### 3. Systems Design Best Practices
+
+#### Significant: Plan includes PinParent before send is confirmed successful
+
+`plan.rs` line 330-334: `PinParent` is added to the operations list immediately after the send operation. In the plan, this is fine -- the plan describes intent. But the executor (Phase 2) must ensure that `PinParent` is only executed if the preceding send succeeded. If the executor naively iterates operations and a send fails, it must skip the subsequent pin.
+
+This ordering dependency between operations is not encoded in the `PlannedOperation` type. The executor will need to handle this as a special case. Consider either:
+1. Grouping related operations (send + pin) into a compound operation type.
+2. Adding a `depends_on_previous: bool` field.
+3. Documenting this as a Phase 2 executor invariant in CLAUDE.md.
+
+This is flagged now because the *plan structure* was designed in Phase 1 and changing it later means changing all the tests.
+
+#### Moderate: `/proc/mounts` parsing is simplistic
+
+`drives.rs` lines 14-24: `is_path_mounted()` splits each line by space and checks if the second field matches the mount path exactly. This has two issues:
+
+1. Mount paths in `/proc/mounts` can contain octal escapes for special characters (e.g., `\040` for space, `\011` for tab). If a mount path contains a space, the raw comparison will fail. The current drive paths (`/run/media/patriark/WD-18TB`) don't have spaces, but this is fragile.
+
+2. The function doesn't distinguish between a path being a mount *point* versus being *under* a mount point. Currently this is correct because the config specifies exact mount points. But if someone configured `mount_path = "/run/media/patriark"`, it would match, which is wrong.
+
+For Phase 1 (read-only planning), this is low risk. For Phase 2 (executing sends), getting this wrong means sending to the wrong filesystem or failing to detect an unmounted drive.
+
+#### Moderate: `filesystem_free_bytes` silently returns `u64::MAX` on error in multiple call sites
+
+`plan.rs` line 226: `fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX)` -- if the statvfs call fails (e.g., path doesn't exist), the code treats it as "infinite free space" and never triggers space pressure. This is a safe default for retention (won't delete extra snapshots), but it means a misconfigured `min_free_bytes` will silently have no effect.
+
+Similarly in `plan.rs` line 352: `fs.filesystem_free_bytes(&ext_dir).unwrap_or(u64::MAX)` for external drives.
+
+A log warning when this fallback triggers would make debugging much easier.
+
+#### Minor: `expand_tilde` uses `to_string_lossy()` which silently corrupts non-UTF8 paths
+
+`config.rs` lines 206-208:
+
+```rust
+self.general.state_db = expand_tilde(&self.general.state_db).to_string_lossy().into();
+```
+
+`expand_tilde` returns a `PathBuf`, but the config fields are `String`. The `to_string_lossy()` call replaces non-UTF8 bytes with the Unicode replacement character. On Linux, paths can contain non-UTF8 bytes. If the home directory contained non-UTF8 characters, the path would be silently corrupted.
+
+In practice, home directories are almost always UTF8. But the right fix is to store paths as `PathBuf` in the config structs, not `String`. This would propagate naturally through the codebase and eliminate the lossy conversion.
+
+### 4. Security
+
+#### Commendation: No shell invocation in Phase 1
+
+Phase 1 does not shell out at all. The `btrfs_path` config is parsed but not used. All filesystem interaction is through `std::fs` and `nix::sys::statvfs`, which are safe. The `FileSystemState` trait ensures that when Phase 2 adds `sudo btrfs` calls, they will be isolated in `RealBtrfs` behind the trait boundary. This is the correct foundation.
+
+#### Moderate: Drive label is used unsanitized in pin file names
+
+`plan.rs` line 330:
+
+```rust
+let pin_file = local_dir.join(format!(".last-external-parent-{}", drive.label));
+```
+
+The `drive.label` comes from the TOML config file. If someone configured a drive label containing path separators (e.g., `../../../etc/passwd`), the `join()` would construct a path outside the intended directory. In Phase 1, this only affects the *plan* (what would be written), not actual file writes. But in Phase 2, this label will be used in `sudo btrfs` commands and actual file writes.
+
+Config validation should reject drive labels containing `/`, `\`, `..`, or null bytes. Similarly for subvolume names and short names, since these appear in paths.
+
+**Suggested fix in `Config::validate()`:**
+
+```rust
+for drive in &self.drives {
+    if drive.label.contains('/') || drive.label.contains("..") || drive.label.contains('\0') {
+        return Err(UrdError::Config(format!("drive label {:?} contains unsafe characters", drive.label)));
+    }
+}
+```
+
+Apply the same check to `subvolume.name` and `subvolume.short_name`.
+
+#### Minor: Config file permissions are not checked
+
+The config file is read without checking its permissions. Since it contains paths that will be passed to `sudo btrfs`, a world-writable config file would allow any user to manipulate what the backup tool deletes. This is a Phase 2+ concern (when execution happens), but worth noting now.
+
+### 5. Rust Best Practices and Idioms
+
+#### Commendation: Newtype pattern for domain types
+
+`SnapshotName`, `Interval`, `ByteSize`, and `DriveRole` are all dedicated types rather than bare `String`/`u64`/`str`. `SnapshotName` enforces format validity at parse time. `Interval` wraps `chrono::Duration` with human-readable parsing. `ByteSize` handles unit conversions. These prevent category errors (passing a random string where a snapshot name is expected) and make the API self-documenting. The `Ord` implementation on `SnapshotName` that sorts by datetime is particularly good -- it means `snapshots.iter().max()` does the right thing everywhere.
+
+#### Commendation: Correct `thiserror` / `anyhow` split
+
+`error.rs` defines `UrdError` with `thiserror` for library-level errors. `main.rs` and `plan_cmd.rs` use `anyhow::Result` at the CLI boundary. This is exactly the right pattern: structured errors where they matter for programmatic handling, flexible context-adding at the application boundary.
+
+#### Moderate: `#[allow(dead_code)]` accumulation
+
+Several items are marked `#[allow(dead_code)]`:
+- `GeneralConfig` (config.rs line 22) -- fields read from TOML but not yet used by any module
+- `local_snapshot_dir()` (config.rs line 176)
+- `Interval` impl block (types.rs line 17)
+- `BackupPlan` and its impl (types.rs lines 399, 406)
+- `count_retention()` (retention.rs line 121)
+- `UrdError::Retention` (error.rs line 22)
+
+These are all scaffolding for Phase 2+. The allows are justified *now*, but they should be tracked. A `// Phase 2` comment next to each one would signal intent. Without that, a future reader cannot distinguish "planned for later" from "forgot to clean up."
+
+#### Minor: `chrono::Duration` deprecation trajectory
+
+The code uses `chrono::Duration::minutes()`, `hours()`, `days()`, `weeks()`. As of chrono 0.4.34+, several `Duration` constructors are being deprecated in favor of `TimeDelta`. The current code compiles without warnings, but this is worth watching during dependency updates.
+
+#### Minor: `ByteSize` float-to-int cast
+
+`types.rs` line 493:
+
+```rust
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+Ok(Self((num * multiplier as f64) as u64))
+```
+
+The `allow` annotations acknowledge the issue. For backup-relevant sizes, truncation is not a practical problem (you won't configure 18.446 EB). But the `cast_sign_loss` allow means a negative float input (from a carefully crafted string like `-1GB` that somehow passed the numeric parser) would wrap to a huge positive value. In practice, `"-1GB".parse::<f64>()` succeeds and `-1.0 * 1_000_000_000.0 = -1e9`, then `as u64` wraps to `u64::MAX - 999999999`. Adding a `num < 0.0` check before the cast would be defensive.
+
+### 6. Code Quality
+
+#### Commendation: Test quality and coverage
+
+59 tests cover config parsing (with inline TOML and the real example file), all retention strategies (empty, within window, thinning at each level, pinned protection, space pressure), plan generation (interval elapsed/not elapsed, first snapshot, filters, incremental/full sends, drive not mounted), pin file reading (drive-specific, legacy fallback, precedence, malformed, empty, whitespace), and type parsing (intervals, snapshot names, byte sizes).
+
+The tests are behavior-focused, not implementation-coupled. They verify *what* the planner decides, not *how* it iterates. The test helpers (`test_config()`, `snap()`, `make_snap()`) are clear and reusable. Test names describe the scenario being verified.
+
+Notably absent: no test for the boundary condition where a snapshot's datetime equals exactly the cutoff time (hourly_cutoff, daily_cutoff, etc.). The `>=` comparisons mean it falls into the more-recent window, which is correct, but should be verified.
+
+#### Commendation: Consistent error handling patterns
+
+Every module that reads the filesystem follows the same pattern: `NotFound` errors return `Ok(empty)` or `Ok(None)`, other errors propagate with context. This is the right choice for a backup tool -- a missing directory is expected state (drive not mounted, first run), not an error.
+
+#### Moderate: `#[allow(clippy::too_many_arguments)]` on three functions
+
+`plan_local_snapshot` (7 args), `plan_local_retention` (8 args), `plan_external_send` (9 args). These functions are internal to `plan.rs` and are called from one place each. The argument lists are mostly data being threaded through. A `PlanContext` struct would clean this up:
+
+```rust
+struct PlanContext<'a> {
+    config: &'a Config,
+    subvol: &'a ResolvedSubvolume,
+    local_dir: &'a Path,
+    local_snaps: &'a [SnapshotName],
+    now: NaiveDateTime,
+    pinned: &'a HashSet<SnapshotName>,
+    fs: &'a dyn FileSystemState,
+}
+```
+
+This is a style issue, not a correctness issue. But 9 arguments makes call sites hard to read.
+
+#### Minor: Unused `_root` parameter in `MockFileSystemState::local_snapshots`
+
+`plan.rs` line 483: `fn local_snapshots(&self, _root: &Path, subvol_name: &str)` -- the mock ignores `_root` and keys only on `subvol_name`. This is fine for current tests where each subvolume has a unique name, but if tests ever need two subvolumes with the same name in different roots, the mock would need updating. The underscore prefix correctly signals this.
+
+#### Minor: `parse_example_config` test has dead code
+
+`config.rs` test `parse_example_config` (line 342) reads the example config file into `toml_str`, then parses an inline string instead, and only uses `toml_str` at the end with `let _ = toml_str;` to suppress the unused variable warning. There's a separate `parse_example_config_file` test that actually tests the file. The first test should drop the file-reading preamble or merge with the second test.
+
+---
+
+## Priority Action Items
+
+Ordered by impact-to-effort ratio:
+
+1. **Fix snapshot naming format to match backward compatibility contract.** Either `SnapshotName::new()` should generate `YYYYMMDD-shortname` format during the coexistence period, or the documentation should be updated to declare the new format. This is a one-line change with outsized impact -- getting it wrong means the Phase 3 parallel run produces divergent data. *(Significant, low effort)*
+
+2. **Add path-safety validation for drive labels, subvolume names, and short names in `Config::validate()`.** Reject `/`, `..`, null bytes. This prevents path traversal when these values are used in `join()` calls and, later, in `sudo btrfs` command arguments. 5-10 lines of code that close a security gap before Phase 2. *(Moderate, low effort)*
+
+3. **Add `subvolume_name` field to all `PlannedOperation` variants.** Eliminates the fragile `op_belongs_to()` path-inspection logic and makes the plan self-describing. Straightforward mechanical change. *(Moderate, low effort)*
+
+4. **Document the plan-then-execute contract for `PinParent` ordering.** Either add a `depends_on_previous` field to `PlannedOperation`, group send+pin into a compound operation, or add a comment in CLAUDE.md that the executor must skip pin operations when the preceding send fails. Do this before Phase 2 implementation begins. *(Significant, low effort)*
+
+5. **Fix the monthly retention window to use calendar months instead of `monthly * 30` days.** Use `chrono::Months` or an equivalent calculation. This prevents the 5-day gap at the end of a 12-month retention window. *(Significant, medium effort)*
+
+6. **Add space-pressure deletion as a conditional/advisory operation.** Mark `DeleteSnapshot` operations generated by space pressure so the executor can re-check free space between deletions instead of deleting everything the planner suggested. *(Significant, medium effort)*
+
+7. **Store config paths as `PathBuf` instead of `String`.** Eliminates `to_string_lossy()` conversions and makes the type system enforce path correctness. Touches multiple structs but is mechanical. *(Moderate, medium effort)*
+
+---
+
+## Open Questions
+
+1. **Is the HHMM snapshot format intentional?** The code generates `20260322-1500-opptak` but the docs say `20260322-opptak`. If the format change is deliberate (supporting sub-daily snapshots), CLAUDE.md and PLAN.md need updating. If it's unintentional, `SnapshotName::new()` needs to change. This is the single most important question before Phase 2.
+
+2. **What happens to pinned snapshots when a drive is permanently removed?** Pin files for that drive label will persist forever, protecting snapshots from retention. There's no mechanism to "unpin" snapshots for a decommissioned drive. Is this intended? It's conservative (data safety), but it means snapshot directories will grow indefinitely.
+
+3. **How does the executor distinguish space-pressure deletions from retention deletions?** The current `PlannedOperation::DeleteSnapshot` has a `reason: String`, which is human-readable but not machine-parseable. The executor will need to branch on deletion type. Should `reason` become an enum?
+
+4. **Is `max_usage_percent` on drives intended to be used?** It appears in `DriveConfig` (config.rs line 56) but is never referenced by the planner or retention logic. Only `min_free_bytes` is checked. If `max_usage_percent` is Phase 2+, it should have a `// Phase 2` comment. If it's an alternative to `min_free_bytes`, the planner should check it.
+
+5. **Will the bash script and Urd ever run simultaneously?** The parallel run plan (Phase 3) schedules Urd at 02:00 and bash at 03:00. If Urd takes more than 60 minutes (large subvolumes), the two could overlap. Since both create snapshots and manage retention, concurrent execution on the same snapshot directories could cause races. Is there a lockfile mechanism planned?
+
+---
+
+## Metadata
+
+- **Commit reviewed:** `afec570` ("feat: Implement Phase 1 -- config, types, retention, planner, and `urd plan` CLI")
+- **PR:** #1 (feat/phase1-skeleton-config-plan)
+- **Files reviewed:** 11 Rust source files, 1 TOML example config, CLAUDE.md, PLAN.md, Cargo.toml (100% of repository source)
+- **Test suite:** 59 tests, all passing. Clippy clean with `-D warnings`.
+- **Areas explicitly excluded:** None. Phase 2+ modules do not exist yet; review comments on future phases are based on the plan and current type definitions.

--- a/docs/99-reports/2026-03-22-phase1-hardening-review.md
+++ b/docs/99-reports/2026-03-22-phase1-hardening-review.md
@@ -1,0 +1,177 @@
+# Urd Phase 1 Hardening Review
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-22
+**Scope:** Phase 1 hardening changes — 7 priority items from architectural review, applied to config.rs, types.rs, plan.rs, plan_cmd.rs, drives.rs, CLAUDE.md
+**Reviewer:** Architectural Adversary (Claude Opus 4.6)
+**Prior review:** docs/99-reports/2026-03-22-phase1-arch-review-v3.md
+
+---
+
+## 1. Executive Summary
+
+The hardening changes successfully address all 7 priority items from the architectural review. The most important change — unsent snapshot protection — is correctly implemented and well-tested. The `PinParent` removal elegantly resolves the send/pin ordering dependency by making pin a property of the send operation. The PathBuf migration and path validation close the security gap before Phase 2 introduces execution. The codebase is tighter, safer, and ready for Phase 2.
+
+---
+
+## 2. What Kills You
+
+The catastrophic failure mode remains **silent data loss**: retention deleting the last copy of irreplaceable data.
+
+**Current distance from catastrophe after hardening:** Significantly improved.
+
+- **Before:** Unsent snapshots could be deleted by local retention. One executor bug away from data loss.
+- **After:** Unsent snapshots are now protected. The planner treats any snapshot newer than the oldest pin as implicitly pinned when `send_enabled` is true. When no pin exists at all (nothing has ever been sent), every local snapshot is protected. This eliminates the most direct path to silent data loss.
+
+The remaining risk lives in the retention algorithm itself (the 30-day month approximation noted in the prior review, unchanged here) and in Phase 2's executor implementation. The foundation is now sound.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | Unsent protection logic is correct. One edge case worth noting (see 5.1). |
+| Security | 4 | Path validation closes the traversal gap. PathBuf eliminates lossy conversions. |
+| Architectural Excellence | 5 | pin_on_success grouping, subvolume_name on all ops, and PathBuf migration all improve the type system's expressiveness. |
+| Systems Design | 4 | Unsent protection prevents the most dangerous failure mode. Future-date warning adds observability. |
+| Rust Idioms | 4 | Clean use of PathBuf, Option tuple for pin_on_success, Component::ParentDir for validation. |
+| Code Quality | 4 | 7 new tests cover the hardening changes. op_subvolume_name replaces fragile path heuristic. |
+
+---
+
+## 4. Design Tensions
+
+### 4.1 Unsent protection: protect-all vs. protect-newer-than-oldest-pin
+
+The implementation protects all snapshots newer than the oldest pin across all drives. When no pin exists, it protects everything.
+
+**Trade-off:** This is conservative — it may prevent retention from cleaning up snapshots that *have* been sent to some drives but not all. A snapshot sent to WD-18TB but not WD-18TB1 is still protected because the oldest pin (from WD-18TB1, which might be much older) is the threshold.
+
+**Verdict:** Correct choice. For a backup tool, conservative means "don't delete data that might be the only copy." The alternative — tracking per-drive sent status — would require knowing which snapshots exist on which drives, which the pin file abstraction doesn't provide (pins only record the *last* sent snapshot, not all sent snapshots). The conservative approach is the right one given the data model.
+
+### 4.2 pin_on_success as Option<(PathBuf, SnapshotName)> vs. separate struct
+
+The pin information is stored as a tuple inside an Option. A named struct would be more self-documenting (`PinInfo { file: PathBuf, snapshot: SnapshotName }`).
+
+**Verdict:** The tuple is fine for now — it has exactly two fields, and the doc comment explains them. If the pin operation gains more fields (e.g., Phase 2 might need a `drive_label` for logging), promote to a struct then. Premature structuring is not a virtue.
+
+---
+
+## 5. Findings by Dimension
+
+### 5.1 Correctness
+
+**[Moderate] Unsent protection doesn't account for the pin snapshot itself.**
+
+`plan.rs` line 248: `if snap > oldest` — this uses strict greater-than. The pin snapshot itself (the oldest pin) is already in the `pinned` set and is therefore protected by the existing mechanism. However, a snapshot that has the *exact same datetime* as the pin but a different short_name would not be caught by `>` (it would be equal). Since `SnapshotName::Ord` sorts by datetime then short_name, two snapshots at the same datetime with different names would have `snap > oldest` be true for the one with the later short_name and false for the one with the earlier short_name.
+
+In practice this is a non-issue: the pin always points to a specific snapshot name, and two snapshots at the exact same minute with different short_names would mean two different subvolumes, which are processed independently. But the comparison could use `>=` without harm — the pin is already in the set and inserting a duplicate is a no-op.
+
+**Consequence:** None in practice. Theoretical edge case only.
+
+**[Commendation] The three-branch structure of unsent protection is clean and correct.**
+
+```
+send_enabled + has pins → protect newer than oldest pin
+send_enabled + no pins  → protect everything
+send_disabled           → no protection (normal retention)
+```
+
+Each branch has a clear invariant, and the tests cover all three. The comment explaining "why" (`plan.rs` lines 238-241) is exactly the right level of documentation — it explains the consequence that motivates the code, not just what the code does.
+
+**[Commendation] pin_on_success resolves the send/pin ordering dependency elegantly.**
+
+The prior review flagged `PinParent` as a separate operation with an implicit ordering dependency on the preceding Send. The fix — embedding pin info as a field on the Send operation — makes the dependency structural. The executor cannot accidentally execute a pin without having access to the send result, because they're the same operation. This is the kind of fix that eliminates a class of bugs rather than patching one instance.
+
+### 5.2 Security
+
+**[Commendation] Path validation is well-designed.**
+
+`validate_path_safe` uses `Component::ParentDir` matching instead of string-based `..` detection. This is correct — it handles paths like `/data/something../foo` (which contains ".." as a substring but not as a path component) without false positives. The use of `std::path::Component` is idiomatic Rust and leverages the stdlib's path parsing.
+
+`validate_name_safe` correctly blocks `/`, `\`, `..`, and null bytes in labels, names, and snapshot_root. The string-based `..` check here is appropriate because these are name components, not full paths.
+
+**[Minor] `validate_name_safe` allows names starting with `.`.**
+
+A drive label or subvolume name starting with `.` (e.g., `.hidden`) would pass validation. In `external_snapshot_dir`, this would create a hidden directory (`.hidden` under `.snapshots`). In `read_snapshot_dir`, hidden entries are skipped (line 493: `if name_str.starts_with('.') { continue; }`). This means a subvolume with short_name `.foo` would create snapshots that the planner's own directory reader would skip.
+
+**Consequence:** A config typo with a leading dot could cause snapshots to be created but never seen by retention or send logic. Low risk — no one would intentionally name a subvolume `.foo` — but a validation check for leading dots would catch it.
+
+### 5.3 Architectural Excellence
+
+**[Commendation] subvolume_name on all PlannedOperation variants makes the plan self-describing.**
+
+The prior review flagged `op_belongs_to` as fragile path-heuristic code. The fix — adding `subvolume_name` to every variant — is the right structural change. The new `op_subvolume_name` function is 5 lines of exhaustive pattern matching, impossible to get wrong. The old version was 15 lines of path inspection that could silently misclassify operations.
+
+**[Commendation] PathBuf migration eliminates a category of silent corruption.**
+
+Config paths are now `PathBuf` throughout. The `to_string_lossy()` roundtrip in `expand_paths()` is gone. `expand_tilde` correctly handles the `&Path` input, falling through to `path.to_path_buf()` for non-UTF-8 paths (which cannot meaningfully start with `~`). This is clean and correct.
+
+### 5.4 Systems Design
+
+**[Commendation] Future-date warning is proportional and non-disruptive.**
+
+The `log::warn!` on future-dated snapshots (`plan.rs` lines 179-190) is the right response — it's informational, doesn't change behavior, and gives the operator a diagnostic breadcrumb. A future-dated snapshot is not an error (it could be from a legitimate timezone change), but it has surprising consequences (suppressed automatic snapshots), so warning is correct.
+
+### 5.5 Rust Idioms
+
+**[Minor] `#[allow(unused_imports)]` on `PathBuf` in plan.rs.**
+
+Line 3: `#[allow(unused_imports)] use std::path::{Path, PathBuf};` — `PathBuf` is used in tests (e.g., `PathBuf::from("/snap/sv1")`) but the allow suppresses the warning for the non-test build. This is fine for now but could be cleaned up by moving the `PathBuf` import into the test module.
+
+### 5.6 Code Quality
+
+**[Commendation] Test coverage for unsent protection is thorough and well-structured.**
+
+Three tests cover the three branches:
+- `unsent_snapshots_protected_from_retention` — has pin, newer snapshots protected
+- `all_snapshots_protected_when_no_pin` — no pin, everything protected
+- `send_disabled_no_unsent_protection` — send disabled, normal retention
+
+Test names describe the scenario being verified. Assertions check both the positive case (what should happen) and the negative case (what should not happen). The `send_disabled_no_unsent_protection` test uses a separate config with `send_enabled = false` to isolate the behavior.
+
+---
+
+## 6. The Simplicity Question
+
+**What was added:**
+- ~30 lines of unsent protection logic in `plan_local_retention` — earns its keep (prevents data loss)
+- ~30 lines of path validation helpers — earns its keep (prevents path traversal in Phase 2)
+- `pin_on_success` field on Send variants — earns its keep (eliminates implicit ordering dependency)
+- `subvolume_name` field on all variants — earns its keep (eliminates fragile path heuristic)
+- Future-date warning: 8 lines — earns its keep (operator observability)
+
+**What was removed:**
+- `PinParent` variant — good, it was a source of implicit coupling
+- `to_string_lossy()` roundtrips in `expand_paths()` — good, lossy conversion is gone
+- `op_belongs_to` with path inspection — good, replaced by trivial field match
+- `pins` field in `PlanSummary` — good, pins are now implicit in sends
+
+**Net assessment:** The codebase got slightly larger but significantly more robust. Every addition is load-bearing. Nothing was added speculatively.
+
+---
+
+## 7. Priority Action Items
+
+The hardening successfully addressed all 7 items from the prior review. Remaining items for Phase 2 readiness:
+
+1. **Retention monthly window still uses `Duration::days(monthly * 30)`** (noted in prior review, not in scope for this hardening). Fix before Phase 2 if retention will be active.
+
+2. **`space_governed_retention` still proposes deleting down to 1 snapshot under pressure** (noted in prior review, not in scope). The executor will need to re-check space between deletions.
+
+3. **Consider validating names don't start with `.`** to prevent hidden-directory edge case (minor, see 5.2).
+
+4. **Move `#[allow(unused_imports)]` on PathBuf** to the test module for cleanliness (minor).
+
+---
+
+## 8. Open Questions
+
+1. **How will the Phase 2 executor use `pin_on_success`?** The plan is clear — write the pin file only on successful send. But should a failed pin-file write fail the entire send operation? Or should the send be considered successful and the pin failure logged as a warning? The pin file is important for incremental chain continuity but not for the integrity of the snapshot that was just sent.
+
+2. **Should unsent protection have an override?** In extreme disk pressure scenarios, the operator might want to force-delete unsent snapshots to free space. Currently, unsent protection prevents this. A `--force-retention` flag or a config option could provide an escape hatch. This is not urgent but worth considering for Phase 4 polish.
+
+---
+
+*Metadata: Review covers the diff between commit `afec570` (Phase 1 original) and the current working tree (Phase 1 hardening). All modified files read in full. 66 tests passing, clippy clean. No areas excluded.*

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -35,7 +35,7 @@ pub fn run(config: Config, args: PlanArgs) -> anyhow::Result<()> {
         let ops: Vec<_> = backup_plan
             .operations
             .iter()
-            .filter(|op| op_belongs_to(op, &subvol.name))
+            .filter(|op| op_subvolume_name(op) == subvol.name)
             .collect();
         let skips: Vec<_> = backup_plan
             .skipped
@@ -73,24 +73,12 @@ pub fn run(config: Config, args: PlanArgs) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn op_belongs_to(op: &PlannedOperation, subvol_name: &str) -> bool {
+fn op_subvolume_name(op: &PlannedOperation) -> &str {
     match op {
-        PlannedOperation::CreateSnapshot {
-            subvolume_name, ..
-        } => subvolume_name == subvol_name,
-        PlannedOperation::SendIncremental { snapshot, .. }
-        | PlannedOperation::SendFull { snapshot, .. } => snapshot
-            .parent()
-            .and_then(|p| p.file_name())
-            .is_some_and(|dir| dir.to_string_lossy() == subvol_name),
-        PlannedOperation::DeleteSnapshot { path, .. } => path
-            .parent()
-            .and_then(|p| p.file_name())
-            .is_some_and(|dir| dir.to_string_lossy() == subvol_name),
-        PlannedOperation::PinParent { pin_file, .. } => pin_file
-            .parent()
-            .and_then(|p| p.file_name())
-            .is_some_and(|dir| dir.to_string_lossy() == subvol_name),
+        PlannedOperation::CreateSnapshot { subvolume_name, .. }
+        | PlannedOperation::SendIncremental { subvolume_name, .. }
+        | PlannedOperation::SendFull { subvolume_name, .. }
+        | PlannedOperation::DeleteSnapshot { subvolume_name, .. } => subvolume_name,
     }
 }
 
@@ -108,14 +96,16 @@ fn print_operation(op: &PlannedOperation) {
             snapshot,
             drive_label,
             parent,
+            pin_on_success,
             ..
         } => {
             let parent_name = parent
                 .file_name()
                 .unwrap_or_default()
                 .to_string_lossy();
+            let pin_suffix = if pin_on_success.is_some() { " + pin" } else { "" };
             println!(
-                "  {}   {} -> {} (incremental, parent: {})",
+                "  {}   {} -> {} (incremental, parent: {}){pin_suffix}",
                 "[SEND]".blue(),
                 snapshot.file_name().unwrap_or_default().to_string_lossy(),
                 drive_label,
@@ -125,32 +115,23 @@ fn print_operation(op: &PlannedOperation) {
         PlannedOperation::SendFull {
             snapshot,
             drive_label,
+            pin_on_success,
             ..
         } => {
+            let pin_suffix = if pin_on_success.is_some() { " + pin" } else { "" };
             println!(
-                "  {}   {} -> {} (full)",
+                "  {}   {} -> {} (full){pin_suffix}",
                 "[SEND]".blue(),
                 snapshot.file_name().unwrap_or_default().to_string_lossy(),
                 drive_label,
             );
         }
-        PlannedOperation::DeleteSnapshot { path, reason } => {
+        PlannedOperation::DeleteSnapshot { path, reason, .. } => {
             println!(
                 "  {} {} ({})",
                 "[DELETE]".yellow(),
                 path.file_name().unwrap_or_default().to_string_lossy(),
                 reason
-            );
-        }
-        PlannedOperation::PinParent {
-            pin_file,
-            snapshot_name,
-        } => {
-            println!(
-                "  {}    {} = {}",
-                "[PIN]".dimmed(),
-                pin_file.file_name().unwrap_or_default().to_string_lossy(),
-                snapshot_name
             );
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use serde::Deserialize;
 
@@ -21,9 +21,9 @@ pub struct Config {
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct GeneralConfig {
-    pub state_db: String,
-    pub metrics_file: String,
-    pub log_dir: String,
+    pub state_db: PathBuf,
+    pub metrics_file: PathBuf,
+    pub log_dir: PathBuf,
     #[serde(default = "default_btrfs_path")]
     pub btrfs_path: String,
 }
@@ -39,7 +39,7 @@ pub struct LocalSnapshotsConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct SnapshotRoot {
-    pub path: String,
+    pub path: PathBuf,
     pub subvolumes: Vec<String>,
     #[serde(default)]
     pub min_free_bytes: Option<ByteSize>,
@@ -49,7 +49,7 @@ pub struct SnapshotRoot {
 #[allow(dead_code)]
 pub struct DriveConfig {
     pub label: String,
-    pub mount_path: String,
+    pub mount_path: PathBuf,
     pub snapshot_root: String,
     pub role: DriveRole,
     #[serde(default)]
@@ -78,7 +78,7 @@ fn default_true() -> bool {
 pub struct SubvolumeConfig {
     pub name: String,
     pub short_name: String,
-    pub source: String,
+    pub source: PathBuf,
     #[serde(default = "default_priority")]
     pub priority: u8,
     pub enabled: Option<bool>,
@@ -125,7 +125,7 @@ impl SubvolumeConfig {
         ResolvedSubvolume {
             name: self.name.clone(),
             short_name: self.short_name.clone(),
-            source: PathBuf::from(&self.source),
+            source: self.source.clone(),
             priority: self.priority,
             enabled: self.enabled.unwrap_or(defaults.enabled),
             snapshot_interval: self.snapshot_interval.unwrap_or(defaults.snapshot_interval),
@@ -165,7 +165,7 @@ impl Config {
     pub fn snapshot_root_for(&self, subvol_name: &str) -> Option<PathBuf> {
         for root in &self.local_snapshots.roots {
             if root.subvolumes.iter().any(|s| s == subvol_name) {
-                return Some(expand_tilde(&root.path));
+                return Some(root.path.clone());
             }
         }
         None
@@ -203,16 +203,20 @@ impl Config {
     }
 
     fn expand_paths(&mut self) {
-        self.general.state_db = expand_tilde(&self.general.state_db).to_string_lossy().into();
-        self.general.metrics_file = expand_tilde(&self.general.metrics_file).to_string_lossy().into();
-        self.general.log_dir = expand_tilde(&self.general.log_dir).to_string_lossy().into();
+        self.general.state_db = expand_tilde(&self.general.state_db);
+        self.general.metrics_file = expand_tilde(&self.general.metrics_file);
+        self.general.log_dir = expand_tilde(&self.general.log_dir);
 
         for root in &mut self.local_snapshots.roots {
-            root.path = expand_tilde(&root.path).to_string_lossy().into();
+            root.path = expand_tilde(&root.path);
         }
 
         for drive in &mut self.drives {
-            drive.mount_path = expand_tilde(&drive.mount_path).to_string_lossy().into();
+            drive.mount_path = expand_tilde(&drive.mount_path);
+        }
+
+        for sv in &mut self.subvolumes {
+            sv.source = expand_tilde(&sv.source);
         }
     }
 
@@ -285,6 +289,27 @@ impl Config {
             }
         }
 
+        // Path safety: all paths must be absolute with no ".." components
+        validate_path_safe(&self.general.state_db, "general.state_db")?;
+        validate_path_safe(&self.general.metrics_file, "general.metrics_file")?;
+        validate_path_safe(&self.general.log_dir, "general.log_dir")?;
+
+        for root in &self.local_snapshots.roots {
+            validate_path_safe(&root.path, "snapshot root path")?;
+        }
+
+        for drive in &self.drives {
+            validate_path_safe(&drive.mount_path, &format!("drive {:?} mount_path", drive.label))?;
+            validate_name_safe(&drive.label, "drive label")?;
+            validate_name_safe(&drive.snapshot_root, "drive snapshot_root")?;
+        }
+
+        for sv in &self.subvolumes {
+            validate_path_safe(&sv.source, &format!("subvolume {:?} source", sv.name))?;
+            validate_name_safe(&sv.name, "subvolume name")?;
+            validate_name_safe(&sv.short_name, "subvolume short_name")?;
+        }
+
         Ok(())
     }
 }
@@ -293,17 +318,53 @@ impl Config {
 
 /// Expand `~` at the start of a path to the user's home directory.
 #[must_use]
-pub fn expand_tilde(path: &str) -> PathBuf {
-    if let Some(rest) = path.strip_prefix("~/") {
+pub fn expand_tilde(path: &Path) -> PathBuf {
+    let Some(s) = path.to_str() else {
+        // Non-UTF-8 path cannot contain a tilde prefix meaningfully
+        return path.to_path_buf();
+    };
+    if let Some(rest) = s.strip_prefix("~/") {
         if let Some(home) = dirs::home_dir() {
             return home.join(rest);
         }
-    } else if path == "~"
+    } else if s == "~"
         && let Some(home) = dirs::home_dir()
     {
         return home;
     }
-    PathBuf::from(path)
+    path.to_path_buf()
+}
+
+/// Validate that a path is absolute and contains no `..` components.
+fn validate_path_safe(path: &Path, label: &str) -> crate::error::Result<()> {
+    if !path.is_absolute() {
+        return Err(UrdError::Config(format!(
+            "{label} must be an absolute path, got: {}",
+            path.display()
+        )));
+    }
+    for component in path.components() {
+        if matches!(component, Component::ParentDir) {
+            return Err(UrdError::Config(format!(
+                "{label} must not contain '..': {}",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate that a name is safe for use in filesystem paths.
+fn validate_name_safe(name: &str, label: &str) -> crate::error::Result<()> {
+    if name.is_empty() {
+        return Err(UrdError::Config(format!("{label} must not be empty")));
+    }
+    if name.contains('/') || name.contains('\\') || name.contains("..") || name.contains('\0') {
+        return Err(UrdError::Config(format!(
+            "{label} contains forbidden characters: {name:?}"
+        )));
+    }
+    Ok(())
 }
 
 fn default_config_path() -> crate::error::Result<PathBuf> {
@@ -321,20 +382,20 @@ mod tests {
 
     #[test]
     fn expand_tilde_with_home() {
-        let expanded = expand_tilde("~/projects/urd");
+        let expanded = expand_tilde(Path::new("~/projects/urd"));
         assert!(expanded.to_string_lossy().contains("projects/urd"));
         assert!(!expanded.to_string_lossy().starts_with('~'));
     }
 
     #[test]
     fn expand_tilde_absolute() {
-        let expanded = expand_tilde("/usr/bin/btrfs");
+        let expanded = expand_tilde(Path::new("/usr/bin/btrfs"));
         assert_eq!(expanded, PathBuf::from("/usr/bin/btrfs"));
     }
 
     #[test]
     fn expand_tilde_bare() {
-        let expanded = expand_tilde("~");
+        let expanded = expand_tilde(Path::new("~"));
         assert!(!expanded.to_string_lossy().contains('~'));
     }
 
@@ -633,5 +694,113 @@ local_retention = { daily = 7, weekly = 4 }
         assert_eq!(resolved.local_retention.hourly, 24); // from defaults (not overridden)
         assert_eq!(resolved.local_retention.monthly, 12); // from defaults (not overridden)
         assert_eq!(resolved.external_retention.daily, 30);
+    }
+
+    #[test]
+    fn validate_relative_path_rejected() {
+        let config_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [{ path = "/snap", subvolumes = ["a"] }]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "test"
+
+[[subvolumes]]
+name = "a"
+short_name = "a"
+source = "relative/path"
+"#;
+        let mut config: Config = toml::from_str(config_str).unwrap();
+        config.expand_paths();
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("absolute path"));
+    }
+
+    #[test]
+    fn validate_path_traversal_rejected() {
+        let config_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [{ path = "/snap", subvolumes = ["a"] }]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "test"
+
+[[subvolumes]]
+name = "a"
+short_name = "a"
+source = "/data/../etc/shadow"
+"#;
+        let mut config: Config = toml::from_str(config_str).unwrap();
+        config.expand_paths();
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains(".."));
+    }
+
+    #[test]
+    fn validate_name_with_slash_rejected() {
+        let config_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [{ path = "/snap", subvolumes = ["foo/bar"] }]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "test"
+
+[[subvolumes]]
+name = "foo/bar"
+short_name = "fb"
+source = "/data"
+"#;
+        let mut config: Config = toml::from_str(config_str).unwrap();
+        config.expand_paths();
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("forbidden characters"));
     }
 }

--- a/src/drives.rs
+++ b/src/drives.rs
@@ -11,13 +11,16 @@ pub fn is_drive_mounted(drive: &DriveConfig) -> bool {
 
 /// Check if a path appears as a mount point in /proc/mounts.
 #[must_use]
-pub fn is_path_mounted(mount_path: &str) -> bool {
+pub fn is_path_mounted(mount_path: &Path) -> bool {
+    let Some(mount_str) = mount_path.to_str() else {
+        return false;
+    };
     let Ok(mounts) = std::fs::read_to_string("/proc/mounts") else {
         return false;
     };
     for line in mounts.lines() {
         let parts: Vec<&str> = line.splitn(3, ' ').collect();
-        if parts.len() >= 2 && parts[1] == mount_path {
+        if parts.len() >= 2 && parts[1] == mount_str {
             return true;
         }
     }
@@ -37,9 +40,7 @@ pub fn filesystem_free_bytes(path: &Path) -> crate::error::Result<u64> {
 /// Returns `{mount_path}/{snapshot_root}/{subvol_name}`.
 #[must_use]
 pub fn external_snapshot_dir(drive: &DriveConfig, subvol_name: &str) -> PathBuf {
-    PathBuf::from(&drive.mount_path)
-        .join(&drive.snapshot_root)
-        .join(subvol_name)
+    drive.mount_path.join(&drive.snapshot_root).join(subvol_name)
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -52,7 +53,7 @@ mod tests {
     fn test_drive() -> DriveConfig {
         DriveConfig {
             label: "WD-18TB".to_string(),
-            mount_path: "/run/media/user/WD-18TB".to_string(),
+            mount_path: PathBuf::from("/run/media/user/WD-18TB"),
             snapshot_root: ".snapshots".to_string(),
             role: DriveRole::Primary,
             max_usage_percent: Some(90),

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -175,6 +175,20 @@ fn plan_local_snapshot(
 ) {
     // Check if interval has elapsed since newest snapshot
     let newest = local_snaps.iter().max();
+
+    // Warn if the newest snapshot is dated in the future (clock skew)
+    if let Some(newest) = newest
+        && newest.datetime() > now
+    {
+        log::warn!(
+            "Subvolume {}: newest snapshot {} is dated in the future ({}); \
+             automatic snapshots will be suppressed until clock catches up",
+            subvol.name,
+            newest,
+            newest.datetime().format("%Y-%m-%d %H:%M"),
+        );
+    }
+
     let should_create = if force {
         true
     } else if let Some(newest) = newest {
@@ -221,6 +235,34 @@ fn plan_local_retention(
         return;
     }
 
+    // Protect unsent snapshots from retention deletion.
+    // If send is enabled, snapshots newer than the oldest pin may not have been
+    // sent to all drives yet. Deleting them would lose the only local copy before
+    // it reaches external storage — one step from silent data loss.
+    let protected = if subvol.send_enabled {
+        let oldest_pin = pinned.iter().min();
+        let mut expanded = pinned.clone();
+        match oldest_pin {
+            Some(oldest) => {
+                for snap in local_snaps {
+                    if snap > oldest {
+                        expanded.insert(snap.clone());
+                    }
+                }
+            }
+            None => {
+                // No pins at all — nothing has ever been sent externally.
+                // Protect all local snapshots until the first send succeeds.
+                for snap in local_snaps {
+                    expanded.insert(snap.clone());
+                }
+            }
+        }
+        expanded
+    } else {
+        pinned.clone()
+    };
+
     // Check space pressure
     let min_free = config.root_min_free_bytes(&subvol.name).unwrap_or(0);
     let free_bytes = fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
@@ -230,7 +272,7 @@ fn plan_local_retention(
         local_snaps,
         now,
         &subvol.local_retention,
-        pinned,
+        &protected,
         space_pressure,
     );
 
@@ -238,6 +280,7 @@ fn plan_local_retention(
         operations.push(PlannedOperation::DeleteSnapshot {
             path: local_dir.join(snap.as_str()),
             reason,
+            subvolume_name: subvol.name.clone(),
         });
     }
 }
@@ -309,6 +352,11 @@ fn plan_external_send(
         false
     };
 
+    let pin_info = Some((
+        local_dir.join(format!(".last-external-parent-{}", drive.label)),
+        snap_to_send.clone(),
+    ));
+
     if is_incremental {
         let parent_name = pin.unwrap();
         let parent_path = local_dir.join(parent_name.as_str());
@@ -317,21 +365,18 @@ fn plan_external_send(
             snapshot: snap_path,
             dest_dir: ext_dir,
             drive_label: drive.label.clone(),
+            subvolume_name: subvol.name.clone(),
+            pin_on_success: pin_info,
         });
     } else {
         operations.push(PlannedOperation::SendFull {
             snapshot: snap_path,
             dest_dir: ext_dir,
             drive_label: drive.label.clone(),
+            subvolume_name: subvol.name.clone(),
+            pin_on_success: pin_info,
         });
     }
-
-    // Pin the sent snapshot
-    let pin_file = local_dir.join(format!(".last-external-parent-{}", drive.label));
-    operations.push(PlannedOperation::PinParent {
-        pin_file,
-        snapshot_name: snap_to_send.clone(),
-    });
 }
 
 fn plan_external_retention(
@@ -365,6 +410,7 @@ fn plan_external_retention(
         operations.push(PlannedOperation::DeleteSnapshot {
             path: ext_dir.join(snap.as_str()),
             reason,
+            subvolume_name: subvol.name.clone(),
         });
     }
 }
@@ -884,7 +930,7 @@ send_enabled = false
     }
 
     #[test]
-    fn pin_parent_emitted_after_send() {
+    fn send_includes_pin_info() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
         fs.local_snapshots.insert(
@@ -898,11 +944,167 @@ send_enabled = false
             ..PlanFilters::default()
         };
         let result = plan(&config, now(), &filters, &fs).unwrap();
-        let pins: Vec<_> = result
+        let sends_with_pin: Vec<_> = result
             .operations
             .iter()
-            .filter(|op| matches!(op, PlannedOperation::PinParent { .. }))
+            .filter(|op| matches!(op,
+                PlannedOperation::SendFull { pin_on_success: Some(_), .. }
+                | PlannedOperation::SendIncremental { pin_on_success: Some(_), .. }
+            ))
             .collect();
-        assert_eq!(pins.len(), 1);
+        assert_eq!(sends_with_pin.len(), 1);
+    }
+
+    #[test]
+    fn unsent_snapshots_protected_from_retention() {
+        // sv1 has send_enabled=true (via defaults). Pin points to an older snapshot.
+        // Snapshots newer than the pin should be protected from retention.
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        let pin_snap = snap("20260320-1000-one");
+        // Create snapshots: the pinned one, plus two newer ones in the daily window
+        // (outside hourly window so they'd normally be thinned to 1/day)
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                pin_snap.clone(),
+                snap("20260320-1400-one"), // same day as pin, normally would be thinned
+                snap("20260321-1000-one"),
+                snap("20260322-1500-one"), // newest
+            ],
+        );
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            pin_snap,
+        );
+
+        let filters = PlanFilters {
+            subvolume: Some("sv1".to_string()),
+            local_only: true,
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        // All snapshots newer than the pin should be protected (not deleted)
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::DeleteSnapshot { .. }))
+            .collect();
+        // The 20260320-1400-one snapshot is newer than pin and should be protected
+        assert!(
+            !deletes.iter().any(|op| matches!(op,
+                PlannedOperation::DeleteSnapshot { path, .. } if path.to_string_lossy().contains("20260320-1400")
+            )),
+            "Unsent snapshot newer than pin should not be deleted"
+        );
+    }
+
+    #[test]
+    fn all_snapshots_protected_when_no_pin() {
+        // send_enabled=true but no pin files — nothing has ever been sent.
+        // All snapshots should be protected from retention deletion.
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260318-1000-one"), // 4 days old, outside hourly, in daily window
+                snap("20260319-1000-one"),
+                snap("20260320-1000-one"),
+                snap("20260322-1500-one"),
+            ],
+        );
+
+        let filters = PlanFilters {
+            subvolume: Some("sv1".to_string()),
+            local_only: true,
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::DeleteSnapshot { .. }))
+            .collect();
+        assert_eq!(deletes.len(), 0, "No snapshots should be deleted when nothing has been sent externally");
+    }
+
+    #[test]
+    fn send_disabled_no_unsent_protection() {
+        // Subvolume with send_enabled=false — retention should work normally
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [{ path = "/snap", subvolumes = ["sv"] }]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+daily = 30
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "test"
+
+[[subvolumes]]
+name = "sv"
+short_name = "sv"
+source = "/data/sv"
+send_enabled = false
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let mut fs = MockFileSystemState::new();
+        // Multiple snapshots on the same day outside hourly window — should be thinned
+        fs.local_snapshots.insert(
+            "sv".to_string(),
+            vec![
+                snap("20260320-0800-sv"),
+                snap("20260320-1000-sv"),
+                snap("20260320-1400-sv"),
+                snap("20260322-1500-sv"),
+            ],
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::DeleteSnapshot { .. }))
+            .collect();
+        // With send_enabled=false, daily thinning should delete the 0800 and 1000 snapshots
+        assert!(deletes.len() >= 2, "Retention should thin normally when send is disabled");
+    }
+
+    #[test]
+    fn future_dated_snapshot_suppresses_creation() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        // Snapshot dated 1 hour in the future
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap("20260322-1600-one")], // now() is 15:00, this is 16:00
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 0, "No snapshot should be created when newest is in the future");
+        assert!(
+            result.skipped.iter().any(|(name, reason)| name == "sv1" && reason.contains("interval")),
+            "Should report interval not elapsed for future-dated snapshot"
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -325,19 +325,22 @@ pub enum PlannedOperation {
         snapshot: PathBuf,
         dest_dir: PathBuf,
         drive_label: String,
+        subvolume_name: String,
+        /// Pin file to write on successful send: (pin_file_path, snapshot_name_to_write)
+        pin_on_success: Option<(PathBuf, SnapshotName)>,
     },
     SendFull {
         snapshot: PathBuf,
         dest_dir: PathBuf,
         drive_label: String,
+        subvolume_name: String,
+        /// Pin file to write on successful send: (pin_file_path, snapshot_name_to_write)
+        pin_on_success: Option<(PathBuf, SnapshotName)>,
     },
     DeleteSnapshot {
         path: PathBuf,
         reason: String,
-    },
-    PinParent {
-        pin_file: PathBuf,
-        snapshot_name: SnapshotName,
+        subvolume_name: String,
     },
 }
 
@@ -351,11 +354,13 @@ impl fmt::Display for PlannedOperation {
                 snapshot,
                 drive_label,
                 parent,
+                pin_on_success,
                 ..
             } => {
+                let pin_suffix = if pin_on_success.is_some() { " + pin" } else { "" };
                 write!(
                     f,
-                    "SEND    {} -> {} (incremental, parent: {})",
+                    "SEND    {} -> {} (incremental, parent: {}){pin_suffix}",
                     snapshot.display(),
                     drive_label,
                     parent.file_name().unwrap_or_default().to_string_lossy()
@@ -364,29 +369,19 @@ impl fmt::Display for PlannedOperation {
             Self::SendFull {
                 snapshot,
                 drive_label,
+                pin_on_success,
                 ..
             } => {
+                let pin_suffix = if pin_on_success.is_some() { " + pin" } else { "" };
                 write!(
                     f,
-                    "SEND    {} -> {} (full)",
+                    "SEND    {} -> {} (full){pin_suffix}",
                     snapshot.display(),
                     drive_label
                 )
             }
-            Self::DeleteSnapshot { path, reason } => {
+            Self::DeleteSnapshot { path, reason, .. } => {
                 write!(f, "DELETE  {} ({})", path.display(), reason)
-            }
-            Self::PinParent {
-                snapshot_name,
-                pin_file,
-                ..
-            } => {
-                write!(
-                    f,
-                    "PIN     {} = {}",
-                    pin_file.file_name().unwrap_or_default().to_string_lossy(),
-                    snapshot_name
-                )
             }
         }
     }
@@ -416,10 +411,10 @@ impl BackupPlan {
         for op in &self.operations {
             match op {
                 PlannedOperation::CreateSnapshot { .. } => s.snapshots += 1,
-                PlannedOperation::SendIncremental { .. } => s.sends += 1,
-                PlannedOperation::SendFull { .. } => s.sends += 1,
+                PlannedOperation::SendIncremental { .. } | PlannedOperation::SendFull { .. } => {
+                    s.sends += 1;
+                }
                 PlannedOperation::DeleteSnapshot { .. } => s.deletions += 1,
-                PlannedOperation::PinParent { .. } => s.pins += 1,
             }
         }
         s.skipped = self.skipped.len();
@@ -432,7 +427,6 @@ pub struct PlanSummary {
     pub snapshots: usize,
     pub sends: usize,
     pub deletions: usize,
-    pub pins: usize,
     pub skipped: usize,
 }
 
@@ -747,10 +741,12 @@ mod tests {
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/snap/old"),
                     reason: "expired".to_string(),
+                    subvolume_name: "htpc-home".to_string(),
                 },
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/snap/old2"),
                     reason: "expired".to_string(),
+                    subvolume_name: "htpc-home".to_string(),
                 },
             ],
             timestamp: NaiveDate::from_ymd_opt(2026, 3, 22)


### PR DESCRIPTION
## Summary

Addresses all 7 priority items from the architectural adversary review (docs/99-reports/2026-03-22-phase1-arch-review-v3.md), ordered by proximity to catastrophic failure (silent data loss):

- **Unsent snapshot protection**: Snapshots not yet backed up externally are now protected from local retention deletion
- **Pin grouped into Send**: `PinParent` variant removed; pin is now a field on Send operations (`pin_on_success`)
- **subvolume_name on all ops**: Every `PlannedOperation` variant is self-describing; fragile path-heuristic grouping eliminated
- **PathBuf migration**: Config paths are `PathBuf` throughout; `to_string_lossy()` roundtrips eliminated
- **Path validation**: All paths validated as absolute with no `..`; names checked for `/`, `\`, null bytes
- **Future-date warning**: `log::warn` when newest snapshot is dated in the future (suppresses automatic snapshots)
- **Snapshot format docs**: CLAUDE.md updated to document HHMM as write format, legacy as read-only

## Changes

| Module | What changed |
|--------|-------------|
| `config.rs` | String → PathBuf for path fields; `validate_path_safe` + `validate_name_safe` helpers; `expand_tilde` takes `&Path` |
| `types.rs` | `PinParent` removed; `pin_on_success` added to Send variants; `subvolume_name` on all variants |
| `plan.rs` | Unsent snapshot protection in `plan_local_retention`; future-date warning; pin grouped into sends |
| `plan_cmd.rs` | `op_belongs_to` replaced with trivial `op_subvolume_name` match |
| `drives.rs` | `is_path_mounted` accepts `&Path`; `external_snapshot_dir` uses PathBuf directly |
| `CLAUDE.md` | Snapshot naming backward compatibility section updated |

## Testing

- 66 tests passing (up from 59 — 7 new tests)
- `cargo clippy -- -D warnings` clean
- New tests: `unsent_snapshots_protected_from_retention`, `all_snapshots_protected_when_no_pin`, `send_disabled_no_unsent_protection`, `validate_relative_path_rejected`, `validate_path_traversal_rejected`, `validate_name_with_slash_rejected`, `future_dated_snapshot_suppresses_creation`

## Plan Phase

Phase 1 hardening — prerequisite for Phase 2 (executor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>