### PR TITLE
feat: Add post-backup structured summary and local space guard

### DIFF
--- a/docs/95-ideas/2026-03-26-design-backup-summary.md
+++ b/docs/95-ideas/2026-03-26-design-backup-summary.md
@@ -1,0 +1,315 @@
+# Design: Post-Backup Structured Summary (2b + 2d)
+
+> **TL;DR:** Unify skip surfacing (2b) and post-backup summary (2d) into a single
+> `BackupSummary` output type rendered by voice.rs. The backup command produces structured
+> data; the presentation layer answers "is my data safer now?" in one screen. 2b is a
+> subset of 2d — skip reasons are one section of the summary.
+
+**Date:** 2026-03-26
+**Status:** proposed
+**Depends on:** Awareness model (3a, complete), Presentation layer (3c, complete), Heartbeat (3b, complete)
+
+## Problem
+
+After a backup run, the user must run three commands (`status`, `verify`, `history`) to
+answer "is my data safe?" The backup command currently uses direct `println!` with ad-hoc
+formatting. Most nightly runs are all-skips (drives not mounted during daily timer), but
+skip reasons are buried among other output — the most important information is the least
+visible.
+
+The returning-from-travel experience (2026-03-26 operational evaluation) proved this: coming
+back to a system that had been running for days, the user needed three commands to understand
+what had happened. The backup output itself didn't answer the question.
+
+Priority 2b (surface skipped sends loudly) and 2d (post-backup structured summary) are
+the same feature at different scopes. 2b is "make skip reasons prominent." 2d is "make
+the entire post-backup output structured and answerable." Building 2d subsumes 2b.
+
+## Proposed Design
+
+### Data Structure: `BackupSummary` (in `output.rs`)
+
+A new structured output type following the established pattern (`StatusOutput`, `GetOutput`):
+
+```rust
+/// Structured output for the post-backup summary.
+#[derive(Debug, Serialize)]
+pub struct BackupSummary {
+    /// Overall run result.
+    pub result: String,                     // "success" | "partial" | "failure"
+    /// Run ID from SQLite (if available).
+    pub run_id: Option<i64>,
+    /// Total wall-clock duration of the run.
+    pub duration_secs: f64,
+
+    /// Per-subvolume execution results.
+    pub subvolumes: Vec<SubvolumeSummary>,
+    /// Subvolumes skipped by the planner (name, reason).
+    pub skipped: Vec<SkippedSubvolume>,
+
+    /// Per-subvolume promise status AFTER the run (from awareness model).
+    pub assessments: Vec<StatusAssessment>,  // reuse existing type
+
+    /// Summary warnings (pin failures, skipped deletions, etc.)
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SubvolumeSummary {
+    pub name: String,
+    pub success: bool,
+    pub duration_secs: f64,
+    pub send_type: String,       // "full" | "incremental" | ""
+    pub send_drive: Option<String>,
+    pub bytes_transferred: Option<u64>,
+    pub errors: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SkippedSubvolume {
+    pub name: String,
+    pub reason: String,
+}
+```
+
+### Data Flow
+
+```
+plan::plan()           → BackupPlan { operations, skipped }
+executor.execute()     → ExecutionResult { overall, subvolume_results, run_id }
+awareness::assess()    → Vec<SubvolAssessment>    [called post-execution, fresh timestamp]
+                         ↓
+backup.rs: build_backup_summary(plan, result, assessments)  →  BackupSummary
+                         ↓
+voice::render_backup_summary(summary, mode)  →  String
+```
+
+The `build_backup_summary()` function lives in `commands/backup.rs` — it's the command
+layer assembling the output type from business logic results. This follows the pattern
+established by the status command: the command function builds the structured data, then
+calls voice to render it.
+
+### Rendering: `voice::render_backup_summary()` (in `voice.rs`)
+
+**Interactive mode** — designed around Priority 2b's insight that skip reasons are the
+most important output of a no-op run:
+
+```
+── Urd backup: success ── [run #47, 12.3s] ──────────────
+
+  OK   htpc-home       [2.1s]
+  OK   htpc-docs       [0.3s] (incremental → WD-18TB)
+  OK   htpc-root       [0.1s]
+
+  SKIP htpc-home       drive 2TB-backup not mounted
+  SKIP htpc-docs       drive 2TB-backup not mounted
+  SKIP subvol3-opptak  drive WD-18TB not mounted
+  SKIP subvol3-opptak  drive 2TB-backup not mounted
+  SKIP subvol3-opptak  send to 2TB-backup skipped: estimated ~3.4 TB exceeds 1.0 TB available
+
+  STATUS     SUBVOLUME       LOCAL  WD-18TB
+  PROTECTED  htpc-home       12     47
+  AT RISK    htpc-docs       5      3
+  PROTECTED  htpc-root       3      —
+  AT RISK    subvol3-opptak  8      —
+
+  NOTE htpc-docs: offsite drive not connected in 14 days
+```
+
+Key rendering decisions:
+1. **Header line** with result, run ID, and total duration — answers "did it work?"
+2. **Executed subvolumes first** — what changed this run.
+3. **Skipped subvolumes block** — prominent, not dimmed. The 2b requirement: most runs are
+   all-skips, so this block IS the output. Group by subvolume to reduce repetition.
+4. **Awareness table** — the status table, reusing the existing `render_subvolume_table()`
+   helper from voice.rs. Answers "is my data safe NOW?" without running a second command.
+5. **Advisories/warnings** last — pin failures, skipped deletions, etc.
+
+**Daemon mode** — JSON serialization of `BackupSummary` (same as StatusOutput pattern).
+
+### Skip Reason Grouping (2b specifics)
+
+The planner produces per-subvolume-per-drive skips. A 7-subvolume config with 2 unmounted
+drives generates 14 skip entries, most saying "drive X not mounted." The raw list is noise.
+
+The renderer groups skips by reason when displaying:
+
+```
+  Drives not mounted: 2TB-backup, WD-18TB
+    → 5 sends skipped (htpc-home, htpc-docs, htpc-root, subvol3-opptak, subvol5-music)
+
+  SKIP subvol3-opptak  estimated ~3.4 TB exceeds 1.0 TB available on 2TB-backup
+```
+
+Common patterns ("drive X not mounted") are collapsed. Unique reasons (space, UUID mismatch,
+disabled, low local space) are shown individually. This is a rendering decision — the
+structured data retains per-subvolume-per-reason granularity for daemon mode consumers.
+
+### Module Changes
+
+| Module | Change | Scope |
+|--------|--------|-------|
+| `output.rs` | Add `BackupSummary`, `SubvolumeSummary`, `SkippedSubvolume` types | New types only |
+| `voice.rs` | Add `render_backup_summary()` + helpers | ~120 lines |
+| `commands/backup.rs` | Replace `println!` block with `build_backup_summary()` + voice render | Refactor existing ~90 lines |
+
+No changes to: plan.rs, executor.rs, awareness.rs, types.rs, heartbeat.rs.
+
+### What Does NOT Change
+
+- **Planner skip format** — `Vec<(String, String)>` stays. The `(name, reason)` tuples are
+  adequate. Structured skip reasons (typed enum) would be nice but is scope creep — the
+  string reasons are human-readable and the renderer can pattern-match on known prefixes
+  for grouping.
+- **ExecutionResult** — no fields added. The summary is assembled from existing data.
+- **Heartbeat** — still written separately, already has awareness data. The summary is a
+  display concern, not a persistence concern.
+- **Metrics** — untouched. Already correct.
+
+## Invariants
+
+1. **ADR-100 (planner/executor separation)** — Preserved. The planner produces skip reasons
+   as data. The executor produces results as data. The command layer assembles. The voice
+   layer renders. No module crosses its boundary.
+
+2. **ADR-108 (pure function modules)** — `build_backup_summary()` is a pure function: plan +
+   result + assessments in, `BackupSummary` out. `render_backup_summary()` is a pure function:
+   summary + mode in, string out.
+
+3. **No new public contracts** — `BackupSummary` is consumed only by voice.rs. Not written
+   to disk, not part of the heartbeat schema, not exposed as API. It can evolve freely.
+
+4. **Backward compatibility** — The only observable change is the backup command's stdout
+   output format. No external contracts (metrics, pin files, snapshot names) are affected.
+
+## Integration Points
+
+- **`StatusAssessment` reuse** — the summary embeds the same assessment type used by
+  `urd status`. The awareness table in the backup output and `urd status` show the same
+  data from the same computation, rendered by the same table helper.
+
+- **`render_subvolume_table()` extraction** — currently a private function in voice.rs called
+  by `render_status_interactive()`. Needs to become a shared helper within voice.rs (not
+  `pub` — just used by both `render_status_interactive` and `render_backup_interactive`).
+
+- **Empty run path** — the `backup_plan.is_empty() && backup_plan.skipped.is_empty()` early
+  return in backup.rs currently prints "Nothing to do." and writes heartbeat. This path
+  should also use the summary (a summary with no subvolumes and no skips renders as the
+  "nothing to do" message). Unifies the output path.
+
+- **Awareness call already exists** — backup.rs already calls `awareness::assess()` for the
+  heartbeat. The summary reuses the same assessment result. No additional filesystem queries.
+
+## Implementation Sequence
+
+**Step 1: Output types** (~15 min)
+Add `BackupSummary`, `SubvolumeSummary`, `SkippedSubvolume` to `output.rs`.
+Test: types derive Serialize, can construct from test data.
+
+**Step 2: Build function** (~30 min)
+Write `build_backup_summary()` in `commands/backup.rs`. Pure function taking
+`&BackupPlan`, `&ExecutionResult`, `&[SubvolAssessment]`, total duration, and returning
+`BackupSummary`.
+Test: unit test with mock plan/results verifying field mapping.
+
+**Step 3: Interactive renderer** (~45 min)
+Write `render_backup_summary()` in `voice.rs`. Extract `render_subvolume_table()` as
+shared helper. Implement skip grouping logic.
+Test: 6–8 tests covering normal run, all-skips run, partial failure, empty run, skip
+grouping, daemon JSON.
+
+**Step 4: Wire into backup command** (~30 min)
+Replace the `println!` block in `backup.rs:run()` (lines 114–204) with:
+1. `build_backup_summary()` call
+2. `render_backup_summary()` call
+3. `println!("{}", rendered)`
+Preserve: metrics writing, heartbeat writing, exit code logic.
+Also handle the empty-run early return path.
+
+**Effort estimate:** ~2 hours. Comparable to presentation layer (output.rs + voice.rs)
+which was 15 voice tests + 4 output tests in one session. The infrastructure exists —
+this is adding a new consumer of established patterns.
+
+## Rejected Alternatives
+
+### 1. Typed skip reason enum
+
+Instead of `Vec<(String, String)>`, define `SkipReason::DriveNotMounted { drive }`,
+`SkipReason::SpaceInsufficient { .. }`, etc. This would make grouping trivial.
+
+**Rejected because:** Requires changing `BackupPlan.skipped` (a types.rs public type used by
+planner, executor, backup, plan_cmd, and metrics). The grouping logic in the renderer is
+~20 lines of prefix matching. The typed enum buys cleanliness at the cost of a larger change
+surface. Can be revisited if the renderer's grouping becomes fragile.
+
+### 2. Separate 2b and 2d as independent features
+
+Build skip surfacing first (just change the `println!` for skips), then build the full
+summary later.
+
+**Rejected because:** 2b's "prominent warning block" IS part of the summary. Building 2b
+standalone would create temporary formatting code that gets replaced by 2d. The effort
+difference is small (~30 min for 2b alone vs. ~2h for 2d-which-includes-2b), and 2d's
+infrastructure (the output type) immediately pays off when other commands migrate to voice.
+
+### 3. BackupSummary in a new module (e.g., `summary.rs`)
+
+**Rejected because:** Output types live in `output.rs`, rendering lives in `voice.rs`,
+command logic lives in `commands/`. The existing module structure handles this cleanly.
+A new module for one type and one builder function doesn't earn its keep.
+
+### 4. Include chain health in the summary
+
+The status command shows chain health. Should the backup summary also show it?
+
+**Rejected for v1:** Chain health requires reading pin files and external snapshots, which
+is already done by the awareness model (indirectly). But the status command does its own
+chain health computation. Adding it to the summary would either duplicate the computation
+or require refactoring chain health into a shared function. Not worth it for v1 — the
+awareness model's promise status already tells the user if something is wrong.
+
+## Open Questions
+
+1. **Skip grouping heuristics** — The design proposes grouping "drive X not mounted" skips.
+   Should this be by drive (group all subvolumes skipped for the same drive) or by reason
+   text (exact string match)? Drive-based grouping is more semantic but requires parsing
+   the reason string. Recommendation: group by exact reason prefix match on
+   `"drive {label} not mounted"`, which is stable and covers the dominant case.
+
+2. **Empty run rendering** — When `is_empty() && skipped.is_empty()`, the current code
+   prints "Nothing to do." Should this flow through the summary path (producing a summary
+   with zero subvolumes and zero skips, rendered as a brief message) or remain as a
+   special case? Recommendation: flow through the summary path for consistency, but keep
+   the rendered output minimal (one line).
+
+3. **Awareness table verbosity** — In a 7-subvolume config, the awareness table adds 9 lines
+   to every backup output. For the daemon (systemd journal), this might be excessive.
+   Options: (a) always show, (b) show only if any subvolume is AT RISK or UNPROTECTED,
+   (c) configurable. Recommendation: (b) — show the table only when there's something worth
+   noting, with a one-line "all subvolumes PROTECTED" summary otherwise. This aligns with
+   the "invisible worker" principle: silence is a good sign.
+
+## Ready for Review
+
+Focus areas for the arch-adversary:
+
+1. **Is reusing `StatusAssessment` the right call?** It was designed for `urd status`. The
+   backup summary embeds the same type. If `StatusAssessment` evolves for status-specific
+   needs, the backup summary inherits those changes. Is this coupling acceptable or should
+   the summary have its own assessment type?
+
+2. **Skip grouping in the renderer vs. structured data.** The design keeps string-based skip
+   reasons in the data layer and does grouping in the renderer. The alternative (typed enum)
+   would be cleaner but touches more files. Is the current approach fragile enough to warrant
+   the larger change?
+
+3. **The empty run path.** Currently a special case with early return. Should it flow through
+   the summary, or is the early return better for clarity?
+
+4. **Awareness table in daemon mode.** The daemon JSON includes the full assessment array.
+   Is this the right default, or should daemon mode omit it (the heartbeat already persists
+   this data)?
+
+5. **Backward compatibility of stdout format.** The backup command's stdout will change
+   format. Any downstream consumers (scripts, monitoring) that parse the old format will
+   break. Is this a concern worth an ADR, or is stdout format explicitly not a contract?

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -5,18 +5,36 @@
 
 ## Current State
 
