### PR TITLE
feat: Pre-send space estimation and first real-world testing

### DIFF
--- a/docs/98-journals/2026-03-23-space-estimation-and-testing.md
+++ b/docs/98-journals/2026-03-23-space-estimation-and-testing.md
@@ -1,0 +1,201 @@
+# Session Journal: Space Estimation & First Real-World Testing
+
+**Date:** 2026-03-23
+**Base commit:** `068f63c` (Phase 4 complete)
+
+## Part 1: What Was Done
+
+### Space estimation feature (+315 / -21 lines, 7 files, 8 new tests)
+
+The planner had no pre-send space checking — sends to undersized drives would run for hours and fail. Built a historical-data-based estimation system:
+
+- **`state.rs`** — New `last_successful_send_size(subvol, drive, send_type)` query. Returns most recent `bytes_transferred` from a successful send of the same type. 5 unit tests.
+- **`plan.rs`** — Extended `FileSystemState` trait with `last_send_size()`. Changed `RealFileSystemState` from unit struct to `RealFileSystemState<'a>` carrying `Option<&'a StateDb>`. Added space check in `plan_external_send`: queries history, applies 1.2x margin, compares against `free - min_free`. Skips with descriptive message if it won't fit. First-ever sends (no history) proceed. 3 unit tests.
+- **`commands/backup.rs`** — Moved `StateDb::open` before planning (was after). Same instance shared with executor. Eliminated duplicate open.
+- **`commands/plan_cmd.rs`** — Opens `StateDb` so `urd plan` shows space-based skips.
+- **`commands/{status,verify,init}.rs`** — Updated to `RealFileSystemState { state: None }`.
+
+Arch-adversary review: `docs/99-reports/2026-03-23-arch-adversary-space-estimation.md`. Score 4-5/5 across dimensions. No critical findings. Two moderate items: pipe bytes vs. on-disk size mismatch (1.2x margin handles common case), and space-skip visibility in plan output.
+
+### First real-world backup testing
+
+All commands run from the installed binary (`cargo install --path .`).
+
+| Step | Command | Result |
+|------|---------|--------|
+| Init | `urd init` | All checks passed. Cleaned 5 partial snapshots on 2TB-backup from interrupted bash transfers. |
+| Plan | `urd plan` | 8 snapshots, 7 sends planned. All sends are full (no incremental chain from bash-era pins). |
+| subvol6-tmp | `urd backup --subvolume subvol6-tmp` | 0.9s. Local snapshot only (`send_enabled=false`). |
+| htpc-root | `urd backup --subvolume htpc-root` | 0.5s first run (snapshot only). 553s second run (full send to WD-18TB1 + 2TB-backup). |
+| subvol1-docs | `urd backup --subvolume subvol1-docs` | 196s. Full send to 2TB-backup. Chain now incremental. |
+| htpc-home | `urd backup --subvolume htpc-home` | 652s. Full send to 2TB-backup (~11 min for full home dir). |
+
+Post-test `urd plan` confirms subvol1-docs and htpc-home are now incremental for subsequent sends.
+
+### Proposal and adversary review of next features
+
+Wrote proposal: `docs/99-reports/2026-03-23-proposal-progress-and-size-estimation.md`. Covers progress indication during sends and proactive size estimation for first-ever sends.
+
+Adversary review of that proposal: `docs/99-reports/2026-03-23-arch-adversary-proposal-review.md`. Key findings:
+
+1. **Record `bytes_transferred` from failed sends** — Highest-value change not in original proposal. The copy thread already counts bytes before the pipe breaks. Recording this makes the system self-healing after one failure.
+2. **Drop Tier 2** (filesystem-level average) — Wrong in both directions for the actual data distribution (7 subvolumes from ~50GB to ~3TB, average lies).
+3. **Drop qgroup option from proposal** — Quotas confirmed off via `btrfs subvolume show` output (`Quota group: n/a`). However, enabling quotas retroactively was discussed as potentially superior to `du -s` caching. See Part 3.
+4. **Keep progress callback out of `BtrfsOps` trait** — Use `AtomicU64` counter in `RealBtrfs`, polled by executor. Trait stays clean.
+5. **Calibrate on snapshots, not live sources** — `du -s` should measure the newest snapshot, not the live subvolume.
+
+### Real-world btrfs command output collected
+
+Ran `btrfs filesystem usage` on all three filesystems (NVMe root, btrfs-pool, WD-18TB1) and `btrfs subvolume show` on all pool subvolumes. Key data:
+
+- btrfs-pool: 10.87TiB used, 3.66TiB free, 4 devices, data single, metadata RAID1
+- NVMe root (/home): 77.64GiB used, 39.40GiB free
+- WD-18TB1: 13.84TiB used, 2.49TiB free, LUKS-encrypted
+- All subvolumes: `Quota group: n/a` — quotas not enabled
+
+---
+
+## Part 2: Hand-Off for Next Session
+
+### Context
+
+The next session should enter planning mode and build two features:
+
+1. **Progress indication during sends**
+2. **Proactive size estimation for first-ever sends**
+
+### Required reading
+
+- `CLAUDE.md` — project conventions, module responsibilities
+- `docs/PLAN.md` — architecture
+- `docs/99-reports/2026-03-23-arch-adversary-proposal-review.md` — the reviewed and revised design direction
+- `docs/99-reports/2026-03-23-proposal-progress-and-size-estimation.md` — original proposal (superseded by adversary review findings on several points)
+
+### Revised design (post-adversary-review)
+
+**Progress counter:**
+- Replace `std::io::copy` in `btrfs.rs:142-145` with a chunked copy loop updating an `AtomicU64` byte counter
+- Do NOT add a progress callback to the `BtrfsOps` trait — keep the trait unchanged
+- The executor creates the counter, constructs `RealBtrfs` with it (or passes it per-send), and polls it from a display thread
+- Only display progress when stdout is a TTY (`std::io::IsTerminal`)
+- Use `\r` to overwrite the line. Show: bytes transferred, rate, elapsed. When estimated total is known, show percentage and ETA
+- `MockBtrfs` is untouched
+
+**Size estimation — three changes, in priority order:**
+
+1. **Record `bytes_transferred` from failed sends.** In `btrfs.rs`, capture the partial byte count from the copy thread even when send/receive fails. Return it alongside the error. In `executor.rs`, record it in SQLite. In the planner, query failed sends with non-null `bytes_transferred` as a lower bound (a failed send that transferred 1.1TB proves the subvolume is at least 1.1TB). This is the highest-value change — it makes the system self-heal after one failure.
+
+2. **`urd calibrate` command.** New command that runs `du -s` on the newest local snapshot for each subvolume. Stores results in a new `subvolume_sizes` SQLite table (`subvolume TEXT PRIMARY KEY, estimated_bytes INTEGER, measured_at TEXT, method TEXT`). Schema migration via `CREATE TABLE IF NOT EXISTS`. The planner queries this as a fallback when Tier 1 (historical send data, including from failures) has no data. Tier 1 always takes priority over calibration.
+
+3. **If qgroups are enabled (see Part 3):** `urd calibrate` can optionally use `btrfs qgroup show -reF` instead of `du -s`. Instant, always-current, no TTL needed. The `method` column in `subvolume_sizes` distinguishes "qgroup" from "du". If qgroups are enabled, calibration is essentially free and could run automatically at the start of every `urd backup`.
+
+**What NOT to build:**
+- Tier 2 (filesystem-level average check) — dropped per adversary review
+- Tier 3 Option A as a separate feature — fold into `urd calibrate` if quotas happen to be enabled
+
+### Key files to modify
+
+| File | Change |
+|------|--------|
+| `src/btrfs.rs` | Chunked copy with `AtomicU64` counter; return partial bytes on failure |
+| `src/executor.rs` | Poll counter for progress display; record partial bytes from failed sends |
+| `src/state.rs` | New `subvolume_sizes` table; query method for calibrated sizes |
+| `src/plan.rs` | Extend `FileSystemState` with `calibrated_size()`; query failed sends in `last_send_size` |
+| `src/commands/calibrate.rs` | New command: `du -s` on newest snapshots, or qgroup if available |
+| `src/cli.rs` | Add `Calibrate` subcommand |
+
+### Testing strategy
+
+- Unit tests with `MockBtrfs` for failed-send byte recording
+- Unit tests for calibration-based space estimation in planner
+- Manual test: run `urd calibrate`, verify sizes in `urd status` or similar, then `urd plan` shows space-based skips for oversized subvolumes on 2TB-backup
+
+---
+
+## Part 3: Enabling BTRFS Quotas (qgroups) on btrfs-pool
+
+Quotas give instant per-subvolume size data, eliminating the need for slow `du -s` walks. On kernel 6.18 with modern btrfs-progs, the performance overhead is acceptable.
+
+### Prerequisites
+
+- Kernel 6.7+ for simple quotas (`squota` mode) — you have 6.18, confirmed
+- btrfs-progs 6.7+ for `--simple` flag — check with `btrfs --version`
+- The filesystem must be mounted read-write
+
+### Step-by-step
+
+**1. Check btrfs-progs version:**
+```bash
+btrfs --version
+```
+Need 6.7+ for `--simple`. If older, use `btrfs quota enable /mnt/btrfs-pool` without the flag (works but uses the older, slower accounting mode).
+
+**2. Enable quotas in simple mode:**
+```bash
+sudo btrfs quota enable --simple /mnt/btrfs-pool
+```
+If `--simple` is not supported by your btrfs-progs version, use:
+```bash
+sudo btrfs quota enable /mnt/btrfs-pool
+```
+Simple quotas (squota) track accounting at the extent level rather than the subvolume tree level. This is significantly faster for snapshot creation and deletion — the exact operations Urd performs frequently.
+
+**3. Wait for the initial accounting scan.**
+
+The scan runs in the background. There is no progress indicator. On a 10.87TiB pool with ~80 snapshots, expect 1-6 hours depending on extent count and disk load. During the scan, qgroup sizes report as 0.
+
+Check if the scan is complete:
+```bash
+sudo btrfs qgroup show -reF /mnt/btrfs-pool
+```
+When the `rfer` (referenced) column shows non-zero values for your subvolumes, the scan is done. Example expected output:
+```
+Qgroupid    Referenced    Exclusive
+--------    ----------    ---------
+0/256       195.23GiB     12.45GiB    (subvol1-docs)
+0/257       847.91GiB    102.33GiB    (subvol2-pics)
+0/258         2.89TiB    456.78GiB    (subvol3-opptak)
+...
+```
+
+The `Referenced` column is what Urd needs — it's the total data reachable from the subvolume, which closely approximates the full send stream size.
+
+**4. Verify with a known subvolume:**
+```bash
+# Compare qgroup referenced size against a known send size
+sudo btrfs qgroup show -reF /mnt/btrfs-pool | grep docs
+# Then check: urd history --subvolume subvol1-docs --last 1
+# The bytes_transferred from the full send should be close to the referenced size
+```
+
+**5. Benchmark snapshot performance (optional but recommended):**
+```bash
+# Time a snapshot create + delete cycle with quotas enabled
+time sudo btrfs subvolume snapshot -r /mnt/btrfs-pool/subvol6-tmp /mnt/btrfs-pool/.snapshots/subvol6-tmp/quota-test
+time sudo btrfs subvolume delete /mnt/btrfs-pool/.snapshots/subvol6-tmp/quota-test
+```
+On kernel 6.18 with simple quotas, snapshot create should be <1 second. If it's noticeably slower (>5 seconds), the overhead may be too high for the 15-minute htpc-home snapshot interval. In that case, consider enabling quotas only on btrfs-pool (not on the NVMe root filesystem where htpc-home lives).
+
+**6. Add sudoers entry for Urd:**
+```bash
+# Add to /etc/sudoers.d/btrfs-backup:
+patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs qgroup show /mnt/btrfs-pool
+patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs qgroup show /mnt
+```
+Note: `btrfs qgroup show` requires the filesystem mount point, not a subvolume path. `/mnt/btrfs-pool` may not work if the pool is mounted at `/mnt` — test which path works.
+
+**7. If performance is unacceptable, disable:**
+```bash
+sudo btrfs quota disable /mnt/btrfs-pool
+```
+This removes all qgroup data. Re-enabling requires another full scan.
+
+### What about the NVMe root filesystem?
+
+htpc-home and htpc-root live on the NVMe (`/`). These are small enough that `du -s` is fast (77GB, <30 seconds). Enabling quotas on the root filesystem is higher-risk (affects all system writes) for lower reward. Recommendation: leave quotas off on NVMe, use `du -s` calibration for htpc-home and htpc-root.
+
+### Impact on Urd when fully operational
+
+When Urd runs at full cadence (15-minute snapshots for htpc-home, hourly for priority 1), the btrfs-pool will accumulate ~200-400 local snapshots across all subvolumes at steady state (governed by retention). Each snapshot create/delete updates qgroup accounting. With simple quotas on kernel 6.18, this should add <100ms per operation — negligible against the I/O time of the snapshot itself.
+
+The real benefit: `urd calibrate` becomes instant (one `btrfs qgroup show` call vs. 7 `du -s` walks), and calibration data is always current. No TTL, no staleness, no silent skips from outdated sizes.

