### PR TITLE
feat: Add presentation layer — structured output with interactive/daemon rendering

### DIFF
--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -5,8 +5,8 @@
 
 ## Current State
 
-**Phase 5 continues. Awareness model (3a) and heartbeat file (3b) are built, reviewed, and
-passing 175 tests.** Operational cutover has not started — the bash script
+**Phase 5 continues. Awareness model (3a), heartbeat file (3b), and presentation layer (3c)
+are built, reviewed, and passing 186 tests.** Operational cutover has not started — the bash script
 (`btrfs-snapshot-backup.sh`) is still the sole production backup system, running nightly at
 02:00 via `btrfs-backup-daily.timer`. Urd v0.1.0 is installed (`~/.cargo/bin/urd`) and has
 been tested manually on real subvolumes (2026-03-23), but is not deployed on a schedule.
@@ -29,6 +29,15 @@ Phase 5 work completed so far:
   awareness model. `heartbeat_file` configurable in `[general]` with sensible default. 7 tests.
   [Design review](../99-reports/2026-03-24-heartbeat-design-review.md) |
   [Implementation review](../99-reports/2026-03-24-heartbeat-implementation-review.md)
+
+- **Presentation layer** (`output.rs` + `voice.rs`) — structured output types + rendering module.
+  `OutputMode` enum (Interactive/Daemon) with match-based dispatch (adversary review rejected
+  trait approach). `StatusOutput` struct rendered by `voice::render_status()`. Interactive mode
+  produces colored table with STATUS column from awareness model. Daemon mode outputs JSON.
+  Global TTY-aware color control (force-off for non-TTY, respects `NO_COLOR`). Status command
+  fully migrated; other commands migrate incrementally. 11 voice tests + 4 output tests.
+  [Design review](../99-reports/2026-03-24-presentation-layer-design-review.md) |
+  [Implementation review](../99-reports/2026-03-24-presentation-layer-implementation-review.md)
 
 Prior work: pre-send space estimation, documentation system (CONTRIBUTING.md), first
 real-world backup testing, failed-send bytes recording, live progress display, `urd calibrate`.
@@ -87,14 +96,19 @@ pre-execution `now`).
 - [x] Includes computation timestamp + `stale_after` advisory
 - [x] Minimal first iteration — add fields later, don't guess what consumers need
 
-**3c. Presentation layer** (`voice.rs`) — commands produce structured output data;
-the presentation layer renders it as text. Two renderers: interactive (rich, colored,
-eventually mythic) and daemon (JSON/terse). TTY detection selects renderer.
+**3c. Presentation layer** (`output.rs` + `voice.rs`) — commands produce structured output
+data; the presentation layer renders it as text. `OutputMode` enum (Interactive/Daemon) with
+match-based dispatch. TTY detection selects mode. Status command migrated first; other commands
+migrate incrementally.
 