-**Phase 5 complete. Safety hardening in progress (2a done). Pre-cutover hardening done.**
-Awareness model (3a), heartbeat file (3b), presentation layer (3c), `urd get` (3d), and UUID
-drive fingerprinting (2a) are built, reviewed, and passing 216 tests. Pre-cutover testing
-(2026-03-24) found and fixed two bugs: executor didn't mkdir before `btrfs receive` (every
-first-send to a new drive would fail), and verify reported false chain breaks from legacy
-pin files. A third bug — space estimation querying per-subvolume dir instead of mount path —
-was also found and fixed in the same session. UUID fingerprints configured for both mounted
-drives. Operational cutover has not started — the bash script (`btrfs-snapshot-backup.sh`)
-is still the sole production backup system, running nightly at 02:00 via
-`btrfs-backup-daily.timer`. Urd v0.2.2026-03-24 is installed (`~/.cargo/bin/urd`) and has
-been tested manually on real subvolumes (all read-only tests pass, one successful incremental
-send to 2TB-backup). Full backup run (Test 11) is the last gate before installing the timer.
+**Operational cutover in progress. Urd is the sole backup system.**
+Urd's systemd timer has been running at 04:00 nightly since 2026-03-24. The bash script
+(`btrfs-snapshot-backup.sh`) is disabled. Five consecutive successful runs (runs 7–11) across
+manual and autonomous operation, passing 241 tests. The parallel-run step was skipped in favor
+of direct cutover — a conscious risk decision documented in
+[first-night journal](../98-journals/2026-03-25-first-night.md). Two nights of unattended
+operation (2026-03-25, 2026-03-26) completed without failures.
+
+A third NVMe space exhaustion incident (2026-03-26) motivated immediate implementation of the
+**local space guard** in `plan_local_snapshot` — the fix designed in the
+[March 24 postmortem](../98-journals/2026-03-24-local-space-exhaustion-postmortem.md) but
+never built. The planner now checks `filesystem_free_bytes` against `min_free_bytes` before
+creating any local snapshot. `force` does not override (a forced snapshot on a full filesystem
+is still catastrophic). 4 new tests. This closes the most dangerous safety gap in the
+application. [Journal](../98-journals/2026-03-26-operational-evaluation.md)
+
+**Post-backup structured summary** (Priorities 2b + 2d) implemented in the same session.
+The backup command now produces a `BackupSummary` output type rendered by the voice layer,
+replacing ~90 lines of ad-hoc `println!`. Answers "is my data safer now?" in one screen:
+executed subvolumes with per-drive send info, grouped skip reasons (drive-not-mounted entries
+collapsed, UUID mismatch/space/disabled shown individually), conditional awareness table
+(shown only when AT RISK or UNPROTECTED), and warning aggregation (pin failures, skipped
+deletions). Daemon mode outputs JSON. 21 new tests (9 builder, 12 renderer).
+[Design](../95-ideas/2026-03-26-design-backup-summary.md) |
+[Review](../99-reports/2026-03-26-backup-summary-design-review.md) |
+[Journal](../98-journals/2026-03-26-backup-summary.md)
+
+Config intervals (1h–6h snapshots, 1h–4h sends) were set for the travel period and are
+misaligned with the daily timer — the awareness model reports UNPROTECTED for most of each
+day. Interval tuning to match daily reality is the next operational action.
 
 Safety hardening completed:
 
