### PR TITLE
feat: Phase 2 — Execute + State + Metrics

### DIFF
--- a/docs/98-journals/2026-03-22-urd-phase02.md
+++ b/docs/98-journals/2026-03-22-urd-phase02.md
@@ -1,0 +1,124 @@
+# Phase 2 Journal: Execute + State + Metrics
+
+**Date:** 2026-03-22
+**Branch:** `master` (not yet committed)
+
+## What Was Built
+
+Phase 2 makes `urd backup` real. Where Phase 1 could plan operations and print them, Phase 2 creates snapshots, pipes `btrfs send | btrfs receive` to external drives, manages graduated retention, records history in SQLite, and writes Prometheus metrics. The entire Executor Contract from PLAN.md was implemented and then hardened through an architectural adversary review in the same session.
+
+### New Modules
+
+| Module | Lines | Tests | Role |
+|---|---|---|---|
+| `btrfs.rs` | 290 | 7 | `BtrfsOps` trait + `RealBtrfs` (subprocess) + `MockBtrfs` (testing) |
+| `executor.rs` | 620 | 12 | Core executor implementing the Executor Contract |
+| `state.rs` | 160 | 5 | SQLite schema (runs + operations), run/operation recording |
+| `metrics.rs` | 200 | 5 | Prometheus `.prom` writer, exact bash-compatible format |
+| `commands/backup.rs` | 180 | 0 | `urd backup` command: plan -> execute -> metrics -> summary |
+| `commands/init.rs` | 170 | 0 | `urd init`: DB creation, path verification, pin validation, partial detection |
+
+### Additions to Existing Modules
+
+| Module | Change |
+|---|---|
+| `chain.rs` | Added `write_pin_file()` with atomic temp+rename. 3 new tests. |
+| `error.rs` | Added `Btrfs` and `State` error variants. |
+| `main.rs` | Wired `btrfs`, `executor`, `state`, `metrics` modules. Connected `Backup` and `Init` commands. |
+| `commands/mod.rs` | Exported `backup` and `init`. |
+| `commands/plan_cmd.rs` | Extracted `run_with_plan()` so backup's `--dry-run` can reuse the display logic. |
+
+**Total new code: ~1620 lines of Rust, 32 new tests (100 total).**
+
+## The Send/Receive Pipeline
+
+The most technically interesting piece is `RealBtrfs::send_receive()`. It spawns two `Command` processes piped together:
+
+```
+sudo btrfs send [-p parent] snapshot  |  sudo btrfs receive dest_dir
+```
+
+Using `Stdio::piped()` on send's stdout as receive's stdin. Send's stderr is drained in a background thread to prevent pipe buffer deadlock. Both exit codes are checked. On failure, any partial snapshot at the destination is cleaned up via `btrfs subvolume delete`.
+
+We chose two `Command` processes over `sh -c "... | ..."` to avoid shell injection risks and to get direct access to both exit codes and both stderr streams. The trade-off is more code, but the safety properties are worth it for a tool that runs `sudo`.
+
+## Executor Contract Implementation
+
+The executor follows every rule specified in PLAN.md's Executor Contract:
+
+1. **Error isolation** — per-subvolume success/failure tracking. Subvolume A's failure never aborts subvolume B.
+2. **Cascading failure** — `failed_creates: HashSet<&Path>` tracks failed snapshot creations. Sends referencing a failed create are skipped with a clear reason, not allowed to fail with a confusing "snapshot not found" error.
+3. **Pin-on-success** — pin file written only after successful send. If pin write fails, the send is still counted as success but `pin_failures` is tracked (see hardening below).
+4. **Crash recovery** — before sending, checks if a snapshot already exists at the destination. If it does but the pin doesn't reference it, deletes it as a partial from an interrupted prior run. If the pin does reference it, skips the send (already completed).
+5. **External retention re-check** — after each deletion on an external drive, checks `filesystem_free_bytes()` against the drive's `min_free_bytes` threshold. Stops deleting once satisfied.
+6. **Pin protection (defense-in-depth)** — before deleting any snapshot, re-reads pin files to verify it's not pinned, even though the planner already excluded pinned snapshots.
+
+## Architectural Adversary Review
+
+After the initial implementation (98 tests passing, clippy clean), we ran an architectural adversary review. The review identified three significant findings and two moderate ones. All were fixed in the same session.
+
+### Findings and Fixes
+
+**S1: `space_recovered` was per-subvolume, should be per-drive.**
+The `space_recovered` flag was declared inside `execute_subvolume()`. If subvolume A's deletions on drive X recovered enough space, subvolume B's deletions on the same drive would still proceed — violating the Executor Contract.
+*Fix:* Moved to a `HashMap<String, bool>` at `execute()` level, keyed by drive label, shared across all subvolumes.
+
+**S2: Pin write failure was invisible.**
+A successful send with a failed pin write reported `OpResult::Success` everywhere. The only evidence was a `WARN` log line. The next send to that drive would silently fall back to a full send (hours instead of minutes for large subvolumes).
+*Fix:* Added `pin_failures: u32` to `SubvolumeResult`. `execute_send()` now returns `(OperationOutcome, bool)`. The backup summary prints a prominent `WARNING` with pin failure count and suggests `urd verify`.
+
+**S3: No concurrent-run protection.**
+Two `urd backup` processes could race on pin files and confuse the incremental chain.
+*Fix:* Added `acquire_lock()` using `nix::fcntl::Flock` with `LockExclusiveNonblock` on `{state_db}.lock`. Clear error message if another instance is running. Dry-run skips locking.
+
+**M2: `execute_delete` inferred subvolume name from path heuristics.**
+The `find_local_dir_for_snapshot()` method used the parent directory's filename to guess the subvolume name. Fragile — if the path structure ever changed, the defense-in-depth pin check would silently fail.
+*Fix:* `execute_delete()` now takes `subvolume_name` directly from `PlannedOperation::DeleteSnapshot` (the field was already there). Removed `find_local_dir_for_snapshot()` entirely. Uses `config.local_snapshot_dir(subvolume_name)` instead.
+
+**m1: `#[allow(dead_code)]` on production types.**
+Removed the unused `UrdError::Executor` variant. `MockBtrfs` and `ExecutionResult.run_id` allows retained (cross-module test usage / Phase 3 need).
+
+### Review Commendations
+
+The review validated three design choices:
+- **Planner/executor separation held under Phase 2 pressure.** The executor never calls the planner. All backup logic is testable without touching the filesystem.
+- **Cascading failure prevention works correctly.** Failed creates cascade to sends cleanly.
+- **Defense-in-depth pin check is the right pattern** for a system where a wrong deletion costs hours of I/O.
+
+Full review at `docs/99-reports/review-phase2.md`.
+
+## Design Decisions Made During Implementation
+
+1. **`BtrfsOps` trait includes `filesystem_free_bytes()`** — this keeps the executor fully testable. `MockBtrfs` returns configurable free space values. Without this, external retention re-check tests would need a real filesystem.
+
+2. **`state: Option<&StateDb>` in Executor** — SQLite is best-effort. If the DB can't be opened, backups continue. This follows CLAUDE.md's rule: "SQLite failures must NOT prevent backups from running." The executor checks `if let Some(state) = self.state` before each recording call and logs warnings on failure.
+
+3. **Metrics written once at end, not incrementally** — matches the bash script's behavior. Prometheus never reads a partial update because of atomic temp+rename.
+
+4. **`urd init` offers cleanup, never silently deletes** — when it detects unpinned newest snapshots on external drives (potentially from interrupted bash script transfers), it asks the operator with `[y/N]` confirmation. Printed as a `sudo btrfs subvolume delete` command the operator can run, since init itself doesn't use sudo for deletions.
+
+5. **Lock file uses `flock()`, not PID files** — advisory file locks are automatically released on process exit (including crashes). PID files can become stale. The lock is on `{state_db}.lock`, which lives in the same directory as the SQLite database.
+
+## What Phase 1's Open Questions Resolved To
+
+From the Phase 1 journal's open questions:
+
+- **"How should `urd backup` handle the first run?"** — `urd init` creates the SQLite DB and reports system state. `urd backup` will open the DB if it can, proceed without it if it can't. No auto-import needed — the filesystem is the source of truth.
+- **"Incremental send parent resolution with legacy names"** — works transparently. The planner resolves parents by datetime ordering, and btrfs send/receive uses subvolume UUIDs internally, not directory names.
+- **"systemd timer interval"** — deferred to Phase 3. The timer will fire at the minimum configured `snapshot_interval` across all subvolumes.
+
+## What's Next: Phase 3
+
+Phase 3 delivers the remaining CLI commands and parallel running with the bash script:
+
+- `commands/status.rs` — drive status, chain health, snapshot counts, last run
+- `commands/history.rs` — SQLite queries with formatted tables
+- `commands/verify.rs` — chain integrity validation, pin file health (now more important given the pin failure tracking from S2)
+- systemd units: `urd-backup.service` + `urd-backup.timer`
+- Two-week parallel run: Urd at 02:00, bash at 03:00, diff Prometheus metrics
+
+## Open Questions for Phase 3
+
+- **Parallel run pin file contention** — both Urd and the bash script write pin files. During the parallel period, should Urd write to a separate pin file namespace (e.g., `.last-external-parent-urd-{LABEL}`) and only take over the real pin files at cutover?
+- **`urd verify` scope** — should it check pin freshness (warn if pin is older than N days), snapshot integrity (btrfs scrub?), or just chain consistency?
+- **Metrics comparison tooling** — how to diff `backup.prom` between Urd and bash runs? A simple script that parses both and reports differences, or a Grafana dashboard with both data sources?

