### PR TITLE
refactor: Prepare PLAN.md and retention for Phase 2

### DIFF
--- a/docs/99-reports/2026-03-22-phase2-plan-review.md
+++ b/docs/99-reports/2026-03-22-phase2-plan-review.md
@@ -1,0 +1,190 @@
+# Urd Phase 2 Plan Review
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-22
+**Scope:** PLAN.md revisions, monthly retention fix (`retention.rs`), import cleanup (`plan.rs`) — changes preparing for Phase 2 implementation
+**Reviewer:** Architectural Adversary (Claude Opus 4.6)
+**Prior reviews:** `docs/99-reports/2026-03-22-phase1-hardening-review.md`
+
+---
+
+## 1. Executive Summary
+
+The plan revisions are substantive and mostly right. The Executor Contract is the most important addition — it makes implicit expectations explicit before code is written, which is when they're cheapest to challenge. The monthly retention fix is correct. The review identified one significant gap (crash recovery) and several moderate issues, all of which have been addressed in this same pass.
+
+---
+
+## 2. What Kills You
+
+Unchanged: **silent data loss** — retention deleting the last copy of irreplaceable data.
+
+**Current distance from catastrophe after these changes:** The plan changes improve the safety margin. The Executor Contract now explicitly addresses the scenarios closest to the catastrophe: crash recovery (partial snapshots at destination), cascading failure handling (skip dependent ops rather than generate confusing errors), pin failure semantics (warn and continue), and external retention re-checking (don't batch-delete based on stale space data). These were previously implicit expectations that would have needed to be discovered during implementation or, worse, after a production failure.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | `checked_sub_months` overflow now handled explicitly with `NaiveDateTime::MIN` fallback. Boundary test sharpened. |
+| Security | 4 | No security changes. Existing path validation is sound. |
+| Architectural Excellence | 4 | Executor Contract is well-structured. Chain Integrity section is the right addition to design principles. |
+| Systems Design | 4 | Crash recovery, cascading failures, and skipped-deletion logging now documented. |
+| Rust Idioms | 5 | `#[cfg(test)]` import is the right fix. `Months` usage is idiomatic. |
+| Code Quality | 4 | Sharpened boundary test catches the actual divergence between calendar months and `days * 30`. |
+
+---
+
+## 4. Design Tensions
+
+### 4.1 Executor Contract: planner proposes, executor disposes — but how much can the executor deviate?
+
+The contract says the executor must "re-check space between deletions" and "stop deleting once `min_free_bytes` is satisfied." This means the executor will execute a *subset* of the plan. That's fine — but it creates a divergence between what `urd plan` shows and what `urd backup` does. If the user runs `urd plan`, sees 5 deletions, then runs `urd backup` and only 2 happen, is that confusing?
+
+**Verdict:** This is the right call. The alternative — having the planner commit to exact deletions — is worse because it requires the planner to know snapshot sizes, which it can't. The contract now specifies that skipped deletions must be logged with reason ("space recovered, N planned deletions skipped") so the divergence is visible to the operator. Resolved.
+
+### 4.2 Pin failure as warning vs. error
+
+The contract says: pin write failure = log warning, continue. The reasoning is sound (the snapshot is valid, the pin self-heals on next send). But this creates a subtle hazard: if the pin *keeps* failing (e.g., the snapshot directory is read-only due to a mount issue), every subsequent send becomes a full send because the pin never advances. That's not data loss — it's performance degradation that could fill the external drive.
+
+**Verdict:** The warning-and-continue behavior is correct. The contract now notes that repeated pin failures should be surfaced by Phase 3's `urd verify` / `urd status`, preventing this from being a silent ongoing problem. Resolved.
+
+### 4.3 Crash recovery: delete-and-retry vs. resume
+
+The contract specifies delete-and-retry for partial snapshots at the destination. The alternative would be to attempt to resume an interrupted `btrfs receive`. BTRFS does not support resumable receives — a partial receive must be deleted and restarted. The delete-and-retry approach is the only correct one given BTRFS constraints.
+
+**Verdict:** No tension — this is the only viable approach. Correctly documented.
+
+### 4.4 Cascading failure: preemptive skip vs. natural failure
+
+When a `CreateSnapshot` fails, should the executor skip the dependent `Send` preemptively, or let it fail naturally? The contract specifies preemptive skip (check source paths exist before attempting). This is more complex but produces better error messages — the operator sees "skipped: snapshot creation failed" instead of "send failed: source not found."
+
+**Verdict:** The clean approach is worth the complexity. A backup tool that produces confusing error messages at 3am is a backup tool the operator learns to ignore. Correct choice for an ambitious project.
+
+---
+
+## 5. Findings by Dimension
+
+### 5.1 Correctness
+
+**[Resolved] `checked_sub_months` overflow handling.**
+
+Previously, `checked_sub_months` returning `None` would silently convert a bounded monthly window to unlimited retention. Now handled explicitly:
+
+```rust
+Some(
+    weekly_cutoff
+        .checked_sub_months(Months::new(config.monthly))
+        .unwrap_or(NaiveDateTime::MIN),
+)
+```
+
+This makes "overflow" mean "keep everything back to the beginning of time" — explicit rather than accidental. The `monthly_cutoff` is now always `Some(...)` when `config.monthly > 0`, which makes the downstream `is_none()` / `unwrap()` pattern cleaner.
+
+**[Resolved] Monthly retention test sharpened to boundary case.**
+
+The test now targets a snapshot at `2025-03-25` — a date that falls between the calendar-month cutoff (~2025-03-22) and the `days * 30` cutoff (~2025-03-28). This snapshot would be deleted by the old implementation but is kept by the new one, making the test a true regression guard.
+
+**[Commendation] The three-branch unsent protection structure remains clean and correct.**
+
+```
+send_enabled + has pins → protect newer than oldest pin
+send_enabled + no pins  → protect everything
+send_disabled           → no protection (normal retention)
+```
+
+Each branch has a clear invariant with test coverage for all three.
+
+### 5.2 Architectural Excellence
+
+**[Commendation] Section 4: Incremental Chain Integrity is the most important addition to the plan.**
+
+Elevating chain integrity to a named design principle — with an explicit invariant and a corollary about executor behavior — is exactly right. This was previously implicit knowledge scattered across pin file handling, unsent protection, and planner logic. Making it a first-class principle means Phase 2 implementors know what they're protecting and why.
+
+The three-layer enforcement model (pinned set -> unsent protection -> planner parent verification) is correctly ordered from strongest to weakest guarantee, with each layer catching failures the previous one missed.
+
+**[Commendation] The Executor Contract makes Phase 2 reviewable before code is written.**
+
+By specifying error isolation, send pipeline behavior, pin semantics, retention execution, crash recovery, cascading failures, and operation ordering in prose, these become testable requirements. A Phase 2 review can check "does the code match the contract?" instead of discovering the contract by reverse-engineering the code.
+
+### 5.3 Systems Design
+
+**[Resolved] Crash recovery added to the Executor Contract.**
+
+The contract now specifies that the executor does not assume clean state. Before sending, it checks for pre-existing subvolumes at the destination. If the pin file does not reference them, they are treated as partials from interrupted prior runs and deleted before retry. This handles the realistic scenario of power loss or drive disconnect during multi-hour transfers.
+
+**[Resolved] `urd init` partial snapshot handling documented.**
+
+The Phase 2 scope now notes that `urd init` must detect and flag incomplete snapshots on external drives, offering cleanup with user confirmation rather than silently deleting. This addresses the transition scenario where the bash script was interrupted mid-send.
+
+**[Resolved] Load-bearing operation ordering marked in `plan.rs`.**
+
+The comment at the emission point makes the ordering invariant visible:
+```
+// LOAD-BEARING ORDER: Operations are emitted as create → send → delete.
+// The executor relies on this ordering within each subvolume.
+// Do not reorder without updating the executor contract in PLAN.md.
+```
+
+This prevents the silent breakage scenario where someone reorders planner logic for "efficiency" without realizing the executor depends on emission order.
+
+### 5.4 Rust Idioms
+
+**[Commendation] The `#[cfg(test)]` import fix is the right approach.**
+
+`#[allow(unused_imports)]` was suppressing a real warning. The `#[cfg(test)]` annotation makes the dependency on `PathBuf` test-only explicit, which is what it actually is (used by `MockFileSystemState`). Clean.
+
+### 5.5 Code Quality
+
+**[Commendation] Test coverage for retention is proportional to risk.**
+
+Retention logic protects against data loss — the most dangerous code path. The test suite covers: empty input, all retention windows (hourly, daily, weekly, monthly), pinned snapshot protection, space pressure thinning, count-based retention, space-governed retention, and now the calendar-month boundary case. 13 retention tests for ~195 lines of retention code is the right density for the riskiest module.
+
+---
+
+## 6. The Simplicity Question
+
+**What was added:**
+- ~100 lines of PLAN.md documentation (Executor Contract with crash recovery, cascading failures, skipped deletion logging, init partial handling) — earns its keep. Documentation that prevents a bad executor implementation is worth more than the executor code itself.
+- 3 lines of retention fix (calendar months + overflow fallback) — earns its keep.
+- 3 lines of load-bearing order comment — earns its keep (prevents silent breakage).
+- 1 test rewrite (35 lines, boundary case) — earns its keep (actual regression guard).
+
+**What was removed:**
+- Stale PLAN.md content (old PlannedOperation enum, undifferentiated Phase 1 task list) — good.
+- `#[allow(unused_imports)]` — good.
+
+**Net assessment:** The changes are proportional. Nothing speculative was added. The Executor Contract is the right weight for a plan document — detailed enough to implement against, not so detailed that it constrains implementation choices unnecessarily. Every addition addresses a specific finding from review.
+
+---
+
+## 7. Priority Action Items
+
+All five priority items from the initial review have been addressed:
+
+1. **Crash recovery in Executor Contract** — Added. Specifies detection and cleanup of partial snapshots at destination before retry. **Done.**
+
+2. **`checked_sub_months` overflow handling** — Changed from silent `None` (unlimited) to explicit `NaiveDateTime::MIN` fallback. **Done.**
+
+3. **Sharpened monthly retention test** — Test now targets the boundary where calendar months and `days * 30` diverge (2025-03-25 with 12-month window). **Done.**
+
+4. **Skipped deletion logging** — Added to Executor Contract. Executor must log when it stops deleting early because space was recovered. **Done.**
+
+5. **Load-bearing operation order comment** — Added to `plan()` in `plan.rs`. Marks the create -> send -> delete emission order as a contract with the executor. **Done.**
+
+**Additional items addressed:**
+- Cascading failure handling added to Executor Contract (preemptive skip of dependent operations).
+- `urd init` partial snapshot detection documented in Phase 2 scope.
+- Pin failure escalation path noted (Phase 3's `urd verify` / `urd status` should surface stale pins).
+
+---
+
+## 8. Open Questions
+
+1. **How will the executor detect whether a pre-existing snapshot at the destination is "complete"?** The contract says "if the pin file does not reference it, it's not trusted." But a snapshot could exist on the external drive from a *different* chain (e.g., manually sent). The safest approach is: only delete if the snapshot name matches the one we're about to send. If it exists with a different name, leave it alone.
+
+2. **Should the executor track consecutive pin failures in SQLite?** The contract notes that repeated pin failures degrade to full sends. Tracking failure counts in the state DB would enable `urd status` to surface the problem. This is a Phase 3 concern but worth considering during Phase 2's state schema design — adding a `pin_failures` column later requires a migration.
+
+---
+
+*Metadata: Review covers uncommitted changes against commit `40c0fab`. Files reviewed: `docs/PLAN.md`, `src/retention.rs`, `src/plan.rs`. 67 tests passing, clippy clean. No areas excluded.*

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -99,30 +99,40 @@ mount_path = "/run/media/patriark/2TB-backup"
 snapshot_root = ".snapshots"
 role = "test"
 
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+send_enabled = true
+enabled = true
+
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0                    # 0 = unlimited
+
 [[subvolumes]]
 name = "htpc-home"
 short_name = "htpc-home"
 source = "/home"
-tier = 1
-local_schedule = "daily"
-external_schedule = "daily"
-external_retention = 14
+priority = 1
+snapshot_interval = "15m"
+send_interval = "1h"
 
 [[subvolumes]]
 name = "subvol3-opptak"
 short_name = "opptak"
 source = "/mnt/btrfs-pool/subvol3-opptak"
-tier = 1
-local_schedule = "daily"
-external_schedule = "daily"
-external_retention = 14
+priority = 1
+snapshot_interval = "1h"
+send_interval = "2h"
 
-# ... (all 9 subvolumes, see full config in urd.toml.example)
-
-[retention.graduated]
-daily_keep = 14
-weekly_keep = 6
-monthly_keep = 3
+# ... (all 9 subvolumes, see config/urd.toml.example for full reference)
 ```
 
 ## Architecture: Key Design Principles
@@ -133,13 +143,14 @@ The planner is a **pure function**: `fn plan(config, state, now, filters) -> Bac
 
 ```rust
 enum PlannedOperation {
-    CreateSnapshot { source, dest },
-    SendIncremental { parent, snapshot, dest_dir, drive },
-    SendFull { snapshot, dest_dir, drive },
-    DeleteSnapshot { path, reason },
-    PinParent { local_dir, snapshot_name, drive },
+    CreateSnapshot { source, dest, subvolume_name },
+    SendIncremental { parent, snapshot, dest_dir, drive_label, subvolume_name, pin_on_success },
+    SendFull { snapshot, dest_dir, drive_label, subvolume_name, pin_on_success },
+    DeleteSnapshot { path, reason, subvolume_name },
 }
 ```
+
+Every variant carries `subvolume_name` so operations are self-describing — no path heuristics needed to determine ownership. Send variants carry `pin_on_success: Option<(PathBuf, SnapshotName)>` — the pin file is written by the executor only on successful send, making the send/pin dependency structural rather than implicit.
 
 `urd plan` prints the plan. `urd backup --dry-run` prints it. `urd backup` executes it. The planner is fully unit-testable without touching any filesystem.
 
@@ -160,14 +171,69 @@ pub trait BtrfsOps {
 
 Individual subvolume failures do NOT abort the run. Failed sends trigger partial cleanup. Pin files are only updated on success. Exit code 1 if any subvolume failed, 0 if all succeeded/skipped.
 
-### 4. Backward Compatibility
+### 4. Incremental Chain Integrity
 
-- Snapshot naming: `YYYYMMDD-shortname` preserved exactly
+The incremental send/receive chain is the most performance-critical property of the system. A broken chain forces a full send (potentially hundreds of GB) instead of a small incremental diff.
+
+**Invariant:** Retention (local or external) must never delete a snapshot that is the current pin parent for any drive. The system enforces this through:
+- Pin file targets are always in the `pinned` set and are never deleted by retention
+- Unsent snapshot protection: when `send_enabled` is true, snapshots newer than the oldest pin are protected from local retention (they may not have been sent to all drives yet)
+- The planner verifies the parent exists on both local and external before planning an incremental send; if not, it falls back to a full send
+
+**Corollary:** The executor must re-check space between deletions on external drives rather than batch-deleting everything the planner proposed, because the planner cannot know exact snapshot sizes.
+
+### 5. Backward Compatibility
+
+- Snapshot naming:
+  - **Current (write):** `YYYYMMDD-HHMM-shortname` (e.g., `20260322-1430-opptak`)
+  - **Legacy (read-only):** `YYYYMMDD-shortname` (e.g., `20260322-opptak`) — parsed as midnight
+  - Both formats coexist transparently in snapshot directories
 - Directory structure: same locations as bash script
-- Pin files: `.last-external-parent-{DRIVE_LABEL}` format preserved (read+write)
-- Prometheus metrics: identical names, labels, value semantics
+- Pin files: `.last-external-parent-{DRIVE_LABEL}` format preserved (read+write), with legacy `.last-external-parent` fallback for reading
+- Prometheus metrics: identical names, labels, value semantics (see Prometheus Metrics below)
+
+## Prometheus Metrics
+
+File: `~/containers/data/backup-metrics/backup.prom` (configurable via `metrics_file`).
+Written atomically (temp file + rename) to prevent partial reads by the Prometheus node exporter.
+
+The metrics format must match the bash script's output exactly. Grafana dashboards and alerting depend on these names and labels.
+
+### Per-subvolume metrics
+
+| Metric | Type | Labels | Values |
+|--------|------|--------|--------|
+| `backup_last_success_timestamp` | gauge | `subvolume` | Unix timestamp; only set when `backup_success=1` |
+| `backup_success` | gauge | `subvolume` | `1`=success, `0`=failure, `2`=schedule-skipped |
+| `backup_duration_seconds` | gauge | `subvolume` | Integer seconds for the subvolume's operations |
+| `backup_snapshot_count` | gauge | `subvolume`, `location` | Count of snapshots; `location` is `"local"` or `"external"` (external = first mounted drive by config order, for bash compat) |
+| `backup_send_type` | gauge | `subvolume` | `0`=full, `1`=incremental, `2`=no send this run |
+
+### Global metrics
+
+| Metric | Type | Labels | Values |
+|--------|------|--------|--------|
+| `backup_external_drive_mounted` | gauge | none | `1`=any external drive mounted, `0`=none |
+| `backup_external_free_bytes` | gauge | none | Free bytes on mounted external drive; `0` when unmounted |
+| `backup_script_last_run_timestamp` | gauge | none | Unix timestamp when the backup ran |
+
+**Multi-drive note:** The bash script assumes a single external drive. These three global metrics maintain that assumption for backward compatibility: `backup_external_drive_mounted` is `1` if *any* configured drive is mounted, and `backup_external_free_bytes` reports the free space of the first mounted drive (by config order). Phase 4 may add per-drive metrics with a `drive` label, but the global metrics must remain for Grafana compatibility.
+
+### File format
+
+Each metric group has `# HELP`, `# TYPE gauge`, then one or more value lines. Groups separated by blank lines. `backup_send_type` must emit an entry for every subvolume that has a `backup_success` entry (never omit a series).
+
+Example:
+```
+# HELP backup_success Backup result: 1=success, 0=failure, 2=schedule-skipped
+# TYPE backup_success gauge
+backup_success{subvolume="subvol3-opptak"} 1
+backup_success{subvolume="htpc-home"} 2
+```
 
 ## SQLite Schema
+
+The SQLite database records backup history. It is **not** the source of truth for current filesystem state — the filesystem (snapshot directories, pin files) is authoritative. SQLite answers "what happened" (runs, operations); the filesystem answers "what exists now" (snapshots, chain state).
 
 ```sql
 CREATE TABLE runs (
@@ -182,25 +248,16 @@ CREATE TABLE operations (
     id INTEGER PRIMARY KEY,
     run_id INTEGER REFERENCES runs(id),
     subvolume TEXT NOT NULL,
-    operation TEXT NOT NULL,   -- "snapshot", "send_incremental", "send_full", "delete", "pin"
+    operation TEXT NOT NULL,   -- "snapshot", "send_incremental", "send_full", "delete"
     drive_label TEXT,
     duration_secs REAL,
     result TEXT NOT NULL,      -- "success", "failure", "skipped"
     error_message TEXT,
     bytes_transferred INTEGER
 );
-
-CREATE TABLE snapshots (
-    id INTEGER PRIMARY KEY,
-    subvolume TEXT NOT NULL,
-    name TEXT NOT NULL,        -- "20260322-opptak"
-    location TEXT NOT NULL,    -- "local" or drive label
-    path TEXT NOT NULL,
-    created_at TEXT NOT NULL,
-    is_pinned INTEGER DEFAULT 0,
-    UNIQUE(subvolume, name, location)
-);
 ```
+
+The `snapshots` table from the original plan has been removed. Pin files remain the source of truth for chain state, and snapshot directories are the source of truth for what exists. Duplicating this in SQLite creates a sync problem with no clear benefit — `urd status` and `urd history` can query the filesystem directly for current state and SQLite for historical data.
 
 ## CLI Commands
 
@@ -244,38 +301,80 @@ Next scheduled: subvol2-pics in 5d (Saturday)
 
 ## Implementation Phases
 
-### Phase 1: Skeleton + Config + Plan (Sessions 1-2)
+### Phase 1: Skeleton + Config + Plan ✅
 
 **Goal:** `urd plan` reads config, discovers real snapshots, prints correct planned operations.
 
-- Install Rust toolchain
-- `cargo init`, add dependencies
-- `config.rs` — TOML parsing, validation, tilde expansion
-- `types.rs` — All domain types (Tier, Schedule, SnapshotName, PlannedOperation)
-- `cli.rs` — clap setup
-- `plan.rs` — planner logic (schedule checking, snapshot discovery, parent resolution)
-- `chain.rs` — pin file reading
-- `retention.rs` — graduated + count-based retention (pure functions)
-- `commands/plan_cmd.rs` — wire up `urd plan`
-- Unit tests for config, retention, plan
+**Completed:**
+- `config.rs` — TOML parsing, validation, tilde expansion, PathBuf throughout
+- `types.rs` — All domain types (Interval, SnapshotName with dual-format, PlannedOperation, ByteSize)
+- `cli.rs` — clap setup for all commands
+- `plan.rs` — planner logic (schedule, snapshot discovery, parent resolution, unsent protection)
+- `chain.rs` — pin file reading (drive-specific + legacy fallback)
+- `retention.rs` — graduated + count-based + space-governed retention
+- `drives.rs` — drive detection, space checks via statvfs, external snapshot dir construction
+- `error.rs` — thiserror error types
+- `commands/plan_cmd.rs` — `urd plan` with colored grouped output
+- 67 unit tests across all modules
 
-**Deliverable:** `urd plan` on live system matches what bash script would do.
+**Hardening (Phase 1.5):**
+- Unsent snapshot protection (prevents retention from deleting snapshots not yet sent externally)
+- `PinParent` removed — pin is now `pin_on_success` field on Send variants
+- `subvolume_name` added to all `PlannedOperation` variants
+- PathBuf migration (no more `to_string_lossy()` roundtrips)
+- Path validation (`validate_path_safe`, `validate_name_safe`)
+- Future-date snapshot warning
+- Monthly retention uses calendar month subtraction (not `days * 30`)
 
 ### Phase 2: Execute + State + Metrics (Sessions 3-4)
 
 **Goal:** `urd backup` creates snapshots, sends to 2TB-backup, manages retention, writes metrics.
 
-- `btrfs.rs` — RealBtrfs + MockBtrfs implementations
-- `executor.rs` — sequential operation execution with error handling + partial cleanup
+**New modules:**
+- `btrfs.rs` — BtrfsOps trait + RealBtrfs + MockBtrfs
+- `executor.rs` — sequential operation execution (see Executor Contract below)
 - `state.rs` — SQLite schema, run/operation recording
 - `metrics.rs` — Prometheus .prom writer (exact format match)
-- `drives.rs` — drive detection, space checks via statvfs
-- `chain.rs` — pin file writing
-- `commands/init.rs` — `urd init` (import existing snapshots/pin files)
-- `commands/backup.rs` — `urd backup` (planner + executor)
-- Integration tests on 2TB-backup drive
+
+**Additions to existing modules:**
+- `chain.rs` — pin file writing (reading already done in Phase 1)
+- `error.rs` — executor error variants (BtrfsError, ExecutorError)
+
+**New commands:**
+- `commands/backup.rs` — `urd backup` (planner + executor), `--dry-run` prints plan
+- `commands/init.rs` — `urd init` (first-run setup: create SQLite DB, verify config paths exist, verify pin files are readable, detect and flag incomplete snapshots on external drives from interrupted bash script runs — offer cleanup with user confirmation, never silently delete, report system state summary)
+
+**Testing:**
+- Unit tests with MockBtrfs for executor logic
+- Integration tests on 2TB-backup drive (`#[ignore]`)
 
 **Deliverable:** Successful backup cycle to test drive. `urd backup --dry-run` on production matches bash.
+
+#### Executor Contract
+
+The executor takes a `BackupPlan` and executes each operation sequentially. Its behavior is governed by these rules:
+
+**Error isolation:** A failure in one subvolume must NOT abort operations for other subvolumes. The executor groups operations by `subvolume_name` and tracks per-subvolume success/failure. The overall result is `success` (all OK), `partial` (some failed), or `failure` (all failed).
+
+**Send execution:** The `btrfs send | btrfs receive` pipeline must:
+- Capture stderr from both the send and receive sides
+- Check exit codes from both processes
+- On failure, clean up any partial snapshot at the destination (`btrfs subvolume delete` on the incomplete receive)
+- Log both stderr streams for diagnostics
+
+**Pin-on-success:** After a successful send, the executor writes the pin file specified in `pin_on_success`. If the pin file write fails, the executor logs a warning and continues — the send itself succeeded and the snapshot is valid on the destination. The pin can be recovered on the next successful send to that drive. Note: repeated pin failures (e.g., due to a read-only mount) degrade performance by forcing full sends. Phase 3's `urd verify` / `urd status` should surface stale pins so the operator can investigate.
+
+**Retention execution on external drives:** The planner proposes deletions based on a point-in-time space check, but it cannot know exact snapshot sizes. The executor must:
+- Execute external deletions oldest-first
+- Re-check free space after each deletion
+- Stop deleting once the `min_free_bytes` threshold is satisfied, logging skipped deletions with reason ("space recovered, N planned deletions skipped") so `urd plan` vs `urd backup` divergence is visible to the operator
+- Never delete a snapshot that is the current pin parent for that drive (defense-in-depth — the planner already excludes these, but the executor double-checks)
+
+**Cascading failure handling:** When an operation fails, the executor must skip dependent operations within the same subvolume rather than letting them fail naturally. Specifically: if a `CreateSnapshot` fails, skip any subsequent `Send` that references the snapshot that was not created. The executor checks that source paths exist before attempting operations. This prevents confusing cascading errors in logs and ensures error messages reflect the root cause.
+
+**Crash recovery:** The executor does not assume clean state from prior runs. Before sending a snapshot to a drive, it checks whether a subvolume with that name already exists at the destination. If it exists but is not the result of a completed send (i.e., the pin file does not point to it), it deletes the partial and proceeds with a fresh send. This handles the case where a prior run was interrupted mid-transfer (power loss, drive disconnect, OOM kill). The pin file is the source of truth for "last successful send" — if the pin doesn't reference a snapshot, that snapshot's presence at the destination is not trusted for incremental chain purposes.
+
+**Operation ordering:** Within a subvolume, operations execute in plan order: create → send → delete. This ensures new snapshots exist before sends reference them, and deletions happen after sends complete. This ordering is load-bearing — the planner emits operations in this order (see comment in `plan()`) and the executor relies on it.
 
 ### Phase 3: CLI + Parallel Run (Sessions 5-6)
 
@@ -313,7 +412,7 @@ Next scheduled: subvol2-pics in 5d (Saturday)
 
 ## Migration Strategy
 
-1. **`urd init`** scans existing snapshot directories, reads pin files, populates SQLite
+1. **`urd init`** creates SQLite DB, verifies config paths, validates pin files, detects incomplete snapshots on external drives
 2. **Parallel running** (2 weeks): Urd at 02:00, bash at 03:00, compare metrics
 3. **Cutover:** disable bash timer, enable Urd timer, monitor 1 week
 4. Pin file format maintained throughout — both systems can coexist

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
-#[allow(unused_imports)]
-use std::path::{Path, PathBuf};
+use std::path::Path;
+#[cfg(test)]
+use std::path::PathBuf;
 
 use chrono::NaiveDateTime;
 
@@ -105,6 +106,9 @@ pub fn plan(
         let pinned = fs.pinned_snapshots(&local_dir, &drive_labels);
 
         // ── Local operations ────────────────────────────────────────
+        // LOAD-BEARING ORDER: Operations are emitted as create → send → delete.
+        // The executor relies on this ordering within each subvolume.
+        // Do not reorder without updating the executor contract in PLAN.md.
         if !filters.external_only {
             plan_local_snapshot(subvol, &local_dir, &local_snaps, now, force, &mut operations, &mut skipped);
             plan_local_retention(

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use chrono::{Datelike, NaiveDateTime, Timelike};
+use chrono::{Datelike, Months, NaiveDateTime, Timelike};
 
 use crate::types::{ResolvedGraduatedRetention, SnapshotName};
 
@@ -50,7 +50,15 @@ pub fn graduated_retention(
     let monthly_cutoff = if config.monthly == 0 {
         None // unlimited
     } else {
-        Some(weekly_cutoff - chrono::Duration::days(i64::from(config.monthly) * 30))
+        // Use calendar month subtraction for accurate window boundaries.
+        // Duration::days(n * 30) drifts ~5 days/year vs real calendar months.
+        // On overflow (unreachable for realistic configs), treat as unlimited
+        // rather than silently changing behavior.
+        Some(
+            weekly_cutoff
+                .checked_sub_months(Months::new(config.monthly))
+                .unwrap_or(NaiveDateTime::MIN),
+        )
     };
 
     // Track which day/week/month slots are already filled
@@ -416,5 +424,50 @@ mod tests {
         // All within daily window, all kept
         assert_eq!(result.keep.len(), 3);
         assert!(result.delete.is_empty());
+    }
+
+    #[test]
+    fn monthly_window_uses_calendar_months() {
+        // Regression: Duration::days(monthly * 30) drifts vs calendar months.
+        //
+        // With 6 months of monthly retention and now = 2026-03-22:
+        //   Calendar months: weekly_cutoff - 6 months ≈ 2025-09-22
+        //   Old days*30:     weekly_cutoff - 180 days ≈ 2025-09-23
+        //
+        // The divergence grows with larger values. With 12 months:
+        //   Calendar months: weekly_cutoff - 12 months ≈ 2025-03-22
+        //   Old days*30:     weekly_cutoff - 360 days ≈ 2025-03-28
+        //
+        // A snapshot between the two cutoffs would be deleted by days*30
+        // but kept by calendar months. This test targets that boundary.
+        let config = ResolvedGraduatedRetention {
+            hourly: 0,  // no hourly/daily/weekly windows — all snapshots land in monthly
+            daily: 0,
+            weekly: 0,
+            monthly: 12,
+        };
+        // now = 2026-03-22 15:00
+        // monthly_cutoff with calendar months ≈ 2025-03-22
+        // monthly_cutoff with days*30 = 2025-03-28
+        // A snapshot at 2025-03-25 falls between: kept by calendar, deleted by days*30
+        let boundary_snap = make_daily_snap("20250325", "home");
+        // A snapshot clearly beyond both cutoffs
+        let old_snap = make_daily_snap("20250101", "home");
+
+        let snaps = vec![
+            make_snap("20260322", "1400", "home"),
+            boundary_snap.clone(),
+            old_snap.clone(),
+        ];
+
+        let result = graduated_retention(&snaps, now(), &config, &HashSet::new(), false);
+        assert!(
+            result.keep.contains(&boundary_snap),
+            "Snapshot at calendar-month boundary (2025-03-25) should be kept with 12-month retention"
+        );
+        assert!(
+            result.delete.iter().any(|(s, _)| s == &old_snap),
+            "Snapshot from 14+ months ago should be beyond retention window"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Fix monthly retention to use calendar months instead of `days * 30` approximation
- Add complete Executor Contract to PLAN.md (error isolation, crash recovery, cascading failures)
- Document all 8 Prometheus metrics with exact names, labels, and multi-drive compatibility decisions
- Simplify SQLite schema (remove snapshots table, filesystem is source of truth)
- Sync PLAN.md config schema, PlannedOperation enum, and phase status with actual code

## Changes

| Module | Change |
|--------|--------|
| `src/retention.rs` | `checked_sub_months(Months)` replaces `Duration::days(n*30)`, overflow handled with `NaiveDateTime::MIN` fallback, boundary regression test added |
| `src/plan.rs` | `#[cfg(test)]` PathBuf import, load-bearing operation order comment |
| `docs/PLAN.md` | Executor Contract, Incremental Chain Integrity principle, Prometheus Metrics spec, SQLite schema simplification, config schema sync, `urd init` scope update |
| `docs/99-reports/` | Phase 2 plan review report |

## Testing

- 67 tests passing, clippy clean
- New test `monthly_window_uses_calendar_months` targets the exact boundary where calendar months and `days*30` diverge (snapshot at 2025-03-25 with 12-month window)

## Plan Phase

Phase 1.5 completion — all gaps identified by architectural review are resolved. PLAN.md is now a complete, self-contained spec for Phase 2 implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>