### PR TITLE
feat: Add failed-send bytes, progress display, and calibrate command

### DIFF
--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -5,13 +5,69 @@
 
 ## Current State
 
-**Phase 4 code is complete. Operational cutover has not started.** The bash script
-(`btrfs-snapshot-backup.sh`) is still the sole production backup system, running nightly
-at 02:00 via `btrfs-backup-daily.timer`. Urd v0.1.0 is installed (`~/.cargo/bin/urd`)
-and has been tested manually, but is not deployed on a schedule.
+**Phase 4 code is complete. Post-cutover features (Priorities 2-4) are built and reviewed.
+Operational cutover has not started.** The bash script (`btrfs-snapshot-backup.sh`) is still
+the sole production backup system, running nightly at 02:00 via `btrfs-backup-daily.timer`.
+Urd v0.1.0 is installed (`~/.cargo/bin/urd`) and has been tested manually on real subvolumes
+(2026-03-23), but is not deployed on a schedule.
 
-**Next milestone:** Operational cutover — install Urd's systemd timer, run in parallel
-with the bash script, validate, then disable the bash script.
+Post-Phase 4 work completed: pre-send space estimation (historical data-based), documentation
+system (CONTRIBUTING.md), first real-world backup testing (subvol6-tmp, htpc-root,
+subvol1-docs, htpc-home — all successful, chains now incremental for tested subvolumes),
+failed-send bytes recording, live progress display during sends, and `urd calibrate` command.
+All three post-cutover features passed adversary review (scores 4-5 across all dimensions)
+and review-identified fixes have been applied.
+
+## What to Build Next — Priority Order
+
+The operational cutover is the gate — nothing else matters until Urd is running production
+backups. All post-cutover code features (Priorities 2-4) are complete.
+
+### Priority 1: Operational Cutover (Phase 4 ops)
+
+**Why first:** All code improvements are valueless until Urd is the production backup system.
+The code is tested and ready. This is purely operational — no code changes needed.
+
+See [Step-by-step cutover checklist](#active-work--operational-cutover) below.
+
+**Blocking question:** The parallel run requires 1-2 weeks of monitoring. Starting the
+cutover now means Urd becomes sole backup system by mid-April 2026.
+
+### Priority 2: Phase 5 — Sentinel daemon + udev rules
+
+**Why deferred:** Requires Urd to be battle-tested as sole backup system first. The nightly
+timer provides reliable scheduled backups. Drive-plug-triggered backups add convenience but
+not safety.
+
+**Scope:** `sentinel.rs` (stubbed), udev rules, `urd-sentinel.service`. Desktop notification
+hooks.
+
+### Completed (Priorities 2-4)
+
+These features are built, adversary-reviewed, and ready to ship:
+
+- **Failed send bytes** (P2) — `UrdError::Btrfs` carries `bytes_transferred: Option<u64>`.
+  Failed sends record partial byte counts. Planner uses MAX(successful, failed) for estimation.
+  System self-heals after one failed send. [Journal](../98-journals/2026-03-23-post-cutover-features.md)
+- **Progress display** (P3) — `AtomicU64` counter in `RealBtrfs`, polled by display thread in
+  `backup.rs`. Shows `bytes @ rate [elapsed]` on stderr when TTY. Counter stays outside
+  `BtrfsOps` trait. [Journal](../98-journals/2026-03-23-post-cutover-features.md)
+- **`urd calibrate`** (P4) — Measures snapshot sizes via `du -sb`, stores in `subvolume_sizes`
+  table. Planner uses as Tier 3 fallback for first-ever full sends. Tier 1 always overrides.
+  Staleness warning at 30 days. [Journal](../98-journals/2026-03-23-post-cutover-features.md)
+
+Review fixes applied: progress timer reset between sends, reject 0-byte calibration, corrupt
+timestamp staleness handling, space check deduplication, ANSI line clearing.
+[Review](../99-reports/2026-03-23-post-cutover-features-review.md)
+
+### Not Building (dropped per adversary review)
+
+- **Tier 2 filesystem-level upper bound** — wrong in both directions for the actual data
+  distribution (7 subvolumes from ~50GB to ~3TB). Average-based check would false-positive
+  on small subvolumes and false-negative on large ones.
+- **Tier 3 Option A opportunistic qgroup query** — quotas confirmed off. Speculative
+  complexity for hypothetical future users. Can be added if quotas are ever enabled (see
+  [qgroup guide](../98-journals/2026-03-23-space-estimation-and-testing.md#part-3-enabling-btrfs-quotas-qgroups-on-btrfs-pool)).
 
 ## Phase Checklist
 
@@ -20,8 +76,9 @@ with the bash script, validate, then disable the bash script.
 - [x] **Phase 2** — Executor + State DB + Metrics + `urd backup`
 - [x] **Phase 3** — CLI commands (`status`, `history`, `verify`) + systemd units
 - [x] **Phase 3.5** — Hardening for cutover (adversary review fixes)
-- [x] **Phase 4 code** — Cutover polish (CLI help, btrfs_path validation, crash-recovery test, verbose flag, dead code removal)
-- [ ] **Phase 4 cutover** — Operational transition from bash to Urd (see active work)
+- [x] **Phase 4 code** — Cutover polish + space estimation + real-world testing
+- [ ] **Phase 4 cutover** — Operational transition from bash to Urd (see below)
+- [x] **Post-cutover features** — failed-send bytes, progress, calibrate (Priorities 2-4)
 - [ ] **Phase 5** — Sentinel daemon + udev rules (deferred)
 - [ ] Notifications (desktop + Discord, deferred until core is battle-tested)
 
@@ -66,20 +123,31 @@ for details.
 |----------|------|-----------|
 | Daily external sends for Tier 1/2 (RPO 7d → 1d) | 2026-03-21 | [ADR-020](../00-foundation/decisions/ADR-relating-to-bash-script/2026-03-21-ADR-020-daily-external-backups.md) |
 | Pre-send space estimation using historical data | 2026-03-23 | [Journal](../98-journals/2026-03-23-space-estimation-and-testing.md) |
+| Drop Tier 2 and qgroup option from size estimation | 2026-03-23 | [Adversary review](../99-reports/2026-03-23-arch-adversary-proposal-review.md) |
+| Keep progress counter out of BtrfsOps trait | 2026-03-23 | [Adversary review](../99-reports/2026-03-23-arch-adversary-proposal-review.md) Finding 4 |
+| Calibrate on snapshots, not live sources | 2026-03-23 | [Adversary review](../99-reports/2026-03-23-arch-adversary-proposal-review.md) Finding 5 |
+| UrdError::Btrfs struct variant (not separate type) for partial bytes | 2026-03-23 | [Post-cutover journal](../98-journals/2026-03-23-post-cutover-features.md) |
+| MAX(successful, failed) for send size estimation | 2026-03-23 | [Post-cutover journal](../98-journals/2026-03-23-post-cutover-features.md) |
 
 ## Key Documents
 
 | Purpose | Document |
 |---------|----------|
 | Original roadmap & architecture | [roadmap.md](roadmap.md) |
-| Latest journal entry | [2026-03-23 Space estimation & testing](../98-journals/2026-03-23-space-estimation-and-testing.md) |
-| Latest adversary review | [2026-03-23 Space estimation review](../99-reports/2026-03-23-arch-adversary-space-estimation.md) |
+| Latest journal entry | [2026-03-23 Post-implementation review fixes](../98-journals/2026-03-23-post-implementation-review-fixes.md) |
+| Latest adversary review | [2026-03-23 Post-cutover features review](../99-reports/2026-03-23-post-cutover-features-review.md) |
+| Post-cutover features journal | [2026-03-23 Post-cutover features](../98-journals/2026-03-23-post-cutover-features.md) |
+| Progress & size estimation proposal | [2026-03-23 Proposal](../99-reports/2026-03-23-proposal-progress-and-size-estimation.md) |
 | Code conventions & architecture | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 
 ## Known Issues & Tech Debt
 
 - Pipe bytes vs. on-disk size mismatch in space estimation (1.2x margin handles common case)
-- Space-skip visibility in plan output could be improved
+- Space-skip visibility in plan output could be improved (`[SKIP:SPACE]` marker suggested)
+- `du -sb` may follow symlinks in snapshots — consider `-P` flag (not yet tested on real snapshots with symlinks)
+- Stale failed send estimates persist indefinitely for (subvolume, drive, send_type) triples with no subsequent sends — consider TTL or clearing on successful calibration
+- Successful sends could update `subvolume_sizes` table to keep calibration fresh, but pipe bytes ≠ `du -sb` bytes (method mixing concern)
 - `sentinel.rs` stubbed but not implemented (Phase 5)
 - Per-drive pin protection for external retention — current all-drives-union is conservative but suboptimal for space
+- Idea: [systemd unit drift check](../95-ideas/2026-03-23-systemd-unit-drift-check.md) in `urd verify`

--- a/docs/99-reports/2026-03-23-post-cutover-features-review.md
+++ b/docs/99-reports/2026-03-23-post-cutover-features-review.md
@@ -1,0 +1,231 @@
+# Architectural Adversary Review: Post-Cutover Features Implementation
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-23
+**Scope:** Post-implementation review of Priorities 2, 3, 4 — failed send bytes, progress indication, `urd calibrate`
+**Reviewer:** Claude (arch-adversary)
+**Base commit:** `a60f031` (master, post-Phase 4)
+**Journal:** `docs/98-journals/2026-03-23-post-cutover-features.md`
+
+---
+
+## Executive Summary
+
+This is clean, disciplined work. Three independently-shippable features were built in priority order, each following the designs validated in the prior adversary review. The planner/executor separation — the most important architectural property of Urd — is preserved throughout. The most significant finding is a timing bug in the progress display that produces misleading rate calculations across multiple sends. The second finding is a correctness edge case in calibrate that silently records 0 bytes when `du` output is malformed. Neither is close to the catastrophic failure mode.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — retention deletes snapshots that haven't reached external drives.
+
+**Distance from these changes:** Far. None of the three features touch retention logic, pin file handling, or snapshot deletion decisions. The closest path to harm:
+
+1. **Failed send bytes → stale MAX → permanent skip (2 steps from reduced protection):** If a failed send records a large partial byte count, and the subvolume later shrinks, the MAX(successful, failed) logic could permanently skip sends to undersized drives. This is protection reduction, not data loss — local snapshots are unaffected. The `ORDER BY id DESC LIMIT 1` mitigates: only the *most recent* failure is compared, so a new successful send to the same drive/type overwrites it. But stale failed data for a *different* drive/type combination persists indefinitely. Distance: two conditions must hold simultaneously (subvolume shrinks AND no subsequent successful send of same type to same drive). Realistic but slow-onset.
+
+2. **Calibration false-positive → send permanently blocked (1 step from reduced protection):** If calibrated size is stale-high, the planner skips sends. The 30-day staleness warning mitigates but doesn't force recalibration. After the first successful send, Tier 1 data takes over. Only the very first send to a new drive is at risk — and only if calibration data exists and is stale-high.
+
+**Verdict:** Neither path reaches data loss. The worst outcome is a delayed external backup. The system's fail-open behavior (proceed without estimate) and Tier 1 override both work in the right direction.
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | Sound logic, good edge case handling; two minor bugs (progress timer, calibrate 0-byte) |
+| Security | 5 | No new privilege paths; `du` runs without sudo; no path injection vectors |
+| Architectural Excellence | 5 | Planner/executor separation rigorously preserved; progress stays outside trait |
+| Systems Design | 4 | Good crash recovery (partial cleanup), good fail-open behavior; progress timer is slightly leaky |
+| Rust Idioms | 4 | Good atomic usage, correct `Ordering`; struct variant is pragmatic |
+| Code Quality | 4 | Well-tested new paths; documentation-driven development; minor test gap in calibrate |
+
+## Design Tensions
+
+### 1. `UrdError::Btrfs` struct variant vs. separate error type
+
+**Trade-off:** Adding `bytes_transferred: Option<u64>` to every `Btrfs` error (including snapshot creation and delete, where it's always `None`) vs. creating a `BtrfsSend` variant just for sends.
+
+**Evaluation:** The struct variant was the right call. The alternative (`BtrfsSend { msg, bytes_transferred }`) would have required the executor's error handler to match on *two* btrfs error variants, adding a code path that's easy to get wrong. The cost of `bytes_transferred: None` on 15 non-send errors is one `Option<u64>` field that the compiler guarantees is always `None` at those sites. This is a textbook trade of type precision for simplicity — and for a single-user backup tool (not a library), simplicity wins.
+
+**Commendation:** The journal explicitly names this trade-off and the alternatives considered. That's exactly the kind of decision documentation that prevents future "why didn't we just..." discussions.
+
+### 2. Global progress timer vs. per-operation timer
+
+**Trade-off:** The progress display uses a single `Instant::now()` at thread creation and computes rate as `total_bytes / total_elapsed`. This gives stable rates but is semantically wrong when the executor runs multiple sends in one backup run — elapsed time includes non-send operations between sends, and the counter resets to 0 between sends while the timer doesn't.
+
+**Evaluation:** This is a bug, not a trade-off (see Finding 1). The timer should reset when the counter resets.
+
+### 3. MAX(successful, failed) in `last_send_size`
+
+**Trade-off:** MAX gives the most conservative (largest) estimate, preventing wasted sends to undersized drives. But a stale failed estimate can persist indefinitely if no new send of the same type to the same drive occurs.
+
+**Evaluation:** MAX is correct for the stated goal (prevent wasted multi-hour sends). The staleness risk is real but low-impact: it causes skipped sends, not data loss, and only for specific (subvolume, drive, send_type) triples. The right mitigation is not to change MAX, but to add a TTL or allow `urd calibrate` to clear stale failed estimates. This is a future enhancement, not a current bug.
+
+### 4. `du -sb` vs. btrfs send stream size
+
+**Trade-off:** `du -sb` can overestimate (reflinks) or underestimate (metadata overhead). The 1.2x margin handles underestimates. Overestimates could cause false-positive skips.
+
+**Evaluation:** For this system's subvolumes (media files, home directories, containers), reflink usage is likely low. The overestimate risk is real but mitigated by Tier 1 always overriding after the first successful send. The calibration exists specifically for the first-send gap — once Tier 1 data exists, calibration is never consulted again. Acceptable for the problem scope.
+
+## Findings
+
+### Significant
+
+#### Finding 1: Progress timer doesn't reset between sends — misleading rate on 2nd+ send
+
+**What:** `progress_display_loop` in `backup.rs:376` creates `start = Instant::now()` once at thread spawn. The byte counter in `RealBtrfs::send_receive` resets to 0 at the start of each send (`counter.store(0, Ordering::Relaxed)` at `btrfs.rs:172`). But the `start` time is never reset.
+
+**Consequence:** For the second send in a backup run, elapsed time includes the entire first send's duration plus any snapshot/retention operations between sends. If the first send took 10 minutes and transferred 1GB, and the second send has transferred 200MB in 30 seconds, the display shows: `200 MB @ 18.2 MB/s [10:30]` — where 10:30 is total wall time since the progress thread started, not time since this send started, and 18.2 MB/s is `200MB / 10.5 minutes`, a dramatic undercount of the actual rate.
+
+**Why it matters:** The progress display exists to answer "is it working or hung?" A rate of 18 MB/s when the actual rate is 400 MB/s is misleading in exactly the wrong direction — it makes a fast send look slow. For a single-subvolume run this doesn't manifest; it only appears when multiple sends execute in one run (the common case: 7 subvolumes × 1-2 drives).
+
+**Suggested fix:** Track a "send start" timestamp that resets when the counter transitions from 0 to non-zero. Something like:
+
+```rust
+if current > 0 && last_display_bytes == 0 {
+    send_start = Instant::now(); // new send started
+}
+let elapsed = send_start.elapsed();
+```
+
+**Severity:** Significant — affects every multi-send backup run's UX.
+
+#### Finding 2: `calibrate` silently stores 0 bytes on malformed `du` output
+
+**What:** In `commands/calibrate.rs:75-79`:
+
+```rust
+let bytes: u64 = stdout
+    .split_whitespace()
+    .next()
+    .and_then(|s| s.parse().ok())
+    .unwrap_or(0);
+```
+
+If `du -sb` produces unexpected output (empty, or first token isn't a number), this silently stores `estimated_bytes = 0` in the database.
+
+**Consequence:** A calibrated size of 0 bytes means the planner's Tier 3 check would compute `estimated = 0 * 1.2 = 0`, which is always ≤ available space, so the send proceeds. This is fail-open, which is the right direction — a 0-byte estimate won't block sends. But it's still semantically wrong: the database now claims the subvolume is 0 bytes, and `urd status` or any future display of calibration data would show "0 bytes" instead of an error.
+
+**Suggested fix:** Treat 0 as an error:
+
+```rust
+let bytes: u64 = stdout
+    .split_whitespace()
+    .next()
+    .and_then(|s| s.parse().ok())
+    .filter(|&b| b > 0)
+    .ok_or_else(|| anyhow::anyhow!("du -sb produced no usable output: {:?}", stdout.trim()))?;
+```
+
+Or at minimum, skip the upsert and count it as a failure instead of calibrating to 0.
+
+**Severity:** Significant — wrong data in the database, even if the downstream effect is benign.
+
+### Moderate
+
+#### Finding 3: `calibration_age_days` returns 0 on parse failure — staleness warning never fires for corrupt data
+
+**What:** In `plan.rs:502-507`:
+
+```rust
+fn calibration_age_days(measured_at: &str) -> i64 {
+    let now = chrono::Local::now().naive_local();
+    chrono::NaiveDateTime::parse_from_str(measured_at, "%Y-%m-%dT%H:%M:%S")
+        .map(|ts| (now - ts).num_days())
+        .unwrap_or(0)
+}
+```
+
+If `measured_at` is corrupt or in an unexpected format, this returns 0 days — meaning "fresh." The staleness warning (>30 days) never fires.
+
+**Consequence:** If the timestamp in the database is somehow malformed, calibration data appears perpetually fresh. Combined with a stale-high estimate, this could cause sends to be permanently skipped without warning.
+
+**Suggested fix:** Return a large value (e.g., `i64::MAX` or `999`) on parse failure, so corrupt timestamps trigger the staleness warning rather than suppressing it.
+
+**Severity:** Moderate — requires database corruption to trigger, but fails in the wrong direction.
+
+#### Finding 4: Space estimation code is duplicated between Tier 1 and Tier 3
+
+**What:** In `plan.rs:375-427`, the space check logic (compute estimated, get free, subtract min_free, compare) appears twice — once for Tier 1 and once for Tier 3. The two blocks are nearly identical except for the estimate source and skip message.
+
+**Consequence:** If the space check logic needs to change (e.g., margin becomes configurable, or `min_free` semantics change), two sites must be updated. This isn't wrong, but it's one abstraction short of clean.
+
+**Suggested fix:** Extract a helper: `fn check_space(estimated: u64, ext_dir: &Path, drive: &DriveConfig, fs: &dyn FileSystemState) -> Option<(u64, u64, u64)>` that returns `(estimated_with_margin, free, available)` or `None` if space check can't be done. The caller formats the skip message.
+
+**Severity:** Moderate — maintenance friction, not a bug.
+
+### Minor
+
+#### Finding 5: `progress_display_loop` hard-codes 60 spaces for line clearing
+
+**What:** `backup.rs:411`: `eprint!("\r{}\r", " ".repeat(60));`
+
+If the progress line exceeds 60 characters (e.g., very large byte counts like `1.2 TB @ 245.3 MB/s [1:23:45]`), the trailing characters from the longest line won't be cleared.
+
+**Suggested fix:** Track the max line length and clear to that length, or use ANSI escape `\x1b[2K` (erase entire line) which works on all modern terminals.
+
+**Severity:** Minor — cosmetic.
+
+#### Finding 6: `format_elapsed` could show `0:03` instead of `0:03` — edge case clarity
+
+**What:** The format `{mins}:{secs:02}` produces `0:03` for 3 seconds. This is correct but some users might read it as "0 hours 3 minutes" instead of "0 minutes 3 seconds."
+
+**Suggested fix:** Not urgent, but `0m03s` or `0:03s` would be unambiguous. Cargo uses `0.03s` for sub-minute. This is a preference, not a bug.
+
+**Severity:** Minor — cosmetic.
+
+### Commendations
+
+#### Commendation 1: Progress counter stays outside `BtrfsOps` trait
+
+The `bytes_counter: Arc<AtomicU64>` lives in `RealBtrfs` (the concrete type), not in `BtrfsOps` (the trait). `MockBtrfs` doesn't know about it. This is exactly right. The progress counter is a presentation concern that belongs in the I/O implementation, not in the behavioral contract. The executor reads it through the shared `Arc`, not through the trait. This preserves the architecture's most valuable property: you can test all backup logic through the mock without dealing with progress display.
+
+#### Commendation 2: Partial bytes flow naturally through existing infrastructure
+
+The decision to extend `UrdError::Btrfs` with `bytes_transferred: Option<u64>` means the executor's existing `match &e { UrdError::Btrfs { .. } => ... }` pattern extracts partial bytes with no new plumbing. The existing `record_operation` call writes them to SQLite with no schema change (the `bytes_transferred` column already exists). The planner reads them through `last_failed_send_size`. This is a textbook example of a well-designed data flow: one change (error struct variant) propagates through three layers without requiring structural changes at any of them.
+
+#### Commendation 3: Tier 1 always overrides Tier 3
+
+The calibration check is in the `else` branch of the Tier 1 check (`plan.rs:397`). This means ground truth (actual send bytes) always wins. There's no code path where stale calibration data can override a recent successful send. This is the right invariant and it's enforced by code structure, not by a runtime check.
+
+#### Commendation 4: Journal's "Design Decisions That Warrant Adversary Scrutiny" section
+
+The journal explicitly lists 7 design decisions the author is uncertain about, with specific alternatives and edge cases. This is unusually honest self-assessment. Every one of the 7 items raised is a genuine trade-off worth discussing. The quality of the journal's analysis means the adversary review can focus on implementation details rather than re-deriving the design space.
+
+## The Simplicity Question
+
+**What could be removed?** Very little. Each of the three features is minimal for what it does:
+
+- Failed send bytes: ~80 lines, 4 tests. The struct variant is more verbose than a tuple variant but the compiler catches every site. No new types, no new modules.
+- Progress display: ~70 lines, no new dependencies. The `AtomicU64` counter is the simplest possible shared state.
+- Calibrate: ~120 lines, 1 new file. Uses existing `FileSystemState` trait, existing `StateDb` infrastructure.
+
+**What's earning its keep?** The `FileSystemState` trait is the unsung hero. It enables testing all space estimation logic (Tier 1, Tier 3, fail-open) through `MockFileSystemState` without touching the filesystem or SQLite. The 6 plan tests for space estimation are fast, deterministic, and cover the critical decision paths.
+
+**What isn't earning its keep?** The `method` column in `subvolume_sizes` stores `"du -sb"` for every row. Today there's only one measurement method. If a second method is never added, this is dead weight. But it's one TEXT column — the cost of removing it later exceeds the cost of carrying it.
+
+## Priority Action Items
+
+1. **Fix progress timer reset** (Finding 1) — Reset the rate timer when counter transitions from 0 to non-zero. Affects every multi-send backup's display. ~5 lines.
+
+2. **Don't store 0-byte calibration** (Finding 2) — Treat `du` returning 0 or unparseable output as a failure. ~5 lines.
+
+3. **Make `calibration_age_days` fail loud** (Finding 3) — Return a large value on parse failure, not 0. ~1 line change.
+
+4. **Extract space check helper** (Finding 4) — Optional, reduces duplication in `plan_external_send`. ~20 lines refactor.
+
+5. **Consider TTL on failed send estimates** (design tension) — Not urgent, but the MAX(successful, failed) approach means a stale failed estimate can linger. Consider clearing failed estimates when a successful calibration runs. Future work.
+
+## Open Questions
+
+1. **Has `du -sb` been tested on btrfs snapshots with xattrs and symlinks on this system?** The journal flags this but doesn't resolve it. Edge case: `du -sb` follows symlinks by default — if snapshots contain symlinks to large files outside the snapshot, the estimate could be wildly wrong. Check whether `-P` (don't follow symlinks) should be added.
+
+2. **Should successful sends update `subvolume_sizes`?** After a successful full send, the exact pipe bytes are known. Storing them in `subvolume_sizes` would keep calibration data fresh without running `urd calibrate`. This would close the staleness gap for subvolumes that successfully send. The trade-off: pipe bytes ≠ `du -sb` bytes (different measurement), so mixing methods in one table could confuse future queries. Worth discussing.
+
+3. **What happens if the progress thread panics?** The thread runs `progress_display_loop` which can't panic (no `unwrap`, no indexing). But if it did, `h.join()` in `backup.rs:98` would return `Err`, which `.ok()` swallows. The backup would complete but the progress line might not be cleared. Low risk, but worth noting.
+
+---
+
+**Metadata:**
+- Commit SHA: `a60f031` (base; changes are unstaged)
+- Test results: 144 passed, 0 failed, 0 ignored
+- Clippy: clean (`-D warnings`)
+- Files reviewed: `src/error.rs`, `src/btrfs.rs`, `src/executor.rs`, `src/state.rs`, `src/plan.rs`, `src/cli.rs`, `src/main.rs`, `src/commands/calibrate.rs`, `src/commands/backup.rs`, `src/commands/init.rs`
+- Areas excluded: retention.rs, chain.rs, metrics.rs (not touched by these changes)

--- a/src/btrfs.rs
+++ b/src/btrfs.rs
@@ -1,8 +1,10 @@
 use std::cell::RefCell;
 use std::collections::HashSet;
-use std::io::Read as _;
+use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use crate::error::UrdError;
 
@@ -33,16 +35,20 @@ pub trait BtrfsOps {
 
 pub struct RealBtrfs {
     btrfs_path: String,
+    /// Live byte counter updated during send/receive. The executor can poll
+    /// this to display transfer progress. Not part of the `BtrfsOps` trait —
+    /// progress display is a presentation concern, not a correctness contract.
+    bytes_counter: Arc<AtomicU64>,
 }
 
 impl RealBtrfs {
     #[must_use]
-    pub fn new(btrfs_path: &str) -> Self {
+    pub fn new(btrfs_path: &str, bytes_counter: Arc<AtomicU64>) -> Self {
         Self {
             btrfs_path: btrfs_path.to_string(),
+            bytes_counter,
         }
     }
-
 }
 
 impl BtrfsOps for RealBtrfs {
@@ -59,15 +65,21 @@ impl BtrfsOps for RealBtrfs {
             .arg(source)
             .arg(dest)
             .output()
-            .map_err(|e| UrdError::Btrfs(format!("failed to spawn btrfs: {e}")))?;
+            .map_err(|e| UrdError::Btrfs {
+                msg: format!("failed to spawn btrfs: {e}"),
+                bytes_transferred: None,
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(UrdError::Btrfs(format!(
-                "snapshot failed (exit {}): {}",
-                output.status.code().unwrap_or(-1),
-                stderr.trim()
-            )));
+            return Err(UrdError::Btrfs {
+                msg: format!(
+                    "snapshot failed (exit {}): {}",
+                    output.status.code().unwrap_or(-1),
+                    stderr.trim()
+                ),
+                bytes_transferred: None,
+            });
         }
         Ok(())
     }
@@ -98,16 +110,25 @@ impl BtrfsOps for RealBtrfs {
 
         let mut send_child = send_cmd
             .spawn()
-            .map_err(|e| UrdError::Btrfs(format!("failed to spawn btrfs send: {e}")))?;
+            .map_err(|e| UrdError::Btrfs {
+                msg: format!("failed to spawn btrfs send: {e}"),
+                bytes_transferred: None,
+            })?;
 
         // Take send's stdout to pipe into receive's stdin
         let mut send_stdout = send_child.stdout.take().ok_or_else(|| {
-            UrdError::Btrfs("failed to capture btrfs send stdout".to_string())
+            UrdError::Btrfs {
+                msg: "failed to capture btrfs send stdout".to_string(),
+                bytes_transferred: None,
+            }
         })?;
 
         // Take send's stderr to drain in a thread
         let send_stderr = send_child.stderr.take().ok_or_else(|| {
-            UrdError::Btrfs("failed to capture btrfs send stderr".to_string())
+            UrdError::Btrfs {
+                msg: "failed to capture btrfs send stderr".to_string(),
+                bytes_transferred: None,
+            }
         })?;
 
         // Drain send stderr in a background thread to prevent deadlock
@@ -132,28 +153,54 @@ impl BtrfsOps for RealBtrfs {
             .stdin(Stdio::piped())
             .stderr(Stdio::piped())
             .spawn()
-            .map_err(|e| UrdError::Btrfs(format!("failed to spawn btrfs receive: {e}")))?;
+            .map_err(|e| UrdError::Btrfs {
+                msg: format!("failed to spawn btrfs receive: {e}"),
+                bytes_transferred: None,
+            })?;
 
         let mut recv_stdin = recv_child.stdin.take().ok_or_else(|| {
-            UrdError::Btrfs("failed to capture btrfs receive stdin".to_string())
+            UrdError::Btrfs {
+                msg: "failed to capture btrfs receive stdin".to_string(),
+                bytes_transferred: None,
+            }
         })?;
 
-        // Copy send stdout → receive stdin in a thread, counting bytes
-        let copy_thread = std::thread::spawn(move || {
-            let bytes = std::io::copy(&mut send_stdout, &mut recv_stdin);
+        // Copy send stdout → receive stdin in a thread, counting bytes.
+        // Uses a chunked loop instead of std::io::copy so the bytes_counter
+        // is updated live for progress display.
+        let counter = self.bytes_counter.clone();
+        counter.store(0, Ordering::Relaxed);
+        let copy_thread = std::thread::spawn(move || -> std::io::Result<u64> {
+            let mut buf = [0u8; 128 * 1024]; // 128KB chunks
+            let mut total: u64 = 0;
+            loop {
+                let n = send_stdout.read(&mut buf)?;
+                if n == 0 {
+                    break;
+                }
+                recv_stdin.write_all(&buf[..n])?;
+                total += n as u64;
+                counter.store(total, Ordering::Relaxed);
+            }
             drop(recv_stdin); // close pipe to signal EOF to receive
-            bytes
+            Ok(total)
         });
 
         // Wait for receive to finish
         let recv_output = recv_child
             .wait_with_output()
-            .map_err(|e| UrdError::Btrfs(format!("failed to wait for btrfs receive: {e}")))?;
+            .map_err(|e| UrdError::Btrfs {
+                msg: format!("failed to wait for btrfs receive: {e}"),
+                bytes_transferred: None,
+            })?;
 
         // Wait for send to finish
         let send_status = send_child
             .wait()
-            .map_err(|e| UrdError::Btrfs(format!("failed to wait for btrfs send: {e}")))?;
+            .map_err(|e| UrdError::Btrfs {
+                msg: format!("failed to wait for btrfs send: {e}"),
+                bytes_transferred: None,
+            })?;
 
         let bytes_copied = copy_thread.join().unwrap_or(Ok(0)).ok();
 
@@ -197,7 +244,10 @@ impl BtrfsOps for RealBtrfs {
                     recv_stderr_str.trim()
                 ));
             }
-            return Err(UrdError::Btrfs(msg));
+            return Err(UrdError::Btrfs {
+                msg,
+                bytes_transferred: bytes_copied,
+            });
         }
 
         if !send_stderr_str.is_empty() {
@@ -223,15 +273,21 @@ impl BtrfsOps for RealBtrfs {
             .args(["subvolume", "delete"])
             .arg(path)
             .output()
-            .map_err(|e| UrdError::Btrfs(format!("failed to spawn btrfs: {e}")))?;
+            .map_err(|e| UrdError::Btrfs {
+                msg: format!("failed to spawn btrfs: {e}"),
+                bytes_transferred: None,
+            })?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(UrdError::Btrfs(format!(
-                "delete failed (exit {}): {}",
-                output.status.code().unwrap_or(-1),
-                stderr.trim()
-            )));
+            return Err(UrdError::Btrfs {
+                msg: format!(
+                    "delete failed (exit {}): {}",
+                    output.status.code().unwrap_or(-1),
+                    stderr.trim()
+                ),
+                bytes_transferred: None,
+            });
         }
         Ok(())
     }
@@ -275,6 +331,8 @@ pub struct MockBtrfs {
     pub existing_subvolumes: RefCell<HashSet<PathBuf>>,
     pub free_bytes: RefCell<u64>,
     pub mock_bytes_transferred: RefCell<Option<u64>>,
+    /// Partial bytes to report when a send fails (simulates partial transfer)
+    pub mock_fail_send_bytes: RefCell<Option<u64>>,
 }
 
 #[allow(dead_code)]
@@ -289,6 +347,7 @@ impl MockBtrfs {
             existing_subvolumes: RefCell::new(HashSet::new()),
             free_bytes: RefCell::new(1_000_000_000_000), // 1TB default
             mock_bytes_transferred: RefCell::new(None),
+            mock_fail_send_bytes: RefCell::new(None),
         }
     }
 
@@ -311,10 +370,10 @@ impl BtrfsOps for MockBtrfs {
             dest: dest.to_path_buf(),
         });
         if self.fail_creates.borrow().contains(dest) {
-            return Err(UrdError::Btrfs(format!(
-                "mock: create snapshot failed for {}",
-                dest.display()
-            )));
+            return Err(UrdError::Btrfs {
+                msg: format!("mock: create snapshot failed for {}", dest.display()),
+                bytes_transferred: None,
+            });
         }
         Ok(())
     }
@@ -331,10 +390,10 @@ impl BtrfsOps for MockBtrfs {
             dest_dir: dest_dir.to_path_buf(),
         });
         if self.fail_sends.borrow().contains(snapshot) {
-            return Err(UrdError::Btrfs(format!(
-                "mock: send failed for {}",
-                snapshot.display()
-            )));
+            return Err(UrdError::Btrfs {
+                msg: format!("mock: send failed for {}", snapshot.display()),
+                bytes_transferred: *self.mock_fail_send_bytes.borrow(),
+            });
         }
         Ok(SendResult {
             bytes_transferred: *self.mock_bytes_transferred.borrow(),
@@ -348,10 +407,10 @@ impl BtrfsOps for MockBtrfs {
                 path: path.to_path_buf(),
             });
         if self.fail_deletes.borrow().contains(path) {
-            return Err(UrdError::Btrfs(format!(
-                "mock: delete failed for {}",
-                path.display()
-            )));
+            return Err(UrdError::Btrfs {
+                msg: format!("mock: delete failed for {}", path.display()),
+                bytes_transferred: None,
+            });
         }
         Ok(())
     }
@@ -454,6 +513,23 @@ mod tests {
 
         let result = mock.send_receive(&snap, None, Path::new("/dest"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn mock_send_failure_with_partial_bytes() {
+        let mock = MockBtrfs::new();
+        let snap = PathBuf::from("/snap/fail");
+        mock.fail_sends.borrow_mut().insert(snap.clone());
+        *mock.mock_fail_send_bytes.borrow_mut() = Some(500_000);
+
+        let result = mock.send_receive(&snap, None, Path::new("/dest"));
+        let err = result.unwrap_err();
+        match err {
+            UrdError::Btrfs { bytes_transferred, .. } => {
+                assert_eq!(bytes_transferred, Some(500_000));
+            }
+            _ => panic!("expected UrdError::Btrfs"),
+        }
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,6 +31,8 @@ pub enum Commands {
     Verify(VerifyArgs),
     /// Initialize state database and validate system readiness
     Init,
+    /// Measure snapshot sizes for space estimation (run before first external send)
+    Calibrate(CalibrateArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -88,6 +90,13 @@ pub struct HistoryArgs {
     /// Show only failed operations
     #[arg(long)]
     pub failures: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct CalibrateArgs {
+    /// Only calibrate this subvolume
+    #[arg(long)]
+    pub subvolume: Option<String>,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,7 +1,9 @@
 use std::collections::HashSet;
 use std::fs::File;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::io::IsTerminal;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use colored::Colorize;
 
@@ -13,6 +15,7 @@ use crate::executor::{Executor, RunResult, SendType};
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
 use crate::state::StateDb;
+use crate::types::ByteSize;
 
 pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let now = chrono::Local::now().naive_local();
@@ -69,11 +72,30 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         log::warn!("Failed to set signal handler: {e}");
     }
 
-    // Set up executor
-    let btrfs = RealBtrfs::new(&config.general.btrfs_path);
+    // Set up executor with live byte counter for progress display
+    let bytes_counter = Arc::new(AtomicU64::new(0));
+    let btrfs = RealBtrfs::new(&config.general.btrfs_path, bytes_counter.clone());
+
+    // Spawn progress display thread if running on a TTY
+    let progress_shutdown = Arc::new(AtomicBool::new(false));
+    let progress_handle = if std::io::stderr().is_terminal() {
+        let counter = bytes_counter.clone();
+        let shutdown_flag = progress_shutdown.clone();
+        Some(std::thread::spawn(move || {
+            progress_display_loop(&counter, &shutdown_flag);
+        }))
+    } else {
+        None
+    };
 
     let executor = Executor::new(&btrfs, state_db.as_ref(), &config, &shutdown);
     let result = executor.execute(&backup_plan, mode);
+
+    // Stop progress display
+    progress_shutdown.store(true, Ordering::SeqCst);
+    if let Some(h) = progress_handle {
+        h.join().ok();
+    }
 
     // Print results
     println!(
@@ -347,4 +369,68 @@ fn count_external_snapshots(
         }
     }
     0
+}
+
+/// Polls the byte counter and displays a live progress line on stderr.
+/// Only runs when stderr is a TTY. Cleans up the line on exit.
+fn progress_display_loop(counter: &AtomicU64, shutdown: &AtomicBool) {
+    let mut send_start = Instant::now();
+    let mut last_display_bytes = 0u64;
+
+    while !shutdown.load(Ordering::SeqCst) {
+        std::thread::sleep(Duration::from_millis(250));
+
+        let current = counter.load(Ordering::Relaxed);
+        if current == 0 {
+            // Counter reset to 0 — between sends or before first send.
+            // Reset tracking so next non-zero read starts a fresh timer.
+            last_display_bytes = 0;
+            continue;
+        }
+        if current == last_display_bytes {
+            continue;
+        }
+
+        // Detect new send start (counter went from 0 to non-zero)
+        if last_display_bytes == 0 {
+            send_start = Instant::now();
+        }
+        last_display_bytes = current;
+
+        let elapsed = send_start.elapsed();
+        let rate = if elapsed.as_secs_f64() > 0.5 {
+            current as f64 / elapsed.as_secs_f64()
+        } else {
+            0.0
+        };
+
+        let elapsed_str = format_elapsed(elapsed);
+
+        if rate > 0.0 {
+            eprint!(
+                "\r  {} @ {}/s  [{}]    ",
+                ByteSize(current),
+                ByteSize(rate as u64),
+                elapsed_str,
+            );
+        } else {
+            eprint!("\r  {}  [{}]    ", ByteSize(current), elapsed_str);
+        }
+    }
+
+    // Clear the progress line
+    eprint!("\r\x1b[2K");
+}
+
+fn format_elapsed(d: Duration) -> String {
+    let total_secs = d.as_secs();
+    let hours = total_secs / 3600;
+    let mins = (total_secs % 3600) / 60;
+    let secs = total_secs % 60;
+
+    if hours > 0 {
+        format!("{hours}:{mins:02}:{secs:02}")
+    } else {
+        format!("{mins}:{secs:02}")
+    }
 }

--- a/src/commands/calibrate.rs
+++ b/src/commands/calibrate.rs
@@ -1,0 +1,122 @@
+use std::io::Write;
+
+use colored::Colorize;
+
+use crate::cli::CalibrateArgs;
+use crate::config::Config;
+use crate::plan::RealFileSystemState;
+use crate::plan::FileSystemState;
+use crate::state::StateDb;
+use crate::types::ByteSize;
+
+pub fn run(config: Config, args: CalibrateArgs) -> anyhow::Result<()> {
+    let state_db = StateDb::open(&config.general.state_db)?;
+    let resolved = config.resolved_subvolumes();
+
+    println!("{}", "Urd calibrate — measuring snapshot sizes".bold());
+    println!();
+
+    let fs_state = RealFileSystemState { state: Some(&state_db) };
+    let mut calibrated = 0usize;
+    let mut skipped = 0usize;
+
+    for subvol in &resolved {
+        // Filter by subvolume name if specified
+        if let Some(ref filter) = args.subvolume
+            && &subvol.name != filter
+        {
+            continue;
+        }
+
+        if !subvol.enabled {
+            println!("  {} {} (disabled)", "SKIP".dimmed(), subvol.name);
+            skipped += 1;
+            continue;
+        }
+
+        let Some(snapshot_root) = config.snapshot_root_for(&subvol.name) else {
+            println!(
+                "  {} {} (no snapshot root configured)",
+                "SKIP".dimmed(),
+                subvol.name,
+            );
+            skipped += 1;
+            continue;
+        };
+
+        let local_snaps = fs_state
+            .local_snapshots(&snapshot_root, &subvol.name)
+            .unwrap_or_default();
+
+        let Some(newest) = local_snaps.iter().max() else {
+            println!(
+                "  {} {} (no local snapshots)",
+                "SKIP".dimmed(),
+                subvol.name,
+            );
+            skipped += 1;
+            continue;
+        };
+
+        let snap_path = snapshot_root.join(&subvol.name).join(newest.as_str());
+
+        print!("  {} ({})... ", subvol.name.bold(), newest);
+        std::io::stdout().flush()?;
+
+        // Run du -sb on the snapshot (apparent size in bytes)
+        let output = std::process::Command::new("du")
+            .args(["-sb"])
+            .arg(&snap_path)
+            .output();
+
+        match output {
+            Ok(output) if output.status.success() => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let bytes: Option<u64> = stdout
+                    .split_whitespace()
+                    .next()
+                    .and_then(|s| s.parse().ok())
+                    .filter(|&b: &u64| b > 0);
+
+                match bytes {
+                    Some(bytes) => {
+                        state_db.upsert_subvolume_size(&subvol.name, bytes, "du -sb")?;
+                        println!("{}", ByteSize(bytes));
+                        calibrated += 1;
+                    }
+                    None => {
+                        println!("{}", "FAILED".red());
+                        eprintln!(
+                            "    du -sb returned no usable size (output: {:?})",
+                            stdout.trim(),
+                        );
+                        skipped += 1;
+                    }
+                }
+            }
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                println!("{}", "FAILED".red());
+                eprintln!("    du failed: {}", stderr.trim());
+                skipped += 1;
+            }
+            Err(e) => {
+                println!("{}", "FAILED".red());
+                eprintln!("    du error: {e}");
+                skipped += 1;
+            }
+        }
+    }
+
+    println!();
+    println!(
+        "Calibrated {} subvolume(s), skipped {}.",
+        calibrated, skipped,
+    );
+    println!(
+        "Sizes stored in state database. The planner will use these as fallback",
+    );
+    println!("estimates when no send history exists.");
+
+    Ok(())
+}

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -256,7 +256,10 @@ pub fn run(config: Config) -> anyhow::Result<()> {
                     let mut input = String::new();
                     std::io::stdin().read_line(&mut input)?;
                     if input.trim().eq_ignore_ascii_case("y") {
-                        let btrfs = RealBtrfs::new(&config.general.btrfs_path);
+                        let btrfs = RealBtrfs::new(
+                            &config.general.btrfs_path,
+                            std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                        );
                         match btrfs.delete_subvolume(&partial_path) {
                             Ok(()) => println!(
                                 "  {} Deleted {}",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod backup;
+pub mod calibrate;
 pub mod history;
 pub mod init;
 pub mod plan_cmd;

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,8 +22,11 @@ pub enum UrdError {
     #[allow(dead_code)]
     Retention(String),
 
-    #[error("Btrfs command failed: {0}")]
-    Btrfs(String),
+    #[error("Btrfs command failed: {msg}")]
+    Btrfs {
+        msg: String,
+        bytes_transferred: Option<u64>,
+    },
 
     #[error("State database error: {0}")]
     State(String),

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -412,7 +412,19 @@ impl<'a> Executor<'a> {
                 )
             }
             Err(e) => {
+                // Extract partial byte count from btrfs errors (e.g., failed sends
+                // that transferred some data before the pipe broke)
+                let partial_bytes = match &e {
+                    crate::error::UrdError::Btrfs { bytes_transferred, .. } => *bytes_transferred,
+                    _ => None,
+                };
                 log::error!("{op_name} failed for {subvol_name} -> {drive_label}: {e}");
+                if let Some(bytes) = partial_bytes {
+                    log::info!(
+                        "Partial transfer: {} bytes copied before failure",
+                        bytes,
+                    );
+                }
                 (
                     OperationOutcome {
                         operation: op_name.to_string(),
@@ -420,7 +432,7 @@ impl<'a> Executor<'a> {
                         result: OpResult::Failure,
                         duration: start.elapsed(),
                         error: Some(e.to_string()),
-                        bytes_transferred: None,
+                        bytes_transferred: partial_bytes,
                     },
                     false,
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Plan(args) => commands::plan_cmd::run(config, args),
         Commands::Backup(args) => commands::backup::run(config, args),
         Commands::Init => commands::init::run(config),
+        Commands::Calibrate(args) => commands::calibrate::run(config, args),
         Commands::Status => commands::status::run(config),
         Commands::History(args) => commands::history::run(config, args),
         Commands::Verify(args) => commands::verify::run(config, args),

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -52,6 +52,10 @@ pub trait FileSystemState {
         drive_label: &str,
         send_type: &str,
     ) -> Option<u64>;
+
+    /// Get a calibrated size estimate for a subvolume (from `urd calibrate`).
+    /// Returns `(estimated_bytes, measured_at)` or None if not calibrated.
+    fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)>;
 }
 
 // ── PlanFilters ─────────────────────────────────────────────────────────
@@ -365,15 +369,14 @@ fn plan_external_send(
         false
     };
 
-    // Space estimation: skip if historical send size exceeds available space
+    // Space estimation: skip if estimated send size exceeds available space.
+    // Tier 1: Historical send data (most accurate). Tier 3: Calibrated sizes (fallback for full sends).
     let send_type_str = if is_incremental { "send_incremental" } else { "send_full" };
     if let Some(last_size) = fs.last_send_size(&subvol.name, &drive.label, send_type_str) {
-        let estimated = (last_size as f64 * 1.2) as u64; // 20% safety margin
-        let free = fs.filesystem_free_bytes(&ext_dir).unwrap_or(u64::MAX);
-        let min_free = drive.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
-        let available = free.saturating_sub(min_free);
-
-        if estimated > available {
+        // Tier 1: historical data from previous sends (successful or failed)
+        if let Some((estimated, available, free, min_free)) =
+            exceeds_available_space(last_size, &ext_dir, drive, fs)
+        {
             use crate::types::ByteSize;
             skipped.push((
                 subvol.name.clone(),
@@ -387,6 +390,33 @@ fn plan_external_send(
                 ),
             ));
             return;
+        }
+    } else if !is_incremental {
+        // Tier 3: Calibrated size from `urd calibrate` (only for full sends)
+        if let Some((cal_bytes, measured_at)) = fs.calibrated_size(&subvol.name) {
+            let age_days = calibration_age_days(&measured_at);
+            let staleness = if age_days > 30 {
+                format!(" (calibrated {} days ago — run `urd calibrate` to refresh)", age_days)
+            } else {
+                String::new()
+            };
+
+            if let Some((estimated, available, _, _)) =
+                exceeds_available_space(cal_bytes, &ext_dir, drive, fs)
+            {
+                use crate::types::ByteSize;
+                skipped.push((
+                    subvol.name.clone(),
+                    format!(
+                        "send to {} skipped: calibrated size ~{} exceeds {} available{}",
+                        drive.label,
+                        ByteSize(estimated),
+                        ByteSize(available),
+                        staleness,
+                    ),
+                ));
+                return;
+            }
         }
     }
 
@@ -463,6 +493,32 @@ fn format_duration_short(minutes: i64) -> String {
     }
 }
 
+/// Check if estimated send size (with 1.2x margin) exceeds available space on the drive.
+/// Returns `Some((estimated, available, free, min_free))` if space is insufficient, `None` if OK.
+fn exceeds_available_space(
+    raw_bytes: u64,
+    ext_dir: &Path,
+    drive: &DriveConfig,
+    fs: &dyn FileSystemState,
+) -> Option<(u64, u64, u64, u64)> {
+    let estimated = (raw_bytes as f64 * 1.2) as u64; // 20% safety margin
+    let free = fs.filesystem_free_bytes(ext_dir).unwrap_or(u64::MAX);
+    let min_free = drive.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
+    let available = free.saturating_sub(min_free);
+    if estimated > available {
+        Some((estimated, available, free, min_free))
+    } else {
+        None
+    }
+}
+
+fn calibration_age_days(measured_at: &str) -> i64 {
+    let now = chrono::Local::now().naive_local();
+    chrono::NaiveDateTime::parse_from_str(measured_at, "%Y-%m-%dT%H:%M:%S")
+        .map(|ts| (now - ts).num_days())
+        .unwrap_or(365) // corrupt timestamp → treat as stale, not fresh
+}
+
 // ── RealFileSystemState ─────────────────────────────────────────────────
 
 /// Real filesystem state — reads actual directories, pin files, and mounts.
@@ -516,9 +572,22 @@ impl FileSystemState for RealFileSystemState<'_> {
         send_type: &str,
     ) -> Option<u64> {
         self.state.and_then(|db| {
-            db.last_successful_send_size(subvol_name, drive_label, send_type)
+            let successful = db.last_successful_send_size(subvol_name, drive_label, send_type)
                 .ok()
-                .flatten()
+                .flatten();
+            let failed = db.last_failed_send_size(subvol_name, drive_label, send_type)
+                .ok()
+                .flatten();
+            match (successful, failed) {
+                (Some(s), Some(f)) => Some(s.max(f)),
+                (s, f) => s.or(f),
+            }
+        })
+    }
+
+    fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)> {
+        self.state.and_then(|db| {
+            db.calibrated_size(subvol_name).ok().flatten()
         })
     }
 }
@@ -564,6 +633,7 @@ pub struct MockFileSystemState {
     pub free_bytes: std::collections::HashMap<PathBuf, u64>,
     pub pin_files: std::collections::HashMap<(PathBuf, String), SnapshotName>,
     pub send_sizes: std::collections::HashMap<(String, String, String), u64>,
+    pub calibrated_sizes: std::collections::HashMap<String, (u64, String)>,
 }
 
 #[cfg(test)]
@@ -576,6 +646,7 @@ impl MockFileSystemState {
             free_bytes: std::collections::HashMap::new(),
             pin_files: std::collections::HashMap::new(),
             send_sizes: std::collections::HashMap::new(),
+            calibrated_sizes: std::collections::HashMap::new(),
         }
     }
 }
@@ -641,6 +712,10 @@ impl FileSystemState for MockFileSystemState {
                 send_type.to_string(),
             ))
             .copied()
+    }
+
+    fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)> {
+        self.calibrated_sizes.get(subvol_name).cloned()
     }
 }
 
@@ -1234,6 +1309,88 @@ send_enabled = false
             .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
             .collect();
         assert_eq!(sends.len(), 1, "First-ever send should proceed without history");
+    }
+
+    #[test]
+    fn calibrated_size_skips_send_when_too_large() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.mounted_drives.insert("D1".to_string());
+        // No send history (Tier 1), but calibrated size says 1TB
+        fs.calibrated_sizes.insert(
+            "sv1".to_string(),
+            (1_000_000_000_000, "2026-03-22T12:00:00".to_string()),
+        );
+        // Drive has only 500GB free
+        fs.free_bytes.insert(
+            PathBuf::from("/mnt/d1/.snapshots/sv1"),
+            500_000_000_000,
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(sends.len(), 0, "Send should be skipped when calibrated size exceeds available space");
+        assert!(
+            result.skipped.iter().any(|(name, reason)| name == "sv1" && reason.contains("calibrated size")),
+            "Skip reason should mention calibrated size"
+        );
+    }
+
+    #[test]
+    fn tier1_overrides_calibrated_size() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.mounted_drives.insert("D1".to_string());
+        // Tier 1 says 100KB (small send)
+        fs.send_sizes.insert(
+            ("sv1".to_string(), "D1".to_string(), "send_full".to_string()),
+            100_000,
+        );
+        // Calibrated says 1TB (would block if used)
+        fs.calibrated_sizes.insert(
+            "sv1".to_string(),
+            (1_000_000_000_000, "2026-03-22T12:00:00".to_string()),
+        );
+        // Drive has 500GB free — enough for Tier 1 estimate, not for calibrated
+        fs.free_bytes.insert(
+            PathBuf::from("/mnt/d1/.snapshots/sv1"),
+            500_000_000_000,
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(sends.len(), 1, "Tier 1 history should override calibrated size");
+    }
+
+    #[test]
+    fn send_proceeds_without_history_or_calibration() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.mounted_drives.insert("D1".to_string());
+        // No send_sizes, no calibrated_sizes — fail open
+        fs.free_bytes.insert(
+            PathBuf::from("/mnt/d1/.snapshots/sv1"),
+            1_000_000,
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(sends.len(), 1, "First-ever send should proceed without history or calibration");
     }
 
     #[test]

--- a/src/state.rs
+++ b/src/state.rs
@@ -100,6 +100,13 @@ impl StateDb {
                     result TEXT NOT NULL,
                     error_message TEXT,
                     bytes_transferred INTEGER
+                );
+
+                CREATE TABLE IF NOT EXISTS subvolume_sizes (
+                    subvolume TEXT PRIMARY KEY,
+                    estimated_bytes INTEGER NOT NULL,
+                    measured_at TEXT NOT NULL,
+                    method TEXT NOT NULL
                 );",
             )
             .map_err(|e| UrdError::State(format!("failed to create schema: {e}")))?;
@@ -275,6 +282,89 @@ impl StateDb {
                 "SELECT bytes_transferred FROM operations
                  WHERE subvolume = ?1 AND drive_label = ?2 AND operation = ?3
                    AND result = 'success' AND bytes_transferred IS NOT NULL
+                 ORDER BY id DESC LIMIT 1",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut rows = stmt
+            .query_map(rusqlite::params![subvol, drive, send_type], |row| {
+                let bytes: i64 = row.get(0)?;
+                Ok(bytes as u64)
+            })
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        match rows.next() {
+            Some(Ok(size)) => Ok(Some(size)),
+            Some(Err(e)) => Err(UrdError::State(format!("failed to read send size: {e}"))),
+            None => Ok(None),
+        }
+    }
+
+    // ── Calibration methods ─────────────────────────────────────────
+
+    /// Store (or update) a calibrated size for a subvolume.
+    pub fn upsert_subvolume_size(
+        &self,
+        subvolume: &str,
+        estimated_bytes: u64,
+        method: &str,
+    ) -> crate::error::Result<()> {
+        let now = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+        self.conn
+            .execute(
+                "INSERT INTO subvolume_sizes (subvolume, estimated_bytes, measured_at, method)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(subvolume) DO UPDATE SET
+                   estimated_bytes = ?2, measured_at = ?3, method = ?4",
+                rusqlite::params![subvolume, estimated_bytes as i64, now, method],
+            )
+            .map_err(|e| UrdError::State(format!("failed to upsert subvolume size: {e}")))?;
+        Ok(())
+    }
+
+    /// Get the calibrated size for a subvolume, if any.
+    /// Returns `(estimated_bytes, measured_at)`.
+    pub fn calibrated_size(
+        &self,
+        subvolume: &str,
+    ) -> crate::error::Result<Option<(u64, String)>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT estimated_bytes, measured_at FROM subvolume_sizes WHERE subvolume = ?1",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut rows = stmt
+            .query_map(rusqlite::params![subvolume], |row| {
+                let bytes: i64 = row.get(0)?;
+                let measured_at: String = row.get(1)?;
+                Ok((bytes as u64, measured_at))
+            })
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        match rows.next() {
+            Some(Ok(result)) => Ok(Some(result)),
+            Some(Err(e)) => Err(UrdError::State(format!("failed to read calibrated size: {e}"))),
+            None => Ok(None),
+        }
+    }
+
+    /// Get the bytes_transferred from the most recent failed send of a given type
+    /// for a subvolume to a specific drive, where partial bytes were recorded.
+    /// This serves as a lower bound: the actual size is at least this large.
+    pub fn last_failed_send_size(
+        &self,
+        subvol: &str,
+        drive: &str,
+        send_type: &str,
+    ) -> crate::error::Result<Option<u64>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT bytes_transferred FROM operations
+                 WHERE subvolume = ?1 AND drive_label = ?2 AND operation = ?3
+                   AND result = 'failure' AND bytes_transferred IS NOT NULL
                  ORDER BY id DESC LIMIT 1",
             )
             .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
@@ -666,5 +756,108 @@ mod tests {
             db.last_successful_send_size("sv1", "D", "send_full").unwrap(),
             Some(999)
         );
+    }
+
+    // ── last_failed_send_size tests ───────────────────────────────────
+
+    #[test]
+    fn last_failed_send_size_returns_partial_bytes() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "subvol5-music".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("2TB-backup".to_string()),
+            duration_secs: Some(600.0),
+            result: "failure".to_string(),
+            error_message: Some("No space left".to_string()),
+            bytes_transferred: Some(1_100_000_000_000),
+        })
+        .unwrap();
+
+        assert_eq!(
+            db.last_failed_send_size("subvol5-music", "2TB-backup", "send_full").unwrap(),
+            Some(1_100_000_000_000)
+        );
+    }
+
+    #[test]
+    fn last_failed_send_size_ignores_null_bytes() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        // Failed send without bytes_transferred (old-style failure)
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("D".to_string()),
+            duration_secs: Some(5.0),
+            result: "failure".to_string(),
+            error_message: Some("error".to_string()),
+            bytes_transferred: None,
+        })
+        .unwrap();
+
+        assert_eq!(
+            db.last_failed_send_size("sv1", "D", "send_full").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn last_failed_send_size_ignores_successes() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("D".to_string()),
+            duration_secs: Some(10.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(500_000),
+        })
+        .unwrap();
+
+        assert_eq!(
+            db.last_failed_send_size("sv1", "D", "send_full").unwrap(),
+            None
+        );
+    }
+
+    // ── calibration tests ─────────────────────────────────────────────
+
+    #[test]
+    fn upsert_and_query_calibrated_size() {
+        let db = StateDb::open_memory().unwrap();
+
+        db.upsert_subvolume_size("htpc-home", 77_640_000_000, "du -sb").unwrap();
+        let result = db.calibrated_size("htpc-home").unwrap();
+        assert!(result.is_some());
+        let (bytes, measured_at) = result.unwrap();
+        assert_eq!(bytes, 77_640_000_000);
+        assert!(!measured_at.is_empty());
+    }
+
+    #[test]
+    fn upsert_overwrites_calibrated_size() {
+        let db = StateDb::open_memory().unwrap();
+
+        db.upsert_subvolume_size("sv1", 100, "du -sb").unwrap();
+        db.upsert_subvolume_size("sv1", 200, "du -sb").unwrap();
+
+        let (bytes, _) = db.calibrated_size("sv1").unwrap().unwrap();
+        assert_eq!(bytes, 200);
+    }
+
+    #[test]
+    fn calibrated_size_returns_none_for_unknown() {
+        let db = StateDb::open_memory().unwrap();
+        assert_eq!(db.calibrated_size("nonexistent").unwrap(), None);
     }
 }


### PR DESCRIPTION
## Summary

- **Failed send bytes (P2):** `UrdError::Btrfs` carries `bytes_transferred` from partial sends. Planner uses MAX(successful, failed) for space estimation — system self-heals after one failed send
- **Progress display (P3):** `AtomicU64` counter in `RealBtrfs` with TTY display thread showing bytes/rate/elapsed on stderr. Stays outside `BtrfsOps` trait
- **`urd calibrate` (P4):** Measures snapshot sizes via `du -sb`, stores in `subvolume_sizes` table as Tier 3 fallback for first-ever full sends. Tier 1 always overrides
- **Adversary review fixes:** Progress timer reset between sends, reject 0-byte calibration, corrupt timestamp staleness handling, space check deduplication, ANSI line clearing

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 144 passed, 0 failed
- Integration tests: not applicable (requires mounted drives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)