--- a/docs/99-reports/review-phase2.md
+++ b/docs/99-reports/review-phase2.md
@@ -1,0 +1,222 @@
+# Architectural Review: Urd Phase 2 — Execute + State + Metrics
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-22
+**Scope:** Phase 2 implementation (btrfs.rs, executor.rs, state.rs, metrics.rs, chain.rs additions, commands/backup.rs, commands/init.rs)
+**Commit:** post-phase2 (pre-commit review)
+**Reviewer:** Architectural Adversary
+
+---
+
+## Executive Summary
+
+Phase 2 is operationally sound for its intended use case (single-host homelab backups) and follows the Phase 1 architectural principles well. The planner/executor separation holds. Error isolation works. The Executor Contract from PLAN.md is faithfully implemented. However, there is one genuine correctness bug in the send/receive pipeline (stderr deadlock potential), one design decision that silently degrades backup efficiency (pin failure tolerance), and a scoping bug where `space_recovered` only tracks per-subvolume when it should track per-drive. These three issues warrant fixing before running against production data.
+
+## What Kills You
+
+**Catastrophic failure mode: silent deletion of a snapshot that is the current incremental chain parent, forcing a multi-hundred-GB full send or — worse — losing the only copy of data that hasn't been sent to any external drive.**
+
+Distance from the code: **two layers of defense.** The planner excludes pinned snapshots from deletion (layer 1). The executor re-checks pins before deleting (layer 2, `executor.rs:403-427`). Both layers would need to fail simultaneously. This is well-defended.
+
+The more realistic danger is **silent efficiency degradation**: pin file write fails, chain state drifts from reality, incremental sends silently become full sends consuming hours instead of minutes. Nobody gets paged. The operator discovers it weeks later by noticing disk I/O patterns.
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 3 | Send pipeline has a real deadlock path; space_recovered scope is wrong; pin failure is silent |
+| Security | 4 | `Command::arg()` prevents injection; paths validated at config time; sudoers scope respected |
+| Architecture | 4 | Planner/executor separation holds cleanly; BtrfsOps trait enables thorough testing |
+| Systems Design | 3 | No concurrent-run protection; crash recovery is send-time only; no observability for pin staleness |
+| Rust Idioms | 4 | Clean ownership, proper error types, good use of let-chains; minor: `#[allow(dead_code)]` on production types |
+| Code Quality | 4 | 98 tests, good coverage of critical paths; executor tests cover the right scenarios |
+
+## Design Tensions
+
+### 1. Pin failure tolerance vs. chain integrity
+
+**Trade-off:** PLAN.md explicitly says pin write failure should log a warning and continue, because "the send itself succeeded." This trades chain tracking accuracy for availability (never abort a successful backup due to a metadata write).
+
+**Verdict: Wrong trade-off for this system.** A stale pin doesn't cause data loss, but it causes the next send to be a full send instead of incremental. For subvol3-opptak (hundreds of GB of recordings), this is the difference between a 2-minute incremental and a 4-hour full send. The operator won't know until they check disk I/O or run `urd verify` (not yet implemented). The pin write failure should at minimum be tracked in metrics and surfaced prominently in the backup summary — not buried in a log line.
+
+### 2. SQLite as optional vs. required
+
+**Trade-off:** The executor treats SQLite as best-effort (`Option<&StateDb>`). This means a corrupted or locked DB never blocks a backup.
+
+**Verdict: Right trade-off.** The filesystem and pin files are the source of truth. SQLite is historical record only. If it breaks, backups continue and an operator can rebuild from filesystem state. The implementation correctly follows CLAUDE.md's rule.
+
+### 3. Flat operation list vs. dependency graph
+
+**Trade-off:** The planner emits a flat `Vec<PlannedOperation>` with implicit ordering (create→send→delete per subvolume). The executor relies on this order but doesn't validate it.
+
+**Verdict: Right trade-off for now.** The planner is the only producer, it's well-tested, and the ordering is documented with a "LOAD-BEARING" comment. A dependency graph adds complexity that doesn't pay for itself until there are multiple plan producers. But the executor should add a debug assertion that validates the ordering invariant.
+
+### 4. Per-subvolume vs. per-drive space tracking
+
+**Trade-off:** `space_recovered` is scoped per-subvolume in `execute_subvolume()`. The Executor Contract says "stop deleting once the min_free_bytes threshold is satisfied."
+
+**Verdict: Bug.** If subvolume A has 5 deletions on drive X and subvolume B has 5 deletions on drive X, the space_recovered flag resets between them. After A's deletions recover enough space, B's deletions proceed anyway — deleting snapshots that didn't need to be deleted. This violates the contract.
+
+## Findings
+
+### Critical
+
+#### C1. Send/receive pipeline can deadlock under high stderr volume
+
+**File:** `btrfs.rs:78-160`
+
+**What:** The pipeline spawns `btrfs send` with `stdout=piped, stderr=piped`, takes stdout and passes it as `btrfs receive`'s stdin, then drains send's stderr in a background thread. The receive is run via `.output()` (blocking).
+
+**The deadlock path:**
+1. Send produces data on stdout faster than receive consumes it → stdout pipe buffer fills → send blocks on stdout write
+2. While blocked, send can't produce stderr, so the stderr drain thread is idle — *but* if stderr was already buffered before the stdout block, the drain thread reads it fine
+3. The actual risk: `.output()` on receive internally reads receive's stderr to completion, then waits for the process. If receive's stderr fills its pipe buffer before receive exits, `.output()` handles this correctly (it drains all streams). So the receive side is fine.
+4. **Real risk:** Send stderr thread calls `read_to_string()` which reads until EOF. EOF comes when the send process exits. The send process exits when it finishes writing stdout (or errors). Receive reads send's stdout via `.output()`. So: receive reads stdout → send can finish → send closes stderr → thread gets EOF → thread joins. **This actually works correctly in the normal case.**
+
+**Revised assessment:** After careful trace, the pipeline ordering is: receive's `.output()` drains stdin (send's stdout) and receive's stderr simultaneously, then receive exits → send's stdout reader gets EOF → send exits → send stderr gets EOF → thread joins. **The deadlock scenario I initially identified doesn't occur** because `.output()` uses internal threading/polling to drain all streams simultaneously.
+
+**However:** If send exits with an error before receive reads all of stdout, receive may hang waiting for more stdin. The `.output()` call on receive will block indefinitely if send dies without closing stdout cleanly. This is handled by the fact that send's stdout is dropped when the send process exits (OS closes the pipe), so receive sees EOF.
+
+**Downgraded to Moderate.** The pipeline is correct for typical btrfs send/receive patterns. It could be made more robust by adding timeouts, but this is not a correctness bug.
+
+### Significant
+
+#### S1. `space_recovered` is per-subvolume, should be per-drive
+
+**File:** `executor.rs:152, 202-204`
+
+**What:** `space_recovered` is declared inside `execute_subvolume()` and passed to `execute_delete()`. If subvolume A's deletions on drive X recover enough space, `space_recovered` becomes true and A's remaining deletions on drive X are skipped. Correct. But when the executor moves to subvolume B, `space_recovered` resets to false, and B's deletions on the same drive X proceed — even though space was already recovered.
+
+**Consequence:** Unnecessary deletions of snapshots on external drives. Not data loss (these are retention-expired snapshots), but violates the Executor Contract's stated behavior: "stop deleting once the min_free_bytes threshold is satisfied." An operator seeing `urd plan` output with 10 deletions and `urd backup` deleting only 5 (for subvolume A) but all 5 for subvolume B would be confused.
+
+**Fix:** Move `space_recovered` to a per-drive `HashMap<String, bool>` at the `execute()` level, shared across subvolumes.
+
+#### S2. Pin write failure is invisible in metrics and exit code
+
+**File:** `executor.rs:350-358`, `commands/backup.rs:76-79`
+
+**What:** When a send succeeds but the pin file write fails, the operation is recorded as `OpResult::Success`. The backup exits 0. Metrics show `backup_success{subvolume="..."} 1`. The only evidence is a `WARN` log line.
+
+**Consequence:** Silent chain degradation. The next send to this drive will be a full send (can't find parent because pin is stale). For large subvolumes this wastes hours of I/O. The operator has no visibility without `urd verify` (not yet implemented) or manually checking logs.
+
+**Fix options (pick one):**
+1. Add a `pin_failures: u32` counter to `SubvolumeResult`. If non-zero, print a prominent warning in the backup summary output and set a `backup_pin_failure` metric.
+2. Treat pin failure as `OpResult::Failure` — the most conservative option, but may cause false-alarm exit codes.
+3. Add an `OpResult::Warning` variant and exit code 2 for "succeeded with warnings."
+
+Option 1 is recommended — it preserves the exit-0 behavior but makes the problem visible.
+
+#### S3. No lock file prevents concurrent execution
+
+**File:** `commands/backup.rs` (absent)
+
+**What:** Two `urd backup` processes can run simultaneously (cron + manual, systemd restart during run, udev trigger during scheduled run). Both will:
+- Read same filesystem state
+- Generate similar plans
+- Both try to create the same snapshot (second fails, logged, continues)
+- Both try to send to external drive (second may overwrite pin file with different snapshot name)
+
+**Consequence:** Confusing error logs, wasted I/O, and potential pin file corruption (last writer wins, which may not be the most recent snapshot). Not data loss, but operational confusion.
+
+**Fix:** Acquire an advisory lock on the state DB path at startup. `flock()` via the `nix` crate (already a dependency) or `rusqlite`'s exclusive locking mode.
+
+### Moderate
+
+#### M1. Crash recovery only runs at send time
+
+**File:** `executor.rs:295-338`
+
+**What:** Partial snapshot cleanup (from interrupted prior runs) only happens when the executor is about to send the *same* snapshot. If a subvolume isn't being sent this run (interval not elapsed), its partials on external drives persist until the next send cycle.
+
+**Consequence:** Wasted space on external drives between runs. Not harmful, but the operator expects `urd init` or `urd backup` to clean up all known partials.
+
+**Recommendation:** `urd init` already detects partials (good). Consider adding a pre-execution scan in `urd backup` that checks all mounted drives for unpinned newest snapshots and cleans them up before starting the plan.
+
+#### M2. `find_local_dir_for_snapshot` uses heuristics for external paths
+
+**File:** `executor.rs:494-507`
+
+**What:** For external paths, the code extracts the subvolume name from the parent directory's filename: `parent.file_name()`. This assumes the external directory structure is always `{mount}/{snapshot_root}/{subvol_name}/{snapshot}`. This matches the config, but if the planner ever constructs a path differently, the mapping breaks silently (returns `None`, pin check is skipped, delete proceeds).
+
+**Consequence:** If the heuristic fails, the defense-in-depth pin check is silently skipped. Low risk because the planner constructs paths consistently, but a silent fallthrough on a safety check is concerning.
+
+**Fix:** Instead of inferring the subvolume name from the path, use the `subvolume_name` field on `PlannedOperation::DeleteSnapshot` (it's already there) to look up the local dir directly. This requires passing `subvolume_name` to `execute_delete()`.
+
+#### M3. `recv_output = Command::new("sudo")...output()` doesn't set a timeout
+
+**File:** `btrfs.rs:131-138`
+
+**What:** `.output()` blocks until the receive process exits. If the external drive hangs (USB disconnect during write, NFS stall), this blocks indefinitely. No timeout mechanism.
+
+**Consequence:** `urd backup` hangs permanently. systemd's `TimeoutStopSec` would eventually kill it, but the partial snapshot cleanup won't run.
+
+**Recommendation:** Not a Phase 2 blocker (the bash script has the same limitation), but worth noting for Phase 3. Consider using `wait_timeout()` or a wrapper that kills both processes after a configurable duration.
+
+### Minor
+
+#### m1. `#[allow(dead_code)]` on production types
+
+**Files:** `btrfs.rs:215,232,243`, `error.rs:29`, `executor.rs:77`
+
+**What:** `MockBtrfs`, `MockBtrfsCall`, `ExecutionResult.run_id`, and `UrdError::Executor` have `#[allow(dead_code)]` because they're only used in tests or not yet used.
+
+**Recommendation:** MockBtrfs should be `#[cfg(test)]` gated. The `Executor` error variant should either be used or removed. `run_id` on `ExecutionResult` is used in tests — add `#[cfg(test)]` to the field if it's test-only, otherwise use it in backup.rs for logging.
+
+#### m2. `space_recovered` doesn't distinguish drives
+
+Related to S1 but a separate symptom: if a plan deletes snapshots on drive A and drive B, recovering space on drive A sets `space_recovered = true` which would (if S1 were fixed to be global) skip deletions on drive B too. The flag should be per-drive.
+
+### Commendations
+
+#### Good: Planner/executor separation holds under Phase 2 pressure
+
+The most important architectural property survived Phase 2 implementation intact. The executor takes a `BackupPlan` and never calls the planner. The planner never calls btrfs. This means all backup *logic* (what to create, what to send, what to delete) is tested without any filesystem interaction — 17 pure-logic planner tests. The executor tests use `MockBtrfs` and never touch real btrfs. This is the right architecture for a tool where a test bug could delete real data.
+
+#### Good: Cascading failure prevention
+
+`executor.rs:280-293` — When `CreateSnapshot` fails, the failed dest path is added to `failed_creates`, and subsequent sends that reference that path are skipped with a clear reason ("snapshot creation failed"). This prevents confusing cascading errors where a send fails because "snapshot not found" when the real cause was "snapshot creation failed." The test at line 808 verifies this behavior explicitly.
+
+#### Good: Defense-in-depth pin protection
+
+`executor.rs:403-427` — Before deleting any snapshot, the executor re-reads pin files and refuses to delete pinned snapshots, even though the planner already excluded them. This is exactly the right pattern for a system where the cost of a wrong deletion is a multi-hour full send.
+
+#### Good: Atomic writes for pin files and metrics
+
+Both pin files (`chain.rs:72-91`) and metrics (`metrics.rs:36-48`) use temp-file + rename. This prevents Prometheus from reading a partial metrics file and prevents a crash mid-write from corrupting the pin file. The temp files are in the same directory as the final files, so the rename is guaranteed atomic on the same filesystem.
+
+## The Simplicity Question
+
+**What could be removed?**
+
+- `StateDb` could be deferred entirely to Phase 3. It's not used for any decisions — only for `urd history` (Phase 3). The executor would be simpler without the `Option<&StateDb>` threading. However, it's already built and tested, and having history from the first production run is valuable for debugging. **Keep it.**
+
+- `UrdError::Executor` variant is defined but never constructed. **Remove it** or use it.
+
+- `ExecutionResult.run_id` is only used in one test assertion. If it's meant for Phase 3's history command, document that. Otherwise **remove it**.
+
+**What's earning its keep?**
+
+- `BtrfsOps` trait — absolutely essential. The 10 executor tests would be impossible without MockBtrfs.
+- `MockBtrfs` with RefCell — the interior mutability pattern is necessary because the trait methods take `&self`. Good design.
+- `group_by_subvolume()` — simple, correct, tested. Better than the alternatives (IndexMap dependency, BTreeMap).
+- Pin file defense-in-depth check in executor — prevents the catastrophic failure mode.
+
+## Priority Action Items
+
+1. **Fix `space_recovered` scoping** (S1) — Move to per-drive `HashMap` at `execute()` level. This is a correctness bug against the Executor Contract. ~20 lines of change.
+
+2. **Make pin write failures visible** (S2) — Add `pin_failures` counter to `SubvolumeResult`, print warning in backup summary, add metric. ~30 lines of change.
+
+3. **Add a lock file** (S3) — `flock()` on the state DB path at backup start. Prevents concurrent run confusion. ~15 lines of change.
+
+4. **Pass `subvolume_name` to `execute_delete`** (M2) — Use the field from `PlannedOperation` instead of inferring from path. Eliminates the heuristic in `find_local_dir_for_snapshot`. ~10 lines of change.
+
+5. **Clean up `#[allow(dead_code)]`** (m1) — Gate MockBtrfs with `#[cfg(test)]`, remove unused `Executor` error variant, document or use `run_id`.
+
+## Open Questions
+
+1. **What happens when the bash script and Urd both run in Phase 3's parallel period?** The bash script writes pin files too. If both systems send the same snapshot, the pin file will be correct (both write the same value). But if they send *different* snapshots, the last writer's pin wins. Is this handled?
+
+2. **Does `btrfs send -p` verify the parent exists on the destination?** If the parent was deleted on the external drive (by the bash script during parallel run), does `btrfs receive` fail cleanly, or does it corrupt the stream? This determines whether the executor's crash recovery handles the parallel-run scenario.
+
+3. **Is `backup_script_last_run_timestamp` the right metric name?** Urd is not a script. Keeping it for Grafana compatibility makes sense in Phase 3, but should it be aliased to `backup_last_run_timestamp` eventually?

--- a/src/btrfs.rs
+++ b/src/btrfs.rs
@@ -1,0 +1,430 @@
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use crate::error::UrdError;
+
+// ── BtrfsOps trait ──────────────────────────────────────────────────────
+
+/// The result of a send/receive operation.
+#[derive(Debug, Clone)]
+pub struct SendResult {
+    pub bytes_transferred: Option<u64>,
+}
+
+/// Trait abstracting btrfs operations. `RealBtrfs` calls the btrfs binary;
+/// `MockBtrfs` records calls for testing.
+pub trait BtrfsOps {
+    fn create_readonly_snapshot(&self, source: &Path, dest: &Path) -> crate::error::Result<()>;
+    fn send_receive(
+        &self,
+        snapshot: &Path,
+        parent: Option<&Path>,
+        dest_dir: &Path,
+    ) -> crate::error::Result<SendResult>;
+    fn delete_subvolume(&self, path: &Path) -> crate::error::Result<()>;
+    fn subvolume_exists(&self, path: &Path) -> bool;
+    fn filesystem_free_bytes(&self, path: &Path) -> crate::error::Result<u64>;
+}
+
+// ── RealBtrfs ───────────────────────────────────────────────────────────
+
+pub struct RealBtrfs {
+    btrfs_path: String,
+}
+
+impl RealBtrfs {
+    #[must_use]
+    pub fn new(btrfs_path: &str) -> Self {
+        Self {
+            btrfs_path: btrfs_path.to_string(),
+        }
+    }
+
+    fn run_btrfs(&self, args: &[&str]) -> crate::error::Result<()> {
+        log::debug!("Running: sudo {} {}", self.btrfs_path, args.join(" "));
+        let output = Command::new("sudo")
+            .arg(&self.btrfs_path)
+            .args(args)
+            .output()
+            .map_err(|e| UrdError::Btrfs(format!("failed to spawn btrfs: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(UrdError::Btrfs(format!(
+                "btrfs {} failed (exit {}): {}",
+                args.first().unwrap_or(&""),
+                output.status.code().unwrap_or(-1),
+                stderr.trim()
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl BtrfsOps for RealBtrfs {
+    fn create_readonly_snapshot(&self, source: &Path, dest: &Path) -> crate::error::Result<()> {
+        self.run_btrfs(&[
+            "subvolume",
+            "snapshot",
+            "-r",
+            &source.to_string_lossy(),
+            &dest.to_string_lossy(),
+        ])
+    }
+
+    fn send_receive(
+        &self,
+        snapshot: &Path,
+        parent: Option<&Path>,
+        dest_dir: &Path,
+    ) -> crate::error::Result<SendResult> {
+        // Build send command
+        let mut send_cmd = Command::new("sudo");
+        send_cmd.arg(&self.btrfs_path).arg("send");
+        if let Some(p) = parent {
+            send_cmd.arg("-p").arg(p);
+        }
+        send_cmd
+            .arg(snapshot)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        log::debug!(
+            "Running: sudo {} send {}{}",
+            self.btrfs_path,
+            parent.map_or(String::new(), |p| format!("-p {} ", p.display())),
+            snapshot.display()
+        );
+
+        let mut send_child = send_cmd
+            .spawn()
+            .map_err(|e| UrdError::Btrfs(format!("failed to spawn btrfs send: {e}")))?;
+
+        // Take send's stdout to pipe into receive's stdin
+        let send_stdout = send_child.stdout.take().ok_or_else(|| {
+            UrdError::Btrfs("failed to capture btrfs send stdout".to_string())
+        })?;
+
+        // Take send's stderr to drain in a thread
+        let send_stderr = send_child.stderr.take().ok_or_else(|| {
+            UrdError::Btrfs("failed to capture btrfs send stderr".to_string())
+        })?;
+
+        // Drain send stderr in a background thread to prevent deadlock
+        let send_stderr_thread = std::thread::spawn(move || {
+            let mut buf = String::new();
+            let mut reader = std::io::BufReader::new(send_stderr);
+            reader.read_to_string(&mut buf).ok();
+            buf
+        });
+
+        // Build receive command
+        log::debug!(
+            "Running: sudo {} receive {}",
+            self.btrfs_path,
+            dest_dir.display()
+        );
+
+        let recv_output = Command::new("sudo")
+            .arg(&self.btrfs_path)
+            .arg("receive")
+            .arg(dest_dir)
+            .stdin(send_stdout)
+            .stderr(Stdio::piped())
+            .output()
+            .map_err(|e| UrdError::Btrfs(format!("failed to spawn btrfs receive: {e}")))?;
+
+        let send_status = send_child
+            .wait()
+            .map_err(|e| UrdError::Btrfs(format!("failed to wait for btrfs send: {e}")))?;
+
+        let send_stderr_str = send_stderr_thread.join().unwrap_or_default();
+        let recv_stderr_str = String::from_utf8_lossy(&recv_output.stderr);
+
+        // Check both exit codes
+        let send_ok = send_status.success();
+        let recv_ok = recv_output.status.success();
+
+        if !send_ok || !recv_ok {
+            // Attempt cleanup of partial snapshot at destination
+            if let Some(snap_name) = snapshot.file_name() {
+                let partial = dest_dir.join(snap_name);
+                if partial.exists() {
+                    log::warn!(
+                        "Cleaning up partial snapshot at {}",
+                        partial.display()
+                    );
+                    if let Err(e) = self.delete_subvolume(&partial) {
+                        log::error!("Failed to clean up partial snapshot: {e}");
+                    }
+                }
+            }
+
+            let mut msg = String::new();
+            if !send_ok {
+                msg.push_str(&format!(
+                    "send failed (exit {}): {}",
+                    send_status.code().unwrap_or(-1),
+                    send_stderr_str.trim()
+                ));
+            }
+            if !recv_ok {
+                if !msg.is_empty() {
+                    msg.push_str("; ");
+                }
+                msg.push_str(&format!(
+                    "receive failed (exit {}): {}",
+                    recv_output.status.code().unwrap_or(-1),
+                    recv_stderr_str.trim()
+                ));
+            }
+            return Err(UrdError::Btrfs(msg));
+        }
+
+        if !send_stderr_str.is_empty() {
+            log::debug!("btrfs send stderr: {}", send_stderr_str.trim());
+        }
+        if !recv_stderr_str.is_empty() {
+            log::debug!("btrfs receive stderr: {}", recv_stderr_str.trim());
+        }
+
+        Ok(SendResult {
+            bytes_transferred: None,
+        })
+    }
+
+    fn delete_subvolume(&self, path: &Path) -> crate::error::Result<()> {
+        self.run_btrfs(&["subvolume", "delete", &path.to_string_lossy()])
+    }
+
+    fn subvolume_exists(&self, path: &Path) -> bool {
+        path.exists()
+    }
+
+    fn filesystem_free_bytes(&self, path: &Path) -> crate::error::Result<u64> {
+        crate::drives::filesystem_free_bytes(path)
+    }
+}
+
+// ── MockBtrfs ───────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum MockBtrfsCall {
+    CreateSnapshot {
+        source: PathBuf,
+        dest: PathBuf,
+    },
+    SendReceive {
+        snapshot: PathBuf,
+        parent: Option<PathBuf>,
+        dest_dir: PathBuf,
+    },
+    DeleteSubvolume {
+        path: PathBuf,
+    },
+}
+
+/// Mock implementation of `BtrfsOps` for testing.
+/// Records all calls and can inject failures for specific paths.
+#[allow(dead_code)]
+pub struct MockBtrfs {
+    pub calls: RefCell<Vec<MockBtrfsCall>>,
+    pub fail_creates: RefCell<HashSet<PathBuf>>,
+    pub fail_sends: RefCell<HashSet<PathBuf>>,
+    pub fail_deletes: RefCell<HashSet<PathBuf>>,
+    pub existing_subvolumes: RefCell<HashSet<PathBuf>>,
+    pub free_bytes: RefCell<u64>,
+}
+
+#[allow(dead_code)]
+impl MockBtrfs {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            calls: RefCell::new(Vec::new()),
+            fail_creates: RefCell::new(HashSet::new()),
+            fail_sends: RefCell::new(HashSet::new()),
+            fail_deletes: RefCell::new(HashSet::new()),
+            existing_subvolumes: RefCell::new(HashSet::new()),
+            free_bytes: RefCell::new(1_000_000_000_000), // 1TB default
+        }
+    }
+
+    #[must_use]
+    pub fn calls(&self) -> Vec<MockBtrfsCall> {
+        self.calls.borrow().clone()
+    }
+}
+
+impl Default for MockBtrfs {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BtrfsOps for MockBtrfs {
+    fn create_readonly_snapshot(&self, source: &Path, dest: &Path) -> crate::error::Result<()> {
+        self.calls.borrow_mut().push(MockBtrfsCall::CreateSnapshot {
+            source: source.to_path_buf(),
+            dest: dest.to_path_buf(),
+        });
+        if self.fail_creates.borrow().contains(dest) {
+            return Err(UrdError::Btrfs(format!(
+                "mock: create snapshot failed for {}",
+                dest.display()
+            )));
+        }
+        Ok(())
+    }
+
+    fn send_receive(
+        &self,
+        snapshot: &Path,
+        parent: Option<&Path>,
+        dest_dir: &Path,
+    ) -> crate::error::Result<SendResult> {
+        self.calls.borrow_mut().push(MockBtrfsCall::SendReceive {
+            snapshot: snapshot.to_path_buf(),
+            parent: parent.map(Path::to_path_buf),
+            dest_dir: dest_dir.to_path_buf(),
+        });
+        if self.fail_sends.borrow().contains(snapshot) {
+            return Err(UrdError::Btrfs(format!(
+                "mock: send failed for {}",
+                snapshot.display()
+            )));
+        }
+        Ok(SendResult {
+            bytes_transferred: None,
+        })
+    }
+
+    fn delete_subvolume(&self, path: &Path) -> crate::error::Result<()> {
+        self.calls
+            .borrow_mut()
+            .push(MockBtrfsCall::DeleteSubvolume {
+                path: path.to_path_buf(),
+            });
+        if self.fail_deletes.borrow().contains(path) {
+            return Err(UrdError::Btrfs(format!(
+                "mock: delete failed for {}",
+                path.display()
+            )));
+        }
+        Ok(())
+    }
+
+    fn subvolume_exists(&self, path: &Path) -> bool {
+        self.existing_subvolumes.borrow().contains(path)
+    }
+
+    fn filesystem_free_bytes(&self, _path: &Path) -> crate::error::Result<u64> {
+        Ok(*self.free_bytes.borrow())
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mock_records_calls() {
+        let mock = MockBtrfs::new();
+        let src = PathBuf::from("/home");
+        let dest = PathBuf::from("/snap/20260322-1430-home");
+
+        mock.create_readonly_snapshot(&src, &dest).unwrap();
+
+        let calls = mock.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0],
+            MockBtrfsCall::CreateSnapshot {
+                source: src,
+                dest,
+            }
+        );
+    }
+
+    #[test]
+    fn mock_failure_injection() {
+        let mock = MockBtrfs::new();
+        let dest = PathBuf::from("/snap/fail");
+        mock.fail_creates.borrow_mut().insert(dest.clone());
+
+        let result = mock.create_readonly_snapshot(Path::new("/home"), &dest);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("mock: create snapshot failed"));
+    }
+
+    #[test]
+    fn mock_send_records_parent() {
+        let mock = MockBtrfs::new();
+        let snap = PathBuf::from("/snap/new");
+        let parent = PathBuf::from("/snap/old");
+        let dest = PathBuf::from("/mnt/drive/.snapshots/home");
+
+        mock.send_receive(&snap, Some(&parent), &dest).unwrap();
+
+        let calls = mock.calls();
+        assert_eq!(
+            calls[0],
+            MockBtrfsCall::SendReceive {
+                snapshot: snap,
+                parent: Some(parent),
+                dest_dir: dest,
+            }
+        );
+    }
+
+    #[test]
+    fn mock_subvolume_exists() {
+        let mock = MockBtrfs::new();
+        let path = PathBuf::from("/snap/exists");
+        assert!(!mock.subvolume_exists(&path));
+
+        mock.existing_subvolumes.borrow_mut().insert(path.clone());
+        assert!(mock.subvolume_exists(&path));
+    }
+
+    #[test]
+    fn mock_free_bytes() {
+        let mock = MockBtrfs::new();
+        assert_eq!(
+            mock.filesystem_free_bytes(Path::new("/mnt")).unwrap(),
+            1_000_000_000_000
+        );
+
+        *mock.free_bytes.borrow_mut() = 500_000_000;
+        assert_eq!(
+            mock.filesystem_free_bytes(Path::new("/mnt")).unwrap(),
+            500_000_000
+        );
+    }
+
+    #[test]
+    fn mock_send_failure() {
+        let mock = MockBtrfs::new();
+        let snap = PathBuf::from("/snap/fail");
+        mock.fail_sends.borrow_mut().insert(snap.clone());
+
+        let result = mock.send_receive(&snap, None, Path::new("/dest"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn mock_delete_failure() {
+        let mock = MockBtrfs::new();
+        let path = PathBuf::from("/snap/nodelete");
+        mock.fail_deletes.borrow_mut().insert(path.clone());
+
+        let result = mock.delete_subvolume(&path);
+        assert!(result.is_err());
+    }
+}

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -65,6 +65,32 @@ pub fn find_pinned_snapshots(
     pinned
 }
 
+/// Write the pin file for a specific drive in a local snapshot directory.
+/// Records the last successfully sent snapshot name.
+/// Uses atomic write (temp file + rename) to prevent corruption.
+pub fn write_pin_file(
+    local_snapshot_dir: &Path,
+    drive_label: &str,
+    snapshot_name: &SnapshotName,
+) -> crate::error::Result<()> {
+    let final_path = local_snapshot_dir.join(format!(".last-external-parent-{drive_label}"));
+    let tmp_path = local_snapshot_dir.join(format!(".last-external-parent-{drive_label}.tmp"));
+
+    std::fs::write(&tmp_path, format!("{}\n", snapshot_name.as_str())).map_err(|e| {
+        UrdError::Io {
+            path: tmp_path.clone(),
+            source: e,
+        }
+    })?;
+
+    std::fs::rename(&tmp_path, &final_path).map_err(|e| UrdError::Io {
+        path: final_path,
+        source: e,
+    })?;
+
+    Ok(())
+}
+
 fn try_read_pin(path: &Path) -> crate::error::Result<Option<SnapshotName>> {
     match std::fs::read_to_string(path) {
         Ok(content) => {
@@ -193,6 +219,41 @@ mod tests {
         assert_eq!(pinned.len(), 2);
         assert!(pinned.iter().any(|s| s.as_str() == "20260322-opptak"));
         assert!(pinned.iter().any(|s| s.as_str() == "20260321-opptak"));
+    }
+
+    #[test]
+    fn write_and_read_pin_roundtrip() {
+        let dir = TempDir::new().unwrap();
+        let name = SnapshotName::parse("20260322-1430-opptak").unwrap();
+
+        write_pin_file(dir.path(), "WD-18TB", &name).unwrap();
+
+        let result = read_pin_file(dir.path(), "WD-18TB").unwrap();
+        assert_eq!(result.unwrap().as_str(), "20260322-1430-opptak");
+    }
+
+    #[test]
+    fn write_pin_overwrites_existing() {
+        let dir = TempDir::new().unwrap();
+        let old = SnapshotName::parse("20260321-opptak").unwrap();
+        let new = SnapshotName::parse("20260322-1430-opptak").unwrap();
+
+        write_pin_file(dir.path(), "WD-18TB", &old).unwrap();
+        write_pin_file(dir.path(), "WD-18TB", &new).unwrap();
+
+        let result = read_pin_file(dir.path(), "WD-18TB").unwrap();
+        assert_eq!(result.unwrap().as_str(), "20260322-1430-opptak");
+    }
+
+    #[test]
+    fn write_pin_no_tmp_file_remains() {
+        let dir = TempDir::new().unwrap();
+        let name = SnapshotName::parse("20260322-1430-opptak").unwrap();
+
+        write_pin_file(dir.path(), "WD-18TB", &name).unwrap();
+
+        let tmp = dir.path().join(".last-external-parent-WD-18TB.tmp");
+        assert!(!tmp.exists());
     }
 
     #[test]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,0 +1,306 @@
+use std::fs::File;
+
+use colored::Colorize;
+
+use crate::btrfs::RealBtrfs;
+use crate::cli::BackupArgs;
+use crate::config::Config;
+use crate::drives;
+use crate::executor::{Executor, RunResult, SendType};
+use crate::metrics::{self, MetricsData, SubvolumeMetrics};
+use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
+use crate::state::StateDb;
+
+pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
+    let now = chrono::Local::now().naive_local();
+    let filters = PlanFilters {
+        priority: args.priority,
+        subvolume: args.subvolume,
+        local_only: args.local_only,
+        external_only: args.external_only,
+    };
+
+    let mode = if args.dry_run {
+        "dry-run"
+    } else if args.local_only {
+        "local-only"
+    } else if args.external_only {
+        "external-only"
+    } else {
+        "full"
+    };
+
+    let fs_state = RealFileSystemState;
+    let backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
+
+    // Dry run: print plan and exit (no lock needed)
+    if args.dry_run {
+        crate::commands::plan_cmd::run_with_plan(&config, &backup_plan)?;
+        return Ok(());
+    }
+
+    // Acquire advisory lock to prevent concurrent backup runs
+    let _lock = acquire_lock(&config)?;
+
+    if backup_plan.is_empty() && backup_plan.skipped.is_empty() {
+        println!("{}", "Nothing to do.".dimmed());
+        write_metrics_for_skipped(&config, &backup_plan, now)?;
+        return Ok(());
+    }
+
+    // Set up executor
+    let btrfs = RealBtrfs::new(&config.general.btrfs_path);
+
+    let state_db = match StateDb::open(&config.general.state_db) {
+        Ok(db) => Some(db),
+        Err(e) => {
+            log::warn!("Failed to open state DB, continuing without history: {e}");
+            None
+        }
+    };
+
+    let executor = Executor::new(&btrfs, state_db.as_ref(), &config);
+    let result = executor.execute(&backup_plan, mode);
+
+    // Print results
+    println!(
+        "{}",
+        format!("Urd backup completed: {}", result.overall.as_str()).bold()
+    );
+    println!();
+
+    let mut total_pin_failures: u32 = 0;
+
+    for sv in &result.subvolume_results {
+        let status = if sv.success {
+            "OK".green()
+        } else {
+            "FAILED".red()
+        };
+        let send_info = match sv.send_type {
+            SendType::Full => " (full send)".to_string(),
+            SendType::Incremental => " (incremental)".to_string(),
+            SendType::NoSend => String::new(),
+        };
+        println!(
+            "  {} {} [{:.1}s]{}",
+            status,
+            sv.name.bold(),
+            sv.duration.as_secs_f64(),
+            send_info,
+        );
+
+        // Print errors for failed operations
+        for op in &sv.operations {
+            if let Some(err) = &op.error
+                && op.result == crate::executor::OpResult::Failure
+            {
+                println!("    {} {}: {}", "ERROR".red(), op.operation, err);
+            }
+        }
+
+        // Print pin failure warnings prominently
+        if sv.pin_failures > 0 {
+            total_pin_failures += sv.pin_failures;
+            println!(
+                "    {} {} pin file write(s) failed — next send may be full instead of incremental",
+                "WARNING".yellow(),
+                sv.pin_failures,
+            );
+        }
+    }
+
+    // Print skipped subvolumes
+    for (name, reason) in &backup_plan.skipped {
+        println!("  {} {} ({})", "SKIP".dimmed(), name, reason.dimmed());
+    }
+
+    // Summary warning for pin failures
+    if total_pin_failures > 0 {
+        println!();
+        println!(
+            "{} {} pin file write(s) failed. Run {} to diagnose.",
+            "WARNING:".yellow().bold(),
+            total_pin_failures,
+            "urd verify".bold(),
+        );
+    }
+
+    // Write metrics
+    write_metrics_after_execution(&config, &result, &backup_plan, now, &fs_state)?;
+
+    // Exit with appropriate code
+    if result.overall != RunResult::Success {
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Acquire an advisory lock to prevent concurrent backup runs.
+/// Returns the lock file (lock is held until dropped).
+fn acquire_lock(config: &Config) -> anyhow::Result<nix::fcntl::Flock<File>> {
+    let lock_path = config.general.state_db.with_extension("lock");
+
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let file = File::create(&lock_path)?;
+
+    match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
+        Ok(lock) => Ok(lock),
+        Err((_, errno)) if errno == nix::errno::Errno::EWOULDBLOCK => {
+            anyhow::bail!(
+                "Another urd backup is already running (lock file: {})",
+                lock_path.display()
+            );
+        }
+        Err((_, errno)) => {
+            anyhow::bail!("Failed to acquire lock {}: {errno}", lock_path.display());
+        }
+    }
+}
+
+fn write_metrics_after_execution(
+    config: &Config,
+    result: &crate::executor::ExecutionResult,
+    plan: &crate::types::BackupPlan,
+    now: chrono::NaiveDateTime,
+    fs_state: &RealFileSystemState,
+) -> anyhow::Result<()> {
+    let now_ts = now.and_utc().timestamp();
+    let mut subvolume_metrics = Vec::new();
+
+    // Metrics for executed subvolumes
+    for sv_result in &result.subvolume_results {
+        let success_val = if sv_result.success { 1 } else { 0 };
+        let last_success_ts = if sv_result.success {
+            Some(now_ts)
+        } else {
+            None
+        };
+
+        // Re-scan snapshot directories for accurate counts
+        let local_count = count_local_snapshots(config, &sv_result.name, fs_state);
+        let external_count = count_external_snapshots(config, &sv_result.name, fs_state);
+
+        subvolume_metrics.push(SubvolumeMetrics {
+            name: sv_result.name.clone(),
+            success: success_val,
+            last_success_timestamp: last_success_ts,
+            duration_seconds: sv_result.duration.as_secs(),
+            local_snapshot_count: local_count,
+            external_snapshot_count: external_count,
+            send_type: sv_result.send_type.metric_value(),
+        });
+    }
+
+    // Metrics for skipped subvolumes
+    for (name, _reason) in &plan.skipped {
+        let local_count = count_local_snapshots(config, name, fs_state);
+        let external_count = count_external_snapshots(config, name, fs_state);
+
+        subvolume_metrics.push(SubvolumeMetrics {
+            name: name.clone(),
+            success: 2, // schedule-skipped
+            last_success_timestamp: None,
+            duration_seconds: 0,
+            local_snapshot_count: local_count,
+            external_snapshot_count: external_count,
+            send_type: 2, // no send
+        });
+    }
+
+    // Global metrics
+    let (drive_mounted, free_bytes) = get_drive_status(config);
+
+    let data = MetricsData {
+        subvolumes: subvolume_metrics,
+        external_drive_mounted: drive_mounted,
+        external_free_bytes: free_bytes,
+        script_last_run_timestamp: now_ts,
+    };
+
+    metrics::write_metrics(&config.general.metrics_file, &data)?;
+    Ok(())
+}
+
+fn write_metrics_for_skipped(
+    config: &Config,
+    plan: &crate::types::BackupPlan,
+    now: chrono::NaiveDateTime,
+) -> anyhow::Result<()> {
+    let now_ts = now.and_utc().timestamp();
+    let fs_state = RealFileSystemState;
+    let mut subvolume_metrics = Vec::new();
+
+    for (name, _reason) in &plan.skipped {
+        let local_count = count_local_snapshots(config, name, &fs_state);
+        let external_count = count_external_snapshots(config, name, &fs_state);
+
+        subvolume_metrics.push(SubvolumeMetrics {
+            name: name.clone(),
+            success: 2,
+            last_success_timestamp: None,
+            duration_seconds: 0,
+            local_snapshot_count: local_count,
+            external_snapshot_count: external_count,
+            send_type: 2,
+        });
+    }
+
+    let (drive_mounted, free_bytes) = get_drive_status(config);
+
+    let data = MetricsData {
+        subvolumes: subvolume_metrics,
+        external_drive_mounted: drive_mounted,
+        external_free_bytes: free_bytes,
+        script_last_run_timestamp: now_ts,
+    };
+
+    metrics::write_metrics(&config.general.metrics_file, &data)?;
+    Ok(())
+}
+
+fn count_local_snapshots(
+    config: &Config,
+    subvol_name: &str,
+    fs_state: &RealFileSystemState,
+) -> usize {
+    if let Some(root) = config.snapshot_root_for(subvol_name) {
+        fs_state
+            .local_snapshots(&root, subvol_name)
+            .map(|snaps| snaps.len())
+            .unwrap_or(0)
+    } else {
+        0
+    }
+}
+
+fn count_external_snapshots(
+    config: &Config,
+    subvol_name: &str,
+    fs_state: &RealFileSystemState,
+) -> usize {
+    // First mounted drive's count (for bash compat)
+    for drive in &config.drives {
+        if drives::is_drive_mounted(drive) {
+            return fs_state
+                .external_snapshots(drive, subvol_name)
+                .map(|snaps| snaps.len())
+                .unwrap_or(0);
+        }
+    }
+    0
+}
+
+fn get_drive_status(config: &Config) -> (bool, u64) {
+    for drive in &config.drives {
+        if drives::is_drive_mounted(drive) {
+            let free = drives::filesystem_free_bytes(&drive.mount_path).unwrap_or(0);
+            return (true, free);
+        }
+    }
+    (false, 0)
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,0 +1,226 @@
+use std::io::Write as _;
+
+use colored::Colorize;
+
+use crate::chain;
+use crate::config::Config;
+use crate::drives;
+use crate::plan::RealFileSystemState;
+use crate::plan::FileSystemState;
+use crate::state::StateDb;
+
+pub fn run(config: Config) -> anyhow::Result<()> {
+    println!("{}", "Urd initialization".bold());
+    println!();
+
+    // 1. Create state database
+    print!("Creating state database... ");
+    match StateDb::open(&config.general.state_db) {
+        Ok(_) => println!("{}", "OK".green()),
+        Err(e) => println!("{}: {e}", "FAILED".red()),
+    }
+
+    // 2. Verify config paths exist
+    println!();
+    println!("{}", "Checking subvolume sources:".bold());
+    for sv in &config.subvolumes {
+        let exists = sv.source.exists();
+        let status = if exists {
+            "OK".green()
+        } else {
+            "MISSING".red()
+        };
+        println!("  {} {}: {}", status, sv.name, sv.source.display());
+    }
+
+    // 3. Check snapshot roots
+    println!();
+    println!("{}", "Checking snapshot roots:".bold());
+    for root in &config.local_snapshots.roots {
+        let exists = root.path.exists();
+        let status = if exists {
+            "OK".green()
+        } else {
+            "MISSING".red()
+        };
+        println!("  {} {}", status, root.path.display());
+    }
+
+    // 4. Check drives
+    println!();
+    println!("{}", "Drive status:".bold());
+    for drive in &config.drives {
+        let mounted = drives::is_drive_mounted(drive);
+        let status = if mounted {
+            "MOUNTED".green()
+        } else {
+            "NOT MOUNTED".yellow()
+        };
+        let free_info = if mounted {
+            drives::filesystem_free_bytes(&drive.mount_path)
+                .map(|b| format!(" ({} free)", crate::types::ByteSize(b)))
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+        println!(
+            "  {} {} [{}] at {}{}",
+            status,
+            drive.label.bold(),
+            drive.role,
+            drive.mount_path.display(),
+            free_info
+        );
+    }
+
+    // 5. Validate pin files
+    println!();
+    println!("{}", "Pin file status:".bold());
+    let drive_labels: Vec<String> = config.drives.iter().map(|d| d.label.clone()).collect();
+    for root in &config.local_snapshots.roots {
+        for subvol_name in &root.subvolumes {
+            let local_dir = root.path.join(subvol_name);
+            for label in &drive_labels {
+                match chain::read_pin_file(&local_dir, label) {
+                    Ok(Some(name)) => {
+                        println!(
+                            "  {} {}/{}: {}",
+                            "OK".green(),
+                            subvol_name,
+                            label,
+                            name
+                        );
+                    }
+                    Ok(None) => {
+                        println!(
+                            "  {} {}/{}: no pin file",
+                            "—".dimmed(),
+                            subvol_name,
+                            label
+                        );
+                    }
+                    Err(e) => {
+                        println!(
+                            "  {} {}/{}: {e}",
+                            "ERROR".red(),
+                            subvol_name,
+                            label
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // 6. Detect incomplete snapshots on external drives
+    let fs_state = RealFileSystemState;
+    let mut incomplete_found = false;
+
+    for drive in &config.drives {
+        if !drives::is_drive_mounted(drive) {
+            continue;
+        }
+
+        for sv in &config.subvolumes {
+            let local_dir = match config.snapshot_root_for(&sv.name) {
+                Some(root) => root.join(&sv.name),
+                None => continue,
+            };
+
+            let external_snaps = match fs_state.external_snapshots(drive, &sv.name) {
+                Ok(snaps) => snaps,
+                Err(_) => continue,
+            };
+
+            if external_snaps.is_empty() {
+                continue;
+            }
+
+            // Get the pinned snapshot for this drive
+            let pinned = chain::read_pin_file(&local_dir, &drive.label)
+                .ok()
+                .flatten();
+
+            // The newest snapshot that is NOT pinned might be a partial
+            let newest = external_snaps.iter().max();
+            if let Some(newest_snap) = newest {
+                let is_pinned = pinned
+                    .as_ref()
+                    .is_some_and(|p| p.as_str() == newest_snap.as_str());
+
+                if !is_pinned {
+                    if !incomplete_found {
+                        println!();
+                        println!(
+                            "{}",
+                            "Potentially incomplete snapshots on external drives:".bold()
+                        );
+                        incomplete_found = true;
+                    }
+
+                    println!(
+                        "  {} {} on {} (not pinned, may be from interrupted transfer)",
+                        "WARNING".yellow(),
+                        newest_snap,
+                        drive.label
+                    );
+
+                    // Offer cleanup
+                    let dest_dir = drives::external_snapshot_dir(drive, &sv.name);
+                    let partial_path = dest_dir.join(newest_snap.as_str());
+
+                    print!("  Delete {}? [y/N] ", partial_path.display());
+                    std::io::stdout().flush()?;
+
+                    let mut input = String::new();
+                    std::io::stdin().read_line(&mut input)?;
+                    if input.trim().eq_ignore_ascii_case("y") {
+                        println!("  Deletion of incomplete snapshots requires sudo btrfs subvolume delete.");
+                        println!("  Run: sudo btrfs subvolume delete {}", partial_path.display());
+                    }
+                }
+            }
+        }
+    }
+
+    // 7. Summary
+    println!();
+    println!("{}", "Snapshot counts:".bold());
+    for sv in &config.subvolumes {
+        let root = config.snapshot_root_for(&sv.name);
+        let local_count = root
+            .as_ref()
+            .and_then(|r| fs_state.local_snapshots(r, &sv.name).ok())
+            .map(|s| s.len())
+            .unwrap_or(0);
+
+        let mut external_info = String::new();
+        for drive in &config.drives {
+            if drives::is_drive_mounted(drive) {
+                let count = fs_state
+                    .external_snapshots(drive, &sv.name)
+                    .map(|s| s.len())
+                    .unwrap_or(0);
+                if !external_info.is_empty() {
+                    external_info.push_str(", ");
+                }
+                external_info.push_str(&format!("{}:{count}", drive.label));
+            }
+        }
+
+        let ext_display = if external_info.is_empty() {
+            "no drives mounted".to_string()
+        } else {
+            external_info
+        };
+
+        println!(
+            "  {} — local: {local_count}, external: [{ext_display}]",
+            sv.name.bold()
+        );
+    }
+
+    println!();
+    println!("{}", "Initialization complete.".green().bold());
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,1 +1,3 @@
+pub mod backup;
+pub mod init;
 pub mod plan_cmd;

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -17,10 +17,19 @@ pub fn run(config: Config, args: PlanArgs) -> anyhow::Result<()> {
     let fs_state = RealFileSystemState;
     let backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
 
+    run_with_plan(&config, &backup_plan)
+}
+
+/// Print a backup plan. Shared by `urd plan` and `urd backup --dry-run`.
+pub fn run_with_plan(config: &Config, backup_plan: &crate::types::BackupPlan) -> anyhow::Result<()> {
     // Print header
     println!(
         "{}",
-        format!("Urd backup plan for {}", now.format("%Y-%m-%d %H:%M")).bold()
+        format!(
+            "Urd backup plan for {}",
+            backup_plan.timestamp.format("%Y-%m-%d %H:%M")
+        )
+        .bold()
     );
     println!();
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,6 +21,12 @@ pub enum UrdError {
     #[error("Retention error: {0}")]
     #[allow(dead_code)]
     Retention(String),
+
+    #[error("Btrfs command failed: {0}")]
+    Btrfs(String),
+
+    #[error("State database error: {0}")]
+    State(String),
 }
 
 pub type Result<T> = std::result::Result<T, UrdError>;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,1094 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::time::Instant;
+
+use crate::btrfs::BtrfsOps;
+use crate::chain;
+use crate::config::Config;
+use crate::state::{OperationRecord, StateDb};
+use crate::types::{BackupPlan, PlannedOperation};
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunResult {
+    Success,
+    Partial,
+    Failure,
+}
+
+impl RunResult {
+    #[must_use]
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Success => "success",
+            Self::Partial => "partial",
+            Self::Failure => "failure",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SendType {
+    Full,
+    Incremental,
+    NoSend,
+}
+
+impl SendType {
+    /// Prometheus metric value: 0=full, 1=incremental, 2=no send
+    #[must_use]
+    pub fn metric_value(&self) -> u8 {
+        match self {
+            Self::Full => 0,
+            Self::Incremental => 1,
+            Self::NoSend => 2,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpResult {
+    Success,
+    Failure,
+    Skipped,
+}
+
+#[derive(Debug)]
+pub struct OperationOutcome {
+    pub operation: String,
+    pub drive_label: Option<String>,
+    pub result: OpResult,
+    pub duration: std::time::Duration,
+    pub error: Option<String>,
+    pub bytes_transferred: Option<u64>,
+}
+
+#[derive(Debug)]
+pub struct SubvolumeResult {
+    pub name: String,
+    pub success: bool,
+    pub operations: Vec<OperationOutcome>,
+    pub duration: std::time::Duration,
+    pub send_type: SendType,
+    /// Number of sends that succeeded but whose pin file write failed.
+    pub pin_failures: u32,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct ExecutionResult {
+    pub overall: RunResult,
+    pub subvolume_results: Vec<SubvolumeResult>,
+    pub run_id: Option<i64>,
+}
+
+// ── Executor ────────────────────────────────────────────────────────────
+
+pub struct Executor<'a> {
+    btrfs: &'a dyn BtrfsOps,
+    state: Option<&'a StateDb>,
+    config: &'a Config,
+}
+
+impl<'a> Executor<'a> {
+    #[must_use]
+    pub fn new(
+        btrfs: &'a dyn BtrfsOps,
+        state: Option<&'a StateDb>,
+        config: &'a Config,
+    ) -> Self {
+        Self {
+            btrfs,
+            state,
+            config,
+        }
+    }
+
+    /// Execute the backup plan, returning results.
+    pub fn execute(&self, plan: &BackupPlan, mode: &str) -> ExecutionResult {
+        // Begin run in SQLite (optional)
+        let run_id = self.begin_run(mode);
+
+        // Group operations by subvolume, preserving order
+        let groups = group_by_subvolume(&plan.operations);
+
+        // Per-drive space recovery tracking (shared across subvolumes)
+        let mut space_recovered: HashMap<String, bool> = HashMap::new();
+
+        let mut subvolume_results = Vec::new();
+
+        for (subvol_name, ops) in &groups {
+            let result = self.execute_subvolume(subvol_name, ops, run_id, &mut space_recovered);
+            subvolume_results.push(result);
+        }
+
+        // Determine overall result
+        let overall = if subvolume_results.is_empty() || subvolume_results.iter().all(|r| r.success)
+        {
+            RunResult::Success
+        } else if subvolume_results.iter().all(|r| !r.success) {
+            RunResult::Failure
+        } else {
+            RunResult::Partial
+        };
+
+        // Finish run in SQLite
+        self.finish_run(run_id, overall.as_str());
+
+        ExecutionResult {
+            overall,
+            subvolume_results,
+            run_id,
+        }
+    }
+
+    fn execute_subvolume(
+        &self,
+        subvol_name: &str,
+        ops: &[&PlannedOperation],
+        run_id: Option<i64>,
+        space_recovered: &mut HashMap<String, bool>,
+    ) -> SubvolumeResult {
+        let subvol_start = Instant::now();
+        let mut operations = Vec::new();
+        let mut failed_creates: HashSet<&Path> = HashSet::new();
+        let mut subvol_success = true;
+        let mut send_type = SendType::NoSend;
+        let mut pin_failures: u32 = 0;
+
+        for op in ops {
+            let outcome = match op {
+                PlannedOperation::CreateSnapshot { source, dest, .. } => {
+                    self.execute_create(source, dest, &mut failed_creates)
+                }
+                PlannedOperation::SendIncremental {
+                    parent,
+                    snapshot,
+                    dest_dir,
+                    drive_label,
+                    pin_on_success,
+                    ..
+                } => {
+                    let (result, pin_failed) = self.execute_send(
+                        snapshot,
+                        Some(parent),
+                        dest_dir,
+                        drive_label,
+                        pin_on_success.as_ref(),
+                        &failed_creates,
+                        subvol_name,
+                    );
+                    if result.result == OpResult::Success {
+                        send_type = SendType::Incremental;
+                    }
+                    if pin_failed {
+                        pin_failures += 1;
+                    }
+                    result
+                }
+                PlannedOperation::SendFull {
+                    snapshot,
+                    dest_dir,
+                    drive_label,
+                    pin_on_success,
+                    ..
+                } => {
+                    let (result, pin_failed) = self.execute_send(
+                        snapshot,
+                        None,
+                        dest_dir,
+                        drive_label,
+                        pin_on_success.as_ref(),
+                        &failed_creates,
+                        subvol_name,
+                    );
+                    if result.result == OpResult::Success {
+                        send_type = SendType::Full;
+                    }
+                    if pin_failed {
+                        pin_failures += 1;
+                    }
+                    result
+                }
+                PlannedOperation::DeleteSnapshot {
+                    path,
+                    subvolume_name,
+                    ..
+                } => self.execute_delete(path, subvolume_name, space_recovered),
+            };
+
+            if outcome.result == OpResult::Failure {
+                subvol_success = false;
+            }
+
+            // Record to SQLite
+            if let Some(rid) = run_id {
+                self.record_operation(rid, subvol_name, &outcome);
+            }
+
+            operations.push(outcome);
+        }
+
+        SubvolumeResult {
+            name: subvol_name.to_string(),
+            success: subvol_success,
+            operations,
+            duration: subvol_start.elapsed(),
+            send_type,
+            pin_failures,
+        }
+    }
+
+    fn execute_create<'b>(
+        &self,
+        source: &Path,
+        dest: &'b Path,
+        failed_creates: &mut HashSet<&'b Path>,
+    ) -> OperationOutcome {
+        let start = Instant::now();
+        log::info!("Creating snapshot: {} -> {}", source.display(), dest.display());
+
+        match self.btrfs.create_readonly_snapshot(source, dest) {
+            Ok(()) => OperationOutcome {
+                operation: "snapshot".to_string(),
+                drive_label: None,
+                result: OpResult::Success,
+                duration: start.elapsed(),
+                error: None,
+                bytes_transferred: None,
+            },
+            Err(e) => {
+                log::error!("Snapshot creation failed: {e}");
+                failed_creates.insert(dest);
+                OperationOutcome {
+                    operation: "snapshot".to_string(),
+                    drive_label: None,
+                    result: OpResult::Failure,
+                    duration: start.elapsed(),
+                    error: Some(e.to_string()),
+                    bytes_transferred: None,
+                }
+            }
+        }
+    }
+
+    /// Returns (outcome, pin_failed) where pin_failed is true if send succeeded
+    /// but pin file write failed.
+    #[allow(clippy::too_many_arguments)]
+    fn execute_send(
+        &self,
+        snapshot: &Path,
+        parent: Option<&Path>,
+        dest_dir: &Path,
+        drive_label: &str,
+        pin_on_success: Option<&(std::path::PathBuf, crate::types::SnapshotName)>,
+        failed_creates: &HashSet<&Path>,
+        subvol_name: &str,
+    ) -> (OperationOutcome, bool) {
+        let start = Instant::now();
+        let op_name = if parent.is_some() {
+            "send_incremental"
+        } else {
+            "send_full"
+        };
+
+        // Cascading failure check: if the snapshot was not created, skip
+        if failed_creates.contains(snapshot) {
+            log::warn!(
+                "Skipping {op_name} for {subvol_name}: snapshot creation failed for {}",
+                snapshot.display()
+            );
+            return (
+                OperationOutcome {
+                    operation: op_name.to_string(),
+                    drive_label: Some(drive_label.to_string()),
+                    result: OpResult::Skipped,
+                    duration: start.elapsed(),
+                    error: Some("snapshot creation failed".to_string()),
+                    bytes_transferred: None,
+                },
+                false,
+            );
+        }
+
+        // Crash recovery: check if snapshot already exists at destination
+        if let Some(snap_name) = snapshot.file_name() {
+            let dest_snap = dest_dir.join(snap_name);
+            if self.btrfs.subvolume_exists(&dest_snap) {
+                // Check if pin references this snapshot — if so, it's already done
+                if let Some((pin_path, _)) = pin_on_success
+                    && let Some(pin_dir) = pin_path.parent()
+                    && let Ok(Some(pinned)) = chain::read_pin_file(pin_dir, drive_label)
+                    && pinned.as_str() == snap_name.to_string_lossy()
+                {
+                    log::info!(
+                        "Snapshot {} already exists at dest and is pinned, skipping send",
+                        snap_name.to_string_lossy()
+                    );
+                    return (
+                        OperationOutcome {
+                            operation: op_name.to_string(),
+                            drive_label: Some(drive_label.to_string()),
+                            result: OpResult::Success,
+                            duration: start.elapsed(),
+                            error: None,
+                            bytes_transferred: None,
+                        },
+                        false,
+                    );
+                }
+
+                // Not pinned — delete as partial from interrupted run
+                log::warn!(
+                    "Deleting partial snapshot at {} from interrupted prior run",
+                    dest_snap.display()
+                );
+                if let Err(e) = self.btrfs.delete_subvolume(&dest_snap) {
+                    log::error!("Failed to clean up partial snapshot: {e}");
+                    return (
+                        OperationOutcome {
+                            operation: op_name.to_string(),
+                            drive_label: Some(drive_label.to_string()),
+                            result: OpResult::Failure,
+                            duration: start.elapsed(),
+                            error: Some(format!(
+                                "failed to clean up partial snapshot at {}: {e}",
+                                dest_snap.display()
+                            )),
+                            bytes_transferred: None,
+                        },
+                        false,
+                    );
+                }
+            }
+        }
+
+        log::info!(
+            "Sending {} to {} ({})",
+            snapshot.display(),
+            drive_label,
+            op_name
+        );
+
+        match self.btrfs.send_receive(snapshot, parent, dest_dir) {
+            Ok(result) => {
+                // Pin-on-success
+                let mut pin_failed = false;
+                if let Some((pin_path, pin_name)) = pin_on_success
+                    && let Some(pin_dir) = pin_path.parent()
+                    && let Err(e) = chain::write_pin_file(pin_dir, drive_label, pin_name)
+                {
+                    log::warn!(
+                        "Send succeeded but pin file write failed for {drive_label}: {e}"
+                    );
+                    pin_failed = true;
+                }
+
+                (
+                    OperationOutcome {
+                        operation: op_name.to_string(),
+                        drive_label: Some(drive_label.to_string()),
+                        result: OpResult::Success,
+                        duration: start.elapsed(),
+                        error: None,
+                        bytes_transferred: result.bytes_transferred,
+                    },
+                    pin_failed,
+                )
+            }
+            Err(e) => {
+                log::error!("{op_name} failed for {subvol_name} -> {drive_label}: {e}");
+                (
+                    OperationOutcome {
+                        operation: op_name.to_string(),
+                        drive_label: Some(drive_label.to_string()),
+                        result: OpResult::Failure,
+                        duration: start.elapsed(),
+                        error: Some(e.to_string()),
+                        bytes_transferred: None,
+                    },
+                    false,
+                )
+            }
+        }
+    }
+
+    fn execute_delete(
+        &self,
+        path: &Path,
+        subvolume_name: &str,
+        space_recovered: &mut HashMap<String, bool>,
+    ) -> OperationOutcome {
+        let start = Instant::now();
+
+        // External retention re-check: if we're deleting on an external drive
+        // and space has already been recovered for this drive, skip
+        if self.is_external_path(path)
+            && let Some(label) = self.drive_label_for_path(path)
+            && *space_recovered.get(&label).unwrap_or(&false)
+        {
+            log::info!(
+                "Skipping deletion of {} (space already recovered on {label})",
+                path.display()
+            );
+            return OperationOutcome {
+                operation: "delete".to_string(),
+                drive_label: Some(label),
+                result: OpResult::Skipped,
+                duration: start.elapsed(),
+                error: Some("space recovered, deletion skipped".to_string()),
+                bytes_transferred: None,
+            };
+        }
+
+        // Pin protection (defense-in-depth): check if this snapshot is pinned
+        if let Some(snap_name_osstr) = path.file_name() {
+            let snap_name_str = snap_name_osstr.to_string_lossy();
+            if let Ok(snap) = crate::types::SnapshotName::parse(&snap_name_str) {
+                let drive_labels: Vec<String> =
+                    self.config.drives.iter().map(|d| d.label.clone()).collect();
+                // Use the subvolume_name from the operation to find the local dir
+                if let Some(local_dir) = self.config.local_snapshot_dir(subvolume_name) {
+                    let pinned = chain::find_pinned_snapshots(&local_dir, &drive_labels);
+                    if pinned.contains(&snap) {
+                        log::warn!(
+                            "Defense-in-depth: refusing to delete pinned snapshot {}",
+                            path.display()
+                        );
+                        return OperationOutcome {
+                            operation: "delete".to_string(),
+                            drive_label: self.drive_label_for_path(path),
+                            result: OpResult::Skipped,
+                            duration: start.elapsed(),
+                            error: Some("snapshot is pinned".to_string()),
+                            bytes_transferred: None,
+                        };
+                    }
+                }
+            }
+        }
+
+        log::info!("Deleting snapshot: {}", path.display());
+
+        match self.btrfs.delete_subvolume(path) {
+            Ok(()) => {
+                // After external deletion, check if min_free_bytes is now satisfied
+                if self.is_external_path(path)
+                    && let Some(drive) = self.drive_for_path(path)
+                    && let Some(min_free_bytes) = drive.min_free_bytes
+                    && min_free_bytes.bytes() > 0
+                    && let Ok(free) = self.btrfs.filesystem_free_bytes(&drive.mount_path)
+                    && free >= min_free_bytes.bytes()
+                {
+                    log::info!(
+                        "Free space on {} is now {} (>= {}), stopping further deletions",
+                        drive.label,
+                        crate::types::ByteSize(free),
+                        min_free_bytes,
+                    );
+                    space_recovered.insert(drive.label.clone(), true);
+                }
+
+                OperationOutcome {
+                    operation: "delete".to_string(),
+                    drive_label: self.drive_label_for_path(path),
+                    result: OpResult::Success,
+                    duration: start.elapsed(),
+                    error: None,
+                    bytes_transferred: None,
+                }
+            }
+            Err(e) => {
+                log::error!("Delete failed for {}: {e}", path.display());
+                OperationOutcome {
+                    operation: "delete".to_string(),
+                    drive_label: self.drive_label_for_path(path),
+                    result: OpResult::Failure,
+                    duration: start.elapsed(),
+                    error: Some(e.to_string()),
+                    bytes_transferred: None,
+                }
+            }
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    fn is_external_path(&self, path: &Path) -> bool {
+        self.config
+            .drives
+            .iter()
+            .any(|d| path.starts_with(&d.mount_path))
+    }
+
+    fn drive_for_path(&self, path: &Path) -> Option<&crate::config::DriveConfig> {
+        self.config
+            .drives
+            .iter()
+            .find(|d| path.starts_with(&d.mount_path))
+    }
+
+    fn drive_label_for_path(&self, path: &Path) -> Option<String> {
+        self.drive_for_path(path).map(|d| d.label.clone())
+    }
+
+    fn begin_run(&self, mode: &str) -> Option<i64> {
+        if let Some(state) = self.state {
+            match state.begin_run(mode) {
+                Ok(id) => Some(id),
+                Err(e) => {
+                    log::warn!("Failed to begin SQLite run: {e}");
+                    None
+                }
+            }
+        } else {
+            None
+        }
+    }
+
+    fn finish_run(&self, run_id: Option<i64>, result: &str) {
+        if let (Some(state), Some(rid)) = (self.state, run_id)
+            && let Err(e) = state.finish_run(rid, result)
+        {
+            log::warn!("Failed to finish SQLite run: {e}");
+        }
+    }
+
+    fn record_operation(&self, run_id: i64, subvol_name: &str, outcome: &OperationOutcome) {
+        if let Some(state) = self.state {
+            let result_str = match outcome.result {
+                OpResult::Success => "success",
+                OpResult::Failure => "failure",
+                OpResult::Skipped => "skipped",
+            };
+            if let Err(e) = state.record_operation(&OperationRecord {
+                run_id,
+                subvolume: subvol_name.to_string(),
+                operation: outcome.operation.clone(),
+                drive_label: outcome.drive_label.clone(),
+                duration_secs: Some(outcome.duration.as_secs_f64()),
+                result: result_str.to_string(),
+                error_message: outcome.error.clone(),
+                bytes_transferred: outcome.bytes_transferred.map(|b| b as i64),
+            }) {
+                log::warn!("Failed to record operation to SQLite: {e}");
+            }
+        }
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Group operations by subvolume name, preserving order within each group
+/// and order of first appearance across groups.
+fn group_by_subvolume(ops: &[PlannedOperation]) -> Vec<(String, Vec<&PlannedOperation>)> {
+    let mut groups: Vec<(String, Vec<&PlannedOperation>)> = Vec::new();
+
+    for op in ops {
+        let name = match op {
+            PlannedOperation::CreateSnapshot { subvolume_name, .. }
+            | PlannedOperation::SendIncremental { subvolume_name, .. }
+            | PlannedOperation::SendFull { subvolume_name, .. }
+            | PlannedOperation::DeleteSnapshot { subvolume_name, .. } => subvolume_name,
+        };
+
+        if let Some(group) = groups.iter_mut().find(|(n, _)| n == name) {
+            group.1.push(op);
+        } else {
+            groups.push((name.clone(), vec![op]));
+        }
+    }
+
+    groups
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::btrfs::{MockBtrfs, MockBtrfsCall};
+    use crate::types::SnapshotName;
+    use chrono::NaiveDate;
+    use std::path::PathBuf;
+
+    fn test_config() -> Config {
+        let config_str = r#"
+[general]
+state_db = "/tmp/urd-test/urd.db"
+metrics_file = "/tmp/urd-test/backup.prom"
+log_dir = "/tmp/urd-test"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv-a", "sv-b"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "TEST-DRIVE"
+mount_path = "/mnt/test"
+snapshot_root = ".snapshots"
+role = "test"
+min_free_bytes = "100GB"
+
+[[subvolumes]]
+name = "sv-a"
+short_name = "a"
+source = "/data/a"
+
+[[subvolumes]]
+name = "sv-b"
+short_name = "b"
+source = "/data/b"
+"#;
+        toml::from_str(config_str).unwrap()
+    }
+
+    fn simple_plan() -> BackupPlan {
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        BackupPlan {
+            operations: vec![
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/a"),
+                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::SendIncremental {
+                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
+                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
+                    drive_label: "TEST-DRIVE".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    pin_on_success: None,
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/snap/sv-a/20260310-a"),
+                    reason: "expired".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+        }
+    }
+
+    #[test]
+    fn happy_path_all_succeed() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+        let plan = simple_plan();
+
+        let result = executor.execute(&plan, "full");
+
+        assert_eq!(result.overall, RunResult::Success);
+        assert_eq!(result.subvolume_results.len(), 1);
+        assert!(result.subvolume_results[0].success);
+        assert_eq!(result.subvolume_results[0].send_type, SendType::Incremental);
+
+        let calls = mock.calls();
+        assert_eq!(calls.len(), 3);
+        assert!(matches!(calls[0], MockBtrfsCall::CreateSnapshot { .. }));
+        assert!(matches!(calls[1], MockBtrfsCall::SendReceive { .. }));
+        assert!(matches!(calls[2], MockBtrfsCall::DeleteSubvolume { .. }));
+    }
+
+    #[test]
+    fn error_isolation_between_subvolumes() {
+        let mock = MockBtrfs::new();
+        // Make sv-a's create fail
+        mock.fail_creates
+            .borrow_mut()
+            .insert(PathBuf::from("/snap/sv-a/20260322-1430-a"));
+
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/a"),
+                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/b"),
+                    dest: PathBuf::from("/snap/sv-b/20260322-1430-b"),
+                    subvolume_name: "sv-b".to_string(),
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        assert_eq!(result.overall, RunResult::Partial);
+        assert!(!result.subvolume_results[0].success); // sv-a failed
+        assert!(result.subvolume_results[1].success); // sv-b succeeded
+    }
+
+    #[test]
+    fn cascading_failure_skips_send() {
+        let mock = MockBtrfs::new();
+        mock.fail_creates
+            .borrow_mut()
+            .insert(PathBuf::from("/snap/sv-a/20260322-1430-a"));
+
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/a"),
+                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::SendFull {
+                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
+                    drive_label: "TEST-DRIVE".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    pin_on_success: None,
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        assert_eq!(result.overall, RunResult::Failure);
+        let sv = &result.subvolume_results[0];
+        assert!(!sv.success);
+        // The send should be skipped, not attempted
+        assert_eq!(sv.operations[1].result, OpResult::Skipped);
+        assert!(sv.operations[1]
+            .error
+            .as_ref()
+            .unwrap()
+            .contains("snapshot creation failed"));
+
+        // Verify send was NOT called on the mock
+        let calls = mock.calls();
+        assert_eq!(calls.len(), 1); // only the create was attempted
+    }
+
+    #[test]
+    fn pin_on_success_writes_pin_file() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+
+        let pin_dir = tempfile::TempDir::new().unwrap();
+        let pin_path = pin_dir
+            .path()
+            .join(".last-external-parent-TEST-DRIVE");
+        let snap_name = SnapshotName::parse("20260322-1430-a").unwrap();
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::SendFull {
+                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
+                drive_label: "TEST-DRIVE".to_string(),
+                subvolume_name: "sv-a".to_string(),
+                pin_on_success: Some((pin_path.clone(), snap_name)),
+            }],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert_eq!(result.overall, RunResult::Success);
+
+        // Pin file should have been written
+        let pin_content = std::fs::read_to_string(&pin_path).unwrap();
+        assert_eq!(pin_content.trim(), "20260322-1430-a");
+    }
+
+    #[test]
+    fn all_failures_gives_failure_result() {
+        let mock = MockBtrfs::new();
+        mock.fail_creates
+            .borrow_mut()
+            .insert(PathBuf::from("/snap/sv-a/20260322-1430-a"));
+        mock.fail_creates
+            .borrow_mut()
+            .insert(PathBuf::from("/snap/sv-b/20260322-1430-b"));
+
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/a"),
+                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/b"),
+                    dest: PathBuf::from("/snap/sv-b/20260322-1430-b"),
+                    subvolume_name: "sv-b".to_string(),
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert_eq!(result.overall, RunResult::Failure);
+    }
+
+    #[test]
+    fn empty_plan_is_success() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert_eq!(result.overall, RunResult::Success);
+    }
+
+    #[test]
+    fn external_retention_recheck_stops_deleting() {
+        let mock = MockBtrfs::new();
+        // Start with low free space, then after first delete it becomes enough
+        *mock.free_bytes.borrow_mut() = 200_000_000_000; // 200GB > 100GB threshold
+
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260301-a"),
+                    reason: "expired".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260302-a"),
+                    reason: "expired".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260303-a"),
+                    reason: "expired".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        // First delete succeeds and triggers space_recovered
+        // Remaining two should be skipped
+        let sv = &result.subvolume_results[0];
+        assert_eq!(sv.operations[0].result, OpResult::Success);
+        assert_eq!(sv.operations[1].result, OpResult::Skipped);
+        assert_eq!(sv.operations[2].result, OpResult::Skipped);
+
+        // Only one delete should have been called on the mock
+        let delete_count = mock
+            .calls()
+            .iter()
+            .filter(|c| matches!(c, MockBtrfsCall::DeleteSubvolume { .. }))
+            .count();
+        assert_eq!(delete_count, 1);
+    }
+
+    #[test]
+    fn with_sqlite_state() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let db = StateDb::open_memory().unwrap();
+        let executor = Executor::new(&mock, Some(&db), &config);
+        let plan = simple_plan();
+
+        let result = executor.execute(&plan, "full");
+
+        assert!(result.run_id.is_some());
+        assert_eq!(result.overall, RunResult::Success);
+    }
+
+    #[test]
+    fn send_type_tracks_full() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::SendFull {
+                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
+                drive_label: "TEST-DRIVE".to_string(),
+                subvolume_name: "sv-a".to_string(),
+                pin_on_success: None,
+            }],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert_eq!(result.subvolume_results[0].send_type, SendType::Full);
+    }
+
+    #[test]
+    fn space_recovered_shared_across_subvolumes() {
+        let mock = MockBtrfs::new();
+        // Free space is above threshold — after first delete, space is recovered
+        *mock.free_bytes.borrow_mut() = 200_000_000_000; // 200GB > 100GB threshold
+
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        // sv-a deletes on external drive, recovers space.
+        // sv-b's deletions on the SAME drive should be skipped.
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260301-a"),
+                    reason: "expired".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/mnt/test/.snapshots/sv-b/20260301-b"),
+                    reason: "expired".to_string(),
+                    subvolume_name: "sv-b".to_string(),
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        // sv-a's delete succeeds and triggers space_recovered for TEST-DRIVE
+        assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Success);
+        // sv-b's delete on the SAME drive should be skipped
+        assert_eq!(result.subvolume_results[1].operations[0].result, OpResult::Skipped);
+
+        // Only one delete should have been called
+        let delete_count = mock
+            .calls()
+            .iter()
+            .filter(|c| matches!(c, MockBtrfsCall::DeleteSubvolume { .. }))
+            .count();
+        assert_eq!(delete_count, 1);
+    }
+
+    #[test]
+    fn pin_failure_tracked_in_result() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let executor = Executor::new(&mock, None, &config);
+
+        // Use a non-existent directory for pin path so the write fails
+        let pin_path = PathBuf::from("/nonexistent/dir/.last-external-parent-TEST-DRIVE");
+        let snap_name = SnapshotName::parse("20260322-1430-a").unwrap();
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::SendFull {
+                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
+                drive_label: "TEST-DRIVE".to_string(),
+                subvolume_name: "sv-a".to_string(),
+                pin_on_success: Some((pin_path, snap_name)),
+            }],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        // Send succeeds but pin fails
+        assert_eq!(result.overall, RunResult::Success);
+        assert!(result.subvolume_results[0].success);
+        assert_eq!(result.subvolume_results[0].pin_failures, 1);
+    }
+
+    #[test]
+    fn group_by_subvolume_preserves_order() {
+        let ops = vec![
+            PlannedOperation::CreateSnapshot {
+                source: PathBuf::from("/a"),
+                dest: PathBuf::from("/snap/a"),
+                subvolume_name: "sv-a".to_string(),
+            },
+            PlannedOperation::CreateSnapshot {
+                source: PathBuf::from("/b"),
+                dest: PathBuf::from("/snap/b"),
+                subvolume_name: "sv-b".to_string(),
+            },
+            PlannedOperation::DeleteSnapshot {
+                path: PathBuf::from("/snap/a/old"),
+                reason: "expired".to_string(),
+                subvolume_name: "sv-a".to_string(),
+            },
+        ];
+
+        let groups = group_by_subvolume(&ops);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0].0, "sv-a");
+        assert_eq!(groups[0].1.len(), 2); // create + delete
+        assert_eq!(groups[1].0, "sv-b");
+        assert_eq!(groups[1].1.len(), 1); // create
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,15 @@
+mod btrfs;
 mod chain;
 mod cli;
 mod commands;
 mod config;
 mod drives;
 mod error;
+mod executor;
+mod metrics;
 mod plan;
 mod retention;
+mod state;
 mod types;
 
 use clap::Parser;
@@ -18,10 +22,8 @@ fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Plan(args) => commands::plan_cmd::run(config, args),
-        Commands::Backup(_) => {
-            eprintln!("Not implemented yet — coming in Phase 2");
-            Ok(())
-        }
+        Commands::Backup(args) => commands::backup::run(config, args),
+        Commands::Init => commands::init::run(config),
         Commands::Status => {
             eprintln!("Not implemented yet — coming in Phase 3");
             Ok(())
@@ -32,10 +34,6 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::Verify => {
             eprintln!("Not implemented yet — coming in Phase 3");
-            Ok(())
-        }
-        Commands::Init => {
-            eprintln!("Not implemented yet — coming in Phase 2");
             Ok(())
         }
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,269 @@
+use std::fmt::Write as _;
+use std::path::Path;
+
+use crate::error::UrdError;
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+/// All metrics data for a single backup run.
+pub struct MetricsData {
+    pub subvolumes: Vec<SubvolumeMetrics>,
+    pub external_drive_mounted: bool,
+    pub external_free_bytes: u64,
+    pub script_last_run_timestamp: i64,
+}
+
+/// Per-subvolume metrics for a backup run.
+pub struct SubvolumeMetrics {
+    pub name: String,
+    /// 0 = failure, 1 = success, 2 = schedule-skipped
+    pub success: u8,
+    /// Unix timestamp; only set when success == 1
+    pub last_success_timestamp: Option<i64>,
+    pub duration_seconds: u64,
+    pub local_snapshot_count: usize,
+    /// Count from first mounted drive (for bash compat)
+    pub external_snapshot_count: usize,
+    /// 0 = full, 1 = incremental, 2 = no send
+    pub send_type: u8,
+}
+
+// ── Writer ──────────────────────────────────────────────────────────────
+
+/// Write metrics to the configured .prom file atomically.
+/// Uses temp file + rename in the same directory.
+pub fn write_metrics(path: &Path, data: &MetricsData) -> crate::error::Result<()> {
+    let content = format_metrics(data);
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| UrdError::Io {
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
+    }
+
+    let tmp_path = path.with_extension("prom.tmp");
+    std::fs::write(&tmp_path, &content).map_err(|e| UrdError::Io {
+        path: tmp_path.clone(),
+        source: e,
+    })?;
+
+    std::fs::rename(&tmp_path, path).map_err(|e| UrdError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    Ok(())
+}
+
+fn format_metrics(data: &MetricsData) -> String {
+    let mut out = String::new();
+
+    // backup_success
+    writeln!(out, "# HELP backup_success Backup result: 1=success, 0=failure, 2=schedule-skipped").unwrap();
+    writeln!(out, "# TYPE backup_success gauge").unwrap();
+    for sv in &data.subvolumes {
+        writeln!(out, "backup_success{{subvolume=\"{}\"}} {}", sv.name, sv.success).unwrap();
+    }
+
+    // backup_last_success_timestamp
+    writeln!(out).unwrap();
+    writeln!(out, "# HELP backup_last_success_timestamp Unix timestamp of last successful backup").unwrap();
+    writeln!(out, "# TYPE backup_last_success_timestamp gauge").unwrap();
+    for sv in &data.subvolumes {
+        if let Some(ts) = sv.last_success_timestamp {
+            writeln!(
+                out,
+                "backup_last_success_timestamp{{subvolume=\"{}\"}} {}",
+                sv.name, ts
+            )
+            .unwrap();
+        }
+    }
+
+    // backup_duration_seconds
+    writeln!(out).unwrap();
+    writeln!(out, "# HELP backup_duration_seconds Duration of backup operations in seconds").unwrap();
+    writeln!(out, "# TYPE backup_duration_seconds gauge").unwrap();
+    for sv in &data.subvolumes {
+        writeln!(
+            out,
+            "backup_duration_seconds{{subvolume=\"{}\"}} {}",
+            sv.name, sv.duration_seconds
+        )
+        .unwrap();
+    }
+
+    // backup_snapshot_count
+    writeln!(out).unwrap();
+    writeln!(out, "# HELP backup_snapshot_count Number of snapshots").unwrap();
+    writeln!(out, "# TYPE backup_snapshot_count gauge").unwrap();
+    for sv in &data.subvolumes {
+        writeln!(
+            out,
+            "backup_snapshot_count{{subvolume=\"{}\",location=\"local\"}} {}",
+            sv.name, sv.local_snapshot_count
+        )
+        .unwrap();
+        writeln!(
+            out,
+            "backup_snapshot_count{{subvolume=\"{}\",location=\"external\"}} {}",
+            sv.name, sv.external_snapshot_count
+        )
+        .unwrap();
+    }
+
+    // backup_send_type
+    writeln!(out).unwrap();
+    writeln!(out, "# HELP backup_send_type Send type: 0=full, 1=incremental, 2=no send").unwrap();
+    writeln!(out, "# TYPE backup_send_type gauge").unwrap();
+    for sv in &data.subvolumes {
+        writeln!(
+            out,
+            "backup_send_type{{subvolume=\"{}\"}} {}",
+            sv.name, sv.send_type
+        )
+        .unwrap();
+    }
+
+    // backup_external_drive_mounted
+    writeln!(out).unwrap();
+    writeln!(out, "# HELP backup_external_drive_mounted Whether an external backup drive is mounted").unwrap();
+    writeln!(out, "# TYPE backup_external_drive_mounted gauge").unwrap();
+    writeln!(
+        out,
+        "backup_external_drive_mounted {}",
+        if data.external_drive_mounted { 1 } else { 0 }
+    )
+    .unwrap();
+
+    // backup_external_free_bytes
+    writeln!(out).unwrap();
+    writeln!(out, "# HELP backup_external_free_bytes Free bytes on external backup drive").unwrap();
+    writeln!(out, "# TYPE backup_external_free_bytes gauge").unwrap();
+    writeln!(out, "backup_external_free_bytes {}", data.external_free_bytes).unwrap();
+
+    // backup_script_last_run_timestamp
+    writeln!(out).unwrap();
+    writeln!(out, "# HELP backup_script_last_run_timestamp Unix timestamp of last backup run").unwrap();
+    writeln!(out, "# TYPE backup_script_last_run_timestamp gauge").unwrap();
+    writeln!(
+        out,
+        "backup_script_last_run_timestamp {}",
+        data.script_last_run_timestamp
+    )
+    .unwrap();
+
+    out
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_data() -> MetricsData {
+        MetricsData {
+            subvolumes: vec![
+                SubvolumeMetrics {
+                    name: "subvol3-opptak".to_string(),
+                    success: 1,
+                    last_success_timestamp: Some(1_711_100_000),
+                    duration_seconds: 120,
+                    local_snapshot_count: 15,
+                    external_snapshot_count: 14,
+                    send_type: 1,
+                },
+                SubvolumeMetrics {
+                    name: "htpc-home".to_string(),
+                    success: 2,
+                    last_success_timestamp: None,
+                    duration_seconds: 0,
+                    local_snapshot_count: 20,
+                    external_snapshot_count: 18,
+                    send_type: 2,
+                },
+            ],
+            external_drive_mounted: true,
+            external_free_bytes: 4_400_000_000_000,
+            script_last_run_timestamp: 1_711_100_120,
+        }
+    }
+
+    #[test]
+    fn format_contains_all_metrics() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+
+        assert!(output.contains("backup_success{subvolume=\"subvol3-opptak\"} 1"));
+        assert!(output.contains("backup_success{subvolume=\"htpc-home\"} 2"));
+        assert!(output.contains("backup_last_success_timestamp{subvolume=\"subvol3-opptak\"} 1711100000"));
+        // htpc-home has no last_success_timestamp (skipped)
+        assert!(!output.contains("backup_last_success_timestamp{subvolume=\"htpc-home\"}"));
+        assert!(output.contains("backup_duration_seconds{subvolume=\"subvol3-opptak\"} 120"));
+        assert!(output.contains("backup_snapshot_count{subvolume=\"subvol3-opptak\",location=\"local\"} 15"));
+        assert!(output.contains("backup_snapshot_count{subvolume=\"subvol3-opptak\",location=\"external\"} 14"));
+        assert!(output.contains("backup_send_type{subvolume=\"subvol3-opptak\"} 1"));
+        assert!(output.contains("backup_send_type{subvolume=\"htpc-home\"} 2"));
+        assert!(output.contains("backup_external_drive_mounted 1"));
+        assert!(output.contains("backup_external_free_bytes 4400000000000"));
+        assert!(output.contains("backup_script_last_run_timestamp 1711100120"));
+    }
+
+    #[test]
+    fn format_has_help_and_type_lines() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+
+        assert!(output.contains("# HELP backup_success"));
+        assert!(output.contains("# TYPE backup_success gauge"));
+        assert!(output.contains("# HELP backup_last_success_timestamp"));
+        assert!(output.contains("# TYPE backup_last_success_timestamp gauge"));
+        assert!(output.contains("# HELP backup_duration_seconds"));
+        assert!(output.contains("# HELP backup_snapshot_count"));
+        assert!(output.contains("# HELP backup_send_type"));
+        assert!(output.contains("# HELP backup_external_drive_mounted"));
+        assert!(output.contains("# HELP backup_external_free_bytes"));
+        assert!(output.contains("# HELP backup_script_last_run_timestamp"));
+    }
+
+    #[test]
+    fn write_metrics_atomic() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("backup.prom");
+        let data = sample_data();
+
+        write_metrics(&path, &data).unwrap();
+
+        assert!(path.exists());
+        // No temp file should remain
+        assert!(!dir.path().join("backup.prom.tmp").exists());
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("backup_success"));
+    }
+
+    #[test]
+    fn write_metrics_creates_parent_dirs() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("subdir").join("backup.prom");
+        let data = sample_data();
+
+        write_metrics(&path, &data).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn unmounted_drive_metrics() {
+        let data = MetricsData {
+            subvolumes: vec![],
+            external_drive_mounted: false,
+            external_free_bytes: 0,
+            script_last_run_timestamp: 1_711_100_000,
+        };
+        let output = format_metrics(&data);
+        assert!(output.contains("backup_external_drive_mounted 0"));
+        assert!(output.contains("backup_external_free_bytes 0"));
+    }
+}

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -398,8 +398,8 @@ mod tests {
         );
 
         // Should keep at least 1 (newest), delete the rest
-        assert!(result.keep.len() >= 1);
-        assert!(result.delete.len() >= 1);
+        assert!(!result.keep.is_empty());
+        assert!(!result.delete.is_empty());
         assert!(result.keep.iter().any(|s| s.as_str() == "20260322-home"));
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,266 @@
+use std::path::Path;
+
+use rusqlite::Connection;
+
+use crate::error::UrdError;
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+pub struct StateDb {
+    conn: Connection,
+}
+
+/// A record of a single operation within a backup run.
+pub struct OperationRecord {
+    pub run_id: i64,
+    pub subvolume: String,
+    pub operation: String,
+    pub drive_label: Option<String>,
+    pub duration_secs: Option<f64>,
+    pub result: String,
+    pub error_message: Option<String>,
+    pub bytes_transferred: Option<i64>,
+}
+
+// ── StateDb ─────────────────────────────────────────────────────────────
+
+impl StateDb {
+    /// Open or create the state database at the given path.
+    /// Creates parent directories and schema if needed.
+    pub fn open(path: &Path) -> crate::error::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| UrdError::Io {
+                path: parent.to_path_buf(),
+                source: e,
+            })?;
+        }
+
+        let conn = Connection::open(path).map_err(|e| {
+            UrdError::State(format!("failed to open state DB at {}: {e}", path.display()))
+        })?;
+
+        let db = Self { conn };
+        db.init_schema()?;
+        Ok(db)
+    }
+
+    /// Open an in-memory database (for testing).
+    #[cfg(test)]
+    pub fn open_memory() -> crate::error::Result<Self> {
+        let conn = Connection::open_in_memory()
+            .map_err(|e| UrdError::State(format!("failed to open in-memory DB: {e}")))?;
+        let db = Self { conn };
+        db.init_schema()?;
+        Ok(db)
+    }
+
+    fn init_schema(&self) -> crate::error::Result<()> {
+        self.conn
+            .execute_batch(
+                "CREATE TABLE IF NOT EXISTS runs (
+                    id INTEGER PRIMARY KEY,
+                    started_at TEXT NOT NULL,
+                    finished_at TEXT,
+                    mode TEXT NOT NULL,
+                    result TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS operations (
+                    id INTEGER PRIMARY KEY,
+                    run_id INTEGER REFERENCES runs(id),
+                    subvolume TEXT NOT NULL,
+                    operation TEXT NOT NULL,
+                    drive_label TEXT,
+                    duration_secs REAL,
+                    result TEXT NOT NULL,
+                    error_message TEXT,
+                    bytes_transferred INTEGER
+                );",
+            )
+            .map_err(|e| UrdError::State(format!("failed to create schema: {e}")))?;
+        Ok(())
+    }
+
+    /// Begin a new backup run. Returns the run ID.
+    pub fn begin_run(&self, mode: &str) -> crate::error::Result<i64> {
+        let now = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+        self.conn
+            .execute(
+                "INSERT INTO runs (started_at, mode, result) VALUES (?1, ?2, 'running')",
+                rusqlite::params![now, mode],
+            )
+            .map_err(|e| UrdError::State(format!("failed to begin run: {e}")))?;
+        Ok(self.conn.last_insert_rowid())
+    }
+
+    /// Record a completed operation within a run.
+    pub fn record_operation(&self, op: &OperationRecord) -> crate::error::Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO operations (run_id, subvolume, operation, drive_label, duration_secs, result, error_message, bytes_transferred)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                rusqlite::params![
+                    op.run_id,
+                    op.subvolume,
+                    op.operation,
+                    op.drive_label,
+                    op.duration_secs,
+                    op.result,
+                    op.error_message,
+                    op.bytes_transferred,
+                ],
+            )
+            .map_err(|e| UrdError::State(format!("failed to record operation: {e}")))?;
+        Ok(())
+    }
+
+    /// Finish a run with the given result ("success", "partial", "failure").
+    pub fn finish_run(&self, run_id: i64, result: &str) -> crate::error::Result<()> {
+        let now = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+        self.conn
+            .execute(
+                "UPDATE runs SET finished_at = ?1, result = ?2 WHERE id = ?3",
+                rusqlite::params![now, result, run_id],
+            )
+            .map_err(|e| UrdError::State(format!("failed to finish run: {e}")))?;
+        Ok(())
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_memory_creates_schema() {
+        let db = StateDb::open_memory().unwrap();
+        // Verify tables exist by querying them
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM runs", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn schema_is_idempotent() {
+        let db = StateDb::open_memory().unwrap();
+        // Calling init_schema again should not error
+        db.init_schema().unwrap();
+    }
+
+    #[test]
+    fn begin_and_finish_run() {
+        let db = StateDb::open_memory().unwrap();
+
+        let run_id = db.begin_run("full").unwrap();
+        assert!(run_id > 0);
+
+        // Check run was created with 'running' result
+        let result: String = db
+            .conn
+            .query_row(
+                "SELECT result FROM runs WHERE id = ?1",
+                [run_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(result, "running");
+
+        // Finish the run
+        db.finish_run(run_id, "success").unwrap();
+
+        let (result, finished): (String, String) = db
+            .conn
+            .query_row(
+                "SELECT result, finished_at FROM runs WHERE id = ?1",
+                [run_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(result, "success");
+        assert!(!finished.is_empty());
+    }
+
+    #[test]
+    fn record_operation() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "htpc-home".to_string(),
+            operation: "snapshot".to_string(),
+            drive_label: None,
+            duration_secs: Some(0.5),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: None,
+        })
+        .unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "htpc-home".to_string(),
+            operation: "send_incremental".to_string(),
+            drive_label: Some("WD-18TB".to_string()),
+            duration_secs: Some(120.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(1_000_000),
+        })
+        .unwrap();
+
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM operations WHERE run_id = ?1",
+                [run_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn record_failed_operation() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "subvol3-opptak".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("WD-18TB".to_string()),
+            duration_secs: Some(5.0),
+            result: "failure".to_string(),
+            error_message: Some("btrfs send failed: No space left".to_string()),
+            bytes_transferred: None,
+        })
+        .unwrap();
+
+        let err_msg: Option<String> = db
+            .conn
+            .query_row(
+                "SELECT error_message FROM operations WHERE subvolume = 'subvol3-opptak'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(err_msg.unwrap(), "btrfs send failed: No space left");
+    }
+
+    #[test]
+    fn open_file_db() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db_path = dir.path().join("subdir").join("urd.db");
+
+        let db = StateDb::open(&db_path).unwrap();
+        let run_id = db.begin_run("test").unwrap();
+        db.finish_run(run_id, "success").unwrap();
+
+        assert!(db_path.exists());
+    }
+}


### PR DESCRIPTION
## Summary

- Implement `urd backup` command: creates snapshots, sends to external drives via `btrfs send | btrfs receive`, manages graduated retention, records history in SQLite, writes Prometheus metrics
- Implement `urd init` command: first-run setup with DB creation, path verification, pin file validation, incomplete snapshot detection
- Full Executor Contract implementation with error isolation, cascading failure prevention, crash recovery, and defense-in-depth pin protection
- Architectural adversary review with 5 findings fixed in-session

## Changes

| Module | What |
|---|---|
| `src/btrfs.rs` | `BtrfsOps` trait, `RealBtrfs` (send\|receive pipeline), `MockBtrfs` |
| `src/executor.rs` | Core executor: error isolation, cascading failure, crash recovery, per-drive space tracking |
| `src/state.rs` | SQLite schema (runs + operations), run/operation recording |
| `src/metrics.rs` | Prometheus `.prom` writer, exact bash-compatible format, atomic writes |
| `src/commands/backup.rs` | `urd backup` with `--dry-run`, `flock()` lock file, pin failure warnings |
| `src/commands/init.rs` | DB creation, path/pin verification, partial snapshot detection with user confirmation |
| `src/chain.rs` | Added `write_pin_file()` with atomic temp+rename |
| `src/error.rs` | Added `Btrfs` and `State` error variants |
| `src/commands/plan_cmd.rs` | Extracted `run_with_plan()` for backup dry-run reuse |

### Post-Review Hardening

- **S1**: `space_recovered` moved from per-subvolume bool to per-drive `HashMap` (shared across subvolumes)
- **S2**: `pin_failures` counter on `SubvolumeResult`, visible in backup summary with `WARNING`
- **S3**: `flock()`-based lock file prevents concurrent `urd backup` runs
- **M2**: `execute_delete` uses `subvolume_name` from `PlannedOperation` instead of path heuristics
- **m1**: Removed unused `UrdError::Executor` variant

## Testing

- 100 tests total (32 new), all passing
- `cargo clippy --tests -- -D warnings` clean
- Key executor tests: happy path, error isolation, cascading failure, pin-on-success, pin failure tracking, per-drive space recovery, SQLite integration
- Integration tests on 2TB-backup drive deferred to Phase 3 parallel run

## Plan Phase

Phase 2 of `docs/PLAN.md` (Execute + State + Metrics). Deliverable: successful backup cycle to test drive, `backup.prom` output matches format exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)