@@ -109,14 +127,18 @@ No code changes. Just do it. See [cutover checklist](#active-work--operational-c
 
 ### Priority 2: Safety Hardening (during/after cutover)
 
-Low-risk, high-value improvements to the existing architecture.
+Low-risk, high-value improvements to the existing architecture. Reordered 2026-03-26 based
+on operational data: surfacing skip reasons and post-backup summaries are the highest-leverage
+UX improvements — the returning-from-travel experience proved that "is my data safe?" is the
+most important question, and currently requires three commands to answer.
 
 | # | Feature | Effort | Notes |
 |---|---------|--------|-------|
 | 2a | ~~**UUID drive fingerprinting**~~ | ~~Low~~ | **COMPLETE.** `DriveAvailability` enum, `findmnt` UUID detection, planner integration, config validation. 10 tests. Adversary-reviewed. |
-| 2b | **Surface skipped sends loudly** | Low | Prominent warning block in backup output. |
-| 2c | **Pre-flight checks** | Low | Extract `init.rs` validation into shared `preflight_checks()`. |
-| 2d | **Post-backup structured summary** | Medium | Answer "is my data safer now?" Format as structured data, render via presentation layer. |
+| 2a+ | ~~**Local space guard**~~ | ~~Low~~ | **COMPLETE.** `plan_local_snapshot` checks `filesystem_free_bytes` against `min_free_bytes` before creating. `force` does not override. Fails open if unreadable. 4 tests. Closes the most dangerous safety gap (three NVMe exhaustion incidents). [Journal](../98-journals/2026-03-26-operational-evaluation.md) |
+| 2b | ~~**Surface skipped sends loudly**~~ | ~~Low~~ | **COMPLETE.** Subsumed by 2d — skip grouping is one section of the structured summary. "Not mounted" skips collapsed by drive; UUID mismatch/space/disabled rendered individually. |
+| 2d | ~~**Post-backup structured summary**~~ | ~~Medium~~ | **COMPLETE.** `BackupSummary` output type in `output.rs`, rendered by `voice::render_backup_summary()`. Replaces ~90 lines of `println!`. Per-drive send info, grouped skips, conditional awareness table, warning aggregation. 21 tests. [Design](../95-ideas/2026-03-26-design-backup-summary.md) | [Review](../99-reports/2026-03-26-backup-summary-design-review.md) | [Journal](../98-journals/2026-03-26-backup-summary.md) |
+| 2c | **Pre-flight checks** | Low | Extract `init.rs` validation into shared `preflight_checks()`. Include retention/send-interval compatibility: warn if retention policy would delete a pinned snapshot before the next send interval can use it as incremental parent (motivated by htpc-root chain break). |
 | 2e | **Structured error messages** | Medium | Pattern-match common btrfs stderr. Build as a translation layer in `error.rs`, not scattered across commands. |
 
 ### Priority 3: Architectural Foundation (design before code)
@@ -159,7 +181,8 @@ migrate incrementally.
 - [x] Daemon mode: JSON serialization of `StatusOutput`
 - [x] Global TTY-aware color control (`colored::control::set_override` in main)
 - [x] Testable: 10 voice tests asserting output contains expected facts
-- [ ] Remaining commands migrate incrementally (not blocked on this)
+- [x] `backup` command returns structured `BackupSummary`, rendered by `voice::render_backup_summary()`
+- [ ] Remaining commands (`plan`, `history`, `verify`, `init`, `calibrate`) migrate incrementally
 
 **3d. `urd get file --at date`** — **COMPLETE.** Restore via direct path construction.
 O(1) — no search, no indexing. Automatic subvolume detection (longest-prefix match on
@@ -180,6 +203,9 @@ filter, added `--output` overwrite protection, removed dead_code allow on `local
 - [ ] Migration path for existing configs (implicit `custom`)
 - [ ] Promise validation: "this promise is unachievable given your drive connection pattern"
 - [ ] `custom` designed as first-class, not afterthought
+- [ ] Timer frequency as input to achievability — promises must be derivable from actual run frequency, not assumed sub-daily (operational data from 2026-03-26 showed awareness model reporting UNPROTECTED 18h/day because config intervals assumed sub-daily runs)
+- [ ] Drive topology constraints — subvolumes that exceed drive capacity cannot have external promises on those drives (subvol3-opptak at ~3.4TB vs 2TB-backup at ~1.1TB)
+- [ ] Awareness threshold mode — should thresholds adapt to timer frequency vs. Sentinel frequency, or should config intervals simply be required to be achievable?
 
 ### Priority 4: Protection Promises (score: 10 — build after ADR)
 
@@ -302,6 +328,25 @@ timestamp staleness handling, space check deduplication, ANSI line clearing.
   uniqueness check, `log::warn!` over `eprintln!`.
   [Design review](../99-reports/2026-03-24-uuid-fingerprinting-design-review.md) |
   [Implementation review](../99-reports/2026-03-24-uuid-fingerprinting-implementation-review.md)
+- **Local space guard** (2026-03-26) — `plan_local_snapshot` checks `filesystem_free_bytes`
+  against `min_free_bytes` before creating any local snapshot. Skips with clear reason if
+  below threshold. `force` does not override — a forced snapshot on a full filesystem is still
+  catastrophic. Fails open if free bytes unreadable (`unwrap_or(u64::MAX)`, per ADR-107).
+  Motivated by third NVMe space exhaustion incident. Design from
+  [postmortem](../98-journals/2026-03-24-local-space-exhaustion-postmortem.md), implemented
+  in [operational evaluation session](../98-journals/2026-03-26-operational-evaluation.md).
+  4 new tests.
+- **Post-backup structured summary** (P2b + P2d, 2026-03-26) — `BackupSummary` output type
+  in `output.rs`, rendered by `voice::render_backup_summary()`. Replaces ~90 lines of ad-hoc
+  `println!` in backup command. Per-subvolume results with multi-drive send info
+  (`Vec<SendSummary>`), grouped skip reasons (drive-not-mounted collapsed, UUID mismatch and
+  other safety-relevant skips rendered individually), conditional awareness table (shown only
+  when AT RISK or UNPROTECTED), warning aggregation (pin failures, skipped deletions). Daemon
+  mode outputs JSON. 2b subsumed by 2d — skip surfacing is one section of the summary.
+  21 new tests (9 builder, 12 renderer). Design-reviewed before implementation.
+  [Design](../95-ideas/2026-03-26-design-backup-summary.md) |
+  [Review](../99-reports/2026-03-26-backup-summary-design-review.md) |
+  [Journal](../98-journals/2026-03-26-backup-summary.md)
 - **Pre-cutover hardening** (2026-03-24) — Three bugs found and fixed during pre-cutover manual
   testing. (1) `executor.rs`: mkdir before `btrfs receive` — first-ever sends to any drive would
   fail without destination directory. Parent-exists guard preserves test behavior and unmounted-drive
@@ -330,7 +375,7 @@ timestamp staleness handling, space check deduplication, ANSI line clearing.
 - [x] **Phase 3** — CLI commands (`status`, `history`, `verify`) + systemd units
 - [x] **Phase 3.5** — Hardening for cutover (adversary review fixes)
 - [x] **Phase 4 code** — Cutover polish + space estimation + real-world testing
-- [ ] **Phase 4 cutover** — Operational transition from bash to Urd (see below)
+- [ ] **Phase 4 cutover** — Operational transition from bash to Urd (in progress — Urd is sole system since 2026-03-25, monitoring until 2026-04-01)
 - [x] **Post-cutover features** — failed-send bytes, progress, calibrate (Priorities 2-4)
 - [x] **Phase 5** — Architectural foundation: awareness model, heartbeat, presentation layer, `urd get`
 - [ ] **Phase 5 gate** — ADR: protection promise design (retention mappings, config conflicts, migration)
@@ -348,21 +393,24 @@ See [Phase 4 journal](../98-journals/2026-03-22-urd-phase4.md) section "What Was
 (`urd-backup.*`) are owned by this repo. See [deployment conventions](../../CONTRIBUTING.md#systemd-deployment)
 for details.
 
-### Step 1: Install Urd units (this repo)
+### Step 1: Install Urd units (this repo) — COMPLETE
 
-- [ ] Install Urd systemd units: `cp ~/projects/urd/systemd/urd-backup.{service,timer} ~/.config/systemd/user/`
-- [ ] Reload and enable: `systemctl --user daemon-reload && systemctl --user enable --now urd-backup.timer`
+- [x] Install Urd systemd units (2026-03-24)
+- [x] Reload and enable urd-backup.timer at 04:00 daily
 
-### Step 2: Parallel run (requires action in ~/containers repo)
+### Step 2: Parallel run — SKIPPED
 
-- [ ] _(~/containers)_ Shift bash timer to 03:00: `systemctl --user edit btrfs-backup-daily.timer` → `OnCalendar=*-*-* 03:00:00`
-- [ ] Verify both systems run nightly and produce equivalent results (compare Prometheus metrics, snapshot directories, pin files)
-- [ ] Run parallel for at least 1 week, ideally 2
+Parallel run was skipped in favor of direct cutover. The bash timer was disabled on
+2026-03-25, not shifted to a different time. This was a conscious risk decision: recent
+snapshots existed on both external drives, and the congestion risk of two backup systems
+outweighed the safety net of parallel operation. Five clean runs (7–11) validate the decision.
+[First-night journal](../98-journals/2026-03-25-first-night.md)
 
-### Step 3: Cutover (requires action in ~/containers repo)
+### Step 3: Cutover — IN PROGRESS
 
-- [ ] _(~/containers)_ Disable bash timer: `systemctl --user disable --now btrfs-backup-daily.timer`
-- [ ] Monitor Urd as sole system for 1 week
+- [x] _(~/containers)_ Bash timer disabled (2026-03-25)
+- [x] Urd running as sole backup system (2 nights unattended, 5 total successful runs)
+- [ ] Monitor for 1 week total (started 2026-03-25, target: 2026-04-01)
 - [ ] Verify Grafana dashboard continuity (metrics names/labels must match)
 
 ### Step 4: Cleanup (cross-repo)
@@ -412,6 +460,14 @@ for the graduation rationale.
 | `PinResult` with `PinSource` enum — legacy pins downgraded to WARN | 2026-03-24 | [Pre-cutover journal](../98-journals/2026-03-24-pre-cutover-hardening.md) |
 | Space estimation queries mount path, not per-subvolume dir | 2026-03-24 | [Pre-cutover journal](../98-journals/2026-03-24-pre-cutover-hardening.md) |
 | Founding ADRs formalized (ADR-100 through ADR-109) | 2026-03-24 | [Design evolution analysis](../99-reports/2026-03-24-design-evolution-analysis.md) |
+| Skip parallel run — direct cutover with bash disabled | 2026-03-25 | [First-night journal](../98-journals/2026-03-25-first-night.md) |
+| Local space guard: planner gates snapshot creation on free space | 2026-03-26 | [Operational evaluation](../98-journals/2026-03-26-operational-evaluation.md) |
+| Priority 2 reordered: 2b/2d before 2c/2e (data-driven) | 2026-03-26 | [Operational evaluation](../98-journals/2026-03-26-operational-evaluation.md) |
+| Promise ADR enriched: timer frequency, drive topology, threshold modes | 2026-03-26 | [Operational evaluation](../98-journals/2026-03-26-operational-evaluation.md) |
+| 2b subsumed by 2d — skip surfacing is one section of the structured summary | 2026-03-26 | [Backup summary design](../95-ideas/2026-03-26-design-backup-summary.md) |
+| `Vec<SendSummary>` for multi-drive sends (not single `send_drive` field) | 2026-03-26 | [Backup summary review](../99-reports/2026-03-26-backup-summary-design-review.md) Finding 1 |
+| Only "not mounted" skips grouped; UUID mismatch always renders individually | 2026-03-26 | [Backup summary review](../99-reports/2026-03-26-backup-summary-design-review.md) Finding 3 |
+| Awareness table conditional: shown only when AT RISK or UNPROTECTED | 2026-03-26 | [Backup summary design](../95-ideas/2026-03-26-design-backup-summary.md) Open Question 3 |
 
 ## Key Documents
 
@@ -424,7 +480,7 @@ for the graduation rationale.
 | Future directions brainstorm | [Feature ideas](../95-ideas/2026-03-23-brainstorm-urd-future.md) |
 | UX design principles brainstorm | [Norman principles](../95-ideas/2026-03-23-brainstorm-ux-norman-principles.md) |
 | Vision architecture review | [2026-03-23 Architectural criteria for vision](../99-reports/2026-03-23-vision-architecture-review.md) |
-| Latest adversary review | [2026-03-24 Pre-cutover testing review](../99-reports/2026-03-24-pre-cutover-testing-review.md) |
+| Latest adversary review | [2026-03-26 Backup summary design review](../99-reports/2026-03-26-backup-summary-design-review.md) |
 | Code conventions & architecture | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 
@@ -435,9 +491,9 @@ for the graduation rationale.
 - Stale failed send estimates persist indefinitely for (subvolume, drive, send_type) triples with no subsequent sends — consider TTL or clearing on successful calibration
 - Successful sends could update `subvolume_sizes` table to keep calibration fresh, but pipe bytes ≠ `du -sb` bytes (method mixing concern)
 - `FileSystemState` trait (10 methods, including `drive_availability`) is outgrowing its name — consider renaming to `SystemState` if more methods are added
-- Awareness model integrated into heartbeat and `urd status` but not yet into backup post-run summary
+- `SubvolumeResult.send_type` in executor.rs records only the last send type when a subvolume is sent to multiple drives — the per-operation data in `OperationOutcome` is correct, but the summary field is misleading. The backup summary works around this by extracting from operations directly
 - `heartbeat::read()` returns `Option` — cannot distinguish missing file from corrupt JSON (upgrade to `Result<Option>` when Sentinel is built)
-- Remaining commands (`plan`, `backup`, `history`, `verify`, `init`, `calibrate`) still use direct `println!` — migrate to voice layer incrementally
+- Remaining commands (`plan`, `history`, `verify`, `init`, `calibrate`) still use direct `println!` — migrate to voice layer incrementally (`status` and `backup` now migrated)
 - Per-drive pin protection for external retention — current all-drives-union is conservative but suboptimal for space
 - `urd get` normalizes paths without filesystem access (no `canonicalize`) — symlinked paths won't match subvolume sources. Documented limitation; correct behavior (use canonical paths)
 - `urd get` doesn't support directory restore — files only in v1. Error message guides user.
@@ -447,4 +503,8 @@ for the graduation rationale.
 - urd-backup.service has 6-hour timeout — may be insufficient for full send of largest subvolume (opptak ~3TB). March 23 failed send ran 2.3 hours
 - Bootstrap pattern — code that touches `external_snapshot_dir()` may assume per-subvolume dirs exist. Three instances found and fixed (mkdir, verify pins, space estimation). Watch for more
 - MockBtrfs tests don't exercise filesystem preconditions — `tempfile::TempDir` approach needed for code that touches real filesystem
+- Journal persistence gap: `journalctl --user -u urd-backup.service --since "2 days ago"` returned no entries despite successful runs (2026-03-26). Journal rotation or vacuum purges user-unit logs. Heartbeat partially compensates, but human-readable run logs may need a local file complement
+- htpc-root retention/send-interval coupling: retention policy (`daily = 3, weekly = 2`) deletes pinned snapshot before the 1-week send interval can use it as incremental parent. Chain self-heals via full send, but the planner does not warn about this incompatibility. Candidate for 2c pre-flight check
+- NVMe snapshot accumulation: 12 htpc-home snapshots (legacy + Urd) on 118GB drive is the primary space pressure source. Space guard now prevents catastrophic exhaustion, but gradual accumulation above the 10GB threshold is not gated. Retention tuning for constrained volumes deserves attention
+- Config/timer interval mismatch: send intervals (1h–4h) assume sub-daily timer but Urd runs once daily. Causes awareness model to report UNPROTECTED for ~18h/day. Operational action: tune intervals to match daily reality. Design question for Promise ADR: should timer frequency be an explicit input?
 - Idea: [systemd unit drift check](../95-ideas/2026-03-23-systemd-unit-drift-check.md) in `urd verify`

--- a/docs/99-reports/2026-03-26-backup-summary-design-review.md
+++ b/docs/99-reports/2026-03-26-backup-summary-design-review.md
@@ -1,0 +1,260 @@
+# Design Review: Post-Backup Structured Summary (2b + 2d)
+
+**Project:** Urd
+**Date:** 2026-03-26
+**Scope:** Design proposal `docs/95-ideas/2026-03-26-design-backup-summary.md`
+**Review type:** Design review (pre-implementation)
+**Reviewer:** Architectural adversary
+**Commit:** ceaa297 (master)
+
+## Executive Summary
+
+A well-scoped, well-motivated design that follows the project's established presentation
+layer pattern. The premise is sound — unifying 2b into 2d is the right call, and the three-file
+change surface is minimal for a feature this impactful. One data modeling issue (multi-drive
+sends flattened to a single field) needs fixing before implementation. The rest is ready to build.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — deleting snapshots that shouldn't be deleted.
+
+**Distance from this design:** Very far. This is a pure presentation layer change. No modules
+that touch btrfs, retention, pin files, or the executor are modified. The design explicitly
+lists "No changes to: plan.rs, executor.rs, awareness.rs, types.rs, heartbeat.rs." The only
+code that changes is display logic in backup.rs, output types, and voice rendering. A bug in
+this feature produces wrong *text*, not wrong *operations*.
+
+The one thing to verify during implementation: the refactored backup.rs must preserve the
+existing exit code logic (`std::process::exit(1)` on non-success) and metrics/heartbeat
+writing. These are side effects interleaved with the display code being replaced, and
+accidentally dropping them would affect monitoring and the Sentinel's future input.
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4 | Sound data flow, one modeling gap (multi-drive sends). |
+| **Security** | 5 | No security surface — pure display, no privilege, no new I/O. |
+| **Architectural Excellence** | 5 | Follows established patterns precisely. Three files, clean boundaries. |
+| **Systems Design** | 4 | Good operational reasoning (the travel experience). One gap in daemon mode verbosity. |
+
+## Design Tensions
+
+### 1. String-typed skip reasons vs. typed enum
+
+The design keeps `Vec<(String, String)>` for skip reasons and does grouping via prefix matching
+in the renderer. The alternative (typed `SkipReason` enum) would make grouping trivial and
+eliminate fragile string coupling between planner and renderer.
+
+**The trade-off was resolved correctly.** The typed enum touches 5+ files for a gain of ~20
+lines of cleaner grouping logic. The string reasons are stable (they've been the same since
+phase 1), and if they change, the grouping degrades gracefully to ungrouped display — not to
+wrong behavior. The pragmatic choice.
+
+### 2. StatusAssessment reuse vs. dedicated type
+
+The design reuses `StatusAssessment` (from `urd status`) inside `BackupSummary`. If
+`StatusAssessment` grows fields specific to the status command, the backup summary inherits them.
+
+**Acceptable coupling.** Both consumers need the same data: subvolume name, promise status,
+local count, external counts, advisories, errors. `StatusAssessment` is a serialization wrapper
+around `SubvolAssessment` — it's unlikely to diverge because the underlying awareness model
+output is the same. If it does diverge, extracting a second type is a 10-minute refactor.
+The design explicitly flags this as a review question, which shows the right instinct.
+
+### 3. Conditional awareness table (Open Question 3)
+
+The design recommends showing the awareness table only when something is AT RISK or UNPROTECTED.
+This is the right call — it aligns with the invisible worker principle and avoids the failure
+mode where users learn to ignore the backup output because it's always a wall of green text.
+A one-line "All subvolumes PROTECTED" when everything is healthy conveys maximum information
+in minimum space.
+
+## Findings
+
+### Finding 1: SubvolumeSummary loses multi-drive information — Significant
+
+**What:** `SubvolumeSummary` has a single `send_drive: Option<String>` and `send_type: String`.
+But a subvolume can be sent to *multiple drives* in one run — the planner iterates over all
+available drives per subvolume. Looking at the executor, `SubvolumeResult.send_type` is
+overwritten per-send (`send_type = SendType::Incremental` / `SendType::Full`), so it only
+records the *last* send's type. The design mirrors this lossy representation.
+
+**Why it matters:** In a two-drive run, `htpc-home` might be sent incrementally to WD-18TB
+and fully to 2TB-backup. The proposed `SubvolumeSummary` would show either "incremental" or
+"full" (whichever was last), and one drive label. The interactive output mockup shows
+`OK htpc-docs [0.3s] (incremental -> WD-18TB)` — but what about the send to 2TB-backup?
+
+**Consequence:** The user thinks one drive got the backup when two did, or sees "full send"
+when the expensive operation was only to one drive. Misleading, but not data-loss-level.
+
+**Suggested fix:** Replace the flat fields with a per-send list:
+
+```rust
+pub struct SubvolumeSummary {
+    pub name: String,
+    pub success: bool,
+    pub duration_secs: f64,
+    pub sends: Vec<SendSummary>,    // zero or more
+    pub errors: Vec<String>,
+}
+
+pub struct SendSummary {
+    pub drive: String,
+    pub send_type: String,          // "full" | "incremental"
+    pub bytes_transferred: Option<u64>,
+}
+```
+
+This data already exists in `SubvolumeResult.operations` — the build function just needs to
+extract it per-operation instead of flattening. The renderer shows:
+
+```
+  OK   htpc-docs  [0.3s] (incremental -> WD-18TB, full -> 2TB-backup)
+```
+
+This is a small change to the proposed types that correctly represents the data the executor
+already produces.
+
+### Finding 2: build_backup_summary needs explicit duration parameter — Moderate
+
+**What:** The design says `build_backup_summary()` takes "total duration" as a parameter.
+Looking at the current backup.rs, the total run duration is *not* explicitly tracked. The
+per-subvolume durations exist in `SubvolumeResult`, and the executor start time is implicit
+(it's before the `executor.execute()` call).
+
+**Why it matters:** If the implementation uses `Instant::now()` before and after `execute()`,
+it measures executor wall time but misses plan generation, lock acquisition, and awareness
+assessment. If it wraps the entire `run()` function, it measures too much (config loading,
+UUID warnings, etc.).
+
+**Consequence:** Minor — the "12.3s" in the header line might be slightly misleading but
+nobody makes decisions based on total backup duration.
+
+**Suggested fix:** Capture `Instant::now()` immediately before `executor.execute()` and
+compute duration immediately after. The header line's duration means "how long the executor
+ran" — which is the useful number. Document in the build function's doc comment what duration
+represents.
+
+### Finding 3: Skip grouping could silently swallow unique skip reasons — Moderate
+
+**What:** The design proposes collapsing "drive X not mounted" skips into a grouped line.
+The grouping works by prefix matching. But the planner also produces drive-scoped skips
+that are *not* "not mounted" — UUID mismatch and UUID check failed. These have different
+prefixes and should NOT be grouped with "not mounted" skips.
+
+**Why it matters:** UUID mismatch is a security-relevant event (potential drive substitution
+attack — the reason UUID fingerprinting was built). If the renderer groups by drive label
+rather than by exact reason prefix, a UUID mismatch could be collapsed into a "2 drives not
+available" line, hiding a security event.
+
+**Consequence:** Missed security signal in the backup output.
+
+**Suggested fix:** The design's recommendation (group by exact reason prefix match on
+`"drive {label} not mounted"`) is already correct. Just make this an explicit invariant:
+**only "not mounted" reasons are grouped; all other skip reasons render individually.** Add a
+test that UUID mismatch and UUID check failures are never grouped. This answers Open Question 1
+definitively.
+
+### Finding 4: Empty run path should stay as early return — Minor
+
+**What:** The design recommends flowing the empty run through the summary path "for consistency."
+
+**The early return is better.** The empty run (no operations AND no skips) means the config
+has no enabled subvolumes, or all subvolumes are filtered out by priority/name flags. This is
+a fundamentally different situation from "all sends skipped because drives aren't mounted"
+(which has operations=0 but skips>0). Routing both through BackupSummary means the summary
+type must handle a degenerate case that doesn't match its purpose.
+
+Keep the early return for truly-empty plans. The "all skips" case (operations empty, skips
+non-empty) should flow through the summary — that's the 2b case.
+
+**Suggested fix:** Keep the existing early return at line 66-76 of backup.rs. Extend it to
+use the voice layer for the "Nothing to do" message (one-liner, not the full summary path).
+The summary path handles: (a) normal runs with results + skips, (b) all-skip runs with only
+skips.
+
+### Finding 5: Established pattern executed cleanly — Commendation
+
+The design follows the `StatusOutput` / `render_status` pattern exactly: structured type in
+output.rs, pure render function in voice.rs, assembly in the command module. The three-file
+change surface, the decision to not touch plan.rs or executor.rs, the reuse of the awareness
+assessment that's already being computed — these are good instincts. The "what does NOT change"
+section is valuable: knowing what *won't* be touched gives confidence about blast radius.
+
+### Finding 6: Merging 2b into 2d is the right call — Commendation
+
+The analysis that 2b is a subset of 2d, with explicit effort comparison (~30 min vs ~2h), is
+the kind of reasoning that prevents throw-away intermediate code. The observation that "most
+nightly runs are all-skips, so the skip block IS the output" correctly identifies the dominant
+use case and designs the rendering order around it (skips prominent, not dimmed).
+
+## The Simplicity Question
+
+**What could be removed?** Not much. The design is already minimal — three types, two functions,
+one refactored command. The skip grouping is the most complex new logic (~20 lines), and it
+directly serves the primary use case.
+
+**What's earning its keep?** Everything. The `BackupSummary` type exists because the backup
+command needs structured output for daemon mode (JSON). The `SkippedSubvolume` type exists
+because the planner's `(String, String)` tuple isn't Serialize-friendly and needs a named
+structure. The awareness table reuse exists because the user asked "is my data safe?" and the
+awareness model already answers that.
+
+**One simplification opportunity:** The `warnings: Vec<String>` field on `BackupSummary` could
+be dropped. Pin failure warnings and skipped deletion notes are derivable from `SubvolumeSummary`
+data (pin_failures, operation outcomes). The renderer can compute these from the subvolume
+results rather than having the build function pre-compute them. This eliminates one field and
+one loop in the builder. However, this is a marginal call — the pre-computed warnings are also
+fine. Implementer's choice.
+
+## For the Dev Team
+
+Priority order:
+
+1. **Fix SubvolumeSummary multi-drive modeling** (Finding 1). Replace `send_drive: Option<String>`
+   and `send_type: String` with `sends: Vec<SendSummary>`. Extract per-send data from
+   `SubvolumeResult.operations` in the build function. This affects: output.rs (type definition),
+   backup.rs (build function), voice.rs (render of per-subvolume line).
+
+2. **Lock down skip grouping invariant** (Finding 3). In the renderer, only group skips matching
+   `"drive {label} not mounted"`. All other skip reasons (UUID mismatch, space, disabled, low
+   local space) render individually. Add a test that UUID mismatch skips are never collapsed.
+
+3. **Keep empty-run early return** (Finding 4). Don't route truly-empty plans through
+   BackupSummary. The all-skips case (operations empty, skips non-empty) uses the summary path.
+   The no-ops-no-skips case stays as early return.
+
+4. **Capture executor duration explicitly** (Finding 2). `Instant::now()` before
+   `executor.execute()`, duration after. Pass to `build_backup_summary()`.
+
+5. **Decide on warnings field** (Simplicity section). Either keep pre-computed warnings or
+   derive in renderer. Minor either way.
+
+## Answers to Open Questions
+
+1. **Skip grouping heuristics (OQ1):** Group by exact prefix `"drive {label} not mounted"` only.
+   All other reasons render individually. This is the right call — see Finding 3.
+
+2. **Empty run rendering (OQ2):** Keep as early return. See Finding 4.
+
+3. **Awareness table verbosity (OQ3):** Option (b) — show only when AT RISK or UNPROTECTED. One
+   line "All subvolumes PROTECTED" otherwise. Correct.
+
+4. **Awareness table in daemon mode (OQ4):** Keep it. The daemon JSON is consumed by scripts
+   and monitoring that may not read the heartbeat. Omitting it creates a "works in interactive,
+   broken in daemon" asymmetry. The heartbeat is for the Sentinel; the daemon JSON is for
+   external tooling.
+
+5. **Backward compatibility of stdout (OQ5):** Not a contract. stdout format has already
+   changed several times (progress display, pin failure warnings). No ADR needed. The daemon
+   JSON format is new (there was no daemon-mode backup output before), so there's nothing to
+   break.
+
+## Open Questions
+
+1. **Should `SubvolumeResult.send_type` in executor.rs also be fixed?** It currently records
+   only the last send type. The data is already preserved per-operation in
+   `OperationOutcome.drive_label`, so nothing is lost — but the summary field is misleading.
+   This is an existing tech debt item, not gated on this design. Flag it in status.md and
+   move on.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -7,17 +7,20 @@ use std::time::{Duration, Instant};
 
 use colored::Colorize;
 
-use crate::awareness;
+use crate::awareness::{self, SubvolAssessment};
 use crate::btrfs::RealBtrfs;
 use crate::cli::BackupArgs;
 use crate::config::Config;
 use crate::drives;
-use crate::executor::{Executor, RunResult, SendType};
+use crate::executor::{Executor, ExecutionResult, OpResult, RunResult};
 use crate::heartbeat;
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
+use crate::output::{
+    BackupSummary, OutputMode, SendSummary, SkippedSubvolume, StatusAssessment, SubvolumeSummary,
+};
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
 use crate::state::StateDb;
-use crate::types::ByteSize;
+use crate::types::{BackupPlan, ByteSize};
 
 pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let now = chrono::Local::now().naive_local();
@@ -102,105 +105,14 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     };
 
     let executor = Executor::new(&btrfs, state_db.as_ref(), &config, &shutdown);
+    let exec_start = Instant::now();
     let result = executor.execute(&backup_plan, mode);
+    let exec_duration = exec_start.elapsed();
 
     // Stop progress display
     progress_shutdown.store(true, Ordering::SeqCst);
     if let Some(h) = progress_handle {
         h.join().ok();
-    }
-
-    // Print results
-    println!(
-        "{}",
-        format!("Urd backup completed: {}", result.overall.as_str()).bold()
-    );
-    println!();
-
-    let mut total_pin_failures: u32 = 0;
-
-    for sv in &result.subvolume_results {
-        let status = if sv.success {
-            "OK".green()
-        } else {
-            "FAILED".red()
-        };
-        let send_info = match sv.send_type {
-            SendType::Full => " (full send)".to_string(),
-            SendType::Incremental => " (incremental)".to_string(),
-            SendType::NoSend => String::new(),
-        };
-        println!(
-            "  {} {} [{:.1}s]{}",
-            status,
-            sv.name.bold(),
-            sv.duration.as_secs_f64(),
-            send_info,
-        );
-
-        // Print errors for failed operations
-        for op in &sv.operations {
-            if let Some(err) = &op.error
-                && op.result == crate::executor::OpResult::Failure
-            {
-                println!("    {} {}: {}", "ERROR".red(), op.operation, err);
-            }
-        }
-
-        // Print pin failure warnings prominently
-        if sv.pin_failures > 0 {
-            total_pin_failures += sv.pin_failures;
-            println!(
-                "    {} {} pin file write(s) failed — next send may be full instead of incremental",
-                "WARNING".yellow(),
-                sv.pin_failures,
-            );
-        }
-    }
-
-    // Print skipped subvolumes
-    for (name, reason) in &backup_plan.skipped {
-        println!("  {} {} ({})", "SKIP".dimmed(), name, reason.dimmed());
-    }
-
-    // Summary for skipped deletions (space recovery)
-    let planned_deletes = backup_plan
-        .operations
-        .iter()
-        .filter(|op| matches!(op, crate::types::PlannedOperation::DeleteSnapshot { .. }))
-        .count();
-    let skipped_deletes: usize = result
-        .subvolume_results
-        .iter()
-        .flat_map(|sv| sv.operations.iter())
-        .filter(|op| {
-            op.operation == "delete"
-                && op.result == crate::executor::OpResult::Skipped
-                && op
-                    .error
-                    .as_ref()
-                    .is_some_and(|e| e.contains("space recovered"))
-        })
-        .count();
-    if skipped_deletes > 0 {
-        println!();
-        println!(
-            "{} {} of {} planned deletion(s) skipped (space recovered)",
-            "NOTE:".dimmed().bold(),
-            skipped_deletes,
-            planned_deletes,
-        );
-    }
-
-    // Summary warning for pin failures
-    if total_pin_failures > 0 {
-        println!();
-        println!(
-            "{} {} pin file write(s) failed. Run {} to diagnose.",
-            "WARNING:".yellow().bold(),
-            total_pin_failures,
-            "urd verify".bold(),
-        );
     }
 
     // Write metrics
@@ -214,12 +126,133 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         log::warn!("Failed to write heartbeat: {e}");
     }
 
+    // Build and render structured summary
+    let summary = build_backup_summary(&backup_plan, &result, &assessments, exec_duration);
+    let output_mode = OutputMode::detect();
+    let rendered = crate::voice::render_backup_summary(&summary, output_mode);
+    println!("{rendered}");
+
     // Exit with appropriate code
     if result.overall != RunResult::Success {
         std::process::exit(1);
     }
 
     Ok(())
+}
+
+// ── Summary builder ─────────────────────────────────────────────────────
+
+/// Build a structured backup summary from plan, execution results, and awareness assessments.
+/// Pure function — no I/O.
+fn build_backup_summary(
+    plan: &BackupPlan,
+    result: &ExecutionResult,
+    assessments: &[SubvolAssessment],
+    duration: Duration,
+) -> BackupSummary {
+    let subvolumes: Vec<SubvolumeSummary> = result
+        .subvolume_results
+        .iter()
+        .map(|sv| {
+            let sends: Vec<SendSummary> = sv
+                .operations
+                .iter()
+                .filter(|op| {
+                    (op.operation == "send_incremental" || op.operation == "send_full")
+                        && op.result == OpResult::Success
+                })
+                .map(|op| SendSummary {
+                    drive: op.drive_label.clone().unwrap_or_default(),
+                    send_type: if op.operation == "send_full" {
+                        "full".to_string()
+                    } else {
+                        "incremental".to_string()
+                    },
+                    bytes_transferred: op.bytes_transferred,
+                })
+                .collect();
+
+            let errors: Vec<String> = sv
+                .operations
+                .iter()
+                .filter(|op| op.result == OpResult::Failure)
+                .filter_map(|op| {
+                    op.error
+                        .as_ref()
+                        .map(|e| format!("{}: {}", op.operation, e))
+                })
+                .collect();
+
+            SubvolumeSummary {
+                name: sv.name.clone(),
+                success: sv.success,
+                duration_secs: sv.duration.as_secs_f64(),
+                sends,
+                errors,
+            }
+        })
+        .collect();
+
+    let skipped: Vec<SkippedSubvolume> = plan
+        .skipped
+        .iter()
+        .map(|(name, reason)| SkippedSubvolume {
+            name: name.clone(),
+            reason: reason.clone(),
+        })
+        .collect();
+
+    let mut warnings = Vec::new();
+
+    // Pin failure warnings
+    let total_pin_failures: u32 = result
+        .subvolume_results
+        .iter()
+        .map(|sv| sv.pin_failures)
+        .sum();
+    if total_pin_failures > 0 {
+        warnings.push(format!(
+            "{total_pin_failures} pin file write(s) failed. Run `urd verify` to diagnose."
+        ));
+    }
+
+    // Skipped deletions (space recovery)
+    let planned_deletes = plan
+        .operations
+        .iter()
+        .filter(|op| matches!(op, crate::types::PlannedOperation::DeleteSnapshot { .. }))
+        .count();
+    let skipped_deletes: usize = result
+        .subvolume_results
+        .iter()
+        .flat_map(|sv| sv.operations.iter())
+        .filter(|op| {
+            op.operation == "delete"
+                && op.result == OpResult::Skipped
+                && op
+                    .error
+                    .as_ref()
+                    .is_some_and(|e| e.contains("space recovered"))
+        })
+        .count();
+    if skipped_deletes > 0 {
+        warnings.push(format!(
+            "{skipped_deletes} of {planned_deletes} planned deletion(s) skipped (space recovered)"
+        ));
+    }
+
+    BackupSummary {
+        result: result.overall.as_str().to_string(),
+        run_id: result.run_id,
+        duration_secs: duration.as_secs_f64(),
+        subvolumes,
+        skipped,
+        assessments: assessments
+            .iter()
+            .map(StatusAssessment::from_assessment)
+            .collect(),
+        warnings,
+    }
 }
 
 /// Acquire an advisory lock to prevent concurrent backup runs.
@@ -465,5 +498,329 @@ fn format_elapsed(d: Duration) -> String {
         format!("{hours}:{mins:02}:{secs:02}")
     } else {
         format!("{mins}:{secs:02}")
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::awareness::{LocalAssessment, PromiseStatus, SubvolAssessment};
+    use crate::types::Interval;
+    use crate::executor::{
+        ExecutionResult, OperationOutcome, OpResult, RunResult, SendType, SubvolumeResult,
+    };
+    use crate::types::PlannedOperation;
+    use std::path::PathBuf;
+
+    fn make_outcome(
+        operation: &str,
+        drive: Option<&str>,
+        result: OpResult,
+        error: Option<&str>,
+        bytes: Option<u64>,
+    ) -> OperationOutcome {
+        OperationOutcome {
+            operation: operation.to_string(),
+            drive_label: drive.map(str::to_string),
+            result,
+            duration: Duration::from_millis(100),
+            error: error.map(str::to_string),
+            bytes_transferred: bytes,
+        }
+    }
+
+    fn make_subvol_result(
+        name: &str,
+        success: bool,
+        operations: Vec<OperationOutcome>,
+        send_type: SendType,
+        pin_failures: u32,
+    ) -> SubvolumeResult {
+        SubvolumeResult {
+            name: name.to_string(),
+            success,
+            operations,
+            duration: Duration::from_secs(2),
+            send_type,
+            pin_failures,
+        }
+    }
+
+    fn empty_assessments() -> Vec<SubvolAssessment> {
+        vec![]
+    }
+
+    fn sample_assessments() -> Vec<SubvolAssessment> {
+        vec![SubvolAssessment {
+            name: "htpc-home".to_string(),
+            status: PromiseStatus::Protected,
+            local: LocalAssessment {
+                status: PromiseStatus::Protected,
+                snapshot_count: 10,
+                newest_age: None,
+                configured_interval: Interval::hours(1),
+            },
+            external: vec![],
+            advisories: vec![],
+            errors: vec![],
+        }]
+    }
+
+    fn empty_plan() -> BackupPlan {
+        BackupPlan {
+            operations: vec![],
+            timestamp: chrono::NaiveDateTime::default(),
+            skipped: vec![],
+        }
+    }
+
+    #[test]
+    fn build_summary_extracts_successful_sends_only() {
+        let result = ExecutionResult {
+            overall: RunResult::Partial,
+            subvolume_results: vec![make_subvol_result(
+                "htpc-home",
+                true,
+                vec![
+                    make_outcome("snapshot", None, OpResult::Success, None, None),
+                    make_outcome(
+                        "send_incremental",
+                        Some("WD-18TB"),
+                        OpResult::Success,
+                        None,
+                        Some(5_000_000),
+                    ),
+                    make_outcome(
+                        "send_full",
+                        Some("2TB-backup"),
+                        OpResult::Failure,
+                        Some("btrfs send failed"),
+                        Some(1_000),
+                    ),
+                ],
+                SendType::Incremental,
+                0,
+            )],
+            run_id: Some(10),
+        };
+
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(5));
+
+        assert_eq!(summary.subvolumes.len(), 1);
+        let sv = &summary.subvolumes[0];
+        // Only the successful send should appear
+        assert_eq!(sv.sends.len(), 1, "failed sends should not appear in sends list");
+        assert_eq!(sv.sends[0].drive, "WD-18TB");
+        assert_eq!(sv.sends[0].send_type, "incremental");
+        assert_eq!(sv.sends[0].bytes_transferred, Some(5_000_000));
+        // The failed send should appear in errors
+        assert_eq!(sv.errors.len(), 1);
+        assert!(sv.errors[0].contains("btrfs send failed"));
+    }
+
+    #[test]
+    fn build_summary_multi_drive_sends() {
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![make_subvol_result(
+                "htpc-docs",
+                true,
+                vec![
+                    make_outcome(
+                        "send_incremental",
+                        Some("WD-18TB"),
+                        OpResult::Success,
+                        None,
+                        Some(2_000_000),
+                    ),
+                    make_outcome(
+                        "send_full",
+                        Some("2TB-backup"),
+                        OpResult::Success,
+                        None,
+                        Some(80_000_000_000),
+                    ),
+                ],
+                SendType::Full,
+                0,
+            )],
+            run_id: Some(11),
+        };
+
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(120));
+
+        let sv = &summary.subvolumes[0];
+        assert_eq!(sv.sends.len(), 2, "both successful sends should appear");
+        assert_eq!(sv.sends[0].drive, "WD-18TB");
+        assert_eq!(sv.sends[0].send_type, "incremental");
+        assert_eq!(sv.sends[1].drive, "2TB-backup");
+        assert_eq!(sv.sends[1].send_type, "full");
+    }
+
+    #[test]
+    fn build_summary_pin_failure_warning() {
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![
+                make_subvol_result("sv1", true, vec![], SendType::NoSend, 1),
+                make_subvol_result("sv2", true, vec![], SendType::NoSend, 2),
+            ],
+            run_id: Some(12),
+        };
+
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(1));
+
+        assert_eq!(summary.warnings.len(), 1);
+        assert!(summary.warnings[0].contains("3 pin file write(s) failed"));
+        assert!(summary.warnings[0].contains("urd verify"));
+    }
+
+    #[test]
+    fn build_summary_no_warnings_when_clean() {
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![make_subvol_result(
+                "sv1",
+                true,
+                vec![],
+                SendType::NoSend,
+                0,
+            )],
+            run_id: Some(13),
+        };
+
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(1));
+
+        assert!(summary.warnings.is_empty(), "should have no warnings on clean run");
+    }
+
+    #[test]
+    fn build_summary_skipped_deletions_warning() {
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/snaps/sv1/20260320-0400-sv1"),
+                    reason: "retention".to_string(),
+                    subvolume_name: "sv1".to_string(),
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/snaps/sv1/20260319-0400-sv1"),
+                    reason: "retention".to_string(),
+                    subvolume_name: "sv1".to_string(),
+                },
+            ],
+            timestamp: chrono::NaiveDateTime::default(),
+            skipped: vec![],
+        };
+
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![make_subvol_result(
+                "sv1",
+                true,
+                vec![make_outcome(
+                    "delete",
+                    None,
+                    OpResult::Skipped,
+                    Some("space recovered by prior deletes"),
+                    None,
+                )],
+                SendType::NoSend,
+                0,
+            )],
+            run_id: Some(14),
+        };
+
+        let summary = build_backup_summary(&plan, &result, &empty_assessments(), Duration::from_secs(1));
+
+        assert_eq!(summary.warnings.len(), 1);
+        assert!(summary.warnings[0].contains("1 of 2 planned deletion(s) skipped"));
+    }
+
+    #[test]
+    fn build_summary_maps_plan_skips() {
+        let plan = BackupPlan {
+            operations: vec![],
+            timestamp: chrono::NaiveDateTime::default(),
+            skipped: vec![
+                ("htpc-home".to_string(), "drive WD-18TB not mounted".to_string()),
+                ("htpc-docs".to_string(), "disabled".to_string()),
+            ],
+        };
+
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![],
+            run_id: None,
+        };
+
+        let summary = build_backup_summary(&plan, &result, &empty_assessments(), Duration::from_secs(0));
+
+        assert_eq!(summary.skipped.len(), 2);
+        assert_eq!(summary.skipped[0].name, "htpc-home");
+        assert_eq!(summary.skipped[0].reason, "drive WD-18TB not mounted");
+        assert_eq!(summary.skipped[1].name, "htpc-docs");
+        assert_eq!(summary.skipped[1].reason, "disabled");
+    }
+
+    #[test]
+    fn build_summary_maps_assessments() {
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![],
+            run_id: Some(15),
+        };
+
+        let summary = build_backup_summary(&empty_plan(), &result, &sample_assessments(), Duration::from_secs(1));
+
+        assert_eq!(summary.assessments.len(), 1);
+        assert_eq!(summary.assessments[0].name, "htpc-home");
+        assert_eq!(summary.assessments[0].status, "PROTECTED");
+    }
+
+    #[test]
+    fn build_summary_overall_fields() {
+        let result = ExecutionResult {
+            overall: RunResult::Partial,
+            subvolume_results: vec![],
+            run_id: Some(99),
+        };
+
+        let summary = build_backup_summary(
+            &empty_plan(),
+            &result,
+            &empty_assessments(),
+            Duration::from_millis(12300),
+        );
+
+        assert_eq!(summary.result, "partial");
+        assert_eq!(summary.run_id, Some(99));
+        assert!((summary.duration_secs - 12.3).abs() < 0.01);
+    }
+
+    #[test]
+    fn build_summary_failed_op_without_error_message() {
+        // An operation can fail without an error message (e.g., if the error
+        // was captured at a higher level). The builder should not panic.
+        let result = ExecutionResult {
+            overall: RunResult::Failure,
+            subvolume_results: vec![make_subvol_result(
+                "sv1",
+                false,
+                vec![make_outcome("send_full", Some("WD-18TB"), OpResult::Failure, None, None)],
+                SendType::NoSend,
+                0,
+            )],
+            run_id: Some(16),
+        };
+
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(1));
+
+        // Failed op with no error message should not appear in errors list
+        assert!(summary.subvolumes[0].errors.is_empty());
+        // And should not appear in sends list (it failed)
+        assert!(summary.subvolumes[0].sends.is_empty());
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -181,6 +181,56 @@ pub struct GetOutput {
     pub file_size: u64,
 }
 
+// ── BackupSummary ──────────────────────────────────────────────────────
+
+/// Structured output for the post-backup summary.
+#[derive(Debug, Serialize)]
+pub struct BackupSummary {
+    /// Overall run result: "success", "partial", or "failure".
+    pub result: String,
+    /// Run ID from SQLite (if available).
+    pub run_id: Option<i64>,
+    /// Total wall-clock duration of the executor run.
+    pub duration_secs: f64,
+
+    /// Per-subvolume execution results.
+    pub subvolumes: Vec<SubvolumeSummary>,
+    /// Subvolumes/sends skipped by the planner (name, reason).
+    pub skipped: Vec<SkippedSubvolume>,
+
+    /// Per-subvolume promise status AFTER the run (from awareness model).
+    pub assessments: Vec<StatusAssessment>,
+
+    /// Summary warnings (pin failures, skipped deletions, etc.)
+    pub warnings: Vec<String>,
+}
+
+/// Per-subvolume execution summary.
+#[derive(Debug, Serialize)]
+pub struct SubvolumeSummary {
+    pub name: String,
+    pub success: bool,
+    pub duration_secs: f64,
+    /// Per-drive send results (zero or more per subvolume).
+    pub sends: Vec<SendSummary>,
+    pub errors: Vec<String>,
+}
+
+/// Result of a single send operation to one drive.
+#[derive(Debug, Serialize)]
+pub struct SendSummary {
+    pub drive: String,
+    pub send_type: String,
+    pub bytes_transferred: Option<u64>,
+}
+
+/// A planner-skipped subvolume/send with reason.
+#[derive(Debug, Serialize)]
+pub struct SkippedSubvolume {
+    pub name: String,
+    pub reason: String,
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -137,12 +137,15 @@ pub fn plan(
         // The executor relies on this ordering within each subvolume.
         // Do not reorder without updating the executor contract in PLAN.md.
         if !filters.external_only {
+            let min_free = config.root_min_free_bytes(&subvol.name).unwrap_or(0);
             plan_local_snapshot(
                 subvol,
                 &local_dir,
                 &local_snaps,
                 now,
                 force,
+                min_free,
+                fs,
                 &mut operations,
                 &mut skipped,
             );
@@ -225,9 +228,31 @@ fn plan_local_snapshot(
     local_snaps: &[SnapshotName],
     now: NaiveDateTime,
     force: bool,
+    min_free: u64,
+    fs: &dyn FileSystemState,
     operations: &mut Vec<PlannedOperation>,
     skipped: &mut Vec<(String, String)>,
 ) {
+    // Space guard: refuse to create if local filesystem is below min_free_bytes threshold.
+    // This prevents the catastrophic failure mode where snapshot creation fills the source
+    // filesystem. force does NOT override — a forced snapshot on a full filesystem is still
+    // catastrophic. See 2026-03-24-local-space-exhaustion-postmortem.md.
+    if min_free > 0 {
+        let free = fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
+        if free < min_free {
+            use crate::types::ByteSize;
+            skipped.push((
+                subvol.name.clone(),
+                format!(
+                    "local filesystem low on space ({} free, {} required)",
+                    ByteSize(free),
+                    ByteSize(min_free),
+                ),
+            ));
+            return;
+        }
+    }
+
     // Check if interval has elapsed since newest snapshot
     let newest = local_snaps.iter().max();
 
@@ -1681,5 +1706,99 @@ send_enabled = false
             !sends.is_empty(),
             "Backward compat: mounted_drives should still trigger sends"
         );
+    }
+
+    // ── Local space guard tests ─────────────────────────────────────────
+
+    #[test]
+    fn skips_snapshot_when_local_space_below_threshold() {
+        let config = test_config(); // min_free_bytes = 10GB
+        let mut fs = MockFileSystemState::new();
+        // sv1 interval elapsed, but local filesystem has only 5GB free (below 10GB threshold)
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        fs.free_bytes
+            .insert(PathBuf::from("/snap/sv1"), 5_000_000_000);
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+
+        // No snapshot should be created for sv1
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert!(creates.is_empty(), "Should not create snapshot when below min_free_bytes");
+
+        // Should have a skip reason mentioning low space
+        let skip_reasons: Vec<_> = result
+            .skipped
+            .iter()
+            .filter(|(name, reason)| name == "sv1" && reason.contains("low on space"))
+            .collect();
+        assert_eq!(skip_reasons.len(), 1, "Should record skip reason for low space");
+    }
+
+    #[test]
+    fn creates_snapshot_when_local_space_above_threshold() {
+        let config = test_config(); // min_free_bytes = 10GB
+        let mut fs = MockFileSystemState::new();
+        // sv1 interval elapsed, local filesystem has 50GB free (above 10GB threshold)
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        fs.free_bytes
+            .insert(PathBuf::from("/snap/sv1"), 50_000_000_000);
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "Should create snapshot when above min_free_bytes");
+    }
+
+    #[test]
+    fn space_guard_not_overridden_by_force() {
+        let config = test_config(); // min_free_bytes = 10GB
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        fs.free_bytes
+            .insert(PathBuf::from("/snap/sv1"), 5_000_000_000);
+
+        // Force sv1 — should still be blocked by space guard
+        let filters = PlanFilters {
+            subvolume: Some("sv1".to_string()),
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert!(creates.is_empty(), "Force should NOT override space guard");
+    }
+
+    #[test]
+    fn space_guard_fails_open_when_free_bytes_unreadable() {
+        let config = test_config(); // min_free_bytes = 10GB
+        let mut fs = MockFileSystemState::new();
+        // sv1 interval elapsed, but no free_bytes entry — defaults to u64::MAX (fail open)
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        // Note: no fs.free_bytes entry for /snap/sv1
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "Should create snapshot when free bytes unreadable (fail open)");
     }
 }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -11,7 +11,7 @@ use std::fmt::Write;
 
 use colored::Colorize;
 
-use crate::output::{GetOutput, OutputMode, StatusOutput};
+use crate::output::{BackupSummary, GetOutput, OutputMode, StatusOutput};
 use crate::types::ByteSize;
 
 // ── Status ──────────────────────────────────────────────────────────────
@@ -261,6 +261,250 @@ fn color_result(result: &str) -> String {
     }
 }
 
+// ── Backup Summary ─────────────────────────────────────────────────────
+
+/// Render post-backup summary according to the given mode.
+#[must_use]
+pub fn render_backup_summary(data: &BackupSummary, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => render_backup_interactive(data),
+        OutputMode::Daemon => render_backup_daemon(data),
+    }
+}
+
+fn render_backup_daemon(data: &BackupSummary) -> String {
+    serde_json::to_string_pretty(data).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
+}
+
+fn render_backup_interactive(data: &BackupSummary) -> String {
+    let mut out = String::new();
+
+    // ── Header ───────────────────────────────────────────────────────
+    let result_colored = color_result(&data.result);
+    let run_info = match data.run_id {
+        Some(id) => format!("run #{id}, "),
+        None => String::new(),
+    };
+    writeln!(
+        out,
+        "{}",
+        format!(
+            "── Urd backup: {result_colored} ── [{run_info}{:.1}s] ──",
+            data.duration_secs,
+        )
+        .bold()
+    )
+    .ok();
+
+    // ── Executed subvolumes ──────────────────────────────────────────
+    if !data.subvolumes.is_empty() {
+        writeln!(out).ok();
+        for sv in &data.subvolumes {
+            let status = if sv.success {
+                "OK".green().to_string()
+            } else {
+                "FAILED".red().to_string()
+            };
+
+            let send_info = format_send_info(&sv.sends);
+            writeln!(
+                out,
+                "  {:<6} {}  [{:.1}s]{}",
+                status,
+                sv.name.bold(),
+                sv.duration_secs,
+                send_info,
+            )
+            .ok();
+
+            for err in &sv.errors {
+                writeln!(out, "    {} {}", "ERROR".red(), err).ok();
+            }
+        }
+    }
+
+    // ── Skipped sends ────────────────────────────────────────────────
+    render_skipped_block(&data.skipped, &mut out);
+
+    // ── Awareness table ──────────────────────────────────────────────
+    let any_not_protected = data
+        .assessments
+        .iter()
+        .any(|a| a.status != "PROTECTED");
+    if any_not_protected {
+        writeln!(out).ok();
+        render_assessment_table(data, &mut out);
+        render_assessment_advisories(data, &mut out);
+    } else if !data.assessments.is_empty() {
+        writeln!(out).ok();
+        writeln!(out, "All subvolumes {}.", "PROTECTED".green()).ok();
+    }
+
+    // ── Warnings ─────────────────────────────────────────────────────
+    if !data.warnings.is_empty() {
+        writeln!(out).ok();
+        for warning in &data.warnings {
+            writeln!(out, "{} {}", "WARNING:".yellow().bold(), warning).ok();
+        }
+    }
+
+    out
+}
+
+fn format_send_info(sends: &[crate::output::SendSummary]) -> String {
+    if sends.is_empty() {
+        return String::new();
+    }
+    let parts: Vec<String> = sends
+        .iter()
+        .map(|s| {
+            let bytes_info = s
+                .bytes_transferred
+                .map(|b| format!(", {}", ByteSize(b)))
+                .unwrap_or_default();
+            format!("{} \u{2192} {}{}", s.send_type, s.drive, bytes_info)
+        })
+        .collect();
+    format!("  ({})", parts.join("; "))
+}
+
+/// Render skipped subvolumes, grouping "drive X not mounted" entries.
+fn render_skipped_block(skipped: &[crate::output::SkippedSubvolume], out: &mut String) {
+    if skipped.is_empty() {
+        return;
+    }
+
+    writeln!(out).ok();
+
+    // Separate "not mounted" skips from unique skips.
+    // Only exact "drive {label} not mounted" reasons are grouped.
+    let mut not_mounted_drives: Vec<String> = Vec::new();
+    let mut not_mounted_subvols: Vec<String> = Vec::new();
+    let mut unique_skips: Vec<&crate::output::SkippedSubvolume> = Vec::new();
+
+    for skip in skipped {
+        if let Some(label) = skip
+            .reason
+            .strip_prefix("drive ")
+            .and_then(|r| r.strip_suffix(" not mounted"))
+        {
+            if !not_mounted_drives.contains(&label.to_string()) {
+                not_mounted_drives.push(label.to_string());
+            }
+            if !not_mounted_subvols.contains(&skip.name) {
+                not_mounted_subvols.push(skip.name.clone());
+            }
+        } else {
+            unique_skips.push(skip);
+        }
+    }
+
+    // Grouped "not mounted" line
+    if !not_mounted_drives.is_empty() {
+        writeln!(
+            out,
+            "  {} {}",
+            "Drives not mounted:".dimmed(),
+            not_mounted_drives.join(", "),
+        )
+        .ok();
+        writeln!(
+            out,
+            "    {} {} send(s) skipped ({})",
+            "\u{2192}".dimmed(),
+            skipped.len() - unique_skips.len(),
+            not_mounted_subvols.join(", "),
+        )
+        .ok();
+    }
+
+    // Individual skips (UUID mismatch, space, disabled, etc.)
+    for skip in &unique_skips {
+        writeln!(
+            out,
+            "  {} {}  {}",
+            "SKIP".yellow(),
+            skip.name.bold(),
+            skip.reason,
+        )
+        .ok();
+    }
+}
+
+/// Render the awareness assessment table (same layout as status command).
+fn render_assessment_table(data: &BackupSummary, out: &mut String) {
+    // Reuse the same table structure as render_subvolume_table in status rendering.
+    // Build a StatusOutput-compatible view for the shared table formatter.
+    if data.assessments.is_empty() {
+        return;
+    }
+
+    // Collect drive labels from assessments
+    let mut drive_labels: Vec<String> = Vec::new();
+    for assessment in &data.assessments {
+        for ext in &assessment.external {
+            if ext.mounted && !drive_labels.contains(&ext.drive_label) {
+                drive_labels.push(ext.drive_label.clone());
+            }
+        }
+    }
+
+    // Build headers: STATUS  SUBVOLUME  LOCAL  [DRIVE1]  [DRIVE2]
+    let mut headers: Vec<String> = vec![
+        "STATUS".to_string(),
+        "SUBVOLUME".to_string(),
+        "LOCAL".to_string(),
+    ];
+    for label in &drive_labels {
+        headers.push(label.clone());
+    }
+
+    // Build rows
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    for assessment in &data.assessments {
+        let mut row = vec![
+            assessment.status.clone(),
+            assessment.name.clone(),
+            assessment.local_snapshot_count.to_string(),
+        ];
+
+        for label in &drive_labels {
+            let count = assessment
+                .external
+                .iter()
+                .find(|e| e.drive_label == *label)
+                .and_then(|e| e.snapshot_count);
+            row.push(match count {
+                Some(c) if c > 0 => c.to_string(),
+                _ => "\u{2014}".to_string(),
+            });
+        }
+
+        rows.push(row);
+    }
+
+    format_table(&headers, &rows, out);
+}
+
+/// Render advisories and errors from awareness assessments.
+fn render_assessment_advisories(data: &BackupSummary, out: &mut String) {
+    for assessment in &data.assessments {
+        for error in &assessment.errors {
+            writeln!(out, "  {} {}: {}", "ERROR".red(), assessment.name, error).ok();
+        }
+        for advisory in &assessment.advisories {
+            writeln!(
+                out,
+                "  {} {}: {}",
+                "NOTE".dimmed(),
+                assessment.name,
+                advisory,
+            )
+            .ok();
+        }
+    }
+}
+
 // ── Get ────────────────────────────────────────────────────────────────
 
 /// Render get metadata according to the given mode (for stderr, not content).
@@ -290,8 +534,8 @@ fn render_get_interactive(data: &GetOutput) -> String {
 mod tests {
     use super::*;
     use crate::output::{
-        ChainHealth, ChainHealthEntry, DriveInfo, LastRunInfo, StatusAssessment,
-        StatusDriveAssessment,
+        BackupSummary, ChainHealth, ChainHealthEntry, DriveInfo, LastRunInfo, SendSummary,
+        SkippedSubvolume, StatusAssessment, StatusDriveAssessment, SubvolumeSummary,
     };
 
     fn test_status_output() -> StatusOutput {
@@ -489,6 +733,272 @@ mod tests {
         assert!(
             output.contains("no runs recorded"),
             "missing no-runs message"
+        );
+    }
+
+    // ── Backup summary tests ────────────────────────────────────────
+
+    fn test_backup_summary() -> BackupSummary {
+        BackupSummary {
+            result: "success".to_string(),
+            run_id: Some(47),
+            duration_secs: 12.3,
+            subvolumes: vec![
+                SubvolumeSummary {
+                    name: "htpc-home".to_string(),
+                    success: true,
+                    duration_secs: 2.1,
+                    sends: vec![],
+                    errors: vec![],
+                },
+                SubvolumeSummary {
+                    name: "htpc-docs".to_string(),
+                    success: true,
+                    duration_secs: 0.3,
+                    sends: vec![SendSummary {
+                        drive: "WD-18TB".to_string(),
+                        send_type: "incremental".to_string(),
+                        bytes_transferred: Some(1_500_000),
+                    }],
+                    errors: vec![],
+                },
+            ],
+            skipped: vec![
+                SkippedSubvolume {
+                    name: "htpc-home".to_string(),
+                    reason: "drive 2TB-backup not mounted".to_string(),
+                },
+                SkippedSubvolume {
+                    name: "htpc-docs".to_string(),
+                    reason: "drive 2TB-backup not mounted".to_string(),
+                },
+            ],
+            assessments: vec![StatusAssessment {
+                name: "htpc-home".to_string(),
+                status: "PROTECTED".to_string(),
+                local_snapshot_count: 12,
+                local_status: "PROTECTED".to_string(),
+                external: vec![],
+                advisories: vec![],
+                errors: vec![],
+            }],
+            warnings: vec![],
+        }
+    }
+
+    #[test]
+    fn backup_interactive_contains_header() {
+        colored::control::set_override(false);
+        let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
+        assert!(output.contains("success"), "missing result in header");
+        assert!(output.contains("#47"), "missing run ID");
+        assert!(output.contains("12.3"), "missing duration");
+    }
+
+    #[test]
+    fn backup_interactive_contains_subvolumes() {
+        colored::control::set_override(false);
+        let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
+        assert!(output.contains("htpc-home"), "missing subvolume name");
+        assert!(output.contains("htpc-docs"), "missing subvolume name");
+        assert!(output.contains("OK"), "missing OK status");
+    }
+
+    #[test]
+    fn backup_interactive_contains_send_info() {
+        colored::control::set_override(false);
+        let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
+        assert!(
+            output.contains("incremental") && output.contains("WD-18TB"),
+            "missing send info"
+        );
+    }
+
+    #[test]
+    fn backup_interactive_groups_not_mounted_skips() {
+        colored::control::set_override(false);
+        let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
+        assert!(
+            output.contains("Drives not mounted"),
+            "missing grouped skip header"
+        );
+        assert!(
+            output.contains("2TB-backup"),
+            "missing drive name in grouped skip"
+        );
+        assert!(
+            output.contains("2 send(s) skipped"),
+            "missing skip count"
+        );
+    }
+
+    #[test]
+    fn backup_interactive_uuid_mismatch_not_grouped() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.skipped = vec![
+            SkippedSubvolume {
+                name: "htpc-home".to_string(),
+                reason: "drive WD-18TB not mounted".to_string(),
+            },
+            SkippedSubvolume {
+                name: "htpc-home".to_string(),
+                reason: "drive 2TB-backup UUID mismatch (expected abc, found def)".to_string(),
+            },
+        ];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("UUID mismatch"),
+            "UUID mismatch must render individually"
+        );
+        assert!(
+            output.contains("SKIP"),
+            "UUID mismatch must show SKIP label"
+        );
+    }
+
+    #[test]
+    fn backup_interactive_all_protected_one_line() {
+        colored::control::set_override(false);
+        let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
+        assert!(
+            output.contains("All subvolumes PROTECTED"),
+            "missing all-protected summary"
+        );
+        // Should NOT contain a table header
+        assert!(
+            !output.contains("SUBVOLUME"),
+            "should not show table when all protected"
+        );
+    }
+
+    #[test]
+    fn backup_interactive_shows_table_when_at_risk() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.assessments[0].status = "AT RISK".to_string();
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("SUBVOLUME"),
+            "should show table when not all protected"
+        );
+        assert!(output.contains("AT RISK"), "missing AT RISK status");
+    }
+
+    #[test]
+    fn backup_interactive_shows_warnings() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.warnings = vec!["2 pin file write(s) failed. Run `urd verify` to diagnose.".to_string()];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("pin file write"),
+            "missing warning"
+        );
+        assert!(
+            output.contains("WARNING"),
+            "missing WARNING label"
+        );
+    }
+
+    #[test]
+    fn backup_interactive_shows_errors() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.subvolumes[1].success = false;
+        data.subvolumes[1].errors = vec!["send_full: btrfs send failed".to_string()];
+        data.result = "partial".to_string();
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("FAILED"),
+            "missing FAILED status"
+        );
+        assert!(
+            output.contains("btrfs send failed"),
+            "missing error detail"
+        );
+    }
+
+    #[test]
+    fn backup_interactive_multi_drive_sends() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.subvolumes[1].sends = vec![
+            SendSummary {
+                drive: "WD-18TB".to_string(),
+                send_type: "incremental".to_string(),
+                bytes_transferred: Some(1_500_000),
+            },
+            SendSummary {
+                drive: "2TB-backup".to_string(),
+                send_type: "full".to_string(),
+                bytes_transferred: Some(50_000_000_000),
+            },
+        ];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(output.contains("WD-18TB"), "missing first drive");
+        assert!(output.contains("2TB-backup"), "missing second drive");
+        assert!(output.contains("full"), "missing full send type");
+        assert!(output.contains("incremental"), "missing incremental send type");
+    }
+
+    #[test]
+    fn backup_daemon_produces_valid_json() {
+        let output = render_backup_summary(&test_backup_summary(), OutputMode::Daemon);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&output).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{output}"));
+        assert_eq!(parsed["result"], "success");
+        assert_eq!(parsed["run_id"], 47);
+        assert!(parsed["subvolumes"].is_array(), "missing subvolumes");
+        assert!(parsed["skipped"].is_array(), "missing skipped");
+        assert!(parsed["assessments"].is_array(), "missing assessments");
+    }
+
+    #[test]
+    fn backup_all_skips_run() {
+        colored::control::set_override(false);
+        let data = BackupSummary {
+            result: "success".to_string(),
+            run_id: Some(48),
+            duration_secs: 0.1,
+            subvolumes: vec![],
+            skipped: vec![
+                SkippedSubvolume {
+                    name: "htpc-home".to_string(),
+                    reason: "drive WD-18TB not mounted".to_string(),
+                },
+                SkippedSubvolume {
+                    name: "htpc-docs".to_string(),
+                    reason: "drive WD-18TB not mounted".to_string(),
+                },
+                SkippedSubvolume {
+                    name: "htpc-home".to_string(),
+                    reason: "drive 2TB-backup not mounted".to_string(),
+                },
+                SkippedSubvolume {
+                    name: "htpc-docs".to_string(),
+                    reason: "drive 2TB-backup not mounted".to_string(),
+                },
+            ],
+            assessments: vec![],
+            warnings: vec![],
+        };
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("Drives not mounted"),
+            "missing grouped header for all-skips run"
+        );
+        assert!(
+            output.contains("WD-18TB"),
+            "missing first drive in grouped skips"
+        );
+        assert!(
+            output.contains("2TB-backup"),
+            "missing second drive in grouped skips"
+        );
+        assert!(
+            output.contains("4 send(s) skipped"),
+            "wrong skip count"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Post-backup structured summary (P2b + P2d):** `BackupSummary` output type rendered by voice layer replaces ad-hoc println! in backup command. Per-subvolume results with multi-drive send info, grouped skip reasons (drive-not-mounted collapsed, UUID mismatch always individual), conditional awareness table, warning aggregation. Daemon mode = JSON. 2b subsumed by 2d.
- **Local space guard (P2a+):** Planner checks `filesystem_free_bytes` against `min_free_bytes` before creating local snapshots. `force` does not override. Closes the most dangerous safety gap (three NVMe exhaustion incidents).
- Design-reviewed before implementation; test-team reviewed after.

## Testing

- cargo clippy: pass (zero warnings)
- cargo test: 241 tests, all passing (+25 new: 9 builder, 12 renderer, 4 space guard)
- Integration tests: not applicable (presentation layer + planner logic, no btrfs calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)