### PR TITLE
docs: Formalize founding ADRs (ADR-100 through ADR-109)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,21 @@ These encode design decisions from the Norman UX analysis and user feedback:
   awareness model, reacts to events (drive plug, timer, backup result), updates promise
   states, and drives notifications. Other features subscribe to its event stream.
 
+### Architectural Invariants
+
+These rules are load-bearing. Violating them causes architectural damage that compounds.
+Each references an ADR in `docs/00-foundation/decisions/` with full rationale.
+
+1. **The planner never modifies anything.** Pure function: config + state in, plan out. (ADR-100)
+2. **All btrfs calls go through `BtrfsOps`.** No other module spawns btrfs subprocesses. (ADR-101)
+3. **Filesystem is truth, SQLite is history.** Pin files and snapshot dirs are authoritative. SQLite failures never prevent backups. (ADR-102)
+4. **Individual subvolume failures never abort the run.** The executor isolates errors per subvolume. (ADR-100)
+5. **Retention never deletes pinned snapshots.** Three independent layers: unsent protection, planner exclusion, executor re-check. (ADR-106)
+6. **Backups fail open; deletions fail closed.** Missing data means proceed and clean up, never refuse to back up. But never delete a snapshot you can't confirm is safe to remove. (ADR-107)
+7. **Core logic modules are pure functions.** Planner, awareness, retention, voice — inputs in, outputs out, no I/O. (ADR-108)
+8. **Validate at config boundary, trust afterward.** Paths and names validated once at load; no re-validation in hot paths. (ADR-109)
+9. **Backward compatibility contracts are sacred.** Snapshot names, pin files, Prometheus metrics — changes require an ADR with migration plan. (ADR-105)
+
 ## Coding Conventions
 
 - Standard Rust: `snake_case` functions, `CamelCase` types

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,18 @@ write a new document. When in doubt, supersede.
 2. Move the superseded document to `90-archive/` (mirroring original directory structure)
 3. Add a header to the new document: `**Supersedes:** [original title](../90-archive/path/to/original.md)`
 
+### ADR Numbering
+
+ADRs use two number ranges:
+
+| Range | Era | Location |
+|-------|-----|----------|
+| ADR-001–099 | Bash script era | `decisions/ADR-relating-to-bash-script/` |
+| ADR-100+ | Urd era | `decisions/` (top level) |
+
+New Urd ADRs increment from the highest existing number. Bash-era ADRs retain their
+original numbers and subdirectory for historical reference.
+
 ### ADR Lifecycle
 
 ADRs use explicit status tracking:
@@ -264,6 +276,34 @@ type should have. Add sections as needed.
 ## Decision
 
 ## Consequences