-- [ ] Commands return structured types, not formatted strings
-- [ ] Renderer trait with interactive and daemon implementations
-- [ ] All user-facing text flows through this layer
-- [ ] Testable: given this state, assert output contains these facts
+- [x] `status` command returns structured `StatusOutput`, rendered by `voice::render_status()`
+- [x] `OutputMode` enum with `detect()` (not a trait — two impls don't justify dynamic dispatch)
+- [x] Awareness model integrated into status output (STATUS column with promise states)
+- [x] Interactive mode: colored table with STATUS, SUBVOLUME, LOCAL, drives, CHAIN
+- [x] Daemon mode: JSON serialization of `StatusOutput`
+- [x] Global TTY-aware color control (`colored::control::set_override` in main)
+- [x] Testable: 10 voice tests asserting output contains expected facts
+- [ ] Remaining commands migrate incrementally (not blocked on this)
 
 **3d. `urd get file@date`** — restore via direct path construction. O(1) — no search,
 no indexing. Parse `@` date reference, resolve snapshot, copy file. ~100 lines. Ship this
@@ -206,6 +220,14 @@ timestamp staleness handling, space check deduplication, ANSI line clearing.
   model.
   [Design review](../99-reports/2026-03-24-heartbeat-design-review.md) |
   [Implementation review](../99-reports/2026-03-24-heartbeat-implementation-review.md)
+- **Presentation layer** (Phase 5, P3c) — `output.rs` + `voice.rs`: structured output types
+  and rendering module. `OutputMode` enum (Interactive/Daemon), `StatusOutput` struct, status
+  command fully migrated with awareness model integration (STATUS column). Daemon mode = JSON.
+  Global TTY color control (respects `NO_COLOR`). Advisories and errors surfaced in interactive
+  mode. 11 voice tests + 4 output tests. Review fixes: `NO_COLOR` respect, disabled subvolume
+  filtering, advisory rendering.
+  [Design review](../99-reports/2026-03-24-presentation-layer-design-review.md) |
+  [Implementation review](../99-reports/2026-03-24-presentation-layer-implementation-review.md)
 
 ### Not Building (dropped per adversary review)
 
@@ -226,7 +248,7 @@ timestamp staleness handling, space check deduplication, ANSI line clearing.
 - [x] **Phase 4 code** — Cutover polish + space estimation + real-world testing
 - [ ] **Phase 4 cutover** — Operational transition from bash to Urd (see below)
 - [x] **Post-cutover features** — failed-send bytes, progress, calibrate (Priorities 2-4)
-- [ ] **Phase 5** — Architectural foundation: ~~awareness model~~, ~~heartbeat~~, presentation layer, `urd get`
+- [ ] **Phase 5** — Architectural foundation: ~~awareness model~~, ~~heartbeat~~, ~~presentation layer~~, `urd get`
 - [ ] **Phase 5 gate** — ADR: protection promise design (retention mappings, config conflicts, migration)
 - [ ] **Phase 6** — Protection promises in config + planner + status
 - [ ] **Phase 7** — Sentinel: notification dispatcher → event reactor → active mode
@@ -284,6 +306,10 @@ for details.
 | Heartbeat written on empty/skipped runs too (prevents false staleness) | 2026-03-24 | [Heartbeat design review](../99-reports/2026-03-24-heartbeat-design-review.md) Finding 3 |
 | stale_after = now + min(configured_intervals) × 2, matching awareness AT_RISK | 2026-03-24 | [Heartbeat design review](../99-reports/2026-03-24-heartbeat-design-review.md) Tension 3 |
 | Heartbeat uses fresh timestamp at write time, not pre-execution `now` | 2026-03-24 | [Heartbeat impl review](../99-reports/2026-03-24-heartbeat-implementation-review.md) Finding 1 |
+| OutputMode enum + match, not Renderer trait (two impls don't justify dyn dispatch) | 2026-03-24 | [Presentation layer review](../99-reports/2026-03-24-presentation-layer-design-review.md) |
+| Status command migrated first; other commands migrate incrementally | 2026-03-24 | [Presentation layer review](../99-reports/2026-03-24-presentation-layer-design-review.md) |
+| Progress display stays in backup.rs (streaming I/O doesn't fit produce-data/render) | 2026-03-24 | [Presentation layer review](../99-reports/2026-03-24-presentation-layer-design-review.md) |
+| TTY color: force-off for non-TTY only, respect NO_COLOR/CLICOLOR on TTY | 2026-03-24 | [Presentation layer impl review](../99-reports/2026-03-24-presentation-layer-implementation-review.md) Finding 1 |
 | Protection promises as core abstraction (score 10/10) | 2026-03-23 | [Vision brainstorm](../95-ideas/2026-03-23-brainstorm-realizing-the-vision.md) |
 | Mythic voice emerges from presentation layer, not scattered string edits | 2026-03-23 | User + architecture review |
 | Two modes: invisible worker + invoked norn | 2026-03-23 | User feedback on vision brainstorm |
@@ -306,7 +332,7 @@ for details.
 | Future directions brainstorm | [Feature ideas](../95-ideas/2026-03-23-brainstorm-urd-future.md) |
 | UX design principles brainstorm | [Norman principles](../95-ideas/2026-03-23-brainstorm-ux-norman-principles.md) |
 | Vision architecture review | [2026-03-23 Architectural criteria for vision](../99-reports/2026-03-23-vision-architecture-review.md) |
-| Latest adversary review | [2026-03-24 Heartbeat impl review](../99-reports/2026-03-24-heartbeat-implementation-review.md) |
+| Latest adversary review | [2026-03-24 Presentation layer impl review](../99-reports/2026-03-24-presentation-layer-implementation-review.md) |
 | Code conventions & architecture | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 
@@ -318,8 +344,8 @@ for details.
 - Stale failed send estimates persist indefinitely for (subvolume, drive, send_type) triples with no subsequent sends — consider TTL or clearing on successful calibration
 - Successful sends could update `subvolume_sizes` table to keep calibration fresh, but pipe bytes ≠ `du -sb` bytes (method mixing concern)
 - `FileSystemState` trait (9 methods) is outgrowing its name — consider renaming to `SystemState` if more history/state methods are added
-- Awareness model integrated into heartbeat but not yet into `urd status` or backup post-run summary
+- Awareness model integrated into heartbeat and `urd status` but not yet into backup post-run summary
 - `heartbeat::read()` returns `Option` — cannot distinguish missing file from corrupt JSON (upgrade to `Result<Option>` when Sentinel is built)
-- `#[allow(dead_code)]` on awareness structs (`SubvolAssessment`, `LocalAssessment`, `DriveAssessment`) — remove when status command integrates awareness
+- Remaining commands (`plan`, `backup`, `history`, `verify`, `init`, `calibrate`) still use direct `println!` — migrate to voice layer incrementally
 - Per-drive pin protection for external retention — current all-drives-union is conservative but suboptimal for space
 - Idea: [systemd unit drift check](../95-ideas/2026-03-23-systemd-unit-drift-check.md) in `urd verify`

--- a/docs/99-reports/2026-03-24-presentation-layer-design-review.md
+++ b/docs/99-reports/2026-03-24-presentation-layer-design-review.md
@@ -1,0 +1,393 @@
+# Architectural Adversary Review: Presentation Layer Design (Priority 3c)
+
+> **TL;DR:** The proposal is sound — structured data in, rendered text out — and the codebase
+> is ready for it. But the design has two under-specified areas that will determine whether this
+> module earns its keep or becomes dead abstraction: (1) what exactly are the "output event" types
+> that commands produce, and (2) does a Renderer trait actually pay for itself when two concrete
+> implementations and a `match` on an enum would be simpler, more explicit, and equally testable?
+> The current command handlers are doing ~300 lines of formatting each. The presentation layer
+> should absorb that complexity, not add a new layer on top of it.
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-24
+**Scope:** Design review of Priority 3c (presentation layer / `voice.rs`) before implementation
+**Commit:** `d4d02d2`
+**Reviewer:** Claude (arch-adversary)
+
+---
+
+## What Kills You
+
+**Catastrophic failure mode:** This is a presentation layer — it cannot cause data loss. The real
+risk is architectural: building an abstraction that doesn't fit the actual output patterns, leading
+to either (a) commands bypassing the layer for "just this one case" until most output is outside
+it, or (b) the layer becoming so generic that it's harder to understand than the scattered
+`println!` calls it replaced. Both outcomes leave the codebase worse than before.
+
+**Distance from catastrophe:** Far. This is a code quality and maintainability concern, not a
+safety concern. But a poorly designed presentation layer will tax every future feature — every
+new command, every new output format, every new status field will need to fight the abstraction.
+Getting it right now saves compounding friction later.
+
+---
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | Output-only layer; hard to get wrong if types are right |
+| Security | 5 | No trust boundaries crossed; read-only rendering |
+| Architectural Excellence | 3 | The proposal is right in spirit but under-specified in the details that matter |
+| Systems Design | 4 | TTY detection + JSON fallback covers the real deployment scenarios |
+| Rust Idioms | 3 | Trait-based renderer may be over-engineered for two implementations |
+| Code Quality | 4 | Testability is explicitly a design goal — good |
+
+---
+
+## Challenging the Premise
+
+### Is a Renderer trait the right abstraction?
+
+The proposal says: "Renderer trait with interactive and daemon implementations." Let's challenge
+this. A trait makes sense when:
+
+1. You have 3+ implementations, or
+2. You need to mock in tests, or
+3. The implementations are in different crates
+
+None of these apply. There are exactly two renderers (interactive and daemon), they're in the
+same crate, and tests don't need to mock the renderer — they test it directly by calling the
+render function and asserting on the output string.
+
+**Alternative:** An enum `OutputMode { Interactive, Daemon }` passed to free functions or a
+struct. The rendering logic uses `match` on the mode. This is simpler, requires no dynamic
+dispatch, and is equally testable.
+
+```rust
+pub enum OutputMode {
+    Interactive,  // TTY: colored, rich, eventually mythic
+    Daemon,       // Non-TTY: JSON or terse plain text
+}
+
+pub fn render_status(data: &StatusOutput, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => render_status_interactive(data),
+        OutputMode::Daemon => render_status_daemon(data),
+    }
+}
+```
+
+A trait adds indirection without benefit here. The `match` approach is explicit, greppable, and
+doesn't require the caller to construct a `Box<dyn Renderer>`. If a third renderer appears
+someday, promoting to a trait is a 15-minute refactor.
+
+**Verdict:** Start with enum + match. Promote to trait only if a third consumer appears or if
+test mocking becomes necessary.
+
+### Is "all user-facing text flows through this layer" achievable in one step?
+
+The architectural gate says: "All user-facing text flows through this layer." Today, 7 command
+files produce output directly. Migrating all 7 simultaneously would be a massive PR that touches
+every command, changes every test, and is essentially unreviewable.
+
+**Better approach:** Define the output types and rendering functions for one command first
+(`status` is the best candidate — it's the most user-facing, most structured, and most in need
+of awareness model integration). Prove the pattern works. Then migrate other commands one at a
+time. The architectural gate should be "the pattern exists and is proven," not "all commands use
+it from day one."
+
+### What exactly is the "structured data" that commands produce?
+
+This is the most important under-specified part of the design. "Commands return structured types,
+not formatted strings" — but what types? Each command produces different output:
+
+| Command | Current output shape | Structured type needed |
+|---------|---------------------|----------------------|
+| `status` | Table + drive summary + last run + pins | `StatusOutput` |
+| `plan` | Grouped operations + summary | Already has `BackupPlan` |
+| `backup` | Execution results + warnings | Already has `ExecutionResult` |
+| `history` | Table of runs or operations | `HistoryOutput` (runs/ops/failures) |
+| `verify` | Checklist of OK/WARN/FAIL + summary | `VerifyOutput` |
+| `init` | Checklist of system readiness | `InitOutput` |
+| `calibrate` | Per-subvolume sizes + summary | `CalibrateOutput` |
+
+Some commands already have structured types (`BackupPlan`, `ExecutionResult`). Others would need
+new types. The key insight: **don't create a generic `CommandOutput` enum that wraps all of these.**
+Each command's output is different enough that a single enum just moves the `match` from "which
+command" to "which variant" without adding value.
+
+Instead, each command should have its own output type and its own render function. The
+presentation layer is a *module*, not a single function.
+
+---
+
+## Design Tensions
+
+### 1. Centralization vs. Locality
+
+**Tension:** Putting all rendering in `voice.rs` centralizes output formatting (good for
+consistency) but separates the rendering logic from the command that produces the data (bad for
+readability — you have to jump between files to understand what a command does).
+
+**Resolution:** The rendering functions should live in the voice module, but the output types
+should live near their producers. `StatusOutput` can be defined in `commands/status.rs` (or in
+a shared `output.rs`), and `voice::render_status()` takes a reference to it. This keeps the
+type near where it's constructed and the rendering where it's centralized.
+
+Actually, the cleanest approach: define all output types in a single `output.rs` module (keeping
+them separate from commands but grouped together), and all rendering in `voice.rs`. The command
+handler constructs the output type, passes it to the voice function, and the voice function
+writes to stdout. This gives clear module boundaries:
+
+- `commands/*.rs` — business logic, construct output types
+- `output.rs` — output type definitions
+- `voice.rs` — rendering functions, one per output type
+
+### 2. Daemon Mode: JSON vs. Terse Text
+
+**Tension:** The proposal says "daemon (JSON/terse)." These are different things. JSON is
+machine-readable, structured, parseable. Terse text is human-readable but minimal. Which one?
+
+**Resolution:** JSON. The daemon mode exists for two consumers: systemd journal (where structured
+JSON is captured and queryable via `journalctl -o json`) and the future Sentinel (which may parse
+output). Terse text serves neither consumer well — it's not structured enough for machines and
+not rich enough for humans. If a human is reading daemon output, they can pipe through `jq`.
+
+One caveat: not every command needs a daemon mode. `urd status` run manually is always
+interactive. The daemon mode matters for `urd backup` (which runs from systemd timer) and
+potentially `urd verify` (which might run as a health check). Start with daemon mode only for
+`backup` and add others as needed.
+
+### 3. Progressive Migration vs. Big Bang
+
+**Tension:** Migrating all 7 commands to structured output at once produces a clean architecture
+but an enormous, risky PR. Migrating one at a time is safer but means two output patterns coexist.
+
+**Resolution:** Progressive migration. The voice module starts with `status` (integrating the
+awareness model — this is the natural first consumer). Other commands migrate as they're touched
+for other reasons. The coexistence of old-style `println!` in some commands and voice-rendered
+output in others is acceptable during transition. The important thing is that new output goes
+through the voice layer.
+
+### 4. Where Does Progress Display Live?
+
+**Tension:** `backup.rs` has a real-time progress display thread that writes to stderr with `\r`
+line overwriting. This is fundamentally different from the "produce structured data, render it"
+pattern. Progress is streaming, ephemeral, and side-effectful.
+
+**Resolution:** Progress display stays in `backup.rs`. It's not part of the presentation layer.
+The voice layer handles *completed* output (results, summaries, status). Progress is a real-time
+I/O concern that belongs in the command handler. Don't force it through an abstraction that
+doesn't fit.
+
+---
+
+## Findings
+
+### Finding 1: Start with `StatusOutput` + Awareness Model Integration
+
+**Severity: Commendation (of the opportunity)**
+
+The `status` command is the ideal first consumer of the presentation layer because:
+
+1. It's the most user-facing command ("is my data safe?")
+2. The awareness model (`SubvolAssessment`) is built but not integrated into status yet
+   (known issue in status.md)
+3. The current status output is a hand-formatted table that would benefit from structured data
+4. It doesn't have streaming/progress concerns
+
+A `StatusOutput` type that combines the current table data with `SubvolAssessment` data gives
+the presentation layer its first real test: can it render promise states, snapshot counts, drive
+status, chain health, and last-run info into both an interactive table and a JSON blob?
+
+### Finding 2: Don't Over-Type the Output
+
+**Severity: Moderate**
+
+There's a temptation to create deeply nested output types:
+
+```rust
+// Too much structure
+pub struct StatusOutput {
+    pub subvolumes: Vec<SubvolumeStatus>,
+    pub drives: Vec<DriveStatus>,
+    pub last_run: Option<LastRunStatus>,
+    pub pins: PinSummary,
+    pub assessments: Vec<SubvolAssessment>,
+}
+```
+
+The risk: each of these sub-types needs its own rendering logic, its own test fixtures, and its
+own maintenance. The awareness model's `SubvolAssessment` already captures most of what status
+needs. Don't duplicate it — reference it.
+
+A simpler approach: `StatusOutput` aggregates references to already-existing types:
+
+```rust
+pub struct StatusOutput {
+    pub assessments: Vec<SubvolAssessment>,
+    pub drives: Vec<DriveInfo>,          // simple struct: label, mounted, free_bytes
+    pub last_run: Option<LastRunInfo>,    // simple struct from DB
+    pub total_pins: usize,
+}
+```
+
+The rendering functions know how to present each piece. The output type is a data bag, not a
+rendering specification.
+
+### Finding 3: TTY Detection Should Happen Once, Early
+
+**Severity: Minor**
+
+Currently, TTY detection happens ad-hoc in `backup.rs` (`std::io::stderr().is_terminal()`).
+The presentation layer should determine the output mode once, at startup in `main.rs`, and
+pass it down. This avoids scattered `is_terminal()` checks and makes testing straightforward
+(pass `OutputMode::Interactive` or `OutputMode::Daemon` explicitly).
+
+```rust
+// In main.rs
+let output_mode = if std::io::stdout().is_terminal() {
+    OutputMode::Interactive
+} else {
+    OutputMode::Daemon
+};
+```
+
+One subtlety: the `colored` crate has its own TTY detection via `CLICOLOR` and `NO_COLOR`
+environment variables. The presentation layer should respect these by calling
+`colored::control::set_override(false)` when in daemon mode. This ensures that even if
+rendering functions use `.green()` etc., no ANSI codes leak into non-TTY output.
+
+### Finding 4: The Mythic Voice Is Not Part of This PR
+
+**Severity: Moderate (scope management)**
+
+The vision architecture review says: "before building mythic voice, at least 10 sample messages
+written and reviewed for tone/clarity balance." The presentation layer is the *architecture* for
+the mythic voice, not the voice itself. This PR should produce a working presentation layer with
+straightforward, clear output. The mythic voice is a content layer that goes on top later.
+
+Concretely: `render_status_interactive()` should produce output that looks like the current
+status command — just centralized and structured. Don't try to make it mythic yet. The mythic
+voice is a separate priority that requires content design, not architecture.
+
+### Finding 5: `init.rs` Has Interactive Prompts That Don't Fit the Pattern
+
+**Severity: Minor**
+
+The `init` command includes interactive `Delete? [y/N]` prompts for potentially incomplete
+snapshots on external drives. This is user *input*, not output. It doesn't fit the
+"produce structured data, render it" pattern.
+
+This is fine. Leave the interactive prompts in `init.rs`. The presentation layer handles output
+formatting, not input collection. When `init` outputs its checklist results, those can go through
+the voice layer. When it asks the user a question, that stays in the command handler.
+
+### Finding 6: Colored Output Without TTY Check in Non-Backup Commands
+
+**Severity: Moderate**
+
+Every command except `backup` applies color unconditionally via the `colored` crate. If `urd
+status` is piped to a file or another program, ANSI escape codes pollute the output. The
+presentation layer fixes this by design — daemon mode produces clean output — but until all
+commands are migrated, the `colored` crate's `set_override` should be called early based on TTY
+detection.
+
+Quick fix independent of the presentation layer: add
+`colored::control::set_override(stdout().is_terminal())` in `main.rs`. This makes all `.green()`
+etc. calls respect TTY status globally.
+
+---
+
+## The Simplicity Question
+
+### What's earning its keep?
+
+- **Structured output types** — yes, absolutely. Commands producing data instead of strings is
+  the right separation. It enables testing, JSON output, and future mythic voice without
+  touching business logic.
+- **Centralized rendering** — yes. Seven command files each doing their own color-coded tables
+  is the current pain point. One module that knows how to format is better.
+- **TTY detection → output mode** — yes. Simple, necessary, already partially implemented.
+
+### What might not earn its keep?
+
+- **Renderer trait** — probably not. Two implementations don't justify a trait. An enum + match
+  is simpler and more explicit.
+- **Generic `CommandOutput` enum** — definitely not. Each command's output is different. Don't
+  unify them under one type.
+- **Full migration of all 7 commands in this PR** — not necessary. Start with `status`, prove
+  the pattern, migrate others incrementally.
+
+### What could be removed or deferred?
+
+- The mythic voice content (defer — this is architecture, not content)
+- Daemon mode for commands that only run interactively (defer — start with `backup`)
+- Output types for commands that aren't being touched (`calibrate`, `init`)
+
+---
+
+## Priority Action Items
+
+1. **Define `OutputMode` enum** (`Interactive` / `Daemon`) — determined once in `main.rs` from
+   TTY detection. Pass to command handlers.
+
+2. **Define `StatusOutput` struct** — aggregates awareness model assessments, drive info,
+   last-run info, pin count. This is the first output type.
+
+3. **Implement `voice::render_status()`** — two branches (interactive/daemon). Interactive
+   produces the current colored table output. Daemon produces JSON. Both are testable.
+
+4. **Refactor `commands/status.rs`** — command constructs `StatusOutput`, calls
+   `voice::render_status()`, prints result. Business logic (filesystem queries, DB reads)
+   stays in the command handler.
+
+5. **Integrate awareness model into status** — the `SubvolAssessment` data that's been computed
+   but not displayed. This is the natural first consumer.
+
+6. **Add `colored::control::set_override()`** in `main.rs` — fixes ANSI leakage for all
+   commands immediately, independent of the presentation layer migration.
+
+7. **Write tests** — for `render_status()`: given a `StatusOutput` with known values, assert
+   the interactive output contains expected strings. Assert the daemon output is valid JSON
+   with expected keys.
+
+---
+
+## Recommended Module Structure
+
+```
+src/
+  output.rs       — Output type definitions (StatusOutput, etc.)
+  voice.rs        — Rendering functions: render_status(), render_plan(), etc.
+  commands/
+    status.rs     — Builds StatusOutput, calls voice::render_status()
+    backup.rs     — (Future: BackupOutput + voice::render_backup())
+    ...
+```
+
+The `output.rs` / `voice.rs` split keeps type definitions separate from rendering logic. As
+commands migrate, each gets a corresponding output type in `output.rs` and render function in
+`voice.rs`.
+
+---
+
+## Open Questions
+
+1. **Should daemon mode be JSON or structured log lines?** JSON is more parseable, but structured
+   log lines (key=value pairs) integrate better with systemd journal. The answer depends on who
+   reads the output — if it's just the journal, plain text with structured keys might be simpler.
+
+2. **Should the voice module write to stdout directly, or return strings?** Returning strings is
+   more testable. Writing directly is simpler for streaming output. Recommendation: return strings
+   for now (testability wins), optimize later if needed.
+
+3. **How does `--verbose` interact with the presentation layer?** Currently, `--verbose` is
+   parsed by clap but not used by most commands. The presentation layer should accept a verbosity
+   level as part of the output mode. Verbose interactive mode shows technical details (intervals,
+   thresholds, ages). Normal mode shows the summary.
+
+4. **Should `voice.rs` use the `colored` crate directly, or return markup that's interpreted
+   later?** Using `colored` directly is simpler and matches the existing pattern. A markup
+   intermediate representation is only useful if the output target isn't always a terminal (e.g.,
+   HTML rendering) — which is not a current or foreseeable need.

--- a/docs/99-reports/2026-03-24-presentation-layer-implementation-review.md
+++ b/docs/99-reports/2026-03-24-presentation-layer-implementation-review.md
@@ -1,0 +1,336 @@
+# Architectural Adversary Review: Presentation Layer Implementation
+
+> **TL;DR:** Clean implementation that does exactly what it set out to do. The data-collection /
+> rendering separation is real and testable. The awareness model integration into status works
+> correctly. Two issues worth fixing: (1) the `colored::control::set_override` in main.rs
+> overrides the `colored` crate's own `NO_COLOR` / `CLICOLOR` handling, which breaks a de facto
+> standard; (2) assessments and chain health are joined by string name lookups at render time,
+> which is an O(n*m) operation on data that was computed together — a minor data modeling issue
+> that should be fixed before more commands migrate. Everything else is solid.
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-24
+**Scope:** Implementation review of Priority 3c (presentation layer), files: `output.rs`,
+`voice.rs`, `commands/status.rs`, `main.rs`, changes to `awareness.rs`
+**Commit:** post-`d4d02d2` (uncommitted)
+**Reviewer:** Claude (arch-adversary)
+
+---
+
+## What Kills You
+
+**Catastrophic failure mode:** This is a presentation layer. It cannot cause data loss, cannot
+execute privileged operations, and cannot corrupt state. The catastrophic failure mode for this
+review is architectural: building a pattern that doesn't survive contact with the remaining 6
+commands, forcing a redesign that touches everything.
+
+**Distance:** Far. The pattern is straightforward (structured data in, rendered string out), and
+the first migration (status) proves it works on the most complex command. The remaining commands
+are simpler in output structure. No redesign is likely.
+
+---
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | Output-only; all data paths verified; one edge case in drive summary |
+| Security | 5 | No trust boundaries crossed; read-only rendering of pre-validated data |
+| Architectural Excellence | 4 | Clean separation; enum-over-trait was the right call; data model has one join smell |
+| Systems Design | 4 | TTY detection solid; daemon JSON clean; one environment variable issue |
+| Rust Idioms | 4 | Good use of `#[must_use]`, serde derives, `.ok()` on infallible writes |
+| Code Quality | 4 | Tests verify behavior not implementation; good coverage; naming is precise |
+
+---
+
+## Design Tensions
+
+### 1. Serializable Wrapper Types vs. Direct Awareness Type Serialization
+
+**Trade-off:** `StatusAssessment` is a serializable wrapper around `SubvolAssessment`, created
+via `from_assessment()`. The alternative was adding `#[derive(Serialize)]` to `SubvolAssessment`
+directly and using it in `StatusOutput`.
+
+**Why the wrapper was chosen:** `SubvolAssessment` contains `chrono::Duration` fields that don't
+serialize naturally, and `PromiseStatus` is an enum that would serialize as its variant name (e.g.,
+`"Protected"`) rather than the display string (`"PROTECTED"`). The wrapper converts these to
+strings at construction time, making the JSON output human-readable without custom serializers.
+
+**Verdict:** Correct call. Adding custom Serialize impls to awareness types would couple them to
+the presentation layer's serialization preferences. The wrapper isolates that concern. The cost
+is ~20 lines of conversion code — well within budget.
+
+### 2. Chain Health as Separate Vec vs. Embedded in Assessment
+
+**Trade-off:** `StatusOutput` stores `chain_health: Vec<ChainHealthEntry>` separately from
+`assessments: Vec<StatusAssessment>`, joined by subvolume name at render time. The alternative
+was embedding chain health directly in the assessment.
+
+**Why separate:** Chain health comes from filesystem I/O (pin file checks), while assessments
+come from the awareness model (a pure function). They're computed by different code paths with
+different error characteristics. Keeping them separate preserves the awareness model's purity.
+
+**Cost:** The renderer does `O(n*m)` string lookups to join them (line 106-111 of voice.rs).
+With 7 subvolumes this is trivial. But the join-by-string-name pattern is a latent data modeling
+issue — if a subvolume name in `chain_health` doesn't match one in `assessments` (e.g., due to
+a disabled subvolume appearing in one but not the other), the data silently fails to join.
+
+**Verdict:** Acceptable for now. If chain health is ever embedded in the assessment (which would
+be natural when more commands consume it), the join disappears. For 7 subvolumes, the O(n*m) cost
+is zero. But see Finding 2 for the name-mismatch concern.
+
+### 3. `print!` vs. `write!` to stdout
+
+**Trade-off:** `voice.rs` returns a String, and `status.rs` prints it with `print!("{rendered}")`.
+The alternative is passing a `&mut dyn Write` to the renderer and writing directly.
+
+**Why String return:** Testability. Tests call `render_status()` and assert on the returned
+string without capturing stdout. This is the simpler, more reliable testing pattern.
+
+**Cost:** The full status output is held in memory as a String. For status output this is a few
+KB — no concern.
+
+**Verdict:** Right call. Testability is worth more than the trivial memory cost.
+
+---
+
+## Findings
+
+### Finding 1: `colored::control::set_override` Conflicts with `NO_COLOR` Convention
+
+**Severity: Significant**
+
+```rust
+// main.rs:29
+colored::control::set_override(std::io::stdout().is_terminal());
+```
+
+The comment says "Also honors NO_COLOR and CLICOLOR env vars via the colored crate." This is
+incorrect. `set_override(true)` *overrides* the `colored` crate's built-in environment variable
+handling. If a user sets `NO_COLOR=1` (a [de facto standard](https://no-color.org/) respected by
+hundreds of CLI tools), `set_override(true)` will ignore it and emit colors anyway, because
+`is_terminal()` returns `true` for an interactive TTY regardless of `NO_COLOR`.
+
+**Consequence:** A user who has `NO_COLOR=1` in their environment (common for accessibility or
+script-friendly terminals) gets colored output from Urd but not from other tools. This violates
+user expectations.
+
+**Fix:** Don't call `set_override` unconditionally. The `colored` crate already handles TTY
+detection, `NO_COLOR`, `CLICOLOR`, and `CLICOLOR_FORCE` correctly by default. The only thing
+`set_override` should do is *force off* colors when in daemon mode, or let the crate handle it:
+
+```rust
+// Option A: Let the crate handle everything (simplest, correct)
+// Remove the set_override line entirely. The colored crate
+// checks is_terminal(), NO_COLOR, and CLICOLOR on its own.
+
+// Option B: Only override to force-off for daemon mode (explicit)
+if !std::io::stdout().is_terminal() {
+    colored::control::set_override(false);
+}
+```
+
+Option A is simpler and correct. Option B is equivalent but more explicit. Either way, never
+call `set_override(true)` — it defeats the user's `NO_COLOR` preference.
+
+### Finding 2: Assessments and Chain Health Can Diverge Silently
+
+**Severity: Moderate**
+
+`StatusOutput` has two parallel collections indexed by subvolume name:
+- `assessments: Vec<StatusAssessment>` — from awareness model (only enabled subvolumes)
+- `chain_health: Vec<ChainHealthEntry>` — from chain health computation (all subvolumes with
+  snapshot roots)
+
+The awareness model skips disabled subvolumes (`if !subvol.enabled { continue; }`). The chain
+health computation in status.rs iterates `config.subvolumes` without checking `enabled`. This
+means a disabled subvolume with a snapshot root will appear in `chain_health` but not in
+`assessments`.
+
+**Consequence:** In daemon mode (JSON), the consumer sees a chain health entry for a subvolume
+that has no matching assessment. In interactive mode, the chain health entry is silently dropped
+because the renderer iterates assessments and looks up chain health (not the reverse). Neither
+case causes a crash, but the JSON output is inconsistent.
+
+**Fix:** Filter `config.subvolumes` in the chain health loop to match the awareness model's
+filtering:
+
+```rust
+for sv in &config.subvolumes {
+    let resolved = config.resolved_subvolumes();
+    // Match awareness model: skip disabled subvolumes
+    let is_enabled = resolved.iter().any(|r| r.name == sv.name && r.enabled);
+    if !is_enabled {
+        continue;
+    }
+    // ... rest of chain health computation
+}
+```
+
+Or simpler: iterate `resolved` instead of `config.subvolumes`, which already has `enabled` resolved.
+
+### Finding 3: Drive Summary Shows "none configured" Only When Empty AND None Mounted
+
+**Severity: Minor**
+
+```rust
+// voice.rs:121-125
+fn render_drive_summary(data: &StatusOutput, out: &mut String) {
+    let any_mounted = data.drives.iter().any(|d| d.mounted);
+    if !any_mounted && data.drives.is_empty() {
+        writeln!(out, "{}", "Drives: none configured".dimmed()).ok();
+        return;
+    }
+```
+
+The condition `!any_mounted && data.drives.is_empty()` only triggers when the drives list is
+empty. If there are drives but none are mounted, the function falls through to the loop and
+prints each drive as "not mounted" — which is correct behavior. But the `!any_mounted` check
+is redundant: if `data.drives.is_empty()`, then `any_mounted` is already false. The `any_mounted`
+variable is unused elsewhere in the function.
+
+**Fix:** Simplify to:
+```rust
+if data.drives.is_empty() {
+    writeln!(out, "{}", "Drives: none configured".dimmed()).ok();
+    return;
+}
+```
+
+### Finding 4: Advisories and Errors Not Rendered in Interactive Mode
+
+**Severity: Moderate**
+
+`StatusAssessment` carries `advisories: Vec<String>` and `errors: Vec<String>` from the awareness
+model. These contain useful information like "offsite drive not connected in 14 days" or
+"can't read snapshot directory." The interactive renderer (`render_status_interactive`) never
+displays them. Only the daemon mode (JSON) includes them because they're serialized automatically.
+
+**Consequence:** A user running `urd status` interactively doesn't see advisories or errors. They
+would only see them by piping to `cat` (daemon mode). This partially defeats the purpose of
+integrating the awareness model into status — the promise states appear, but the explanatory
+context doesn't.
+
+**Fix:** After the subvolume table, render non-empty advisories and errors:
+```rust
+for assessment in &data.assessments {
+    for error in &assessment.errors {
+        writeln!(out, "  {} {}: {}", "ERROR".red(), assessment.name, error).ok();
+    }
+    for advisory in &assessment.advisories {
+        writeln!(out, "  {} {}: {}", "NOTE".dimmed(), assessment.name, advisory).ok();
+    }
+}
+```
+
+This is a content decision, not an architecture one, so it could reasonably be deferred to the
+mythic voice work. But the data is computed and available — not displaying it is a missed
+opportunity.
+
+### Finding 5: `colored::control::set_override(false)` in Tests Is Globally Mutable State
+
+**Severity: Minor**
+
+Every interactive rendering test calls `colored::control::set_override(false)` to disable ANSI
+codes for reliable string assertions. This modifies global state. If tests run in parallel
+(Rust's default), one test's `set_override(false)` could affect another test that expects colors.
+
+**In practice:** This is not a problem because:
+1. The tests only assert on content, not on ANSI codes
+2. Setting `false` means "no colors" — assertions that check `contains("PROTECTED")` work
+   regardless of whether colors are on or off
+3. The `colored` crate's override is thread-local in practice (it uses `ShouldColorize` which
+   checks per-call)
+
+**But be aware:** If future tests ever assert on colored output (e.g., checking that PROTECTED
+is green), they'll need to handle this global state carefully. The current approach is fine for
+content-based assertions.
+
+### Commendation: Clean Data Flow in Status Command
+
+The refactored `commands/status.rs` reads top-to-bottom as a data pipeline: open DB → assess →
+compute chain health → collect drive info → query last run → count pins → assemble → render →
+print. Each step produces data consumed by the next. No control flow surprises, no callbacks, no
+shared mutable state. This is how command handlers should read.
+
+The single `print!("{rendered}")` at line 128 is the only I/O in the entire function (aside from
+the data collection queries). This makes the command trivially testable if integration tests are
+ever needed — mock the data sources and assert on the rendered string.
+
+### Commendation: Enum Over Trait Was the Right Call
+
+The design review recommended `OutputMode` enum with match-based dispatch instead of a
+`Renderer` trait. The implementation proves this was right: `render_status()` is 5 lines (a match
+with two arms), each arm calls a private function, and there's no `Box<dyn Renderer>` anywhere.
+Adding a new output mode (e.g., `Prometheus` for metrics-as-output) would be a new match arm and
+a new function — not a new struct implementing a trait.
+
+The code is greppable, explicit, and has zero indirection cost. Good engineering judgment.
+
+### Commendation: Serializable Output Types Enable Future Consumers
+
+By deriving `Serialize` on all output types, the daemon mode is literally one function call
+(`serde_json::to_string_pretty`). But more importantly, these types are now usable by any future
+consumer: the Sentinel could read `StatusOutput` as structured data, a tray icon could consume
+the JSON, tests can construct fixtures directly. The types are the API — the rendering is just
+one consumer of that API.
+
+---
+
+## The Simplicity Question
+
+### What's earning its keep?
+
+- **`output.rs`** — yes. The types are the contract between data collection and rendering.
+  Without them, you're back to scattered `println!` calls.
+- **`voice.rs`** — yes. Centralized rendering with two modes. 237 lines including tests for a
+  complete table formatter + two rendering paths is lean.
+- **`StatusAssessment` wrapper** — yes. Isolates serialization concerns from the awareness model.
+- **`OutputMode::detect()`** — borderline. It's 4 lines that duplicate `is_terminal()`. The
+  detect method exists for symmetry with future modes, but today it could just be the enum
+  constructed directly in main.rs. Not harmful, but not earning much.
+
+### What could be simpler?
+
+- **Chain health as a separate Vec** — could be embedded in `StatusAssessment` if the data model
+  allowed it. The current separate-Vec approach works but creates the join-by-name pattern.
+- **`DriveInfo` re-queries mount status** — `drives::is_drive_mounted()` is called twice per
+  drive in status.rs: once at line 32 (to filter mounted drives for chain health) and again at
+  line 69 (to populate `DriveInfo`). This is harmless I/O duplication, not a correctness issue.
+
+---
+
+## Priority Action Items
+
+1. **Fix `colored::control::set_override`** — either remove the line (let the crate handle it)
+   or only force-off for non-TTY. Currently overrides the user's `NO_COLOR` preference.
+   Severity: Significant.
+
+2. **Filter disabled subvolumes from chain health computation** — match the awareness model's
+   filtering to prevent divergent collections in `StatusOutput`. Severity: Moderate.
+
+3. **Render advisories and errors in interactive mode** — the data is computed; not displaying
+   it is a missed opportunity for the "is my data safe?" question. Severity: Moderate (could
+   defer to mythic voice).
+
+4. **Simplify drive summary guard** — remove redundant `!any_mounted` check. Severity: Minor.
+
+---
+
+## Open Questions
+
+1. **Should daemon mode include a schema version?** The heartbeat file has `schema_version: 1`.
+   The `StatusOutput` JSON has no version field. If external tools start consuming it (scripts,
+   tray icon), schema changes will need a migration story. Adding a version field now costs one
+   line; adding it later may break consumers who don't expect it.
+
+2. **Should `urd status --json` be an explicit flag?** Currently, daemon mode is TTY-detected.
+   A user who wants JSON output from an interactive terminal must `urd status | cat`. An explicit
+   `--json` flag would be more discoverable. This is a UX decision, not an architecture one —
+   the architecture supports both approaches.
+
+3. **Which command migrates next?** The design review suggests migrating commands "as they're
+   touched for other reasons." But the `backup` post-run summary is the next natural consumer
+   of the awareness model (known issue in status.md). Should backup migrate to the voice layer
+   as part of that integration, or should the awareness integration happen with inline
+   `println!` first?

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -50,7 +50,6 @@ impl std::fmt::Display for PromiseStatus {
 
 /// Complete assessment for a single subvolume.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct SubvolAssessment {
     pub name: String,
     pub status: PromiseStatus,
@@ -64,23 +63,25 @@ pub struct SubvolAssessment {
 
 /// Local snapshot freshness assessment.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct LocalAssessment {
     pub status: PromiseStatus,
     pub snapshot_count: usize,
+    #[allow(dead_code)] // consumed by verbose status display (future)
     pub newest_age: Option<Duration>,
+    #[allow(dead_code)] // consumed by verbose status display (future)
     pub configured_interval: Interval,
 }
 
 /// External drive send freshness assessment.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct DriveAssessment {
     pub drive_label: String,
     pub status: PromiseStatus,
     pub mounted: bool,
     pub snapshot_count: Option<usize>,
+    #[allow(dead_code)] // consumed by verbose status display (future)
     pub last_send_age: Option<Duration>,
+    #[allow(dead_code)] // consumed by verbose status display (future)
     pub configured_interval: Interval,
 }
 
@@ -130,8 +131,7 @@ pub fn assess(
         let mut advisories = Vec::new();
         let local = match fs.local_snapshots(&snapshot_root, &subvol.name) {
             Ok(snaps) => {
-                let (assessment, advisory) =
-                    assess_local(&snaps, now, subvol.snapshot_interval);
+                let (assessment, advisory) = assess_local(&snaps, now, subvol.snapshot_interval);
                 if let Some(adv) = advisory {
                     advisories.push(adv);
                 }
@@ -153,8 +153,7 @@ pub fn assess(
 
         if subvol.send_enabled {
             if config.drives.is_empty() {
-                advisories
-                    .push("send_enabled but no drives configured".to_string());
+                advisories.push("send_enabled but no drives configured".to_string());
             }
 
             for drive in &config.drives {
@@ -175,23 +174,21 @@ pub fn assess(
                     None
                 };
 
-                let last_send_time =
-                    fs.last_successful_send_time(&subvol.name, &drive.label);
+                let last_send_time = fs.last_successful_send_time(&subvol.name, &drive.label);
                 // Clamp negative ages to zero (clock skew protection, same as local)
                 let last_send_age = last_send_time.map(|t| {
                     let age = now - t;
-                    if age < Duration::zero() { Duration::zero() } else { age }
+                    if age < Duration::zero() {
+                        Duration::zero()
+                    } else {
+                        age
+                    }
                 });
 
-                let status = assess_external_status(
-                    last_send_age,
-                    subvol.send_interval,
-                );
+                let status = assess_external_status(last_send_age, subvol.send_interval);
 
                 // Advisory for stale offsite drives
-                if !mounted
-                    && let Some(age) = last_send_age
-                {
+                if !mounted && let Some(age) = last_send_age {
                     let days = age.num_days();
                     if days > 7 {
                         advisories.push(format!(
@@ -287,10 +284,7 @@ fn assess_local(
     )
 }
 
-fn assess_external_status(
-    last_send_age: Option<Duration>,
-    interval: Interval,
-) -> PromiseStatus {
+fn assess_external_status(last_send_age: Option<Duration>, interval: Interval) -> PromiseStatus {
     match last_send_age {
         None => PromiseStatus::Unprotected,
         Some(age) => freshness_status(
@@ -322,10 +316,7 @@ fn freshness_status(
 
 /// Overall status: min(local, best_external).
 /// External uses max() across drives (best connected drive wins).
-fn compute_overall_status(
-    local: &LocalAssessment,
-    drives: &[DriveAssessment],
-) -> PromiseStatus {
+fn compute_overall_status(local: &LocalAssessment, drives: &[DriveAssessment]) -> PromiseStatus {
     if drives.is_empty() {
         return local.status;
     }
@@ -451,10 +442,8 @@ source = "/data/sv2"
         let mut fs = MockFileSystemState::new();
 
         // Snapshot 3h ago: > 2× of 1h interval but < 5× → AT_RISK
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap(dt(2026, 3, 23, 11, 0), "sv1")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 11, 0), "sv1")]);
 
         // Fresh send so external doesn't drag status down
         fs.send_times.insert(
@@ -477,10 +466,8 @@ source = "/data/sv2"
         let mut fs = MockFileSystemState::new();
 
         // Snapshot 6h ago: > 5× of 1h interval → UNPROTECTED
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap(dt(2026, 3, 23, 8, 0), "sv1")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 8, 0), "sv1")]);
         fs.mounted_drives.insert("WD-18TB".to_string());
 
         let results = assess(&config, now, &fs);
@@ -708,11 +695,19 @@ source = "/data/sv1"
         let results = assess(&config, now, &fs);
 
         // Primary drive is PROTECTED
-        let primary = &results[0].external.iter().find(|d| d.drive_label == "primary").unwrap();
+        let primary = &results[0]
+            .external
+            .iter()
+            .find(|d| d.drive_label == "primary")
+            .unwrap();
         assert_eq!(primary.status, PromiseStatus::Protected);
 
         // Offsite is UNPROTECTED
-        let offsite = &results[0].external.iter().find(|d| d.drive_label == "offsite").unwrap();
+        let offsite = &results[0]
+            .external
+            .iter()
+            .find(|d| d.drive_label == "offsite")
+            .unwrap();
         assert_eq!(offsite.status, PromiseStatus::Unprotected);
 
         // Overall: max(PROTECTED, UNPROTECTED) = PROTECTED for external,
@@ -729,10 +724,8 @@ source = "/data/sv1"
         let mut fs = MockFileSystemState::new();
 
         // Stale local → AT_RISK (3h old, > 2× of 1h)
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap(dt(2026, 3, 23, 11, 0), "sv1")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 11, 0), "sv1")]);
 
         // Fresh external → PROTECTED
         fs.send_times.insert(
@@ -805,10 +798,8 @@ enabled = false
         let mut fs = MockFileSystemState::new();
 
         // Exactly 2h ago = exactly 2× of 1h interval → PROTECTED (≤)
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap(dt(2026, 3, 23, 12, 0), "sv1")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 12, 0), "sv1")]);
 
         let results = assess(&config, now, &fs);
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
@@ -830,19 +821,15 @@ enabled = false
         let mut fs = MockFileSystemState::new();
 
         // Exactly 5h ago = exactly 5× of 1h interval → AT_RISK (≤)
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap(dt(2026, 3, 23, 9, 0), "sv1")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 9, 0), "sv1")]);
 
         let results = assess(&config, now, &fs);
         assert_eq!(results[0].local.status, PromiseStatus::AtRisk);
 
         // 5h + 1min ago → UNPROTECTED (> 5×)
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap(dt(2026, 3, 23, 8, 59), "sv1")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 8, 59), "sv1")]);
 
         let results = assess(&config, now, &fs);
         assert_eq!(results[0].local.status, PromiseStatus::Unprotected);
