### PR TITLE
feat: Add pre-flight config consistency checks

### DIFF
--- a/docs/95-ideas/2026-03-26-design-next-sessions.md
+++ b/docs/95-ideas/2026-03-26-design-next-sessions.md
@@ -1,0 +1,509 @@
+# Design: Next 2–3 Implementation Sessions
+
+> **TL;DR:** Three sessions: (1) Pre-flight checks + interval tuning, (2) Voice migration
+> for remaining commands, (3) Protection Promise ADR. Sessions are largely independent;
+> verify voice migration (Session 2) integrates preflight results if Session 1 is complete,
+> otherwise defers that integration. Sequence optimizes for operational safety first, then
+> presentation consistency, then unlocking Phase 6.
+
+**Date:** 2026-03-26
+**Status:** reviewed (all findings addressed)
+**Context:** All Priority 2a/2a+/2b/2d and Phase 5 foundations complete. Urd is sole backup
+system since 2026-03-25, monitoring until 2026-04-01.
+
+## Current Position
+
+What's done:
+- Safety hardening: UUID fingerprinting, local space guard, backup summary (2a, 2a+, 2b, 2d)
+- Architectural foundations: awareness model, heartbeat, presentation layer, `urd get` (3a–3d)
+- Operational cutover in progress (2 unattended nights, 5 total successful runs)
+
+What remains before Phase 6 (protection promises):
+- **2c:** Pre-flight checks (safety hardening, last open item)
+- **2e:** Structured error messages (medium effort, can defer)
+- **3c remaining:** Voice migration for `plan`, `history`, `verify`, `calibrate`
+- **Operational:** Config intervals misaligned with daily timer
+- **Gate:** Protection Promise ADR (blocks all of Phase 6)
+
+## Session 1: Pre-Flight Checks + Interval Tuning
+
+**Goal:** Close Priority 2 safety hardening. Fix the interval mismatch that causes false
+UNPROTECTED status.
+
+### 1a. Config Interval Tuning (operational, no code)
+
+The config has send intervals of 1h–4h from the travel period, but Urd runs once daily via
+systemd timer. The awareness model multiplies intervals by thresholds (local: 2×/5×,
+external: 1.5×/3×), so a 4h send interval means UNPROTECTED after 12h — the system reports
+broken promises 18h/day despite working correctly.
+
+**Action:**
+
+1. **Document the mismatch first.** Before changing anything, capture the current `urd status`
+   output and awareness model readings in a journal entry. This preserves the operational
+   evidence of the timer/interval mismatch for the Promise ADR (Session 3). The ADR needs
+   real data showing how sub-daily intervals interact with a daily timer — once tuned, this
+   evidence is gone.
+
+2. **Update `urd.toml` intervals** to reflect daily reality:
+   - `snapshot_interval`: 24h (or close to timer frequency)
+   - `send_interval`: 24h per drive
+
+This is a config change, not code. Do it first so that `urd status` gives honest readings
+during the rest of the session.
+
+### 1b. Pre-Flight Checks Module (`preflight.rs`)
+
+**Problem:** `init.rs` performs 10+ validation checks that are useful before any backup run,
+but they're locked inside the `init` command. The `backup` command doesn't call them.
+Meanwhile, the htpc-root chain break showed that retention/send-interval incompatibility
+isn't caught anywhere.
+
+**Proposed design:**
+
+#### New module: `src/preflight.rs`
+
+A pure function (per ADR-108) that takes config and returns a list of check results.
+Config-only — no I/O, no `FileSystemState`. Path-existence and drive-capacity checks
+stay in `init.rs` where I/O is expected.
+
+```rust
+/// A single pre-flight check result.
+#[derive(Debug, Clone, Serialize)]
+pub struct PreflightCheck {
+    pub name: &'static str,
+    pub severity: Severity,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub enum Severity {
+    Ok,
+    Warning,
+    Error,
+}
+
+/// Run all pre-flight checks. Pure function — config only, no I/O.
+pub fn preflight_checks(config: &Config) -> Vec<PreflightCheck>
+```
+
+#### Checks to extract/add:
+
+**From `init.rs` (extract — these are currently I/O-dependent, so only the *logic* moves):**
+
+The init command's checks involve I/O (testing sudo, writing test files, reading pin files).
+These can't become pure functions. Instead, the approach is:
+
+1. **Keep `init.rs` as-is** for its I/O-based environment validation
+2. **Build `preflight.rs` as a new layer** for config-level consistency checks that don't
+   need I/O — the kind of checks that catch misconfigurations before they cause operational
+   problems
+
+**Checks in `preflight.rs` (pure, config-only — no I/O):**
+
+| Check | Severity | Logic |
+|-------|----------|-------|
+| Retention/send interval compatibility | Warning | For each subvolume where `send_enabled`: guaranteed retention floor < `send_interval`. See detailed model below. |
+| Snapshot interval vs. timer frequency advisory | Warning | If `snapshot_interval` < reasonable minimum (e.g., 1h) and no Sentinel is running, warn that the timer can't honor the interval. (Preparatory for Promise ADR — timer frequency as input.) |
+| Send enabled but no drives configured | Warning | Subvolume has `send_enabled = true` but no drives exist in config. |
+
+**Checks that stay in `init.rs` (I/O-dependent):**
+
+| Check | Reason |
+|-------|--------|
+| Subvolume source exists | Needs filesystem access |
+| Snapshot root exists | Needs filesystem access |
+| Drive too small for subvolume | Needs `calibrated_size()` from state DB and drive capacity from filesystem |
+
+These are already implemented in `init.rs` and work well there. The preflight module's
+value is config consistency checks — things you can detect from config alone without
+touching disk.
+
+**The key new check — retention/send interval compatibility:**
+
+This is the htpc-root chain break pattern. The chain breaks when:
+- Retention policy deletes snapshots faster than the send interval creates new pins
+- Specifically: if `daily = 3` keeps only 3 days of daily snapshots, but `send_interval = 1w`,
+  the pinned parent (which might be 4+ days old) gets deleted before the next send
+
+The guaranteed survival floor for a snapshot is the sum of the hourly and daily windows.
+Weekly/monthly windows provide only *probabilistic* survival — a pinned snapshot might
+be the representative for its week, but that depends on which other snapshots exist at
+runtime. Per ADR-107 (fail closed on deletions): when in doubt about whether a snapshot
+survives, assume it won't.
+
+Detection logic:
+```
+For each subvolume where send_enabled:
+    // Guaranteed survival: hourly window + daily window
+    // A snapshot survives `hourly` hours, then `daily` more days
+    // in the daily window. After that, it enters weekly selection
+    // where survival is not guaranteed.
+    guaranteed_survival_hours = hourly + (daily * 24)
+    send_interval_hours = send_interval.as_secs() / 3600
+
+    if send_interval_hours > guaranteed_survival_hours:
+        warn("retention guarantees snapshot survival for {guaranteed},
+              but send interval is {send_interval} — pinned parent
+              may be deleted before next send, forcing a full send")
+```
+
+**Test cases for the retention/send model:**
+
+| Config | Guaranteed survival | Send interval | Result |
+|--------|-------------------|---------------|--------|
+| `hourly=24, daily=3, send=1w` (htpc-root) | 24h + 72h = 96h | 168h | WARN (168 > 96) |
+| `hourly=24, daily=7, send=1w` | 24h + 168h = 192h | 168h | OK (168 < 192) |
+| `hourly=168, daily=0, send=5d` | 168h + 0h = 168h | 120h | OK (120 < 168) |
+| `hourly=0, daily=3, send=4d` | 0h + 72h = 72h | 96h | WARN (96 > 72) |
+| `hourly=0, daily=10, send=12d` | 0h + 240h = 240h | 288h | WARN (288 > 240) |
+
+#### Integration points:
+
+1. **`backup` command:** Call `preflight_checks(&config)` before planning. Log warnings
+   via `log::warn!`. Do NOT abort on warnings — backups fail open (ADR-107). Preflight
+   warnings merge into the existing `BackupSummary.warnings: Vec<String>` (no new section
+   needed — they're warnings like any other).
+2. **`init` command:** Call `preflight_checks(&config)` as an additional section after
+   existing I/O checks. Render results.
+3. **`verify` command:** Call `preflight_checks(&config)` and include in `VerifyOutput`.
+
+#### Module boundaries:
+
+| Module | Responsibility |
+|--------|---------------|
+| `preflight.rs` | Pure config consistency checks (new) |
+| `commands/init.rs` | I/O environment validation (unchanged) |
+| `commands/verify.rs` | Chain integrity + preflight results (calls preflight) |
+| `plan.rs` | Runtime pre-conditions during planning (unchanged) |
+
+**Effort:** ~1 session. Comparable to UUID fingerprinting (1 new module, 3 checks, ~10-12
+tests). The retention/send compatibility check is the novel logic; the rest is straightforward.
+
+**Tests:**
+- Retention/send compatibility: htpc-root case (`hourly=24, daily=3, send=1w`) → warning
+- Retention/send compatibility: safe case (`hourly=24, daily=7, send=1w`) → no warning
+- Retention/send: large hourly compensates for zero daily (`hourly=168, daily=0, send=5d`) → no warning
+- Retention/send: zero hourly, small daily (`hourly=0, daily=3, send=4d`) → warning
+- Send enabled with no drives → warning
+- Timer/interval advisory: sub-hourly interval → warning
+- All-clear config → empty results
+- Disabled subvolumes skipped
+- Send-disabled subvolumes skipped for retention/send check
+- Edge cases: zero retention values (hourly=0, daily=0) → guaranteed survival is 0 → always warns if send enabled
+
+### Session 1 deliverables:
+- [ ] Journal entry documenting current awareness mismatch (before tuning)
+- [ ] Config intervals tuned to daily timer
+- [ ] `src/preflight.rs` with 3 pure config-only checks
+- [ ] Integration into `backup`, `init`, and `verify` commands
+- [ ] 10-12 tests
+- [ ] Adversary review
+
+---
+
+## Session 2: Voice Migration for Remaining Commands
+
+**Goal:** Complete Priority 3c — all commands produce structured output rendered by the
+voice layer. Daemon mode (JSON) works for every command.
+
+### Commands to migrate (in order):
+
+#### 2a. `plan_cmd.rs` → `PlanView` (Low, ~1h)
+
+**Current:** 11 `println!` with inline colors and formatting. `run_with_plan()` is already
+shared between `urd plan` and `urd backup --dry-run` — the structured output must serve both.
+
+**Design decision (from review Finding 3):** The existing `BackupPlan` and `PlannedOperation`
+in `types.rs` contain internal details (`pin_on_success` paths, full filesystem paths) that
+shouldn't be exposed to JSON consumers. Rather than adding `#[derive(Serialize)]` to core
+types and leaking internals, build a thin **view adapter** that projects the domain model
+into a presentation-safe shape.
+
+**Structured type:**
+```rust
+/// Presentation view of a BackupPlan. Thin adapter — not a parallel domain model.
+/// Built from BackupPlan by the plan command, consumed by voice::render_plan().
+#[derive(Debug, Serialize)]
+pub struct PlanView {
+    pub timestamp: String,
+    pub subvolumes: Vec<PlannedSubvolumeView>,
+    pub summary: PlanSummaryView,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PlannedSubvolumeView {
+    pub name: String,
+    pub priority: u8,
+    pub operations: Vec<PlannedOperationView>,
+    pub skip_reasons: Vec<String>,
+}
+
+/// Flattened, presentation-safe view of a PlannedOperation.
+/// Internal paths (pin files, full source paths) are stripped.
+#[derive(Debug, Serialize)]
+pub struct PlannedOperationView {
+    pub op_type: String,       // "create", "send-incremental", "send-full", "delete"
+    pub snapshot: String,      // snapshot name only, not full path
+    pub drive: Option<String>, // drive label for sends
+    pub detail: String,        // human-readable detail (parent name, delete reason, etc.)
+}
+
+#[derive(Debug, Serialize)]
+pub struct PlanSummaryView {
+    pub snapshots: usize,
+    pub sends: usize,
+    pub deletions: usize,
+    pub skipped: usize,
+}
+```
+
+**Conversion:** `impl From<&BackupPlan> for PlanView` (with config for subvolume grouping).
+The adapter extracts file names from paths and drops `pin_on_success`. `PlanSummaryView`
+mirrors the existing `PlanSummary` from `types.rs` but with `Serialize`.
+
+**Voice rendering:** Reuse the colored tag pattern from current code (`[CREATE]`, `[SEND]`,
+etc.) but through `voice::render_plan()`.
+
+**Why first:** Simplest migration, establishes the adapter pattern for others.
+
+#### 2b. `calibrate.rs` → `CalibrateOutput` (Low-Med, ~1.5h)
+
+**Current:** 16 `println!` + 3 `eprintln!` with inline progress.
+
+**Challenge:** Interactive progress (`print!` + `flush()` for "Measuring... done") happens
+during execution, not after. The structured output captures final results only; progress
+display stays in the command handler (it's inherently interactive).
+
+**Structured type:**
+```rust
+#[derive(Debug, Serialize)]
+pub struct CalibrateOutput {
+    pub results: Vec<CalibrateResult>,
+    pub summary: CalibrateSummary,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CalibrateResult {
+    pub subvolume: String,
+    pub snapshot: String,
+    pub size_bytes: Option<u64>,
+    pub error: Option<String>,
+}
+```
+
+**Design decision:** Progress display during measurement remains as direct `print!` in
+interactive mode (same as backup progress — it's inherently streaming). The final summary
+goes through voice.
+
+#### 2c. `history.rs` → `HistoryOutput` (Medium, ~2h)
+
+**Current:** 14 `println!` with three mode-dependent table formats.
+
+**Structured type:**
+```rust
+#[derive(Debug, Serialize)]
+pub struct HistoryOutput {
+    pub mode: HistoryMode,
+    pub entries: Vec<HistoryEntry>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+pub enum HistoryMode {
+    RecentRuns,
+    SubvolumeHistory { subvolume: String },
+    Failures,
+}
+
+#[derive(Debug, Serialize)]
+pub struct HistoryEntry {
+    pub run_id: i64,
+    pub timestamp: String,
+    pub result: String,
+    pub subvolume: Option<String>,
+    pub duration_secs: Option<f64>,
+    pub bytes_transferred: Option<u64>,
+    pub error: Option<String>,
+}
+```
+
+**Voice rendering:** Table formatting using the existing column-width pattern. Move
+`truncate_str()` and `color_result()` helpers to `voice.rs`.
+
+#### 2d. `verify.rs` → `VerifyOutput` (Medium-High, ~3h)
+
+**Current:** 29 `println!` with complex nested structure (subvolume → drive → checks).
+
+**Most complex migration.** The verify command has hierarchical output with per-check
+severity levels (OK/WARN/FAIL).
+
+**Structured type:**
+```rust
+#[derive(Debug, Serialize)]
+pub struct VerifyOutput {
+    pub subvolumes: Vec<VerifySubvolume>,
+    pub preflight: Vec<PreflightCheck>,  // from session 1
+    pub summary: VerifySummary,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VerifySubvolume {
+    pub name: String,
+    pub drives: Vec<VerifyDrive>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VerifyDrive {
+    pub label: String,
+    pub checks: Vec<VerifyCheck>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VerifyCheck {
+    pub name: String,
+    pub status: String,       // "OK", "WARN", "FAIL"
+    pub message: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VerifySummary {
+    pub ok_count: usize,
+    pub warn_count: usize,
+    pub fail_count: usize,
+}
+
+impl VerifyOutput {
+    /// Derive exit code from verification results.
+    /// Single source of truth — command handler calls this, never re-derives.
+    pub fn exit_code(&self) -> i32 {
+        if self.summary.fail_count > 0 { 1 } else { 0 }
+    }
+}
+```
+
+**Why last:** Benefits from patterns established in the earlier migrations. Also integrates
+preflight checks from Session 1 (if complete; otherwise defers preflight integration).
+
+### Session 2 deliverables:
+- [ ] 4 new output types in `output.rs` (`PlanView`, `CalibrateOutput`, `HistoryOutput`, `VerifyOutput`)
+- [ ] 4 new render functions in `voice.rs`
+- [ ] All commands produce JSON in daemon mode
+- [ ] ~20-25 voice tests (5-7 per command)
+- [ ] Adversary review
+
+**Effort:** One full session. Comparable to the presentation layer initial build (3c) which
+created `StatusOutput` + `GetOutput` + `BackupSummary` with 15 voice tests.
+
+---
+
+## Session 3: Protection Promise ADR
+
+**Goal:** Write the ADR that gates Phase 6. This is design work, not code. The ADR must
+resolve the open questions listed in status.md's Phase 5 gate.
+
+### Questions the ADR must answer:
+
+1. **Promise levels and their derivations:**
+   - `guarded`: local snapshots only, no external requirement
+   - `protected`: local + at least one external drive current
+   - `resilient`: local + multiple external drives current
+   - `archival`: long-term retention, relaxed freshness
+   - `custom`: existing operation-focused config (the default for migration)
+   - For each level: exact `snapshot_interval`, `send_interval`, and retention policy
+
+2. **Config conflict resolution:**
+   - If `protection_level = "protected"` AND `send_interval = "6h"`, which wins?
+   - Proposal: promise-derived values are defaults; explicit overrides win with a warning
+   - Alternative: explicit overrides are errors when a promise is set
+
+3. **Migration path:**
+   - Existing configs have no `protection_level` → implicit `custom`
+   - `custom` means "I manage intervals and retention manually"
+   - Zero breaking changes — all existing configs continue to work identically
+
+4. **Timer frequency as input:**
+   - Operational data showed awareness reporting UNPROTECTED 18h/day
+   - Promise achievability must account for actual run frequency
+   - Option A: `timer_frequency` in config, planner uses it for achievability checks
+   - Option B: Derive from heartbeat history (last N run timestamps)
+   - Option C: Require Sentinel for sub-daily promises
+
+5. **Drive topology constraints:**
+   - subvol3-opptak (~3.4TB) cannot have external promises on 2TB-backup (~1.1TB available)
+   - Per-subvolume `drives = [...]` mapping (Priority 4c) is prerequisite
+   - Promise validation: "this promise is unachievable given your drive topology"
+
+6. **Awareness threshold mode:**
+   - Current: fixed multipliers (2×/5× local, 1.5×/3× external)
+   - Should thresholds adapt based on whether Sentinel is running?
+   - Recommendation: No — keep thresholds simple. Timer frequency feeds into *achievability
+     validation*, not threshold computation.
+
+### ADR structure:
+
+Following the existing ADR format (ADR-100 through ADR-109):
+- **Context:** Why promises, what operational data shows
+- **Decision:** Promise levels, derivation rules, config schema, migration
+- **Consequences:** What this enables (Phase 6), what it constrains
+- **Alternatives considered:** Each open question's rejected alternatives
+
+### Session 3 deliverables:
+- [ ] ADR-110: Protection Promise Design
+- [ ] Updated status.md Phase 5 gate checklist (all items resolved)
+- [ ] Adversary review of ADR
+
+---
+
+## What's Deliberately Deferred
+
+| Item | Why defer |
+|------|-----------|
+| **2e: Structured error messages** | Medium effort, lower operational impact than 2c. Build when a specific btrfs error pattern causes user confusion. The translation layer is well-scoped but not urgent. |
+| **Journal persistence gap** | Operational concern, not code. `journalctl --vacuum-time` settings or a local log file complement. Address when it causes a real problem. |
+| **NVMe snapshot accumulation** | Space guard prevents catastrophe. Gradual accumulation above threshold is a retention tuning issue, not a code issue. Revisit during Promise ADR when retention derivations are defined. |
+| **`heartbeat::read()` Result upgrade** | Blocked on Sentinel design (the consumer). Build when 5a starts. |
+| **`init` command voice migration** | `init` has interactive deletion prompts that don't fit the structured output pattern cleanly. Defer until the interaction model is clearer. |
+
+## Sequencing Rationale
+
+**Session 1 first** because:
+- Pre-flight checks close the last safety hardening item (2c)
+- Interval tuning fixes false UNPROTECTED status immediately
+- Both are small, high-value changes during the monitoring period
+
+**Session 2 second** because:
+- Voice migration is independent of Session 1 (but benefits from preflight integration in verify)
+- Gives presentation consistency before the Promise ADR (Session 3) introduces new promise-level
+  status displays
+- Daemon JSON output for all commands is prerequisite for Sentinel consumers
+
+**Session 3 third** because:
+- The ADR is a design exercise that benefits from operational experience
+- More monitoring data (target: past 2026-04-01 cutover completion) informs timer frequency questions
+- Sessions 1-2 ensure all existing features are polished before adding the next layer
+
+## Review Findings Addressed
+
+This design was reviewed by arch-adversary on 2026-03-26. All findings addressed:
+
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| 1. Retention/send compatibility model error | Significant | Replaced `daily_count > send_interval_days` with guaranteed survival floor: `hourly + (daily * 24)`. Added 5 test cases covering the model. |
+| 2. Path-existence checks aren't pure | Moderate | Dropped from preflight. Simplified signature to `preflight_checks(config: &Config)`. I/O checks stay in `init.rs`. |
+| 3. PlanOutput duplicates planner types | Moderate | Renamed to `PlanView` — thin adapter that projects `BackupPlan` into presentation-safe shape. Internal paths stripped, `pin_on_success` dropped. |
+| 4. VerifyOutput omits exit code semantics | Moderate | Added `exit_code(&self) -> i32` method. Single source of truth for severity → exit code. |
+| 5. Interval tuning may mask mismatch evidence | Minor | Added journal documentation step before tuning. Preserves evidence for Promise ADR. |
+| 6. Session independence claim overstated | Minor | Softened TL;DR to acknowledge verify/preflight soft dependency. |
+
+**Open questions from review (resolved):**
+
+1. **Should `preflight_checks` accept `FileSystemState`?** No. Pure config-only. Drive-too-small
+   check stays in `init.rs`/`verify` where I/O is expected.
+2. **Where do preflight warnings surface in backup summary?** Merged into existing
+   `BackupSummary.warnings: Vec<String>`. No new section needed.
+3. **Should `PlanView` support `--dry-run`?** Yes. `run_with_plan()` is already shared between
+   `urd plan` and `urd backup --dry-run`. Both will build a `PlanView` from the `BackupPlan`.
+
+[Review report](../99-reports/2026-03-26-next-sessions-design-review.md)

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,7 +8,7 @@
 **Operational cutover in progress. Urd is the sole backup system.**
 Urd's systemd timer has been running at 04:00 nightly since 2026-03-24. The bash script
 (`btrfs-snapshot-backup.sh`) is disabled. Five consecutive successful runs (runs 7–11) across
-manual and autonomous operation, passing 241 tests. The parallel-run step was skipped in favor
+manual and autonomous operation, passing 251 tests. The parallel-run step was skipped in favor
 of direct cutover — a conscious risk decision documented in
 [first-night journal](../98-journals/2026-03-25-first-night.md). Two nights of unattended
 operation (2026-03-25, 2026-03-26) completed without failures.
@@ -31,6 +31,27 @@ deletions). Daemon mode outputs JSON. 21 new tests (9 builder, 12 renderer).
 [Design](../95-ideas/2026-03-26-design-backup-summary.md) |
 [Review](../99-reports/2026-03-26-backup-summary-design-review.md) |
 [Journal](../98-journals/2026-03-26-backup-summary.md)
+
+**Pre-flight config consistency checks** (Priority 2c) implemented in a later session.
+New `preflight.rs` module — pure function of `&Config`, no I/O (ADR-108). Two checks:
+(1) retention/send interval compatibility — computes guaranteed survival floor
+(`hourly + daily * 24` hours) and warns when send interval exceeds it; (2) send-without-drives
+— single global warning when `send_enabled` subvolumes exist but no drives are configured.
+Integrated into `backup` (log + summary warnings), `init` (rendered section), and `verify`
+(rendered + counted in summary). The arch-adversary review revealed that the three-layer pin
+protection system (planner unsent protection, retention `is_pinned` guard, executor re-check)
+prevents the originally claimed consequence ("pinned parent deleted") — the warning was reframed
+as a defense-in-depth signal about config depending on pin protection rather than retention
+alignment. 10 new tests (251 total).
+[Design](../95-ideas/2026-03-26-design-next-sessions.md) |
+[Design review](../99-reports/2026-03-26-next-sessions-design-review.md) |
+[Implementation review](../99-reports/2026-03-26-preflight-implementation-review.md) |
+[Journal](../98-journals/2026-03-26-preflight-checks.md)
+
+**Multi-session design** for the next 2–3 sessions was produced and reviewed alongside the
+preflight work. Session 2: voice migration for remaining commands (plan, calibrate, history,
+verify). Session 3: Protection Promise ADR (ADR-110, gates Phase 6). Both designs are reviewed
+and ready to build. [Design](../95-ideas/2026-03-26-design-next-sessions.md)
 
 Config intervals (1h–6h snapshots, 1h–4h sends) were set for the travel period and are
 misaligned with the daily timer — the awareness model reports UNPROTECTED for most of each
@@ -138,7 +159,7 @@ most important question, and currently requires three commands to answer.
 | 2a+ | ~~**Local space guard**~~ | ~~Low~~ | **COMPLETE.** `plan_local_snapshot` checks `filesystem_free_bytes` against `min_free_bytes` before creating. `force` does not override. Fails open if unreadable. 4 tests. Closes the most dangerous safety gap (three NVMe exhaustion incidents). [Journal](../98-journals/2026-03-26-operational-evaluation.md) |
 | 2b | ~~**Surface skipped sends loudly**~~ | ~~Low~~ | **COMPLETE.** Subsumed by 2d — skip grouping is one section of the structured summary. "Not mounted" skips collapsed by drive; UUID mismatch/space/disabled rendered individually. |
 | 2d | ~~**Post-backup structured summary**~~ | ~~Medium~~ | **COMPLETE.** `BackupSummary` output type in `output.rs`, rendered by `voice::render_backup_summary()`. Replaces ~90 lines of `println!`. Per-drive send info, grouped skips, conditional awareness table, warning aggregation. 21 tests. [Design](../95-ideas/2026-03-26-design-backup-summary.md) | [Review](../99-reports/2026-03-26-backup-summary-design-review.md) | [Journal](../98-journals/2026-03-26-backup-summary.md) |
-| 2c | **Pre-flight checks** | Low | Extract `init.rs` validation into shared `preflight_checks()`. Include retention/send-interval compatibility: warn if retention policy would delete a pinned snapshot before the next send interval can use it as incremental parent (motivated by htpc-root chain break). |
+| 2c | ~~**Pre-flight checks**~~ | ~~Low~~ | **COMPLETE.** `preflight.rs` — pure function of `&Config`, 2 checks: retention/send compatibility (guaranteed survival floor model) and send-without-drives. Integrated into backup, init, verify. Arch-adversary review revealed three-layer pin protection prevents the originally claimed consequence; warning reframed as defense-in-depth signal. 10 tests. [Design](../95-ideas/2026-03-26-design-next-sessions.md) | [Implementation review](../99-reports/2026-03-26-preflight-implementation-review.md) | [Journal](../98-journals/2026-03-26-preflight-checks.md) |
 | 2e | **Structured error messages** | Medium | Pattern-match common btrfs stderr. Build as a translation layer in `error.rs`, not scattered across commands. |
 
 ### Priority 3: Architectural Foundation (design before code)
@@ -347,6 +368,18 @@ timestamp staleness handling, space check deduplication, ANSI line clearing.
   [Design](../95-ideas/2026-03-26-design-backup-summary.md) |
   [Review](../99-reports/2026-03-26-backup-summary-design-review.md) |
   [Journal](../98-journals/2026-03-26-backup-summary.md)
+- **Pre-flight config consistency checks** (P2c, 2026-03-26) — `preflight.rs`: pure function
+  of `&Config` (ADR-108), 2 checks. (1) Retention/send compatibility: guaranteed survival floor
+  (`hourly + daily × 24` hours) vs. send interval — warns when retention window is shorter,
+  meaning incremental chain depends on pin protection rather than retention alignment.
+  (2) Send-without-drives: single global warning when `send_enabled` subvolumes exist but no
+  drives configured. Integrated into backup (log + summary warnings), init (rendered section),
+  verify (rendered + counted). Arch-adversary review revealed three-layer pin protection
+  prevents the originally claimed consequence; warning reframed as defense-in-depth signal.
+  10 tests. Design-reviewed and implementation-reviewed.
+  [Design](../95-ideas/2026-03-26-design-next-sessions.md) |
+  [Implementation review](../99-reports/2026-03-26-preflight-implementation-review.md) |
+  [Journal](../98-journals/2026-03-26-preflight-checks.md)
 - **Pre-cutover hardening** (2026-03-24) — Three bugs found and fixed during pre-cutover manual
   testing. (1) `executor.rs`: mkdir before `btrfs receive` — first-ever sends to any drive would
   fail without destination directory. Parent-exists guard preserves test behavior and unmounted-drive
@@ -468,6 +501,10 @@ for the graduation rationale.
 | `Vec<SendSummary>` for multi-drive sends (not single `send_drive` field) | 2026-03-26 | [Backup summary review](../99-reports/2026-03-26-backup-summary-design-review.md) Finding 1 |
 | Only "not mounted" skips grouped; UUID mismatch always renders individually | 2026-03-26 | [Backup summary review](../99-reports/2026-03-26-backup-summary-design-review.md) Finding 3 |
 | Awareness table conditional: shown only when AT RISK or UNPROTECTED | 2026-03-26 | [Backup summary design](../95-ideas/2026-03-26-design-backup-summary.md) Open Question 3 |
+| Preflight module is pure `&Config` only — no `FileSystemState`, no I/O | 2026-03-26 | [Design review](../99-reports/2026-03-26-next-sessions-design-review.md) Finding 2 |
+| Retention/send warning reframed: defense-in-depth signal, not active threat | 2026-03-26 | [Implementation review](../99-reports/2026-03-26-preflight-implementation-review.md) Finding 1 |
+| Voice migration: `PlanView` adapter (not `Serialize` on core types) | 2026-03-26 | [Design review](../99-reports/2026-03-26-next-sessions-design-review.md) Finding 3 |
+| `VerifyOutput.exit_code()` as single source of truth for severity→exit | 2026-03-26 | [Design review](../99-reports/2026-03-26-next-sessions-design-review.md) Finding 4 |
 
 ## Key Documents
 
@@ -480,7 +517,7 @@ for the graduation rationale.
 | Future directions brainstorm | [Feature ideas](../95-ideas/2026-03-23-brainstorm-urd-future.md) |
 | UX design principles brainstorm | [Norman principles](../95-ideas/2026-03-23-brainstorm-ux-norman-principles.md) |
 | Vision architecture review | [2026-03-23 Architectural criteria for vision](../99-reports/2026-03-23-vision-architecture-review.md) |
-| Latest adversary review | [2026-03-26 Backup summary design review](../99-reports/2026-03-26-backup-summary-design-review.md) |
+| Latest adversary review | [2026-03-26 Preflight implementation review](../99-reports/2026-03-26-preflight-implementation-review.md) |
 | Code conventions & architecture | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 
@@ -504,7 +541,7 @@ for the graduation rationale.
 - Bootstrap pattern — code that touches `external_snapshot_dir()` may assume per-subvolume dirs exist. Three instances found and fixed (mkdir, verify pins, space estimation). Watch for more
 - MockBtrfs tests don't exercise filesystem preconditions — `tempfile::TempDir` approach needed for code that touches real filesystem
 - Journal persistence gap: `journalctl --user -u urd-backup.service --since "2 days ago"` returned no entries despite successful runs (2026-03-26). Journal rotation or vacuum purges user-unit logs. Heartbeat partially compensates, but human-readable run logs may need a local file complement
-- htpc-root retention/send-interval coupling: retention policy (`daily = 3, weekly = 2`) deletes pinned snapshot before the 1-week send interval can use it as incremental parent. Chain self-heals via full send, but the planner does not warn about this incompatibility. Candidate for 2c pre-flight check
+- htpc-root retention/send-interval coupling: chain break likely caused by manual snapshot deletion during third NVMe exhaustion incident (unverified hypothesis), not by automated retention — the three-layer pin protection system prevents retention from deleting pinned parents. Pre-flight check (2c) now warns about the config inconsistency as a defense-in-depth signal. Chain self-heals via full send
 - NVMe snapshot accumulation: 12 htpc-home snapshots (legacy + Urd) on 118GB drive is the primary space pressure source. Space guard now prevents catastrophic exhaustion, but gradual accumulation above the 10GB threshold is not gated. Retention tuning for constrained volumes deserves attention
 - Config/timer interval mismatch: send intervals (1h–4h) assume sub-daily timer but Urd runs once daily. Causes awareness model to report UNPROTECTED for ~18h/day. Operational action: tune intervals to match daily reality. Design question for Promise ADR: should timer frequency be an explicit input?
 - Idea: [systemd unit drift check](../95-ideas/2026-03-23-systemd-unit-drift-check.md) in `urd verify`

--- a/docs/99-reports/2026-03-26-next-sessions-design-review.md
+++ b/docs/99-reports/2026-03-26-next-sessions-design-review.md
@@ -1,0 +1,289 @@
+# Design Review: Next 2-3 Implementation Sessions
+
+**Project:** Urd
+**Date:** 2026-03-26
+**Scope:** `docs/95-ideas/2026-03-26-design-next-sessions.md` (design review)
+**Reviewer:** Arch-adversary
+**Mode:** Design review (4 dimensions)
+
+## Executive Summary
+
+A well-sequenced plan that correctly prioritizes operational safety over presentation polish
+over architectural ambition. The main risk is in Session 1: the retention/send compatibility
+check has a subtle logic error that would produce false negatives for the exact scenario it's
+designed to catch. The voice migration (Session 2) and Promise ADR (Session 3) are
+well-scoped and appropriately ordered.
+
+## What Kills You
+
+**Catastrophic failure mode: silent data loss via retention deleting pinned snapshots.**
+
+The design's proximity: **two steps away.** The pre-flight check for retention/send
+compatibility (Session 1) is specifically designed to warn about this pattern. But the
+proposed detection logic has an error in its model of pin survival — if it ships with a
+false sense of security, the htpc-root chain break pattern continues undetected. The
+existing three-layer pin protection (planner, retention, executor) prevents actual data
+loss, but a chain break forces expensive full sends and degrades the incremental backup
+guarantee. The pre-flight check is an early warning system, not a safety net — but
+shipping a broken early warning system is worse than not having one.
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 3 | Retention/send compatibility logic has a modeling error; path-existence checks claim purity but need trait extension |
+| **Security** | 4 | No new trust boundaries or privilege escalation; pre-flight stays read-only |
+| **Architectural Excellence** | 4 | Clean separation between pure preflight and I/O init; voice migration follows established patterns; sequencing is sound |
+| **Systems Design** | 4 | Interval tuning first is the right operational call; deferral list is well-reasoned; Promise ADR timing aligns with monitoring window |
+
+## Design Tensions
+
+### Tension 1: Preflight purity vs. useful checks
+
+The design wants `preflight.rs` to be a pure function (ADR-108), but several of the most
+useful checks are inherently I/O-dependent: "does this source path exist?", "is this drive
+too small?" The design resolves this by claiming `FileSystemState` can provide path existence,
+but the trait doesn't have a `path_exists()` method and adding one starts expanding the trait
+beyond its original purpose (snapshot and drive state).
+
+**Evaluation:** The design is half-right. The retention/send compatibility check, the
+"send enabled with no drives" check, and the timer/interval advisory are genuinely pure —
+they need only config. The source-exists and root-exists checks need I/O. The drive-too-small
+check needs `calibrated_size()` from `FileSystemState` plus drive capacity, which the trait
+also doesn't expose. The resolution is to split the checks: pure config checks in
+`preflight_checks(config)` (no `FileSystemState` argument), I/O checks stay in `init.rs`.
+
+### Tension 2: Conservative heuristic vs. accurate model
+
+The retention/send compatibility heuristic `daily_count > send_interval_days` is described
+as "conservative" (false positives over false negatives). But it's actually **neither
+conservative nor accurate** — it has blind spots in both directions. See Finding 1.
+
+### Tension 3: Voice migration completeness vs. `init` deferral
+
+The design defers `init` voice migration because of interactive prompts (orphan deletion).
+This is reasonable, but it creates an asymmetry: `verify` (Session 2) calls
+`preflight_checks()` through the voice layer, while `init` calls it through raw `println!`.
+If a user runs `urd init` in daemon mode (unlikely but possible), they get no JSON for the
+preflight section.
+
+**Evaluation:** Acceptable trade-off. `init` is inherently interactive (it creates
+databases, tests sudo). Daemon mode for `init` is not a real use case. Defer stands.
+
+### Tension 4: Promise ADR timing
+
+Session 3 is positioned after the 2026-04-01 monitoring target, which gives more operational
+data. But the ADR is design work that could also benefit from happening *during* the monitoring
+period — thinking about promises while watching the system operate might surface insights that
+are harder to reconstruct later.
+
+**Evaluation:** The design's sequencing is correct. The interval tuning in Session 1 changes
+the awareness model's behavior, and the ADR should be written against the post-tuning baseline,
+not the current misconfigured one. Waiting is right.
+
+## Findings
+
+### Finding 1: Retention/send compatibility logic has a modeling error (Significant)
+
+**What:** The proposed detection logic:
+```
+pin_survival_days = local_retention.daily
+send_interval_days = send_interval.as_secs() / 86400
+if send_interval_days > pin_survival_days: warn
+```
+
+This equates `daily` retention count with pin survival days. But retention windows are
+cumulative: a snapshot survives through the hourly window *then* the daily window. A
+snapshot created now survives for `hourly` hours + `daily` days before it falls into the
+weekly window. In the weekly window, only one snapshot per week is kept — the pinned
+snapshot may or may not be the one selected.
+
+**Consequence:** For the htpc-root case (the motivation for this check): `daily = 3,
+weekly = 2, send_interval = 1w`. The heuristic says `7 > 3` → warn. This happens to be
+correct. But consider: `hourly = 24, daily = 7, weekly = 0, send_interval = 10d`. The
+heuristic says `10 > 7` → warn. But the snapshot actually survives 24h + 7d = 8 days in
+guaranteed retention, then falls into no weekly window (0 = disabled). It would be deleted
+after 8 days. The warning is correct but the reasoning is wrong.
+
+Now the dangerous case: `hourly = 168, daily = 0, weekly = 4, send_interval = 5d`. The
+heuristic says `5 > 0` → warn (daily is 0). But 168 hours = 7 days of hourly retention.
+The snapshot survives 7 full days. The `send_interval` of 5d is safely within that. **False
+positive.**
+
+Worse: `hourly = 0, daily = 10, weekly = 0, send_interval = 12d`. The heuristic says
+`12 > 10` → warn. Correct. But `hourly = 0, daily = 10, weekly = 4, send_interval = 12d`.
+The heuristic still says `12 > 10` → warn, but the snapshot might survive into the weekly
+window. Whether it does depends on whether it's the *selected* representative for its week
+— which is a runtime property, not a config property. **This is the fundamental
+undecidability**: retention representative selection is deterministic but depends on which
+other snapshots exist at runtime.
+
+**Suggested fix:** Model the guaranteed survival floor:
+```
+guaranteed_survival_hours = hourly + (daily * 24)
+```
+Then: `if send_interval.as_hours() > guaranteed_survival_hours: warn`. This is truly
+conservative — it ignores weekly/monthly survival because representative selection isn't
+guaranteed. The message should say: "retention guarantees snapshot survival for N
+hours/days, but send interval is M — pinned parent may be deleted before next send."
+
+The weekly/monthly windows provide *probabilistic* survival (the pinned snapshot might be
+the representative), but guaranteed survival is only `hourly + daily` hours. This matches
+the fail-closed principle (ADR-107): when in doubt about whether a snapshot survives,
+assume it won't.
+
+### Finding 2: Path-existence checks aren't pure (Moderate)
+
+**What:** The design lists "Subvolume source exists" and "Snapshot root exists" as pure
+preflight checks using `FileSystemState`. But `FileSystemState` has no `path_exists()`
+method, and these checks are inherently I/O.
+
+**Consequence:** Either the trait gets a new method (expanding its scope beyond
+snapshot/drive state), or the function signature changes to accept a path-existence
+callback, or these checks stay in `init.rs`.
+
+**Suggested fix:** Drop these two checks from `preflight.rs`. They're already in `init.rs`
+and work fine there. The preflight module's value is in *config consistency* checks that
+don't need I/O: retention/send compatibility, send-with-no-drives, interval advisories.
+A clean signature of `preflight_checks(config: &Config) -> Vec<PreflightCheck>` (no
+`FileSystemState`) is simpler and more honest about what "pure" means.
+
+Similarly, the "drive too small for subvolume" check needs calibrated size data from
+`FileSystemState`. Move it to `verify` where I/O is already expected, or accept the
+`FileSystemState` dependency and drop the "pure" claim.
+
+### Finding 3: `PlanOutput` duplicates planner types (Moderate)
+
+**What:** The design proposes `PlannedOperation` and `PlannedSubvolume` structs in
+`output.rs` that closely mirror the existing `PlannedOperation` enum and `BackupPlan`
+in `types.rs`. The plan command already has access to `BackupPlan` — introducing parallel
+types in the output layer means two representations of the same data.
+
+**Consequence:** Every change to the planner's operation types requires a corresponding
+change in the output types. This is the kind of duplication that starts small and compounds.
+
+**Suggested fix:** Derive `Serialize` on the existing `PlannedOperation` and `BackupPlan`
+types (or a subset). The voice layer renders *those* directly. If the rendering needs a
+different shape than the internal representation, create a thin adapter — but don't
+duplicate the domain model. Check whether `PlannedOperation` in `types.rs` can gain
+`#[derive(Serialize)]` without pulling serde into the core types. If that's undesirable,
+the adapter is the right call — but name it as such (`PlanView` not `PlanOutput`).
+
+### Finding 4: `VerifyOutput` omits exit code semantics (Moderate)
+
+**What:** The current verify command returns exit code 1 if any failures exist. The
+`VerifyOutput` struct has `VerifySummary` with counts but doesn't define how the exit
+code is derived. When the voice layer takes over rendering, the command handler still needs
+to compute the exit code from the output type.
+
+**Consequence:** If the exit code logic stays in the command handler but severity assessment
+moves to the output builder, there's a risk of the two disagreeing about what constitutes
+a "failure."
+
+**Suggested fix:** Add `fn exit_code(&self) -> i32` to `VerifyOutput` (or compute it in
+the builder). The command handler calls `output.exit_code()` and doesn't re-derive severity
+from the raw data.
+
+### Finding 5: Interval tuning may mask the config/timer mismatch permanently (Minor)
+
+**What:** Session 1a tunes intervals to 24h to match the daily timer. This fixes the
+immediate false-UNPROTECTED problem. But it also removes the operational evidence that
+motivated the "timer frequency as input" question in the Promise ADR.
+
+**Consequence:** When Session 3 designs timer frequency handling, the developer no longer
+has a live system demonstrating the mismatch. The ADR may underweight this concern.
+
+**Suggested fix:** Before tuning, document the current state in the journal: what `urd
+status` shows now, what the awareness model reports, and why. The operational evidence is
+valuable for the ADR even if the config is fixed. This is a documentation action, not a
+design change.
+
+### Finding 6: Session independence claim is overstated (Minor)
+
+**What:** The TL;DR says "Each session is independent — no session blocks another." But
+Session 2's `VerifyOutput` includes `preflight: Vec<PreflightCheck>` from Session 1. If
+Session 2 runs before Session 1, the verify migration either omits preflight integration
+or builds a stub.
+
+**Consequence:** Minor ordering dependency. If sessions are reordered, the verify migration
+needs adjustment.
+
+**Suggested fix:** Acknowledge the soft dependency: "Sessions are largely independent;
+verify voice migration integrates preflight if available." Don't overstate independence.
+
+### Commendation: Sequencing by operational risk
+
+The decision to do interval tuning first (before any code changes) is exactly right. The
+system is in its monitoring window — code changes introduce risk, config changes are
+reversible. Fixing the false UNPROTECTED readings before building new features means every
+subsequent `urd status` gives honest data. This is the kind of operational discipline that
+prevents "we built the feature but the test environment was lying to us."
+
+### Commendation: Deferral discipline
+
+The "What's Deliberately Deferred" section is unusually well-reasoned. Each deferral has a
+specific trigger for when to revisit. The `init` voice migration deferral (interactive
+prompts don't fit structured output) is a genuine architectural observation, not laziness.
+The `heartbeat::read()` upgrade blocked on Sentinel design avoids premature interface
+commitment. This is how a project stays focused.
+
+## The Simplicity Question
+
+**What could be removed?** The path-existence checks from preflight (Finding 2) — they
+add trait expansion complexity for checks that already work in `init.rs`. The
+`PlanOutput` parallel types (Finding 3) — render the existing `BackupPlan` directly.
+
+**What's earning its keep?** The retention/send compatibility check is the entire reason
+for the preflight module. If that check is wrong (Finding 1), the module's value
+proposition weakens to "send enabled with no drives" (a config validation that could
+live in `config.rs`) and a timer advisory (useful but thin). Get the retention check
+right and the module justifies itself.
+
+**Session 2 is the right size.** Four command migrations in one session is aggressive but
+achievable given the established pattern (three were done in the original presentation
+layer build). The order (plan → calibrate → history → verify) correctly ramps complexity.
+
+## For the Dev Team
+
+Priority order:
+
+1. **Fix the retention/send compatibility model** (Finding 1, preflight.rs design).
+   Change from `daily_count > send_interval_days` to
+   `(hourly_hours + daily_count * 24) < send_interval_hours`. This is the load-bearing
+   check in the module — get it right. Include a test case for the htpc-root scenario
+   and for the "large hourly window compensates for small daily" case.
+
+2. **Drop path-existence checks from preflight** (Finding 2). Simplify the signature to
+   `preflight_checks(config: &Config)`. Keep I/O checks in init. If the "drive too small"
+   check is important enough to keep, accept `FileSystemState` as a second parameter but
+   don't call the module "pure."
+
+3. **Decide on PlanOutput strategy** (Finding 3). Before Session 2, check whether
+   `#[derive(Serialize)]` on `BackupPlan` / `PlannedOperation` in `types.rs` is acceptable.
+   If yes, render directly. If no (serde in core types is unwanted), build a thin adapter
+   and name it `PlanView`.
+
+4. **Add exit_code() to VerifyOutput** (Finding 4). Small addition that prevents
+   severity-assessment duplication between builder and command handler.
+
+5. **Document current awareness state before interval tuning** (Finding 5). Journal entry
+   with `urd status` output showing the mismatch. Takes 5 minutes, preserves evidence for
+   the Promise ADR.
+
+6. **Soften the session independence claim** (Finding 6). Minor text edit.
+
+## Open Questions
+
+1. **Should `preflight_checks` accept `FileSystemState` or not?** The answer determines
+   whether the "drive too small" check lives in preflight or verify. The pure-config-only
+   approach is simpler; the trait-accepting approach is more useful. The design should pick
+   one and be explicit.
+
+2. **Where does the retention/send compatibility check surface in the backup summary?**
+   The design says preflight warnings appear in backup output, but the `BackupSummary`
+   type doesn't have a preflight section. Does it get one, or do preflight warnings merge
+   into the existing `warnings: Vec<String>`?
+
+3. **Should `PlanOutput` support `--dry-run` output?** The current plan command and
+   `backup --dry-run` both render plans. If `PlanOutput` is the structured type, both
+   commands should use it. Is this intended?

--- a/docs/99-reports/2026-03-26-preflight-implementation-review.md
+++ b/docs/99-reports/2026-03-26-preflight-implementation-review.md
@@ -1,0 +1,209 @@
+# Implementation Review: Pre-flight Checks Module
+
+**Project:** Urd
+**Date:** 2026-03-26
+**Scope:** `src/preflight.rs` (new), integration changes in `commands/backup.rs`,
+`commands/init.rs`, `commands/verify.rs`, `main.rs`
+**Reviewer:** Arch-adversary
+**Mode:** Implementation review (6 dimensions)
+
+## Executive Summary
+
+Clean, well-scoped module that follows the project's established patterns. The core retention
+model is technically sound but its warning message overstates the risk — the three-layer pin
+protection system means the scenario described ("pinned parent may be deleted") can't actually
+happen through normal operation. The implementation is solid; the messaging needs calibration.
+
+## What Kills You
+
+**Catastrophic failure mode: silent data loss via retention deleting pinned snapshots.**
+
+**Distance from this code: three layers away.** The preflight module is read-only — it examines
+config and produces warnings. It never touches filesystem state, never modifies pins, never
+interacts with retention. It cannot cause data loss. The question is whether its *warnings* are
+accurate, because a misleading warning can cause a user to make a wrong operational decision
+(e.g., changing retention policy based on a false alarm, inadvertently reducing protection).
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 3 | Retention model math is right, but the warning describes a scenario the pin system prevents. See Finding 1. |
+| **Security** | 5 | Pure function, no I/O, no privilege escalation, no trust boundary changes. |
+| **Architectural Excellence** | 5 | Clean module boundary. Pure function of config. Follows ADR-108. Does not contaminate existing modules. Integration is minimal and non-intrusive. |
+| **Systems Design** | 4 | Runs at the right time in each command. Warnings merge naturally into existing output. One edge case in backup dry-run path. |
+| **Rust Idioms** | 4 | Clean, idiomatic code. `#[must_use]` on public function. Minor: single-variant enum is unusual (see Finding 3). |
+| **Code Quality** | 4 | Good test coverage, clear naming, well-documented. Tests cover the motivating scenario and edge cases. |
+
+## Design Tensions
+
+### Tension 1: Warning accuracy vs. warning usefulness
+
+The retention/send compatibility model correctly computes the guaranteed survival floor. But
+the warning message says "pinned parent may be deleted before next send, forcing a full send."
+In reality, the pinned parent is protected by three independent layers: the planner's unsent
+snapshot protection, retention's `is_pinned` check, and the executor's re-check. The pinned
+parent will NOT be deleted by retention.
+
+The warning is still useful — it detects a config inconsistency where the retention windows
+are tighter than the send interval, which is a smell. But the *consequence* described is wrong.
+The actual consequence is subtler: if the user manually deletes the pin file, or if a future
+code change weakens pin protection, this config would be vulnerable. It's a defense-in-depth
+signal, not an active threat.
+
+**Resolution:** The math should stay. The message should be reframed.
+
+### Tension 2: Preflight in backup vs. log-only
+
+The design calls for preflight warnings to be logged via `log::warn!` AND included in the
+`BackupSummary.warnings`. This means the same warning appears in two places: the log output
+during the run, and the structured summary at the end. For an autonomous nightly run viewed
+in journal output, this is fine — redundancy is cheap. For an interactive run, the user sees
+it twice. The current approach is correct: the log line serves daemon mode, the summary serves
+interactive mode. The duplication is the cost of serving both.
+
+## Findings
+
+### Finding 1: Warning message overstates risk (Significant)
+
+**What:** The retention/send compatibility warning says: "pinned parent may be deleted before
+next send, forcing a full send."
+
+**Why it matters:** The three-layer pin protection system (planner unsent protection in
+`plan_local_retention` lines 326-348, retention's `is_pinned` guard in `graduated_retention`
+line 74/88/99/108/116/121, and executor re-check) means the pinned parent snapshot cannot be
+deleted by automated retention. The pin file records the last successfully sent snapshot. That
+snapshot name is always in the `pinned` set. Retention always checks `is_pinned` before
+deleting. This is the system working as designed.
+
+The status.md note about htpc-root says "retention policy deletes pinned snapshot before the
+next send interval can use it as incremental parent." If this actually happened, it would
+represent a bug in the pin protection system, not a config incompatibility. More likely, the
+chain break was caused by a different mechanism (legacy pin migration, manual deletion, or a
+period before pin protection was fully implemented).
+
+**Consequence:** A user reading this warning might take unnecessary action (changing retention
+policy, adding workarounds) based on a threat that the system already handles. The warning
+reduces trust in the pin protection system.
+
+**Suggested fix:** Reframe the message to describe what the config inconsistency actually
+means:
+
+```
+"{name}: retention window ({survival_display}) is shorter than send interval ({interval_display}).
+ Snapshots are currently protected by pin files, but this config depends on pin protection
+ rather than retention to keep incremental parents alive."
+```
+
+Or more concisely: flag it as a config hygiene issue without claiming the pinned parent will
+be deleted. The warning is valuable as "your retention and send intervals are misaligned" —
+just don't claim a consequence that the existing safety system prevents.
+
+### Finding 2: Backup dry-run path skips preflight warnings in summary (Moderate)
+
+**What:** In `backup.rs` line 67-70, the dry-run path returns early after printing the plan,
+before `build_backup_summary` is called. Preflight warnings are logged via `log::warn!`
+(line 63-64), but they never appear in the plan output.
+
+**Consequence:** `urd backup --dry-run` logs preflight warnings to stderr (if log level
+allows), but they're not visible in the plan display. An interactive user running `--dry-run`
+to preview their backup may miss config warnings.
+
+**Suggested fix:** Either (a) print preflight warnings before the plan output in the dry-run
+path, or (b) accept this as a known limitation since `urd plan` also doesn't show them. If
+(b), consider that `urd verify` is the intended surface for config warnings, and `plan` is
+for operational preview only.
+
+### Finding 3: Single-variant enum `Severity` (Minor)
+
+**What:** `Severity` has only one variant: `Warning`. The `Error` variant was removed during
+implementation to avoid a dead-code warning.
+
+**Consequence:** An enum with one variant is semantically equivalent to a unit struct — it
+carries no information. Every check produces `Severity::Warning`. The `severity` field on
+`PreflightCheck` always has the same value.
+
+**Suggested fix:** Two options:
+- (a) Remove the `severity` field entirely. All preflight checks are warnings. If `Error`
+  severity is needed later (when init's I/O checks migrate), add it then.
+- (b) Keep the enum as-is, anticipating that Error will be added when more checks arrive.
+  This is the "leave room for growth" argument — reasonable given the design doc plans
+  for future checks.
+
+Option (a) is simpler. Option (b) is fine if it doesn't trigger clippy.
+
+### Finding 4: `send-without-drives` emits one warning per subvolume (Minor)
+
+**What:** If the config has 5 subvolumes with `send_enabled = true` and no drives, the user
+gets 5 identical warnings (differing only in subvolume name). The drives configuration is
+global, not per-subvolume.
+
+**Consequence:** Noisy output when the underlying issue is a single config-level fact: "no
+drives configured." Five warnings for one problem.
+
+**Suggested fix:** Check `config.drives.is_empty()` once at the top of `preflight_checks`,
+outside the per-subvolume loop, and emit a single warning. The per-subvolume loop doesn't
+add information for this particular check.
+
+### Commendation: Pure function boundary
+
+The decision to accept only `&Config` (not `&dyn FileSystemState`) is the right call. It
+was explicitly reviewed in the design review (Finding 2) and the implementation honors that
+decision. The module cannot regress into I/O-dependent code without changing its public
+signature. This is the kind of constraint that prevents architectural drift — not through
+documentation, but through the type system.
+
+### Commendation: Integration minimalism
+
+The integration into backup, init, and verify is minimal: 3-5 lines in each command. The
+preflight module has zero coupling to command internals. Adding it to `build_backup_summary`
+required only a new parameter, not a structural change. This is well-calibrated — the feature
+fits into the existing architecture without reshaping it.
+
+## The Simplicity Question
+
+**What could be removed?** The `severity` field (Finding 3) — it's always `Warning`. The
+per-subvolume `send-without-drives` check (Finding 4) — it should be a single global check.
+
+**What's earning its keep?** The retention/send compatibility model. The `hourly + daily * 24`
+guaranteed survival floor is the right abstraction. It correctly handles the design review's
+test cases. The model is sound even though the warning message needs reframing.
+
+**Overall:** This is a well-sized module. 115 lines of production code, 245 lines of tests.
+Two checks. Nothing speculative.
+
+## For the Dev Team
+
+Priority order:
+
+1. **Reframe the retention/send warning message** (Finding 1, `preflight.rs` line 82-89).
+   Remove the claim that "pinned parent may be deleted." Replace with a message that describes
+   the config inconsistency without claiming a consequence that pin protection prevents. The
+   math stays; the framing changes.
+
+2. **Move `send-without-drives` check outside the per-subvolume loop** (Finding 4,
+   `preflight.rs` line 96-114). Check `config.drives.is_empty()` once. Emit one warning
+   listing which subvolumes have `send_enabled`, or just state "no drives configured but
+   send_enabled subvolumes exist."
+
+3. **Decide on dry-run preflight visibility** (Finding 2, `backup.rs` line 67-70). Either
+   add a preflight print before the plan output in the dry-run path, or accept that `urd
+   verify` is the surface for config warnings. Both are reasonable.
+
+4. **Optionally simplify Severity** (Finding 3, `preflight.rs` line 24-27). Remove the
+   field if it's not earning its keep. Minor.
+
+## Open Questions
+
+1. **What actually caused the htpc-root chain break?** The status.md note says retention
+   deleted the pinned parent, but the pin protection system should prevent this. Was it during
+   the legacy pin migration period? Was pin protection not yet implemented? Understanding the
+   root cause would clarify whether the preflight warning is detecting a real operational risk
+   or a theoretical one. If the chain break happened before the three-layer defense was in
+   place, the warning is purely forward-looking ("if pin protection ever weakens, this config
+   is vulnerable").
+
+2. **Should preflight checks run on `urd plan`?** Currently `plan_cmd.rs` doesn't call
+   preflight. The `plan` command shows what operations would happen — config consistency
+   warnings would be natural there too. But the design may intentionally keep `plan` focused
+   on operational preview.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -19,6 +19,7 @@ use crate::output::{
     BackupSummary, OutputMode, SendSummary, SkippedSubvolume, StatusAssessment, SubvolumeSummary,
 };
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
+use crate::preflight;
 use crate::state::StateDb;
 use crate::types::{BackupPlan, ByteSize};
 
@@ -56,6 +57,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 
     // Warn about drives without UUID fingerprinting
     drives::warn_missing_uuids(&config.drives);
+
+    // Run pre-flight config consistency checks
+    let preflight_warnings = preflight::preflight_checks(&config);
+    for check in &preflight_warnings {
+        log::warn!("[preflight] {}", check.message);
+    }
 
     // Dry run: print plan and exit (no lock needed)
     if args.dry_run {
@@ -127,7 +134,13 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     }
 
     // Build and render structured summary
-    let summary = build_backup_summary(&backup_plan, &result, &assessments, exec_duration);
+    let summary = build_backup_summary(
+        &backup_plan,
+        &result,
+        &assessments,
+        exec_duration,
+        &preflight_warnings,
+    );
     let output_mode = OutputMode::detect();
     let rendered = crate::voice::render_backup_summary(&summary, output_mode);
     println!("{rendered}");
@@ -149,6 +162,7 @@ fn build_backup_summary(
     result: &ExecutionResult,
     assessments: &[SubvolAssessment],
     duration: Duration,
+    preflight_warnings: &[preflight::PreflightCheck],
 ) -> BackupSummary {
     let subvolumes: Vec<SubvolumeSummary> = result
         .subvolume_results
@@ -203,6 +217,11 @@ fn build_backup_summary(
         .collect();
 
     let mut warnings = Vec::new();
+
+    // Pre-flight config consistency warnings
+    for check in preflight_warnings {
+        warnings.push(format!("[preflight] {}", check.message));
+    }
 
     // Pin failure warnings
     let total_pin_failures: u32 = result
@@ -606,7 +625,7 @@ mod tests {
             run_id: Some(10),
         };
 
-        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(5));
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(5), &[]);
 
         assert_eq!(summary.subvolumes.len(), 1);
         let sv = &summary.subvolumes[0];
@@ -649,7 +668,7 @@ mod tests {
             run_id: Some(11),
         };
 
-        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(120));
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(120), &[]);
 
         let sv = &summary.subvolumes[0];
         assert_eq!(sv.sends.len(), 2, "both successful sends should appear");
@@ -670,7 +689,7 @@ mod tests {
             run_id: Some(12),
         };
 
-        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(1));
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(1), &[]);
 
         assert_eq!(summary.warnings.len(), 1);
         assert!(summary.warnings[0].contains("3 pin file write(s) failed"));
@@ -691,7 +710,7 @@ mod tests {
             run_id: Some(13),
         };
 
-        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(1));
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(1), &[]);
 
         assert!(summary.warnings.is_empty(), "should have no warnings on clean run");
     }