+```
+
+#### Design Proposal
+
+Use for features that introduce a new module, change a public interface, or affect more
+than 3 existing files. Not needed for bug fixes, config tweaks, or self-contained additions.
+The adversary review reviews the proposal before implementation begins.
+
+```markdown
+# Design: {Feature Name}
+
+> **TL;DR:** {2-3 sentences: what, why, key constraint}
+
+**Date:** YYYY-MM-DD
+**Status:** proposed | reviewed | accepted | abandoned
+**Depends on:** {prior features or ADRs}
+
+## Problem
+
+## Proposed Design
+
+## Invariants
+
+## Integration Points
+
+## Rejected Alternatives
+
+## Open Questions
 ```
 
 #### Idea

--- a/docs/00-foundation/decisions/2026-03-24-ADR-100-planner-executor-separation.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-100-planner-executor-separation.md
@@ -1,0 +1,79 @@
+# ADR-100: Planner/Executor Separation
+
+> **TL;DR:** The planner is a pure function that decides what operations to run. The executor
+> takes a plan and runs it. Neither crosses the boundary. This is the most important
+> architectural property in Urd — it enables full unit testing of backup logic without
+> touching the filesystem, and prevents the "did it decide wrong or execute wrong?" ambiguity
+> that plagued the bash script.
+
+**Date:** 2026-03-22 (formalized 2026-03-24)
+**Status:** Accepted
+**Supersedes:** None (founding decision from project inception)
+
+## Context
+
+The bash script (`btrfs-snapshot-backup.sh`, 1710 lines) interleaved decision logic with
+execution throughout. When a backup failed, diagnosing whether the *decision* was wrong
+(e.g., wrong parent selected for incremental send) or the *execution* was wrong (e.g.,
+btrfs command failed) required reading through tangled control flow. Testing required a
+real filesystem with real btrfs commands.
+
+Urd was designed from inception to separate these concerns completely.
+
+## Decision
+
+**The planner (`plan.rs`) is a pure function:**
+`fn plan(config, filesystem_state, now, filters) -> BackupPlan`
+
+- It reads config and filesystem state through the `FileSystemState` trait
+- It produces a list of `PlannedOperation` variants (CreateSnapshot, SendIncremental,
+  SendFull, DeleteSnapshot)
+- It never calls btrfs, writes files, modifies state, or performs I/O
+- It is fully unit-testable via `MockFileSystemState`
+
+**The executor (`executor.rs`) takes a plan and runs it:**
+
+- It executes each operation sequentially in plan order
+- It never decides *what* to do — that is the planner's job
+- It handles error isolation, cascading failure detection, crash recovery, and cleanup
+- It writes pin files, records state in SQLite, and calls btrfs via `BtrfsOps`
+
+**`urd plan` prints the plan. `urd backup --dry-run` prints it. `urd backup` executes it.**
+
+Every variant in `PlannedOperation` carries `subvolume_name` so operations are
+self-describing. Send variants carry `pin_on_success: Option<(PathBuf, SnapshotName)>` so
+the send/pin dependency is structural, not implicit.
+
+## Consequences
+
+### Positive
+
+- Backup logic is fully testable without a filesystem, sudo, or btrfs commands
+- `urd plan` gives the user a preview of exactly what `urd backup` will do
+- Bug diagnosis is unambiguous: plan bugs are in `plan.rs`, execution bugs are in
+  `executor.rs`
+- The `MockFileSystemState` + `MockBtrfs` combination enables comprehensive test coverage
+  (216 tests at time of writing, none requiring real btrfs)
+
+### Negative
+
+- The planner cannot know exact snapshot sizes, so the executor must re-check space during
+  external retention deletions (the planner proposes, the executor verifies)
+- Some operations have implicit ordering dependencies (create before send, send before
+  delete) that exist only in the plan emission order, not in a formal dependency graph
+
+### Constraints
+
+- New backup logic must go through the planner. No module may bypass the plan to execute
+  btrfs operations directly.
+- The `FileSystemState` trait is the planner's only window into the real world. Extending
+  the planner's awareness requires extending this trait.
+- The executor must not contain decision logic beyond error-handling decisions (skip
+  dependent operations after failure, stop deletions when space is sufficient).
+
+## Related
+
+- [Roadmap](../../96-project-supervisor/roadmap.md) §Architecture: Key Design Principles
+- [Phase 1 journal](../../98-journals/2026-03-22-urd-phase01.md) — original implementation
+- [Phase 2 journal](../../98-journals/2026-03-22-urd-phase02.md) — Executor Contract
+- ADR-101: BtrfsOps trait (the executor's interface to btrfs)

--- a/docs/00-foundation/decisions/2026-03-24-ADR-101-btrfsops-trait.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-101-btrfsops-trait.md
@@ -1,0 +1,81 @@
+# ADR-101: BtrfsOps Trait as Sole Btrfs Interface
+
+> **TL;DR:** All btrfs subprocess calls go through a single trait (`BtrfsOps`) in a single
+> module (`btrfs.rs`). `RealBtrfs` shells out to `sudo btrfs`; `MockBtrfs` records calls
+> for testing. No other module spawns btrfs processes. This constrains the sudo surface
+> area to one auditable location and makes the entire backup pipeline testable without
+> root privileges.
+
+**Date:** 2026-03-22 (formalized 2026-03-24)
+**Status:** Accepted
+**Supersedes:** None (founding decision)
+
+## Context
+
+Urd runs `sudo btrfs` commands that can create, send, receive, and delete subvolumes. A
+bug in path construction or argument handling could delete the wrong data. The bash script
+scattered btrfs calls across multiple functions, making it difficult to audit the full
+sudo surface area.
+
+Additionally, testing backup logic requires either real btrfs operations (slow, requires
+root, risks real data) or a way to mock them. The trait approach solves both problems.
+
+## Decision
+
+**`btrfs.rs` defines the `BtrfsOps` trait:**
+
+```rust
+pub trait BtrfsOps {
+    fn create_readonly_snapshot(&self, source: &Path, dest: &Path) -> Result<()>;
+    fn send_receive(&self, snapshot: &Path, parent: Option<&Path>,
+                    dest: &Path) -> Result<SendStats>;
+    fn delete_subvolume(&self, path: &Path) -> Result<()>;
+    fn subvolume_show(&self, path: &Path) -> Result<SubvolumeInfo>;
+}
+```
+
+**`RealBtrfs`** implements the trait by spawning `sudo btrfs` via `std::process::Command`.
+The send/receive pipeline spawns two processes piped together (not `sh -c "... | ..."`),
+captures stderr from both sides in background threads, checks both exit codes, and cleans
+up partial snapshots on failure.
+
+**`MockBtrfs`** records all calls for test assertions. It enables the executor's 12+ unit
+tests to run without root, without btrfs, and without a real filesystem.
+
+**No other module spawns btrfs subprocesses.** The executor, planner, commands, and all
+other modules interact with btrfs exclusively through this trait.
+
+## Consequences
+
+### Positive
+
+- The sudo surface area is one file (`btrfs.rs`), auditable in a single read
+- Two-process pipeline avoids shell injection risks from `sh -c` approach
+- Both stderr streams are captured, enabling precise error diagnostics
+- The entire backup pipeline (216 tests) runs without root privileges
+- Path arguments are passed as `&Path` to `Command::arg()`, never stringified — this
+  preserves non-UTF-8 paths and prevents injection
+
+### Negative
+
+- Two-process pipeline is more code than a shell pipe (thread for stderr draining, two
+  exit code checks, partial cleanup logic)
+- `MockBtrfs` cannot test filesystem preconditions (e.g., directory must exist for
+  `btrfs receive`) — tests requiring real filesystem interaction use `tempfile::TempDir`
+
+### Constraints
+
+- Adding new btrfs operations requires extending the `BtrfsOps` trait, both implementations,
+  and updating `MockBtrfs` assertions
+- The progress counter (`AtomicU64` for bytes transferred) stays outside the trait — it is
+  an implementation detail of `RealBtrfs`, not part of the interface
+- `subvolume_show` is used for crash recovery (checking if a partial snapshot exists at the
+  destination); it does not bypass the planner — the executor uses it for pre-execution
+  validation only
+
+## Related
+
+- ADR-100: Planner/executor separation (the trait's primary consumer)
+- [Phase 2 journal](../../98-journals/2026-03-22-urd-phase02.md) — send/receive pipeline design
+- [Phase 3 adversary review](../../99-reports/2026-03-22-phase3-adversary-review.md) —
+  removed `to_string_lossy()` from `RealBtrfs`

--- a/docs/00-foundation/decisions/2026-03-24-ADR-102-filesystem-truth-sqlite-history.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-102-filesystem-truth-sqlite-history.md
@@ -1,0 +1,79 @@
+# ADR-102: Filesystem as Source of Truth, SQLite as History
+
+> **TL;DR:** Snapshot directories and pin files on disk are the authoritative record of
+> what exists and what the incremental chain state is. SQLite records what *happened*
+> (runs, operations, outcomes) but is never consulted to determine what *exists*. SQLite
+> failures must never prevent backups from running.
+
+**Date:** 2026-03-22 (formalized 2026-03-24)
+**Status:** Accepted
+**Supersedes:** None (founding decision; supersedes early roadmap's `snapshots` table)
+
+## Context
+
+The original roadmap included a `snapshots` SQLite table that would track every snapshot's
+existence. This was removed before implementation because it created a sync problem:
+snapshot directories are the real truth (btrfs commands operate on them), and duplicating
+this in SQLite means either constantly syncing (expensive, error-prone) or tolerating
+divergence (confusing, dangerous for a backup tool).
+
+The bash script had no database and relied entirely on the filesystem. This worked but
+made historical queries impossible ("when did the last backup run? how long did it take?").
+
+## Decision
+
+**Filesystem is authoritative for current state:**
+
+- Snapshot directories (`<snapshot_root>/<subvolume>/`) determine what snapshots exist
+- Pin files (`.last-external-parent-<DRIVE_LABEL>`) determine the incremental chain state
+- Drive mount status (`/proc/mounts`, `statvfs`) determines drive availability
+- The planner reads all of these through the `FileSystemState` trait
+
+**SQLite is authoritative for historical state:**
+
+- `runs` table: when backups ran, how long they took, overall result
+- `operations` table: per-subvolume operations, duration, bytes transferred, errors
+- Queried by `urd history`, `urd status` (last run info), and space estimation
+
+**SQLite failures are non-fatal:**
+
+- If SQLite cannot record a run, the backup still executes
+- If SQLite is corrupt or missing, `urd backup` still works (it just can't report history)
+- `urd init` creates the database; if the database disappears, history is lost but backups
+  continue
+
+## Consequences
+
+### Positive
+
+- No sync problem between database and filesystem — one source of truth per domain
+- Crash recovery is simple: the filesystem is always the ground truth, regardless of
+  whether the last run recorded its state in SQLite
+- SQLite corruption (which does happen on unexpected power loss) cannot prevent the next
+  backup from running
+- `urd verify` checks pin files and snapshot directories directly, not a database cache
+
+### Negative
+
+- Some queries require both sources: `urd status` reads snapshot directories *and* SQLite
+  for a complete picture. This is acceptable because the two sources answer different
+  questions (what exists vs. what happened).
+- Space estimation uses historical SQLite data (last send sizes) — if history is lost,
+  estimation falls back to calibration data or fails open (allows the send)
+- No single "backup inventory" database — tools that want a snapshot catalog must enumerate
+  directories
+
+### Constraints
+
+- No module should write snapshot state to SQLite that contradicts what the filesystem shows.
+  If a snapshot was deleted but SQLite still lists it, the filesystem wins.
+- The `subvolume_sizes` table (used by `urd calibrate`) is calibration data, not source of
+  truth — it supplements but never overrides filesystem queries.
+- Pin files must be written atomically (temp file + rename) to prevent corruption on crash.
+
+## Related
+
+- ADR-100: Planner/executor separation (planner reads filesystem through trait)
+- [Roadmap](../../96-project-supervisor/roadmap.md) §SQLite Schema — documents the decision
+  to remove the `snapshots` table
+- [Phase 2 journal](../../98-journals/2026-03-22-urd-phase02.md) — state.rs implementation

--- a/docs/00-foundation/decisions/2026-03-24-ADR-103-interval-scheduling.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-103-interval-scheduling.md
@@ -1,0 +1,72 @@
+# ADR-103: Interval-Based Scheduling
+
+> **TL;DR:** Urd uses time intervals (`15m`, `1h`, `1d`) for snapshot and send scheduling
+> instead of cron-like schedules (`Daily`, `Weekly`, `FirstSaturday`). This was a conscious
+> departure from the bash script's model, driven by the Time Machine ambition: frequent
+> snapshots at configurable cadences per subvolume, not fixed calendar events.
+
+**Date:** 2026-03-22 (formalized 2026-03-24)
+**Status:** Accepted
+**Supersedes:** Roadmap's original `Schedule` enum (Daily/Weekly/Monthly/FirstSaturday/Never)
+
+## Context
+
+The original roadmap specified a `Schedule` enum with calendar-based variants matching the
+bash script's model: daily snapshots, weekly external sends, first-Saturday-of-month for
+some subvolumes. This was a direct port of the bash script's behavior.
+
+During Phase 1 implementation, the project's ambition was reconsidered: Urd is a "Time
+Machine for BTRFS on Linux," not a Rust rewrite of the bash script. Time Machine backs up
+*frequently* — every hour by default, every 15 minutes if the data is critical. Calendar
+schedules are too coarse for this model.
+
+## Decision
+
+Replace the `Schedule` enum with an `Interval` type that accepts human-readable duration
+strings:
+
+- `snapshot_interval`: how often to create local snapshots (e.g., `"15m"`, `"1h"`, `"1d"`)
+- `send_interval`: how often to send to external drives (e.g., `"1h"`, `"4h"`, `"1d"`)
+
+These are decoupled — a subvolume can snapshot every 15 minutes but only send externally
+every hour, reducing I/O on external drives while maintaining fine-grained local recovery.
+
+The planner checks whether enough time has elapsed since the last snapshot/send for each
+subvolume. If not, the operation is skipped with a "next in ~Xh" message. This makes the
+plan idempotent and safe to run repeatedly.
+
+Per-subvolume overrides inherit from `[defaults]`. Most subvolumes share the same policy;
+only those with different needs specify their own intervals.
+
+## Consequences
+
+### Positive
+
+- Sub-daily snapshots are natural (15m, 1h) — matches Time Machine's frequent-backup model
+- Per-subvolume cadences let critical data (home directory) snapshot more frequently than
+  stable data (music collection)
+- Decoupled snapshot/send intervals reduce unnecessary external I/O
+- The `[defaults]` inheritance model means most config is 3 lines, not repeated per subvolume
+
+### Negative
+
+- The planner needs "last snapshot time" from filesystem state to decide whether an interval
+  has elapsed — this is a filesystem read on every plan
+- No concept of "run on specific days" (e.g., "only send on Saturdays") — intervals always
+  run if enough time has elapsed. Weekly sends use `"1w"` interval, which is approximately
+  weekly but not day-specific.
+
+### Constraints
+
+- Snapshot naming includes time (`YYYYMMDD-HHMM-shortname`) to support sub-daily snapshots.
+  Legacy `YYYYMMDD-shortname` names are parsed as midnight for backward compatibility.
+- The systemd timer fires at a fixed time (02:00 daily). Interval-based scheduling means
+  "at least this much time between operations," not "run at this exact time." The timer
+  is the trigger; the intervals are the filter.
+
+## Related
+
+- ADR-104: Graduated retention (the retention model that handles frequent snapshots)
+- [Phase 1 journal](../../98-journals/2026-03-22-urd-phase01.md) — documents the redesign
+  from calendar schedules to intervals
+- [Roadmap](../../96-project-supervisor/roadmap.md) — original Schedule enum specification

--- a/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
@@ -1,0 +1,91 @@
+# ADR-104: Graduated Retention Model
+
+> **TL;DR:** Urd uses Time Machine-style graduated retention — keep everything recent, thin
+> progressively with age — instead of fixed snapshot counts. Local retention has four time
+> windows (hourly, daily, weekly, monthly). External retention uses count-based limits with
+> space-governed cleanup. Space pressure mode aggressively thins when the filesystem is low.
+
+**Date:** 2026-03-22 (formalized 2026-03-24)
+**Status:** Accepted
+**Supersedes:** Roadmap's original fixed-count retention (`daily_keep`/`weekly_keep`/`monthly_keep`)
+
+## Context
+
+The bash script used flat retention: keep the last N snapshots, delete the rest. With daily
+snapshots this was adequate (keep 15 = 15 days of history). But with interval-based
+scheduling producing snapshots every 15 minutes to every hour, flat retention would either
+keep too few (losing history depth) or too many (filling the disk).
+
+The NVMe system drive (~128GB) hosts `htpc-home` and `htpc-root` snapshots. The btrfs-pool
+(multi-TB) hosts 7 subvolumes. These have very different space constraints, and the
+retention model must handle both.
+
+## Decision
+
+### Local retention: graduated time windows
+
+```toml
+[defaults.local_retention]
+hourly = 24      # keep 24 hourly snapshots (1 day of hourly granularity)
+daily = 30       # then 30 daily (1 per day, newest in each day)
+weekly = 26      # then 26 weekly (1 per ISO week)
+monthly = 12     # then 12 monthly (1 per calendar month)
+```
+
+Within each window, keep the *newest* snapshot per time period. This produces ~92 snapshots
+covering ~18 months, with fine granularity for recent data and coarse granularity for old.
+
+Per-subvolume overrides use `Option<u32>` fields that merge with defaults. A subvolume can
+override `daily = 7` without restating all four windows.
+
+### Space pressure mode
+
+When a snapshot root's filesystem drops below `min_free_bytes`, the retention engine enters
+space pressure mode: the hourly window is thinned to 1 per hour instead of keeping
+everything. This is the first line of defense for the NVMe drive.
+
+### External retention: count-based + space-governed
+
+External drives use simpler count-based retention (e.g., keep last 14 per subvolume) with
+space-governed cleanup. The executor deletes oldest-first and re-checks free space after
+each deletion, stopping when the space threshold is met. This fills the drive intelligently
+without requiring the planner to know exact snapshot sizes.
+
+### Monthly retention uses calendar month subtraction
+
+Not `days * 30`. A snapshot from January 31 is "1 month old" on February 28, not on
+March 2. This prevents the slow drift that accumulates with day-based month approximation.
+
+## Consequences
+
+### Positive
+
+- Recovery window spans months with manageable snapshot counts (~92 per subvolume locally)
+- Fine granularity when most useful (recent) and coarse when acceptable (old)
+- Space pressure prevents the NVMe from filling — critical for system health
+- Offsite drive pin parents survive for ~5 months under graduated retention, supporting
+  quarterly drive rotation without forcing full sends (see ADR-020)
+- External space-governed cleanup adapts to actual snapshot sizes without estimation
+
+### Negative
+
+- Graduated retention is more complex to implement and reason about than flat counts
+- Space pressure mode can delete snapshots the user expects to keep — this is intentional
+  (disk full is worse) but may surprise users
+- The planner's retention proposals and the executor's space-governed reality can diverge
+  — the executor logs skipped deletions so the operator can see the difference
+
+### Constraints
+
+- Retention must never delete a snapshot that is the current pin parent for any drive.
+  This is enforced at both the planner level (exclusion) and executor level
+  (defense-in-depth re-check before deletion).
+- When `send_enabled` is true, snapshots newer than the oldest pin are protected from
+  local retention — they may not have been sent to all drives yet.
+
+## Related
+
+- ADR-020: Daily external backups (graduated retention enables quarterly offsite rotation)
+- ADR-103: Interval-based scheduling (frequent snapshots require graduated retention)
+- [Phase 1 journal](../../98-journals/2026-03-22-urd-phase01.md) — retention redesign
+- [Roadmap](../../96-project-supervisor/roadmap.md) — original flat retention specification

--- a/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
@@ -1,0 +1,92 @@
+# ADR-105: Backward Compatibility Contracts
+
+> **TL;DR:** Four data formats are load-bearing — snapshot names, snapshot directory
+> structure, pin files, and Prometheus metrics. External systems (bash script, Grafana,
+> monitoring) depend on them. Urd reads both legacy and current formats but only writes
+> the current format. Breaking these contracts requires a migration plan and an ADR.
+
+**Date:** 2026-03-22 (formalized 2026-03-24)
+**Status:** Accepted
+**Supersedes:** None (founding decision)
+
+## Context
+
+Urd replaces a 1710-line bash script that has been running production backups. During the
+migration period (parallel running) and afterward, Urd must coexist with existing data:
+snapshot directories created by the bash script, pin files written by either system,
+Prometheus metrics consumed by Grafana dashboards with existing alerting rules.
+
+Breaking any of these formats would mean either data loss (can't find/use existing
+snapshots), monitoring blindness (Grafana dashboards break), or chain corruption (wrong
+pin file format breaks incremental sends).
+
+## Decision
+
+### Contract 1: Snapshot naming
+
+- **Current (write):** `YYYYMMDD-HHMM-shortname` (e.g., `20260322-1430-opptak`)
+- **Legacy (read-only):** `YYYYMMDD-shortname` (e.g., `20260322-opptak`)
+- Legacy names are parsed as midnight. Both formats coexist in snapshot directories.
+- Ordering is by parsed datetime, not by string sort.
+- `SnapshotName` type in `types.rs` handles both formats transparently.
+
+### Contract 2: Snapshot directory structure
+
+- `<snapshot_root>/<subvolume_name>/<snapshot_name>`
+- Same structure as the bash script. No migration needed.
+- `urd get` relies on this structure for O(1) path construction.
+
+### Contract 3: Pin files
+
+- **Current (read+write):** `.last-external-parent-<DRIVE_LABEL>` containing snapshot name
+- **Legacy (read-only):** `.last-external-parent` (no drive label, single-drive era)
+- Drive-specific pins take precedence over legacy when both exist.
+- `PinResult` type distinguishes `DriveSpecific` from `Legacy` source.
+- Legacy pins are downgraded to WARN (not FAIL) in `urd verify`.
+- Pin files are written atomically (temp file + rename).
+
+### Contract 4: Prometheus metrics
+
+- Exact metric names, label names, label values, and value semantics match the bash
+  script's output.
+- `backup_success`, `backup_last_success_timestamp`, `backup_duration_seconds`,
+  `backup_snapshot_count`, `backup_send_type` (per-subvolume with `subvolume` label).
+- `backup_external_drive_mounted`, `backup_external_free_bytes`,
+  `backup_script_last_run_timestamp` (global).
+- Multi-drive note: global metrics report first mounted drive for bash compatibility.
+  Per-drive metrics may be added later but must not replace the global ones.
+- Written atomically (temp file + rename) to prevent partial reads by node exporter.
+
+## Consequences
+
+### Positive
+
+- Parallel running with the bash script works without conflicts — both systems read and
+  write the same formats (pin files: last writer wins, which is correct behavior)
+- Grafana dashboards continue working during and after migration with zero changes
+- Existing snapshots (potentially months of history) are immediately usable by Urd
+- `urd verify` can validate the entire snapshot estate, including legacy data
+
+### Negative
+
+- Legacy format support adds parsing complexity (dual-format `SnapshotName`, legacy pin
+  fallback, `PinSource` enum)
+- Global Prometheus metrics assume a single-drive model — multi-drive metrics will need
+  new metric names alongside (not replacing) the existing ones
+- Legacy pin files should eventually be cleaned up (planned for 30+ days after bash
+  retirement) but must be kept during the transition
+
+### Constraints
+
+- Changes to any of these four formats require a new ADR with a migration plan.
+- New metrics may be added freely but existing metric names, labels, and semantics must
+  not change.
+- Legacy snapshot names will exist on disk indefinitely (old snapshots are not renamed).
+  All code that handles snapshot names must support both formats permanently.
+
+## Related
+
+- ADR-020: Daily external backups (established the dual pin file format)
+- [Roadmap](../../96-project-supervisor/roadmap.md) §Backward Compatibility, §Prometheus Metrics
+- [Pre-cutover hardening journal](../../98-journals/2026-03-24-pre-cutover-hardening.md) —
+  legacy pin handling refinement

--- a/docs/00-foundation/decisions/2026-03-24-ADR-106-defense-in-depth-data-integrity.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-106-defense-in-depth-data-integrity.md
@@ -1,0 +1,91 @@
+# ADR-106: Defense-in-Depth for Data Integrity
+
+> **TL;DR:** Retention and deletion logic uses multiple independent layers of protection so
+> that silent data loss requires multiple simultaneous failures. Pinned snapshots are guarded
+> by the planner (exclusion), executor (re-check), and unsent snapshot protection (blanket
+> guard). Each layer is independently testable and independently sufficient.
+
+**Date:** 2026-03-22 (identified in Phase 1 hardening; formalized 2026-03-24)
+**Status:** Accepted
+**Supersedes:** None (crystallized across Phase 1–5 adversary reviews)
+
+## Context
+
+For a backup tool on a BTRFS pool with no RAID, silent data loss is the catastrophic
+failure mode. The most direct path to it: retention deletes the last copy of a snapshot
+that hasn't been sent to an external drive. If this happens silently (no error, no log),
+the user discovers the gap only when they need to restore — which is too late.
+
+The Phase 1 adversary review identified this risk. The Phase 1 hardening review introduced
+unsent snapshot protection. Every subsequent review validated and extended the layered
+approach.
+
+## Decision
+
+### Layer 1: Unsent snapshot protection (planner)
+
+When `send_enabled` is true for a subvolume, the planner protects snapshots that may not
+yet have been sent to all drives:
+
+- If pins exist: protect all snapshots newer than the oldest pin parent
+- If no pins exist (first run): protect everything — no snapshot is deleted until at
+  least one successful send establishes a pin
+- If `send_enabled` is false: no protection (normal retention applies)
+
+This is a blanket guard. It does not check whether each individual snapshot has been sent
+— it protects the entire window between the oldest pin and now.
+
+### Layer 2: Pin-based exclusion (planner)
+
+The planner's retention logic excludes all pinned snapshot names from the deletion candidate
+set. A snapshot that is any drive's current pin parent is never proposed for deletion,
+regardless of its age or retention window.
+
+### Layer 3: Pin re-check (executor)
+
+Before executing any `DeleteSnapshot` operation, the executor re-reads pin files and
+verifies the target is not currently pinned. This catches any TOCTOU race between planning
+and execution (e.g., another process wrote a pin file between plan and execute).
+
+### Each layer is independently sufficient
+
+If Layer 1 fails (bug in unsent protection), Layer 2 still excludes pinned snapshots.
+If Layer 2 fails (bug in retention exclusion), Layer 3 catches it at execution time.
+If Layer 3 fails (bug in re-check), Layers 1 and 2 have already prevented the snapshot
+from being in the deletion list.
+
+Silent data loss requires all three layers to fail simultaneously on the same snapshot.
+
+## Consequences
+
+### Positive
+
+- The most direct path to catastrophic failure requires three independent bugs
+- Each layer is unit-testable in isolation (planner tests for Layer 1–2, executor tests
+  for Layer 3)
+- The layers compose without knowing about each other — no coupling between them
+
+### Negative
+
+- Redundant checks add code complexity (the executor's pin re-check is "unnecessary" if
+  the planner works correctly)
+- The defense-in-depth philosophy means some code exists solely for safety, not for
+  correctness under normal operation — this can look like dead code to someone unfamiliar
+  with the rationale
+
+### Constraints
+
+- New deletion paths (e.g., `urd prune`, manual cleanup commands) must implement at
+  minimum Layer 2 (pin exclusion) and Layer 3 (pre-deletion pin check). Layer 1 applies
+  only to automated retention.
+- Pin file writes must be atomic (temp + rename). A corrupted pin file could cause both
+  Layer 2 and Layer 3 to miss the protection.
+
+## Related
+
+- ADR-100: Planner/executor separation (the layers map to the planner/executor boundary)
+- ADR-104: Graduated retention (the retention logic where these layers operate)
+- [Phase 1 hardening review](../../99-reports/2026-03-22-phase1-hardening-review.md) —
+  unsent snapshot protection introduced
+- [Phase 3.5 adversary review](../../99-reports/2026-03-22-arch-adversary-phase35.md) —
+  "three layers of protection" articulated

--- a/docs/00-foundation/decisions/2026-03-24-ADR-107-fail-open-cleanup-on-failure.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-107-fail-open-cleanup-on-failure.md
@@ -1,0 +1,104 @@
+# ADR-107: Fail-Open for Backups, Clean Up on Failure
+
+> **TL;DR:** When Urd cannot determine whether an operation is safe (missing size data,
+> unknown drive state, no history), it proceeds with the backup and cleans up on failure.
+> For a backup tool, "tried and failed" is strictly better than "refused to try." The one
+> exception: operations that could delete data fail closed.
+
+**Date:** 2026-03-22 (implicit in Phase 2; crystallized in space estimation review 2026-03-23)
+**Status:** Accepted
+**Supersedes:** None (crystallized across space estimation and awareness model reviews)
+
+## Context
+
+Urd faces many situations where it has incomplete information:
+
+- First send to a drive: no size history, no calibration data
+- Drive with unknown free space: statvfs may fail
+- Filesystem query error: can't enumerate snapshots
+- Awareness model: can't determine last send time from SQLite
+
+The bash script handled most of these by aborting. This meant a single transient error
+(unmounted drive, SQLite lock) could prevent all backups from running.
+
+## Decision
+
+### Backup operations fail open
+
+When information is missing or uncertain, Urd proceeds with the backup attempt:
+
+- **No send size history:** Send proceeds. If it fills the drive, the executor cleans up
+  the partial snapshot. The next run has history to estimate from.
+- **SQLite query fails:** Log warning, continue with backup. History is lost but data is
+  protected.
+- **Filesystem enumeration fails for one subvolume:** Log error, skip that subvolume,
+  continue with others (error isolation per ADR-100).
+- **Awareness model can't compute status:** Return best-effort assessment with errors
+  captured in the assessment, not UNPROTECTED by default.
+
+### Cleanup, not resumption
+
+BTRFS does not support resumable receives. When a send/receive fails mid-transfer:
+
+1. The executor detects the failure (both exit codes, both stderr streams)
+2. The partial snapshot at the destination is deleted via `btrfs subvolume delete`
+3. The pin file is not updated (send did not succeed)
+4. The next run attempts a fresh send
+
+On subsequent startup, the executor checks for pre-existing snapshots at the destination.
+If the pin file doesn't reference them, they're treated as partials from an interrupted
+prior run and deleted before proceeding.
+
+### Deletion operations fail closed
+
+The fail-open principle applies to *creating* backups, not to *deleting* data:
+
+- Retention won't delete a snapshot it can't confirm is unpinned (Layer 3, ADR-106)
+- Space estimation won't delete more than planned, even if more space is needed
+- External retention stops deleting once the space threshold is met
+
+### The clock-skew exception
+
+The awareness model clamps negative ages (future-dated snapshots) to zero rather than
+reporting them as "fresh." A negative duration evaluating as PROTECTED would be a
+false-positive — one step from the catastrophic failure mode. This is the one case where
+fail-open was constrained to prevent masking a real problem.
+
+## Consequences
+
+### Positive
+
+- First-ever sends to a new drive always succeed (given sufficient space), establishing
+  the history needed for future estimation
+- Transient errors (SQLite locks, network filesystem hiccups) don't prevent backups
+- The system self-heals: one failed send provides the size data to avoid the next failure
+- No "bootstrap problem" where the tool can't run because it lacks the data it can only
+  get by running
+
+### Negative
+
+- A first send to a nearly-full drive will fail and require cleanup — this is a known
+  cost, and cleanup is well-tested
+- Fail-open means Urd may attempt operations that will predictably fail (e.g., sending
+  a 3TB subvolume to a drive with 1TB free on the first attempt before history exists)
+- The user may see a failed send on the first run that succeeds on subsequent runs —
+  this can be confusing without context
+
+### Constraints
+
+- All fail-open paths must log clearly why the operation proceeded with incomplete data.
+  Silent fail-open is indistinguishable from a bug.
+- Partial snapshot cleanup must be idempotent — the cleanup itself must not fail in a way
+  that prevents the next run.
+- The `bytes_transferred` field on failed sends must be recorded so that even failed
+  attempts contribute to future size estimation (MAX of successful and failed).
+
+## Related
+
+- ADR-106: Defense-in-depth (deletion fails closed while backup fails open)
+- ADR-102: Filesystem truth (crash recovery relies on filesystem, not SQLite)
+- [Space estimation adversary review](../../99-reports/2026-03-23-arch-adversary-space-estimation.md) —
+  "No history → allow the send"
+- [Awareness model design review](../../99-reports/2026-03-23-awareness-model-design-review.md) —
+  clock skew exception
+- [Phase 2 journal](../../98-journals/2026-03-22-urd-phase02.md) — crash recovery design

--- a/docs/00-foundation/decisions/2026-03-24-ADR-108-pure-function-module-pattern.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-108-pure-function-module-pattern.md
@@ -1,0 +1,105 @@
+# ADR-108: Pure-Function Module Pattern
+
+> **TL;DR:** Core logic modules are pure functions: inputs in (config, state, time),
+> outputs out (plan, assessment, rendered text). No I/O, no side effects, fully testable
+> with mocks. This pattern was established by the planner, validated by adversary reviews,
+> and is now the required pattern for new logic modules.
+
+**Date:** 2026-03-22 (established by planner; pattern recognized 2026-03-23)
+**Status:** Accepted
+**Supersedes:** None (crystallized across awareness model and presentation layer reviews)
+
+## Context
+
+The planner was designed as a pure function from the start (ADR-100). When the awareness
+model was designed in Phase 5, the adversary review explicitly required it to follow the
+same pattern: "Following the planner pattern, the awareness model is a pure function."
+
+When the presentation layer was designed, the same pattern applied again: commands produce
+structured data, the voice module renders it without I/O dependencies.
+
+Three independent modules following the same pattern is no longer a coincidence — it's an
+architectural convention that should be explicit.
+
+## Decision
+
+**New modules that compute, decide, or transform must be pure functions.**
+
+The pattern:
+
+```rust
+// Module signature
+pub fn assess(config: &Config, now: NaiveDateTime,
+              fs: &dyn FileSystemState) -> Vec<SubvolAssessment>
+
+pub fn plan(config: &Config, now: NaiveDateTime,
+            fs: &dyn FileSystemState) -> BackupPlan
+
+pub fn render_status(output: &StatusOutput, mode: OutputMode) -> String
+```
+
+**Inputs:** Config, current time, filesystem state (via trait), structured data from
+other modules. All passed as arguments, never read from global state or I/O.
+
+**Outputs:** Structured types (plans, assessments, rendered strings). Never write to
+disk, network, or database.
+
+**Testing:** Use `MockFileSystemState` (or equivalent mock) to control all inputs.
+Tests are deterministic — same inputs always produce same outputs.
+
+### Modules that follow this pattern
+
+| Module | Function | Inputs | Output |
+|--------|----------|--------|--------|
+| `plan.rs` | `plan()` | Config, time, FileSystemState | BackupPlan |
+| `awareness.rs` | `assess()` | Config, time, FileSystemState | Vec\<SubvolAssessment\> |
+| `retention.rs` | `graduated_retention()` | Snapshots, config, time | Keep/delete lists |
+| `voice.rs` | `render_status()` | StatusOutput, OutputMode | String |
+
+### Modules that are intentionally NOT pure
+
+| Module | Why |
+|--------|-----|
+| `executor.rs` | Performs I/O by design — the impure counterpart to the pure planner |
+| `btrfs.rs` | Wraps subprocess calls — the I/O boundary |
+| `state.rs` | SQLite operations — the persistence boundary |
+| `commands/` | CLI handlers that wire pure modules to I/O |
+
+## Consequences
+
+### Positive
+
+- Core logic is testable without filesystem, sudo, network, or database
+- 216 tests run without root privileges, with deterministic results
+- Modules compose freely: the heartbeat writer calls the awareness model, the status
+  command calls both awareness and voice — no coupling through shared I/O state
+- Bug diagnosis is clear: if the output is wrong, the bug is in the pure function's
+  logic, not in I/O timing or state
+
+### Negative
+
+- The `FileSystemState` trait grows as modules need more information about the real world
+  (currently 10 methods). This is acceptable — the trait is the explicit boundary between
+  pure logic and impure I/O.
+- Some operations don't fit the pattern cleanly (e.g., progress display is streaming I/O
+  interleaved with execution). These stay in impure modules, which is correct.
+
+### Constraints
+
+- New logic modules (e.g., trend analysis, notification rules, config validation/simulation)
+  should follow this pattern unless there is a clear reason not to.
+- The `FileSystemState` trait is the planner's and awareness model's only window into the
+  real world. Extending a pure module's awareness requires extending this trait, not
+  adding I/O calls.
+- Test coverage for pure modules should be exhaustive — the absence of I/O removes any
+  excuse for untested paths.
+
+## Related
+
+- ADR-100: Planner/executor separation (the original instance of this pattern)
+- [Awareness model design review](../../99-reports/2026-03-23-awareness-model-design-review.md) —
+  "Following the planner pattern"
+- [Presentation layer design review](../../99-reports/2026-03-24-presentation-layer-design-review.md) —
+  "commands produce structured types, not formatted strings"
+- [Vision architecture review](../../99-reports/2026-03-23-vision-architecture-review.md) §2 —
+  awareness model must work without Sentinel

--- a/docs/00-foundation/decisions/2026-03-24-ADR-109-config-boundary-validation.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-109-config-boundary-validation.md
@@ -1,0 +1,95 @@
+# ADR-109: Config-Boundary Validation
+
+> **TL;DR:** All user-provided paths and names are validated once at config load time.
+> After validation, internal code trusts the values. This constrains the sudo attack
+> surface to a single auditable validation point rather than scattered checks throughout
+> the codebase.
+
+**Date:** 2026-03-22 (added during Phase 1 hardening; formalized 2026-03-24)
+**Status:** Accepted
+**Supersedes:** None (crystallized across Phase 1 hardening and Phase 3.5 reviews)
+
+## Context
+
+Urd passes user-configured paths to `sudo btrfs subvolume delete`, `sudo btrfs send`,
+and `sudo btrfs receive`. A path traversal bug (e.g., `../../../important-data` in a
+snapshot name) could cause deletion of arbitrary data with root privileges.
+
+The Phase 1 hardening review identified this risk and introduced validation functions.
+The Phase 3.5 adversary review confirmed the approach: "Every path that reaches `sudo
+btrfs` has been validated."
+
+## Decision
+
+### Validate at config load, trust afterward
+
+`Config::validate()` runs once when the config is loaded. It enforces:
+
+| Check | Rejects | Why |
+|-------|---------|-----|
+| Paths are absolute | `./relative/path` | Prevents CWD-dependent behavior |
+| No `..` components | `/snapshots/../etc/shadow` | Prevents path traversal |
+| Names contain no path separators | `foo/bar` as subvolume name | Prevents directory escape |
+| Names contain no null bytes | `foo\x00bar` | Prevents C-string truncation |
+| Drive labels are filesystem-safe | Labels with `/` or `\` | Labels become path components |
+| UUIDs are unique (case-insensitive) | Two drives with same UUID | Prevents identity confusion |
+
+### Config file is trusted input
+
+The config file (`~/.config/urd/urd.toml`) is owned by the user and writable only by
+them. It is treated as trusted input — if the user can write arbitrary content to their
+own config file, they already have the access that a config injection would provide.
+
+This means validation is for **correctness** (catching typos, malformed paths), not for
+**security against the config author**. The security boundary is between the config and
+the system — validated paths are safe to pass to sudo commands.
+
+### No re-validation in hot paths
+
+After `Config::validate()` succeeds, modules that consume config values (planner, executor,
+btrfs.rs) do not re-validate paths. This is intentional — re-validation in hot paths is
+both wasteful and prone to inconsistency (different modules validating different subsets
+of rules).
+
+### Filesystem-derived values get separate validation
+
+Values read from the filesystem (snapshot names from directory listings, pin file contents)
+are validated at their own boundary — when they are parsed. `SnapshotName::new()` validates
+format. Pin file contents are validated against the expected snapshot name pattern. These
+are separate from config validation because they come from a different trust boundary.
+
+## Consequences
+
+### Positive
+
+- The sudo attack surface is auditable in one function (`Config::validate()`)
+- Path construction throughout the codebase is simple — `join()` on validated components
+  without defensive checks at every call site
+- Config errors are caught early (at startup), not mid-backup when a malformed path
+  reaches a sudo command
+
+### Negative
+
+- If validation is incomplete (a new field is added without validation), the gap silently
+  passes invalid values through. Mitigation: adversary reviews check new config fields
+  against the validation function.
+- Snapshot names from the filesystem could theoretically contain adversarial values if
+  someone manually creates a snapshot with a malicious name. Mitigation: `SnapshotName`
+  parsing rejects names that don't match the expected format.
+
+### Constraints
+
+- New config fields that become path components or command arguments must be added to
+  `Config::validate()`.
+- `btrfs.rs` must pass paths as `&Path` to `Command::arg()`, never as stringified
+  arguments. This preserves non-UTF-8 paths and prevents shell injection.
+- `urd get` has its own path validation (normalize, traversal check, starts_with) because
+  it accepts user-provided paths at runtime, not from config.
+
+## Related
+
+- ADR-101: BtrfsOps trait (the module where validated paths reach sudo commands)
+- [Phase 1 hardening review](../../99-reports/2026-03-22-phase1-hardening-review.md) —
+  path validation introduced
+- [Phase 3.5 adversary review](../../99-reports/2026-03-22-arch-adversary-phase35.md) —
+  "Every path that reaches `sudo btrfs` has been validated"

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -373,59 +373,51 @@ for details.
 - [ ] _(this repo)_ Write ADR-021: migration decision record
 - [ ] _(this repo)_ Clean up legacy `.last-external-parent` pin files (wait 30+ days after bash retirement)
 
+## Founding ADRs
+
+These architectural decisions were made at project inception and formalized as ADRs on
+2026-03-24. They constrain all future work. See `docs/00-foundation/decisions/` for full
+rationale.
+
+| ADR | Decision | Reference |
+|-----|----------|-----------|
+| [ADR-100](../00-foundation/decisions/2026-03-24-ADR-100-planner-executor-separation.md) | Planner is a pure function; executor runs the plan | Founding decision |
+| [ADR-101](../00-foundation/decisions/2026-03-24-ADR-101-btrfsops-trait.md) | All btrfs calls go through `BtrfsOps` trait | Founding decision |
+| [ADR-102](../00-foundation/decisions/2026-03-24-ADR-102-filesystem-truth-sqlite-history.md) | Filesystem is truth, SQLite is history | Founding decision |
+| [ADR-103](../00-foundation/decisions/2026-03-24-ADR-103-interval-scheduling.md) | Interval-based scheduling, not cron-like | Phase 1 redesign |
+| [ADR-104](../00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md) | Graduated retention (hourly/daily/weekly/monthly) | Phase 1 redesign |
+| [ADR-105](../00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md) | Snapshot names, pin files, metrics are contracts | Founding decision |
+| [ADR-106](../00-foundation/decisions/2026-03-24-ADR-106-defense-in-depth-data-integrity.md) | Three-layer protection against silent data loss | Phase 1 hardening |
+| [ADR-107](../00-foundation/decisions/2026-03-24-ADR-107-fail-open-cleanup-on-failure.md) | Backups fail open; deletions fail closed | Phase 2 + space estimation |
+| [ADR-108](../00-foundation/decisions/2026-03-24-ADR-108-pure-function-module-pattern.md) | Core logic modules are pure functions | Planner → awareness → voice |
+| [ADR-109](../00-foundation/decisions/2026-03-24-ADR-109-config-boundary-validation.md) | Validate at config boundary, trust afterward | Phase 1 hardening |
+| [ADR-020](../00-foundation/decisions/ADR-relating-to-bash-script/2026-03-21-ADR-020-daily-external-backups.md) | Daily external sends, graduated local retention | Bash-era, still active |
+
 ## Recent Decisions
+
+Current-phase decisions. Older decisions have been graduated to ADRs or remain in their
+review/journal references. See the [design evolution analysis](../99-reports/2026-03-24-design-evolution-analysis.md)
+for the graduation rationale.
 
 | Decision | Date | Reference |
 |----------|------|-----------|
-| Asymmetric multipliers: local 2x/5x, external 1.5x/3x | 2026-03-23 | [Awareness model design review](../99-reports/2026-03-23-awareness-model-design-review.md) |
-| Overall status = max() across drives (best drive wins), offsite as advisory | 2026-03-23 | [Awareness model design review](../99-reports/2026-03-23-awareness-model-design-review.md) |
-| Clock skew: clamp negative ages to zero, emit advisory | 2026-03-23 | [Awareness model impl review](../99-reports/2026-03-23-awareness-model-implementation-review.md) |
 | Awareness model as standalone pure function (not inside Sentinel) | 2026-03-23 | [Vision architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §2 |
 | Sentinel decomposed: awareness + event reactor + notification dispatcher | 2026-03-23 | [Vision architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §2 |
 | Protection promises need ADR before code (policy design problem) | 2026-03-23 | [Vision architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §1 |
 | Presentation layer: commands produce data, voice module renders text | 2026-03-23 | [Vision architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §4 |
-| `urd get` (O(1) path) ships before `urd find` (unsolved perf problem) | 2026-03-23 | [Vision architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §5 |
-| Heartbeat schema versioned from day one, atomic writes, staleness advisory | 2026-03-23 | [Vision architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §6 |
-| Heartbeat includes per-subvolume promise status (not just timestamp) | 2026-03-24 | [Heartbeat design review](../99-reports/2026-03-24-heartbeat-design-review.md) Finding 1 |
-| Heartbeat written on empty/skipped runs too (prevents false staleness) | 2026-03-24 | [Heartbeat design review](../99-reports/2026-03-24-heartbeat-design-review.md) Finding 3 |
-| stale_after = now + min(configured_intervals) × 2, matching awareness AT_RISK | 2026-03-24 | [Heartbeat design review](../99-reports/2026-03-24-heartbeat-design-review.md) Tension 3 |
-| Heartbeat uses fresh timestamp at write time, not pre-execution `now` | 2026-03-24 | [Heartbeat impl review](../99-reports/2026-03-24-heartbeat-implementation-review.md) Finding 1 |
-| OutputMode enum + match, not Renderer trait (two impls don't justify dyn dispatch) | 2026-03-24 | [Presentation layer review](../99-reports/2026-03-24-presentation-layer-design-review.md) |
-| Status command migrated first; other commands migrate incrementally | 2026-03-24 | [Presentation layer review](../99-reports/2026-03-24-presentation-layer-design-review.md) |
-| Progress display stays in backup.rs (streaming I/O doesn't fit produce-data/render) | 2026-03-24 | [Presentation layer review](../99-reports/2026-03-24-presentation-layer-design-review.md) |
-| TTY color: force-off for non-TTY only, respect NO_COLOR/CLICOLOR on TTY | 2026-03-24 | [Presentation layer impl review](../99-reports/2026-03-24-presentation-layer-implementation-review.md) Finding 1 |
-| Protection promises as core abstraction (score 10/10) | 2026-03-23 | [Vision brainstorm](../95-ideas/2026-03-23-brainstorm-realizing-the-vision.md) |
-| Mythic voice emerges from presentation layer, not scattered string edits | 2026-03-23 | User + architecture review |
-| Two modes: invisible worker + invoked norn | 2026-03-23 | User feedback on vision brainstorm |
-| SSH remote targets deferred — keep app simple for now | 2026-03-23 | User ranking (score 4/10) |
-| Daily external sends for Tier 1/2 (RPO 7d → 1d) | 2026-03-21 | [ADR-020](../00-foundation/decisions/ADR-relating-to-bash-script/2026-03-21-ADR-020-daily-external-backups.md) |
-| Pre-send space estimation using historical data | 2026-03-23 | [Journal](../98-journals/2026-03-23-space-estimation-and-testing.md) |
-| Drop Tier 2 and qgroup option from size estimation | 2026-03-23 | [Adversary review](../99-reports/2026-03-23-arch-adversary-proposal-review.md) |
-| Keep progress counter out of BtrfsOps trait | 2026-03-23 | [Adversary review](../99-reports/2026-03-23-arch-adversary-proposal-review.md) Finding 4 |
-| Calibrate on snapshots, not live sources | 2026-03-23 | [Adversary review](../99-reports/2026-03-23-arch-adversary-proposal-review.md) Finding 5 |
-| UrdError::Btrfs struct variant (not separate type) for partial bytes | 2026-03-23 | [Post-cutover journal](../98-journals/2026-03-23-post-cutover-features.md) |
-| MAX(successful, failed) for send size estimation | 2026-03-23 | [Post-cutover journal](../98-journals/2026-03-23-post-cutover-features.md) |
-| `urd get` uses `--at` flag not `@` syntax (avoids filename ambiguity) | 2026-03-24 | [urd get design review](../99-reports/2026-03-24-urd-get-design-review.md) Tension 1 |
-| Automatic subvolume detection via longest-prefix match on source paths | 2026-03-24 | [urd get design review](../99-reports/2026-03-24-urd-get-design-review.md) Tension 2 |
-| Nearest-before-or-equal snapshot selection (time-travel semantic) | 2026-03-24 | [urd get design review](../99-reports/2026-03-24-urd-get-design-review.md) Tension 3 |
-| stdout for content, stderr for metadata (Unix tool convention) | 2026-03-24 | [urd get design review](../99-reports/2026-03-24-urd-get-design-review.md) Tension 4 |
-| Minimal date parsing: 5 formats, no NLP (extend later if needed) | 2026-03-24 | [urd get design review](../99-reports/2026-03-24-urd-get-design-review.md) Finding 3 |
-| Remove short_name snapshot filter — directory structure already scopes | 2026-03-24 | [urd get impl review](../99-reports/2026-03-24-urd-get-implementation-review.md) Finding 1 |
-| `--output` overwrite protection (error if file exists) | 2026-03-24 | [urd get impl review](../99-reports/2026-03-24-urd-get-implementation-review.md) Finding 3 |
+| OutputMode enum + match, not Renderer trait | 2026-03-24 | [Presentation layer review](../99-reports/2026-03-24-presentation-layer-design-review.md) |
 | `DriveAvailability` enum (not bool) — skip reasons are safety-critical | 2026-03-24 | [UUID design review](../99-reports/2026-03-24-uuid-fingerprinting-design-review.md) Tension 2 |
-| `findmnt -n -o UUID` for detection (no sudo, handles LUKS) | 2026-03-24 | [UUID design review](../99-reports/2026-03-24-uuid-fingerprinting-design-review.md) Tension 4 |
-| No auto-learn UUID — defeats threat model (wrong drive learns wrong UUID) | 2026-03-24 | [UUID design review](../99-reports/2026-03-24-uuid-fingerprinting-design-review.md) Finding 1 |
-| UUID optional with warning, not required — backward compat, gradual adoption | 2026-03-24 | [UUID design review](../99-reports/2026-03-24-uuid-fingerprinting-design-review.md) |
-| Default `is_drive_mounted()` on trait delegates to `drive_availability()` | 2026-03-24 | [UUID impl review](../99-reports/2026-03-24-uuid-fingerprinting-implementation-review.md) Tension 3 |
-| Case-insensitive UUID comparison and uniqueness validation | 2026-03-24 | [UUID impl review](../99-reports/2026-03-24-uuid-fingerprinting-implementation-review.md) Finding 1 |
-| Executor mkdir with parent-exists guard (skip for unmounted drives and tests) | 2026-03-24 | [Pre-cutover journal](../98-journals/2026-03-24-pre-cutover-hardening.md) |
-| `PinResult` with `PinSource` enum — legacy pins downgraded to WARN in verify | 2026-03-24 | [Pre-cutover journal](../98-journals/2026-03-24-pre-cutover-hardening.md) |
+| No auto-learn UUID — defeats threat model | 2026-03-24 | [UUID design review](../99-reports/2026-03-24-uuid-fingerprinting-design-review.md) Finding 1 |
+| Executor mkdir with parent-exists guard | 2026-03-24 | [Pre-cutover journal](../98-journals/2026-03-24-pre-cutover-hardening.md) |
+| `PinResult` with `PinSource` enum — legacy pins downgraded to WARN | 2026-03-24 | [Pre-cutover journal](../98-journals/2026-03-24-pre-cutover-hardening.md) |
 | Space estimation queries mount path, not per-subvolume dir | 2026-03-24 | [Pre-cutover journal](../98-journals/2026-03-24-pre-cutover-hardening.md) |
+| Founding ADRs formalized (ADR-100 through ADR-109) | 2026-03-24 | [Design evolution analysis](../99-reports/2026-03-24-design-evolution-analysis.md) |
 
 ## Key Documents
 
 | Purpose | Document |
 |---------|----------|
+| Founding ADRs (ADR-100–105) | [decisions/](../00-foundation/decisions/) |
 | Original roadmap & architecture | [roadmap.md](roadmap.md) |
 | Feature priorities & user rankings | [Brainstorm synthesis](../99-reports/2026-03-23-brainstorm-synthesis.md) + [review](../99-reports/2026-03-23-brainstorm-synthesis-review.md) |
 | Vision brainstorm (promises, mythic voice, sentinel) | [Realizing the vision](../95-ideas/2026-03-23-brainstorm-realizing-the-vision.md) |

--- a/docs/99-reports/2026-03-24-design-evolution-analysis.md
+++ b/docs/99-reports/2026-03-24-design-evolution-analysis.md
@@ -1,0 +1,449 @@
+# Design Evolution Analysis: ADRs and Documentation Tools for Urd
+
+> **TL;DR:** Urd has an exceptionally mature documentation practice — journals, adversary
+> reviews, brainstorms, and a living status tracker — but most architectural decisions live
+> in scattered one-line entries rather than formal ADRs. Only one ADR exists (ADR-020) while
+> 40+ decisions are recorded informally in status.md. The project needs a lightweight ADR
+> practice, a design proposal template, and a few supporting tools to bridge the gap between
+> "decisions were made" and "decisions are findable, challengeable, and evolvable."
+
+**Date:** 2026-03-24
+**Scope:** Full project evolution — journals (18), reports (30), git history (43 commits),
+plans (1), ADRs (1), ideas (4), CLAUDE.md, CONTRIBUTING.md, status.md, roadmap.md
+**Reviewer:** Claude (arch-adversary)
+**Commit:** `4712be2`
+
+---
+
+## Executive Summary
+
+Urd's design evolution workflow is remarkably disciplined for a 3-day-old project. The
+design-review-before-implementation pattern (adversary review → code → adversary review)
+has caught real bugs (clock skew, mkdir precondition, legacy pin false positives) and
+prevented architectural mistakes (Sentinel as monolith, promises as config extension).
+The journal → status.md → tracked docs pipeline preserves institutional memory while
+maintaining privacy.
+
+But there is a structural gap: **decisions are being made and recorded, but not in a form
+that makes them findable, challengeable, or evolvable.** The "Recent Decisions" table in
+status.md has 40+ entries — each a one-line summary with a reference. These are effectively
+ADR titles without ADR bodies. When a future session needs to understand *why* asymmetric
+multipliers were chosen for the awareness model, it must chase through a design review,
+find Finding 1, reconstruct the reasoning, and hope it's complete.
+
+This report identifies where the current workflow works well, where it breaks down, and
+what documentation tools would keep Urd's architecture consistent as it grows.
+
+---
+
+## How Ideas Currently Flow from Conception to Implementation
+
+### The observed pipeline
+
+```
+Brainstorm (95-ideas/)
+    ↓ user ranking + editorial judgment
+Vision document (CLAUDE.md updates, brainstorm synthesis)
+    ↓ adversary review of vision
+Architectural constraints identified (vision architecture review)
+    ↓ decomposition into priorities
+status.md priority list (with architectural gates)
+    ↓ design plan (in journal or ad-hoc)
+Design review (arch-adversary, saved to 99-reports/)
+    ↓ findings change the design
+Implementation (code)
+    ↓ implementation review (arch-adversary)
+Fix review findings → merge
+    ↓
+status.md updated (Recent Decisions table, completed items)
+Journal written (98-journals/)
+```
+
+### What works well
+
+**1. The adversary review as architectural gate.** Every significant feature gets a design
+review *before* code is written. This has prevented real problems:
+- Sentinel decomposed into three systems instead of one monolith (vision architecture review)
+- Promises identified as policy design problem, not config extension (vision architecture review)
+- Asymmetric multipliers for awareness model (awareness model design review)
+- Best-drive aggregation instead of worst-drive (awareness model design review)
+- `urd get` shipped before `urd find` due to unsolved performance problem (vision architecture review)
+
+**2. Journals as private working memory.** The tracked/untracked split is well-designed.
+Journals capture raw learning with authentic command output; status.md and ADRs capture
+the sanitized public record. This means the human operator has full context locally while
+the public repo stays clean.
+
+**3. status.md as living router.** The information hierarchy (CLAUDE.md → status.md →
+specific docs) gives every session a reliable starting point. The "What to Build Next"
+section with architectural gates prevents building features on shaky foundations.
+
+**4. The "design before code" culture.** The awareness model journal shows the ideal
+pattern: read existing code → write design plan → adversary review of design → implement
+→ adversary review of implementation → fix findings. This produced a module that scored
+4-5/5 across all dimensions.
+
+### What breaks down
+
+**1. Decisions scatter across document types.** The decision that `OutputMode` should be
+an enum rather than a trait lives in the presentation layer design review. The decision
+that `urd get` should use `--at` instead of `@` syntax lives in the urd get design review.
+The decision that the executor must mkdir before `btrfs receive` lives in the pre-cutover
+journal. None of these are in the ADR directory where a future session would look for
+architectural decisions.
+
+**2. The "Recent Decisions" table is an ADR registry without ADR bodies.** Status.md has
+40+ entries like:
+
+```
+| OutputMode enum + match, not Renderer trait | 2026-03-24 | Presentation layer review |
+```
+
+This tells you *what* was decided and *where* the reasoning lives. But to understand *why*,
+you must read the referenced review, find the relevant finding or tension, and reconstruct
+the reasoning. This works when the project is 3 days old. It will not work in 3 months.
+
+**3. No clear "design proposal" template.** When a new feature is designed, the plan
+currently lives in a journal entry or ad-hoc in the adversary review's scope description.
+There is a plan template in CONTRIBUTING.md but only one plan document exists
+(`git-history-pii-scrub.md`, an operational plan). There are no *design* plans — the
+closest equivalent is the awareness model section of its journal entry.
+
+**4. Founding decisions have no ADRs.** The most important architectural decisions were
+made during project inception and are documented in CLAUDE.md and roadmap.md, but not as
+ADRs:
+- Planner/executor separation (pure function planner, never-modify-anything)
+- BtrfsOps trait as the only module that calls btrfs
+- SQLite for history, filesystem for source of truth
+- Two-process pipeline for send|receive (not shell pipe)
+- Interval-based scheduling replacing cron-like schedules
+- Graduated retention replacing fixed counts
+
+These founding decisions are the most important to preserve because they constrain everything
+built on top of them. Without ADRs, a future session might unknowingly violate one.
+
+**5. The ADR numbering is opaque.** The single existing ADR is ADR-020, which implies 19
+prior ADRs from the bash script era. The ADR directory structure
+(`decisions/ADR-relating-to-bash-script/`) suggests a pre-Urd numbering space. There is no
+documented ADR numbering scheme for the Urd era.
+
+---
+
+## Proposed Documentation Tools
+
+### Tool 1: Lightweight ADRs for Architectural Decisions
+
+**Problem:** Decisions are made and recorded, but not in a findable, challengeable form.
+
+**Proposal:** Write ADRs for decisions that constrain future work. Not every decision needs
+one — only those where violating the decision would cause architectural damage. Use the
+existing ADR template from CONTRIBUTING.md but keep them short (under 50 lines for most).
+
+**Categories of decisions that warrant ADRs:**
+
+| Category | Example | Why it needs an ADR |
+|----------|---------|---------------------|
+| **Foundational invariant** | Planner/executor separation | Violating it breaks testability and the entire architecture |
+| **Data format contract** | Snapshot naming, pin file format, Prometheus metrics | External systems depend on the format |
+| **Policy design** | Protection promise levels → retention derivation | Affects user trust and data safety |
+| **Technology choice** | SQLite for history, filesystem for truth | Constrains future features |
+| **Rejected alternative** | No async/tokio, no shell pipes for send/receive | Future contributors will ask "why not?" |
+
+**Categories that do NOT need ADRs:**
+
+| Category | Example | Where it lives instead |
+|----------|---------|----------------------|
+| Implementation detail | `OutputMode` as enum vs. trait | Code comment or review finding |
+| Bug fix | mkdir before btrfs receive | Commit message + journal |
+| Config field design | `--at` vs `@` syntax for urd get | Review finding |
+| Operational procedure | Systemd copy-not-symlink | CONTRIBUTING.md |
+
+**Proposed ADR numbering:** Start fresh at ADR-100 for the Urd era. ADR-020 and any
+bash-era ADRs keep their numbers in the `ADR-relating-to-bash-script/` subdirectory.
+New ADRs go in `docs/00-foundation/decisions/` directly.
+
+**Retroactive ADRs to write (prioritized):**
+
+1. **ADR-100: Planner/executor separation.** The core invariant. Why the planner is a pure
+   function. Why the executor never decides what to do. What breaks if this is violated.
+2. **ADR-101: BtrfsOps trait as sole btrfs interface.** Why all btrfs calls go through one
+   module. How MockBtrfs enables testing. What happens if someone bypasses it.
+3. **ADR-102: Filesystem as source of truth, SQLite as history.** Why snapshots and pin
+   files are authoritative. Why SQLite failures must never prevent backups.
+4. **ADR-103: Interval-based scheduling.** Why Urd uses intervals instead of cron. How
+   this differs from the bash script and why.
+5. **ADR-104: Graduated retention model.** Why Time Machine-style retention. How space
+   pressure interacts. What the NVMe constraint means.
+6. **ADR-105: Backward compatibility contracts.** Which formats are load-bearing (snapshot
+   names, pin files, metrics). What "backward compatible" means concretely.
+
+These are all already decided and documented — the ADRs just formalize them in a findable
+location. Each should be under 50 lines and reference the original journal/roadmap for
+full context.
+
+**Forward ADRs already identified:**
+
+- **ADR for protection promises** (already gated in status.md Priority 4)
+- **ADR for Sentinel decomposition** (awareness + reactor + notifications)
+- **ADR for migration** (ADR-021, already planned for cutover)
+
+### Tool 2: Design Proposal Template
+
+**Problem:** Feature design currently lives in journals or ad-hoc in review scopes. There
+is no consistent place for "here is what we plan to build and why" before the adversary
+review happens.
+
+**Proposal:** Add a design proposal template for `docs/97-plans/`. A design proposal is
+distinct from an operational plan — it describes an architectural addition, its interfaces,
+its invariants, and its integration points. The adversary review then reviews the proposal.
+
+```markdown
+# Design: {Feature Name}
+
+> **TL;DR:** {2-3 sentences: what, why, and key constraint}
+
+**Date:** YYYY-MM-DD
+**Status:** proposed | reviewed | accepted | abandoned
+**Depends on:** {prior features or ADRs}
+
+## Problem
+
+{What problem does this solve? What happens if we don't build it?}
+
+## Proposed Design
+
+{Module name, key types, function signatures, data flow}
+
+## Invariants
+
+{What must always be true? What would break if these were violated?}
+
+## Integration Points
+
+{Which existing modules are affected? What interfaces change?}
+
+## Rejected Alternatives
+
+{What else was considered and why it was rejected?}
+
+## Open Questions
+
+{What needs to be resolved before or during implementation?}
+```
+
+**When to write one:** Before any feature that introduces a new module, changes a public
+interface, or affects more than 3 existing files. Not needed for bug fixes, config tweaks,
+or self-contained additions.
+
+### Tool 3: Decision Log Graduation
+
+**Problem:** The "Recent Decisions" table in status.md is growing unboundedly (40+ entries)
+and mixing foundational decisions with implementation details.
+
+**Proposal:** Graduate decisions from status.md into appropriate permanent homes:
+
+1. **Foundational decisions → ADRs** (as described above)
+2. **Design decisions → code comments or review references** (no change needed, but stop
+   adding one-liners to the table for these)
+3. **Active/recent decisions → keep in status.md** (last 30 days or last major phase)
+4. **Graduated decisions → remove from status.md** (the ADR or review is the permanent home)
+
+**Target:** The "Recent Decisions" table should have 10-15 entries at any time, covering
+the current and previous phase. Older decisions should be findable via ADRs or reviews,
+not via an ever-growing table.
+
+### Tool 4: Architectural Invariant Checklist
+
+**Problem:** CLAUDE.md documents module responsibilities and conventions, but architectural
+invariants are scattered. A new session can read CLAUDE.md and still not know that "the
+planner must never call btrfs" or "SQLite failures must never prevent backups."
+
+**Proposal:** Add an "Architectural Invariants" section to CLAUDE.md (or a linked document)
+that lists the rules a session must never violate, with references to the ADRs that explain
+why.
+
+```markdown
+## Architectural Invariants
+
+These rules are load-bearing. Violating them causes architectural damage that compounds.
+Each links to an ADR explaining the rationale.
+
+1. **The planner is a pure function.** It reads config and filesystem state through traits.
+   It never calls btrfs, writes files, or modifies state. (ADR-100)
+2. **All btrfs calls go through BtrfsOps.** No module except btrfs.rs spawns btrfs
+   subprocesses. (ADR-101)
+3. **Filesystem is source of truth. SQLite is history.** Pin files and snapshot directories
+   are authoritative. SQLite failures must never prevent backups. (ADR-102)
+4. **Individual subvolume failures never abort the run.** The executor isolates errors
+   per subvolume. (ADR-100)
+5. **Retention never deletes pinned snapshots.** Defense-in-depth: planner excludes them,
+   executor re-checks before deletion. (ADR-105)
+6. **Send pipeline captures both exit codes and both stderr streams.** Partial snapshots
+   are cleaned up on failure. (ADR-101)
+```
+
+This is a quick-reference for sessions that need to make changes without reading every ADR.
+
+### Tool 5: Phase Retrospective Practice
+
+**Problem:** The project has grown from 0 to 216 tests in 3 days with excellent per-feature
+reviews, but there has been no cross-cutting retrospective asking "what patterns are
+emerging that we should codify or correct?"
+
+**Proposal:** After each major phase (or every ~2 weeks during active development), write
+a brief retrospective in `99-reports/` covering:
+
+1. **What architectural patterns emerged?** (e.g., the "pure function + trait + mock" pattern
+   used by planner, awareness, heartbeat)
+2. **What decisions were made implicitly?** (e.g., the awareness model quietly established
+   that new modules follow the pure-function pattern)
+3. **What should be codified?** (e.g., write an ADR for the pure-function module pattern)
+4. **What tech debt accumulated?** (status.md already tracks this; the retrospective reviews
+   whether it's growing or shrinking)
+
+---
+
+## How the Tools Compose
+
+The proposed tools create a complete lifecycle for architectural decisions:
+
+```
+Brainstorm (95-ideas/)
+    ↓ user ranking
+Design Proposal (97-plans/)          ← Tool 2: NEW
+    ↓ adversary review
+Reviewed proposal (99-reports/)      ← existing practice
+    ↓ implementation
+Code + tests
+    ↓ implementation review
+Merged code
+    ↓
+ADR written for load-bearing decisions  ← Tool 1: NEW
+status.md updated (recent decisions)
+    ↓ periodically
+Decisions graduated from status.md      ← Tool 3: NEW
+Invariants updated in CLAUDE.md         ← Tool 4: NEW
+Phase retrospective                     ← Tool 5: NEW
+```
+
+The key insight: **the existing workflow is already doing most of the work.** The adversary
+reviews are catching real problems. The journals are preserving context. The status.md is
+routing sessions to the right information. What's missing is the final step: distilling
+decisions into findable, permanent, challengeable records (ADRs) and keeping the invariant
+documentation current.
+
+---
+
+## Design Tensions in the Current Workflow
+
+### Tension 1: Thoroughness vs. Velocity
+
+The adversary review practice is thorough — every feature gets design + implementation
+reviews. But each review is a substantial document (50-150 lines of findings). At the
+current development velocity (multiple features per day), the reviews may become a
+bottleneck or, worse, may be conducted less carefully to maintain pace.
+
+**Resolution:** The reviews are earning their keep. The clock skew bug, mkdir precondition,
+and legacy pin false positives were all caught by reviews. But consider *scoping* reviews:
+not every feature needs a full six-dimension review. A low-risk bug fix needs a focused
+correctness check, not an architecture assessment. The skill already supports this
+(arguments can scope the review), but the practice should explicitly distinguish between
+full reviews and focused reviews.
+
+### Tension 2: Living Documents vs. Immutable Records
+
+Status.md is a living document that is also accumulating historical decisions. This creates
+a tension: it needs to be concise for new sessions (living document concern) but also
+comprehensive for decision traceability (immutable record concern).
+
+**Resolution:** Tool 3 (graduation) resolves this. Status.md stays focused on current state
+and recent decisions. ADRs take over as the permanent record for foundational choices.
+
+### Tension 3: Journal Privacy vs. Decision Traceability
+
+Journals are gitignored (correctly, for privacy). But some decisions are only documented in
+journals. If the local machine's disk fails before those decisions are distilled into tracked
+docs, the reasoning is lost.
+
+**Resolution:** The existing journal → tracked doc workflow handles this, but it depends on
+discipline. The phase retrospective (Tool 5) creates a periodic checkpoint that catches any
+decisions that were made in journals but not yet distilled into ADRs or status.md.
+
+### Tension 4: CLAUDE.md Size vs. Completeness
+
+CLAUDE.md is auto-loaded and should stay under ~200 lines. But architectural invariants,
+module responsibilities, and coding conventions are all competing for space. Adding an
+invariant checklist (Tool 4) pushes the document longer.
+
+**Resolution:** Keep the invariant checklist short (6-8 items, one line each). Move the
+detailed module responsibility table to a separate reference document if CLAUDE.md grows
+beyond 200 lines. The invariant list is more important than the module table — invariants
+prevent architectural damage; module tables prevent confusion.
+
+---
+
+## Commendations
+
+**1. The "architectural gates" pattern in status.md.** Gating Priority 4 (protection
+promises) on an ADR is exactly right. This prevents building on undefined foundations.
+More priorities should have explicit gates.
+
+**2. The adversary review integration.** Using the arch-adversary skill as a standard step
+in the design workflow is unusual and effective. The design review → implementation review
+cycle catches problems at both the conceptual and code levels. The presentation layer
+review's rejection of the trait approach in favor of an enum is a good example of a review
+preventing unnecessary abstraction.
+
+**3. The "Not Building" section in status.md.** Explicitly recording what was *rejected*
+and why (Tier 2 filesystem-level upper bound, qgroup opportunistic query) is as valuable
+as recording what was accepted. This prevents future sessions from re-proposing rejected
+ideas without new information.
+
+**4. The decision to decompose the Sentinel.** The vision architecture review identified
+that "Sentinel" was actually three systems. This decomposition happened *before* any
+Sentinel code was written, saving potentially months of refactoring.
+
+---
+
+## Priority Action Items
+
+1. **Write retroactive ADRs for founding decisions** (ADR-100 through ADR-105). These are
+   the most load-bearing decisions in the project and currently have no formal record. Start
+   with ADR-100 (planner/executor separation) since it is the "core invariant" mentioned
+   throughout the codebase.
+
+2. **Establish ADR numbering for the Urd era.** Document that ADR-100+ is the Urd space.
+   Add a brief note to CONTRIBUTING.md's ADR section.
+
+3. **Graduate 25+ older decisions from status.md.** The Recent Decisions table should cover
+   the current phase, not the entire project history. Move foundational decisions to ADRs;
+   let implementation details live in their review references.
+
+4. **Add architectural invariant checklist to CLAUDE.md.** Six to eight rules, one line
+   each, with ADR references. This is the "don't violate these" quick-reference.
+
+5. **Create the design proposal template.** Add to CONTRIBUTING.md's document templates
+   section. Use it for the protection promises ADR (already gated), Sentinel decomposition,
+   and any future multi-module features.
+
+6. **Write a Phase 1-5 retrospective.** Capture the patterns that emerged (pure-function
+   modules, design-review-before-code, trait-based testing seams) and codify them as
+   project conventions.
+
+---
+
+## Open Questions
+
+- **ADR granularity:** Should each founding decision get its own ADR, or should related
+  decisions be grouped (e.g., one ADR for "data integrity invariants" covering planner
+  purity, pin protection, and error isolation)?
+
+- **Review scoping:** Should CONTRIBUTING.md define when a full adversary review is needed
+  vs. a focused review? What's the threshold (new module? interface change? risk level?)?
+
+- **Decision table lifecycle:** Should status.md decisions auto-archive after a certain
+  period, or should graduation be a manual step during retrospectives?
+
+- **Who writes the mythic voice text for ADRs?** The vision architecture review correctly
+  identified that Urd's character requires sustained creative attention. Should ADRs (which
+  are public-facing) use the mythic voice, or stay technical?


### PR DESCRIPTION
## Summary

- Graduates 10 implicit architectural decisions into explicit ADRs (ADR-100 through ADR-109), covering planner/executor separation, BtrfsOps trait boundary, filesystem-as-truth, interval scheduling, graduated retention, backward compatibility contracts, defense-in-depth, fail-open/fail-closed policy, pure function modules, and config boundary validation
- Adds architectural invariants summary to CLAUDE.md so Claude sessions always see the constraints
- Adds ADR numbering conventions (bash-era 001–099 vs Urd-era 100+) and design proposal template to CONTRIBUTING.md
- Condenses Recent Decisions table in status.md — graduated entries now reference their ADRs instead of duplicating content
- Includes design evolution analysis report documenting the graduation rationale

## Testing

- Documentation-only changes — no Rust code modified
- All ADR cross-references verified against existing file paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)