@@ -888,14 +875,10 @@ source = "/data/sv1"
 
         // 2 days ago: within 2× local (PROTECTED) but > 1.5× external (AT_RISK)
         let two_days_ago = dt(2026, 3, 21, 14, 0);
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap(two_days_ago, "sv1")],
-        );
-        fs.send_times.insert(
-            ("sv1".to_string(), "WD-18TB".to_string()),
-            two_days_ago,
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(two_days_ago, "sv1")]);
+        fs.send_times
+            .insert(("sv1".to_string(), "WD-18TB".to_string()), two_days_ago);
         fs.mounted_drives.insert("WD-18TB".to_string());
 
         let results = assess(&config, now, &fs);
@@ -985,7 +968,12 @@ source = "/data/sv1"
         // Drive NOT mounted
 
         let results = assess(&config, now, &fs);
-        assert!(results[0].advisories.iter().any(|a| a.contains("consider cycling")));
+        assert!(
+            results[0]
+                .advisories
+                .iter()
+                .any(|a| a.contains("consider cycling"))
+        );
         assert!(results[0].advisories[0].contains("WD-18TB"));
     }
 
@@ -1006,7 +994,10 @@ source = "/data/sv1"
             newest_age: Some(Duration::minutes(30)),
             configured_interval: Interval::hours(1),
         };
-        assert_eq!(compute_overall_status(&local, &[]), PromiseStatus::Protected);
+        assert_eq!(
+            compute_overall_status(&local, &[]),
+            PromiseStatus::Protected
+        );
 
         let local_risk = LocalAssessment {
             status: PromiseStatus::AtRisk,
@@ -1014,7 +1005,10 @@ source = "/data/sv1"
             newest_age: Some(Duration::hours(3)),
             configured_interval: Interval::hours(1),
         };
-        assert_eq!(compute_overall_status(&local_risk, &[]), PromiseStatus::AtRisk);
+        assert_eq!(
+            compute_overall_status(&local_risk, &[]),
+            PromiseStatus::AtRisk
+        );
     }
 
     // ── PromiseStatus ordering ─────────────────────────────────────
@@ -1062,10 +1056,8 @@ source = "/data/sv1"
         let mut fs = MockFileSystemState::new();
 
         // Snapshot from 14:00, but clock says 12:00 → snapshot is "from the future"
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap(dt(2026, 3, 23, 14, 0), "sv1")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 14, 0), "sv1")]);
         fs.send_times.insert(
             ("sv1".to_string(), "WD-18TB".to_string()),
             dt(2026, 3, 23, 10, 0),
@@ -1077,7 +1069,12 @@ source = "/data/sv1"
         // (not falsely PROTECTED from negative duration)
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         // Clock skew advisory should be present
-        assert!(results[0].advisories.iter().any(|a| a.contains("clock skew")));
+        assert!(
+            results[0]
+                .advisories
+                .iter()
+                .any(|a| a.contains("clock skew"))
+        );
         // Age should be zero, not negative
         assert_eq!(results[0].local.newest_age, Some(Duration::zero()));
     }

--- a/src/btrfs.rs
+++ b/src/btrfs.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::UrdError;
 
@@ -108,27 +108,21 @@ impl BtrfsOps for RealBtrfs {
             snapshot.display()
         );
 
-        let mut send_child = send_cmd
-            .spawn()
-            .map_err(|e| UrdError::Btrfs {
-                msg: format!("failed to spawn btrfs send: {e}"),
-                bytes_transferred: None,
-            })?;
+        let mut send_child = send_cmd.spawn().map_err(|e| UrdError::Btrfs {
+            msg: format!("failed to spawn btrfs send: {e}"),
+            bytes_transferred: None,
+        })?;
 
         // Take send's stdout to pipe into receive's stdin
