### PR TITLE
feat: Add heartbeat file — JSON health signal after every backup run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,7 @@ dependencies = [
  "nix 0.29.0",
  "rusqlite",
  "serde",
+ "serde_json",
  "tempfile",
  "thiserror",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ clap = { version = "4", features = ["derive"] }
 
 # Serialization & config
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 toml = "0.8"
 
 # Database

--- a/config/urd.toml.example
+++ b/config/urd.toml.example
@@ -10,6 +10,8 @@ metrics_file = "~/containers/data/backup-metrics/backup.prom"
 log_dir = "~/containers/data/backup-logs"
 # Path to btrfs binary (sudoers entries reference this)
 btrfs_path = "/usr/sbin/btrfs"
+# Heartbeat file — JSON health signal written after each backup run
+# heartbeat_file = "~/.local/share/urd/heartbeat.json"
 
 # ─── Local Snapshot Roots ──────────────────────────────────────────────
 # Each root maps to a directory where snapshot subdirectories are created.

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -5,20 +5,30 @@
 
 ## Current State
 
-**Phase 5 has begun. The awareness model (Priority 3a) is built, double-reviewed, and
-passing 168 tests.** Operational cutover has not started — the bash script
+**Phase 5 continues. Awareness model (3a) and heartbeat file (3b) are built, reviewed, and
+passing 175 tests.** Operational cutover has not started — the bash script
 (`btrfs-snapshot-backup.sh`) is still the sole production backup system, running nightly at
 02:00 via `btrfs-backup-daily.timer`. Urd v0.1.0 is installed (`~/.cargo/bin/urd`) and has
 been tested manually on real subvolumes (2026-03-23), but is not deployed on a schedule.
 
-Phase 5 work completed: awareness model (`awareness.rs`) — a pure function computing
-PROTECTED / AT RISK / UNPROTECTED per subvolume from config + filesystem state + history.
-Design-reviewed before implementation, implementation-reviewed after. Asymmetric thresholds
-(local 2x/5x, external 1.5x/3x), best-drive aggregation (max across drives), clock skew
-protection, per-subvolume error capture. 24 awareness tests.
-[Journal](../98-journals/2026-03-23-awareness-model.md) |
-[Design review](../99-reports/2026-03-23-awareness-model-design-review.md) |
-[Implementation review](../99-reports/2026-03-23-awareness-model-implementation-review.md)
+Phase 5 work completed so far:
+
+- **Awareness model** (`awareness.rs`) — pure function computing PROTECTED / AT RISK /
+  UNPROTECTED per subvolume from config + filesystem state + history. Asymmetric thresholds
+  (local 2x/5x, external 1.5x/3x), best-drive aggregation (max across drives), clock skew
+  protection, per-subvolume error capture. 24 awareness tests. Double adversary-reviewed.
+  [Journal](../98-journals/2026-03-23-awareness-model.md) |
+  [Design review](../99-reports/2026-03-23-awareness-model-design-review.md) |
+  [Implementation review](../99-reports/2026-03-23-awareness-model-implementation-review.md)
+
+- **Heartbeat file** (`heartbeat.rs`) — JSON health signal at `~/.local/share/urd/heartbeat.json`,
+  written after every backup run (including empty runs). Schema v1 with `schema_version`,
+  `timestamp`, `stale_after` (derived from min interval × 2), `run_result`, `run_id`, and
+  per-subvolume promise status from the awareness model. Atomic writes (temp + rename).
+  Non-fatal — write failures are logged but never block backups. First real consumer of the
+  awareness model. `heartbeat_file` configurable in `[general]` with sensible default. 7 tests.
+  [Design review](../99-reports/2026-03-24-heartbeat-design-review.md) |
+  [Implementation review](../99-reports/2026-03-24-heartbeat-implementation-review.md)
 
 Prior work: pre-send space estimation, documentation system (CONTRIBUTING.md), first
 real-world backup testing, failed-send bytes recording, live progress display, `urd calibrate`.
@@ -65,13 +75,17 @@ Advisories for offsite cycling reminders. 24 tests. Double adversary-reviewed.
 - [x] Computable from existing `FileSystemState` trait (extended with `last_successful_send_time`)
 - [x] Testable with `MockFileSystemState` (including error injection)
 
-**3b. Heartbeat file** — JSON at `~/.local/share/urd/heartbeat.json`. Written after every
-backup run. Versioned schema, atomic writes (temp + rename), staleness advisory timestamp.
+**3b. Heartbeat file** (`heartbeat.rs`) — **COMPLETE.** JSON at
+`~/.local/share/urd/heartbeat.json`. Written after every backup run (including empty runs).
+Schema v1 with per-subvolume promise status from awareness model. Atomic writes,
+configurable path, non-fatal errors. 7 tests. Design-reviewed before implementation,
+implementation-reviewed after. Review fix applied: fresh timestamp at write time (not
+pre-execution `now`).
 
-- [ ] Schema versioned from day one (`schema_version` field)
-- [ ] Atomic write via temp file + rename
-- [ ] Includes computation timestamp + `stale_after` advisory
-- [ ] Minimal first iteration — add fields later, don't guess what consumers need
+- [x] Schema versioned from day one (`schema_version` field)
+- [x] Atomic write via temp file + rename
+- [x] Includes computation timestamp + `stale_after` advisory
+- [x] Minimal first iteration — add fields later, don't guess what consumers need
 
 **3c. Presentation layer** (`voice.rs`) — commands produce structured output data;
 the presentation layer renders it as text. Two renderers: interactive (rich, colored,
@@ -123,7 +137,7 @@ The Sentinel is three independent systems that compose. Build and test them sepa
 
 Architectural gates:
 - [x] Awareness model works independently (tested, no Sentinel dependency)
-- [ ] Heartbeat works independently (written by `urd backup`, read by Sentinel)
+- [x] Heartbeat works independently (written by `urd backup`, read by Sentinel)
 - [ ] Event/action types defined as enums (testable state machine)
 - [ ] Lock contention with manual `urd backup` designed
 - [ ] Circuit breaker designed (min interval between auto-triggers)
@@ -182,8 +196,16 @@ timestamp staleness handling, space check deduplication, ANSI line clearing.
 - **Awareness model** (Phase 5, P3a) — `awareness.rs`: pure function `assess(config, now, fs)`
   computing PROTECTED / AT RISK / UNPROTECTED per subvolume. Asymmetric thresholds, best-drive
   aggregation, clock skew protection, error capture, offsite advisories. `FileSystemState`
-  extended with `last_successful_send_time()`. 24 tests. Not yet integrated into status command.
+  extended with `last_successful_send_time()`. 24 tests. Integrated into heartbeat; not yet
+  integrated into status command.
   [Journal](../98-journals/2026-03-23-awareness-model.md)
+- **Heartbeat file** (Phase 5, P3b) — `heartbeat.rs`: JSON health signal written after every
+  backup run. Schema v1 with per-subvolume promise status from awareness model. Atomic writes,
+  configurable path (`heartbeat_file` in `[general]`), `stale_after` derived from min interval
+  × 2. Non-fatal errors. Fresh timestamp at write time. 7 tests. First consumer of awareness
+  model.
+  [Design review](../99-reports/2026-03-24-heartbeat-design-review.md) |
+  [Implementation review](../99-reports/2026-03-24-heartbeat-implementation-review.md)
 
 ### Not Building (dropped per adversary review)
 
@@ -204,7 +226,7 @@ timestamp staleness handling, space check deduplication, ANSI line clearing.
 - [x] **Phase 4 code** — Cutover polish + space estimation + real-world testing
 - [ ] **Phase 4 cutover** — Operational transition from bash to Urd (see below)
 - [x] **Post-cutover features** — failed-send bytes, progress, calibrate (Priorities 2-4)
-- [ ] **Phase 5** — Architectural foundation: ~~awareness model~~, heartbeat, presentation layer, `urd get`
+- [ ] **Phase 5** — Architectural foundation: ~~awareness model~~, ~~heartbeat~~, presentation layer, `urd get`
 - [ ] **Phase 5 gate** — ADR: protection promise design (retention mappings, config conflicts, migration)
 - [ ] **Phase 6** — Protection promises in config + planner + status
 - [ ] **Phase 7** — Sentinel: notification dispatcher → event reactor → active mode
@@ -258,6 +280,10 @@ for details.
 | Presentation layer: commands produce data, voice module renders text | 2026-03-23 | [Vision architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §4 |
 | `urd get` (O(1) path) ships before `urd find` (unsolved perf problem) | 2026-03-23 | [Vision architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §5 |
 | Heartbeat schema versioned from day one, atomic writes, staleness advisory | 2026-03-23 | [Vision architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §6 |
+| Heartbeat includes per-subvolume promise status (not just timestamp) | 2026-03-24 | [Heartbeat design review](../99-reports/2026-03-24-heartbeat-design-review.md) Finding 1 |
+| Heartbeat written on empty/skipped runs too (prevents false staleness) | 2026-03-24 | [Heartbeat design review](../99-reports/2026-03-24-heartbeat-design-review.md) Finding 3 |
+| stale_after = now + min(configured_intervals) × 2, matching awareness AT_RISK | 2026-03-24 | [Heartbeat design review](../99-reports/2026-03-24-heartbeat-design-review.md) Tension 3 |
+| Heartbeat uses fresh timestamp at write time, not pre-execution `now` | 2026-03-24 | [Heartbeat impl review](../99-reports/2026-03-24-heartbeat-implementation-review.md) Finding 1 |
 | Protection promises as core abstraction (score 10/10) | 2026-03-23 | [Vision brainstorm](../95-ideas/2026-03-23-brainstorm-realizing-the-vision.md) |
 | Mythic voice emerges from presentation layer, not scattered string edits | 2026-03-23 | User + architecture review |
 | Two modes: invisible worker + invoked norn | 2026-03-23 | User feedback on vision brainstorm |
@@ -280,7 +306,7 @@ for details.
 | Future directions brainstorm | [Feature ideas](../95-ideas/2026-03-23-brainstorm-urd-future.md) |
 | UX design principles brainstorm | [Norman principles](../95-ideas/2026-03-23-brainstorm-ux-norman-principles.md) |
 | Vision architecture review | [2026-03-23 Architectural criteria for vision](../99-reports/2026-03-23-vision-architecture-review.md) |
-| Latest adversary review | [2026-03-23 Awareness model impl review](../99-reports/2026-03-23-awareness-model-implementation-review.md) |
+| Latest adversary review | [2026-03-24 Heartbeat impl review](../99-reports/2026-03-24-heartbeat-implementation-review.md) |
 | Code conventions & architecture | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 
@@ -292,6 +318,8 @@ for details.
 - Stale failed send estimates persist indefinitely for (subvolume, drive, send_type) triples with no subsequent sends — consider TTL or clearing on successful calibration
 - Successful sends could update `subvolume_sizes` table to keep calibration fresh, but pipe bytes ≠ `du -sb` bytes (method mixing concern)
 - `FileSystemState` trait (9 methods) is outgrowing its name — consider renaming to `SystemState` if more history/state methods are added
-- Awareness model not yet integrated into `urd status` or backup post-run summary (follow-up task)
+- Awareness model integrated into heartbeat but not yet into `urd status` or backup post-run summary
+- `heartbeat::read()` returns `Option` — cannot distinguish missing file from corrupt JSON (upgrade to `Result<Option>` when Sentinel is built)
+- `#[allow(dead_code)]` on awareness structs (`SubvolAssessment`, `LocalAssessment`, `DriveAssessment`) — remove when status command integrates awareness
 - Per-drive pin protection for external retention — current all-drives-union is conservative but suboptimal for space
 - Idea: [systemd unit drift check](../95-ideas/2026-03-23-systemd-unit-drift-check.md) in `urd verify`

--- a/docs/99-reports/2026-03-24-heartbeat-design-review.md
+++ b/docs/99-reports/2026-03-24-heartbeat-design-review.md
@@ -1,0 +1,255 @@
+# Heartbeat File — Architectural Adversary Design Review
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-24
+**Scope:** Priority 3b design review (pre-implementation)
+**Reviewer:** Architectural Adversary (Claude)
+**Commit:** 0220229 (master)
+
+---
+
+## Executive Summary
+
+The heartbeat file is a simple, well-scoped feature with a clear insertion point and an
+established pattern to follow (metrics atomic writes). The main risk is not in the
+heartbeat itself but in **what it omits** — if the first schema is too thin, the Sentinel
+(P5) will need to re-derive state that was available at write time, adding fragile
+coupling to SQLite. If too thick, it violates the "minimal first iteration" principle and
+becomes a second source of truth. The design challenge is finding the minimal schema that
+makes the heartbeat a **self-contained health signal** — readable without SQLite.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent backup failure — the system stops protecting data
+and nobody notices.
+
+The heartbeat is specifically designed to close this gap. Its catastrophic failure mode is
+therefore **a heartbeat that lies** — reporting success when backups are failing, or
+becoming stale without anyone noticing. Distance to catastrophe: one missed write + one
+unchecked staleness = silent data loss.
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | Straightforward write-after-run; main risk is clock/staleness edge cases |
+| Security | 5 | No privilege escalation, no untrusted input, user-owned file |
+| Architecture | 4 | Clean insertion point, follows established pattern; schema scope needs care |
+| Systems Design | 3 | Atomic writes are right; crash timing, stale detection, and consumer contract need design |
+| Rust Idioms | N/A | Pre-implementation review |
+| Code Quality | N/A | Pre-implementation review |
+
+## Design Tensions
+
+### Tension 1: Minimal Schema vs. Self-Contained Health Signal
+
+The status.md says "minimal first iteration — add fields later, don't guess what consumers
+need." This is wise in general. But the heartbeat's only consumer is the Sentinel (P5b),
+whose job is to answer "is the system healthy?" If the heartbeat contains only a timestamp
+and overall result, the Sentinel must query SQLite for per-subvolume detail — which means
+the heartbeat doesn't actually decouple the Sentinel from the database.
+
+**Resolution:** Include per-subvolume summary (name, success, promise status) in the
+heartbeat. This is not guessing — the awareness model already computes it, and the
+Sentinel's event reactor explicitly needs it. But stop there: no operation details, no
+byte counts, no durations. Those belong in SQLite.
+
+### Tension 2: Heartbeat as Record vs. Heartbeat as Signal
+
+Two possible designs:
+- **Record:** The heartbeat accumulates history (array of recent runs). Richer, but now
+  you have two history stores (heartbeat + SQLite) that can diverge.
+- **Signal:** The heartbeat is a single snapshot — "the last thing that happened." Simpler,
+  but a consumer that missed a run sees nothing about it.
+
+**Resolution:** Signal. The heartbeat is a point-in-time health snapshot, not a history.
+SQLite owns history. The Sentinel polls heartbeat for freshness and reads SQLite for
+detail when needed. This keeps the heartbeat dead simple and avoids dual-source-of-truth
+problems.
+
+### Tension 3: `stale_after` — Who Decides?
+
+The `stale_after` advisory timestamp raises a design question: stale relative to what? The
+backup timer runs daily at 02:00. If a run completes at 02:05, `stale_after` should be
+roughly 02:05 + some margin the next day. But "some margin" depends on:
+- The configured backup interval (which varies per subvolume)
+- Whether the user expects intra-day runs
+- Timer jitter and execution duration
+
+**Resolution:** `stale_after` should be computed as `now + min(configured_intervals) * 2`.
+This is the same threshold the awareness model uses for local AT_RISK. It means "if you
+don't hear from me by this time, something is probably wrong." The 2x multiplier gives
+enough margin for timer jitter and long runs without being so generous that real failures
+hide.
+
+### Tension 4: Heartbeat Path — Config or Convention?
+
+Should the heartbeat path be configurable (like `metrics_file` and `state_db`) or
+hardcoded by convention (`~/.local/share/urd/heartbeat.json`)?
+
+**Resolution:** Add it to `GeneralConfig` with a sensible default. This follows the
+pattern of `state_db` and `metrics_file`. The Sentinel needs to know where to find it,
+and a config field makes that explicit without hardcoding paths.
+
+## Findings
+
+### Finding 1: Schema Must Include Awareness Summary (Significant)
+
+**What:** If the heartbeat only contains `{ timestamp, overall_result }`, it cannot answer
+"is my data safe?" — the core question from CLAUDE.md. The Sentinel would need to
+re-derive awareness state from SQLite + filesystem, defeating the purpose of having a
+heartbeat at all.
+
+**Consequence:** The heartbeat becomes a glorified timestamp file. The Sentinel gains a
+fragile dependency on SQLite availability for its core health assessment.
+
+**Recommendation:** Include per-subvolume promise status from the awareness model. The
+`assess()` function is already called with all needed context at the heartbeat write point.
+The schema should carry:
+
+```json
+{
+  "schema_version": 1,
+  "timestamp": "2026-03-24T02:05:32",
+  "stale_after": "2026-03-25T04:05:32",
+  "run_result": "success",
+  "run_id": 42,
+  "subvolumes": [
+    {
+      "name": "home",
+      "backup_success": true,
+      "promise_status": "PROTECTED"
+    }
+  ]
+}
+```
+
+Three fields per subvolume — not more. No operation details, no byte counts.
+
+### Finding 2: Crash Between Backup and Heartbeat Write (Moderate)
+
+**What:** The heartbeat is written after metrics (line 194 in `backup.rs`). If the process
+is killed between executor completion and heartbeat write, the backup succeeded but the
+heartbeat is stale. The Sentinel would see an old heartbeat and potentially raise a false
+alarm.
+
+**Consequence:** False positive "system unhealthy" alert. Annoying but not dangerous — the
+data is actually safe. The next successful run fixes it.
+
+**Recommendation:** This is acceptable for Phase 5. The heartbeat write is fast (one
+`write` + `rename`). The window is tiny. A crash in this window is recoverable by the next
+run. Do not add complexity (like writing heartbeat inside the executor) to close a
+millisecond-wide window. Document the behavior: "heartbeat may lag one run behind reality
+after a crash."
+
+### Finding 3: `stale_after` Must Handle Empty/Skipped Runs (Moderate)
+
+**What:** When the backup plan is empty (nothing to do), the current code writes skipped
+metrics and returns early (line 59-63 of `backup.rs`). If the heartbeat is only written
+after execution, empty runs won't update it. The heartbeat goes stale even though the
+system is healthy (just idle).
+
+**Consequence:** False positive staleness for configurations where some runs legitimately
+have nothing to do (e.g., local-only on a day when the external drive isn't connected).
+
+**Recommendation:** Write the heartbeat on every `urd backup` invocation, including
+empty/skipped runs. The heartbeat answers "did the system try to run?" — not "did it do
+work?" An empty plan with `run_result: "empty"` is a valid heartbeat. Insert the heartbeat
+write in both the early-return path (line 62) and the normal path (after line 194).
+
+### Finding 4: Schema Version Must Be Structural, Not Decorative (Minor)
+
+**What:** "Schema versioned from day one" is a requirement. But a `schema_version` field
+alone doesn't help unless consumers know what to do when they see an unexpected version.
+
+**Recommendation:** Document the version contract: consumers MUST check `schema_version`
+and refuse to interpret fields they don't understand from a higher version. The heartbeat
+writer MUST NOT remove fields between versions — only add. This is semver for JSON: additive
+changes bump minor (still readable), breaking changes bump major (consumer must update).
+For v1, a simple `schema_version: 1` integer is sufficient. Don't over-engineer with
+compatibility tables.
+
+### Finding 5: Awareness Model Integration — First Real Consumer (Commendation)
+
+**What:** The awareness model was built as a standalone pure function with no consumers
+yet. The heartbeat is its first integration point. This validates the design decision to
+build awareness independently — it slots in cleanly as a function call at the heartbeat
+write point.
+
+**Why this is good:** The awareness model takes `(&Config, NaiveDateTime, &dyn
+FileSystemState)` — all three are available in `backup.rs` at the write point. No new
+plumbing needed. The `SubvolAssessment` output contains exactly what the heartbeat schema
+needs (name, overall status). This is the architectural payoff of the pure-function design.
+
+### Finding 6: Atomic Write Pattern Is Proven (Commendation)
+
+**What:** The `metrics.rs` module already implements temp-file-then-rename atomic writes
+with proper error handling. The heartbeat can reuse or parallel this pattern trivially.
+
+**Recommendation:** Consider extracting a shared `atomic_write_json(path, &impl Serialize)`
+utility, or just inline the same 5-line pattern in the heartbeat module. Either way, the
+pattern is proven and there's no design risk here. If there's only two call sites (metrics
++ heartbeat), inlining is fine — don't create an abstraction for two uses.
+
+### Finding 7: Dry-Run Should Not Write Heartbeat (Minor)
+
+**What:** `urd backup --dry-run` exits early (line 51-54). It should not write a
+heartbeat, since no backup was attempted.
+
+**Recommendation:** Confirm the heartbeat write is placed after the dry-run exit. This is
+likely natural given the insertion points, but worth a test case.
+
+## The Simplicity Question
+
+**What could be removed?** The heartbeat is already minimal. The risk is adding too much,
+not having too little. Resist the urge to add:
+- Per-operation details (SQLite has this)
+- Byte transfer summaries (metrics has this)
+- Drive mount status at write time (awareness model captures this transiently)
+- Historical run arrays (SQLite owns history)
+
+**What's earning its keep?** Every proposed field:
+- `schema_version`: Necessary for forward compatibility. Costs one line.
+- `timestamp`: The core datum — when did the system last speak.
+- `stale_after`: Saves consumers from re-deriving the staleness threshold.
+- `run_result`: Distinguishes "ran and failed" from "didn't run" — critical.
+- `run_id`: Cross-reference to SQLite for consumers that need detail. One integer.
+- Per-subvolume summary: The awareness bridge. Without this, the heartbeat is just a
+  fancy timestamp.
+
+## Priority Action Items
+
+1. **Include per-subvolume promise status** in the schema (Finding 1). This is the
+   difference between a useful health signal and a decorated timestamp.
+
+2. **Write heartbeat on empty/skipped runs too** (Finding 3). Two write points in
+   `backup.rs`: early return and post-execution.
+
+3. **Compute `stale_after` from minimum configured interval × 2** (Tension 3). Derive
+   from config, don't hardcode.
+
+4. **Add `heartbeat_file` to `GeneralConfig`** (Tension 4). Follow the `metrics_file`
+   pattern with a sensible default.
+
+5. **Document the schema version contract** (Finding 4). One paragraph in the module doc
+   comment: additive-only changes, consumers check version.
+
+6. **Test: stale heartbeat detection, empty-run heartbeat, schema roundtrip** — these are
+   the three scenarios most likely to go wrong in production.
+
+## Open Questions
+
+1. **Should the heartbeat include a human-readable summary string?** Something like
+   `"summary": "6/7 subvolumes protected, 1 at risk"`. This is presentation-layer
+   territory (P3c), but a single pre-computed string in the heartbeat could be useful for
+   external consumers (scripts, tray icon tooltip) that don't want to parse the subvolume
+   array. Defer unless there's a concrete consumer.
+
+2. **Should `urd status` read the heartbeat?** Currently `urd status` would query SQLite
+   directly. If the heartbeat is the canonical "last run" signal, status could read it
+   instead. This is a P3c/P4b decision — don't solve it now, but keep the option open.
+
+3. **What happens when awareness assessment fails for a subvolume?** The awareness model
+   captures errors in `SubvolAssessment.errors`. The heartbeat should propagate these — a
+   subvolume with assessment errors should appear in the heartbeat with its error, not be
+   silently omitted.

--- a/docs/99-reports/2026-03-24-heartbeat-implementation-review.md
+++ b/docs/99-reports/2026-03-24-heartbeat-implementation-review.md
@@ -1,0 +1,234 @@
+# Heartbeat File — Implementation Review
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-24
+**Scope:** Priority 3b implementation — `src/heartbeat.rs`, integration in `backup.rs`, config changes
+**Reviewer:** Architectural Adversary (Claude)
+**Commit:** uncommitted (post-0220229 on master)
+**Files reviewed:** `src/heartbeat.rs`, `src/commands/backup.rs`, `src/main.rs`, `src/config.rs`, `src/awareness.rs` (types), `config/urd.toml.example`
+
+---
+
+## Executive Summary
+
+Clean, minimal implementation that follows established patterns and delivers on the design
+review's recommendations. The module is 178 lines of production code with 7 well-targeted
+tests. Two findings need fixing: the awareness assessment uses stale post-execution state
+(the `now` timestamp is from before execution), and there's a missing second heartbeat
+write point for the skipped-but-non-empty case. Everything else is solid.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent backup failure — the system stops protecting data
+and nobody notices.
+
+The heartbeat's job is to make this failure mode *loud*. The implementation's proximity to
+the catastrophe: **low risk, correct direction**. The heartbeat is non-fatal (write
+failures are logged, not propagated), so it can't cause data loss. The risk is a heartbeat
+that's misleading — and Finding 1 identifies one such scenario.
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 3 | Awareness assessment uses pre-execution `now`, creating stale promise states; missing write point for skipped-with-work case |
+| Security | 5 | No privilege escalation, no untrusted input, user-owned JSON file |
+| Architecture | 4 | Clean module boundary, follows metrics pattern, pure builder functions |
+| Systems Design | 4 | Atomic writes, non-fatal errors, crash-safe by design |
+| Rust Idioms | 4 | Good use of `Option`, `#[must_use]`, serde derives; minor String-vs-enum tension |
+| Code Quality | 4 | Well-tested, readable top-to-bottom, good test helpers |
+
+## Design Tensions
+
+### Tension 1: `now` Timestamp — Pre-execution vs. Post-execution
+
+The `now` variable is captured at backup.rs:23 (before planning and execution). The
+heartbeat is written at line 204 using this same `now`. For a backup that takes 30 minutes
+to execute, the heartbeat's `timestamp` and `stale_after` are 30 minutes in the past
+relative to when the heartbeat was actually written.
+
+**Consequence for `timestamp`:** Mostly cosmetic — it's the "backup started" time, which
+is a reasonable interpretation. But the doc comment says "when did the last backup run" —
+a consumer expecting "when did it finish" would compute a tighter-than-reality staleness
+margin.
+
+**Consequence for `stale_after`:** More concerning. If `stale_after` is computed as
+`now + interval * 2` where `now` is 30 minutes old, then the staleness window is 30
+minutes shorter than intended. For a 15-minute interval (stale_after = 30m), this means
+the heartbeat is already stale when written.
+
+**Resolution:** This is a real bug for short-interval subvolumes. Use a fresh
+`chrono::Local::now().naive_local()` when building the heartbeat, not the pre-execution
+`now`. The `timestamp` should reflect when the heartbeat was computed, not when the backup
+was planned.
+
+### Tension 2: Strings vs. Enums in JSON Schema
+
+`run_result` and `promise_status` are strings in the Heartbeat struct. The design review
+recommended this for human-readability and forward-compatibility. The trade-off is that
+`build_empty` uses a magic string `"empty"` (line 86) while `build_from_run` uses
+`result.overall.as_str()` — two different provenance paths for the same field.
+
+**Resolution:** Acceptable for v1. The `"empty"` literal is used in exactly one place
+and is tested. If a third run result type is needed, the pattern scales. Not worth adding
+a dedicated enum just for this.
+
+## Findings
+
+### Finding 1: Awareness Assessment Uses Stale `now` (Significant)
+
+**What:** In backup.rs:204, `awareness::assess(&config, now, &fs_state)` uses the `now`
+captured at line 23, before execution. The awareness model computes snapshot freshness as
+`now - snapshot_timestamp`. After a 30-minute backup, this `now` is 30 minutes behind
+reality.
+
+**Consequence:** Promise statuses in the heartbeat are slightly more optimistic than
+reality — snapshots appear 30 minutes younger than they are. For most intervals (1h+) this
+is within noise. For the 15-minute `htpc-home` subvolume, a 30-minute-old `now` could flip
+a status from AT_RISK to PROTECTED when the real assessment would say AT_RISK.
+
+**But more importantly:** `stale_after` is computed as `now + interval*2`. With `now` 30
+minutes old and `htpc-home` at 15m interval, `stale_after` would be the pre-execution time
++ 30 minutes — which is exactly the current wall clock. The heartbeat is born stale.
+
+**Fix:** Compute a fresh `now` for the heartbeat:
+
+```rust
+// Write heartbeat
+let heartbeat_now = chrono::Local::now().naive_local();
+let assessments = awareness::assess(&config, heartbeat_now, &fs_state);
+let hb = heartbeat::build_from_run(&config, heartbeat_now, &result, &assessments);
+```
+
+Apply the same fix to the empty-run write point at line 64.
+
+### Finding 2: Missing Heartbeat Write for Skipped-With-Work Runs (Moderate)
+
+**What:** The backup command has three possible exit paths:
+1. **Dry run** (line 53) — no heartbeat, correct.
+2. **Empty plan, no skips** (line 61) — heartbeat written, correct.
+3. **Normal execution** (line 204) — heartbeat written, correct.
+
+But there's a fourth implicit path: when `backup_plan.is_empty()` is true but
+`backup_plan.skipped` is NOT empty (filtered subvolumes). This path falls through to
+the execution branch (line 72+), where the executor receives an empty plan and produces
+an empty `ExecutionResult` with `RunResult::Success`. The heartbeat IS written via the
+normal path — so this is actually handled correctly.
+
+**On closer inspection:** This is not a bug. The executor handles empty plans gracefully
+(tested: `executor::tests::empty_plan_is_success`). The heartbeat write at line 204 fires
+for this case. **Retracting this as a finding — the code is correct.**
+
+### Finding 3: Temp File Extension Creates Ambiguous Path (Minor)
+
+**What:** `path.with_extension("json.tmp")` on `heartbeat.json` produces
+`heartbeat.json.tmp` (line 155). This is correct. But if someone configures the path as
+`heartbeat` (no extension), `with_extension("json.tmp")` produces `heartbeat.json.tmp` —
+still fine but semantically different (adds an extension rather than replacing).
+
+**Consequence:** None in practice — the default and documented path has `.json`. The
+metrics module uses the same pattern (`.prom.tmp`). Consistent behavior.
+
+**Resolution:** No fix needed. Documenting for completeness.
+
+### Finding 4: `read()` Silently Swallows Parse Errors (Minor)
+
+**What:** `heartbeat::read()` (line 174-177) returns `None` for both "file doesn't exist"
+and "file exists but is corrupt JSON." A consumer can't distinguish "never written" from
+"broken."
+
+**Consequence:** Minimal for now — `read()` is not called in production yet (`#[allow
+(dead_code)]`). When the Sentinel uses it, it may want to distinguish "no heartbeat" from
+"corrupt heartbeat" to decide whether to raise an alarm.
+
+**Resolution:** Acceptable for v1. When the Sentinel is built (P5b), this function should
+return `Result<Option<Heartbeat>>` to distinguish missing vs. corrupt. The `#[allow
+(dead_code)]` is a good signal that this API isn't finalized.
+
+### Finding 5: Module Structure and Separation (Commendation)
+
+**What:** The heartbeat module is cleanly separated:
+- Types are serializable structs with no behavior beyond serde.
+- Builder functions are pure — they take data in and produce a `Heartbeat` out.
+- The writer handles only I/O (create_dir_all, write, rename).
+- The caller in `backup.rs` orchestrates: call awareness, build heartbeat, write file.
+
+**Why this is good:** This mirrors the planner/executor pattern that CLAUDE.md identifies
+as the core architectural property. The heartbeat module can be tested without a filesystem
+(builder tests), and the write function can be tested with tempdir (I/O tests). No test
+needs to actually run a backup.
+
+### Finding 6: Non-Fatal Error Handling (Commendation)
+
+**What:** Both heartbeat write points use `if let Err(e) = ... { log::warn!(...) }` — the
+heartbeat never blocks a backup. This follows the CLAUDE.md principle: "SQLite failures
+must NOT prevent backups."
+
+**Why this matters:** The heartbeat is a secondary output. If the disk is full and the
+heartbeat can't be written, the backup should still succeed. The `log::warn!` ensures the
+failure is observable (in journal/logs) without blocking the primary operation.
+
+### Finding 7: `#[allow(dead_code)]` on Awareness Structs (Minor)
+
+**What:** The implementation added `#[allow(dead_code)]` to `SubvolAssessment`,
+`LocalAssessment`, and `DriveAssessment` because not all fields are read outside tests.
+The heartbeat reads only `name` and `status` from `SubvolAssessment`.
+
+**Consequence:** The allows are technically correct — the fields *are* dead code in the
+non-test build. But they suppress warnings that would fire when the status command (P3c)
+integrates the awareness model. When that happens, remove the allows and verify all fields
+are used.
+
+**Resolution:** Acceptable. The allows are on the structs (not the module), which is the
+right granularity. The old TODO comment on the module was removed, which is good — the
+module is no longer dead code.
+
+## The Simplicity Question
+
+**What could be removed?** Very little. The module is already near-minimal:
+- Two builder functions could be collapsed into one with `Option<&ExecutionResult>`, but
+  having `build_from_run` and `build_empty` with distinct signatures makes the call sites
+  clearer. Worth keeping.
+- The `read()` function is unused but tiny (4 lines) and will be needed by the Sentinel.
+  Worth keeping with `#[allow(dead_code)]`.
+
+**What's earning its keep?**
+- `compute_stale_after` as a separate function: yes — it's independently testable and the
+  logic (find min interval, multiply) is non-trivial enough to warrant isolation.
+- `build_subvolume_entries` as a shared helper: yes — called by both builders, avoids
+  duplicating the assessment-to-heartbeat mapping.
+- Atomic write: yes — proven pattern, prevents corrupt reads.
+
+**What's NOT in the module that shouldn't be?** Correct omissions: no operation details,
+no byte counts, no history. The heartbeat is a health signal, not a log.
+
+## Priority Action Items
+
+1. **Fix stale `now` in heartbeat writes** (Finding 1). Use a fresh
+   `chrono::Local::now().naive_local()` at each heartbeat write point. This is the only
+   correctness issue.
+
+2. **Add a test for stale_after with very short intervals** — e.g., 15m interval, verify
+   `stale_after` is 30m from the provided `now`, not from some other reference.
+   (Already exists: `stale_after_picks_minimum_interval` covers this. No action needed.)
+
+3. **When building P3c (status command) or P5b (Sentinel):** remove `#[allow(dead_code)]`
+   from awareness structs, upgrade `heartbeat::read()` to return
+   `Result<Option<Heartbeat>>`.
+
+## Open Questions
+
+1. **Should `stale_after` account for execution duration?** The current design uses
+   interval × 2 from the heartbeat timestamp. A backup that routinely takes 45 minutes
+   with a 1h interval would have stale_after at 2h from start, meaning the next run (1h
+   after start + 45m execution) writes a new heartbeat at 1h45m — well within the 2h
+   window. This seems fine for typical workloads. But if execution time exceeds interval ×
+   2, the heartbeat is born stale. This is an edge case for very long backups with short
+   intervals — probably worth a `stale_after` advisory rather than a code change.
+
+2. **Should the heartbeat include `errors` from awareness assessments?** Currently, if
+   the awareness model can't read a snapshot directory, the error lands in
+   `SubvolAssessment.errors` but is not propagated to the heartbeat. The Sentinel would
+   need to re-derive these errors. For v1 this is fine — the promise_status already
+   reflects the error (it would be UNPROTECTED). Consider adding an `errors` field to
+   `SubvolumeHeartbeat` when the Sentinel is built.

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -50,6 +50,7 @@ impl std::fmt::Display for PromiseStatus {
 
 /// Complete assessment for a single subvolume.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct SubvolAssessment {
     pub name: String,
     pub status: PromiseStatus,
@@ -63,6 +64,7 @@ pub struct SubvolAssessment {
 
 /// Local snapshot freshness assessment.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct LocalAssessment {
     pub status: PromiseStatus,
     pub snapshot_count: usize,
@@ -72,6 +74,7 @@ pub struct LocalAssessment {
 
 /// External drive send freshness assessment.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct DriveAssessment {
     pub drive_label: String,
     pub status: PromiseStatus,

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -7,11 +7,13 @@ use std::time::{Duration, Instant};
 
 use colored::Colorize;
 
+use crate::awareness;
 use crate::btrfs::RealBtrfs;
 use crate::cli::BackupArgs;
 use crate::config::Config;
 use crate::drives;
 use crate::executor::{Executor, RunResult, SendType};
+use crate::heartbeat;
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
 use crate::state::StateDb;
@@ -59,6 +61,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     if backup_plan.is_empty() && backup_plan.skipped.is_empty() {
         println!("{}", "Nothing to do.".dimmed());
         write_metrics_for_skipped(&config, &backup_plan, now)?;
+        let heartbeat_now = chrono::Local::now().naive_local();
+        let assessments = awareness::assess(&config, heartbeat_now, &fs_state);
+        let hb = heartbeat::build_empty(&config, heartbeat_now, &assessments);
+        if let Err(e) = heartbeat::write(&config.general.heartbeat_file, &hb) {
+            log::warn!("Failed to write heartbeat: {e}");
+        }
         return Ok(());
     }
 
@@ -192,6 +200,14 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 
     // Write metrics
     write_metrics_after_execution(&config, &result, &backup_plan, now, &fs_state)?;
+
+    // Write heartbeat (fresh timestamp — `now` is from before execution)
+    let heartbeat_now = chrono::Local::now().naive_local();
+    let assessments = awareness::assess(&config, heartbeat_now, &fs_state);
+    let hb = heartbeat::build_from_run(&config, heartbeat_now, &result, &assessments);
+    if let Err(e) = heartbeat::write(&config.general.heartbeat_file, &hb) {
+        log::warn!("Failed to write heartbeat: {e}");
+    }
 
     // Exit with appropriate code
     if result.overall != RunResult::Success {

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,10 +26,16 @@ pub struct GeneralConfig {
     pub log_dir: PathBuf,
     #[serde(default = "default_btrfs_path")]
     pub btrfs_path: String,
+    #[serde(default = "default_heartbeat_path")]
+    pub heartbeat_file: PathBuf,
 }
 
 fn default_btrfs_path() -> String {
     "/usr/sbin/btrfs".to_string()
+}
+
+fn default_heartbeat_path() -> PathBuf {
+    PathBuf::from("~/.local/share/urd/heartbeat.json")
 }
 
 #[derive(Debug, Deserialize)]
@@ -206,6 +212,7 @@ impl Config {
         self.general.state_db = expand_tilde(&self.general.state_db);
         self.general.metrics_file = expand_tilde(&self.general.metrics_file);
         self.general.log_dir = expand_tilde(&self.general.log_dir);
+        self.general.heartbeat_file = expand_tilde(&self.general.heartbeat_file);
 
         for root in &mut self.local_snapshots.roots {
             root.path = expand_tilde(&root.path);

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -1,0 +1,427 @@
+// Heartbeat file — JSON health signal written after every backup run.
+//
+// The heartbeat answers "when did the last backup run, and is my data safe?"
+// without requiring SQLite access. It bridges the backup command and future
+// consumers (Sentinel, tray icon, external scripts).
+//
+// Schema contract: consumers MUST check `schema_version` and refuse to interpret
+// fields from a higher version. The writer MUST NOT remove fields between
+// versions — only add. Additive changes bump the version.
+
+use std::path::Path;
+
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+use crate::awareness::SubvolAssessment;
+use crate::config::Config;
+use crate::error::UrdError;
+use crate::executor::ExecutionResult;
+
+/// Current schema version. Bump when adding fields (never remove fields).
+const SCHEMA_VERSION: u32 = 1;
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+/// Top-level heartbeat structure, serialized to JSON.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Heartbeat {
+    pub schema_version: u32,
+    pub timestamp: String,
+    pub stale_after: String,
+    pub run_result: String,
+    pub run_id: Option<i64>,
+    pub subvolumes: Vec<SubvolumeHeartbeat>,
+}
+
+/// Per-subvolume summary in the heartbeat.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SubvolumeHeartbeat {
+    pub name: String,
+    /// `None` if not attempted (empty/skipped run), `Some(true/false)` if attempted.
+    pub backup_success: Option<bool>,
+    /// Promise status from the awareness model: "PROTECTED", "AT RISK", "UNPROTECTED".
+    pub promise_status: String,
+}
+
+// ── Builder ─────────────────────────────────────────────────────────────
+
+/// Build a heartbeat from a completed backup run with awareness assessments.
+#[must_use]
+pub fn build_from_run(
+    config: &Config,
+    now: NaiveDateTime,
+    result: &ExecutionResult,
+    assessments: &[SubvolAssessment],
+) -> Heartbeat {
+    let subvolumes = build_subvolume_entries(Some(result), assessments);
+
+    Heartbeat {
+        schema_version: SCHEMA_VERSION,
+        timestamp: now.format("%Y-%m-%dT%H:%M:%S").to_string(),
+        stale_after: compute_stale_after(config, now)
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string(),
+        run_result: result.overall.as_str().to_string(),
+        run_id: result.run_id,
+        subvolumes,
+    }
+}
+
+/// Build a heartbeat for an empty/skipped run (no execution result).
+#[must_use]
+pub fn build_empty(
+    config: &Config,
+    now: NaiveDateTime,
+    assessments: &[SubvolAssessment],
+) -> Heartbeat {
+    let subvolumes = build_subvolume_entries(None, assessments);
+
+    Heartbeat {
+        schema_version: SCHEMA_VERSION,
+        timestamp: now.format("%Y-%m-%dT%H:%M:%S").to_string(),
+        stale_after: compute_stale_after(config, now)
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string(),
+        run_result: "empty".to_string(),
+        run_id: None,
+        subvolumes,
+    }
+}
+
+fn build_subvolume_entries(
+    result: Option<&ExecutionResult>,
+    assessments: &[SubvolAssessment],
+) -> Vec<SubvolumeHeartbeat> {
+    assessments
+        .iter()
+        .map(|a| {
+            let backup_success = result.and_then(|r| {
+                r.subvolume_results
+                    .iter()
+                    .find(|sv| sv.name == a.name)
+                    .map(|sv| sv.success)
+            });
+
+            SubvolumeHeartbeat {
+                name: a.name.clone(),
+                backup_success,
+                promise_status: a.status.to_string(),
+            }
+        })
+        .collect()
+}
+
+// ── Staleness ───────────────────────────────────────────────────────────
+
+/// Compute when this heartbeat becomes stale: `now + min(snapshot_intervals) * 2`.
+///
+/// Uses the minimum snapshot interval across all enabled subvolumes, matching
+/// the awareness model's local AT_RISK threshold (2x multiplier). Falls back
+/// to 24 hours if no enabled subvolumes exist.
+#[must_use]
+pub fn compute_stale_after(config: &Config, now: NaiveDateTime) -> NaiveDateTime {
+    let min_interval_secs = config
+        .resolved_subvolumes()
+        .iter()
+        .filter(|sv| sv.enabled)
+        .map(|sv| sv.snapshot_interval.as_secs())
+        .min();
+
+    let stale_secs = match min_interval_secs {
+        Some(secs) => secs * 2,
+        None => 24 * 3600, // 24h fallback
+    };
+
+    now + chrono::Duration::seconds(stale_secs)
+}
+
+// ── Writer ──────────────────────────────────────────────────────────────
+
+/// Write heartbeat to disk atomically (temp file + rename).
+pub fn write(path: &Path, heartbeat: &Heartbeat) -> crate::error::Result<()> {
+    let content = serde_json::to_string_pretty(heartbeat).map_err(|e| UrdError::Io {
+        path: path.to_path_buf(),
+        source: std::io::Error::other(e),
+    })?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| UrdError::Io {
+            path: parent.to_path_buf(),
+            source: e,
+        })?;
+    }
+
+    let tmp_path = path.with_extension("json.tmp");
+    std::fs::write(&tmp_path, &content).map_err(|e| UrdError::Io {
+        path: tmp_path.clone(),
+        source: e,
+    })?;
+
+    std::fs::rename(&tmp_path, path).map_err(|e| UrdError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    Ok(())
+}
+
+// ── Reader (for consumers / testing) ────────────────────────────────────
+
+/// Read and parse a heartbeat file. Returns `None` if the file doesn't exist.
+#[must_use]
+#[allow(dead_code)]
+pub fn read(path: &Path) -> Option<Heartbeat> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::awareness::{DriveAssessment, LocalAssessment, PromiseStatus};
+    use crate::config::{
+        Config, DefaultsConfig, DriveConfig, GeneralConfig, LocalSnapshotsConfig, SnapshotRoot,
+        SubvolumeConfig,
+    };
+    use crate::executor::{ExecutionResult, RunResult, SendType, SubvolumeResult};
+    use crate::types::{DriveRole, GraduatedRetention, Interval};
+    use std::path::PathBuf;
+
+    fn test_config(intervals: &[(&str, &str)]) -> Config {
+        let subvolumes: Vec<SubvolumeConfig> = intervals
+            .iter()
+            .map(|(name, interval)| SubvolumeConfig {
+                name: name.to_string(),
+                short_name: name.to_string(),
+                source: PathBuf::from("/test"),
+                priority: 2,
+                enabled: Some(true),
+                snapshot_interval: Some(interval.parse::<Interval>().unwrap()),
+                send_interval: None,
+                send_enabled: None,
+                local_retention: None,
+                external_retention: None,
+            })
+            .collect();
+
+        Config {
+            general: GeneralConfig {
+                state_db: PathBuf::from("/tmp/test.db"),
+                metrics_file: PathBuf::from("/tmp/test.prom"),
+                log_dir: PathBuf::from("/tmp"),
+                btrfs_path: "/usr/sbin/btrfs".to_string(),
+                heartbeat_file: PathBuf::from("/tmp/heartbeat.json"),
+            },
+            local_snapshots: LocalSnapshotsConfig {
+                roots: vec![SnapshotRoot {
+                    path: PathBuf::from("/tmp/snapshots"),
+                    subvolumes: intervals.iter().map(|(n, _)| n.to_string()).collect(),
+                    min_free_bytes: None,
+                }],
+            },
+            defaults: DefaultsConfig {
+                snapshot_interval: "1h".parse().unwrap(),
+                send_interval: "4h".parse().unwrap(),
+                send_enabled: true,
+                enabled: true,
+                local_retention: GraduatedRetention {
+                    hourly: Some(24),
+                    daily: Some(30),
+                    weekly: Some(26),
+                    monthly: Some(12),
+                },
+                external_retention: GraduatedRetention {
+                    hourly: None,
+                    daily: Some(30),
+                    weekly: Some(26),
+                    monthly: Some(0),
+                },
+            },
+            drives: vec![],
+            subvolumes,
+        }
+    }
+
+    fn test_assessments() -> Vec<SubvolAssessment> {
+        vec![
+            SubvolAssessment {
+                name: "home".to_string(),
+                status: PromiseStatus::Protected,
+                local: LocalAssessment {
+                    status: PromiseStatus::Protected,
+                    snapshot_count: 24,
+                    newest_age: Some(chrono::Duration::minutes(30)),
+                    configured_interval: Interval::hours(1),
+                },
+                external: vec![DriveAssessment {
+                    drive_label: "WD-18TB".to_string(),
+                    status: PromiseStatus::Protected,
+                    mounted: true,
+                    snapshot_count: Some(10),
+                    last_send_age: Some(chrono::Duration::hours(2)),
+                    configured_interval: Interval::hours(4),
+                }],
+                advisories: vec![],
+                errors: vec![],
+            },
+            SubvolAssessment {
+                name: "docs".to_string(),
+                status: PromiseStatus::AtRisk,
+                local: LocalAssessment {
+                    status: PromiseStatus::AtRisk,
+                    snapshot_count: 5,
+                    newest_age: Some(chrono::Duration::hours(3)),
+                    configured_interval: Interval::hours(1),
+                },
+                external: vec![],
+                advisories: vec![],
+                errors: vec![],
+            },
+        ]
+    }
+
+    fn test_execution_result() -> ExecutionResult {
+        ExecutionResult {
+            overall: RunResult::Partial,
+            subvolume_results: vec![
+                SubvolumeResult {
+                    name: "home".to_string(),
+                    success: true,
+                    operations: vec![],
+                    duration: std::time::Duration::from_secs(5),
+                    send_type: SendType::Incremental,
+                    pin_failures: 0,
+                },
+                SubvolumeResult {
+                    name: "docs".to_string(),
+                    success: false,
+                    operations: vec![],
+                    duration: std::time::Duration::from_secs(1),
+                    send_type: SendType::NoSend,
+                    pin_failures: 0,
+                },
+            ],
+            run_id: Some(42),
+        }
+    }
+
+    // ── Schema roundtrip ────────────────────────────────────────────────
+
+    #[test]
+    fn schema_roundtrip() {
+        let config = test_config(&[("home", "1h"), ("docs", "1h")]);
+        let now = NaiveDateTime::parse_from_str("2026-03-24T02:05:00", "%Y-%m-%dT%H:%M:%S")
+            .unwrap();
+        let assessments = test_assessments();
+        let result = test_execution_result();
+
+        let heartbeat = build_from_run(&config, now, &result, &assessments);
+        let json = serde_json::to_string_pretty(&heartbeat).unwrap();
+        let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.schema_version, 1);
+        assert_eq!(parsed.timestamp, "2026-03-24T02:05:00");
+        assert_eq!(parsed.run_result, "partial");
+        assert_eq!(parsed.run_id, Some(42));
+        assert_eq!(parsed.subvolumes.len(), 2);
+        assert_eq!(parsed.subvolumes[0].name, "home");
+        assert_eq!(parsed.subvolumes[0].backup_success, Some(true));
+        assert_eq!(parsed.subvolumes[0].promise_status, "PROTECTED");
+        assert_eq!(parsed.subvolumes[1].name, "docs");
+        assert_eq!(parsed.subvolumes[1].backup_success, Some(false));
+        assert_eq!(parsed.subvolumes[1].promise_status, "AT RISK");
+    }
+
+    // ── stale_after ─────────────────────────────────────────────────────
+
+    #[test]
+    fn stale_after_picks_minimum_interval() {
+        let config = test_config(&[("fast", "15m"), ("slow", "1d")]);
+        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
+            .unwrap();
+
+        let stale = compute_stale_after(&config, now);
+        // 15m * 2 = 30m
+        let expected = now + chrono::Duration::minutes(30);
+        assert_eq!(stale, expected);
+    }
+
+    #[test]
+    fn stale_after_no_enabled_subvolumes_defaults_to_24h() {
+        let mut config = test_config(&[("only", "1h")]);
+        config.subvolumes[0].enabled = Some(false);
+        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
+            .unwrap();
+
+        let stale = compute_stale_after(&config, now);
+        let expected = now + chrono::Duration::hours(24);
+        assert_eq!(stale, expected);
+    }
+
+    // ── Empty run ───────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_run_heartbeat() {
+        let config = test_config(&[("home", "1h")]);
+        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
+            .unwrap();
+        let assessments = test_assessments();
+
+        let heartbeat = build_empty(&config, now, &assessments);
+
+        assert_eq!(heartbeat.run_result, "empty");
+        assert_eq!(heartbeat.run_id, None);
+        // No execution result → backup_success is None for all
+        for sv in &heartbeat.subvolumes {
+            assert_eq!(sv.backup_success, None);
+        }
+        // Promise statuses still present
+        assert_eq!(heartbeat.subvolumes[0].promise_status, "PROTECTED");
+        assert_eq!(heartbeat.subvolumes[1].promise_status, "AT RISK");
+    }
+
+    // ── Atomic write ────────────────────────────────────────────────────
+
+    #[test]
+    fn write_and_read_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("heartbeat.json");
+
+        let config = test_config(&[("home", "1h")]);
+        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
+            .unwrap();
+        let assessments = test_assessments();
+
+        let heartbeat = build_empty(&config, now, &assessments);
+        write(&path, &heartbeat).unwrap();
+
+        // Temp file cleaned up
+        assert!(!dir.path().join("heartbeat.json.tmp").exists());
+        // File exists and is valid
+        let read_back = read(&path).unwrap();
+        assert_eq!(read_back.schema_version, 1);
+        assert_eq!(read_back.timestamp, "2026-03-24T02:00:00");
+    }
+
+    #[test]
+    fn write_creates_parent_directories() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("dir").join("heartbeat.json");
+
+        let config = test_config(&[("home", "1h")]);
+        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
+            .unwrap();
+        let heartbeat = build_empty(&config, now, &test_assessments());
+        write(&path, &heartbeat).unwrap();
+
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn read_nonexistent_returns_none() {
+        assert!(read(Path::new("/tmp/nonexistent-heartbeat-test.json")).is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-// TODO: Remove allow(dead_code) when commands/status.rs integrates the awareness model.
-#[allow(dead_code)]
 mod awareness;
 mod btrfs;
 mod chain;
@@ -9,6 +7,7 @@ mod config;
 mod drives;
 mod error;
 mod executor;
+mod heartbeat;
 mod metrics;
 mod plan;
 mod retention;


### PR DESCRIPTION
## Summary

- **New module: `heartbeat.rs`** — JSON health signal at `~/.local/share/urd/heartbeat.json`, written after every backup run (including empty/skipped runs)
- **Schema v1** with `schema_version`, `timestamp`, `stale_after` (min interval × 2), `run_result`, `run_id`, and per-subvolume promise status from the awareness model
- **First consumer of the awareness model** — validates the pure-function design (slots in with no new plumbing)
- **Atomic writes** (temp + rename), non-fatal errors, configurable path in `[general]`
- Design-reviewed before implementation, implementation-reviewed after; review fix applied (fresh timestamp at write time)

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 175 tests pass (7 new heartbeat tests)
- Integration tests: not applicable (no btrfs operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)