@@ -733,7 +752,7 @@ mod tests {
             run_id: Some(14),
         };
 
-        let summary = build_backup_summary(&plan, &result, &empty_assessments(), Duration::from_secs(1));
+        let summary = build_backup_summary(&plan, &result, &empty_assessments(), Duration::from_secs(1), &[]);
 
         assert_eq!(summary.warnings.len(), 1);
         assert!(summary.warnings[0].contains("1 of 2 planned deletion(s) skipped"));
@@ -756,7 +775,7 @@ mod tests {
             run_id: None,
         };
 
-        let summary = build_backup_summary(&plan, &result, &empty_assessments(), Duration::from_secs(0));
+        let summary = build_backup_summary(&plan, &result, &empty_assessments(), Duration::from_secs(0), &[]);
 
         assert_eq!(summary.skipped.len(), 2);
         assert_eq!(summary.skipped[0].name, "htpc-home");
@@ -773,7 +792,7 @@ mod tests {
             run_id: Some(15),
         };
 
-        let summary = build_backup_summary(&empty_plan(), &result, &sample_assessments(), Duration::from_secs(1));
+        let summary = build_backup_summary(&empty_plan(), &result, &sample_assessments(), Duration::from_secs(1), &[]);
 
         assert_eq!(summary.assessments.len(), 1);
         assert_eq!(summary.assessments[0].name, "htpc-home");