--- a/docs/99-reports/2026-03-23-arch-adversary-proposal-review.md
+++ b/docs/99-reports/2026-03-23-arch-adversary-proposal-review.md
@@ -1,0 +1,209 @@
+# Architectural Adversary Review: Progress & Size Estimation Proposal
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-23
+**Scope:** Proposal review — `docs/99-reports/2026-03-23-proposal-progress-and-size-estimation.md` + conversation context including real `btrfs` command output from the production system
+**Reviewer:** Claude (arch-adversary)
+**Base commit:** `068f63c` (master, post-space-estimation feature)
+
+---
+
+## Executive Summary
+
+The proposal identifies the right problems and the right general direction, but Tier 2 (filesystem-level upper bound) should be dropped — it adds code for a check that's wrong more often than it's right. The progress counter is well-designed. The `urd calibrate` approach is sound but the proposal underestimates a subtle correctness issue with `du -s` vs. btrfs send stream size. The proposal also misses a simpler alternative that solves 80% of the problem with 20% of the machinery.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — retention deletes snapshots that haven't reached all external drives.
+
+**Distance from this proposal:** Far. Neither progress indication nor size estimation affects retention, pin files, or deletion logic. The worst outcome of a bad size estimate is a skipped send (backup delayed) or a failed send (wasted I/O, executor cleans up). Neither path reaches data loss.
+
+That said, there's a subtler risk: **false positives in size estimation could permanently block sends.** If the calibrated size is stale-high (subvolume shrank after data cleanup), the planner would skip sends indefinitely until recalibration. This means a subvolume silently stops getting backed up externally — not data loss, but reduced protection. This is the closest the proposal gets to the catastrophic failure mode and it warrants explicit mitigation.
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 3 | Tier 2 logic is flawed; `du -s` vs. send stream size mismatch unaddressed |
+| Security | 4 | No new privilege escalation paths; sudoers additions are read-only |
+| Architectural Excellence | 4 | Progress counter design preserves existing seams; calibrate is well-separated |
+| Systems Design | 3 | Stale calibration data could silently block sends; no recalibration trigger |
+| Rust Idioms | 4 | Progress callback design is idiomatic; `AtomicU64` is the right primitive |
+| Code Quality | 4 | Proposal is clear and well-structured; good analysis of btrfs command limitations |
+
+## Design Tensions
+
+### 1. Estimation accuracy vs. implementation complexity
+
+**Trade-off:** The proposal offers three tiers of increasing accuracy and cost. This is the right structure. But the middle tier (filesystem upper bound) occupies an awkward position — it's too inaccurate to prevent wasted sends on the only system that matters (the btrfs-pool with 7 subvolumes varying from ~50GB to ~3TB), yet adds code and a concept to explain.
+
+**Verdict:** Drop Tier 2. Go from Tier 1 (already done) directly to Tier 3 (`urd calibrate`). The gap between "no history" and "calibrated size" is exactly one `urd calibrate` run — the user can do this before the first backup. Simpler is better.
+
+### 2. Proactive estimation vs. reactive learning
+
+**Trade-off:** The proposal leans heavily on proactive measurement (calibrate before first send). The alternative is reactive: let the first send attempt proceed, observe the `bytes_transferred` result (even from a failed send), and use that for future planning.
+
+This deserves more attention. Today, the executor records `bytes_transferred: None` for failed sends. But the copy thread *does* count bytes before the pipe breaks. If we recorded the partial byte count from failed sends, the system would learn "subvol5-music sent 1.1TB before failing on the 1.3TB-free drive" — and that's enough to skip it next time. No calibration needed.
+
+**Verdict:** This is a Finding (see below). It doesn't eliminate the need for calibration (you still want to prevent the first wasted attempt), but it means the system self-heals after one failure. That significantly reduces the urgency of `urd calibrate`.
+
+### 3. Progress callback in BtrfsOps trait vs. outside it
+
+**Trade-off:** The proposal adds a progress callback parameter to `send_receive` in the `BtrfsOps` trait. This means `MockBtrfs` must handle it too. An alternative is to keep `BtrfsOps::send_receive` unchanged and have `RealBtrfs` expose the `AtomicU64` byte counter separately — the executor reads it from outside.
+
+**Verdict:** The callback approach is cleaner. The `AtomicU64` approach would require the executor to spawn a polling thread and deal with lifecycle (when to stop polling). The callback inverts the control: the copy loop pushes updates, the executor consumes them. This is the right direction. But the trait change should use a concrete type, not `dyn Fn` — see Finding below.
+
+### 4. `du -s` vs. actual send stream size
+
+**Trade-off:** The proposal assumes `du -s` gives a close estimate of full send size. This is approximately true but has a specific failure mode worth naming.
+
+`du -s` reports the sum of file sizes (or block usage with `--apparent-size`). A btrfs send stream includes:
+- All file data
+- All metadata (xattrs, permissions, directory structure)
+- Inline extents (small files stored in metadata)
+
+But it does NOT include:
+- Extents shared via reflinks (these appear once in the stream, but `du -s` counts them per-file)
+
+For subvolumes with heavy reflink use (CoW copies, deduplication), `du -s` can significantly **overestimate** the send stream size. This matters for subvol3-opptak if recordings share extents, or for subvol7-containers if container images use reflinks.
+
+Conversely, metadata overhead means the send stream can be slightly **larger** than `du -s` reports for subvolumes with millions of small files.
+
+**Verdict:** The 1.2x margin handles the underestimate case. The overestimate case (reflinks) could cause false-positive skips. This should be documented and the margin should be tunable.
+
+## Findings
+
+### Significant
+
+#### Finding 1: Record `bytes_transferred` from failed sends
+
+**What:** Today, `executor.rs` records `bytes_transferred: None` for failed sends (lines 420-424). But `btrfs.rs` returns `Err(UrdError::Btrfs(...))` without the byte count, even though the copy thread has already counted bytes before the pipe broke.
+
+**Consequence:** After a failed send to an undersized drive, the system has no data to prevent the same wasted attempt next run. The user must either run `urd calibrate` or wait for a successful send to a different drive (which may never happen for that subvolume if it's too large for all configured drives except the unmounted one).
+
+**Suggested fix:** In `btrfs.rs`, when the send fails, capture the byte count from the copy thread and include it in the error or return it alongside the error. Then in the executor, record it as a failed operation with `bytes_transferred` populated.
+
+One approach:
+
+```rust
+// In btrfs.rs, change the error return to also carry partial byte count:
+struct SendFailure {
+    error: UrdError,
+    bytes_transferred: Option<u64>,
+}
+```
+
+Or simpler: change `send_receive` to always return `SendResult` alongside `Result`, e.g., `Result<SendResult, (UrdError, Option<u64>)>`.
+
+Then in the planner's `last_send_size` query, consider also querying failed sends with non-null `bytes_transferred` as a lower bound. If a failed send transferred 1.1TB before dying, the full subvolume is at least 1.1TB — enough to skip a drive with 1.3TB free given the 1.2x margin.
+
+**Priority:** High. This makes the system self-healing after one failed attempt, which is the exact scenario the proposal is trying to prevent. It's also cheaper than `urd calibrate` and requires no user action.
+
+#### Finding 2: Stale calibration can silently block sends
+
+**What:** The `subvolume_sizes` table stores `estimated_bytes` with a `measured_at` timestamp, and the proposal mentions a TTL. But the proposal doesn't specify what happens when a calibration entry exists but is stale, or when a subvolume shrinks after data deletion.
+
+**Consequence:** If `subvol3-opptak` is calibrated at 3TB, then the user deletes 1.5TB of old recordings, the calibrated size blocks sends to the 2TB-backup drive even though the subvolume now fits. The planner sees "estimated ~3.6TB (with 1.2x margin) > 1.3TB free" and skips indefinitely. The user gets no indication that the skip reason is stale data.
+
+**Suggested fix:** Two mitigations:
+
+1. **Age-based staleness warning.** If calibration data is older than N days (configurable, default 30), include "calibrated N days ago — run `urd calibrate` to refresh" in the skip message. This makes stale data visible.
+
+2. **Successful-send-overrides-calibration.** If Tier 1 (historical send data) has a value, always prefer it over Tier 3 (calibration). `bytes_transferred` from a real send is ground truth. Calibration is only the fallback for first-ever sends.
+
+3. **Auto-recalibrate on first send to new drive.** When the planner would use calibration data to skip a send, and there's no Tier 1 history for that (subvolume, drive, send_type) triple, flag it as "estimated from calibration — may be stale" rather than silently skipping.
+
+### Moderate
+
+#### Finding 3: Tier 2 (filesystem upper bound) is not worth building
+
+**What:** The proposal recommends Tier 2: "If the filesystem total used exceeds destination free x number of subvolumes on that root, log a warning."
+
+**Why it fails:** The btrfs-pool has 10.87TiB used across 7 subvolumes. The average is ~1.55TB. But the actual distribution is wildly uneven — subvol1-docs is likely ~200GB while subvol5-music is ~1TB+. An average-based check would:
+- **False-positive skip** subvol1-docs on 2TB-backup (average 1.55TB > 1.3TB free, but actual ~200GB fits easily)
+- **False-negative allow** subvol5-music on 2TB-backup (if the average happened to be below free space due to many small subvolumes, the 1TB+ music would still fail)
+
+The "per-root-group" refinement acknowledges this weakness but doesn't fix it — the distribution is the problem, not the averaging method.
+
+**Suggested fix:** Drop Tier 2 entirely. The implementation cost is low but it adds a concept that's wrong more often than right, and wrong in both directions. Go directly from Tier 1 (history) to Tier 3 (calibration). The gap is exactly one `urd calibrate` run.
+
+#### Finding 4: Progress callback should not change the `BtrfsOps` trait signature
+
+**What:** The proposal adds `progress: Option<&dyn Fn(SendProgress)>` to `send_receive` in the `BtrfsOps` trait. This forces `MockBtrfs` to accept a parameter it will never use, and adds a `dyn Fn` trait object to an interface that's currently simple and clean.
+
+**Consequence:** Every test that calls `send_receive` must now pass `None` as the progress parameter, or the trait becomes harder to mock. The progress callback is a presentation concern — it doesn't affect the send's correctness, and the mock doesn't need to know about it.
+
+**Suggested fix:** Keep `BtrfsOps::send_receive` unchanged. Instead, add a separate `send_receive_with_progress` method only on `RealBtrfs` (not on the trait). The executor can downcast or use a different code path for real vs. mock. Or simpler: have `RealBtrfs` accept an `Arc<AtomicU64>` byte counter in its constructor, which the copy loop updates. The executor creates the counter, passes it to `RealBtrfs`, and polls it for progress display. The trait stays clean.
+
+Actually, the cleanest approach: the executor already knows whether it has a TTY. It can construct a `RealBtrfs` that has a byte counter, spawn a progress display thread that polls the counter, and let the existing `send_receive` trait method work unchanged. The counter is an implementation detail of `RealBtrfs`, not a contract on `BtrfsOps`.
+
+#### Finding 5: `du -s` measures the source subvolume, not the snapshot
+
+**What:** The proposal says "Run `du -s --apparent-size <source_path>` to measure the live subvolume." But sends operate on *snapshots*, not live subvolumes. A snapshot is a point-in-time freeze — its size may differ from the live subvolume if data was added or deleted between the snapshot and the calibration.
+
+**Consequence:** For subvolumes with high churn (htpc-home, subvol7-containers), the difference could be significant. A `du -s` on `/home` right now gives 77.64GB, but the snapshot taken 15 minutes ago might be 77.5GB or 77.8GB. For static subvolumes (music, multimedia), the difference is negligible.
+
+**Suggested fix:** Run `du -s` on the most recent snapshot, not the live source. The snapshot directory is known from the config (`root/subvol_name/latest_snapshot`). This gives the exact size that would be sent. For the `urd calibrate` command, iterate subvolumes, find their newest local snapshot, and `du -s` that.
+
+Caveat: if the snapshot is a read-only btrfs subvolume (which it is), `du -s` still works and gives the correct size. No sudo needed since the files are readable by the user.
+
+### Minor
+
+#### Finding 6: Progress display format should handle very large transfers
+
+**What:** The proposal shows `12.4GB / ~45.2GB`. For subvol3-opptak at ~3TB, this would show `1234.5GB / ~3000.0GB`. The `ByteSize` Display impl handles TiB, so it would actually be `1.2TB / ~3.0TB`, which is fine. But the elapsed time and ETA for a multi-hour transfer should use a clear format.
+
+**Suggested fix:** For transfers over 1 hour, show `[1:23:45 / ~4:30:00]` instead of `[83:45 / ~270:00]`. Use `HH:MM:SS` format. The proposal's `[2:18 / ~7:26]` example is ambiguous — is that hours:minutes or minutes:seconds?
+
+### Commendations
+
+#### Commendation 1: TTY detection for progress output
+
+The proposal correctly identifies that progress output must be suppressed when stdout is not a TTY (systemd journal, piped output, cron). `std::io::stdout().is_terminal()` is the right API, and it was called out explicitly. This is the kind of systems-awareness that separates a tool that works in testing from one that works in production.
+
+#### Commendation 2: Honest assessment of btrfs command limitations
+
+The "Available btrfs commands and what they tell us" section is excellent. Each command is evaluated with a clear verdict, backed by what actually happens on the production system (now confirmed with real output). The proposal doesn't pretend `btrfs subvolume show` gives useful size data — it names the limitation and moves on. This kind of honest assessment prevents wasted implementation effort.
+
+#### Commendation 3: Fail-open as default for missing data
+
+The existing Tier 1 implementation and the proposal's overall philosophy of "if we don't know, let it try" is correct for a backup tool. The only danger is silent permanent skipping from stale calibration (Finding 2), which is the mirror failure of fail-open and needs explicit mitigation.
+
+## The Simplicity Question
+
+**What should be removed?**
+
+- **Tier 2 (filesystem upper bound).** Adds code and a concept for a check that's wrong in both directions for the actual data distribution. Drop it.
+- **Tier 3 Option A (opportunistic qgroup).** Quotas are confirmed off. This option exists only for hypothetical future users who might enable quotas. It's speculative complexity. If a future user wants qgroup support, they can add it then. Don't build it now.
+
+**What should be added that isn't in the proposal?**
+
+- **Record partial byte counts from failed sends.** This is the single highest-value change not in the proposal. It makes the system self-healing.
+
+**What's earning its keep?**
+
+- **Progress counter.** Every send benefits. High value, low complexity.
+- **`urd calibrate` with cached sizes.** Solves the first-send problem definitively. Worth the new table and command.
+- **Tier 1 (historical send data).** Already built, already working. Foundation for everything else.
+
+## Priority Action Items
+
+1. **Record `bytes_transferred` from failed sends** — Highest value-to-effort ratio. Makes the system learn from failures without user intervention. Requires changes to `btrfs.rs` error path and `executor.rs` recording logic.
+
+2. **Build the progress counter** — Highest UX impact. Keep it outside the `BtrfsOps` trait. Use an `AtomicU64` counter in `RealBtrfs` that the executor polls for display.
+
+3. **Build `urd calibrate`** — Runs `du -s` on the newest snapshot (not the live source) for each subvolume. Stores results in `subvolume_sizes` table. Planner queries this as Tier 3 fallback when Tier 1 has no data.
+
+4. **Add staleness warning to calibration-based skips** — When a skip is based on calibration data older than 30 days, include the age in the skip message.
+
+5. **Drop Tier 2 and Tier 3 Option A** — Simplify the plan. Don't build what doesn't earn its keep.
+
+6. **Ensure Tier 1 always overrides Tier 3** — Historical send data is ground truth. Calibration is a fallback for first-ever sends only.
+
+## Open Questions
+
+1. **How fast is `du -s` on your largest snapshots?** The proposal says "minutes for large subvolumes." For subvol3-opptak (~3TB of recordings), this could be 5-15 minutes depending on file count and disk cache state. Is this acceptable for a manual `urd calibrate` run? Consider running it with `--one-file-system` to avoid crossing mount points, and with `ionice -c3` to avoid disrupting other I/O.
+
+2. **Does the copy thread in `btrfs.rs` actually have the byte count when the send fails?** The `copy_thread.join().unwrap_or(Ok(0)).ok()` on line 158 — if the pipe breaks due to a full disk, `io::copy` returns the number of bytes successfully copied before the error. This should be the partial count. Worth verifying with a test on the actual system.
+
+3. **Should `urd calibrate` run automatically as part of `urd init`?** For the initial setup case, the user runs `urd init` and then discovers their first send will fail because there's no history. If `urd init` offered to calibrate sizes (with a "this may take several minutes" warning), the first `urd backup` would already have size data.

--- a/docs/99-reports/2026-03-23-arch-adversary-space-estimation.md
+++ b/docs/99-reports/2026-03-23-arch-adversary-space-estimation.md
@@ -1,0 +1,114 @@
+# Architectural Adversary Review: Pre-Send Space Estimation
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-23
+**Scope:** Space estimation feature — 7 files, +315 / -21 lines
+**Base commit:** `068f63c` (master)
+**Reviewer:** Claude (arch-adversary)
+
+---
+
+## Executive Summary
+
+A clean, well-scoped feature that prevents wasted I/O by skipping sends that won't fit. The implementation respects the planner/executor separation, fails open (no history = proceed), and uses the existing architectural seams correctly. Two moderate findings, no critical issues.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — retention deletes snapshots that haven't been sent to all external drives.
+
+**Distance from this change:** Far. The space estimation feature only *skips* sends; it never triggers deletions. A false positive (incorrectly skipping a send that would have fit) delays external backup but does not delete data. A false negative (allowing a send that won't fit) wastes I/O but the executor's crash recovery handles the partial. Neither path reaches the catastrophic failure mode.
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | Logic is sound; one edge case worth noting (see Finding 1) |
+| Security | 5 | No new trust boundaries; no new paths to privileged operations |
+| Architectural Excellence | 5 | Extends the existing trait seam perfectly; planner stays pure |
+| Systems Design | 4 | Fails open correctly; one observability gap (see Finding 2) |
+| Rust Idioms | 5 | Clean trait extension, proper lifetime handling, no unnecessary complexity |
+| Code Quality | 4 | Tests cover the three main paths; good test coverage proportional to risk |
+
+## Design Tensions
+
+### 1. Accuracy vs. simplicity in estimation
+
+**Trade-off:** Using last send size × 1.2 instead of a statistical model (average, median, weighted).
+
+**Why this is right:** A single data point with a margin is dead simple, predictable, and easy to reason about. Subvolumes like `subvol3-opptak` (recordings) grow monotonically — yesterday's full send is a lower bound for today's. Subvolumes that churn (home, containers) have incremental sends that are small and unlikely to hit space limits. The 20% margin is conservative enough. A weighted average across multiple historical sends would be more "accurate" but also more complex, harder to explain in skip messages, and not meaningfully better for the real failure mode (200GB subvolume vs 1.2TB drive).
+
+### 2. Fail-open vs. fail-closed on missing history
+
+**Trade-off:** No history → allow the send, even to a tiny drive.
+
+**Why this is right:** The alternative (fail-closed: block sends without history) would prevent Urd from ever completing its first send to a new drive, creating a chicken-and-egg problem. The first send *should* attempt — if it fails, the executor cleans up, and the next run has history to use. This is the correct bootstrap behavior.
+
+### 3. Per-drive vs. cross-drive estimation
+
+**Trade-off:** The query filters by `(subvolume, drive_label, send_type)` rather than using any-drive history as a fallback.
+
+**Why this is right for incrementals** — incremental sizes vary by how long since last send, which is per-drive. **Arguable for full sends** — a full send of the same snapshot is the same size regardless of destination. If you've never done a full send to 2TB-backup but you have done one to WD-18TB, the WD-18TB history would be a valid estimate. This is a minor gap that only matters during the very first full send to a new drive, so it's acceptable.
+
+## Findings
+
+### Moderate
+
+#### Finding 1: `bytes_transferred` is pipe bytes, not on-disk usage
+
+**What:** The `bytes_transferred` value comes from `std::io::copy` between `btrfs send` stdout and `btrfs receive` stdin (`btrfs.rs:142-145`). This is the *send stream* size, not the resulting on-disk size at the destination. For full sends, the destination snapshot's on-disk size depends on BTRFS metadata overhead, compression settings, and CoW reflinks — it can be larger or smaller than the stream.
+
+**Consequence:** The 1.2x margin handles the common case (on-disk is slightly larger than stream), but for heavily-compressed source data or subvolumes with many reflinks, the ratio could exceed 1.2x. For a 200GB subvolume, a 1.5x ratio means 300GB on disk vs. 240GB estimated — the send proceeds, fills the drive, and the executor cleans up the partial.
+
+**Why this is moderate, not significant:** The executor already handles failed sends gracefully (partial cleanup, no data loss). The worst case is a wasted transfer, which is the exact problem this feature was built to prevent — but for an edge case with unusual compression ratios. The 1.2x margin is a reasonable starting point.
+
+**Suggested fix:** No code change needed now. After accumulating real-world data from production runs, compare `bytes_transferred` against actual on-disk usage (via `btrfs subvolume show` if quotas are enabled, or `du -s` on the destination). If the ratio consistently exceeds 1.2x, bump the margin. Consider making the margin configurable in `urd.toml` as a future refinement.
+
+#### Finding 2: Space-skip not visible in `urd plan` output format
+
+**What:** When a send is skipped due to space estimation, the skip message goes into `backup_plan.skipped` as `(subvol_name, reason)`. The `plan_cmd.rs` renderer shows these as `[SKIP]` lines. However, the message format is dense:
+
+```
+[SKIP] send to 2TB-backup skipped: estimated ~240.0GB exceeds 100.0GB available (free: 200.0GB, min_free: 100.0GB)
+```
+
+This is informative but may not stand out from other skip reasons (interval not elapsed, drive not mounted, already sent). An operator glancing at `urd plan` might not realize a subvolume *will never* reach a drive due to size constraints vs. one that will reach it next run.
+
+**Consequence:** Reduced operational visibility. Not a correctness issue — the skip reason is there if you read it.
+
+**Suggested fix:** Consider prefixing with a distinct marker like `[SKIP:SPACE]` or using a different color for space-based skips. Low priority.
+
+### Commendations
+
+#### Commendation 1: Planner purity preserved
+
+The most important architectural property of Urd is planner/executor separation. This feature needed database access in the planner — a natural temptation to break the purity constraint. Instead, the implementation extends `FileSystemState` with `last_send_size()`, pipes `StateDb` through `RealFileSystemState` via a reference, and keeps `MockFileSystemState` trivially mockable. The planner still takes `&dyn FileSystemState` and never knows about SQLite. This is the correct way to add state-dependent logic to a pure function.
+
+#### Commendation 2: Backward-compatible trait extension
+
+Adding `last_send_size` to `FileSystemState` with `MockFileSystemState::new()` initializing `send_sizes` as empty means `None` is returned for all existing tests. Every existing test passes without modification — no behavioral change. This is clean trait evolution.
+
+#### Commendation 3: StateDb consolidation in backup.rs
+
+Moving `StateDb::open` before planning and sharing the same instance with the executor eliminates a duplicate open. This is a net simplification — fewer system calls, fewer error paths, and the `Option<StateDb>` → `Option<&StateDb>` pattern handles both planning and execution cleanly.
+
+#### Commendation 4: Fail-open safety
+
+`unwrap_or(u64::MAX)` for filesystem queries on non-existent directories, `saturating_sub` for the min_free calculation, and `None` → proceed for missing history. Every edge case fails toward allowing the send, not blocking it. For a backup tool, "try and clean up" is strictly better than "refuse to back up" when the estimation is uncertain.
+
+## The Simplicity Question
+
+**What could be removed?** Nothing. This is 151 new lines in `plan.rs` (including 80 lines of tests) and 145 in `state.rs` (including 100 lines of tests). The production code is ~45 lines in `plan.rs` and ~30 lines in `state.rs`. For the value it provides (preventing multi-hour wasted transfers), this is well-proportioned.
+
+**What's earning its keep?** The `send_type` parameter in the query. At first glance, you might think "just query the last send, regardless of type." But full sends are orders of magnitude larger than incrementals. If you used incremental history to estimate a full send, you'd always allow it. If you used full send history to estimate an incremental, you'd always block it. The type-specific query is load-bearing.
+
+## Priority Action Items
+
+1. **No critical or significant items.** Ship as-is.
+2. (Optional) After production data accumulates, validate the 1.2x margin against actual on-disk usage.
+3. (Optional) Consider a distinct skip marker for space-based skips in `urd plan` output.
+
+## Open Questions
+
+1. **What is the actual pipe-to-disk ratio for your subvolumes?** If BTRFS compression is enabled on the destination, the on-disk size could be significantly smaller than the pipe bytes, making the 1.2x margin overly conservative (false positives — skipping sends that would fit). If compression is disabled, the ratio is typically close to 1.0x, making 1.2x well-calibrated.
+
+2. **Should the margin be configurable?** A `space_estimation_margin = 1.2` field in `[defaults]` would let operators tune it. Not needed now, but worth considering if the fixed 1.2x causes friction.

--- a/docs/99-reports/2026-03-23-proposal-progress-and-size-estimation.md
+++ b/docs/99-reports/2026-03-23-proposal-progress-and-size-estimation.md
@@ -1,0 +1,264 @@
+# Proposal: Send Progress Indication & Proactive Size Estimation
+
+**Date:** 2026-03-23
+**Status:** Proposal
+**Context:** During first real-world testing, two UX gaps emerged:
+1. Long-running sends show only a blinking cursor — no indication of progress or what's happening
+2. Full sends to undersized drives (e.g., 1TB+ music to 2TB-backup) attempt and fail after hours, wasting time and I/O
+
+---
+
+## Problem 1: Silent Progress
+
+### What happens today
+
+When `urd backup` runs a send, the executor calls `btrfs.send_receive()` which pipes `btrfs send` stdout to `btrfs receive` stdin via `std::io::copy` in a background thread. The copy thread counts bytes but only reports the total after completion. During the transfer — which can take minutes to hours — the terminal shows nothing.
+
+An experienced user recognizes a blinking cursor as "working." A new user might think Urd has hung.
+
+### Proposed solution: Live transfer counter
+
+Replace the atomic `std::io::copy` in `btrfs.rs` with a chunked copy loop that reports progress periodically.
+
+#### What to show
+
+```
+  htpc-home -> WD-18TB1 (incremental)  47.3MB / ? @ 156.2MB/s  [0:03]
+  subvol3-opptak -> 2TB-backup (full)  12.4GB / ~45.2GB @ 89.1MB/s  [2:18 / ~7:26]
+```
+
+Two modes:
+- **Unknown total** (always true for incremental, true for first full send): Show bytes transferred, transfer rate, elapsed time. No percentage bar.
+- **Known estimate** (full send with historical `bytes_transferred` or btrfs-reported size): Show bytes transferred, estimated total, transfer rate, elapsed time, estimated remaining.
+
+#### Implementation
+
+**`btrfs.rs`** — Add a progress callback to `send_receive`:
+
+```rust
+pub struct SendProgress {
+    pub bytes_transferred: u64,
+    pub elapsed: Duration,
+    pub rate_bytes_per_sec: f64,
+}
+
+fn send_receive(
+    &self,
+    snapshot: &Path,
+    parent: Option<&Path>,
+    dest: &Path,
+    progress: Option<&dyn Fn(SendProgress)>,
+) -> Result<SendResult>
+```
+
+The copy thread changes from `std::io::copy` to a loop reading 256KB chunks, updating an `AtomicU64` byte counter. A separate reporting thread (or the main thread via periodic check) calls the progress callback every 1-2 seconds.
+
+**`executor.rs`** — Pass a closure that formats and prints the progress line using `\r` (carriage return) to overwrite the current line. When the send completes, print the final line with a newline.
+
+**`BtrfsOps` trait** — The trait method signature gets the optional callback. `MockBtrfs` ignores it.
+
+**Terminal detection** — Only show progress when stdout is a TTY (`std::io::stdout().is_terminal()` on Rust 1.70+). When piped or running under systemd (no TTY), skip progress output to avoid polluting logs.
+
+#### Complexity: Low-Medium
+
+~50 lines in `btrfs.rs` (chunked copy + atomic counter), ~30 lines in `executor.rs` (progress formatting), minor trait change. No architectural impact.
+
+#### Risks
+
+- **Performance**: 256KB chunk reads add negligible overhead vs. the `std::io::copy` 8KB default. The `io::copy` implementation already reads in chunks internally.
+- **Thread safety**: The `AtomicU64` byte counter is lock-free. The reporting thread only reads it.
+- **Systemd compatibility**: No TTY detection avoids spurious output in journal logs.
+
+---
+
+## Problem 2: Proactive Size Estimation for First Sends
+
+### What happens today
+
+The space estimation implemented today queries SQLite for historical `bytes_transferred`. This works well after the first successful send — but for first-ever full sends, there's no history. The planner allows the send to proceed (fail-open), which is correct for safety but means a 1TB music subvolume will attempt to send to a 2TB drive, run for hours, and fail when the drive fills up.
+
+### The challenge
+
+BTRFS doesn't make it easy to know "how big will this send stream be?" before running the send. The send stream size depends on:
+- **Full send**: All data in the snapshot — roughly equals the subvolume's data usage
+- **Incremental send**: Only the delta since the parent — unpredictable without running the diff
+
+For full sends (the problematic case), we need to estimate the source subvolume's data size and compare it against destination free space.
+
+### Available btrfs commands and what they tell us
+
+#### `sudo btrfs subvolume show <path>`
+
+Shows subvolume metadata. Example output:
+```
+/mnt/btrfs-pool/subvol5-music
+        Name:                   subvol5-music
+        UUID:                   a1b2c3d4-...
+        ...
+        Exclusive:              0.00B
+```
+
+The **Exclusive** field shows data unique to this subvolume. However, this field is only populated when **quotas (qgroups) are enabled**. Without quotas, it reports `0.00B` or `none`.
+
+**Verdict:** Unreliable without quotas. Enabling quotas has a performance cost (BTRFS tracks per-subvolume usage on every write). Not recommended to require it.
+
+#### `sudo btrfs filesystem usage <path>`
+
+Shows space breakdown for the entire filesystem. Example:
+```
+Overall:
+    Device size:            18.19TiB
+    Device allocated:       12.73TiB
+    Used:                   12.47TiB
+    Free (estimated):        5.72TiB
+    ...
+Data,single: Size:12.70TiB, Used:12.45TiB
+Metadata,DUP: Size:15.00GiB, Used:10.27GiB
+```
+
+This tells us how much data is on the **entire filesystem**, not per-subvolume. Useful for destination free space (more accurate than `statvfs` because it accounts for BTRFS metadata overhead), but not for estimating a single subvolume's size.
+
+**Verdict:** Useful for accurate destination free space. Not useful for per-subvolume source size.
+
+#### `sudo btrfs filesystem show <path>`
+
+Shows device-level info (device sizes, used). Similar to `filesystem usage` but less detailed. Already in sudoers.
+
+**Verdict:** Redundant with `statvfs` for free space. No per-subvolume info.
+
+#### `sudo btrfs filesystem du <path>` (or `du -s <snapshot>`)
+
+Walks the directory tree and sums file sizes. Gives the actual data size of a snapshot directory.
+
+**Verdict:** Accurate but **very slow** for large subvolumes. Running `du -s` on a 1TB music collection could take minutes itself. Acceptable as a one-time calibration, not as a per-run check.
+
+#### `sudo btrfs qgroup show <path>`
+
+If quotas are enabled, shows per-subvolume data usage (referenced and exclusive bytes). This is the ideal data source.
+
+**Verdict:** Accurate and fast — but requires quotas to be enabled. Could be used opportunistically.
+
+### Proposed solution: Layered estimation
+
+A three-tier approach, each tier more accurate but more expensive:
+
+#### Tier 1: Historical data (already implemented)
+
+Query `bytes_transferred` from SQLite for the last successful send of the same type. Apply 1.2x safety margin.
+
+- **When it works:** After the first successful send
+- **Cost:** One SQLite query, negligible
+- **Accuracy:** Good for incrementals, good-enough for full sends of stable subvolumes
+
+#### Tier 2: Filesystem-level upper bound (new, cheap)
+
+For full sends where Tier 1 has no data: compare the **source filesystem's total used space** against the **destination's free space**. If the entire source filesystem is larger than the destination's free space, no individual subvolume can possibly fit.
+
+This is a coarse check but catches the obvious cases: "this 8TB pool can't possibly fit on a 2TB drive."
+
+Implementation:
+- Call `filesystem_free_bytes()` on the source subvolume's path (already available via `statvfs`)
+- Call `filesystem_free_bytes()` on the destination drive
+- If source filesystem total used > destination free, skip
+
+More precisely: get the source filesystem's *used* bytes. This requires either:
+- `statvfs`: `total_blocks - available_blocks` gives used space (but this is filesystem-wide)
+- `btrfs filesystem usage`: more accurate, accounts for metadata
+
+This catches: "The btrfs-pool has 12TB of data, 2TB-backup has 1.3TB free — even the smallest subvolume probably won't trigger a false skip, but the 1TB+ subvolumes definitely won't fit."
+
+The weakness: a filesystem with 12TB used might have nine subvolumes of varying sizes. The 50GB docs subvolume fits fine on 2TB-backup even though the pool total is 12TB. So this tier only catches the "destination is clearly too small for anything from this pool" case.
+
+**Refinement — per-root-group check:**
+Since `local_snapshots.roots` groups subvolumes by filesystem, we could track which subvolumes share a filesystem and compare counts. If a root has 7 subvolumes and the filesystem uses 12TB, the average is ~1.7TB per subvolume. If the destination has 1.3TB free, flag a warning. This is still coarse but better than nothing.
+
+- **Cost:** One additional `statvfs` call per source root, per plan run
+- **Accuracy:** Low — only catches the "obviously impossible" cases
+- **Sudoers:** No new entries needed (`statvfs` is unprivileged)
+
+#### Tier 3: Source subvolume size estimation (new, moderate cost)
+
+For full sends where Tier 1 has no data and Tier 2 didn't skip: estimate the specific subvolume's data size.
+
+**Option A: Opportunistic qgroup query**
+
+Try `sudo btrfs qgroup show -reF <path>`. If quotas are enabled, this returns per-subvolume "referenced" bytes in one fast query. If quotas are disabled, the command fails — fall back gracefully.
+
+```rust
+fn try_qgroup_size(&self, subvol_path: &Path) -> Option<u64> {
+    // Run: sudo btrfs qgroup show -reF <filesystem_path>
+    // Parse the output for the subvolume's qgroup entry
+    // Return referenced bytes, or None if quotas disabled/parse fails
+}
+```
+
+- **Cost:** One subprocess call, fast if quotas are enabled
+- **Accuracy:** Exact subvolume data size
+- **Sudoers:** Needs new entry: `btrfs qgroup show /mnt/btrfs-pool` (read-only, safe)
+- **Failure mode:** If quotas are disabled, returns None — Tier 2 or fail-open applies
+
+**Option B: `du -s` on source (not snapshot)**
+
+Run `du -s --apparent-size <source_path>` to measure the live subvolume. This gives the current data size, which is a close estimate of what a full send of a recent snapshot would be.
+
+- **Cost:** High — walks entire directory tree. Minutes for large subvolumes.
+- **Accuracy:** Very accurate upper bound
+- **Sudoers:** No new entries needed (read-only traversal as user)
+- **Failure mode:** Slow. Unacceptable as a per-run check.
+
+**Option C: Cached `du` with TTL**
+
+Run `du -s` once, store the result in SQLite with a timestamp. Reuse the cached value for subsequent plans until it expires (e.g., 7-day TTL for priority 3 subvolumes, 1-day for priority 1). A background job or `urd calibrate` command could refresh stale entries.
+
+```sql
+CREATE TABLE subvolume_sizes (
+    subvolume TEXT PRIMARY KEY,
+    estimated_bytes INTEGER NOT NULL,
+    measured_at TEXT NOT NULL,
+    method TEXT NOT NULL  -- "qgroup", "du", "send_history"
+);
+```
+
+- **Cost:** One-time expensive measurement, then free lookups
+- **Accuracy:** Good, degrades as subvolume grows between measurements
+- **Complexity:** New table, new command or background logic, TTL management
+
+### Recommendation
+
+**Phase 1 (implement now):**
+- Tier 1 is already done
+- Add Tier 2 as a cheap sanity check — one `statvfs` call on the source path's filesystem. If the filesystem total used exceeds destination free × number of subvolumes on that root, log a warning. This is ~10 lines of code.
+
+**Phase 2 (implement after cutover):**
+- Add Option A (opportunistic qgroup query). Try it; if quotas aren't enabled, fall back. If they are, you get exact sizes for free.
+- Add a `urd calibrate` command that runs `du -s` on each source subvolume and stores results in SQLite. The user runs this once manually; the planner uses cached sizes as Tier 3 fallback.
+
+**Phase 3 (if needed):**
+- If qgroups aren't enabled and `urd calibrate` is too manual, consider enabling qgroups on the btrfs-pool and measuring the performance impact. Modern BTRFS (kernel 6.x) has significantly improved qgroup performance.
+
+### Sudoers changes needed
+
+For Tier 3 Option A (qgroup query):
+```
+patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs qgroup show /mnt/btrfs-pool
+patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs qgroup show /
+```
+
+For `btrfs filesystem usage` (if used for accurate destination free space):
+```
+patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs filesystem usage /run/media/patriark/*
+patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs filesystem usage /mnt/btrfs-pool
+```
+
+---
+
+## Implementation Priority
+
+| Feature | Effort | Value | Priority |
+|---------|--------|-------|----------|
+| Progress counter during sends | Low-Medium | High (UX) | Do first |
+| Tier 2 filesystem upper bound | Low | Medium | Do with progress |
+| Tier 3a opportunistic qgroup | Medium | High (accuracy) | After cutover |
+| `urd calibrate` command | Medium | Medium | After cutover |
+
+The progress counter is the highest-value change — it transforms the user experience for every send, not just the edge case of too-large subvolumes. The Tier 2 check is cheap enough to bundle with it. Tier 3 can wait until Urd is the sole backup system and there's real-world data on how often the first-send estimation gap matters.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -33,7 +33,15 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         "full"
     };
 
-    let fs_state = RealFileSystemState;
+    let state_db = match StateDb::open(&config.general.state_db) {
+        Ok(db) => Some(db),
+        Err(e) => {
+            log::warn!("Failed to open state DB, continuing without history: {e}");
+            None
+        }
+    };
+
+    let fs_state = RealFileSystemState { state: state_db.as_ref() };
     let backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
 
     // Dry run: print plan and exit (no lock needed)
@@ -63,14 +71,6 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 
     // Set up executor
     let btrfs = RealBtrfs::new(&config.general.btrfs_path);
-
-    let state_db = match StateDb::open(&config.general.state_db) {
-        Ok(db) => Some(db),
-        Err(e) => {
-            log::warn!("Failed to open state DB, continuing without history: {e}");
-            None
-        }
-    };
 
     let executor = Executor::new(&btrfs, state_db.as_ref(), &config, &shutdown);
     let result = executor.execute(&backup_plan, mode);
@@ -209,7 +209,7 @@ fn write_metrics_after_execution(
     result: &crate::executor::ExecutionResult,
     plan: &crate::types::BackupPlan,
     now: chrono::NaiveDateTime,
-    fs_state: &RealFileSystemState,
+    fs_state: &dyn FileSystemState,
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
     let mut subvolume_metrics = Vec::new();
@@ -258,7 +258,7 @@ fn write_metrics_for_skipped(
     now: chrono::NaiveDateTime,
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
-    let fs_state = RealFileSystemState;
+    let fs_state = RealFileSystemState { state: None };
     let mut subvolume_metrics = Vec::new();
 
     append_skipped_metrics(config, plan, &fs_state, &mut subvolume_metrics, &HashSet::new());
@@ -273,7 +273,7 @@ fn write_metrics_for_skipped(
 fn append_skipped_metrics(
     config: &Config,
     plan: &crate::types::BackupPlan,
-    fs_state: &RealFileSystemState,
+    fs_state: &dyn FileSystemState,
     subvolume_metrics: &mut Vec<SubvolumeMetrics>,
     already_emitted: &HashSet<String>,
 ) {
@@ -320,7 +320,7 @@ fn write_global_metrics(
 fn count_local_snapshots(
     config: &Config,
     subvol_name: &str,
-    fs_state: &RealFileSystemState,
+    fs_state: &dyn FileSystemState,
 ) -> usize {
     if let Some(root) = config.snapshot_root_for(subvol_name) {
         fs_state
@@ -335,7 +335,7 @@ fn count_local_snapshots(
 fn count_external_snapshots(
     config: &Config,
     subvol_name: &str,
-    fs_state: &RealFileSystemState,
+    fs_state: &dyn FileSystemState,
 ) -> usize {
     // First mounted drive's count (for bash compat)
     for drive in &config.drives {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -194,7 +194,7 @@ pub fn run(config: Config) -> anyhow::Result<()> {
     }
 
     // 6. Detect incomplete snapshots on external drives
-    let fs_state = RealFileSystemState;
+    let fs_state = RealFileSystemState { state: None };
     let mut incomplete_found = false;
 
     for drive in &config.drives {

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -3,6 +3,7 @@ use colored::Colorize;
 use crate::cli::PlanArgs;
 use crate::config::Config;
 use crate::plan::{self, PlanFilters, RealFileSystemState};
+use crate::state::StateDb;
 use crate::types::PlannedOperation;
 
 pub fn run(config: Config, args: PlanArgs) -> anyhow::Result<()> {
@@ -14,7 +15,8 @@ pub fn run(config: Config, args: PlanArgs) -> anyhow::Result<()> {
         external_only: args.external_only,
     };
 
-    let fs_state = RealFileSystemState;
+    let state_db = StateDb::open(&config.general.state_db).ok();
+    let fs_state = RealFileSystemState { state: state_db.as_ref() };
     let backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
 
     run_with_plan(&config, &backup_plan)

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -7,7 +7,7 @@ use crate::plan::{FileSystemState, RealFileSystemState};
 use crate::state::StateDb;
 
 pub fn run(config: Config) -> anyhow::Result<()> {
-    let fs_state = RealFileSystemState;
+    let fs_state = RealFileSystemState { state: None };
     let drive_labels: Vec<String> = config.drives.iter().map(|d| d.label.clone()).collect();
     let mounted_drives: Vec<_> = config
         .drives

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -9,7 +9,7 @@ use crate::drives;
 use crate::plan::{FileSystemState, RealFileSystemState};
 
 pub fn run(config: Config, args: VerifyArgs) -> anyhow::Result<()> {
-    let fs_state = RealFileSystemState;
+    let fs_state = RealFileSystemState { state: None };
     let mut total_ok: u32 = 0;
     let mut total_warn: u32 = 0;
     let mut total_fail: u32 = 0;
@@ -187,7 +187,7 @@ pub fn run(config: Config, args: VerifyArgs) -> anyhow::Result<()> {
 }
 
 fn check_orphans(
-    fs_state: &RealFileSystemState,
+    fs_state: &dyn FileSystemState,
     drive: &crate::config::DriveConfig,
     subvol_name: &str,
     pin: &crate::types::SnapshotName,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -43,6 +43,15 @@ pub trait FileSystemState {
         local_dir: &Path,
         drive_labels: &[String],
     ) -> HashSet<SnapshotName>;
+
+    /// Get the bytes_transferred from the most recent successful send of a given type.
+    /// Returns None if no history exists (e.g., first-ever send).
+    fn last_send_size(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+        send_type: &str,
+    ) -> Option<u64>;
 }
 
 // ── PlanFilters ─────────────────────────────────────────────────────────
@@ -356,6 +365,31 @@ fn plan_external_send(
         false
     };
 
+    // Space estimation: skip if historical send size exceeds available space
+    let send_type_str = if is_incremental { "send_incremental" } else { "send_full" };
+    if let Some(last_size) = fs.last_send_size(&subvol.name, &drive.label, send_type_str) {
+        let estimated = (last_size as f64 * 1.2) as u64; // 20% safety margin
+        let free = fs.filesystem_free_bytes(&ext_dir).unwrap_or(u64::MAX);
+        let min_free = drive.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
+        let available = free.saturating_sub(min_free);
+
+        if estimated > available {
+            use crate::types::ByteSize;
+            skipped.push((
+                subvol.name.clone(),
+                format!(
+                    "send to {} skipped: estimated ~{} exceeds {} available (free: {}, min_free: {})",
+                    drive.label,
+                    ByteSize(estimated),
+                    ByteSize(available),
+                    ByteSize(free),
+                    ByteSize(min_free),
+                ),
+            ));
+            return;
+        }
+    }
+
     let pin_info = Some((
         local_dir.join(format!(".last-external-parent-{}", drive.label)),
         snap_to_send.clone(),
@@ -432,9 +466,12 @@ fn format_duration_short(minutes: i64) -> String {
 // ── RealFileSystemState ─────────────────────────────────────────────────
 
 /// Real filesystem state — reads actual directories, pin files, and mounts.
-pub struct RealFileSystemState;
+/// Optionally carries a StateDb reference for historical send size estimation.
+pub struct RealFileSystemState<'a> {
+    pub state: Option<&'a crate::state::StateDb>,
+}
 
-impl FileSystemState for RealFileSystemState {
+impl FileSystemState for RealFileSystemState<'_> {
     fn local_snapshots(&self, root: &Path, subvol_name: &str) -> crate::error::Result<Vec<SnapshotName>> {
         read_snapshot_dir(&root.join(subvol_name))
     }
@@ -470,6 +507,19 @@ impl FileSystemState for RealFileSystemState {
         drive_labels: &[String],
     ) -> HashSet<SnapshotName> {
         crate::chain::find_pinned_snapshots(local_dir, drive_labels)
+    }
+
+    fn last_send_size(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+        send_type: &str,
+    ) -> Option<u64> {
+        self.state.and_then(|db| {
+            db.last_successful_send_size(subvol_name, drive_label, send_type)
+                .ok()
+                .flatten()
+        })
     }
 }
 
@@ -513,6 +563,7 @@ pub struct MockFileSystemState {
     pub mounted_drives: HashSet<String>,
     pub free_bytes: std::collections::HashMap<PathBuf, u64>,
     pub pin_files: std::collections::HashMap<(PathBuf, String), SnapshotName>,
+    pub send_sizes: std::collections::HashMap<(String, String, String), u64>,
 }
 
 #[cfg(test)]
@@ -524,6 +575,7 @@ impl MockFileSystemState {
             mounted_drives: HashSet::new(),
             free_bytes: std::collections::HashMap::new(),
             pin_files: std::collections::HashMap::new(),
+            send_sizes: std::collections::HashMap::new(),
         }
     }
 }
@@ -574,6 +626,21 @@ impl FileSystemState for MockFileSystemState {
             }
         }
         pinned
+    }
+
+    fn last_send_size(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+        send_type: &str,
+    ) -> Option<u64> {
+        self.send_sizes
+            .get(&(
+                subvol_name.to_string(),
+                drive_label.to_string(),
+                send_type.to_string(),
+            ))
+            .copied()
     }
 }
 
@@ -1087,6 +1154,86 @@ send_enabled = false
             .collect();
         // With send_enabled=false, daily thinning should delete the 0800 and 1000 snapshots
         assert!(deletes.len() >= 2, "Retention should thin normally when send is disabled");
+    }
+
+    // ── Space estimation tests ──────────────────────────────────────────
+
+    #[test]
+    fn send_skipped_insufficient_space() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.mounted_drives.insert("D1".to_string());
+        // Historical full send was 200GB
+        fs.send_sizes.insert(
+            ("sv1".to_string(), "D1".to_string(), "send_full".to_string()),
+            200_000_000_000,
+        );
+        // Only 150GB free on external drive (min_free=100GB, so available=50GB)
+        fs.free_bytes.insert(
+            PathBuf::from("/mnt/d1/.snapshots/sv1"),
+            150_000_000_000,
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(sends.len(), 0, "Send should be skipped when space is insufficient");
+        assert!(
+            result.skipped.iter().any(|(name, reason)| name == "sv1" && reason.contains("estimated")),
+            "Should report space estimation skip"
+        );
+    }
+
+    #[test]
+    fn send_proceeds_with_sufficient_space() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.mounted_drives.insert("D1".to_string());
+        // Historical full send was 50GB
+        fs.send_sizes.insert(
+            ("sv1".to_string(), "D1".to_string(), "send_full".to_string()),
+            50_000_000_000,
+        );
+        // 500GB free on external drive (min_free=100GB, available=400GB, estimated=60GB)
+        fs.free_bytes.insert(
+            PathBuf::from("/mnt/d1/.snapshots/sv1"),
+            500_000_000_000,
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(sends.len(), 1, "Send should proceed when space is sufficient");
+    }
+
+    #[test]
+    fn send_proceeds_without_history() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.mounted_drives.insert("D1".to_string());
+        // No send_sizes entry — first-ever send
+        // Tiny free space — but no history means we can't estimate, so proceed
+        fs.free_bytes.insert(
+            PathBuf::from("/mnt/d1/.snapshots/sv1"),
+            1_000_000,
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(sends.len(), 1, "First-ever send should proceed without history");
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -261,6 +261,38 @@ impl StateDb {
             .map_err(|e| UrdError::State(format!("failed to read operations: {e}")))
     }
 
+    /// Get the bytes_transferred from the most recent successful send of a given type
+    /// for a subvolume to a specific drive. Returns None if no matching history exists.
+    pub fn last_successful_send_size(
+        &self,
+        subvol: &str,
+        drive: &str,
+        send_type: &str,
+    ) -> crate::error::Result<Option<u64>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT bytes_transferred FROM operations
+                 WHERE subvolume = ?1 AND drive_label = ?2 AND operation = ?3
+                   AND result = 'success' AND bytes_transferred IS NOT NULL
+                 ORDER BY id DESC LIMIT 1",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut rows = stmt
+            .query_map(rusqlite::params![subvol, drive, send_type], |row| {
+                let bytes: i64 = row.get(0)?;
+                Ok(bytes as u64)
+            })
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        match rows.next() {
+            Some(Ok(size)) => Ok(Some(size)),
+            Some(Err(e)) => Err(UrdError::State(format!("failed to read send size: {e}"))),
+            None => Ok(None),
+        }
+    }
+
     fn map_operation_row(row: &rusqlite::Row) -> rusqlite::Result<OperationRow> {
         Ok(OperationRow {
             id: row.get(0)?,
@@ -521,5 +553,118 @@ mod tests {
         assert_eq!(failures.len(), 1);
         assert_eq!(failures[0].subvolume, "subvol3-opptak");
         assert_eq!(failures[0].error_message.as_deref(), Some("No space left"));
+    }
+
+    // ── last_successful_send_size tests ────────────────────────────────
+
+    #[test]
+    fn last_send_size_returns_bytes() {
+        let db = StateDb::open_memory().unwrap();
+        seed_db(&db); // htpc-home send_incremental to WD-18TB = 1_000_000 bytes
+
+        let size = db
+            .last_successful_send_size("htpc-home", "WD-18TB", "send_incremental")
+            .unwrap();
+        assert_eq!(size, Some(1_000_000));
+    }
+
+    #[test]
+    fn last_send_size_excludes_failures() {
+        let db = StateDb::open_memory().unwrap();
+        seed_db(&db); // subvol3-opptak send_full to WD-18TB failed
+
+        let size = db
+            .last_successful_send_size("subvol3-opptak", "WD-18TB", "send_full")
+            .unwrap();
+        assert_eq!(size, None);
+    }
+
+    #[test]
+    fn last_send_size_no_history() {
+        let db = StateDb::open_memory().unwrap();
+
+        let size = db
+            .last_successful_send_size("nonexistent", "WD-18TB", "send_full")
+            .unwrap();
+        assert_eq!(size, None);
+    }
+
+    #[test]
+    fn last_send_size_filters_by_drive() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "htpc-home".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("DRIVE-A".to_string()),
+            duration_secs: Some(10.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(500_000),
+        })
+        .unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "htpc-home".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("DRIVE-B".to_string()),
+            duration_secs: Some(20.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(600_000),
+        })
+        .unwrap();
+
+        assert_eq!(
+            db.last_successful_send_size("htpc-home", "DRIVE-A", "send_full").unwrap(),
+            Some(500_000)
+        );
+        assert_eq!(
+            db.last_successful_send_size("htpc-home", "DRIVE-B", "send_full").unwrap(),
+            Some(600_000)
+        );
+        assert_eq!(
+            db.last_successful_send_size("htpc-home", "DRIVE-C", "send_full").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn last_send_size_returns_most_recent() {
+        let db = StateDb::open_memory().unwrap();
+
+        let r1 = db.begin_run("full").unwrap();
+        db.record_operation(&OperationRecord {
+            run_id: r1,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("D".to_string()),
+            duration_secs: Some(10.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(100),
+        })
+        .unwrap();
+
+        let r2 = db.begin_run("full").unwrap();
+        db.record_operation(&OperationRecord {
+            run_id: r2,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("D".to_string()),
+            duration_secs: Some(10.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(999),
+        })
+        .unwrap();
+
+        assert_eq!(
+            db.last_successful_send_size("sv1", "D", "send_full").unwrap(),
+            Some(999)
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add historical-data-based space estimation to the planner — skip sends when the destination drive can't fit them
- First real-world backup testing: subvol6-tmp, htpc-root, subvol1-docs, htpc-home all successful
- Arch-adversary reviews and proposal for next features (progress indication, proactive size estimation)

## Changes

- **`state.rs`** — New `last_successful_send_size()` SQL query returning most recent `bytes_transferred` for a (subvolume, drive, send_type) triple
- **`plan.rs`** — Extended `FileSystemState` trait with `last_send_size()`. Changed `RealFileSystemState` from unit struct to carry `Option<&StateDb>`. Space check in `plan_external_send`: 1.2x margin, `saturating_sub` for min_free, fail-open on missing history
- **`backup.rs`** — Moved `StateDb::open` before planning phase (was after). Same instance shared with executor, eliminating duplicate open
- **`plan_cmd.rs`** — Opens `StateDb` so `urd plan` also shows space-based skips
- **`status/verify/init`** — Updated `RealFileSystemState { state: None }`

## Documentation

- Session journal: `docs/98-journals/2026-03-23-space-estimation-and-testing.md`
- Arch-adversary review of space estimation: `docs/99-reports/2026-03-23-arch-adversary-space-estimation.md`
- Proposal for progress + size estimation: `docs/99-reports/2026-03-23-proposal-progress-and-size-estimation.md`
- Arch-adversary review of proposal: `docs/99-reports/2026-03-23-arch-adversary-proposal-review.md`

## Testing

- `cargo test`: 134 passed (8 new), 0 failed
- `cargo clippy -- -D warnings`: clean
- Real-world testing on production system with 2TB-backup and WD-18TB1 drives

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>