### PR TITLE
chore: Add workflow commands and shift backup timer to 04:00

### DIFF
--- a/.claude/commands/brainstorm.md
+++ b/.claude/commands/brainstorm.md
@@ -1,0 +1,21 @@
+Generate ideas through divergent thinking. Expand the possibility space — convergence comes later.
+
+## Rules
+
+1. **Generate first, evaluate never.** Do not score, rank, or filter ideas during generation. Quantitative scoring by LLMs produces systematic errors (75% arithmetic mistakes in the 2026-03-23 synthesis). If the user asks for synthesis afterward, use qualitative tier placement only: Build soon / Design first / Explore further / Park — with one sentence of reasoning per placement. Account for every idea (no silent drops).
+
+2. **Use the project vision as generative prompts.** CLAUDE.md's two north stars — "does it make data safer?" and "does it reduce attention on backups?" — are springboards, not filters. Ask "what *else* could make data safer?" Don't kill ideas that fail both tests — they may inspire ideas that pass.
+
+3. **Reference real architecture.** Ideas that name real modules, traits, and types are more useful downstream. Read CLAUDE.md's module table. "What if `awareness.rs` tracked drive temperature?" beats "what about drive health?"
+
+4. **"Data safety" is always a lens.** For a backup tool, every idea should be evaluated for whether it makes data safer, less safe, or is neutral. The 2026-03-23 synthesis omitted this entirely.
+
+5. **Include uncomfortable ideas.** At least 2-3 ideas that feel too ambitious. The solutions-architect will tell you what's infeasible.
+
+## Output
+
+Write to `docs/95-ideas/YYYY-MM-DD-slug.md` per CONTRIBUTING.md idea template. Status: `raw`. End with a **Handoff to Architecture** section listing 3-5 most promising ideas with one sentence each on why they deserve deeper analysis.
+
+## Arguments
+
+$ARGUMENTS — Optional: topic to brainstorm about. If empty, read status.md for current priorities and explore open areas.

--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -1,0 +1,32 @@
+Decompose an idea or feature into an architecturally sound, implementable design.
+
+## Before designing
+
+Read CLAUDE.md (module table, invariants), `docs/96-project-supervisor/status.md` (current state), and any relevant ideas in `docs/95-ideas/`. Understand what exists before proposing what to build.
+
+## Core job
+
+1. **Decompose to module level.** Which existing modules are affected? What new types/traits/enums? What's the data flow? What's the test strategy? If an operation doesn't fit cleanly into one module per CLAUDE.md's table, that's a design signal.
+
+2. **Identify architectural gates.** Features that introduce new public contracts, change existing contract meanings, or cross module boundaries need an ADR before code. Flag explicitly: "Gate: ADR needed for X."
+
+3. **Calibrate effort to completed work.** Use status.md as reference:
+   - UUID fingerprinting: 1 module extended, 10 tests, one session
+   - Awareness model: 1 new module, 24 tests, one session
+   - `urd get`: 1 new command, 19 tests, one session
+
+4. **The 9 founding ADRs (ADR-100 through ADR-109) are hard constraints.** If the design benefits from relaxing one, that's an ADR-gate finding, not a design assumption.
+
+5. **Sequence for risk.** High-risk, assumption-heavy pieces first so bugs surface early. The pre-cutover hardening found 3 bugs sharing one root cause — sequencing should expose those patterns.
+
+6. **Leave room for review.** State alternatives you rejected and assumptions you're making. The arch-adversary will push against these — make it productive by being explicit.
+
+## Output
+
+For features affecting >3 files or introducing new modules: write a design proposal per CONTRIBUTING.md template to `docs/95-ideas/YYYY-MM-DD-design-slug.md` (status: proposed). Include a **Ready for Review** section telling the arch-adversary what to focus on.
+
+For smaller features: deliver the decomposition conversationally with module mapping, effort estimate, and any gate flags.
+
+## Arguments
+
+$ARGUMENTS — The idea or feature to design. Can be a reference to an idea doc, a feature name from status.md, or a free-form description.

--- a/.claude/commands/post-review.md
+++ b/.claude/commands/post-review.md
@@ -1,0 +1,23 @@
+Address arch-adversary review findings systematically.
+
+## Workflow
+
+1. **Find the review report.** Look in `docs/99-reports/` for the most recent review matching the current work, or use the report path provided as argument. Read the **For the Dev Team** section first — it lists exactly what to fix in priority order.
+
+2. **Address findings by severity.** Critical first, then Significant, then Moderate. Minor findings can be batched or deferred if purely stylistic.
+
+3. **For each finding:**
+   - Understand the *consequence* (why it matters), not just the fix
+   - Implement the fix
+   - Add or update tests to cover the fixed case
+   - If you disagree with a finding, document why in the commit message
+
+4. **Run quality gates** after all fixes: `cargo clippy -- -D warnings`, `cargo test`, `cargo build`.
+
+5. **Commit message format:** "fix: Address arch-adversary findings — [list of addressed items]"
+
+6. **PII check** before committing — scan diffs for real usernames, home paths, hostnames per CONTRIBUTING.md.
+
+## Arguments
+
+$ARGUMENTS — Optional: path to the specific review report. If empty, finds the most recent report in `docs/99-reports/` matching `*-review.md`.

--- a/systemd/urd-backup.timer
+++ b/systemd/urd-backup.timer
@@ -2,7 +2,7 @@
 Description=Urd nightly backup
 
 [Timer]
-OnCalendar=*-*-* 02:00:00
+OnCalendar=*-*-* 04:00:00
 Persistent=true
 RandomizedDelaySec=300
 


### PR DESCRIPTION
## Summary

- Add three development workflow commands (`/brainstorm`, `/design`, `/post-review`) that encode project conventions as lightweight slash commands rather than full skills
- Shift backup timer from 02:00 to 04:00 for the parallel-run test period, giving Urd uncontested access to btrfs operations

## Testing

- Manual `urd backup` completed successfully with all 8 subvolumes OK, 6 sends, 1 retention deletion
- Timer installed and verified via `systemctl --user list-timers` — next run at 04:02
- Dry run output matched live run exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)