@@ -793,6 +812,7 @@ mod tests {
             &result,
             &empty_assessments(),
             Duration::from_millis(12300),
+            &[],
         );
 
         assert_eq!(summary.result, "partial");
@@ -816,7 +836,7 @@ mod tests {
             run_id: Some(16),
         };
 
-        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(1));
+        let summary = build_backup_summary(&empty_plan(), &result, &empty_assessments(), Duration::from_secs(1), &[]);
 
         // Failed op with no error message should not appear in errors list
         assert!(summary.subvolumes[0].errors.is_empty());

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -298,6 +298,16 @@ pub fn run(config: Config) -> anyhow::Result<()> {
         );
     }
 
+    // 8. Pre-flight config consistency checks
+    let preflight_results = crate::preflight::preflight_checks(&config);
+    if !preflight_results.is_empty() {
+        println!();
+        println!("{}", "Config consistency checks:".bold());
+        for check in &preflight_results {
+            println!("  {} {}", "WARN".yellow(), check.message);
+        }
+    }
+
     println!();
     println!("{}", "Initialization complete.".green().bold());
     Ok(())

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -196,6 +196,17 @@ pub fn run(config: Config, args: VerifyArgs) -> anyhow::Result<()> {
     }
 
     // Summary
+    // Pre-flight config consistency checks
+    let preflight_results = crate::preflight::preflight_checks(&config);
+    if !preflight_results.is_empty() {
+        println!();
+        println!("{}", "Config consistency:".bold());
+        for check in &preflight_results {
+            println!("  {} {}", "WARN".yellow(), check.message);
+            total_warn += 1;
+        }
+    }
+
     let summary = format!(
         "Verify complete: {} OK, {} warnings, {} failures",
         total_ok, total_warn, total_fail

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod heartbeat;
 mod metrics;
 mod output;
 mod plan;
+mod preflight;
 mod retention;
 mod state;
 mod types;

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -1,0 +1,366 @@
+// Pre-flight checks — pure config consistency analysis.
+//
+// Detects misconfigurations that would cause operational problems:
+// retention/send incompatibility, impossible intervals, missing drives.
+//
+// Pure function: takes &Config, returns check results. No I/O.
+// I/O-dependent checks (path existence, drive capacity) stay in init.rs.
+
+use serde::Serialize;
+
+use crate::config::Config;
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+/// A single pre-flight check result (always a warning — config consistency issues).
+#[derive(Debug, Clone, Serialize)]
+pub struct PreflightCheck {
+    pub name: &'static str,
+    pub message: String,
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+/// Run all pre-flight checks against config. Pure function — no I/O.
+///
+/// Returns only checks that found problems.
+/// An empty Vec means all checks passed.
+#[must_use]
+pub fn preflight_checks(config: &Config) -> Vec<PreflightCheck> {
+    let mut checks = Vec::new();
+    let resolved = config.resolved_subvolumes();
+
+    // Global checks (not per-subvolume)
+    check_send_without_drives(&resolved, config, &mut checks);
+
+    // Per-subvolume checks
+    for subvol in &resolved {
+        if !subvol.enabled {
+            continue;
+        }
+
+        check_retention_send_compatibility(subvol, &mut checks);
+    }
+
+    checks
+}
+
+// ── Individual checks ──────────────────────────────────────────────────
+
+/// Check that retention policy guarantees snapshot survival through the send interval.
+///
+/// The guaranteed survival floor is the sum of the hourly and daily retention windows.
+/// Weekly/monthly windows provide only probabilistic survival — a pinned snapshot might
+/// be the representative for its week, but that depends on which other snapshots exist
+/// at runtime.
+///
+/// Note: the three-layer pin protection system (planner unsent protection, retention's
+/// is_pinned guard, executor re-check) prevents automated retention from deleting pinned
+/// parents. This check detects a config inconsistency where incremental chain integrity
+/// depends on pin protection rather than retention windows — a defense-in-depth concern,
+/// not an active threat under normal operation.
+fn check_retention_send_compatibility(
+    subvol: &crate::config::ResolvedSubvolume,
+    checks: &mut Vec<PreflightCheck>,
+) {
+    if !subvol.send_enabled {
+        return;
+    }
+
+    let retention = &subvol.local_retention;
+    let guaranteed_survival_hours =
+        i64::from(retention.hourly) + i64::from(retention.daily) * 24;
+    let send_interval_hours = subvol.send_interval.as_secs() / 3600;
+
+    if send_interval_hours > guaranteed_survival_hours {
+        let survival_display = format_hours(guaranteed_survival_hours);
+        let interval_display = format_hours(send_interval_hours);
+
+        checks.push(PreflightCheck {
+            name: "retention-send-compatibility",
+            message: format!(
+                "{}: retention window ({}, hourly={}, daily={}) is shorter than \
+                 send interval ({}) — incremental chain depends on pin protection \
+                 rather than retention to keep parents alive",
+                subvol.name,
+                survival_display,
+                retention.hourly,
+                retention.daily,
+                interval_display,
+            ),
+        });
+    }
+}
+
+/// Check that at least one drive is configured when any subvolume has send_enabled.
+/// Global check — emitted once, not per-subvolume.
+fn check_send_without_drives(
+    resolved: &[crate::config::ResolvedSubvolume],
+    config: &Config,
+    checks: &mut Vec<PreflightCheck>,
+) {
+    if !config.drives.is_empty() {
+        return;
+    }
+
+    let send_enabled: Vec<&str> = resolved
+        .iter()
+        .filter(|sv| sv.enabled && sv.send_enabled)
+        .map(|sv| sv.name.as_str())
+        .collect();
+
+    if !send_enabled.is_empty() {
+        checks.push(PreflightCheck {
+            name: "send-without-drives",
+            message: format!(
+                "no drives configured but send is enabled for: {}",
+                send_enabled.join(", "),
+            ),
+        });
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/// Format hours into a human-readable duration string.
+fn format_hours(hours: i64) -> String {
+    if hours >= 24 && hours % 24 == 0 {
+        let days = hours / 24;
+        format!("{days}d")
+    } else if hours >= 24 {
+        let days = hours / 24;
+        let rem = hours % 24;
+        format!("{days}d {rem}h")
+    } else {
+        format!("{hours}h")
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{
+        Config, DefaultsConfig, DriveConfig, GeneralConfig, LocalSnapshotsConfig,
+        SnapshotRoot, SubvolumeConfig,
+    };
+    use crate::types::{ByteSize, DriveRole, GraduatedRetention};
+    use std::path::PathBuf;
+
+    /// Build a minimal valid config for testing.
+    fn test_config(
+        subvolumes: Vec<SubvolumeConfig>,
+        drives: Vec<DriveConfig>,
+    ) -> Config {
+        Config {
+            general: GeneralConfig {
+                state_db: PathBuf::from("/tmp/urd-test.db"),
+                metrics_file: PathBuf::from("/tmp/urd-test.prom"),
+                log_dir: PathBuf::from("/tmp/urd-logs"),
+                btrfs_path: "/usr/sbin/btrfs".to_string(),
+                heartbeat_file: PathBuf::from("/tmp/urd-heartbeat.json"),
+            },
+            local_snapshots: LocalSnapshotsConfig {
+                roots: vec![SnapshotRoot {
+                    path: PathBuf::from("/snapshots"),
+                    subvolumes: subvolumes.iter().map(|s| s.name.clone()).collect(),
+                    min_free_bytes: Some(ByteSize(1_073_741_824)), // 1GB
+                }],
+            },
+            defaults: DefaultsConfig {
+                snapshot_interval: "24h".parse().unwrap(),
+                send_interval: "24h".parse().unwrap(),
+                send_enabled: true,
+                enabled: true,
+                local_retention: default_retention(),
+                external_retention: default_retention(),
+            },
+            drives,
+            subvolumes,
+        }
+    }
+
+    fn default_retention() -> GraduatedRetention {
+        GraduatedRetention {
+            hourly: Some(24),
+            daily: Some(7),
+            weekly: Some(4),
+            monthly: Some(0),
+        }
+    }
+
+    fn test_drive() -> DriveConfig {
+        DriveConfig {
+            label: "test-drive".to_string(),
+            uuid: None,
+            mount_path: PathBuf::from("/mnt/test"),
+            snapshot_root: "urd-snapshots".to_string(),
+            role: DriveRole::Primary,
+            max_usage_percent: Some(90),
+            min_free_bytes: None,
+        }
+    }
+
+    fn test_subvolume(name: &str) -> SubvolumeConfig {
+        SubvolumeConfig {
+            name: name.to_string(),
+            short_name: name.to_string(),
+            source: PathBuf::from(format!("/{name}")),
+            priority: 1,
+            enabled: None,
+            snapshot_interval: None,
+            send_interval: None,
+            send_enabled: None,
+            local_retention: None,
+            external_retention: None,
+        }
+    }
+
+    fn subvol_with_retention_and_send(
+        name: &str,
+        hourly: u32,
+        daily: u32,
+        send_interval: &str,
+    ) -> SubvolumeConfig {
+        SubvolumeConfig {
+            name: name.to_string(),
+            short_name: name.to_string(),
+            source: PathBuf::from(format!("/{name}")),
+            priority: 1,
+            enabled: None,
+            snapshot_interval: None,
+            send_interval: Some(send_interval.parse().unwrap()),
+            send_enabled: None,
+            local_retention: Some(GraduatedRetention {
+                hourly: Some(hourly),
+                daily: Some(daily),
+                weekly: Some(0),
+                monthly: Some(0),
+            }),
+            external_retention: None,
+        }
+    }
+
+    // ── Retention/send compatibility ─────────────────────────────────
+
+    #[test]
+    fn htpc_root_case_warns() {
+        // htpc-root: hourly=24, daily=3, send=1w
+        // Survival: 24h + 72h = 96h. Send interval: 168h. Should warn.
+        let sv = subvol_with_retention_and_send("htpc-root", 24, 3, "1w");
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results = preflight_checks(&config);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "retention-send-compatibility");
+        assert!(results[0].message.contains("htpc-root"));
+        assert!(results[0].message.contains("pin protection"));
+    }
+
+    #[test]
+    fn safe_daily_retention_no_warning() {
+        // hourly=24, daily=7, send=1w
+        // Survival: 24h + 168h = 192h. Send interval: 168h. OK.
+        let sv = subvol_with_retention_and_send("test-subvol", 24, 7, "1w");
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results = preflight_checks(&config);
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn large_hourly_compensates_for_zero_daily() {
+        // hourly=168, daily=0, send=5d
+        // Survival: 168h + 0h = 168h. Send interval: 120h. OK.
+        let sv = subvol_with_retention_and_send("test-subvol", 168, 0, "5d");
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results = preflight_checks(&config);
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn zero_hourly_small_daily_warns() {
+        // hourly=0, daily=3, send=4d
+        // Survival: 0h + 72h = 72h. Send interval: 96h. Should warn.
+        let sv = subvol_with_retention_and_send("test-subvol", 0, 3, "4d");
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results = preflight_checks(&config);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "retention-send-compatibility");
+    }
+
+    #[test]
+    fn zero_retention_always_warns_when_send_enabled() {
+        // hourly=0, daily=0 → guaranteed survival is 0h
+        let sv = subvol_with_retention_and_send("test-subvol", 0, 0, "1d");
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results = preflight_checks(&config);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "retention-send-compatibility");
+    }
+
+    #[test]
+    fn send_disabled_skips_retention_check() {
+        let mut sv = subvol_with_retention_and_send("test-subvol", 0, 0, "1d");
+        sv.send_enabled = Some(false);
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results = preflight_checks(&config);
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn disabled_subvolume_skipped() {
+        let mut sv = subvol_with_retention_and_send("test-subvol", 0, 0, "1d");
+        sv.enabled = Some(false);
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results = preflight_checks(&config);
+
+        assert!(results.is_empty());
+    }
+
+    // ── Send without drives ──────────────────────────────────────────
+
+    #[test]
+    fn send_enabled_no_drives_warns_once() {
+        // Two subvolumes, both send_enabled, no drives — should emit ONE warning.
+        let sv1 = test_subvolume("subvol-a");
+        let sv2 = test_subvolume("subvol-b");
+        let config = test_config(vec![sv1, sv2], vec![]);
+        let results: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "send-without-drives")
+            .collect();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].message.contains("subvol-a"));
+        assert!(results[0].message.contains("subvol-b"));
+    }
+
+    #[test]
+    fn send_enabled_with_drives_no_warning() {
+        let sv = test_subvolume("test-subvol");
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "send-without-drives")
+            .collect();
+
+        assert!(results.is_empty());
+    }
+
+    // ── All clear ────────────────────────────────────────────────────
+
+    #[test]
+    fn healthy_config_returns_empty() {
+        let sv = test_subvolume("test-subvol");
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results = preflight_checks(&config);
+
+        assert!(results.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- **New `preflight.rs` module** — pure function of `&Config` (ADR-108), detects config misalignments before they cause operational problems
- **Retention/send compatibility check** — computes guaranteed snapshot survival floor (`hourly + daily × 24` hours) and warns when send interval exceeds it. Arch-adversary review revealed three-layer pin protection prevents actual deletion; warning reframed as defense-in-depth signal
- **Send-without-drives check** — single global warning when `send_enabled` subvolumes exist but no drives configured
- **Integrated into backup, init, verify** commands with minimal coupling (3-5 lines each)
- **Multi-session design** for next 2-3 sessions (voice migration, Promise ADR) — reviewed and ready to build

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 251 tests, pass (10 new preflight tests)
- cargo build --release: pass
- Integration tests: not applicable (no btrfs interaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)