-        let mut send_stdout = send_child.stdout.take().ok_or_else(|| {
-            UrdError::Btrfs {
-                msg: "failed to capture btrfs send stdout".to_string(),
-                bytes_transferred: None,
-            }
+        let mut send_stdout = send_child.stdout.take().ok_or_else(|| UrdError::Btrfs {
+            msg: "failed to capture btrfs send stdout".to_string(),
+            bytes_transferred: None,
         })?;
 
         // Take send's stderr to drain in a thread
-        let send_stderr = send_child.stderr.take().ok_or_else(|| {
-            UrdError::Btrfs {
-                msg: "failed to capture btrfs send stderr".to_string(),
-                bytes_transferred: None,
-            }
+        let send_stderr = send_child.stderr.take().ok_or_else(|| UrdError::Btrfs {
+            msg: "failed to capture btrfs send stderr".to_string(),
+            bytes_transferred: None,
         })?;
 
         // Drain send stderr in a background thread to prevent deadlock
@@ -158,11 +152,9 @@ impl BtrfsOps for RealBtrfs {
                 bytes_transferred: None,
             })?;
 
-        let mut recv_stdin = recv_child.stdin.take().ok_or_else(|| {
-            UrdError::Btrfs {
-                msg: "failed to capture btrfs receive stdin".to_string(),
-                bytes_transferred: None,
-            }
+        let mut recv_stdin = recv_child.stdin.take().ok_or_else(|| UrdError::Btrfs {
+            msg: "failed to capture btrfs receive stdin".to_string(),
+            bytes_transferred: None,
         })?;
 
         // Copy send stdout → receive stdin in a thread, counting bytes.
@@ -187,20 +179,16 @@ impl BtrfsOps for RealBtrfs {
         });
 
         // Wait for receive to finish
-        let recv_output = recv_child
-            .wait_with_output()
-            .map_err(|e| UrdError::Btrfs {
-                msg: format!("failed to wait for btrfs receive: {e}"),
-                bytes_transferred: None,
-            })?;
+        let recv_output = recv_child.wait_with_output().map_err(|e| UrdError::Btrfs {
+            msg: format!("failed to wait for btrfs receive: {e}"),
+            bytes_transferred: None,
+        })?;
 
         // Wait for send to finish
-        let send_status = send_child
-            .wait()
-            .map_err(|e| UrdError::Btrfs {
-                msg: format!("failed to wait for btrfs send: {e}"),
-                bytes_transferred: None,
-            })?;
+        let send_status = send_child.wait().map_err(|e| UrdError::Btrfs {
+            msg: format!("failed to wait for btrfs send: {e}"),
+            bytes_transferred: None,
+        })?;
 
         let bytes_copied = copy_thread.join().unwrap_or(Ok(0)).ok();
 
@@ -216,10 +204,7 @@ impl BtrfsOps for RealBtrfs {
             if let Some(snap_name) = snapshot.file_name() {
                 let partial = dest_dir.join(snap_name);
                 if partial.exists() {
-                    log::warn!(
-                        "Cleaning up partial snapshot at {}",
-                        partial.display()
-                    );
+                    log::warn!("Cleaning up partial snapshot at {}", partial.display());
                     if let Err(e) = self.delete_subvolume(&partial) {
                         log::error!("Failed to clean up partial snapshot: {e}");
                     }
@@ -442,10 +427,7 @@ mod tests {
         assert_eq!(calls.len(), 1);
         assert_eq!(
             calls[0],
-            MockBtrfsCall::CreateSnapshot {
-                source: src,
-                dest,
-            }
+            MockBtrfsCall::CreateSnapshot { source: src, dest }
         );
     }
 
@@ -457,7 +439,12 @@ mod tests {
 
         let result = mock.create_readonly_snapshot(Path::new("/home"), &dest);
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("mock: create snapshot failed"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("mock: create snapshot failed")
+        );
     }
 
     #[test]
@@ -525,7 +512,9 @@ mod tests {
         let result = mock.send_receive(&snap, None, Path::new("/dest"));
         let err = result.unwrap_err();
         match err {
-            UrdError::Btrfs { bytes_transferred, .. } => {
+            UrdError::Btrfs {
+                bytes_transferred, ..
+            } => {
                 assert_eq!(bytes_transferred, Some(500_000));
             }
             _ => panic!("expected UrdError::Btrfs"),

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -99,10 +99,7 @@ fn try_read_pin(path: &Path) -> crate::error::Result<Option<SnapshotName>> {
                 return Ok(None);
             }
             let name = SnapshotName::parse(trimmed).map_err(|e| {
-                UrdError::Chain(format!(
-                    "malformed pin file {}: {e}",
-                    path.display()
-                ))
+                UrdError::Chain(format!("malformed pin file {}: {e}", path.display()))
             })?;
             Ok(Some(name))
         }
@@ -138,11 +135,7 @@ mod tests {
     #[test]
     fn read_legacy_fallback() {
         let dir = TempDir::new().unwrap();
-        fs::write(
-            dir.path().join(".last-external-parent"),
-            "20260322-opptak",
-        )
-        .unwrap();
+        fs::write(dir.path().join(".last-external-parent"), "20260322-opptak").unwrap();
 
         // No drive-specific file, should fall back to legacy
         let result = read_pin_file(dir.path(), "WD-18TB").unwrap();
@@ -157,11 +150,7 @@ mod tests {
             "20260322-1400-opptak",
         )
         .unwrap();
-        fs::write(
-            dir.path().join(".last-external-parent"),
-            "20260321-opptak",
-        )
-        .unwrap();
+        fs::write(dir.path().join(".last-external-parent"), "20260321-opptak").unwrap();
 
         let result = read_pin_file(dir.path(), "WD-18TB").unwrap();
         assert_eq!(result.unwrap().as_str(), "20260322-1400-opptak");
@@ -190,11 +179,7 @@ mod tests {
     #[test]
     fn empty_pin_file() {
         let dir = TempDir::new().unwrap();
-        fs::write(
-            dir.path().join(".last-external-parent-WD-18TB"),
-            "  \n  ",
-        )
-        .unwrap();
+        fs::write(dir.path().join(".last-external-parent-WD-18TB"), "  \n  ").unwrap();
 
         let result = read_pin_file(dir.path(), "WD-18TB").unwrap();
         assert!(result.is_none());

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 use std::fs::File;
 use std::io::IsTerminal;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use colored::Colorize;
@@ -46,7 +46,9 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         }
     };
 
-    let fs_state = RealFileSystemState { state: state_db.as_ref() };
+    let fs_state = RealFileSystemState {
+        state: state_db.as_ref(),
+    };
     let backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
 
     // Dry run: print plan and exit (no lock needed)
@@ -281,7 +283,13 @@ fn write_metrics_after_execution(
         .iter()
         .map(|sv| sv.name.clone())
         .collect();
-    append_skipped_metrics(config, plan, fs_state, &mut subvolume_metrics, &already_emitted);
+    append_skipped_metrics(
+        config,
+        plan,
+        fs_state,
+        &mut subvolume_metrics,
+        &already_emitted,
+    );
 
     // Carry forward last_success_timestamp from previous .prom file
     let carried = metrics::read_existing_timestamps(&config.general.metrics_file);
@@ -299,7 +307,13 @@ fn write_metrics_for_skipped(
     let fs_state = RealFileSystemState { state: None };
     let mut subvolume_metrics = Vec::new();
 
-    append_skipped_metrics(config, plan, &fs_state, &mut subvolume_metrics, &HashSet::new());
+    append_skipped_metrics(
+        config,
+        plan,
+        &fs_state,
+        &mut subvolume_metrics,
+        &HashSet::new(),
+    );
 
     // Carry forward last_success_timestamp from previous .prom file
     let carried = metrics::read_existing_timestamps(&config.general.metrics_file);

--- a/src/commands/calibrate.rs
+++ b/src/commands/calibrate.rs
@@ -4,8 +4,8 @@ use colored::Colorize;
 
 use crate::cli::CalibrateArgs;
 use crate::config::Config;
-use crate::plan::RealFileSystemState;
 use crate::plan::FileSystemState;
+use crate::plan::RealFileSystemState;
 use crate::state::StateDb;
 use crate::types::ByteSize;
 
@@ -16,7 +16,9 @@ pub fn run(config: Config, args: CalibrateArgs) -> anyhow::Result<()> {
     println!("{}", "Urd calibrate — measuring snapshot sizes".bold());
     println!();
 
-    let fs_state = RealFileSystemState { state: Some(&state_db) };
+    let fs_state = RealFileSystemState {
+        state: Some(&state_db),
+    };
     let mut calibrated = 0usize;
     let mut skipped = 0usize;
 
@@ -49,11 +51,7 @@ pub fn run(config: Config, args: CalibrateArgs) -> anyhow::Result<()> {
             .unwrap_or_default();
 
         let Some(newest) = local_snaps.iter().max() else {
-            println!(
-                "  {} {} (no local snapshots)",
-                "SKIP".dimmed(),
-                subvol.name,
-            );
+            println!("  {} {} (no local snapshots)", "SKIP".dimmed(), subvol.name,);
             skipped += 1;
             continue;
         };
@@ -113,9 +111,7 @@ pub fn run(config: Config, args: CalibrateArgs) -> anyhow::Result<()> {
         "Calibrated {} subvolume(s), skipped {}.",
         calibrated, skipped,
     );
-    println!(
-        "Sizes stored in state database. The planner will use these as fallback",
-    );
+    println!("Sizes stored in state database. The planner will use these as fallback",);
     println!("estimates when no send history exists.");
 
     Ok(())

--- a/src/commands/history.rs
+++ b/src/commands/history.rs
@@ -194,4 +194,3 @@ mod tests {
         assert!(result.is_char_boundary(result.len()));
     }
 }
-

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -6,8 +6,8 @@ use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::chain;
 use crate::config::Config;
 use crate::drives;
-use crate::plan::RealFileSystemState;
 use crate::plan::FileSystemState;
+use crate::plan::RealFileSystemState;
 use crate::state::StateDb;
 
 pub fn run(config: Config) -> anyhow::Result<()> {
@@ -164,29 +164,13 @@ pub fn run(config: Config) -> anyhow::Result<()> {
             for label in &drive_labels {
                 match chain::read_pin_file(&local_dir, label) {
                     Ok(Some(name)) => {
-                        println!(
-                            "  {} {}/{}: {}",
-                            "OK".green(),
-                            subvol_name,
-                            label,
-                            name
-                        );
+                        println!("  {} {}/{}: {}", "OK".green(), subvol_name, label, name);
                     }
                     Ok(None) => {
-                        println!(
-                            "  {} {}/{}: no pin file",
-                            "—".dimmed(),
-                            subvol_name,
-                            label
-                        );
+                        println!("  {} {}/{}: no pin file", "—".dimmed(), subvol_name, label);
                     }
                     Err(e) => {
-                        println!(
-                            "  {} {}/{}: {e}",
-                            "ERROR".red(),
-                            subvol_name,
-                            label
-                        );
+                        println!("  {} {}/{}: {e}", "ERROR".red(), subvol_name, label);
                     }
                 }
             }
@@ -261,11 +245,9 @@ pub fn run(config: Config) -> anyhow::Result<()> {
                             std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
                         );
                         match btrfs.delete_subvolume(&partial_path) {
-                            Ok(()) => println!(
-                                "  {} Deleted {}",
-                                "OK".green(),
-                                partial_path.display()
-                            ),
+                            Ok(()) => {
+                                println!("  {} Deleted {}", "OK".green(), partial_path.display())
+                            }
                             Err(e) => println!(
                                 "  {} Failed to delete {}: {e}",
                                 "ERROR".red(),

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -16,14 +16,19 @@ pub fn run(config: Config, args: PlanArgs) -> anyhow::Result<()> {
     };
 
     let state_db = StateDb::open(&config.general.state_db).ok();
-    let fs_state = RealFileSystemState { state: state_db.as_ref() };
+    let fs_state = RealFileSystemState {
+        state: state_db.as_ref(),
+    };
     let backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
 
     run_with_plan(&config, &backup_plan)
 }
 
 /// Print a backup plan. Shared by `urd plan` and `urd backup --dry-run`.
-pub fn run_with_plan(config: &Config, backup_plan: &crate::types::BackupPlan) -> anyhow::Result<()> {
+pub fn run_with_plan(
+    config: &Config,
+    backup_plan: &crate::types::BackupPlan,
+) -> anyhow::Result<()> {
     // Print header
     println!(
         "{}",
@@ -76,10 +81,7 @@ pub fn run_with_plan(config: &Config, backup_plan: &crate::types::BackupPlan) ->
 
     // Summary
     let summary = backup_plan.summary();
-    println!(
-        "{}",
-        format!("Summary: {summary}").bold()
-    );
+    println!("{}", format!("Summary: {summary}").bold());
 
     Ok(())
 }
@@ -110,11 +112,12 @@ fn print_operation(op: &PlannedOperation) {
             pin_on_success,
             ..
         } => {
-            let parent_name = parent
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy();
-            let pin_suffix = if pin_on_success.is_some() { " + pin" } else { "" };
+            let parent_name = parent.file_name().unwrap_or_default().to_string_lossy();
+            let pin_suffix = if pin_on_success.is_some() {
+                " + pin"
+            } else {
+                ""
+            };
             println!(
                 "  {}   {} -> {} (incremental, parent: {}){pin_suffix}",
                 "[SEND]".blue(),
@@ -129,7 +132,11 @@ fn print_operation(op: &PlannedOperation) {
             pin_on_success,
             ..
         } => {
-            let pin_suffix = if pin_on_success.is_some() { " + pin" } else { "" };
+            let pin_suffix = if pin_on_success.is_some() {
+                " + pin"
+            } else {
+                ""
+            };
             println!(
                 "  {}   {} -> {} (full){pin_suffix}",
                 "[SEND]".blue(),

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,150 +1,110 @@
-use colored::Colorize;
-
+use crate::awareness;
 use crate::chain;
 use crate::config::Config;
 use crate::drives;
+use crate::output::{
+    ChainHealth, ChainHealthEntry, DriveInfo, LastRunInfo, OutputMode, StatusAssessment,
+    StatusOutput,
+};
 use crate::plan::{FileSystemState, RealFileSystemState};
 use crate::state::StateDb;
+use crate::voice;
 
-pub fn run(config: Config) -> anyhow::Result<()> {
-    let fs_state = RealFileSystemState { state: None };
+pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
+    let state_db = if config.general.state_db.exists() {
+        StateDb::open(&config.general.state_db).ok()
+    } else {
+        None
+    };
+    let fs_state = RealFileSystemState {
+        state: state_db.as_ref(),
+    };
     let drive_labels: Vec<String> = config.drives.iter().map(|d| d.label.clone()).collect();
+
+    // ── Awareness model ─────────────────────────────────────────────
+    let now = chrono::Local::now().naive_local();
+    let assessments = awareness::assess(&config, now, &fs_state);
+
+    // ── Chain health per subvolume ───────────────────────────────────
     let mounted_drives: Vec<_> = config
         .drives
         .iter()
         .filter(|d| drives::is_drive_mounted(d))
         .collect();
 
-    // ── Per-subvolume table ────────────────────────────────────────────
-
-    // Build header: SUBVOLUME  LOCAL  [DRIVE1]  [DRIVE2]  CHAIN
-    let mut headers: Vec<String> = vec!["SUBVOLUME".to_string(), "LOCAL".to_string()];
-    for drive in &mounted_drives {
-        headers.push(drive.label.clone());
-    }
-    headers.push("CHAIN".to_string());
-
-    let mut rows: Vec<Vec<String>> = Vec::new();
-
-    for sv in &config.subvolumes {
+    let resolved = config.resolved_subvolumes();
+    let mut chain_health_entries: Vec<ChainHealthEntry> = Vec::new();
+    for sv in &resolved {
+        if !sv.enabled {
+            continue;
+        }
         let Some(root) = config.snapshot_root_for(&sv.name) else {
             continue;
         };
         let local_dir = root.join(&sv.name);
 
-        // Local snapshot count
-        let local_count = fs_state
-            .local_snapshots(&root, &sv.name)
-            .map(|s| s.len())
-            .unwrap_or(0);
-
-        let mut row = vec![sv.name.clone(), local_count.to_string()];
-
-        // Per-drive: external snapshot count + chain health (worst case)
         let mut worst_health: Option<ChainHealth> = None;
-        let mut any_ext = false;
         for drive in &mounted_drives {
             let ext_count = fs_state
                 .external_snapshots(drive, &sv.name)
                 .map(|s| s.len())
                 .unwrap_or(0);
-            row.push(if ext_count > 0 {
-                any_ext = true;
-                ext_count.to_string()
-            } else {
-                "\u{2014}".to_string() // em dash
-            });
-
-            // Chain health: track worst case across all drives
             let ext_dir = drives::external_snapshot_dir(drive, &sv.name);
-            let health = chain_health(&local_dir, &drive.label, ext_count, &ext_dir);
+            let health = compute_chain_health(&local_dir, &drive.label, ext_count, &ext_dir);
             worst_health = Some(match worst_health {
                 Some(current) => current.min(health),
                 None => health,
             });
         }
 
-        let chain_display = if mounted_drives.is_empty() || (!any_ext && worst_health.is_none()) {
-            "\u{2014}".to_string()
-        } else {
-            worst_health.map_or("\u{2014}".to_string(), |h| h.to_string())
-        };
-
-        row.push(chain_display);
-        rows.push(row);
-    }
-
-    // Print table with simple column alignment
-    print_table(&headers, &rows);
-
-    // ── Drive summary ──────────────────────────────────────────────────
-
-    println!();
-    if mounted_drives.is_empty() {
-        println!("{}", "Drives: none mounted".dimmed());
-    } else {
-        for drive in &mounted_drives {
-            let free = drives::filesystem_free_bytes(&drive.mount_path).unwrap_or(0);
-            println!(
-                "Drives: {} {} ({} free)",
-                drive.label.bold(),
-                "mounted".green(),
-                crate::types::ByteSize(free),
-            );
+        if let Some(health) = worst_health {
+            chain_health_entries.push(ChainHealthEntry {
+                subvolume: sv.name.clone(),
+                health,
+            });
         }
     }
 
-    // Unmounted drives
-    for drive in &config.drives {
-        if !drives::is_drive_mounted(drive) {
-            println!(
-                "Drives: {} {}",
-                drive.label.bold(),
-                "not mounted".dimmed(),
-            );
+    // ── Drive info ──────────────────────────────────────────────────
+    let drive_infos: Vec<DriveInfo> = config
+        .drives
+        .iter()
+        .map(|d| {
+            let mounted = drives::is_drive_mounted(d);
+            DriveInfo {
+                label: d.label.clone(),
+                mounted,
+                free_bytes: if mounted {
+                    drives::filesystem_free_bytes(&d.mount_path).ok()
+                } else {
+                    None
+                },
+            }
+        })
+        .collect();
+
+    // ── Last run ────────────────────────────────────────────────────
+    let last_run = state_db.as_ref().and_then(|db| match db.last_run() {
+        Ok(Some(run)) => {
+            let duration = run
+                .finished_at
+                .as_ref()
+                .and_then(|f| crate::types::format_run_duration(&run.started_at, f));
+            Some(LastRunInfo {
+                id: run.id,
+                started_at: run.started_at.clone(),
+                result: run.result.clone(),
+                duration,
+            })
         }
-    }
-
-    // ── Last run ───────────────────────────────────────────────────────
-
-    if config.general.state_db.exists() {
-        match StateDb::open(&config.general.state_db) {
-            Ok(db) => match db.last_run() {
-                Ok(Some(run)) => {
-                    let result_colored = match run.result.as_str() {
-                        "success" => run.result.green().to_string(),
-                        "partial" => run.result.yellow().to_string(),
-                        "failure" => run.result.red().to_string(),
-                        _ => run.result.clone(),
-                    };
-                    let duration_str = run
-                        .finished_at
-                        .as_ref()
-                        .and_then(|f| crate::types::format_run_duration(&run.started_at, f))
-                        .unwrap_or_default();
-                    println!(
-                        "Last backup: {} ({}{}) [#{}]",
-                        run.started_at,
-                        result_colored,
-                        if duration_str.is_empty() {
-                            String::new()
-                        } else {
-                            format!(", {duration_str}")
-                        },
-                        run.id,
-                    );
-                }
-                Ok(None) => println!("{}", "Last backup: no runs recorded".dimmed()),
-                Err(e) => log::warn!("Failed to query last run: {e}"),
-            },
-            Err(_) => println!("{}", "Last backup: state database not available".dimmed()),
+        Ok(None) => None,
+        Err(e) => {
+            log::warn!("Failed to query last run: {e}");
+            None
         }
-    } else {
-        println!("{}", "Last backup: no runs recorded".dimmed());
-    }
+    });
 
-    // ── Pin file summary ───────────────────────────────────────────────
-
+    // ── Pin count ───────────────────────────────────────────────────
     let total_pins: usize = config
         .subvolumes
         .iter()
@@ -156,61 +116,27 @@ pub fn run(config: Config) -> anyhow::Result<()> {
         })
         .sum();
 
-    if total_pins > 0 {
-        println!(
-            "Pinned snapshots: {} across {} subvolumes",
-            total_pins,
-            config.subvolumes.len()
-        );
-    }
+    // ── Assemble and render ─────────────────────────────────────────
+    let status_output = StatusOutput {
+        assessments: assessments
+            .iter()
+            .map(StatusAssessment::from_assessment)
+            .collect(),
+        chain_health: chain_health_entries,
+        drives: drive_infos,
+        last_run,
+        total_pins,
+    };
+
+    let rendered = voice::render_status(&status_output, output_mode);
+    print!("{rendered}");
 
     Ok(())
 }
 
-// ── ChainHealth ─────────────────────────────────────────────────────
+// ── Chain health computation (filesystem I/O) ───────────────────────────
 
-/// Chain health status for a subvolume/drive pair, ordered worst-to-best.
-/// `min()` across drives yields the worst health.
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum ChainHealth {
-    NoDriveData,
-    Full(String),
-    Incremental(String),
-}
-
-impl ChainHealth {
-    fn severity(&self) -> u8 {
-        match self {
-            Self::NoDriveData => 0,
-            Self::Full(_) => 1,
-            Self::Incremental(_) => 2,
-        }
-    }
-}
-
-impl Ord for ChainHealth {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.severity().cmp(&other.severity())
-    }
-}
-
-impl PartialOrd for ChainHealth {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl std::fmt::Display for ChainHealth {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NoDriveData => write!(f, "none"),
-            Self::Full(reason) => write!(f, "full ({reason})"),
-            Self::Incremental(pin) => write!(f, "incremental ({pin})"),
-        }
-    }
-}
-
-fn chain_health(
+fn compute_chain_health(
     local_dir: &std::path::Path,
     drive_label: &str,
     ext_count: usize,
@@ -236,94 +162,3 @@ fn chain_health(
         Err(_) => ChainHealth::Full("pin error".to_string()),
     }
 }
-
-fn print_table(headers: &[String], rows: &[Vec<String>]) {
-    if rows.is_empty() {
-        println!("{}", "No subvolumes configured.".dimmed());
-        return;
-    }
-
-    // Calculate column widths
-    let cols = headers.len();
-    let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
-    for row in rows {
-        for (i, cell) in row.iter().enumerate() {
-            if i < cols {
-                widths[i] = widths[i].max(cell.len());
-            }
-        }
-    }
-
-    // Print header
-    let header_line: Vec<String> = headers
-        .iter()
-        .enumerate()
-        .map(|(i, h)| format!("{:<width$}", h, width = widths[i]))
-        .collect();
-    println!("{}", header_line.join("  ").bold());
-
-    // Print rows
-    for row in rows {
-        let line: Vec<String> = row
-            .iter()
-            .enumerate()
-            .map(|(i, cell)| {
-                let w = widths.get(i).copied().unwrap_or(cell.len());
-                format!("{:<width$}", cell, width = w)
-            })
-            .collect();
-        println!("{}", line.join("  "));
-    }
-}
-
-// ── Tests ───────────────────────────────────────────────────────────────
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn chain_health_ordering() {
-        let none = ChainHealth::NoDriveData;
-        let full = ChainHealth::Full("no pin".to_string());
-        let inc = ChainHealth::Incremental("20260322-1430-opptak".to_string());
-
-        assert!(none < full);
-        assert!(full < inc);
-        assert!(none < inc);
-    }
-
-    #[test]
-    fn chain_health_min_finds_worst() {
-        let inc = ChainHealth::Incremental("snap".to_string());
-        let full = ChainHealth::Full("no pin".to_string());
-        let none = ChainHealth::NoDriveData;
-
-        assert_eq!(inc.clone().min(full.clone()), full);
-        assert_eq!(full.min(none.clone()), none);
-        assert_eq!(inc.min(none.clone()), none);
-    }
-
-    #[test]
-    fn chain_health_display() {
-        assert_eq!(ChainHealth::NoDriveData.to_string(), "none");
-        assert_eq!(
-            ChainHealth::Full("no pin".to_string()).to_string(),
-            "full (no pin)"
-        );
-        assert_eq!(
-            ChainHealth::Incremental("20260322-snap".to_string()).to_string(),
-            "incremental (20260322-snap)"
-        );
-    }
-
-    #[test]
-    fn chain_health_min_two_fulls_keeps_first() {
-        let full_a = ChainHealth::Full("pin missing locally".to_string());
-        let full_b = ChainHealth::Full("pin missing on drive".to_string());
-        // Both are Full — min returns self (first), which is fine
-        let result = full_a.clone().min(full_b);
-        assert!(matches!(result, ChainHealth::Full(_)));
-    }
-}
-

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -155,7 +155,10 @@ pub fn run(config: Config, args: VerifyArgs) -> anyhow::Result<()> {
                         );
                         total_warn += 1;
                     } else {
-                        println!("    {}    No pin file (no snapshots on drive)", "OK".green());
+                        println!(
+                            "    {}    No pin file (no snapshots on drive)",
+                            "OK".green()
+                        );
                         total_ok += 1;
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -158,8 +158,8 @@ impl Config {
             source: e,
         })?;
 
-        let mut config: Config =
-            toml::from_str(&contents).map_err(|e| UrdError::Config(format!("{config_path:?}: {e}")))?;
+        let mut config: Config = toml::from_str(&contents)
+            .map_err(|e| UrdError::Config(format!("{config_path:?}: {e}")))?;
 
         config.expand_paths();
         config.validate()?;
@@ -251,7 +251,8 @@ impl Config {
         }
 
         // Every subvolume referenced in roots must exist in [[subvolumes]]
-        let subvol_names: HashSet<&str> = self.subvolumes.iter().map(|sv| sv.name.as_str()).collect();
+        let subvol_names: HashSet<&str> =
+            self.subvolumes.iter().map(|sv| sv.name.as_str()).collect();
         for root in &self.local_snapshots.roots {
             for name in &root.subvolumes {
                 if !subvol_names.contains(name.as_str()) {
@@ -310,7 +311,10 @@ impl Config {
         }
 
         for drive in &self.drives {
-            validate_path_safe(&drive.mount_path, &format!("drive {:?} mount_path", drive.label))?;
+            validate_path_safe(
+                &drive.mount_path,
+                &format!("drive {:?} mount_path", drive.label),
+            )?;
             validate_name_safe(&drive.label, "drive label")?;
             validate_name_safe(&drive.snapshot_root, "drive snapshot_root")?;
         }
@@ -379,9 +383,8 @@ fn validate_name_safe(name: &str, label: &str) -> crate::error::Result<()> {
 }
 
 fn default_config_path() -> crate::error::Result<PathBuf> {
-    let config_dir = dirs::config_dir().ok_or_else(|| {
-        UrdError::Config("could not determine XDG config directory".to_string())
-    })?;
+    let config_dir = dirs::config_dir()
+        .ok_or_else(|| UrdError::Config("could not determine XDG config directory".to_string()))?;
     Ok(config_dir.join("urd").join("urd.toml"))
 }
 
@@ -506,13 +509,21 @@ send_interval = "2h"
         assert_eq!(config.defaults.send_interval, Interval::hours(4));
 
         // Verify a subvolume with overrides
-        let htpc = config.subvolumes.iter().find(|s| s.name == "htpc-home").unwrap();
+        let htpc = config
+            .subvolumes
+            .iter()
+            .find(|s| s.name == "htpc-home")
+            .unwrap();
         assert_eq!(htpc.snapshot_interval, Some(Interval::minutes(15)));
         assert_eq!(htpc.send_interval, Some(Interval::hours(1)));
         assert_eq!(htpc.priority, 1);
 
         // Verify a subvolume with send_enabled=false
-        let tmp = config.subvolumes.iter().find(|s| s.name == "subvol6-tmp").unwrap();
+        let tmp = config
+            .subvolumes
+            .iter()
+            .find(|s| s.name == "subvol6-tmp")
+            .unwrap();
         assert_eq!(tmp.send_enabled, Some(false));
 
         // Verify validation passes
@@ -604,7 +615,10 @@ source = "/b"
         let mut config: Config = toml::from_str(config_str).unwrap();
         config.expand_paths();
         let err = config.validate().unwrap_err();
-        assert!(err.to_string().contains("not assigned to any snapshot root"));
+        assert!(
+            err.to_string()
+                .contains("not assigned to any snapshot root")
+        );
     }
 
     #[test]
@@ -646,8 +660,14 @@ short_name = "b"
 source = "/b"
 "#;
         let config: Config = toml::from_str(config_str).unwrap();
-        assert_eq!(config.snapshot_root_for("a"), Some(PathBuf::from("/snap-a")));
-        assert_eq!(config.snapshot_root_for("b"), Some(PathBuf::from("/snap-b")));
+        assert_eq!(
+            config.snapshot_root_for("a"),
+            Some(PathBuf::from("/snap-a"))
+        );
+        assert_eq!(
+            config.snapshot_root_for("b"),
+            Some(PathBuf::from("/snap-b"))
+        );
         assert_eq!(config.snapshot_root_for("c"), None);
     }
 

--- a/src/drives.rs
+++ b/src/drives.rs
@@ -40,7 +40,10 @@ pub fn filesystem_free_bytes(path: &Path) -> crate::error::Result<u64> {
 /// Returns `{mount_path}/{snapshot_root}/{subvol_name}`.
 #[must_use]
 pub fn external_snapshot_dir(drive: &DriveConfig, subvol_name: &str) -> PathBuf {
-    drive.mount_path.join(&drive.snapshot_root).join(subvol_name)
+    drive
+        .mount_path
+        .join(&drive.snapshot_root)
+        .join(subvol_name)
 }
 
 /// Get the mount status and free bytes of the first mounted drive in the config.

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -261,7 +261,11 @@ impl<'a> Executor<'a> {
         failed_creates: &mut HashSet<&'b Path>,
     ) -> OperationOutcome {
         let start = Instant::now();
-        log::info!("Creating snapshot: {} -> {}", source.display(), dest.display());
+        log::info!(
+            "Creating snapshot: {} -> {}",
+            source.display(),
+            dest.display()
+        );
 
         match self.btrfs.create_readonly_snapshot(source, dest) {
             Ok(()) => OperationOutcome {
@@ -393,9 +397,7 @@ impl<'a> Executor<'a> {
                     && let Some(pin_dir) = pin_path.parent()
                     && let Err(e) = chain::write_pin_file(pin_dir, drive_label, pin_name)
                 {
-                    log::warn!(
-                        "Send succeeded but pin file write failed for {drive_label}: {e}"
-                    );
+                    log::warn!("Send succeeded but pin file write failed for {drive_label}: {e}");
                     pin_failed = true;
                 }
 
@@ -415,15 +417,14 @@ impl<'a> Executor<'a> {
                 // Extract partial byte count from btrfs errors (e.g., failed sends
                 // that transferred some data before the pipe broke)
                 let partial_bytes = match &e {
-                    crate::error::UrdError::Btrfs { bytes_transferred, .. } => *bytes_transferred,
+                    crate::error::UrdError::Btrfs {
+                        bytes_transferred, ..
+                    } => *bytes_transferred,
                     _ => None,
                 };
                 log::error!("{op_name} failed for {subvol_name} -> {drive_label}: {e}");
                 if let Some(bytes) = partial_bytes {
-                    log::info!(
-                        "Partial transfer: {} bytes copied before failure",
-                        bytes,
-                    );
+                    log::info!("Partial transfer: {} bytes copied before failure", bytes,);
                 }
                 (
                     OperationOutcome {
@@ -818,11 +819,13 @@ source = "/data/b"
         assert!(!sv.success);
         // The send should be skipped, not attempted
         assert_eq!(sv.operations[1].result, OpResult::Skipped);
-        assert!(sv.operations[1]
-            .error
-            .as_ref()
-            .unwrap()
-            .contains("snapshot creation failed"));
+        assert!(
+            sv.operations[1]
+                .error
+                .as_ref()
+                .unwrap()
+                .contains("snapshot creation failed")
+        );
 
         // Verify send was NOT called on the mock
         let calls = mock.calls();
@@ -837,9 +840,7 @@ source = "/data/b"
         let executor = Executor::new(&mock, None, &config, &shutdown);
 
         let pin_dir = tempfile::TempDir::new().unwrap();
-        let pin_path = pin_dir
-            .path()
-            .join(".last-external-parent-TEST-DRIVE");
+        let pin_path = pin_dir.path().join(".last-external-parent-TEST-DRIVE");
         let snap_name = SnapshotName::parse("20260322-1430-a").unwrap();
 
         let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
@@ -1058,9 +1059,15 @@ source = "/data/b"
         let result = executor.execute(&plan, "full");
 
         // sv-a's delete succeeds and triggers space_recovered for TEST-DRIVE
-        assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Success);
+        assert_eq!(
+            result.subvolume_results[0].operations[0].result,
+            OpResult::Success
+        );
         // sv-b's delete on the SAME drive should be skipped
-        assert_eq!(result.subvolume_results[1].operations[0].result, OpResult::Skipped);
+        assert_eq!(
+            result.subvolume_results[1].operations[0].result,
+            OpResult::Skipped
+        );
 
         // Only one delete should have been called
         let delete_count = mock

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -183,11 +183,10 @@ mod tests {
     use super::*;
     use crate::awareness::{DriveAssessment, LocalAssessment, PromiseStatus};
     use crate::config::{
-        Config, DefaultsConfig, DriveConfig, GeneralConfig, LocalSnapshotsConfig, SnapshotRoot,
-        SubvolumeConfig,
+        Config, DefaultsConfig, GeneralConfig, LocalSnapshotsConfig, SnapshotRoot, SubvolumeConfig,
     };
     use crate::executor::{ExecutionResult, RunResult, SendType, SubvolumeResult};
-    use crate::types::{DriveRole, GraduatedRetention, Interval};
+    use crate::types::{GraduatedRetention, Interval};
     use std::path::PathBuf;
 
     fn test_config(intervals: &[(&str, &str)]) -> Config {
@@ -313,8 +312,8 @@ mod tests {
     #[test]
     fn schema_roundtrip() {
         let config = test_config(&[("home", "1h"), ("docs", "1h")]);
-        let now = NaiveDateTime::parse_from_str("2026-03-24T02:05:00", "%Y-%m-%dT%H:%M:%S")
-            .unwrap();
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:05:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let assessments = test_assessments();
         let result = test_execution_result();
 
@@ -340,8 +339,8 @@ mod tests {
     #[test]
     fn stale_after_picks_minimum_interval() {
         let config = test_config(&[("fast", "15m"), ("slow", "1d")]);
-        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
-            .unwrap();
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
 
         let stale = compute_stale_after(&config, now);
         // 15m * 2 = 30m
@@ -353,8 +352,8 @@ mod tests {
     fn stale_after_no_enabled_subvolumes_defaults_to_24h() {
         let mut config = test_config(&[("only", "1h")]);
         config.subvolumes[0].enabled = Some(false);
-        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
-            .unwrap();
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
 
         let stale = compute_stale_after(&config, now);
         let expected = now + chrono::Duration::hours(24);
@@ -366,8 +365,8 @@ mod tests {
     #[test]
     fn empty_run_heartbeat() {
         let config = test_config(&[("home", "1h")]);
-        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
-            .unwrap();
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let assessments = test_assessments();
 
         let heartbeat = build_empty(&config, now, &assessments);
@@ -391,8 +390,8 @@ mod tests {
         let path = dir.path().join("heartbeat.json");
 
         let config = test_config(&[("home", "1h")]);
-        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
-            .unwrap();
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let assessments = test_assessments();
 
         let heartbeat = build_empty(&config, now, &assessments);
@@ -412,8 +411,8 @@ mod tests {
         let path = dir.path().join("nested").join("dir").join("heartbeat.json");
 
         let config = test_config(&[("home", "1h")]);
-        let now = NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S")
-            .unwrap();
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let heartbeat = build_empty(&config, now, &test_assessments());
         write(&path, &heartbeat).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,16 +9,27 @@ mod error;
 mod executor;
 mod heartbeat;
 mod metrics;
+mod output;
 mod plan;
 mod retention;
 mod state;
 mod types;
+mod voice;
+
+use std::io::IsTerminal;
 
 use clap::Parser;
 use cli::{Cli, Commands};
 
 fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
+
+    // Force colors off when not a TTY (piped output, daemon mode).
+    // When stdout IS a TTY, let the colored crate handle NO_COLOR and
+    // CLICOLOR env vars on its own — don't override with set_override(true).
+    if !std::io::stdout().is_terminal() {
+        colored::control::set_override(false);
+    }
 
     env_logger::Builder::new()
         .filter_level(if cli.verbose {
@@ -30,12 +41,14 @@ fn main() -> anyhow::Result<()> {
         .init();
     let config = config::Config::load(cli.config.as_deref())?;
 
+    let output_mode = output::OutputMode::detect();
+
     match cli.command {
         Commands::Plan(args) => commands::plan_cmd::run(config, args),
         Commands::Backup(args) => commands::backup::run(config, args),
         Commands::Init => commands::init::run(config),
         Commands::Calibrate(args) => commands::calibrate::run(config, args),
-        Commands::Status => commands::status::run(config),
+        Commands::Status => commands::status::run(config, output_mode),
         Commands::History(args) => commands::history::run(config, args),
         Commands::Verify(args) => commands::verify::run(config, args),
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -106,15 +106,28 @@ fn format_metrics(data: &MetricsData) -> String {
     let mut out = String::new();
 
     // backup_success
-    writeln!(out, "# HELP backup_success Backup result: 1=success, 0=failure, 2=schedule-skipped").unwrap();
+    writeln!(
+        out,
+        "# HELP backup_success Backup result: 1=success, 0=failure, 2=schedule-skipped"
+    )
+    .unwrap();
     writeln!(out, "# TYPE backup_success gauge").unwrap();
     for sv in &data.subvolumes {
-        writeln!(out, "backup_success{{subvolume=\"{}\"}} {}", sv.name, sv.success).unwrap();
+        writeln!(
+            out,
+            "backup_success{{subvolume=\"{}\"}} {}",
+            sv.name, sv.success
+        )
+        .unwrap();
     }
 
     // backup_last_success_timestamp
     writeln!(out).unwrap();
-    writeln!(out, "# HELP backup_last_success_timestamp Unix timestamp of last successful backup").unwrap();
+    writeln!(
+        out,
+        "# HELP backup_last_success_timestamp Unix timestamp of last successful backup"
+    )
+    .unwrap();
     writeln!(out, "# TYPE backup_last_success_timestamp gauge").unwrap();
     for sv in &data.subvolumes {
         if let Some(ts) = sv.last_success_timestamp {
@@ -129,7 +142,11 @@ fn format_metrics(data: &MetricsData) -> String {
 
     // backup_duration_seconds
     writeln!(out).unwrap();
-    writeln!(out, "# HELP backup_duration_seconds Duration of backup operations in seconds").unwrap();
+    writeln!(
+        out,
+        "# HELP backup_duration_seconds Duration of backup operations in seconds"
+    )
+    .unwrap();
     writeln!(out, "# TYPE backup_duration_seconds gauge").unwrap();
     for sv in &data.subvolumes {
         writeln!(
@@ -161,7 +178,11 @@ fn format_metrics(data: &MetricsData) -> String {
 
     // backup_send_type
     writeln!(out).unwrap();
-    writeln!(out, "# HELP backup_send_type Send type: 0=full, 1=incremental, 2=no send").unwrap();
+    writeln!(
+        out,
+        "# HELP backup_send_type Send type: 0=full, 1=incremental, 2=no send"
+    )
+    .unwrap();
     writeln!(out, "# TYPE backup_send_type gauge").unwrap();
     for sv in &data.subvolumes {
         writeln!(
@@ -174,7 +195,11 @@ fn format_metrics(data: &MetricsData) -> String {
 
     // backup_external_drive_mounted
     writeln!(out).unwrap();
-    writeln!(out, "# HELP backup_external_drive_mounted Whether an external backup drive is mounted").unwrap();
+    writeln!(
+        out,
+        "# HELP backup_external_drive_mounted Whether an external backup drive is mounted"
+    )
+    .unwrap();
     writeln!(out, "# TYPE backup_external_drive_mounted gauge").unwrap();
     writeln!(
         out,
@@ -185,13 +210,26 @@ fn format_metrics(data: &MetricsData) -> String {
 
     // backup_external_free_bytes
     writeln!(out).unwrap();
-    writeln!(out, "# HELP backup_external_free_bytes Free bytes on external backup drive").unwrap();
+    writeln!(
+        out,
+        "# HELP backup_external_free_bytes Free bytes on external backup drive"
+    )
+    .unwrap();
     writeln!(out, "# TYPE backup_external_free_bytes gauge").unwrap();
-    writeln!(out, "backup_external_free_bytes {}", data.external_free_bytes).unwrap();
+    writeln!(
+        out,
+        "backup_external_free_bytes {}",
+        data.external_free_bytes
+    )
+    .unwrap();
 
     // backup_script_last_run_timestamp
     writeln!(out).unwrap();
-    writeln!(out, "# HELP backup_script_last_run_timestamp Unix timestamp of last backup run").unwrap();
+    writeln!(
+        out,
+        "# HELP backup_script_last_run_timestamp Unix timestamp of last backup run"
+    )
+    .unwrap();
     writeln!(out, "# TYPE backup_script_last_run_timestamp gauge").unwrap();
     writeln!(
         out,
@@ -244,12 +282,21 @@ mod tests {
 
         assert!(output.contains("backup_success{subvolume=\"subvol3-opptak\"} 1"));
         assert!(output.contains("backup_success{subvolume=\"htpc-home\"} 2"));
-        assert!(output.contains("backup_last_success_timestamp{subvolume=\"subvol3-opptak\"} 1711100000"));
+        assert!(
+            output
+                .contains("backup_last_success_timestamp{subvolume=\"subvol3-opptak\"} 1711100000")
+        );
         // htpc-home has no last_success_timestamp (skipped)
         assert!(!output.contains("backup_last_success_timestamp{subvolume=\"htpc-home\"}"));
         assert!(output.contains("backup_duration_seconds{subvolume=\"subvol3-opptak\"} 120"));
-        assert!(output.contains("backup_snapshot_count{subvolume=\"subvol3-opptak\",location=\"local\"} 15"));
-        assert!(output.contains("backup_snapshot_count{subvolume=\"subvol3-opptak\",location=\"external\"} 14"));
+        assert!(
+            output.contains(
+                "backup_snapshot_count{subvolume=\"subvol3-opptak\",location=\"local\"} 15"
+            )
+        );
+        assert!(output.contains(
+            "backup_snapshot_count{subvolume=\"subvol3-opptak\",location=\"external\"} 14"
+        ));
         assert!(output.contains("backup_send_type{subvolume=\"subvol3-opptak\"} 1"));
         assert!(output.contains("backup_send_type{subvolume=\"htpc-home\"} 2"));
         assert!(output.contains("backup_external_drive_mounted 1"));

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,220 @@
+// Output types — structured data produced by commands for the presentation layer.
+//
+// Each command constructs an output type from its business logic results.
+// The voice module renders these types into text (interactive or daemon mode).
+
+use std::io::IsTerminal;
+
+use serde::Serialize;
+
+use crate::awareness::{DriveAssessment, SubvolAssessment};
+
+// ── OutputMode ──────────────────────────────────────────────────────────
+
+/// How to render command output: rich interactive or machine-readable daemon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputMode {
+    /// TTY: colored, tables, human-readable.
+    Interactive,
+    /// Non-TTY: JSON, no ANSI codes.
+    Daemon,
+}
+
+impl OutputMode {
+    /// Detect from stdout's terminal status.
+    #[must_use]
+    pub fn detect() -> Self {
+        if std::io::stdout().is_terminal() {
+            Self::Interactive
+        } else {
+            Self::Daemon
+        }
+    }
+}
+
+// ── ChainHealth ─────────────────────────────────────────────────────────
+
+/// Chain health status for a subvolume/drive pair, ordered worst-to-best.
+/// `min()` across drives yields the worst health.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "status", content = "detail")]
+pub enum ChainHealth {
+    NoDriveData,
+    Full(String),
+    Incremental(String),
+}
+
+impl ChainHealth {
+    fn severity(&self) -> u8 {
+        match self {
+            Self::NoDriveData => 0,
+            Self::Full(_) => 1,
+            Self::Incremental(_) => 2,
+        }
+    }
+}
+
+impl Ord for ChainHealth {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.severity().cmp(&other.severity())
+    }
+}
+
+impl PartialOrd for ChainHealth {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl std::fmt::Display for ChainHealth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoDriveData => write!(f, "none"),
+            Self::Full(reason) => write!(f, "full ({reason})"),
+            Self::Incremental(pin) => write!(f, "incremental ({pin})"),
+        }
+    }
+}
+
+// ── StatusOutput ────────────────────────────────────────────────────────
+
+/// Structured output for the `urd status` command.
+#[derive(Debug, Serialize)]
+pub struct StatusOutput {
+    /// Per-subvolume promise assessments from the awareness model.
+    pub assessments: Vec<StatusAssessment>,
+    /// Chain health per subvolume (worst across drives).
+    pub chain_health: Vec<ChainHealthEntry>,
+    /// Drive mount status and free space.
+    pub drives: Vec<DriveInfo>,
+    /// Last backup run info (if any).
+    pub last_run: Option<LastRunInfo>,
+    /// Total pinned snapshot count across all subvolumes.
+    pub total_pins: usize,
+}
+
+/// Serializable wrapper around SubvolAssessment data.
+#[derive(Debug, Serialize)]
+pub struct StatusAssessment {
+    pub name: String,
+    pub status: String,
+    pub local_snapshot_count: usize,
+    pub local_status: String,
+    pub external: Vec<StatusDriveAssessment>,
+    pub advisories: Vec<String>,
+    pub errors: Vec<String>,
+}
+
+impl StatusAssessment {
+    #[must_use]
+    pub fn from_assessment(a: &SubvolAssessment) -> Self {
+        Self {
+            name: a.name.clone(),
+            status: a.status.to_string(),
+            local_snapshot_count: a.local.snapshot_count,
+            local_status: a.local.status.to_string(),
+            external: a
+                .external
+                .iter()
+                .map(StatusDriveAssessment::from_assessment)
+                .collect(),
+            advisories: a.advisories.clone(),
+            errors: a.errors.clone(),
+        }
+    }
+}
+
+/// Serializable external drive assessment.
+#[derive(Debug, Serialize)]
+pub struct StatusDriveAssessment {
+    pub drive_label: String,
+    pub status: String,
+    pub mounted: bool,
+    pub snapshot_count: Option<usize>,
+}
+
+impl StatusDriveAssessment {
+    #[must_use]
+    pub fn from_assessment(a: &DriveAssessment) -> Self {
+        Self {
+            drive_label: a.drive_label.clone(),
+            status: a.status.to_string(),
+            mounted: a.mounted,
+            snapshot_count: a.snapshot_count,
+        }
+    }
+}
+
+/// Chain health entry for one subvolume.
+#[derive(Debug, Serialize)]
+pub struct ChainHealthEntry {
+    pub subvolume: String,
+    pub health: ChainHealth,
+}
+
+/// Drive mount status and free space.
+#[derive(Debug, Serialize)]
+pub struct DriveInfo {
+    pub label: String,
+    pub mounted: bool,
+    pub free_bytes: Option<u64>,
+}
+
+/// Last backup run summary.
+#[derive(Debug, Serialize)]
+pub struct LastRunInfo {
+    pub id: i64,
+    pub started_at: String,
+    pub result: String,
+    pub duration: Option<String>,
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_health_ordering() {
+        let none = ChainHealth::NoDriveData;
+        let full = ChainHealth::Full("no pin".to_string());
+        let inc = ChainHealth::Incremental("20260322-1430-opptak".to_string());
+
+        assert!(none < full);
+        assert!(full < inc);
+        assert!(none < inc);
+    }
+
+    #[test]
+    fn chain_health_min_finds_worst() {
+        let inc = ChainHealth::Incremental("snap".to_string());
+        let full = ChainHealth::Full("no pin".to_string());
+        let none = ChainHealth::NoDriveData;
+
+        assert_eq!(inc.clone().min(full.clone()), full);
+        assert_eq!(full.min(none.clone()), none);
+        assert_eq!(inc.min(none.clone()), none);
+    }
+
+    #[test]
+    fn chain_health_display() {
+        assert_eq!(ChainHealth::NoDriveData.to_string(), "none");
+        assert_eq!(
+            ChainHealth::Full("no pin".to_string()).to_string(),
+            "full (no pin)"
+        );
+        assert_eq!(
+            ChainHealth::Incremental("20260322-snap".to_string()).to_string(),
+            "incremental (20260322-snap)"
+        );
+    }
+
+    #[test]
+    fn chain_health_min_two_fulls_keeps_first() {
+        let full_a = ChainHealth::Full("pin missing locally".to_string());
+        let full_b = ChainHealth::Full("pin missing on drive".to_string());
+        let result = full_a.clone().min(full_b);
+        assert!(matches!(result, ChainHealth::Full(_)));
+    }
+}

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -15,7 +15,11 @@ use crate::types::{BackupPlan, PlannedOperation, SnapshotName};
 /// Abstraction over filesystem state for testing.
 pub trait FileSystemState {
     /// List snapshot names in a local snapshot directory.
-    fn local_snapshots(&self, root: &Path, subvol_name: &str) -> crate::error::Result<Vec<SnapshotName>>;
+    fn local_snapshots(
+        &self,
+        root: &Path,
+        subvol_name: &str,
+    ) -> crate::error::Result<Vec<SnapshotName>>;
 
     /// List snapshot names on an external drive for a subvolume.
     fn external_snapshots(
@@ -38,20 +42,11 @@ pub trait FileSystemState {
     ) -> crate::error::Result<Option<SnapshotName>>;
 
     /// Collect all pinned snapshot names for a subvolume across all drives.
-    fn pinned_snapshots(
-        &self,
-        local_dir: &Path,
-        drive_labels: &[String],
-    ) -> HashSet<SnapshotName>;
+    fn pinned_snapshots(&self, local_dir: &Path, drive_labels: &[String]) -> HashSet<SnapshotName>;
 
     /// Get the bytes_transferred from the most recent successful send of a given type.
     /// Returns None if no history exists (e.g., first-ever send).
-    fn last_send_size(
-        &self,
-        subvol_name: &str,
-        drive_label: &str,
-        send_type: &str,
-    ) -> Option<u64>;
+    fn last_send_size(&self, subvol_name: &str, drive_label: &str, send_type: &str) -> Option<u64>;
 
     /// Get a calibrated size estimate for a subvolume (from `urd calibrate`).
     /// Returns `(estimated_bytes, measured_at)` or None if not calibrated.
@@ -106,7 +101,10 @@ pub fn plan(
         }
 
         // Filter: specific subvolume (overrides interval check)
-        let force = filters.subvolume.as_ref().is_some_and(|s| s == &subvol.name);
+        let force = filters
+            .subvolume
+            .as_ref()
+            .is_some_and(|s| s == &subvol.name);
         if filters.subvolume.is_some() && !force {
             continue;
         }
@@ -121,7 +119,9 @@ pub fn plan(
         let local_dir = snapshot_root.join(&subvol.name);
 
         // Get existing local snapshots
-        let local_snaps = fs.local_snapshots(&snapshot_root, &subvol.name).unwrap_or_default();
+        let local_snaps = fs
+            .local_snapshots(&snapshot_root, &subvol.name)
+            .unwrap_or_default();
 
         // Get pinned snapshots
         let pinned = fs.pinned_snapshots(&local_dir, &drive_labels);
@@ -131,7 +131,15 @@ pub fn plan(
         // The executor relies on this ordering within each subvolume.
         // Do not reorder without updating the executor contract in PLAN.md.
         if !filters.external_only {
-            plan_local_snapshot(subvol, &local_dir, &local_snaps, now, force, &mut operations, &mut skipped);
+            plan_local_snapshot(
+                subvol,
+                &local_dir,
+                &local_snaps,
+                now,
+                force,
+                &mut operations,
+                &mut skipped,
+            );
             plan_local_retention(
                 config,
                 subvol,
@@ -167,14 +175,7 @@ pub fn plan(
                     &mut skipped,
                 );
 
-                plan_external_retention(
-                    subvol,
-                    drive,
-                    now,
-                    fs,
-                    &pinned,
-                    &mut operations,
-                );
+                plan_external_retention(subvol, drive, now, fs, &pinned, &mut operations);
             }
         } else if !filters.local_only && !subvol.send_enabled {
             skipped.push((subvol.name.clone(), "send disabled".to_string()));
@@ -236,11 +237,15 @@ fn plan_local_snapshot(
             subvolume_name: subvol.name.clone(),
         });
     } else {
-        let next_in = subvol.snapshot_interval.as_chrono() - now.signed_duration_since(newest.unwrap().datetime());
+        let next_in = subvol.snapshot_interval.as_chrono()
+            - now.signed_duration_since(newest.unwrap().datetime());
         let mins = next_in.num_minutes();
         skipped.push((
             subvol.name.clone(),
-            format!("interval not elapsed (next in ~{})", format_duration_short(mins)),
+            format!(
+                "interval not elapsed (next in ~{})",
+                format_duration_short(mins)
+            ),
         ));
     }
 }
@@ -323,7 +328,9 @@ fn plan_external_send(
     skipped: &mut Vec<(String, String)>,
 ) {
     let ext_dir = crate::drives::external_snapshot_dir(drive, &subvol.name);
-    let ext_snaps = fs.external_snapshots(drive, &subvol.name).unwrap_or_default();
+    let ext_snaps = fs
+        .external_snapshots(drive, &subvol.name)
+        .unwrap_or_default();
 
     // Check send interval
     let newest_ext = ext_snaps.iter().max();
@@ -337,7 +344,8 @@ fn plan_external_send(
     };
 
     if !should_send {
-        let next_in = subvol.send_interval.as_chrono() - now.signed_duration_since(newest_ext.unwrap().datetime());
+        let next_in = subvol.send_interval.as_chrono()
+            - now.signed_duration_since(newest_ext.unwrap().datetime());
         skipped.push((
             subvol.name.clone(),
             format!(
@@ -351,12 +359,18 @@ fn plan_external_send(
 
     // Find the snapshot to send (newest local)
     let Some(snap_to_send) = local_snaps.iter().max() else {
-        skipped.push((subvol.name.clone(), "no local snapshots to send".to_string()));
+        skipped.push((
+            subvol.name.clone(),
+            "no local snapshots to send".to_string(),
+        ));
         return;
     };
 
     // Check if already on external
-    if ext_snaps.iter().any(|s| s.as_str() == snap_to_send.as_str()) {
+    if ext_snaps
+        .iter()
+        .any(|s| s.as_str() == snap_to_send.as_str())
+    {
         skipped.push((
             subvol.name.clone(),
             format!("{} already on {}", snap_to_send, drive.label),
@@ -370,7 +384,9 @@ fn plan_external_send(
     let pin = fs.read_pin_file(local_dir, &drive.label).unwrap_or(None);
     let is_incremental = if let Some(ref parent_name) = pin {
         // Parent must exist both locally and on the external drive
-        let parent_exists_local = local_snaps.iter().any(|s| s.as_str() == parent_name.as_str());
+        let parent_exists_local = local_snaps
+            .iter()
+            .any(|s| s.as_str() == parent_name.as_str());
         let parent_exists_ext = ext_snaps.iter().any(|s| s.as_str() == parent_name.as_str());
         parent_exists_local && parent_exists_ext
     } else {
@@ -379,7 +395,11 @@ fn plan_external_send(
 
     // Space estimation: skip if estimated send size exceeds available space.
     // Tier 1: Historical send data (most accurate). Tier 3: Calibrated sizes (fallback for full sends).
-    let send_type_str = if is_incremental { "send_incremental" } else { "send_full" };
+    let send_type_str = if is_incremental {
+        "send_incremental"
+    } else {
+        "send_full"
+    };
     if let Some(last_size) = fs.last_send_size(&subvol.name, &drive.label, send_type_str) {
         // Tier 1: historical data from previous sends (successful or failed)
         if let Some((estimated, available, free, min_free)) =
@@ -404,7 +424,10 @@ fn plan_external_send(
         if let Some((cal_bytes, measured_at)) = fs.calibrated_size(&subvol.name) {
             let age_days = calibration_age_days(&measured_at);
             let staleness = if age_days > 30 {
-                format!(" (calibrated {} days ago — run `urd calibrate` to refresh)", age_days)
+                format!(
+                    " (calibrated {} days ago — run `urd calibrate` to refresh)",
+                    age_days
+                )
             } else {
                 String::new()
             };
@@ -464,7 +487,9 @@ fn plan_external_retention(
     operations: &mut Vec<PlannedOperation>,
 ) {
     let ext_dir = crate::drives::external_snapshot_dir(drive, &subvol.name);
-    let ext_snaps = fs.external_snapshots(drive, &subvol.name).unwrap_or_default();
+    let ext_snaps = fs
+        .external_snapshots(drive, &subvol.name)
+        .unwrap_or_default();
 
     if ext_snaps.is_empty() {
         return;
@@ -536,7 +561,11 @@ pub struct RealFileSystemState<'a> {
 }
 
 impl FileSystemState for RealFileSystemState<'_> {
-    fn local_snapshots(&self, root: &Path, subvol_name: &str) -> crate::error::Result<Vec<SnapshotName>> {
+    fn local_snapshots(
+        &self,
+        root: &Path,
+        subvol_name: &str,
+    ) -> crate::error::Result<Vec<SnapshotName>> {
         read_snapshot_dir(&root.join(subvol_name))
     }
 
@@ -565,25 +594,18 @@ impl FileSystemState for RealFileSystemState<'_> {
         crate::chain::read_pin_file(local_dir, drive_label)
     }
 
-    fn pinned_snapshots(
-        &self,
-        local_dir: &Path,
-        drive_labels: &[String],
-    ) -> HashSet<SnapshotName> {
+    fn pinned_snapshots(&self, local_dir: &Path, drive_labels: &[String]) -> HashSet<SnapshotName> {
         crate::chain::find_pinned_snapshots(local_dir, drive_labels)
     }
 
-    fn last_send_size(
-        &self,
-        subvol_name: &str,
-        drive_label: &str,
-        send_type: &str,
-    ) -> Option<u64> {
+    fn last_send_size(&self, subvol_name: &str, drive_label: &str, send_type: &str) -> Option<u64> {
         self.state.and_then(|db| {
-            let successful = db.last_successful_send_size(subvol_name, drive_label, send_type)
+            let successful = db
+                .last_successful_send_size(subvol_name, drive_label, send_type)
                 .ok()
                 .flatten();
-            let failed = db.last_failed_send_size(subvol_name, drive_label, send_type)
+            let failed = db
+                .last_failed_send_size(subvol_name, drive_label, send_type)
                 .ok()
                 .flatten();
             match (successful, failed) {
@@ -594,9 +616,8 @@ impl FileSystemState for RealFileSystemState<'_> {
     }
 
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)> {
-        self.state.and_then(|db| {
-            db.calibrated_size(subvol_name).ok().flatten()
-        })
+        self.state
+            .and_then(|db| db.calibrated_size(subvol_name).ok().flatten())
     }
 
     fn last_successful_send_time(
@@ -620,7 +641,7 @@ fn read_snapshot_dir(dir: &Path) -> crate::error::Result<Vec<SnapshotName>> {
             return Err(UrdError::Io {
                 path: dir.to_path_buf(),
                 source: e,
-            })
+            });
         }
     };
 
@@ -678,14 +699,25 @@ impl MockFileSystemState {
 
 #[cfg(test)]
 impl FileSystemState for MockFileSystemState {
-    fn local_snapshots(&self, _root: &Path, subvol_name: &str) -> crate::error::Result<Vec<SnapshotName>> {
+    fn local_snapshots(
+        &self,
+        _root: &Path,
+        subvol_name: &str,
+    ) -> crate::error::Result<Vec<SnapshotName>> {
         if self.fail_local_snapshots.contains(subvol_name) {
             return Err(crate::error::UrdError::Io {
                 path: std::path::PathBuf::from(format!("/snap/{subvol_name}")),
-                source: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "permission denied"),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "permission denied",
+                ),
             });
         }
-        Ok(self.local_snapshots.get(subvol_name).cloned().unwrap_or_default())
+        Ok(self
+            .local_snapshots
+            .get(subvol_name)
+            .cloned()
+            .unwrap_or_default())
     }
 
     fn external_snapshots(
@@ -694,7 +726,11 @@ impl FileSystemState for MockFileSystemState {
         subvol_name: &str,
     ) -> crate::error::Result<Vec<SnapshotName>> {
         let key = (drive.label.clone(), subvol_name.to_string());
-        Ok(self.external_snapshots.get(&key).cloned().unwrap_or_default())
+        Ok(self
+            .external_snapshots
+            .get(&key)
+            .cloned()
+            .unwrap_or_default())
     }
 
     fn is_drive_mounted(&self, drive: &DriveConfig) -> bool {
@@ -716,26 +752,20 @@ impl FileSystemState for MockFileSystemState {
             .cloned())
     }
 
-    fn pinned_snapshots(
-        &self,
-        local_dir: &Path,
-        drive_labels: &[String],
-    ) -> HashSet<SnapshotName> {
+    fn pinned_snapshots(&self, local_dir: &Path, drive_labels: &[String]) -> HashSet<SnapshotName> {
         let mut pinned: HashSet<SnapshotName> = HashSet::new();
         for label in drive_labels {
-            if let Some(name) = self.pin_files.get(&(local_dir.to_path_buf(), label.clone())) {
+            if let Some(name) = self
+                .pin_files
+                .get(&(local_dir.to_path_buf(), label.clone()))
+            {
                 pinned.insert(name.clone());
             }
         }
         pinned
     }
 
-    fn last_send_size(
-        &self,
-        subvol_name: &str,
-        drive_label: &str,
-        send_type: &str,
-    ) -> Option<u64> {
+    fn last_send_size(&self, subvol_name: &str, drive_label: &str, send_type: &str) -> Option<u64> {
         self.send_sizes
             .get(&(
                 subvol_name.to_string(),
@@ -837,10 +867,8 @@ priority = 2
         let config = test_config();
         let mut fs = MockFileSystemState::new();
         // sv1 last snapshot was 20 minutes ago (interval is 15m)
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap("20260322-1440-one")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
         let creates: Vec<_> = result
@@ -856,10 +884,8 @@ priority = 2
         let config = test_config();
         let mut fs = MockFileSystemState::new();
         // sv1 last snapshot was 10 minutes ago (interval is 15m)
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap("20260322-1455-one")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1455-one")]);
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
         let creates: Vec<_> = result
@@ -868,7 +894,12 @@ priority = 2
             .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
             .collect();
         assert_eq!(creates.len(), 0);
-        assert!(result.skipped.iter().any(|(name, reason)| name == "sv1" && reason.contains("interval")));
+        assert!(
+            result
+                .skipped
+                .iter()
+                .any(|(name, reason)| name == "sv1" && reason.contains("interval"))
+        );
     }
 
     #[test]
@@ -892,10 +923,8 @@ priority = 2
         let config = test_config();
         let mut fs = MockFileSystemState::new();
         // sv1 last snapshot was 5 minutes ago (interval is 15m — not elapsed)
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap("20260322-1458-one")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1458-one")]);
 
         let filters = PlanFilters {
             subvolume: Some("sv1".to_string()),
@@ -937,14 +966,10 @@ priority = 2
         let parent = snap("20260322-1400-one");
         let current = snap("20260322-1500-one");
 
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![parent.clone(), current.clone()],
-        );
-        fs.external_snapshots.insert(
-            ("D1".to_string(), "sv1".to_string()),
-            vec![parent.clone()],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![parent.clone(), current.clone()]);
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![parent.clone()]);
         fs.mounted_drives.insert("D1".to_string());
         fs.pin_files.insert(
             (PathBuf::from("/snap/sv1"), "D1".to_string()),
@@ -968,10 +993,8 @@ priority = 2
     fn full_send_when_no_pin() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap("20260322-1500-one")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1500-one")]);
         fs.mounted_drives.insert("D1".to_string());
 
         let filters = PlanFilters {
@@ -999,10 +1022,8 @@ priority = 2
         );
         // Pin points to parent, but parent is NOT on external drive
         fs.mounted_drives.insert("D1".to_string());
-        fs.pin_files.insert(
-            (PathBuf::from("/snap/sv1"), "D1".to_string()),
-            parent,
-        );
+        fs.pin_files
+            .insert((PathBuf::from("/snap/sv1"), "D1".to_string()), parent);
 
         let filters = PlanFilters {
             subvolume: Some("sv1".to_string()),
@@ -1021,18 +1042,26 @@ priority = 2
     fn skips_send_when_drive_not_mounted() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap("20260322-1500-one")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1500-one")]);
         // Drive NOT mounted
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
-        assert!(result.skipped.iter().any(|(_, reason)| reason.contains("not mounted")));
+        assert!(
+            result
+                .skipped
+                .iter()
+                .any(|(_, reason)| reason.contains("not mounted"))
+        );
         let sends: Vec<_> = result
             .operations
             .iter()
-            .filter(|op| matches!(op, PlannedOperation::SendIncremental { .. } | PlannedOperation::SendFull { .. }))
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::SendIncremental { .. } | PlannedOperation::SendFull { .. }
+                )
+            })
             .collect();
         assert_eq!(sends.len(), 0);
     }
@@ -1076,7 +1105,12 @@ send_enabled = false
         fs.mounted_drives.insert("D1".to_string());
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
-        assert!(result.skipped.iter().any(|(_, reason)| reason.contains("send disabled")));
+        assert!(
+            result
+                .skipped
+                .iter()
+                .any(|(_, reason)| reason.contains("send disabled"))
+        );
     }
 
     #[test]
@@ -1093,7 +1127,12 @@ send_enabled = false
         let sends: Vec<_> = result
             .operations
             .iter()
-            .filter(|op| matches!(op, PlannedOperation::SendIncremental { .. } | PlannedOperation::SendFull { .. }))
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::SendIncremental { .. } | PlannedOperation::SendFull { .. }
+                )
+            })
             .collect();
         assert_eq!(sends.len(), 0);
     }
@@ -1120,10 +1159,8 @@ send_enabled = false
     fn send_includes_pin_info() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
-        fs.local_snapshots.insert(
-            "sv1".to_string(),
-            vec![snap("20260322-1500-one")],
-        );
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1500-one")]);
         fs.mounted_drives.insert("D1".to_string());
 
         let filters = PlanFilters {
@@ -1134,10 +1171,18 @@ send_enabled = false
         let sends_with_pin: Vec<_> = result
             .operations
             .iter()
-            .filter(|op| matches!(op,
-                PlannedOperation::SendFull { pin_on_success: Some(_), .. }
-                | PlannedOperation::SendIncremental { pin_on_success: Some(_), .. }
-            ))
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::SendFull {
+                        pin_on_success: Some(_),
+                        ..
+                    } | PlannedOperation::SendIncremental {
+                        pin_on_success: Some(_),
+                        ..
+                    }
+                )
+            })
             .collect();
         assert_eq!(sends_with_pin.len(), 1);
     }
@@ -1160,10 +1205,8 @@ send_enabled = false
                 snap("20260322-1500-one"), // newest
             ],
         );
-        fs.pin_files.insert(
-            (PathBuf::from("/snap/sv1"), "D1".to_string()),
-            pin_snap,
-        );
+        fs.pin_files
+            .insert((PathBuf::from("/snap/sv1"), "D1".to_string()), pin_snap);
 
         let filters = PlanFilters {
             subvolume: Some("sv1".to_string()),
@@ -1213,7 +1256,11 @@ send_enabled = false
             .iter()
             .filter(|op| matches!(op, PlannedOperation::DeleteSnapshot { .. }))
             .collect();
-        assert_eq!(deletes.len(), 0, "No snapshots should be deleted when nothing has been sent externally");
+        assert_eq!(
+            deletes.len(),
+            0,
+            "No snapshots should be deleted when nothing has been sent externally"
+        );
     }
 
     #[test]
@@ -1269,7 +1316,10 @@ send_enabled = false
             .filter(|op| matches!(op, PlannedOperation::DeleteSnapshot { .. }))
             .collect();
         // With send_enabled=false, daily thinning should delete the 0800 and 1000 snapshots
-        assert!(deletes.len() >= 2, "Retention should thin normally when send is disabled");
+        assert!(
+            deletes.len() >= 2,
+            "Retention should thin normally when send is disabled"
+        );
     }
 
     // ── Space estimation tests ──────────────────────────────────────────
@@ -1278,7 +1328,8 @@ send_enabled = false
     fn send_skipped_insufficient_space() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
-        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
         fs.mounted_drives.insert("D1".to_string());
         // Historical full send was 200GB
         fs.send_sizes.insert(
@@ -1286,10 +1337,8 @@ send_enabled = false
             200_000_000_000,
         );
         // Only 150GB free on external drive (min_free=100GB, so available=50GB)
-        fs.free_bytes.insert(
-            PathBuf::from("/mnt/d1/.snapshots/sv1"),
-            150_000_000_000,
-        );
+        fs.free_bytes
+            .insert(PathBuf::from("/mnt/d1/.snapshots/sv1"), 150_000_000_000);
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
         let sends: Vec<_> = result
@@ -1297,9 +1346,16 @@ send_enabled = false
             .iter()
             .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
             .collect();
-        assert_eq!(sends.len(), 0, "Send should be skipped when space is insufficient");
+        assert_eq!(
+            sends.len(),
+            0,
+            "Send should be skipped when space is insufficient"
+        );
         assert!(
-            result.skipped.iter().any(|(name, reason)| name == "sv1" && reason.contains("estimated")),
+            result
+                .skipped
+                .iter()
+                .any(|(name, reason)| name == "sv1" && reason.contains("estimated")),
             "Should report space estimation skip"
         );
     }
@@ -1308,7 +1364,8 @@ send_enabled = false
     fn send_proceeds_with_sufficient_space() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
-        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
         fs.mounted_drives.insert("D1".to_string());
         // Historical full send was 50GB
         fs.send_sizes.insert(
@@ -1316,10 +1373,8 @@ send_enabled = false
             50_000_000_000,
         );
         // 500GB free on external drive (min_free=100GB, available=400GB, estimated=60GB)
-        fs.free_bytes.insert(
-            PathBuf::from("/mnt/d1/.snapshots/sv1"),
-            500_000_000_000,
-        );
+        fs.free_bytes
+            .insert(PathBuf::from("/mnt/d1/.snapshots/sv1"), 500_000_000_000);
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
         let sends: Vec<_> = result
@@ -1327,21 +1382,24 @@ send_enabled = false
             .iter()
             .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
             .collect();
-        assert_eq!(sends.len(), 1, "Send should proceed when space is sufficient");
+        assert_eq!(
+            sends.len(),
+            1,
+            "Send should proceed when space is sufficient"
+        );
     }
 
     #[test]
     fn send_proceeds_without_history() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
-        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
         fs.mounted_drives.insert("D1".to_string());
         // No send_sizes entry — first-ever send
         // Tiny free space — but no history means we can't estimate, so proceed
-        fs.free_bytes.insert(
-            PathBuf::from("/mnt/d1/.snapshots/sv1"),
-            1_000_000,
-        );
+        fs.free_bytes
+            .insert(PathBuf::from("/mnt/d1/.snapshots/sv1"), 1_000_000);
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
         let sends: Vec<_> = result
@@ -1349,14 +1407,19 @@ send_enabled = false
             .iter()
             .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
             .collect();
-        assert_eq!(sends.len(), 1, "First-ever send should proceed without history");
+        assert_eq!(
+            sends.len(),
+            1,
+            "First-ever send should proceed without history"
+        );
     }
 
     #[test]
     fn calibrated_size_skips_send_when_too_large() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
-        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
         fs.mounted_drives.insert("D1".to_string());
         // No send history (Tier 1), but calibrated size says 1TB
         fs.calibrated_sizes.insert(
@@ -1364,10 +1427,8 @@ send_enabled = false
             (1_000_000_000_000, "2026-03-22T12:00:00".to_string()),
         );
         // Drive has only 500GB free
-        fs.free_bytes.insert(
-            PathBuf::from("/mnt/d1/.snapshots/sv1"),
-            500_000_000_000,
-        );
+        fs.free_bytes
+            .insert(PathBuf::from("/mnt/d1/.snapshots/sv1"), 500_000_000_000);
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
         let sends: Vec<_> = result
@@ -1375,9 +1436,16 @@ send_enabled = false
             .iter()
             .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
             .collect();
-        assert_eq!(sends.len(), 0, "Send should be skipped when calibrated size exceeds available space");
+        assert_eq!(
+            sends.len(),
+            0,
+            "Send should be skipped when calibrated size exceeds available space"
+        );
         assert!(
-            result.skipped.iter().any(|(name, reason)| name == "sv1" && reason.contains("calibrated size")),
+            result
+                .skipped
+                .iter()
+                .any(|(name, reason)| name == "sv1" && reason.contains("calibrated size")),
             "Skip reason should mention calibrated size"
         );
     }
@@ -1386,7 +1454,8 @@ send_enabled = false
     fn tier1_overrides_calibrated_size() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
-        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
         fs.mounted_drives.insert("D1".to_string());
         // Tier 1 says 100KB (small send)
         fs.send_sizes.insert(
@@ -1399,10 +1468,8 @@ send_enabled = false
             (1_000_000_000_000, "2026-03-22T12:00:00".to_string()),
         );
         // Drive has 500GB free — enough for Tier 1 estimate, not for calibrated
-        fs.free_bytes.insert(
-            PathBuf::from("/mnt/d1/.snapshots/sv1"),
-            500_000_000_000,
-        );
+        fs.free_bytes
+            .insert(PathBuf::from("/mnt/d1/.snapshots/sv1"), 500_000_000_000);
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
         let sends: Vec<_> = result
@@ -1410,20 +1477,23 @@ send_enabled = false
             .iter()
             .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
             .collect();
-        assert_eq!(sends.len(), 1, "Tier 1 history should override calibrated size");
+        assert_eq!(
+            sends.len(),
+            1,
+            "Tier 1 history should override calibrated size"
+        );
     }
 
     #[test]
     fn send_proceeds_without_history_or_calibration() {
         let config = test_config();
         let mut fs = MockFileSystemState::new();
-        fs.local_snapshots.insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
         fs.mounted_drives.insert("D1".to_string());
         // No send_sizes, no calibrated_sizes — fail open
-        fs.free_bytes.insert(
-            PathBuf::from("/mnt/d1/.snapshots/sv1"),
-            1_000_000,
-        );
+        fs.free_bytes
+            .insert(PathBuf::from("/mnt/d1/.snapshots/sv1"), 1_000_000);
 
         let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
         let sends: Vec<_> = result
@@ -1431,7 +1501,11 @@ send_enabled = false
             .iter()
             .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
             .collect();
-        assert_eq!(sends.len(), 1, "First-ever send should proceed without history or calibration");
+        assert_eq!(
+            sends.len(),
+            1,
+            "First-ever send should proceed without history or calibration"
+        );
     }
 
     #[test]
@@ -1450,9 +1524,16 @@ send_enabled = false
             .iter()
             .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
             .collect();
-        assert_eq!(creates.len(), 0, "No snapshot should be created when newest is in the future");
+        assert_eq!(
+            creates.len(),
+            0,
+            "No snapshot should be created when newest is in the future"
+        );
         assert!(
-            result.skipped.iter().any(|(name, reason)| name == "sv1" && reason.contains("interval")),
+            result
+                .skipped
+                .iter()
+                .any(|(name, reason)| name == "sv1" && reason.contains("interval")),
             "Should report interval not elapsed for future-dated snapshot"
         );
     }

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -79,7 +79,12 @@ pub fn graduated_retention(
         } else if dt >= hourly_cutoff {
             // Hourly window
             if space_pressure {
-                let slot = (dt.date().year(), dt.date().month(), dt.date().day(), dt.time().hour());
+                let slot = (
+                    dt.date().year(),
+                    dt.date().month(),
+                    dt.date().day(),
+                    dt.time().hour(),
+                );
                 if hourly_slots.insert(slot) || is_pinned {
                     keep.push(snap.clone());
                 } else {
@@ -116,7 +121,10 @@ pub fn graduated_retention(
         } else if is_pinned {
             keep.push(snap.clone());
         } else {
-            delete.push((snap.clone(), "graduated: beyond retention window".to_string()));
+            delete.push((
+                snap.clone(),
+                "graduated: beyond retention window".to_string(),
+            ));
         }
     }
 
@@ -264,10 +272,7 @@ mod tests {
     fn graduated_pinned_never_deleted() {
         // Snapshot outside all windows but pinned
         let old_snap = make_daily_snap("20240101", "home");
-        let snaps = vec![
-            make_snap("20260322", "1400", "home"),
-            old_snap.clone(),
-        ];
+        let snaps = vec![make_snap("20260322", "1400", "home"), old_snap.clone()];
         let mut pinned = HashSet::new();
         pinned.insert(old_snap.clone());
 
@@ -362,7 +367,7 @@ mod tests {
         // A snapshot between the two cutoffs would be deleted by days*30
         // but kept by calendar months. This test targets that boundary.
         let config = ResolvedGraduatedRetention {
-            hourly: 0,  // no hourly/daily/weekly windows — all snapshots land in monthly
+            hourly: 0, // no hourly/daily/weekly windows — all snapshots land in monthly
             daily: 0,
             weekly: 0,
             monthly: 12,

--- a/src/state.rs
+++ b/src/state.rs
@@ -61,7 +61,10 @@ impl StateDb {
         }
 
         let conn = Connection::open(path).map_err(|e| {
-            UrdError::State(format!("failed to open state DB at {}: {e}", path.display()))
+            UrdError::State(format!(
+                "failed to open state DB at {}: {e}",
+                path.display()
+            ))
         })?;
 
         let db = Self { conn };
@@ -243,7 +246,10 @@ impl StateDb {
             .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
 
         let rows = stmt
-            .query_map(rusqlite::params![name, limit as i64], Self::map_operation_row)
+            .query_map(
+                rusqlite::params![name, limit as i64],
+                Self::map_operation_row,
+            )
             .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
 
         rows.collect::<Result<Vec<_>, _>>()
@@ -364,10 +370,7 @@ impl StateDb {
 
     /// Get the calibrated size for a subvolume, if any.
     /// Returns `(estimated_bytes, measured_at)`.
-    pub fn calibrated_size(
-        &self,
-        subvolume: &str,
-    ) -> crate::error::Result<Option<(u64, String)>> {
+    pub fn calibrated_size(&self, subvolume: &str) -> crate::error::Result<Option<(u64, String)>> {
         let mut stmt = self
             .conn
             .prepare(
@@ -385,7 +388,9 @@ impl StateDb {
 
         match rows.next() {
             Some(Ok(result)) => Ok(Some(result)),
-            Some(Err(e)) => Err(UrdError::State(format!("failed to read calibrated size: {e}"))),
+            Some(Err(e)) => Err(UrdError::State(format!(
+                "failed to read calibrated size: {e}"
+            ))),
             None => Ok(None),
         }
     }
@@ -472,11 +477,9 @@ mod tests {
         // Check run was created with 'running' result
         let result: String = db
             .conn
-            .query_row(
-                "SELECT result FROM runs WHERE id = ?1",
-                [run_id],
-                |row| row.get(0),
-            )
+            .query_row("SELECT result FROM runs WHERE id = ?1", [run_id], |row| {
+                row.get(0)
+            })
             .unwrap();
         assert_eq!(result, "running");
 
@@ -749,15 +752,18 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            db.last_successful_send_size("htpc-home", "DRIVE-A", "send_full").unwrap(),
+            db.last_successful_send_size("htpc-home", "DRIVE-A", "send_full")
+                .unwrap(),
             Some(500_000)
         );
         assert_eq!(
-            db.last_successful_send_size("htpc-home", "DRIVE-B", "send_full").unwrap(),
+            db.last_successful_send_size("htpc-home", "DRIVE-B", "send_full")
+                .unwrap(),
             Some(600_000)
         );
         assert_eq!(
-            db.last_successful_send_size("htpc-home", "DRIVE-C", "send_full").unwrap(),
+            db.last_successful_send_size("htpc-home", "DRIVE-C", "send_full")
+                .unwrap(),
             None
         );
     }
@@ -793,7 +799,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            db.last_successful_send_size("sv1", "D", "send_full").unwrap(),
+            db.last_successful_send_size("sv1", "D", "send_full")
+                .unwrap(),
             Some(999)
         );
     }
@@ -818,7 +825,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            db.last_failed_send_size("subvol5-music", "2TB-backup", "send_full").unwrap(),
+            db.last_failed_send_size("subvol5-music", "2TB-backup", "send_full")
+                .unwrap(),
             Some(1_100_000_000_000)
         );
     }
@@ -876,7 +884,8 @@ mod tests {
     fn upsert_and_query_calibrated_size() {
         let db = StateDb::open_memory().unwrap();
 
-        db.upsert_subvolume_size("htpc-home", 77_640_000_000, "du -sb").unwrap();
+        db.upsert_subvolume_size("htpc-home", 77_640_000_000, "du -sb")
+            .unwrap();
         let result = db.calibrated_size("htpc-home").unwrap();
         assert!(result.is_some());
         let (bytes, measured_at) = result.unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -139,15 +139,12 @@ impl SnapshotName {
     pub fn parse(s: &str) -> crate::error::Result<Self> {
         let s = s.trim();
         if s.len() < 10 {
-            return Err(UrdError::Parse(format!(
-                "snapshot name too short: {s:?}"
-            )));
+            return Err(UrdError::Parse(format!("snapshot name too short: {s:?}")));
         }
 
         let date_str = &s[..8];
-        let date = NaiveDate::parse_from_str(date_str, "%Y%m%d").map_err(|e| {
-            UrdError::Parse(format!("invalid date in snapshot name {s:?}: {e}"))
-        })?;
+        let date = NaiveDate::parse_from_str(date_str, "%Y%m%d")
+            .map_err(|e| UrdError::Parse(format!("invalid date in snapshot name {s:?}: {e}")))?;
 
         // After the date, expect a '-'
         if s.as_bytes().get(8) != Some(&b'-') {
@@ -161,8 +158,7 @@ impl SnapshotName {
         // Try new format: HHMM-shortname (rest starts with 4 digits then '-')
         if rest.len() >= 5
             && rest.as_bytes()[4] == b'-'
-            && let (Ok(hour), Ok(minute)) =
-                (rest[..2].parse::<u32>(), rest[2..4].parse::<u32>())
+            && let (Ok(hour), Ok(minute)) = (rest[..2].parse::<u32>(), rest[2..4].parse::<u32>())
             && hour < 24
             && minute < 60
         {
@@ -172,9 +168,8 @@ impl SnapshotName {
                     "empty short name in snapshot name: {s:?}"
                 )));
             }
-            let time = NaiveTime::from_hms_opt(hour, minute, 0).ok_or_else(|| {
-                UrdError::Parse(format!("invalid time in snapshot name: {s:?}"))
-            })?;
+            let time = NaiveTime::from_hms_opt(hour, minute, 0)
+                .ok_or_else(|| UrdError::Parse(format!("invalid time in snapshot name: {s:?}")))?;
             return Ok(Self {
                 raw: s.to_string(),
                 datetime: NaiveDateTime::new(date, time),
@@ -188,9 +183,8 @@ impl SnapshotName {
                 "empty short name in snapshot name: {s:?}"
             )));
         }
-        let time = NaiveTime::from_hms_opt(0, 0, 0).ok_or_else(|| {
-            UrdError::Parse("failed to create midnight time".to_string())
-        })?;
+        let time = NaiveTime::from_hms_opt(0, 0, 0)
+            .ok_or_else(|| UrdError::Parse("failed to create midnight time".to_string()))?;
         Ok(Self {
             raw: s.to_string(),
             datetime: NaiveDateTime::new(date, time),
@@ -357,7 +351,11 @@ impl fmt::Display for PlannedOperation {
                 pin_on_success,
                 ..
             } => {
-                let pin_suffix = if pin_on_success.is_some() { " + pin" } else { "" };
+                let pin_suffix = if pin_on_success.is_some() {
+                    " + pin"
+                } else {
+                    ""
+                };
                 write!(
                     f,
                     "SEND    {} -> {} (incremental, parent: {}){pin_suffix}",
@@ -372,7 +370,11 @@ impl fmt::Display for PlannedOperation {
                 pin_on_success,
                 ..
             } => {
-                let pin_suffix = if pin_on_success.is_some() { " + pin" } else { "" };
+                let pin_suffix = if pin_on_success.is_some() {
+                    " + pin"
+                } else {
+                    ""
+                };
                 write!(
                     f,
                     "SEND    {} -> {} (full){pin_suffix}",
@@ -477,11 +479,7 @@ impl FromStr for ByteSize {
             "MIB" => 1_048_576,
             "GIB" => 1_073_741_824,
             "TIB" => 1_099_511_627_776,
-            _ => {
-                return Err(UrdError::Parse(format!(
-                    "unknown byte size unit: {unit:?}"
-                )))
-            }
+            _ => return Err(UrdError::Parse(format!("unknown byte size unit: {unit:?}"))),
         };
         #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         Ok(Self((num * multiplier as f64) as u64))
@@ -712,7 +710,10 @@ mod tests {
     fn parse_byte_sizes() {
         assert_eq!("10GB".parse::<ByteSize>().unwrap().bytes(), 10_000_000_000);
         assert_eq!("500MB".parse::<ByteSize>().unwrap().bytes(), 500_000_000);
-        assert_eq!("1TB".parse::<ByteSize>().unwrap().bytes(), 1_000_000_000_000);
+        assert_eq!(
+            "1TB".parse::<ByteSize>().unwrap().bytes(),
+            1_000_000_000_000
+        );
         assert_eq!("1GiB".parse::<ByteSize>().unwrap().bytes(), 1_073_741_824);
         assert_eq!("100KB".parse::<ByteSize>().unwrap().bytes(), 100_000);
         assert_eq!("1024B".parse::<ByteSize>().unwrap().bytes(), 1024);
@@ -774,7 +775,10 @@ mod tests {
                 .unwrap()
                 .and_hms_opt(14, 30, 0)
                 .unwrap(),
-            skipped: vec![("subvol6-tmp".to_string(), "interval not elapsed".to_string())],
+            skipped: vec![(
+                "subvol6-tmp".to_string(),
+                "interval not elapsed".to_string(),
+            )],
         };
         let s = plan.summary();
         assert_eq!(s.snapshots, 1);

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1,0 +1,471 @@
+// Voice — the presentation layer.
+//
+// Commands produce structured output types (defined in `output.rs`).
+// This module renders them into text: interactive (colored, tables) or
+// daemon (JSON). All user-facing text for migrated commands flows through here.
+//
+// The mythic voice is a future content layer on top of this architecture.
+// For now, output is clear and informative, not evocative.
+
+use std::fmt::Write;
+
+use colored::Colorize;
+
+use crate::output::{OutputMode, StatusOutput};
+use crate::types::ByteSize;
+
+// ── Status ──────────────────────────────────────────────────────────────
+
+/// Render status output according to the given mode.
+#[must_use]
+pub fn render_status(data: &StatusOutput, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => render_status_interactive(data),
+        OutputMode::Daemon => render_status_daemon(data),
+    }
+}
+
+fn render_status_daemon(data: &StatusOutput) -> String {
+    serde_json::to_string_pretty(data).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
+}
+
+fn render_status_interactive(data: &StatusOutput) -> String {
+    let mut out = String::new();
+
+    // ── Per-subvolume table ──────────────────────────────────────────
+    render_subvolume_table(data, &mut out);
+
+    // ── Advisories and errors from awareness model ─────────────────
+    render_advisories(data, &mut out);
+
+    // ── Drive summary ───────────────────────────────────────────────
+    writeln!(out).ok();
+    render_drive_summary(data, &mut out);
+
+    // ── Last run ────────────────────────────────────────────────────
+    render_last_run(data, &mut out);
+
+    // ── Pin summary ─────────────────────────────────────────────────
+    if data.total_pins > 0 {
+        writeln!(
+            out,
+            "Pinned snapshots: {} across subvolumes",
+            data.total_pins
+        )
+        .ok();
+    }
+
+    out
+}
+
+fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
+    if data.assessments.is_empty() {
+        writeln!(out, "{}", "No subvolumes configured.".dimmed()).ok();
+        return;
+    }
+
+    // Collect mounted drive labels for column headers
+    let mounted_drives: Vec<&str> = data
+        .drives
+        .iter()
+        .filter(|d| d.mounted)
+        .map(|d| d.label.as_str())
+        .collect();
+
+    // Build headers: STATUS  SUBVOLUME  LOCAL  [DRIVE1]  [DRIVE2]  CHAIN
+    let mut headers: Vec<String> = vec![
+        "STATUS".to_string(),
+        "SUBVOLUME".to_string(),
+        "LOCAL".to_string(),
+    ];
+    for label in &mounted_drives {
+        headers.push(label.to_string());
+    }
+    headers.push("CHAIN".to_string());
+
+    // Build rows
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    for assessment in &data.assessments {
+        let mut row = vec![
+            assessment.status.clone(),
+            assessment.name.clone(),
+            assessment.local_snapshot_count.to_string(),
+        ];
+
+        // Per-drive external snapshot count
+        for label in &mounted_drives {
+            let count = assessment
+                .external
+                .iter()
+                .find(|e| e.drive_label == *label)
+                .and_then(|e| e.snapshot_count);
+            row.push(match count {
+                Some(c) if c > 0 => c.to_string(),
+                _ => "\u{2014}".to_string(), // em dash
+            });
+        }
+
+        // Chain health
+        let chain = data
+            .chain_health
+            .iter()
+            .find(|c| c.subvolume == assessment.name)
+            .map(|c| c.health.to_string())
+            .unwrap_or_else(|| "\u{2014}".to_string());
+        row.push(chain);
+
+        rows.push(row);
+    }
+
+    format_table(&headers, &rows, out);
+}
+
+fn render_advisories(data: &StatusOutput, out: &mut String) {
+    let mut any = false;
+    for assessment in &data.assessments {
+        for error in &assessment.errors {
+            writeln!(out, "  {} {}: {}", "ERROR".red(), assessment.name, error).ok();
+            any = true;
+        }
+        for advisory in &assessment.advisories {
+            writeln!(
+                out,
+                "  {} {}: {}",
+                "NOTE".dimmed(),
+                assessment.name,
+                advisory
+            )
+            .ok();
+        }
+    }
+    if any {
+        writeln!(out).ok();
+    }
+}
+
+fn render_drive_summary(data: &StatusOutput, out: &mut String) {
+    if data.drives.is_empty() {
+        writeln!(out, "{}", "Drives: none configured".dimmed()).ok();
+        return;
+    }
+
+    for drive in &data.drives {
+        if drive.mounted {
+            let free_str = drive
+                .free_bytes
+                .map(|b| format!(" ({} free)", ByteSize(b)))
+                .unwrap_or_default();
+            writeln!(
+                out,
+                "Drives: {} {}{}",
+                drive.label.bold(),
+                "mounted".green(),
+                free_str,
+            )
+            .ok();
+        } else {
+            writeln!(
+                out,
+                "Drives: {} {}",
+                drive.label.bold(),
+                "not mounted".dimmed(),
+            )
+            .ok();
+        }
+    }
+}
+
+fn render_last_run(data: &StatusOutput, out: &mut String) {
+    match &data.last_run {
+        Some(run) => {
+            let result_colored = color_result(&run.result);
+            let duration_str = run
+                .duration
+                .as_ref()
+                .map(|d| format!(", {d}"))
+                .unwrap_or_default();
+            writeln!(
+                out,
+                "Last backup: {} ({}{}) [#{}]",
+                run.started_at, result_colored, duration_str, run.id,
+            )
+            .ok();
+        }
+        None => {
+            writeln!(out, "{}", "Last backup: no runs recorded".dimmed()).ok();
+        }
+    }
+}
+
+// ── Table formatter ─────────────────────────────────────────────────────
+
+fn format_table(headers: &[String], rows: &[Vec<String>], out: &mut String) {
+    let cols = headers.len();
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            if i < cols {
+                widths[i] = widths[i].max(cell.len());
+            }
+        }
+    }
+
+    // Header
+    let header_line: Vec<String> = headers
+        .iter()
+        .enumerate()
+        .map(|(i, h)| format!("{:<width$}", h, width = widths[i]))
+        .collect();
+    writeln!(out, "{}", header_line.join("  ").bold()).ok();
+
+    // Rows — color the STATUS column
+    for row in rows {
+        let line: Vec<String> = row
+            .iter()
+            .enumerate()
+            .map(|(i, cell)| {
+                let w = widths.get(i).copied().unwrap_or(cell.len());
+                if i == 0 {
+                    // STATUS column — apply color
+                    let colored = color_status_str(cell);
+                    // Pad after coloring (colored strings have invisible ANSI bytes)
+                    let visible_len = cell.len();
+                    let padding = w.saturating_sub(visible_len);
+                    format!("{colored}{:padding$}", "", padding = padding)
+                } else {
+                    format!("{:<width$}", cell, width = w)
+                }
+            })
+            .collect();
+        writeln!(out, "{}", line.join("  ")).ok();
+    }
+}
+
+// ── Color helpers ───────────────────────────────────────────────────────
+
+fn color_status_str(status: &str) -> String {
+    match status {
+        "PROTECTED" => "PROTECTED".green().to_string(),
+        "AT RISK" => "AT RISK".yellow().to_string(),
+        "UNPROTECTED" => "UNPROTECTED".red().to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn color_result(result: &str) -> String {
+    match result {
+        "success" => "success".green().to_string(),
+        "partial" => "partial".yellow().to_string(),
+        "failure" => "failure".red().to_string(),
+        other => other.to_string(),
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::{
+        ChainHealth, ChainHealthEntry, DriveInfo, LastRunInfo, StatusAssessment,
+        StatusDriveAssessment,
+    };
+
+    fn test_status_output() -> StatusOutput {
+        StatusOutput {
+            assessments: vec![
+                StatusAssessment {
+                    name: "htpc-home".to_string(),
+                    status: "PROTECTED".to_string(),
+                    local_snapshot_count: 47,
+                    local_status: "PROTECTED".to_string(),
+                    external: vec![StatusDriveAssessment {
+                        drive_label: "WD-18TB".to_string(),
+                        status: "PROTECTED".to_string(),
+                        mounted: true,
+                        snapshot_count: Some(12),
+                    }],
+                    advisories: vec![],
+                    errors: vec![],
+                },
+                StatusAssessment {
+                    name: "htpc-docs".to_string(),
+                    status: "AT RISK".to_string(),
+                    local_snapshot_count: 5,
+                    local_status: "AT RISK".to_string(),
+                    external: vec![StatusDriveAssessment {
+                        drive_label: "WD-18TB".to_string(),
+                        status: "UNPROTECTED".to_string(),
+                        mounted: true,
+                        snapshot_count: Some(0),
+                    }],
+                    advisories: vec![],
+                    errors: vec![],
+                },
+            ],
+            chain_health: vec![
+                ChainHealthEntry {
+                    subvolume: "htpc-home".to_string(),
+                    health: ChainHealth::Incremental("20260322-1430-htpc-home".to_string()),
+                },
+                ChainHealthEntry {
+                    subvolume: "htpc-docs".to_string(),
+                    health: ChainHealth::Full("no pin".to_string()),
+                },
+            ],
+            drives: vec![
+                DriveInfo {
+                    label: "WD-18TB".to_string(),
+                    mounted: true,
+                    free_bytes: Some(5_000_000_000_000),
+                },
+                DriveInfo {
+                    label: "Offsite-4TB".to_string(),
+                    mounted: false,
+                    free_bytes: None,
+                },
+            ],
+            last_run: Some(LastRunInfo {
+                id: 42,
+                started_at: "2026-03-24T02:00:00".to_string(),
+                result: "success".to_string(),
+                duration: Some("1m 30s".to_string()),
+            }),
+            total_pins: 3,
+        }
+    }
+
+    #[test]
+    fn interactive_contains_subvolume_names() {
+        colored::control::set_override(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("htpc-home"), "missing htpc-home");
+        assert!(output.contains("htpc-docs"), "missing htpc-docs");
+    }
+
+    #[test]
+    fn interactive_contains_promise_statuses() {
+        colored::control::set_override(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("PROTECTED"), "missing PROTECTED");
+        assert!(output.contains("AT RISK"), "missing AT RISK");
+    }
+
+    #[test]
+    fn interactive_contains_drive_info() {
+        colored::control::set_override(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("WD-18TB"), "missing drive label");
+        assert!(output.contains("mounted"), "missing mounted status");
+        assert!(output.contains("Offsite-4TB"), "missing unmounted drive");
+        assert!(output.contains("not mounted"), "missing not mounted status");
+    }
+
+    #[test]
+    fn interactive_contains_last_run() {
+        colored::control::set_override(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("#42"), "missing run ID");
+        assert!(output.contains("success"), "missing run result");
+        assert!(output.contains("1m 30s"), "missing duration");
+    }
+
+    #[test]
+    fn interactive_contains_chain_health() {
+        colored::control::set_override(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("incremental"), "missing incremental chain");
+        assert!(output.contains("full (no pin)"), "missing full chain");
+    }
+
+    #[test]
+    fn interactive_contains_pin_count() {
+        colored::control::set_override(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("3"), "missing pin count");
+    }
+
+    #[test]
+    fn interactive_no_subvolumes() {
+        colored::control::set_override(false);
+        let data = StatusOutput {
+            assessments: vec![],
+            chain_health: vec![],
+            drives: vec![],
+            last_run: None,
+            total_pins: 0,
+        };
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("No subvolumes configured"),
+            "missing empty message"
+        );
+    }
+
+    #[test]
+    fn daemon_produces_valid_json() {
+        let output = render_status(&test_status_output(), OutputMode::Daemon);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&output).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{output}"));
+        assert!(
+            parsed.get("assessments").is_some(),
+            "missing assessments key"
+        );
+        assert!(parsed.get("drives").is_some(), "missing drives key");
+        assert!(parsed.get("last_run").is_some(), "missing last_run key");
+        assert!(
+            parsed.get("chain_health").is_some(),
+            "missing chain_health key"
+        );
+    }
+
+    #[test]
+    fn daemon_contains_subvolume_data() {
+        let output = render_status(&test_status_output(), OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let assessments = parsed["assessments"].as_array().unwrap();
+        assert_eq!(assessments.len(), 2);
+        assert_eq!(assessments[0]["name"], "htpc-home");
+        assert_eq!(assessments[0]["status"], "PROTECTED");
+        assert_eq!(assessments[1]["name"], "htpc-docs");
+        assert_eq!(assessments[1]["status"], "AT RISK");
+    }
+
+    #[test]
+    fn interactive_renders_advisories_and_errors() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        data.assessments[0]
+            .errors
+            .push("can't read snapshot directory".to_string());
+        data.assessments[1]
+            .advisories
+            .push("offsite drive not connected in 14 days".to_string());
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("can't read snapshot directory"),
+            "missing error"
+        );
+        assert!(
+            output.contains("offsite drive not connected"),
+            "missing advisory"
+        );
+    }
+
+    #[test]
+    fn interactive_no_last_run() {
+        colored::control::set_override(false);
+        let data = StatusOutput {
+            assessments: vec![],
+            chain_health: vec![],
+            drives: vec![],
+            last_run: None,
+            total_pins: 0,
+        };
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("no runs recorded"),
+            "missing no-runs message"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- **New modules:** `output.rs` (structured output types, `OutputMode` enum) and `voice.rs` (rendering with interactive/daemon branches)
- **Status command migrated** as first consumer — produces `StatusOutput`, delegates rendering to `voice::render_status()`, integrates awareness model (STATUS column with promise states)
- **Global TTY color control** — force-off for non-TTY, respects `NO_COLOR`/`CLICOLOR` env vars on TTY
- **Double adversary-reviewed:** design review before code (rejected Renderer trait for enum + match), implementation review after (fixed 4 issues: `NO_COLOR` override, disabled subvolume filtering, redundant guard, missing advisory rendering)

## Testing

- cargo clippy: pass (zero warnings)
- cargo test: 186 tests, all passing
- Integration tests: not applicable (presentation layer, no I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)