### PR TITLE
docs: Design proposals for structured errors, Sentinel, and protection promises

### DIFF
--- a/docs/95-ideas/2026-03-26-design-protection-promises.md
+++ b/docs/95-ideas/2026-03-26-design-protection-promises.md
@@ -1,0 +1,749 @@
+# Design: Protection Promise ADR (ADR-110)
+
+> **TL;DR:** Protection promises are named levels (`guarded`, `protected`, `resilient`,
+> `custom`) that map to concrete retention and interval policies. The planner derives
+> operations from the promise level; the awareness model evaluates whether the promise
+> is being kept. Existing configs continue to work as implicit `custom`. Timer frequency
+> and drive topology are explicit inputs to achievability validation.
+
+**Date:** 2026-03-26
+**Status:** reviewed (all findings addressed)
+**Depends on:** Awareness model (3a, complete), pre-flight checks (2c, complete),
+voice migration (Session 2, in progress)
+
+## Problem
+
+Urd currently speaks in operations: snapshot intervals, send intervals, retention
+windows. Users must reason backwards from these to answer "is my data safe?" The
+awareness model (already built) computes PROTECTED / AT RISK / UNPROTECTED, but the
+thresholds are derived from whatever intervals the user configured — there's no semantic
+link between the user's *intent* ("keep my recordings safe") and the system's *behavior*
+(1h snapshots, 2h sends).
+
+Protection promises bridge this gap. The user declares what they want; Urd derives
+what to do. This is the foundation for:
+- Promise-anchored status ("your recordings are PROTECTED")
+- Config validation ("this promise is unachievable with your drives")
+- Sentinel triggers ("a drive appeared — promises need attention")
+- Future: conversational setup ("what matters most to you?")
+
+### Operational evidence
+
+The config/timer mismatch incident (2026-03-26) demonstrated the problem: the user
+configured 1h–4h intervals during a travel period, but the systemd timer fires daily.
+The awareness model reported UNPROTECTED for 18h/day — technically correct (intervals
+were violated) but misleading (data was fine). This happened because the config
+describes *desired cadence* without reference to *actual run frequency*.
+
+Promise levels must be defined in terms of outcomes ("snapshot no older than X"), not
+frequencies ("snapshot every Y"), so they're evaluable regardless of how often Urd runs.
+
+### Gate checklist from status.md
+
+The Phase 5 gate requires the ADR to answer:
+- [x] Exact retention/interval derivations for each promise level
+- [x] Config conflict resolution: promise + manual intervals
+- [x] Migration path for existing configs (implicit `custom`)
+- [x] Promise validation: achievability given drive topology
+- [x] `custom` designed as first-class
+- [x] Timer frequency as input to achievability
+- [x] Drive topology constraints (subvolume × drive capacity)
+- [x] Awareness threshold mode (adapt to Sentinel vs. timer?)
+
+## Proposed Design
+
+### Promise levels
+
+Four named levels plus `custom`. Each level defines outcome targets, from which the
+planner derives operational parameters.
+
+```rust
+/// Protection promise level for a subvolume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProtectionLevel {
+    /// Local snapshots only. No external send requirement.
+    /// For: temp data, caches, build artifacts, data you can re-derive.
+    Guarded,
+    /// Local snapshots + at least one external drive current.
+    /// For: documents, photos, personal projects — things you'd hate to lose.
+    Protected,
+    /// Local snapshots + multiple external drives current.
+    /// For: irreplaceable data — recordings, archives, creative work.
+    Resilient,
+    /// User manages all parameters manually. Default for migration.
+    Custom,
+}
+```
+
+**Why no `archival` level?** The original brainstorm included `archival` (long-term
+retention, relaxed freshness). On reflection, archival is an orthogonal concern —
+it's about *how long* to keep history, not *how safe* data is right now. A subvolume
+can be `protected` (current copies exist) *and* have archival retention (keep monthly
+snapshots indefinitely). Conflating them creates confusing semantics: is an archival
+subvolume "less protected" because its freshness threshold is relaxed? No — it just
+has a longer retention tail.
+
+If archival becomes needed, it should be a `retention_profile` separate from
+`protection_level`. Defer until there's a concrete use case.
+
+### Outcome targets per level
+
+Each promise level defines **maximum acceptable age** for local and external copies.
+These are the thresholds the awareness model evaluates against.
+
+| Level | Local max age | External max age | Min external drives | Retention floor |
+|-------|--------------|------------------|--------------------|-----------------------|
+| `guarded` | 48h | — (no external) | 0 | daily=7, weekly=4 |
+| `protected` | 24h | 48h | 1 | daily=30, weekly=26, monthly=12 |
+| `resilient` | 24h | 48h | 2 | daily=30, weekly=26, monthly=12 |
+| `custom` | (from config) | (from config) | (from config) | (from config) |
+
+**Key insight:** The max ages are *outcomes*, not intervals. A daily timer achieving
+24h local max age means `snapshot_interval = 24h`. A Sentinel achieving 24h means
+it could use `snapshot_interval = 1h` with more frequent runs. The promise level
+doesn't change — the derived intervals adapt to the run frequency.
+
+**These outcome targets are primary policy, not awareness-multiplier derivations
+(review M3).** The targets define what each promise level *means* to users. The
+awareness model's multiplier constants (2×/5× local, 1.5×/3× external) happen to
+be consistent with these targets today, but the targets should be defensible on their
+own terms. If the awareness multipliers change (module-level constants, not config),
+promise semantics must not silently shift — add a consistency check between promise
+outcome targets and awareness thresholds in the preflight module.
+
+### Planner derivation
+
+The planner derives operational parameters from the promise level + run frequency:
+
+```rust
+/// Derived operational parameters for a promise level.
+#[derive(Debug, Clone)]
+pub struct DerivedPolicy {
+    pub snapshot_interval: Interval,
+    pub send_interval: Interval,
+    pub send_enabled: bool,
+    pub local_retention: ResolvedGraduatedRetention,
+    pub external_retention: ResolvedGraduatedRetention,
+    pub min_external_drives: usize,
+}
+
+/// Derive operational parameters from a promise level.
+/// Pure function — promise level + run frequency in, policy out.
+pub fn derive_policy(
+    level: ProtectionLevel,
+    run_frequency: RunFrequency,
+) -> DerivedPolicy
+```
+
+**Run frequency** is an explicit input, not inferred:
+
+```rust
+/// How often Urd runs. Determines interval derivation.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RunFrequency {
+    /// systemd timer, typically daily
+    Timer { interval: Interval },
+    /// Sentinel daemon, sub-hourly checks
+    Sentinel,
+}
+```
+
+**Derivation rules:**
+
+For `Timer { interval: 24h }`:
+- `guarded`: snapshot_interval=24h, send_enabled=false
+- `protected`: snapshot_interval=24h, send_interval=24h (one send per run)
+- `resilient`: snapshot_interval=24h, send_interval=24h (sends to all available drives)
+
+For `Sentinel`:
+- `guarded`: snapshot_interval=4h, send_enabled=false
+- `protected`: snapshot_interval=1h, send_interval=4h
+- `resilient`: snapshot_interval=1h, send_interval=2h
+
+The derived intervals are chosen so that the awareness model's thresholds (2× local,
+1.5× external) keep the subvolume PROTECTED under normal operation:
+- Timer 24h + local threshold 2× = PROTECTED up to 48h = `guarded` max age ✓
+- Timer 24h + external threshold 1.5× = PROTECTED up to 36h, AT RISK at 48h
+  → fits `protected` max age of 48h ✓
+
+**Retention derivation by level:**
+
+```
+guarded:
+  local:    daily=7, weekly=4
+  external: (none — send disabled)
+
+protected:
+  local:    hourly=24, daily=30, weekly=26, monthly=12
+  external: daily=30, weekly=26, monthly=0
+
+resilient:
+  local:    hourly=24, daily=30, weekly=26, monthly=12
+  external: daily=30, weekly=26, monthly=0
+```
+
+Retention is the same for `protected` and `resilient` — the distinction is about
+*how many copies*, not *how long to keep them*. The name "resilient" implies
+redundancy (more drives), not deeper history (review M4). If users expect `resilient`
+to also mean longer retention, the levels can diverge later (e.g., `resilient` with
+`monthly = 0` for unlimited monthly). Defer until user feedback confirms the need.
+Document this explicitly: "resilient = protected + multi-drive redundancy."
+
+### Config schema
+
+```toml
+# Option 1: Promise level (Urd derives everything)
+[[subvolumes]]
+name = "subvol3-opptak"
+source = "/mnt/btrfs-pool/subvol3-opptak"
+protection_level = "resilient"
+drives = ["WD-18TB"]  # which drives serve this promise
+
+# Option 2: Custom (user specifies everything, same as today)
+[[subvolumes]]
+name = "subvol6-tmp"
+source = "/mnt/btrfs-pool/subvol6-tmp"
+# No protection_level → implicit "custom"
+snapshot_interval = "1d"
+send_enabled = false
+local_retention = { daily = 7 }
+
+# Option 3: Promise with overrides (advanced)
+[[subvolumes]]
+name = "htpc-home"
+source = "/home"
+protection_level = "protected"
+drives = ["WD-18TB", "2TB-backup"]
+snapshot_interval = "15m"  # Override: more frequent than derived
+# send_interval, retention: derived from "protected"
+```
+
+### Config conflict resolution
+
+**Rule:** When `protection_level` is set, the promise derives default values for all
+operational parameters. Explicit overrides replace the derived values. The preflight
+check warns when an override weakens the promise.
+
+```rust
+/// Resolve a subvolume's operational parameters.
+/// Promise-derived values are the baseline; explicit config overrides replace them.
+///
+/// For `custom` (or absent `protection_level`): derive_policy returns None,
+/// and resolution falls through to the existing defaults-based path — identical
+/// to today's SubvolumeConfig::resolved(&defaults). (Review M1: property test
+/// must verify byte-identical output for configs without protection_level.)
+fn resolve_subvolume(
+    sv: &SubvolumeConfig,
+    defaults: &DefaultsConfig,
+    run_frequency: RunFrequency,
+) -> ResolvedSubvolume {
+    match sv.protection_level {
+        Some(ProtectionLevel::Custom) | None => {
+            // Existing resolution path — unchanged behavior
+            sv.resolved(defaults)
+        }
+        Some(level) => {
+            let derived = derive_policy(level, run_frequency);
+            ResolvedSubvolume {
+                snapshot_interval: sv.snapshot_interval.unwrap_or(derived.snapshot_interval),
+                send_interval: sv.send_interval.unwrap_or(derived.send_interval),
+                send_enabled: sv.send_enabled.unwrap_or(derived.send_enabled),
+                local_retention: sv.local_retention
+                    .map(|r| r.merged_with(&derived.local_retention).resolved())
+                    .unwrap_or(derived.local_retention),
+                // ... etc
+            }
+        }
+    }
+}
+```
+
+**Property test (review M1):** For every existing subvolume config (no `protection_level`),
+`resolve_subvolume(sv, defaults, any_frequency)` must produce identical output to
+`sv.resolved(defaults)`. This guarantees the migration path is truly zero-breaking-change.
+
+**Weakening detection in preflight:**
+
+```
+For each subvolume with protection_level set:
+  derived = derive_policy(level, run_frequency)
+  actual = resolved values (after overrides)
+
+  if actual.snapshot_interval > derived.snapshot_interval:
+    warn("snapshot_interval override ({actual}) is less frequent than
+          {level} promise requires ({derived})")
+
+  if actual.send_interval > derived.send_interval:
+    warn("send_interval override weakens {level} promise")
+```
+
+**Weakening vs. voiding (review S2):** Not all overrides are equal. Some weaken the
+promise (longer intervals than derived — performance still degrades gracefully); others
+structurally void it (disabling sends on a level that requires external copies).
+
+**Voiding overrides** (status display must reflect):
+- `send_enabled = false` on `protected` or `resilient` (requires external sends)
+- `drives = []` (empty list) on any level requiring external copies
+
+**Weakening overrides** (warning in preflight, status shows promise level normally):
+- `snapshot_interval` longer than derived
+- `send_interval` longer than derived
+- `local_retention` tighter than derived
+
+When a voiding override is detected:
+- Preflight emits an **error** (not warning): "protected requires external sends,
+  but send_enabled = false — promise cannot be met"
+- Status output displays the promise level with a degradation marker:
+  `protected (degraded — no external sends)` instead of bare `protected`
+- The awareness model evaluates normally (it doesn't know about promises), so
+  the STATUS column will show the actual protection state
+
+This means a user sees both the promise they set *and* the reality:
+```
+  subvol3-opptak   UNPROTECTED   protected (degraded — no external sends)
+```
+
+This is a warning, not a config error. The user may know what they're doing (mid-migration,
+drive not yet purchased). But it surfaces the tension persistently in status output, not
+just in a one-time log message.
+
+### Config field: `run_frequency`
+
+New top-level config field:
+
+```toml
+[general]
+# How often Urd runs. Affects promise-derived intervals.
+# "daily" = systemd timer at ~24h intervals (default)
+# "sentinel" = Sentinel daemon manages timing
+# Custom: "6h", "12h", etc.
+run_frequency = "daily"
+```
+
+```rust
+// In config.rs
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct GeneralConfig {
+    // ... existing fields ...
+    #[serde(default = "default_run_frequency")]
+    pub run_frequency: RunFrequency,
+}
+
+fn default_run_frequency() -> RunFrequency {
+    RunFrequency::Timer { interval: Interval::days(1) }
+}
+```
+
+**Why explicit, not inferred from heartbeat?** Heartbeat history can drift (missed
+runs, clock changes). An explicit config field is: (a) deterministic — same config
+always produces same derivation, (b) validatable at config time, (c) clear to the
+user about expectations.
+
+When the Sentinel is running, it sets `run_frequency = "sentinel"` effectively (or
+the config is updated to reflect this). The Sentinel design (5b) determines the exact
+mechanism.
+
+**Run-frequency consistency check (review S3):** To detect drift between declared and
+actual run frequency, add a preflight check that compares `run_frequency` against
+heartbeat history (when available). If the last N run timestamps show a cadence
+inconsistent with the declared frequency (e.g., `run_frequency = "daily"` but runs are
+6h apart, or runs are 3 days apart), warn:
+
+```
+⚠ run_frequency is "daily" but actual runs average 2.8 days apart.
+  Promise-derived intervals assume daily runs — promises may be unachievable.
+  Update run_frequency or check your systemd timer.
+```
+
+This doesn't infer the "correct" frequency — it uses the explicit config as the
+expectation and heartbeat as the reality check. The check requires ≥3 heartbeat
+timestamps to compute a meaningful average.
+
+### Subvolume-to-drive mapping
+
+New optional field on `SubvolumeConfig`:
+
+```toml
+[[subvolumes]]
+name = "subvol3-opptak"
+protection_level = "resilient"
+drives = ["WD-18TB"]  # Only send to these drives
+```
+
+```rust
+// In config.rs
+pub struct SubvolumeConfig {
+    // ... existing fields ...
+    /// Which drives serve this subvolume's external promise.
+    /// None = all drives (current behavior).
+    #[serde(default)]
+    pub drives: Option<Vec<String>>,
+}
+```
+
+**Behavior:**
+- `drives = None` (default, backward compatible): Send to all configured drives.
+  Current behavior unchanged.
+- `drives = Some(["WD-18TB"])`: Send only to WD-18TB. Other drives are skipped for
+  this subvolume.
+- Validation: all listed drives must exist in `[[drives]]`. Error if not.
+
+**Promise validation with drive mapping:**
+- `resilient` requires `min_external_drives = 2`. If `drives = ["WD-18TB"]` (only 1),
+  the preflight check warns: "resilient requires 2 external drives, but only 1
+  configured for subvol3-opptak."
+- Drive capacity check: if `subvol3-opptak` (~3.4TB) maps to `2TB-backup` (~1.1TB
+  available), preflight warns: "2TB-backup has insufficient capacity for subvol3-opptak
+  (estimated 3.4TB, available 1.1TB)."
+
+### Achievability validation
+
+A promise is **achievable** if the derived policy can be fulfilled given:
+1. Run frequency (can the timer/Sentinel create snapshots often enough?)
+2. Drive topology (are enough drives configured and large enough?)
+3. Retention alignment (do retention windows keep snapshots long enough for sends?)
+
+Achievability is checked by the preflight module (pure, config-only for topology
+checks; with `FileSystemState` for capacity checks in `init`/`verify`).
+
+```rust
+/// Achievability check results for a subvolume's promise.
+pub struct AchievabilityResult {
+    pub subvolume: String,
+    pub level: ProtectionLevel,
+    pub achievable: bool,
+    pub issues: Vec<AchievabilityIssue>,
+}
+
+pub enum AchievabilityIssue {
+    InsufficientDrives { required: usize, configured: usize },
+    DriveCapacityInsufficient { drive: String, estimated_size: u64, available: u64 },
+    RunFrequencyInsufficient { required_interval: Interval, actual: Interval },
+    RetentionOverrideWeakens { field: String, derived: String, actual: String },
+}
+```
+
+**Where achievability is checked:**
+- `urd init`: Full check including drive capacity (has I/O)
+- `urd verify`: Full check including drive capacity (has I/O)
+- `urd backup` preflight: Config-only subset (no I/O), logs warnings
+- `urd status`: Shows achievability in promise display (computed from awareness model
+  + config, no new I/O)
+
+### Awareness model integration
+
+The awareness model already computes PROTECTED / AT RISK / UNPROTECTED using
+multiplier thresholds on configured intervals. With promises:
+
+**No change to the core algorithm.** The awareness model evaluates the *resolved*
+intervals (after promise derivation + overrides). The promise level doesn't change
+how freshness is computed — it changes what intervals are configured.
+
+**New: Promise-level status display.**
+
+```
+urd status
+
+  subvol3-opptak   PROTECTED   (resilient — 1 of 1 required drives current)
+  htpc-home        AT RISK     (protected — external send overdue by 6h)
+  subvol6-tmp      PROTECTED   (guarded — local only)
+  htpc-root        PROTECTED   (custom)
+```
+
+The promise level appears as context alongside the status. For `custom`, no
+derived expectation is shown.
+
+**Threshold adaptation question (resolved):** Should thresholds change based on
+whether the Sentinel is running? **No.** The thresholds evaluate outcomes (is the
+data fresh enough?), not process (how often does Urd run?). `run_frequency` feeds
+into *interval derivation*, not *threshold computation*. The awareness model is
+agnostic to how the intervals were chosen.
+
+### Migration path
+
+**Zero breaking changes.** Every existing config continues to work identically.
+
+1. No `protection_level` field → implicit `custom`
+2. `custom` means: "I manage intervals and retention manually; the planner uses my
+   explicit values; the awareness model evaluates against my configured intervals."
+3. No `drives` field on subvolume → send to all drives (current behavior)
+4. No `run_frequency` field → default `daily` (24h timer)
+
+**Protection-level transition safety (review S1):**
+
+Changing `protection_level` on an existing subvolume can cause retroactive snapshot
+deletion if the derived retention is tighter than the previous explicit retention.
+Example: switching from `monthly = 0` (unlimited) to `protected` (which derives
+`monthly = 12`) would delete all monthly snapshots older than 12 months on the next
+retention pass.
+
+**Mitigation:** When `urd init` or `urd verify` detects a subvolume where the resolved
+retention policy is strictly tighter than what the previous run used (detectable by
+comparing against the most recent heartbeat's config snapshot or a stored config hash),
+it warns:
+
+```
+⚠ subvol3-opptak: switching to "resilient" would reduce monthly retention
+  from unlimited to 12 months. 3 monthly snapshots older than 12 months
+  would be eligible for deletion on the next backup run.
+  Run `urd backup --confirm-retention-change` to acknowledge.
+```
+
+The `--confirm-retention-change` flag is required for the first run after a retention
+tightening. Without it, the backup runs but skips retention for the affected subvolumes
+(fail open — backups happen, deletions are deferred until confirmed). This flag is
+needed once; subsequent runs proceed normally.
+
+**Implementation:** Store the last-used retention config per subvolume in the state DB.
+On backup, compare resolved retention against stored. If any dimension is tighter and
+the flag is not set, log a warning and skip retention for that subvolume.
+
+**Upgrade path for users who want promises:**
+
+```diff
+ [[subvolumes]]
+ name = "subvol3-opptak"
+ source = "/mnt/btrfs-pool/subvol3-opptak"
+-priority = 1
+-snapshot_interval = "1h"
+-send_interval = "2h"
++protection_level = "resilient"
++drives = ["WD-18TB"]
+```
+
+The user removes explicit intervals and adds a promise level. `urd init` shows the
+derived policy so they can verify it matches their expectations.
+
+### `urd status` with promises
+
+Status output changes to lead with the promise perspective:
+
+```
+Urd Status — 2026-03-26 04:05
+
+  SUBVOLUME          STATUS       PROMISE      LOCAL    WD-18TB   WD-18TB1   2TB-backup
+  subvol3-opptak     PROTECTED    resilient    12       8         —          —
+  htpc-home          AT RISK      protected    47       23        15         —
+  subvol1-docs       PROTECTED    protected    12       8         5          3
+  htpc-root          PROTECTED    custom       7        3         3          —
+  subvol6-tmp        PROTECTED    guarded      7        —         —          —
+
+  ⚠ htpc-home: external send to WD-18TB overdue (last: 30h ago, threshold: 36h)
+```
+
+The PROMISE column shows the configured level. For `custom`, no promise expectations
+are displayed in advisories.
+
+## Invariants
+
+1. **Promises derive operations; they don't bypass the planner.** The planner still
+   receives `ResolvedSubvolume` with concrete intervals and retention. Promise
+   derivation happens at config resolution time, before the planner runs. (ADR-100)
+2. **`custom` is first-class.** No code path treats `custom` as inferior or special-cased.
+   It's the default, and it means "the user's config is the policy." (ADR-109)
+3. **Promise derivation is a pure function.** `derive_policy(level, run_frequency)`
+   has no I/O, no state, no side effects. (ADR-108)
+4. **Existing configs don't break.** All fields added by this ADR are optional with
+   backward-compatible defaults. No migration script needed. (ADR-105)
+5. **Achievability is advisory, not blocking.** An unachievable promise generates
+   warnings, not errors. The user may be in transition (new drive arriving, config
+   change pending). Blocking on unachievable promises would violate ADR-107 (fail open).
+6. **The awareness model is unchanged.** Promise levels affect what intervals are
+   configured, not how the awareness model evaluates them. The model remains a pure
+   function of config + filesystem state. (ADR-108)
+
+## Integration Points
+
+| Module | Change | Scope |
+|--------|--------|-------|
+| `config.rs` | `ProtectionLevel` enum, `drives` field, `run_frequency` field, derivation in `resolve_subvolume()` | Medium — extends existing resolution logic |
+| `types.rs` | `ProtectionLevel`, `RunFrequency`, `DerivedPolicy` types | New types |
+| `preflight.rs` | Achievability checks (drive count, retention weakening) | Extension (~3 new checks) |
+| `awareness.rs` | **No changes** | — |
+| `plan.rs` | Filter drive iteration per subvolume's `drives` field (review M2) | Small — add `drives: Option<Vec<String>>` to `ResolvedSubvolume`, skip unmapped drives in send loop |
+| `voice.rs` | Promise column in status, promise context in advisories | Extension |
+| `output.rs` | Promise level in `StatusOutput`, achievability in output types | Extension |
+| `commands/init.rs` | Show derived policy for promise subvolumes | Extension |
+
+**Files affected:** ~6 (config, types, preflight, voice, output, init)
+**New module:** No (extends existing modules)
+
+## Effort Estimate
+
+| Task | Effort |
+|------|--------|
+| `ProtectionLevel` enum + `derive_policy()` | Low (types + pure function) |
+| Config extension (3 new fields) + validation | Medium |
+| Preflight achievability checks | Medium |
+| Voice/output integration (status display) | Medium |
+| Tests | Medium (~20-25 tests) |
+| **Total** | **~2 sessions** |
+
+Calibration: UUID fingerprinting was 1 module, 10 tests, 1 session. This is 0 new
+modules but touches more files and has more test scenarios.
+
+## Test Strategy
+
+```
+// Promise derivation (pure function)
+test_derive_guarded_timer_daily
+test_derive_protected_timer_daily
+test_derive_resilient_timer_daily
+test_derive_protected_sentinel
+test_derive_custom_returns_none (no derivation for custom)
+
+// Config resolution with promises
+test_promise_sets_default_intervals
+test_explicit_override_replaces_derived
+test_no_protection_level_is_custom
+test_migration_existing_config_unchanged  // property test: byte-identical (M1)
+test_voiding_override_detected            // send_enabled=false on protected (S2)
+test_weakening_override_generates_warning // longer interval on protected
+
+// Achievability validation
+test_resilient_with_one_drive_warns
+test_protected_with_no_drives_warns
+test_drive_capacity_insufficient_warns
+test_retention_override_weakens_warns
+test_run_frequency_insufficient_warns
+test_all_achievable_no_warnings
+test_custom_skips_achievability (no expectations to validate)
+
+// Drive mapping
+test_drives_field_filters_send_targets
+test_drives_field_none_sends_to_all
+test_drives_field_invalid_drive_errors
+test_drives_field_validated_at_config_load
+
+// Transition safety (S1)
+test_retention_tightening_detected
+test_retention_loosening_no_flag_needed
+test_confirm_flag_allows_tighter_retention
+test_skip_retention_without_confirm_flag
+
+// Integration with awareness model
+test_promise_derived_intervals_evaluated_correctly
+test_custom_intervals_evaluated_as_before
+
+// Run frequency consistency (S3)
+test_run_frequency_matches_heartbeat_history
+test_run_frequency_mismatch_warns
+test_run_frequency_check_skipped_insufficient_history
+
+// Pin protection with derived retention (test-team: critical)
+test_promise_derived_retention_preserves_pinned_snapshots
+test_promise_derived_retention_with_space_pressure_preserves_pins
+
+// Full pipeline: promise → planner → retention (test-team: critical)
+test_promise_level_to_retention_decision_pipeline
+
+// Protection level downgrade (test-team: high)
+test_downgrade_resilient_to_guarded_disables_sends
+test_downgrade_does_not_delete_external_snapshots
+
+// Planner drive mapping integration (test-team: high)
+test_planner_skips_unmapped_drives_for_subvolume
+test_planner_sends_to_all_drives_when_no_mapping
+test_planner_drive_mapping_with_uuid_mismatch
+
+// Migration identity property (test-team: proptest candidate)
+test_migration_identity_property  // proptest: all configs without protection_level
+                                  // produce identical output through old and new paths
+
+// Voice rendering
+test_status_shows_promise_column
+test_advisory_includes_promise_context
+test_custom_shows_no_promise_advisory
+test_status_shows_degraded_promise_when_sends_disabled
+```
+
+## Rejected Alternatives
+
+### A. `archival` as a promise level
+
+Archival is about retention depth, not protection freshness. A subvolume can be
+`protected` (fresh copies exist) with archival retention (monthly snapshots kept
+indefinitely). Conflating them creates confusing status: "archival + AT RISK" could
+mean either "old snapshots are fine but recent ones are stale" or "the archival promise
+itself is degraded." Keep them separate. Add `retention_profile` later if needed.
+
+### B. Infer run frequency from heartbeat history
+
+Heartbeat history can show actual run frequency, but: (a) new installs have no history,
+(b) missed runs skew the average, (c) config should be deterministic — same config
+always produces the same derivation. An explicit `run_frequency` field is simpler and
+more reliable. The Sentinel can update this field (or effectively override it) when
+it takes over scheduling.
+
+### C. Promise levels as interval multipliers
+
+Instead of named levels, define promises as multipliers: "2× the default interval" for
+protected, "1× for resilient." This is elegant but opaque — users can't reason about
+what "2× the default" means without knowing the default. Named levels with documented
+outcome targets are more transparent.
+
+### D. Require drive mapping for all promise levels
+
+Making `drives = [...]` mandatory (not just for `resilient`) would be more explicit but
+adds friction for simple cases. A user with one drive who sets `protection_level =
+"protected"` shouldn't have to also list that drive. Default: send to all drives.
+`drives` mapping becomes important for `resilient` (counting) and for topology
+validation, but it's always optional.
+
+### E. Dynamic thresholds based on promise level
+
+Make the awareness model use tighter multipliers for `resilient` than `protected`. This
+couples the promise level to the evaluation logic, creating two paths through the
+awareness model. The current design keeps evaluation uniform (same multipliers for all)
+and varies the *inputs* (intervals derived from promise level). Simpler, more testable.
+
+### F. Config conflict as error (not warning)
+
+If a user sets `protection_level = "protected"` and `send_enabled = false`, that's
+contradictory. Should it be an error (refuse to load) or a warning (load with override)?
+Errors are safer but hostile — the user might be mid-migration. Warnings respect user
+intent while surfacing the tension. ADR-107 (fail open) supports warnings.
+
+## Open Questions
+
+1. **Should `priority` be derived from `protection_level`?** Currently, priority is a
+   separate field (1-3) controlling execution order. It would be natural for `resilient`
+   to imply priority 1 and `guarded` to imply priority 3. But this couples two concepts
+   that might want independent control. Recommendation: derive default priority from
+   promise level, allow override.
+
+2. **Per-drive send intervals.** Should `protected` allow different send intervals per
+   drive? ("Send to WD-18TB daily, to WD-18TB1 weekly.") This is drive-level policy,
+   not subvolume-level. Defer — the current model sends to all mapped drives at the
+   same interval. Per-drive intervals can come later if the use case materializes.
+
+3. **How does `urd setup` (Priority 6c) use promises?** The conversational setup wizard
+   would guide users to choose a promise level rather than configuring intervals. This
+   is the ideal entry point for promises. But the wizard isn't built yet. Promises must
+   work well in TOML config first.
+
+4. **Display name for promise levels.** Should `urd status` show "resilient" or
+   "RESILIENT" or "Resilient"? Recommendation: lowercase in config, UPPERCASE in status
+   output (matching PROTECTED/AT RISK/UNPROTECTED convention). But this might look
+   noisy with two uppercase fields per row.
+
+## Review Findings Addressed
+
+This design was reviewed by arch-adversary on 2026-03-26. All findings addressed:
+
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| S1. Protection level change triggers retroactive deletion | Significant | Added transition safety: `--confirm-retention-change` flag required on first run after retention tightening. Backup proceeds but skips retention for affected subvolumes until confirmed. |
+| S2. Override combinations void promise with no persistent signal | Significant | Distinguished weakening (warning) from voiding (degradation marker in status). Voiding overrides show `protected (degraded — reason)` in status output. |
+| S3. run_frequency as manual config drifts from reality | Significant | Added preflight check comparing declared frequency against heartbeat history. Warns when actual cadence diverges (≥3 timestamps required). |
+| M1. custom derivation path underspecified | Moderate | `Custom` / absent `protection_level` falls through to existing `sv.resolved(defaults)` path unchanged. Property test verifies byte-identical output. |
+| M2. Drive mapping requires planner change | Moderate | Acknowledged: `ResolvedSubvolume` gains `drives: Option<Vec<String>>`, planner filters drive iteration. Integration table updated. |
+| M3. Outcome targets derived from multipliers, not policy | Moderate | Documented targets as primary policy. Added consistency check between promise targets and awareness multipliers in preflight. |
+| M4. Identical retention for protected/resilient | Moderate | Documented: resilient = protected + multi-drive redundancy. Retention divergence deferred until user feedback confirms need. |
+| N1. short_name absent from examples | Minor | Noted. Config examples are illustrative; short_name remains required. |
+| N2. Display convention unresolved | Minor | Decision: lowercase in config and status output. UPPERCASE reserved for STATUS column (PROTECTED/AT RISK/UNPROTECTED). |
+
+[Review report](../99-reports/2026-03-26-protection-promises-design-review.md)

--- a/docs/95-ideas/2026-03-26-design-sentinel.md
+++ b/docs/95-ideas/2026-03-26-design-sentinel.md
@@ -1,0 +1,791 @@
+# Design: The Sentinel (Priority 5)
+
+> **TL;DR:** The Sentinel is three independent systems built and shipped separately:
+> (5a) notification dispatcher — reacts to promise state changes after backup runs,
+> (5b) event reactor — long-running daemon watching drive events and managing timers,
+> (5c) active mode — auto-triggers backups to meet promises. Each has its own systemd
+> unit, its own test strategy, and clear dependency ordering. A backup lock file prevents
+> concurrent runs across all entry points.
+
+**Date:** 2026-03-26
+**Status:** reviewed (all findings addressed)
+**Depends on:** Protection Promise ADR (ADR-110), voice migration (Session 2 complete)
+
+## Problem
+
+Urd currently runs as a one-shot `urd backup` triggered by a systemd timer at 04:00
+daily. Between runs, the system is blind — drives can be plugged/unplugged, promise
+states can degrade, and the user gets no feedback until the next morning. The heartbeat
+file provides a point-in-time cache, but nothing watches it.
+
+The vision describes the Sentinel as "an event-driven state machine that holds the
+awareness model, reacts to events, updates promise states, and drives notifications."
+The [architecture review](../99-reports/2026-03-23-vision-architecture-review.md) §2
+identified that this conflates three distinct systems with different failure modes,
+testing requirements, and deployment constraints.
+
+### What the Sentinel is NOT
+
+- **Not the awareness model.** The awareness model (`awareness.rs`) is a pure function
+  already built and available to all commands. The Sentinel *uses* it, doesn't *own* it.
+- **Not the heartbeat.** The heartbeat (`heartbeat.rs`) is written by `urd backup` and
+  readable by anyone. The Sentinel reads it, doesn't generate it exclusively.
+- **Not required for basic operation.** `urd backup` + systemd timer must continue to
+  work without the Sentinel. The Sentinel adds responsiveness, not correctness.
+
+## Proposed Design
+
+### Component 5a: Notification Dispatcher
+
+**What it does:** After each backup run, evaluates promise state changes and dispatches
+notifications through configured channels. Runs as a post-backup hook, not a daemon.
+
+**Why first:** Highest value-to-complexity ratio. Users get feedback without running a
+daemon. The notification infrastructure built here is reused by 5b and 5c.
+
+#### Architecture
+
+```
+urd backup
+  → executor runs
+  → awareness::assess() computes promise states
+  → heartbeat written (includes promise states)
+  → notification_dispatcher::evaluate_and_notify(previous_heartbeat, current_heartbeat, config)
+```
+
+The dispatcher is a **pure function** (ADR-108) that computes which notifications to
+send, plus an I/O layer that sends them.
+
+```rust
+// src/notify.rs
+
+/// What happened that might warrant a notification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NotificationEvent {
+    /// A subvolume's promise state worsened (e.g., PROTECTED → AT RISK)
+    PromiseDegraded {
+        subvolume: String,
+        from: PromiseStatus,
+        to: PromiseStatus,
+    },
+    /// A subvolume's promise state improved
+    PromiseRecovered {
+        subvolume: String,
+        from: PromiseStatus,
+        to: PromiseStatus,
+    },
+    /// Backup run had failures
+    BackupFailures {
+        failed_count: usize,
+        total_count: usize,
+    },
+    /// All promises are now UNPROTECTED (critical)
+    AllUnprotected,
+    /// First successful external send after a long gap
+    ExternalSendRestored {
+        drive: String,
+        gap_hours: u64,
+    },
+    /// Heartbeat is stale — no backup completed within expected window (review S3).
+    /// Fires regardless of lock state. Catches hung backups, crashed timers,
+    /// and misconfigured schedulers.
+    BackupOverdue {
+        last_heartbeat_age_hours: u64,
+        stale_after_hours: u64,
+    },
+}
+
+/// Urgency determines which channels fire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Urgency {
+    Info,       // Recovery, first send
+    Warning,    // Single subvolume degraded
+    Critical,   // All unprotected, all failures
+}
+
+/// A notification ready to be dispatched.
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub event: NotificationEvent,
+    pub urgency: Urgency,
+    pub title: String,    // One-line summary
+    pub body: String,     // Detail paragraph
+}
+
+/// Pure function: compute notifications from state transition.
+/// No I/O — takes before/after state, returns what to notify about.
+pub fn compute_notifications(
+    previous: Option<&Heartbeat>,
+    current: &Heartbeat,
+) -> Vec<Notification>
+```
+
+#### Notification channels
+
+```rust
+/// How to deliver a notification.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type")]
+pub enum NotificationChannel {
+    /// Desktop notification via notify-send (or dbus directly)
+    Desktop,
+    /// Webhook POST (Slack, Discord, Ntfy, generic)
+    Webhook { url: String, template: Option<String> },
+    /// Command execution (arbitrary script)
+    Command { path: PathBuf, args: Vec<String> },
+    /// Write to a log file (always enabled, no config needed)
+    Log,
+}
+```
+
+Config extension (in `urd.toml`):
+
+```toml
+[notifications]
+enabled = true
+# Channels receive notifications at or above their urgency threshold
+min_urgency = "warning"  # "info", "warning", "critical"
+
+[[notifications.channels]]
+type = "desktop"
+
+[[notifications.channels]]
+type = "webhook"
+url = "https://ntfy.sh/my-backups"
+```
+
+#### Integration
+
+The dispatcher runs at the end of `commands/backup.rs`, after the heartbeat is written:
+
+```rust
+// In backup.rs, after heartbeat::write():
+if config.notifications_enabled() {
+    let previous = heartbeat::read(&config.general.heartbeat_file);
+    // current heartbeat already computed
+    let notifications = notify::compute_notifications(previous.as_ref(), &current_hb);
+    notify::dispatch(&notifications, &config.notifications);
+}
+```
+
+**Critical subtlety:** The previous heartbeat must be read *before* the current one is
+written. Reorder: read old → compute assessments → build new heartbeat → compute
+notifications → write new heartbeat → dispatch. This keeps `compute_notifications` pure
+while ensuring the before/after comparison is valid.
+
+**Crash window (review S2):** If the process crashes between heartbeat write and
+notification dispatch, the notification is lost. If it crashes between notification
+computation and heartbeat write, the next run sends duplicate notifications. This is
+an accepted trade-off: duplicate notifications on crash are better than lost
+notifications. To detect the lost-notification case, add a `notifications_dispatched`
+boolean field to the heartbeat. On recovery (next run), if `notifications_dispatched =
+false`, re-compute and re-send. The sequence becomes: read old → compute →
+write heartbeat with `notifications_dispatched: false` → dispatch → update heartbeat
+to `notifications_dispatched: true`.
+
+#### 5a/5b notification deduplication (review m2)
+
+When 5b ships, two notification paths exist: backup-embedded (5a) and Sentinel-driven
+(5b). To prevent duplicate notifications, the heartbeat includes a
+`notifications_dispatched: bool` field (added in 5a). The Sentinel (5b) checks this
+field: if `true`, it skips notification dispatch for that heartbeat. If `false`
+(backup crashed before dispatching), the Sentinel re-sends.
+
+This means:
+- **5a standalone:** backup dispatches notifications, sets `notifications_dispatched = true`.
+- **5b running:** backup writes heartbeat with `notifications_dispatched = false`.
+  Sentinel detects heartbeat change via inotify, reads heartbeat, dispatches, updates
+  flag. The backup-embedded dispatch path is disabled when `sentinel_running` is detected
+  (via sentinel state file existence or a config flag).
+
+#### Effort: ~1.5 sessions
+
+- `notify.rs`: event types, compute_notifications, dispatch (1 session)
+- Config extension for channels (part of session)
+- Desktop notification via `notify-send` subprocess (~1h)
+- Webhook POST via `ureq` or `reqwest` (~1h) — evaluate if adding an HTTP dep is worth it
+  vs. shelling out to `curl`
+- Tests: ~15 (notification computation is pure; dispatch is integration-tested)
+
+#### Test strategy
+
+```
+// Pure computation tests
+test_degraded_generates_notification
+test_recovered_generates_notification
+test_no_change_no_notification
+test_all_unprotected_is_critical
+test_partial_failures_generate_warning
+test_first_heartbeat_no_previous → no degradation notification (nothing to compare)
+test_urgency_ordering
+
+// Dispatch tests (integration, #[ignore])
+test_desktop_notification_fires
+test_webhook_post_format
+test_command_channel_executes
+```
+
+---
+
+### Component 5b: Event Reactor
+
+**What it does:** A long-running daemon that watches for events (drive plug/unplug,
+timer tick, manual trigger) and reacts by running assessments and dispatching
+notifications. Does NOT trigger backups (that's 5c).
+
+**Why second:** Enables real-time drive detection and promise state monitoring between
+backup runs. Depends on 5a for notification delivery.
+
+#### Architecture: Event-driven state machine
+
+```rust
+// src/sentinel.rs
+
+/// Events the Sentinel can observe.
+#[derive(Debug, Clone)]
+pub enum SentinelEvent {
+    /// A drive was mounted (udev or polling)
+    DriveMounted { label: String, mount_path: PathBuf },
+    /// A drive was unmounted
+    DriveUnmounted { label: String },
+    /// Scheduled assessment tick (periodic re-evaluation)
+    AssessmentTick,
+    /// A backup run completed (heartbeat file changed)
+    BackupCompleted,
+    /// Shutdown signal (SIGTERM, SIGINT)
+    Shutdown,
+}
+
+/// Actions the Sentinel can take in response to events.
+#[derive(Debug, Clone)]
+pub enum SentinelAction {
+    /// Re-assess promise states and notify if changed
+    Assess,
+    /// Log a drive state change
+    LogDriveChange { label: String, mounted: bool },
+    /// Record drive connection in history
+    RecordDriveConnection { label: String, timestamp: NaiveDateTime },
+    /// No action needed
+    Noop,
+    /// Shut down cleanly
+    Exit,
+}
+
+/// State machine: pure function mapping (current_state, event) → (new_state, actions).
+pub fn sentinel_transition(
+    state: &SentinelState,
+    event: &SentinelEvent,
+) -> (SentinelState, Vec<SentinelAction>)
+```
+
+The state machine is a **pure function** (ADR-108). The I/O layer (`SentinelRunner`)
+translates real-world events into `SentinelEvent`, calls `sentinel_transition`, and
+executes the resulting `SentinelAction`s.
+
+```rust
+/// Sentinel's mutable state.
+/// Deliberately minimal — promise states are recomputed from the awareness model
+/// on every Assess action, not cached (review finding: eliminates divergence risk
+/// between cached state and filesystem truth).
+#[derive(Debug, Clone)]
+pub struct SentinelState {
+    /// Known mounted drives (for event deduplication)
+    pub mounted_drives: HashSet<String>,
+    /// Last assessment time (for tick scheduling)
+    pub last_assessment: NaiveDateTime,
+    /// Last dispatched promise states (for change detection in notifications).
+    /// Stored as status enum per subvolume name, not full SubvolAssessment —
+    /// the minimum needed for notification comparison.
+    pub last_promise_states: HashMap<String, PromiseStatus>,
+    /// Circuit breaker state (for trigger decisions in active mode)
+    pub circuit_breaker: CircuitBreaker,
+}
+```
+
+**Design decision (review):** `last_assessments: Vec<SubvolAssessment>` was removed from
+state. The awareness model is a pure function designed to be called on demand. Caching its
+output creates a divergence risk — any filesystem change between Sentinel ticks makes the
+cached state wrong. Instead, the Sentinel stores only `last_promise_states` (a lightweight
+`HashMap<String, PromiseStatus>`) for notification change detection. On every `Assess`
+action, the Sentinel calls `awareness::assess()` fresh, compares the result against
+`last_promise_states`, and dispatches notifications for changes.
+
+#### Event sources
+
+1. **Drive events:** `inotify` on `/proc/mounts` as primary, with polling fallback
+   (review M1). `inotify` provides instant detection for most mount events but is not
+   universally reliable: some container runtimes present a static `/proc/mounts`, and
+   FUSE/automount entries may not trigger events. Polling sweep every 60 seconds catches
+   missed events. On each `inotify` event, debounce 500ms before checking — LUKS unlock +
+   mount is a two-step process; UUID verification may fail transiently if checked too early.
+
+2. **Assessment tick:** Adaptive interval (review M4). Three tiers based on current state:
+   - All PROTECTED: 15 minutes (low urgency, saves battery on laptops)
+   - Any AT RISK: 5 minutes
+   - Any UNPROTECTED: 2 minutes
+   No configuration needed — urgency drives polling frequency automatically.
+
+3. **Heartbeat file watch:** `inotify` on the heartbeat file. When `urd backup` writes
+   a new heartbeat, the Sentinel detects the change and updates its cached state.
+
+4. **Signals:** SIGTERM → clean shutdown. SIGHUP → reload config.
+
+#### The I/O runner
+
+```rust
+/// Runs the Sentinel event loop. I/O-heavy — not pure.
+pub struct SentinelRunner {
+    config: Config,
+    state: SentinelState,
+    /// Notification dispatcher from 5a
+    notifier: NotificationDispatcher,
+}
+
+impl SentinelRunner {
+    pub fn run(&mut self) -> Result<()> {
+        // 1. Set up event sources (inotify, timer)
+        // 2. Loop:
+        //    a. Wait for next event (blocking, with timeout for assessment tick)
+        //    b. Translate to SentinelEvent
+        //    c. Call sentinel_transition(state, event)
+        //    d. Execute actions
+        //    e. If action is Assess: run awareness model, compare, notify
+        //    f. If action is Exit: break
+    }
+}
+```
+
+#### Drive connection tracking
+
+New SQLite table for drive connection history:
+
+```sql
+CREATE TABLE IF NOT EXISTS drive_connections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    drive_label TEXT NOT NULL,
+    event_type TEXT NOT NULL,  -- 'mounted' or 'unmounted'
+    timestamp TEXT NOT NULL,   -- ISO 8601
+    detected_by TEXT NOT NULL  -- 'sentinel', 'backup', 'manual'
+);
+```
+
+This table enables:
+- Promise achievability validation: "WD-18TB averages 3 days connected per week"
+- Awareness model enrichment: external staleness can consider connection patterns
+- `urd status` reporting: "WD-18TB last connected 5 days ago"
+
+The table is history (ADR-102: SQLite is history, not truth). Drive mount state is
+checked live via `drives::drive_availability()`.
+
+#### systemd integration
+
+```ini
+# urd-sentinel.service
+[Unit]
+Description=Urd Sentinel — backup awareness daemon
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=%h/.cargo/bin/urd sentinel
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+```
+
+**Relationship with urd-backup.timer:** They coexist. The timer continues to trigger
+`urd backup` at 04:00. The Sentinel watches for the result (via heartbeat inotify) and
+dispatches notifications. In passive mode (5b), the Sentinel never triggers backups —
+it only observes and notifies.
+
+#### Observability (review M3)
+
+The Sentinel needs its own health indicators. Without them, "is the Sentinel running?"
+is unanswerable. Implement:
+
+- **`urd sentinel status` subcommand:** Shows last assessment time, circuit breaker
+  state (closed/open/half-open + failure count), event count since startup, current
+  mounted drives, and adaptive tick interval.
+- **Sentinel state file** (`~/.local/share/urd/sentinel-state.json`): Written on every
+  assessment tick. Contains the same data as `sentinel status`. Serves as both
+  persistence (circuit breaker survives restart) and external observability (shell
+  prompts, monitoring scripts can read it).
+- **Command channel validation (review M2):** At config load time, verify the command
+  path exists and is owned by the current user. Warn (don't block) if the config file
+  itself has overly permissive permissions (`g+w` or `o+w`). Document that the
+  `Command` channel runs with the Sentinel's privileges.
+
+#### Effort: ~2–3 sessions
+
+- Session 1: State machine types, `sentinel_transition` pure function, tests (~20)
+- Session 2: I/O runner, inotify integration, drive connection table, systemd unit
+- Session 3: Integration testing, signal handling, observability, config reload
+
+#### Test strategy
+
+```
+// Pure state machine tests (~20)
+test_drive_mounted_triggers_assess
+test_drive_unmounted_triggers_assess
+test_assessment_tick_triggers_assess
+test_backup_completed_updates_state
+test_shutdown_produces_exit
+test_repeated_mount_same_drive_is_noop
+test_state_tracks_mounted_drives
+test_assessment_detects_promise_degradation
+test_assessment_detects_promise_recovery
+
+// Circuit breaker state transitions (test-team: critical, non-negotiable)
+test_circuit_breaker_closes_after_success
+test_circuit_breaker_opens_after_max_failures
+test_circuit_breaker_half_open_after_backoff
+test_circuit_breaker_half_open_to_closed_on_success
+test_circuit_breaker_half_open_to_open_on_failure
+test_circuit_breaker_partial_success_on_scheduled_run → counts as failure
+test_circuit_breaker_partial_success_on_drive_mounted → counts as resolved
+test_circuit_breaker_manual_backup_ignores_open_circuit
+test_circuit_breaker_exponential_backoff_caps_at_24h
+
+// Lock file (test-team: high priority)
+test_lock_acquired_successfully
+test_lock_contention_returns_error
+test_lock_released_on_drop
+test_lock_file_contains_pid_and_trigger
+
+// BackupOverdue (test-team: high priority)
+test_backup_overdue_fires_when_stale
+test_backup_overdue_does_not_fire_when_fresh
+test_backup_overdue_urgency_is_critical
+
+// Adaptive tick (test-team: moderate)
+test_adaptive_tick_all_protected → 15 minutes
+test_adaptive_tick_any_at_risk → 5 minutes
+test_adaptive_tick_any_unprotected → 2 minutes
+
+// Notification deduplication (test-team: moderate)
+test_notifications_dispatched_flag_prevents_resend
+test_sentinel_skips_dispatch_when_flag_true
+
+// Integration tests (#[ignore])
+test_inotify_detects_heartbeat_change
+test_sentinel_runs_and_shuts_down_on_sigterm
+test_sentinel_survives_missing_heartbeat
+test_sentinel_triggered_backup_produces_heartbeat
+test_lock_survives_process_crash
+```
+
+---
+
+### Component 5c: Active Mode
+
+**What it does:** Extends the event reactor to trigger backup runs when promises are
+at risk and a drive is available. The Sentinel becomes proactive, not just observant.
+
+**Why last:** Highest complexity, highest risk. Introduces concurrent backup execution,
+lock contention, and cascade potential. Must not ship until passive mode (5b) is proven.
+
+#### Trigger logic
+
+```rust
+/// Decides whether to trigger a backup. Pure function.
+pub fn should_trigger_backup(
+    state: &SentinelState,
+    event: &SentinelEvent,
+    config: &Config,
+) -> Option<BackupTrigger>
+
+#[derive(Debug, Clone)]
+pub struct BackupTrigger {
+    pub reason: TriggerReason,
+    pub subvolumes: Option<Vec<String>>,  // None = all, Some = specific
+}
+
+#[derive(Debug, Clone)]
+pub enum TriggerReason {
+    /// A drive was mounted and subvolumes need external sends
+    DriveMounted { label: String },
+    /// Promise states degraded below threshold
+    PromiseDegraded { subvolumes: Vec<String> },
+    /// Scheduled maintenance run (if Sentinel replaces timer)
+    ScheduledRun,
+}
+```
+
+Trigger conditions:
+1. **Drive mounted + subvolumes need sends:** A configured drive appears and at least
+   one subvolume has AT RISK or UNPROTECTED external status for that drive.
+2. **Promise degradation below threshold:** A subvolume transitions to UNPROTECTED and
+   a backup might help (local snapshot overdue).
+3. **NOT triggered by:** assessment ticks alone (avoids cascade), config changes
+   (require manual run), drive unmount (nothing to do).
+
+#### Circuit breaker
+
+The circuit breaker prevents cascade-triggering: if backups keep failing, the Sentinel
+must not keep hammering.
+
+```rust
+#[derive(Debug, Clone)]
+pub struct CircuitBreaker {
+    /// Minimum interval between auto-triggered backups
+    pub min_interval: Duration,
+    /// Last auto-triggered backup time
+    pub last_trigger: Option<NaiveDateTime>,
+    /// Consecutive failure count
+    pub failure_count: u32,
+    /// Maximum consecutive failures before circuit opens
+    pub max_failures: u32,
+    /// Circuit state
+    pub state: CircuitState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircuitState {
+    /// Normal operation — triggers allowed
+    Closed,
+    /// Too many failures — triggers blocked
+    Open,
+    /// Testing recovery — one trigger allowed
+    HalfOpen,
+}
+```
+
+**Rules:**
+- `min_interval`: 1 hour (configurable). No auto-trigger within 1h of the last.
+- `max_failures`: 3. After 3 consecutive auto-triggered backup failures, circuit opens.
+- Open → HalfOpen: after `min_interval × 2^failure_count` (exponential backoff, capped
+  at 24h).
+- HalfOpen → Closed: one successful auto-triggered run.
+- HalfOpen → Open: one more failure.
+- Manual `urd backup` always runs regardless of circuit state (user intent overrides).
+- Circuit state persisted in a separate `~/.local/share/urd/sentinel-state.json` file
+  (survives daemon restart). Not in heartbeat — manual `urd backup` writes heartbeats
+  and must not inadvertently reset the circuit breaker (review OQ1).
+
+**Partial-failure semantics (review S1):** A backup run can be "success", "partial",
+or "failure". The circuit breaker evaluates against *the specific trigger condition*:
+
+- If trigger was `DriveMounted { label }` and external sends to that drive all failed:
+  **failure** — increment counter.
+- If trigger was `DriveMounted { label }` and some sends to that drive succeeded:
+  **resolved** — reset counter, do not re-trigger for this drive within `min_interval`.
+- If trigger was `PromiseDegraded` and the promise state improved after the run:
+  **resolved** — reset counter.
+- If trigger was `PromiseDegraded` and promise state did not improve:
+  **failure** — increment counter.
+- If trigger was `ScheduledRun`: use the executor's `overall` result. "partial" counts
+  as **failure** for circuit breaker purposes (conservative — prevents a consistently
+  partially-failing config from running every `min_interval` indefinitely, which risks
+  snapshot congestion per the catastrophic failure history).
+
+#### Backup lock file
+
+**The lock prevents concurrent backup runs** from any entry point: manual `urd backup`,
+systemd timer, Sentinel auto-trigger.
+
+```rust
+// src/lock.rs
+
+/// Acquire an exclusive backup lock. Returns a guard that releases on drop.
+pub fn acquire_backup_lock(lock_path: &Path) -> Result<LockGuard>
+
+pub struct LockGuard {
+    _file: std::fs::File,  // held open with flock
+    path: PathBuf,
+}
+
+impl Drop for LockGuard {
+    fn drop(&mut self) {
+        // flock released automatically when file is closed
+    }
+}
+```
+
+**Implementation:** `flock(2)` advisory lock on `~/.local/share/urd/urd.lock`. This is:
+- **Process-safe:** Two `urd backup` processes cannot both hold the lock.
+- **Crash-safe:** `flock` locks are released when the process dies (unlike PID files).
+- **NFS-safe:** Not applicable (local filesystem only).
+
+**Lock file content (review m1):** After acquiring the lock, write PID, start time,
+and trigger source to the lock file. This is advisory metadata (not the locking
+mechanism itself) that enables the "another backup is running" message to say *who*
+holds the lock and *since when*:
+
+```json
+{"pid": 12345, "started": "2026-03-26T04:00:03", "trigger": "timer"}
+```
+
+**Lock contention behavior:**
+- `urd backup` (manual): Tries lock. If held, prints "Another backup is running" and
+  exits with code 4.
+- Sentinel auto-trigger: Tries lock non-blocking. If held, logs "Backup already running,
+  skipping auto-trigger" and returns. No error — this is expected during timer overlap.
+- systemd timer: Same as manual — it calls `urd backup`, which tries the lock.
+
+**Gate: ADR needed?** The lock file is a new backward-compatibility contract. However,
+its scope is narrow (one file, one behavior) and the alternative (no lock, concurrent
+corruption risk) is worse. Recommendation: document in the Sentinel design, not a
+separate ADR.
+
+#### Sentinel as timer replacement (future)
+
+In active mode, the Sentinel *could* replace the systemd timer entirely:
+- `ScheduledRun` trigger at configurable intervals
+- Eliminates the timer/Sentinel coordination problem
+
+**Decision: Defer.** The systemd timer is proven reliable. The Sentinel should coexist
+with it in v1. Timer replacement is a future option once active mode is stable.
+
+#### Effort: ~2 sessions
+
+- Session 1: Lock file, trigger logic, circuit breaker (pure + integration)
+- Session 2: Active mode integration into SentinelRunner, testing with real backups
+
+---
+
+## Invariants
+
+1. **The Sentinel can be killed at any time without data loss.** Promise states are
+   computed by the awareness model (pure function). The heartbeat is written by
+   `urd backup`. The Sentinel is an observer and trigger, not a data owner. (ADR-102)
+2. **The awareness model never depends on the Sentinel.** All commands compute promise
+   states independently. The Sentinel is an optimization for responsiveness. (ADR-108)
+3. **Backups fail open; the lock fails closed.** If the Sentinel can't acquire the lock,
+   it skips. If `urd backup` can't acquire the lock, it exits with an error. Neither
+   waits indefinitely. (ADR-107)
+4. **The state machine is a pure function.** `sentinel_transition()` takes state + event,
+   returns new state + actions. No I/O. Testable without mocks. (ADR-108)
+5. **The circuit breaker protects against cascade.** Auto-triggered backups are rate-limited
+   and fail-counted. Manual backups bypass the circuit breaker (user intent is explicit).
+6. **Each component ships independently.** 5a works without 5b or 5c. 5b works without
+   5c. 5c requires 5b. This is a strict dependency chain, not a monolith.
+
+## Integration Points
+
+### Component 5a (Notification Dispatcher)
+
+| Module | Change | Scope |
+|--------|--------|-------|
+| `notify.rs` | New module: event types, compute_notifications, dispatch | New |
+| `config.rs` | `[notifications]` config section | Extension |
+| `commands/backup.rs` | Call dispatcher after heartbeat write | ~10 lines |
+| `voice.rs` | Notification text rendering | New render functions |
+
+### Component 5b (Event Reactor)
+
+| Module | Change | Scope |
+|--------|--------|-------|
+| `sentinel.rs` | New module: state machine, events, actions | New |
+| `sentinel_runner.rs` | New module: I/O event loop | New |
+| `state.rs` | `drive_connections` table | Schema addition |
+| `commands/sentinel.rs` | `urd sentinel` CLI command | New subcommand |
+
+### Component 5c (Active Mode)
+
+| Module | Change | Scope |
+|--------|--------|-------|
+| `lock.rs` | New module: flock-based backup lock | New |
+| `sentinel.rs` | Trigger logic, circuit breaker | Extension |
+| `commands/backup.rs` | Acquire lock before execution | ~5 lines |
+
+## Effort Summary
+
+| Component | Sessions | Tests | New modules |
+|-----------|----------|-------|-------------|
+| 5a: Notification dispatcher | 1.5 | ~15 | `notify.rs` |
+| 5b: Event reactor | 2–3 | ~20 | `sentinel.rs`, `sentinel_runner.rs` |
+| 5c: Active mode | 2 | ~15 | `lock.rs` |
+| **Total** | **5.5–6.5** | **~50** | **4** |
+
+This is the largest feature in Urd's roadmap. The sequencing — 5a → 5b → 5c — means
+each component can be shipped, used, and stabilized before the next begins.
+
+## Rejected Alternatives
+
+### A. Monolithic Sentinel daemon from day one
+
+Building all three components as a single daemon conflates the testable (state machine)
+with the I/O-heavy (event loop) and the risky (auto-trigger). The architecture review
+rejected this explicitly.
+
+### B. DBus integration for drive events
+
+DBus provides drive mount/unmount signals via UDisks2. However: (a) adds a heavy
+dependency (dbus crate + system bus access), (b) LUKS decryption events are separate
+from mount events, (c) polling `/proc/mounts` or `inotify` on mount changes is simpler
+and covers the same use case. DBus integration can be added later as an alternative
+event source without changing the state machine.
+
+### C. Replacing the systemd timer immediately
+
+Making the Sentinel the sole backup trigger increases risk during the transition period.
+The timer is proven; the Sentinel is new. Coexistence is safer. The lock file prevents
+duplicate runs. Timer replacement can happen later when active mode is stable.
+
+### D. HTTP-based notification without dependencies
+
+Using `curl` subprocess for webhooks (instead of adding an HTTP client dep). Trade-off:
+avoids `ureq`/`reqwest` dependency but loses error handling, timeout control, and
+testability. Recommendation: evaluate `ureq` (minimal, sync, no tokio dependency) vs.
+subprocess. If Urd wants to stay dependency-light, `curl` subprocess is acceptable for
+v1.
+
+### E. PID file instead of flock
+
+PID files are not crash-safe — if `urd backup` crashes, the PID file persists and
+requires manual cleanup or stale-PID detection. `flock(2)` is released automatically
+on process death. The only downside: `flock` doesn't tell you *who* holds the lock
+(no PID information). Mitigate by writing PID to the lock file after acquiring it
+(advisory, not the locking mechanism).
+
+## Open Questions
+
+1. **HTTP dependency.** Should Urd add `ureq` for webhook notifications, or shell out
+   to `curl`? `ureq` is ~200KB, sync, no tokio. `curl` is available on every Linux
+   system. The answer depends on how important error handling and testability are for
+   notifications.
+
+2. **Assessment interval.** 5-minute default for the Sentinel's assessment tick. Is this
+   too frequent? Battery impact on laptops? Should the interval adapt to whether any
+   promises are AT RISK (more frequent) vs. all PROTECTED (less frequent)?
+
+3. **Notification deduplication.** If the Sentinel ticks every 5 minutes and promise
+   states don't change, no notifications fire. But what about "reminder" notifications?
+   Should the Sentinel re-notify after 24h of sustained UNPROTECTED status? Configurable
+   or fixed?
+
+4. **Config reload.** SIGHUP → reload config is conventional but requires re-parsing
+   `urd.toml` and rebuilding internal state. Should the Sentinel watch the config file
+   with inotify instead? Or require restart?
+
+5. **Tray icon integration.** The tray icon is a separate process that reads the
+   heartbeat file. Should the Sentinel also expose a Unix socket for richer IPC
+   (promise states, drive status, trigger history)? Or is the heartbeat file sufficient
+   for v1?
+
+## Review Findings Addressed
+
+This design was reviewed by arch-adversary on 2026-03-26. All findings addressed:
+
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| S1. Partial-failure circuit breaker semantics undefined | Significant | Defined: circuit breaker evaluates against specific trigger condition, not global pass/fail. Partial success on ScheduledRun counts as failure (conservative, prevents snapshot congestion). |
+| S2. Crash window between notification and heartbeat write | Significant | Accepted trade-off. Added `notifications_dispatched` field to heartbeat for crash recovery. Re-sends on recovery if flag is false. |
+| S3. `backup_in_progress` has no timeout | Significant | Added `BackupOverdue` notification event based on heartbeat staleness. Fires regardless of lock state. |
+| M1. inotify on /proc/mounts not universally reliable | Moderate | Adopted inotify-with-polling-fallback (60s sweep). Added 500ms debounce for LUKS settle time. |
+| M2. Command channel is unaudited execution path | Moderate | Added config-load-time validation: command path exists, owned by current user. Warn on permissive config file permissions. |
+| M3. No observability for Sentinel daemon | Moderate | Added `urd sentinel status` subcommand and sentinel state file. Last assessment time, circuit breaker state, event count. |
+| M4. Assessment tick should be adaptive | Moderate | Three-tier adaptive interval: all PROTECTED=15m, any AT RISK=5m, any UNPROTECTED=2m. |
+| m1. flock doesn't identify lock holder | Minor | PID + start time + trigger source written to lock file as advisory metadata. Firm requirement, not suggestion. |
+| m2. 5a/5b notification deduplication | Minor | `notifications_dispatched` boolean in heartbeat. 5b skips if true. Backup-embedded dispatch disabled when Sentinel is running. |
+
+**Resolved open questions from review:**
+- **Circuit breaker reset on Sentinel restart (OQ1):** State persisted in separate
+  `sentinel-state.json` file, not heartbeat. Manual `urd backup` writes heartbeats
+  without resetting circuit breaker.
+- **5a standalone value (original OQ6):** Confirmed correct — immediate user value,
+  deduplication contract defined for 5b transition.
+
+[Review report](../99-reports/2026-03-26-sentinel-design-review.md)

--- a/docs/95-ideas/2026-03-26-design-structured-errors.md
+++ b/docs/95-ideas/2026-03-26-design-structured-errors.md
@@ -1,0 +1,456 @@
+# Design: Structured Error Messages (Priority 2e)
+
+> **TL;DR:** A translation layer in `error.rs` that pattern-matches common btrfs stderr
+> patterns into structured "what / why / what to do" error messages, replacing raw stderr
+> passthrough. Pure function — no I/O, no behavior change, presentation only.
+
+**Date:** 2026-03-26
+**Status:** reviewed (all findings addressed)
+**Depends on:** None (existing `UrdError::Btrfs { msg, bytes_transferred }` is sufficient)
+
+## Problem
+
+Btrfs errors currently flow to users as raw stderr wrapped in a fixed format:
+
+```
+ERROR send_full: btrfs command failed: send failed (exit 1): ERROR: ...
+```
+
+This tells a developer what happened but fails every Norman UX principle for error design.
+Users must decode exit codes, recognize btrfs-specific error strings, and independently
+figure out remediation steps. The [UX brainstorm](2026-03-23-brainstorm-ux-norman-principles.md)
+§6 established the hierarchy: **human summary → cause → remediation → technical details**.
+
+Real failure patterns observed during cutover and testing:
+
+| Failure | Raw stderr | Frequency |
+|---------|-----------|-----------|
+| Destination full | `ERROR: receive: No space left on device` | 3 incidents (NVMe exhaustion) |
+| Source full (snapshot creation) | `ERROR: cannot snapshot: No space left on device` | Same root cause |
+| Missing parent (chain break) | `ERROR: send: parent not found` or similar | htpc-root chain break |
+| Destination dir missing | `btrfs receive` fails, no dir | Pre-cutover bug (fixed, but still possible on new drives) |
+| Permission denied | `ERROR: cannot snapshot: Permission denied` | Setup misconfiguration |
+| Read-only filesystem | `ERROR: ...read-only file system` | Drive hardware failure |
+| Subvolume not found (delete) | `ERROR: cannot delete: No such file or directory` | Stale retention target |
+
+## Proposed Design
+
+### Module: Translation layer in `error.rs`
+
+A single pure function that takes a raw btrfs error context and returns a structured
+error with layered detail:
+
+```rust
+/// Structured representation of a btrfs error for user presentation.
+#[derive(Debug, Clone)]
+pub struct BtrfsErrorDetail {
+    /// Human-readable one-line summary (e.g., "Destination drive is full")
+    pub summary: String,
+    /// What caused it (e.g., "WD-18TB has insufficient space for this send")
+    pub cause: String,
+    /// Actionable remediation steps
+    pub remediation: Vec<String>,
+    /// Raw technical details (exit codes, stderr, bytes transferred)
+    pub technical: BtrfsTechnical,
+}
+
+#[derive(Debug, Clone)]
+pub struct BtrfsTechnical {
+    pub operation: String,         // "snapshot", "send", "receive", "delete"
+    pub exit_code: Option<i32>,
+    pub stderr: String,            // raw, unmodified
+    pub bytes_transferred: Option<u64>,
+}
+
+/// Context passed to the translator. Built at error construction sites in btrfs.rs.
+#[derive(Debug)]
+pub struct BtrfsErrorContext {
+    pub operation: BtrfsOperation,
+    pub exit_code: Option<i32>,
+    pub stderr: String,
+    pub bytes_transferred: Option<u64>,
+    /// Destination drive label, if applicable
+    pub drive_label: Option<String>,
+    /// Subvolume name, if applicable
+    pub subvolume: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum BtrfsOperation {
+    Snapshot,
+    Send,
+    Receive,
+    Delete,
+}
+
+/// Translate raw btrfs error into structured detail.
+/// Pure function — pattern-matches stderr, always succeeds.
+/// Unknown patterns produce a generic message with full technical details preserved.
+pub fn translate_btrfs_error(ctx: &BtrfsErrorContext) -> BtrfsErrorDetail
+```
+
+### Pattern matching rules
+
+Each rule matches a substring or regex in stderr and produces a specific
+(summary, cause, remediation) triple. Rules are tried in order; first match wins.
+Unknown stderr falls through to a generic handler.
+
+```rust
+struct ErrorPattern {
+    /// Substring match on stderr (case-insensitive)
+    pattern: &'static str,
+    /// Which operations this pattern applies to (None = any)
+    operations: Option<&'static [BtrfsOperation]>,
+    /// Builder for the structured detail
+    build: fn(&BtrfsErrorContext) -> (String, String, Vec<String>),
+}
+```
+
+**Initial pattern set** (ordered by frequency/severity):
+
+| # | Pattern (stderr substring) | Operations | Summary |
+|---|---------------------------|-----------|---------|
+| 1 | `No space left on device` | Receive | "Destination drive is full" |
+| 2 | `No space left on device` | Snapshot | "Local filesystem is full" |
+| 3 | `Permission denied` | Any | "Insufficient permissions" |
+| 4 | `Read-only file system` | Any | "Drive is read-only (possible hardware failure)" |
+| 5 | `No such file or directory` | Delete | "Snapshot not found at expected path" |
+| 6 | `No such file or directory` | Receive | "Destination directory missing" |
+| 7 | `parent not found` | Send | "Incremental parent missing (chain broken)" |
+| 8 | (fallthrough) | Any | "btrfs {operation} failed" |
+
+**Remediation examples:**
+
+Pattern 1 (destination full):
+```
+What to do:
+  • Check drive space: df -h /run/media/.../WD-18TB
+  • Run `urd backup` again — retention may free space first
+  • If persistent, consider increasing `max_usage_percent` or adding a drive
+```
+
+Pattern 3 (permission denied):
+```
+What to do:
+  • Verify sudoers configuration: `urd init` checks this
+  • Expected entry: <user> ALL=(root) NOPASSWD: /usr/bin/btrfs
+```
+
+Pattern 7 (parent not found):
+```
+What to do:
+  • This is recoverable — next send will be a full send
+  • Check `urd verify` for chain health
+  • If recurring, check retention/send interval alignment: `urd verify`
+```
+
+### Integration: Typed context on `UrdError::Btrfs`
+
+**Decision (post-review):** The arch-adversary review (S1) rejected Option A (parsing
+structured context back from flattened error strings at render time). The round-trip —
+`btrfs.rs` has typed data, formats it into a string, then `voice.rs` regex-parses the
+string to recover the types — is a lossy reconstruction with no compiler enforcement.
+If the format string changes, the parser silently breaks.
+
+**Adopted approach: Carry typed context on the error variant.**
+
+Replace `UrdError::Btrfs { msg, bytes_transferred }` with:
+
+```rust
+#[derive(Debug, Error)]
+pub enum UrdError {
+    // ... other variants unchanged ...
+
+    #[error("btrfs command failed: {}", context.display_summary())]
+    Btrfs {
+        context: BtrfsErrorContext,
+    },
+}
+```
+
+`BtrfsErrorContext` carries the structured data that `btrfs.rs` already has in local
+variables at every construction site:
+
+```rust
+/// Structured context from a failed btrfs subprocess call.
+/// Built at error construction sites in btrfs.rs — no parsing needed.
+#[derive(Debug, Clone)]
+pub struct BtrfsErrorContext {
+    pub operation: BtrfsOperation,
+    pub exit_code: Option<i32>,
+    /// Raw stderr from the subprocess, unmodified
+    pub stderr: String,
+    pub bytes_transferred: Option<u64>,
+}
+```
+
+For send/receive composite errors (review finding S2), carry both sides:
+
+```rust
+/// Send|receive pipeline can fail on either or both sides.
+#[derive(Debug, Clone)]
+pub struct SendReceiveContext {
+    pub send_error: Option<SubprocessError>,
+    pub recv_error: Option<SubprocessError>,
+    pub bytes_transferred: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SubprocessError {
+    pub exit_code: Option<i32>,
+    pub stderr: String,
+}
+```
+
+The `BtrfsOperation::SendReceive` variant carries `SendReceiveContext` so the
+translation layer can inspect both sides independently. This prevents the first-match
+problem where a send stderr masks the receive stderr.
+
+**Why this works:**
+1. `btrfs.rs` already has exit_code, stderr, and operation in local variables at all
+   8 construction sites — they just populate a struct instead of `format!()`.
+2. `Display` impl renders a flat one-line summary for log output (same as today).
+3. The voice layer receives typed `BtrfsErrorContext` and calls
+   `translate_btrfs_error()` — no parsing, no regex, compiler-enforced contract.
+4. `btrfs.rs` still doesn't know about remediation, drives, or subvolume names.
+   The translation function adds that context from `OperationOutcome` fields.
+
+**`OperationOutcome` enrichment:**
+
+```rust
+pub struct OperationOutcome {
+    pub operation: BtrfsOperation, // typed enum, not String (review N1)
+    pub drive_label: Option<String>,
+    pub result: OpResult,
+    pub duration: Duration,
+    pub error_context: Option<BtrfsErrorContext>, // replaces error: Option<String>
+    pub bytes_transferred: Option<u64>,
+    pub subvolume: Option<String>,
+}
+```
+
+The voice layer calls `translate_btrfs_error()` using the typed context directly:
+
+```rust
+fn render_operation_error(outcome: &OperationOutcome) {
+    if let Some(ref ctx) = outcome.error_context {
+        let detail = translate_btrfs_error(ctx, outcome.drive_label.as_deref(),
+                                            outcome.subvolume.as_deref());
+        // Render layered output
+    }
+}
+```
+
+### Locale hardening
+
+**Decision (review M2):** Set `LC_ALL=C` on all btrfs subprocess calls in `btrfs.rs`.
+This forces English stderr regardless of system locale, eliminating the pattern-matching
+locale dependency. One-line change per `Command::new()` call (`.env("LC_ALL", "C")`).
+This should be done immediately, independent of the structured errors work.
+
+### Voice rendering
+
+Interactive mode renders the full hierarchy:
+
+```
+  ERROR  Send failed: htpc-home → WD-18TB
+         Destination drive is full
+         Why: WD-18TB has insufficient space (transferred 1.1 TB before failure)
+         What to do:
+           • Check drive space: df -h /run/media/.../WD-18TB
+           • Run `urd backup` again — retention may free space first
+```
+
+Daemon mode includes the structured detail in JSON:
+
+```json
+{
+  "error": {
+    "summary": "Destination drive is full",
+    "cause": "WD-18TB has insufficient space",
+    "remediation": ["Check drive space: df -h ...", "Run urd backup again..."],
+    "technical": { "operation": "receive", "exit_code": 1, "stderr": "...", "bytes_transferred": 1100000000000 }
+  }
+}
+```
+
+### Exit codes
+
+Adopt the graduated exit code scheme from the UX brainstorm, as a separate concern
+that can be implemented alongside or independently:
+
+| Code | Meaning | Current |
+|------|---------|---------|
+| 0 | All operations succeeded | Same |
+| 1 | Partial — some operations failed | Same |
+| 2 | Total failure — all operations failed | New (currently 1) |
+| 3 | Config error — couldn't start | New (currently 1) |
+
+This is a **backward compatibility concern** (ADR-105) since scripts may check for
+`exit 1`. Gate: document the change and provide a transition period, OR keep 0/1 and
+add the granular codes only in daemon mode JSON.
+
+**Recommendation:** Keep exit codes 0/1 for now. The structured errors are the
+high-value change; exit code granularity can come later without architectural impact.
+
+## Invariants
+
+1. **Translation is pure.** `translate_btrfs_error()` is a function of its input only.
+   No I/O, no config access, no filesystem queries. (ADR-108)
+2. **Unknown patterns always produce output.** The fallthrough case renders the raw
+   error with full technical details. Translation never swallows information.
+3. **Raw stderr is always preserved.** `BtrfsTechnical.stderr` contains the unmodified
+   btrfs output. The structured message is an addition, not a replacement.
+4. **No behavior change.** Translation is presentation only. Error propagation, cleanup
+   on failure, partial byte tracking — all unchanged.
+5. **Pattern list is data, not scattered code.** All patterns in one array/vec in
+   `error.rs`. Adding a new pattern is adding an entry, not modifying control flow.
+6. **Subprocess locale is forced to `C`.** All btrfs subprocess calls set `LC_ALL=C`
+   so stderr is always English, regardless of system locale. Pattern matching depends
+   on this.
+
+## Integration Points
+
+| Module | Change | Scope |
+|--------|--------|-------|
+| `error.rs` | `BtrfsErrorContext`, `BtrfsErrorDetail`, `BtrfsOperation` enum, `translate_btrfs_error()`, pattern table | New types + function |
+| `btrfs.rs` | Construct `BtrfsErrorContext` instead of `format!()` at 8 sites; add `.env("LC_ALL", "C")` to all subprocess calls; split send/receive into `SendReceiveContext` | Mechanical refactor |
+| `executor.rs` | `OperationOutcome.operation` becomes `BtrfsOperation` enum; `error: Option<String>` becomes `error_context: Option<BtrfsErrorContext>`; add `subvolume: Option<String>` | Struct change |
+| `voice.rs` | Call `translate_btrfs_error()` when rendering errors in backup summary | New render path |
+| `output.rs` | Extend daemon JSON error representation | Minor |
+| `plan.rs` | **No changes** | — |
+
+**Files affected:** 5 (error.rs, btrfs.rs, executor.rs, voice.rs, output.rs)
+**New module:** No (extends error.rs)
+
+## Effort Estimate
+
+Comparable to pre-flight checks (Priority 2c): one module with a table of rules, integration
+into voice layer, ~12-15 tests.
+
+- Pattern table + `translate_btrfs_error()`: ~2h
+- Context extraction (parsing existing error format): ~1h
+- Voice rendering (interactive + daemon): ~2h
+- Tests: ~2h (one per pattern + edge cases + unknown fallthrough)
+- Integration into backup summary rendering: ~1h
+
+**Total: ~1 session**
+
+## Test Strategy
+
+```
+// Pattern matching (pure function, typed context input)
+test_translate_no_space_receive → "Destination drive is full"
+test_translate_no_space_snapshot → "Local filesystem is full"
+test_translate_permission_denied → "Insufficient permissions"
+test_translate_read_only_fs → "Drive is read-only"
+test_translate_no_such_file_delete → "Snapshot not found at expected path"
+test_translate_no_such_file_receive → "Destination directory missing"
+test_translate_parent_not_found → "Incremental parent missing"
+test_translate_unknown_error → generic with full stderr preserved
+
+// Composite send/receive errors (review S2)
+test_translate_send_parent_not_found_recv_no_space → both translated independently
+test_translate_send_only_failure → recv_error is None
+test_translate_recv_only_failure → send_error is None
+
+// Rendering
+test_render_structured_error_interactive → layered output with color
+test_render_structured_error_daemon → JSON with all fields
+test_bytes_transferred_in_output → "transferred 1.1 TB before failure"
+
+// Fallthrough monitoring (review M3)
+test_unknown_pattern_logs_fallthrough → log::debug with raw stderr for monitoring
+
+// Hardening (test-team additions)
+test_btrfs_error_display_contains_operation_and_stderr
+test_backup_summary_renders_structured_error_instead_of_raw
+// LC_ALL=C enforcement: verify via grep in btrfs.rs (all Command::new sites)
+```
+
+## Rejected Alternatives
+
+### A. Parse structured context from flattened error strings (original Option A)
+
+**Rejected per arch-adversary review (S1).** The original design recommended leaving
+`UrdError::Btrfs { msg, bytes_transferred }` unchanged and regex-parsing the error
+string in `voice.rs` to recover exit codes and stderr. This creates a lossy round-trip
+with no compiler enforcement — if the format string in `btrfs.rs` changes, the parser
+in `voice.rs` silently breaks. Additionally, composite send/receive errors (review S2)
+would require splitting on `"; "` which is fragile. Carrying typed context eliminates
+the entire parsing layer.
+
+### B. Translate at construction time in `btrfs.rs`
+
+This would require `btrfs.rs` to know about remediation advice, drive labels, and
+subvolume names — violating its module boundary (CLAUDE.md: "btrfs.rs does NOT know
+about retention, plans, config"). The adopted approach keeps translation in the voice
+layer while providing typed input. `btrfs.rs` constructs `BtrfsErrorContext` (which
+is its own data) but doesn't translate it.
+
+### C. Regex-based pattern matching
+
+Full regex gives more precision but is harder to maintain and test. Substring matching
+covers all observed patterns. If a pattern needs regex later (e.g., extracting a
+specific path from stderr), add it as a single-pattern enhancement, not a wholesale
+change.
+
+### D. Separate `error_translation.rs` module
+
+A separate module would be cleaner in theory, but the translation types (`BtrfsErrorDetail`,
+`BtrfsErrorContext`) are closely coupled to `UrdError::Btrfs`. Keeping them in `error.rs`
+avoids circular dependencies and keeps error-related types together. If the pattern table
+grows beyond ~20 entries, revisit.
+
+## Open Questions
+
+1. **Should `urd verify` also translate errors it encounters?** Currently verify
+   produces its own check results. If verify calls btrfs operations that fail, the
+   translation layer would apply. Low priority — verify errors are rare.
+
+2. **Voice tone for errors.** The mythic voice applies to success states. Should errors
+   also carry the mythic register, or should they be direct and clinical? Recommendation:
+   errors should be direct. "The well overflows" is less helpful than "destination drive
+   is full" when you're debugging at 3am.
+
+3. **Sentinel error classification (review OQ3).** The Sentinel will need to make
+   decisions based on error types (e.g., "drive full" triggers different awareness than
+   "permission denied"). Should `BtrfsErrorContext` / `BtrfsErrorDetail` be the shared
+   vocabulary, or does the Sentinel need its own classification? Decide before
+   implementation to avoid a second refactor.
+
+4. **How deep should remediation advice go (review OQ1)?** Should remediation include
+   actual paths from config (e.g., `df -h /run/media/.../WD-18TB`)? This requires the
+   translation function to receive config data, conflicting with "pure function, no config
+   access." Resolution: the translation function receives `drive_label` and `subvolume`
+   from `OperationOutcome` fields (already available). Generic path templates use these
+   names, not full filesystem paths.
+
+## Resolved Questions (from review)
+
+- **Locale dependency (was OQ3):** Resolved by setting `LC_ALL=C` on all btrfs subprocess
+  calls. Pattern matching always operates on English stderr.
+- **Option A vs typed context (was review focus 1):** Rejected Option A. Typed context
+  on `UrdError::Btrfs` is the adopted approach.
+- **Pattern table vs match block (was review focus 2):** Data table confirmed as right
+  choice. Domain (arbitrary stderr strings) is inherently open-ended; exhaustiveness
+  checking buys little. Fallthrough handler is the correct substitute.
+- **Exit codes (was review focus 3):** Deferred, confirmed correct. Revisit when Sentinel
+  needs granular exit discrimination.
+
+## Review Findings Addressed
+
+This design was reviewed by arch-adversary on 2026-03-26. All findings addressed:
+
+| Finding | Severity | Resolution |
+|---------|----------|------------|
+| S1. String-parsing reconstruction is fragile | Significant | Rejected Option A. Adopted typed `BtrfsErrorContext` on `UrdError::Btrfs`. Eliminates regex parsing entirely. |
+| S2. Composite send/receive errors break pattern matcher | Significant | `SendReceiveContext` carries separate `send_error` and `recv_error`. Each side translated independently. |
+| S3. `OperationOutcome` enrichment insufficient | Significant | `OperationOutcome` now carries typed `BtrfsOperation` enum and `error_context: Option<BtrfsErrorContext>`. |
+| M1. Pattern 5 normalizes abnormal condition | Moderate | Reframed as "Snapshot not found at expected path" with dual-interpretation remediation. |
+| M2. Locale dependence under-mitigated | Moderate | `LC_ALL=C` on all btrfs subprocess calls. One-line change, eliminates risk. |
+| M3. No staleness detection for pattern table | Moderate | Added `log::debug` on fallthrough for monitoring. Spike after btrfs upgrade signals stale patterns. |
+| N1. `BtrfsOperation` duplicates `OperationOutcome.operation` | Minor | Unified: `OperationOutcome.operation` becomes `BtrfsOperation` enum. |
+| N2. Effort estimate optimistic for Option A | Minor | Moot — Option A rejected. Typed context approach is closer to original estimate. |
+
+[Review report](../99-reports/2026-03-26-structured-errors-design-review.md)

--- a/docs/99-reports/2026-03-26-protection-promises-design-review.md
+++ b/docs/99-reports/2026-03-26-protection-promises-design-review.md
@@ -1,0 +1,166 @@
+# Arch-Adversary Review: Protection Promise ADR Design
+**Project:** Urd -- BTRFS Time Machine for Linux
+**Date:** 2026-03-26
+**Scope:** Design proposal -- `docs/95-ideas/2026-03-26-design-protection-promises.md`
+**Review type:** Design review (pre-implementation)
+
+---
+
+## 1. Executive Summary
+
+This is a well-structured design that correctly identifies the semantic gap between operational config and user intent. The core approach -- promise levels as derivation inputs to existing pure functions, with `custom` as a first-class migration path -- respects the planner/executor separation and avoids architectural damage. The primary risk is that achievability-as-warning creates a zone where the system promises more than it delivers, and the user learns to ignore the warnings until data loss occurs.
+
+## 2. What Kills You (Catastrophic Failure Proximity)
+
+The catastrophic failure mode for Urd is silent data loss: deleting snapshots that should be kept, or failing to back up when it should.
+
+**Proximity to catastrophe: Moderate.** The design introduces a new indirection layer between user intent and retention policy. The retention algorithm itself is unchanged, which is good -- the danger is in the derivation, not the execution. Specifically:
+
+- A user sets `protection_level = "resilient"`, trusts the label, but the derived retention is `daily=30, weekly=26, monthly=12`. If they previously had `monthly=0` (unlimited), switching to promises *silently reduces retention depth*. The label says "resilient" but the outcome is fewer snapshots kept than before.
+- A user overrides `send_enabled = false` on a `protected` subvolume. The system warns but proceeds. The user now has a subvolume labeled "protected" with no external copies. The status output says "PROTECTED" if local snapshots are fresh, even though the promise semantics require external copies.
+- Changing `protection_level` on an existing subvolume with hundreds of existing snapshots: the next retention pass uses the new derived policy, which may be tighter than the old explicit policy. Snapshots that survived under the old policy get deleted.
+
+None of these are bugs -- they are design consequences that must be addressed explicitly.
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 -- Solid | Core derivation logic is well-defined and pure. Edge cases around level transitions and override interactions need tightening. |
+| Security | 3 -- Adequate | Achievability-as-warning creates a gap between stated promise and actual behavior. No mechanism prevents override combinations that void the promise semantics entirely. |
+| Architectural Excellence | 4 -- Solid | Respects planner/executor separation, keeps awareness model unchanged, derivation is a pure function. Integration points are well-scoped. |
+| Systems Design | 3 -- Adequate | `run_frequency` as manual config is fragile. The interaction between promise labels in status output and actual override-weakened behavior risks user confusion. |
+
+## 4. Design Tensions
+
+### Tension 1: Promise Labels vs. Override Freedom
+
+The design allows overrides that can completely contradict the promise level (`protection_level = "protected"` with `send_enabled = false`). This is defended by ADR-107 (fail open) and "the user may know what they're doing." But it creates a system where the promise label in `urd status` can be actively misleading. The label says "protected"; the behavior is "guarded." The user sees the label, not the warning that fired once during `urd backup` preflight.
+
+**The question:** Is a promise label that doesn't match actual behavior better or worse than no promise label at all?
+
+### Tension 2: Explicit run_frequency vs. Operational Reality
+
+The user declares `run_frequency = "daily"` in config, but then changes their systemd timer to 6h. Or they forget to update the config when they deploy the Sentinel. The derivation produces intervals based on the declared frequency, not the actual frequency. The awareness model catches the mismatch eventually (snapshots become stale), but the root cause is a config lie, not an operational failure.
+
+### Tension 3: Simplicity of Named Levels vs. Adequacy of Fixed Derivations
+
+The appeal of `protected` is that the user doesn't think about numbers. But the fixed derivation (`daily=30, weekly=26, monthly=12`) is a policy claim: "this is what protected means." For a user with 500GB of recordings changing hourly, this retention depth may be fine. For a user with 50GB of documents changing monthly, keeping 30 daily snapshots of identical content is waste. The promise level flattens different use cases into one policy.
+
+### Tension 4: Advisory Achievability vs. Promise Integrity
+
+If a promise is unachievable and the system only warns, then promises are aspirational, not contractual. The user sets `resilient` with one drive, gets a warning, and the system silently operates as `protected`. The status output could show "resilient" next to "AT RISK" without explaining that the promise itself is structurally impossible, not just temporarily degraded.
+
+## 5. Findings
+
+### Critical
+
+*None.* The design does not introduce a direct path to silent data loss that bypasses existing safeguards. The retention algorithm, pin protection, and planner/executor separation remain intact.
+
+### Significant
+
+**S1. Protection level change on existing subvolumes can trigger retroactive snapshot deletion.**
+
+When a user changes from explicit `local_retention = { monthly = 0 }` to `protection_level = "protected"` (which derives `monthly = 12`), the next retention pass will delete all monthly snapshots older than 12 months. This is correct behavior for the new policy, but the user may not realize that adopting a promise level can *reduce* their retention depth. The migration path section says "zero breaking changes" but this scenario shows that switching to promises can cause data loss relative to the user's previous configuration.
+
+*Recommendation:* Add a migration safety check. When `urd init` or `urd verify` detects a subvolume switching from explicit retention to promise-derived retention, compare the two policies and warn if the derived policy is strictly tighter in any dimension. Consider a one-time `--confirm-retention-change` flag or a "retention floor" that preserves existing snapshots through at least one full retention cycle.
+
+**S2. Override combinations can void promise semantics with no persistent signal.**
+
+A user can set `protection_level = "protected"` and `send_enabled = false`. The preflight warning fires during `urd backup`, is logged, and forgotten. The status output shows the promise level "protected" alongside the awareness state. If local snapshots are fresh, the status shows "PROTECTED" -- even though the subvolume has zero external copies and structurally cannot meet the `protected` contract (which requires `min_external_drives = 1`).
+
+*Recommendation:* When an override structurally voids the promise (not merely weakens it), the status display should reflect this. Options: (a) downgrade the displayed promise level to match actual behavior, (b) add a persistent "DEGRADED" qualifier (e.g., "protected*" with footnote), (c) refuse to display the promise level when structural overrides contradict it.
+
+**S3. `run_frequency` as manual config will drift from reality.**
+
+The design argues for explicit over inferred because it is "deterministic" and "validatable at config time." But the cost is that config lies are invisible. A user sets `run_frequency = "daily"`, deploys a 6h timer, and the derived intervals assume 24h runs. The awareness model will eventually flag staleness, but the root cause -- a config/reality mismatch -- is never surfaced. Worse: when the Sentinel launches, the user must remember to update `run_frequency = "sentinel"` in the config file. The design acknowledges this ("the Sentinel design determines the exact mechanism") but defers the answer.
+
+*Recommendation:* At minimum, add a preflight check that compares `run_frequency` against the heartbeat history (when available). If the last N runs show a pattern inconsistent with the declared frequency, warn. This doesn't require inference -- it uses the explicit config as the expectation and heartbeat as the reality check.
+
+### Moderate
+
+**M1. The `custom` derivation path for `derive_policy(Custom, _)` is underspecified.**
+
+The design says `custom` means "the user's config is the policy." But `derive_policy(Custom, run_frequency)` must return *something* -- what? The test plan includes `test_derive_custom_returns_none`, suggesting it returns no derivation. But the `resolve_subvolume` pseudocode calls `derive_policy(ProtectionLevel::Custom, run_frequency)` as the fallback when no `protection_level` is set. If `derive_policy` returns `None` for `custom`, what populates the `base` variable in the resolution logic? The existing `resolved()` method on `SubvolumeConfig` falls back to `DefaultsConfig`. The proposed `resolve_subvolume()` must produce identical results for configs with no `protection_level` field.
+
+*Recommendation:* Specify explicitly: for `custom`, `derive_policy` returns a sentinel value that causes `resolve_subvolume` to fall through to the existing `defaults`-based resolution. Write a property test: for every existing subvolume config (no `protection_level`), the resolved output from the new `resolve_subvolume` must be byte-identical to the output from the existing `SubvolumeConfig::resolved()`.
+
+**M2. Drive mapping does not interact with the planner's existing drive loop.**
+
+The planner (`plan.rs:164-198`) iterates over `config.drives` for every subvolume. The design adds `drives: Option<Vec<String>>` to `SubvolumeConfig` as a filter. But the planner currently receives `ResolvedSubvolume`, which has no `drives` field -- it loops over `config.drives` directly. The design's integration table says plan.rs has "no changes," but filtering sends by the `drives` field requires the planner to know which drives are mapped to which subvolume.
+
+*Recommendation:* Either (a) add a `drives` filter to `ResolvedSubvolume` and update the planner's drive loop to skip unmapped drives, or (b) restructure so drive mapping is resolved at config time and the drives list in `Config` is already filtered per-subvolume. Option (a) is a planner change that the integration table currently denies. Be honest about the scope.
+
+**M3. The outcome targets (24h/48h) are derived from awareness multipliers, not from operational data.**
+
+The design says: "Timer 24h + local threshold 2x = PROTECTED up to 48h = guarded max age." This is mathematically consistent with the awareness model's constants, but it means the "outcome targets" are reverse-engineered from implementation constants, not from user research or operational requirements. The 48h external max age for `protected` means a user's external copy can be nearly two days stale and still show "PROTECTED." For irreplaceable recordings that change hourly, this may not match user expectations of what "protected" means.
+
+*Recommendation:* Document the outcome targets as explicit policy decisions, not as derivations from awareness constants. If the awareness multipliers change (which they might, as they are module-level constants, not config), the promise semantics would silently shift. Consider making the outcome targets the primary definition, and derive the awareness multipliers from them (or at least validate consistency between the two).
+
+**M4. Retention is identical for `protected` and `resilient`, which weakens the semantic distinction.**
+
+Both levels derive `hourly=24, daily=30, weekly=26, monthly=12` for local retention and `daily=30, weekly=26, monthly=0` for external. The only difference is `min_external_drives` (1 vs. 2). This means `resilient` is strictly "protected + one more drive." The name "resilient" implies something stronger -- more history, faster recovery, deeper safety net. A user choosing between `protected` and `resilient` might expect the latter to keep snapshots longer, not just on more drives.
+
+*Recommendation:* This is a minor semantic issue now but will become a support burden. Either (a) accept and document that resilient = protected + redundancy (the design's position), or (b) give resilient deeper retention (e.g., `monthly=24` or `monthly=0`). The design can defer this, but should explicitly acknowledge the user-expectation risk.
+
+### Minor
+
+**N1. The `short_name` field on `SubvolumeConfig` is absent from the design's config schema examples.**
+
+The proposed config examples show `name` and `source` but omit `short_name`, which is a required field in the current `SubvolumeConfig`. This is likely just an omission in the design document, but if the design intends to make `short_name` optional (derived from `name`), that should be stated.
+
+**N2. Display convention for promise levels in status output is unresolved.**
+
+Open Question 4 asks whether to show "resilient" or "RESILIENT." The design leans toward lowercase but flags noise concerns. This is minor but should be decided before implementation to avoid a format change later. Recommendation: lowercase, since the PROTECTED/AT RISK/UNPROTECTED status already uses uppercase and two uppercase columns would indeed be noisy.
+
+### Commendation
+
+**C1. Promise derivation as a pure function at config resolution time is the right architectural choice.**
+
+By placing derivation between config parsing and planner input, the design avoids touching the planner, awareness model, or executor. The planner still receives `ResolvedSubvolume` with concrete intervals. This means the entire promise system can be tested in isolation with unit tests on the derivation function. This is textbook adherence to ADR-100 and ADR-108.
+
+**C2. Dropping `archival` is the right call.**
+
+The rationale is sound: archival is about retention depth, not protection freshness. Conflating them creates ambiguous status semantics. Deferring to a separate `retention_profile` concept keeps the promise model clean. The design correctly identifies that a subvolume can be `protected` (current copies exist) AND have deep retention (keep monthly forever) -- these are orthogonal concerns.
+
+**C3. The design addresses every item in the Phase 5 gate checklist.**
+
+Each gate requirement from `status.md` lines 221-229 has a corresponding section in the design. The timer frequency issue from the 2026-03-26 operational incident is directly addressed. The drive topology constraint (subvol3-opptak vs. 2TB-backup) is handled by the achievability validation. This is thorough preparation.
+
+## 6. The Simplicity Question
+
+The design adds three new config fields (`protection_level`, `drives`, `run_frequency`), one new enum (`ProtectionLevel`), one new struct (`DerivedPolicy`), and one new pure function (`derive_policy`). It modifies six existing files and adds zero new modules. This is restrained.
+
+The complexity risk is not in the implementation but in the *conceptual model*. Users now have two mental models for configuring a subvolume: promise-based (set a level, trust the derivation) and operation-based (set intervals and retention explicitly). The `custom` level bridges them, but a user reading the config file must understand both systems to reason about behavior. The override mechanism adds a third mode: promise-with-tweaks.
+
+**Verdict:** The design earns its complexity. The promise abstraction directly serves the project's north star ("does it reduce the attention the user needs to spend on backups?"). The risk is manageable if the override interaction is tightened per findings S1 and S2.
+
+## 7. For the Dev Team (Prioritized Action Items)
+
+1. **Define the protection-level transition behavior.** What happens to existing snapshots when `protection_level` changes? Write a test that switches from `monthly=0` to `protected` (which derives `monthly=12`) and verify no unexpected deletions occur on the first retention pass. Consider a grace period or confirmation. (Addresses S1)
+
+2. **Decide: can overrides void a promise, or only weaken it?** If `send_enabled = false` on a `protected` subvolume is allowed, the status output must not display "protected" without qualification. Define which overrides are "weakening" (longer intervals) vs. "voiding" (disabling sends on a level that requires them). Handle them differently. (Addresses S2)
+
+3. **Add heartbeat-vs-run_frequency consistency check to preflight.** When heartbeat history exists, compare actual run cadence against declared `run_frequency`. Warn on mismatch. This is a natural extension of the existing preflight module. (Addresses S3)
+
+4. **Specify `derive_policy(Custom, _)` behavior precisely.** Write the property test: existing configs without `protection_level` must produce identical `ResolvedSubvolume` output through both the old and new resolution paths. (Addresses M1)
+
+5. **Acknowledge the planner drive-loop change.** The `drives` field on subvolumes requires the planner to filter its drive iteration. Update the integration table to reflect this. It is a small change but it is a planner change. (Addresses M2)
+
+6. **Document outcome targets as primary policy, not as awareness-multiplier derivations.** The numbers should be defensible on their own terms. If someone changes the awareness multipliers, promise semantics should not silently shift. (Addresses M3)
+
+## 8. Open Questions
+
+1. **What is the retention behavior during a protection-level transition?** If a subvolume moves from explicit `monthly=0` to `protected` (deriving `monthly=12`), should there be a grace period before the tighter retention takes effect? Or should the user be required to confirm the change via `urd init --confirm-retention-change`?
+
+2. **Should `urd status` show the effective promise level or the configured promise level?** If overrides void the promise, showing the configured level is misleading. Showing the effective level requires computing what the overrides actually amount to. This is non-trivial but important for trust.
+
+3. **How does `run_frequency` interact with mixed-mode operation?** A user might run `urd backup` manually between timer fires, or have both a timer and occasional manual runs. The derivation assumes a single cadence. Is this adequate, or does it need a "minimum guaranteed frequency" semantic?
+
+4. **Is `monthly=12` the right floor for `protected`?** The current example config uses `monthly=12` in defaults and `monthly=0` in external retention. A user switching from defaults to `protected` gets the same local retention but loses unlimited external monthly retention (external derives `monthly=0`, which is actually unlimited -- but this inconsistency between the table in the design and the retention derivation code block needs to be reconciled: the table says "monthly=12" in the retention floor column, but the derivation block says `monthly = 0` for external).
+
+5. **Does the `drives` field validation happen at config load time or at plan time?** If validated at load time, a typo in a drive name prevents Urd from starting entirely. If validated at plan time, the error surfaces late. The design says "all listed drives must exist in `[[drives]]`. Error if not" -- but when?
+
+---
+
+*Review conducted as architectural adversary. Findings reflect design-phase analysis; implementation may resolve some concerns through testing and iteration.*

--- a/docs/99-reports/2026-03-26-sentinel-design-review.md
+++ b/docs/99-reports/2026-03-26-sentinel-design-review.md
@@ -1,0 +1,158 @@
+# Arch-Adversary Review: Sentinel Design
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-26
+**Scope:** Design proposal — `docs/95-ideas/2026-03-26-design-sentinel.md`
+**Review type:** Design review (pre-implementation)
+
+---
+
+## 1. Executive Summary
+
+The design makes the right big decision — decomposing the Sentinel into three independently shippable components (5a/5b/5c) with strict dependency ordering — and it correctly separates the pure state machine from the I/O runner. However, the notification-before-heartbeat-write ordering has a crash-consistency gap that can cause duplicate or lost notifications, the circuit breaker lacks a time-based reset for the "permanent half-dead" state, and the `SentinelState` carries cached assessments that create a subtle divergence risk between the Sentinel's view and the awareness model's ground truth.
+
+## 2. What Kills You (Catastrophic Failure Proximity)
+
+The catastrophic failure mode for Urd is **silent data loss**. For the Sentinel specifically: **cascade-triggering that exhausts disk space**, or **lock contention that prevents legitimate backups**.
+
+**Cascade risk.** The circuit breaker addresses this, but incompletely. The design caps at 3 failures with exponential backoff — good. But consider: what if the failure is *partial* (2 of 5 subvolumes fail)? The design doesn't define whether a partial success counts as a failure for circuit breaker purposes. If partial success resets the failure count, a consistently-partial-failing backup never trips the breaker and runs every hour indefinitely, creating snapshot congestion. Given Urd's catastrophic storage failure history from snapshot congestion, this is the closest thing to a live wire in this design.
+
+**Lock preventing legitimate backups.** The `flock(2)` mechanism is crash-safe and sound for single-machine use. The real risk is the Sentinel holding the lock during a long external send (hours for multi-TB subvolumes) while the user manually runs `urd backup` and gets a terse rejection. The user has no way to know *why* the lock is held or *when* it will release. This isn't data loss, but it is a "trust failure" — the user loses confidence in the tool.
+
+**Notification masking real problems.** If notification dispatch fails silently (webhook timeout, `notify-send` not installed), the user believes the Sentinel is watching when it is not. The design has a `Log` channel that's "always enabled," which mitigates this, but only if someone reads the log. The system should detect notification delivery failures and escalate — a meta-notification problem.
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4 | Pure state machine is well-bounded; crash-consistency gap in notification ordering and partial-failure circuit breaker semantics are fixable before implementation. |
+| **Security** | 3 | `Command` notification channel executes arbitrary scripts from config — acceptable for a local tool, but the design doesn't discuss permission model, path validation, or what happens if config is writable by another user. `flock` is advisory-only. |
+| **Architectural Excellence** | 4 | Clean decomposition, correct dependency ordering, pure/impure boundary is well-drawn. The `SentinelState` accumulation problem and the two-notification-path issue (5a-standalone vs 5b-integrated) slightly muddy the architecture. |
+| **Systems Design** | 3 | Missing several operational concerns: no observability story for the daemon itself, no health check endpoint, no way to inspect circuit breaker state, no graceful degradation when inotify watches are exhausted. Assessment interval is fixed when it should be adaptive. |
+
+## 4. Design Tensions
+
+### Tension 1: Cached State vs. Recomputation
+
+`SentinelState.last_assessments` caches promise states in the daemon's memory. The awareness model is a pure function that recomputes from filesystem truth. If anything changes the filesystem between Sentinel ticks (manual snapshot deletion, another tool touching btrfs), the cached state diverges from truth. The design partially addresses this with the assessment tick, but the tick interval (5 minutes) means up to 5 minutes of stale state. The real question: should `SentinelState` store assessments at all, or should every event that might trigger a notification force a fresh `assess()` call? The latter is simpler and truer to "filesystem is truth."
+
+### Tension 2: 5a Standalone vs. 5a-in-5b
+
+The design ships 5a as a post-backup hook embedded in `commands/backup.rs`. When 5b ships, the Sentinel also dispatches notifications. Now there are two notification paths: backup-embedded and Sentinel-driven. The design acknowledges this in Open Question 6 but doesn't resolve it. If both paths exist, the user can receive duplicate notifications (backup finishes, dispatches notification; Sentinel detects heartbeat change, re-assesses, dispatches again if state changed). The mitigation is that the Sentinel compares cached state to new state and only notifies on *change*, but the timing is fragile.
+
+### Tension 3: Simplicity vs. Completeness in Drive Tracking
+
+The `drive_connections` table is forward-looking infrastructure for promise achievability. But the awareness model doesn't use it yet, and the design doesn't specify when it will. This is speculative schema. The counter-argument — that it's cheap to record and expensive to retrofit — is valid, but it's also how tables accumulate without consumers. The design should commit: either define the achievability query that uses this data (even as a TODO with a concrete signature), or defer the table until a consumer exists.
+
+### Tension 4: Timer Coexistence vs. Timer Replacement
+
+The design correctly defers timer replacement. But the coexistence model has an unaddressed edge case: the systemd timer fires at 04:00, and the Sentinel's active mode also decides to trigger a backup at 03:58 (because a drive was just mounted). The lock prevents concurrent runs, so the 04:00 timer run gets rejected. The user's expected daily backup didn't happen from the timer's perspective. systemd will report the timer unit as failed. This is cosmetically bad and operationally confusing.
+
+## 5. Findings
+
+### Critical
+
+*None.* The design avoids the worst traps. No finding rises to "do not build this."
+
+### Significant
+
+**S1. Partial-failure circuit breaker semantics are undefined.**
+The circuit breaker counts "consecutive failures" but the design doesn't define what constitutes a failure when some subvolumes succeed and others fail. In the executor, `ExecutionResult` has an `overall` field that can be "partial." If partial success doesn't increment the failure counter, a consistently-partial-failing configuration runs auto-triggered backups every `min_interval` forever, potentially creating snapshot congestion. If partial success *does* increment it, a single flaky subvolume disables auto-backups for all subvolumes.
+
+*Recommendation:* Define circuit breaker failure as "the specific trigger condition was not resolved." If the trigger was `DriveMounted` and the external sends all failed, that's a failure. If some sends succeeded, the trigger condition is partially resolved — reset the counter but don't re-trigger for the same drive within `min_interval`.
+
+**S2. Crash window between notification computation and heartbeat write.**
+The design reorders to: read old heartbeat, compute assessments, compute notifications, write new heartbeat, dispatch. If the process crashes after computing notifications but before writing the heartbeat, the next run will re-read the old heartbeat, re-compute the same state transition, and send duplicate notifications. If the process crashes after writing the heartbeat but before dispatching, the notification is lost entirely (the state transition is recorded but never communicated). The design acknowledges this subtlety but doesn't resolve it.
+
+*Recommendation:* Accept this as a known trade-off and document it explicitly. Duplicate notifications on crash are better than lost notifications. Add a "last notification state" field to the heartbeat so that on recovery, the system can detect "I wrote a heartbeat but never confirmed notification dispatch" and re-send.
+
+**S3. `SentinelState.backup_in_progress` has no timeout.**
+The state tracks whether a backup is running, but there's no mechanism to detect a hung backup. If `urd backup` acquires the flock and then hangs (waiting on a stuck btrfs send, for example), `backup_in_progress` stays true indefinitely. The Sentinel will never auto-trigger, and the user gets no notification that something is wrong. The `flock` will be held until the process is killed.
+
+*Recommendation:* The Sentinel should monitor the heartbeat file's `stale_after` timestamp. If the current time exceeds `stale_after` and no new heartbeat has appeared, emit a `BackupOverdue` notification regardless of lock state. This doesn't require knowing about the lock — it uses the existing staleness mechanism.
+
+### Moderate
+
+**M1. `inotify` on `/proc/mounts` is not universally reliable.**
+The design recommends `inotify` on `/proc/mounts` for instant drive detection. `/proc/mounts` is a procfs virtual file. While Linux does generate `inotify` events on it, this behavior is an implementation detail, not a POSIX guarantee. Some container runtimes (Flatpak, certain Docker configurations) present a static `/proc/mounts`. FUSE mounts and automount entries may not trigger inotify. Additionally, LUKS unlock + mount is a two-step process; the inotify fires on the mount step but the design should handle the case where inotify fires but the mount isn't yet fully settled (UUID verification may fail transiently).
+
+*Recommendation:* Use inotify as the primary mechanism but implement polling as a fallback. On each inotify event, wait 500ms before checking (debounce for LUKS settle time). Run a polling sweep every 60 seconds regardless of inotify to catch missed events. Document the container/FUSE limitations.
+
+**M2. `Command` notification channel is an unaudited execution path.**
+`NotificationChannel::Command { path, args }` executes an arbitrary binary with arbitrary arguments. The config file is user-owned, so this is "user executes their own code" — acceptable. But: if the config file is world-writable (misconfiguration), or if the Sentinel runs as a systemd user service with broader permissions than expected, this becomes a privilege escalation vector. The design doesn't validate the command path or check file permissions.
+
+*Recommendation:* At config load time, verify the command path exists and is owned by the current user. Warn (don't block) if the config file itself has overly permissive permissions. Document that the `Command` channel runs with the Sentinel's privileges.
+
+**M3. No observability for the Sentinel daemon itself.**
+The design covers Prometheus metrics for backup operations but doesn't define any metrics or health indicators for the Sentinel process. There's no way to answer: "Is the Sentinel running? When did it last assess? Is the circuit breaker open? How many events has it processed?" For a daemon that's supposed to be the "invisible worker," this is a gap — the user needs to trust that it's working.
+
+*Recommendation:* Write a Sentinel-specific heartbeat (or extend the existing one) with: last assessment time, circuit breaker state, event count since startup, current mounted drives. Expose via `urd sentinel status` subcommand. This is low effort and high diagnostic value.
+
+**M4. Assessment tick interval should be adaptive, not fixed.**
+A 5-minute tick when all promises are PROTECTED is wasteful, especially on laptops (battery, disk wake). A 5-minute tick when promises are UNPROTECTED may be too slow. The design raises this in Open Question 2 but doesn't propose a solution.
+
+*Recommendation:* Three tiers: all PROTECTED = 15 minutes, any AT RISK = 5 minutes, any UNPROTECTED = 2 minutes. Simple, no config needed, aligns urgency with polling frequency.
+
+### Minor
+
+**m1. `flock(2)` doesn't identify the lock holder.**
+The design notes this and suggests writing PID to the lock file after acquiring it. This should be a firm requirement, not a suggestion. When the user runs `urd backup` and gets "Another backup is running," the next question is always "what backup? since when?" The lock file should contain PID, start time, and trigger source (manual/timer/sentinel).
+
+**m2. Notification deduplication across 5a and 5b needs an explicit contract.**
+When 5b ships, the backup-embedded notification path (5a) should be disabled if the Sentinel is running, or the Sentinel should detect that notifications were already dispatched for a given heartbeat write. Without this contract, the two paths will produce duplicates. A simple mechanism: include a `notifications_dispatched: bool` field in the heartbeat. The Sentinel skips notification if the flag is true.
+
+### Commendation
+
+**C1. The 3-component decomposition is the right call.**
+Shipping 5a as a post-backup hook is the fastest path to user value. The strict 5a-then-5b-then-5c ordering means each component is proven before the next adds complexity. This is disciplined engineering that resists the temptation to build the exciting part (active mode) first.
+
+**C2. Pure state machine with I/O runner separation.**
+`sentinel_transition()` as a pure function is exactly right. It makes the hardest part of the Sentinel (the decision logic) trivially testable. The 20+ pure tests for the state machine will catch edge cases that integration tests would miss. This follows the planner/executor pattern that already works well in the codebase.
+
+**C3. Coexistence with the systemd timer.**
+Not replacing the timer in v1 is a mature decision. The timer is proven. The Sentinel is new. Running both with a lock file is safer than a hard cutover. This shows lessons learned from the catastrophic storage failure.
+
+## 6. The Simplicity Question
+
+> "Should 5a be part of 5b instead of standalone?"
+
+No. 5a standalone is correct. The notification dispatcher is a pure function + I/O dispatch layer. Embedding it in the backup command gives immediate value (users get notifications today) with zero daemon complexity. The cost is a second notification path when 5b arrives, but that's solvable with a simple deduplication flag (see m2). The alternative — waiting for 5b to ship any notifications — delays user value by 2-3 sessions for no architectural benefit.
+
+> "Is `SentinelState` carrying too much?"
+
+Yes, slightly. `last_assessments` should not be cached in state. The awareness model is designed to be called on demand, and caching its output creates a divergence risk. The Sentinel should store only: mounted drives (for event deduplication), last assessment *time* (for tick scheduling), and circuit breaker state (for trigger decisions). Promise states should be recomputed on every Assess action by calling `awareness::assess()` fresh. This makes the state machine simpler and the truth model cleaner.
+
+> "Is the `drive_connections` table premature?"
+
+Borderline. It's cheap to implement and harmless to have. But it has no consumer in this design. Recommendation: implement the table as part of 5b (it's ~20 lines of schema + insert), but do not build any query infrastructure until the achievability model is designed. If the table sits unused for two priority cycles, reconsider.
+
+## 7. For the Dev Team (Prioritized Action Items)
+
+1. **Define partial-failure semantics for the circuit breaker** before implementing 5c. This is the closest thing to a cascade risk in the design. Write it into the design doc as a decision, not an open question.
+
+2. **Remove `last_assessments` from `SentinelState`.** Recompute promise states on every Assess action. This eliminates the divergence risk and simplifies the state machine. The performance cost is negligible (assess reads a few directories and pin files).
+
+3. **Add a `BackupOverdue` notification event** that fires based on heartbeat staleness, independent of lock state. This catches hung backups that neither the circuit breaker nor the lock mechanism can detect.
+
+4. **Design the 5a/5b notification deduplication contract** before shipping 5b. A `notifications_dispatched` field in the heartbeat is the simplest mechanism. Document it now so 5a's implementation includes the field.
+
+5. **Implement inotify-with-polling-fallback** for `/proc/mounts` rather than committing to either alone. The debounce delay for LUKS settle time should be explicit in the design.
+
+6. **Write PID + timestamp + trigger source into the lock file** as a firm requirement, not a suggestion. This is a single-session addition that dramatically improves the "another backup is running" user experience.
+
+7. **Define Sentinel observability** (last assessment time, circuit breaker state, event count) before shipping 5b. Even a simple `urd sentinel status` subcommand is sufficient for v1.
+
+## 8. Open Questions
+
+1. **What is the circuit breaker's reset mechanism when the Sentinel restarts?** The design says circuit state is "persisted in heartbeat or a separate state file" but doesn't decide. If persisted in the heartbeat, a manual `urd backup` that writes a new heartbeat could inadvertently reset the circuit breaker. If in a separate file, that's another backward-compatibility contract.
+
+2. **Should the Sentinel hold sudo credentials?** Backup execution requires `sudo btrfs`. If the Sentinel auto-triggers a backup, does it need passwordless sudo? The systemd timer presumably runs with the user's sudoers configuration, but a user-level daemon may not have the same privilege context. This is an operational concern that affects whether 5c is deployable.
+
+3. **What happens to in-flight notifications when the Sentinel receives SIGTERM?** The design handles SIGTERM as clean shutdown, but if a webhook POST is in-flight, does it complete or get interrupted? For `Command` channels, does the child process get orphaned?
+
+4. **Is the 5-minute assessment tick the right default for the heartbeat file watch?** If the Sentinel already watches the heartbeat via inotify, and `urd backup` writes the heartbeat on every run, the assessment tick is only needed for detecting drive changes and time-based staleness transitions. The tick could be longer (15 minutes) with inotify handling the real-time cases.
+
+5. **How does config reload interact with the circuit breaker?** If the user edits `urd.toml` to fix a broken drive path and sends SIGHUP, should that reset the circuit breaker? The failure was caused by misconfiguration, so continuing to penalize with the open circuit is wrong. But auto-resetting on config reload could mask persistent issues.
+
+---
+
+*Review conducted as architectural adversary. Findings reflect design-phase analysis; implementation may resolve or introduce additional concerns.*

--- a/docs/99-reports/2026-03-26-structured-errors-design-review.md
+++ b/docs/99-reports/2026-03-26-structured-errors-design-review.md
@@ -1,0 +1,284 @@
+# Arch-Adversary Review: Structured Error Messages Design
+**Project:** Urd -- BTRFS Time Machine for Linux
+**Date:** 2026-03-26
+**Scope:** Design proposal -- `docs/95-ideas/2026-03-26-design-structured-errors.md`
+**Review type:** Design review (pre-implementation)
+
+---
+
+## 1. Executive Summary
+
+This design proposes a pure-function translation layer that pattern-matches btrfs stderr
+strings into structured (summary / cause / remediation / technical) error messages. The
+architecture is sound in principle -- presentation-only, no behavior change, raw stderr
+preserved -- but the recommended integration path (Option A: parse structured context back
+out of flattened error strings at render time) introduces a fragile intermediate
+representation that will silently degrade as error message formats drift. The design should
+be redirected toward carrying structured context through the executor rather than
+reconstructing it from strings.
+
+## 2. What Kills You (Catastrophic Failure Proximity)
+
+This design is **presentation-only** and explicitly declares "no behavior change." That is
+its greatest safety property. It does not touch the planner, does not alter error
+propagation, does not change cleanup-on-failure logic. For a backup tool where the
+catastrophic failure mode is silent data loss, a presentation-only change is low-risk by
+nature.
+
+However, two failure modes deserve attention:
+
+**Misclassification leading to wrong remediation.** Pattern 5 maps "No such file or
+directory" on delete to "Snapshot already removed" -- framing the error as benign. If the
+actual cause is a filesystem corruption or a wrong path (not a stale target), the user
+receives reassurance when they should be alarmed. The translation layer cannot distinguish
+these cases from substring matching alone. This is not catastrophic on its own -- the raw
+stderr is preserved -- but it reduces the probability that a user investigates a real
+problem.
+
+**Future btrfs stderr format changes.** When btrfs changes its error strings (which it has
+done between versions), patterns silently stop matching and fall through to the generic
+handler. This is the correct failure mode -- it degrades to today's behavior, not to
+information loss. No catastrophic risk here.
+
+**Verdict:** Low proximity to catastrophic failure. The design respects the "no behavior
+change" boundary. The main risk is diagnostic misdirection, not data loss.
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 3/5 | Option A's string-parsing reconstruction of structured context is fragile and adds an unnecessary failure mode to a system that already has the data in typed form |
+| **Security** | 4/5 | No new attack surface; sudo/btrfs interaction unchanged; remediation advice could theoretically leak path info in logs but this is marginal |
+| **Architectural Excellence** | 4/5 | Pure function, data-driven pattern table, presentation-only scope, invariants well-stated; docked for choosing the wrong integration point |
+| **Systems Design** | 3/5 | The design creates information, destroys it (flattening to string in btrfs.rs), then attempts to reconstruct it (parsing in voice.rs) -- a classic lossy round-trip |
+
+**Overall: 3.5/5 -- Solid concept, wrong plumbing.**
+
+## 4. Design Tensions
+
+### Tension 1: Module Purity vs. Information Preservation
+
+The design argues Option A keeps `btrfs.rs` focused on subprocess management. True. But
+`btrfs.rs` already formats structured data (exit code, stderr, operation name) into a
+string, destroying structure. Option A then proposes regex-parsing that string to recover
+the structure. The module boundary is maintained at the cost of a lossy round-trip. The
+cleaner resolution is not Option B (translation in btrfs.rs) but a **third option**: carry
+`BtrfsErrorContext` as a typed field on `UrdError::Btrfs` alongside or instead of the
+`msg: String`, and let the voice layer translate from the typed context. This preserves
+both the module boundary and the information.
+
+### Tension 2: Data Table vs. Match Block
+
+The pattern table as `&[ErrorPattern]` with function pointers is extensible but not
+exhaustive. A `match` block on an enum is exhaustive but less extensible. For a table of
+7 patterns that may grow to 15, the data table is the right call -- exhaustiveness checking
+buys little when the domain (arbitrary stderr strings) is inherently open-ended. The
+fallthrough handler is the correct substitute for exhaustiveness.
+
+### Tension 3: Helpful Framing vs. Diagnostic Accuracy
+
+Translating "No such file or directory" on delete into "Snapshot already removed" is
+helpful when true and misleading when false. The design optimizes for the common case
+(stale retention target) at the cost of the uncommon case (filesystem corruption,
+misconfigured path). This tension is inherent in any translation layer and cannot be fully
+resolved, but the design should acknowledge it explicitly and ensure the raw stderr is
+rendered prominently enough that a user who reads past the summary will see the truth.
+
+### Tension 4: Backward Compatibility of Exit Codes
+
+Deferring exit code granularity is pragmatic. The structured errors deliver 90% of the
+value; exit codes can follow. But the design should note that the deferred exit codes
+intersect with the Sentinel/daemon work -- the Sentinel will need to distinguish "config
+error" from "partial failure" to make awareness decisions. If exit codes are deferred too
+long, the Sentinel will parse strings instead, recreating the same problem this design
+solves.
+
+## 5. Findings
+
+### Critical
+
+None.
+
+### Significant
+
+**S1. Option A's string-parsing reconstruction is a design smell.**
+
+The design recommends parsing exit codes via `\(exit (-?\d+)\)` regex and extracting stderr
+via splitting on `": "`. This works today because `btrfs.rs` formats errors as `"send
+failed (exit 1): <stderr>"`. But this format is not a contract -- it is an implementation
+detail of `btrfs.rs`. If someone changes the format string (adds context, rewords, changes
+punctuation), the parser in `voice.rs` silently breaks. The design creates a hidden coupling
+between `btrfs.rs` error formatting and `voice.rs` error parsing with no compiler
+enforcement.
+
+**Recommendation:** Do not parse strings. Instead, add `BtrfsErrorContext` (or a simpler
+typed struct with operation, exit_code, stderr, bytes_transferred) as a field on
+`UrdError::Btrfs`. This is a smaller change than the design suggests -- it touches `btrfs.rs`
+construction sites (8 locations, mechanical change) but eliminates the parsing layer entirely
+and makes the coupling explicit and type-checked. The `Display` impl on `UrdError::Btrfs`
+can still render the flat string for log output.
+
+**S2. Combined send/receive error messages break the pattern matcher.**
+
+When both send and receive fail (lines 214-231 of `btrfs.rs`), the error message is
+semicolon-joined: `"send failed (exit 141): <send stderr>; receive failed (exit 1): <recv
+stderr>"`. The pattern table matches on substrings of the full message. If the send stderr
+contains "No space left on device" (it won't -- the receiver does), pattern matching works.
+But if the send fails with "parent not found" AND the receive fails with "No space left on
+device", the first-match-wins rule will match pattern 7 (parent not found) and miss the
+space issue entirely. The design does not address composite errors.
+
+**Recommendation:** If sticking with Option A, the parser must split on `"; "` and translate
+each half independently, or the design must document that composite errors always match on
+the first component. Better: carry separate send/receive error contexts in the typed struct.
+
+**S3. The `subvolume` field addition to `OperationOutcome` is insufficient.**
+
+The design proposes adding only `subvolume: Option<String>` to `OperationOutcome`. But the
+translation function also needs `operation` parsed as `BtrfsOperation` (not the string
+"send_full" / "send_incremental") and `exit_code` and `stderr` as separate fields. If the
+design is going to enrich `OperationOutcome` at all, it should carry the full typed context
+rather than a single field that forces the rest to be string-parsed.
+
+### Moderate
+
+**M1. Pattern 5 ("Snapshot already removed") normalizes a potentially abnormal condition.**
+
+"No such file or directory" on delete could mean: (a) snapshot was already deleted (benign),
+(b) path is misconfigured (bug), (c) filesystem corruption (serious). Labeling all three as
+"Snapshot already removed" is misleading for cases (b) and (c). The remediation advice
+("this is normal") actively discourages investigation.
+
+**Recommendation:** Use a more neutral summary like "Snapshot not found at expected path"
+and include remediation that covers both benign and concerning interpretations: "If this
+snapshot was already deleted, this is safe to ignore. If unexpected, check the subvolume
+path configuration."
+
+**M2. Locale dependence is acknowledged but under-mitigated.**
+
+The design notes that btrfs stderr language depends on system locale and accepts this as
+"acceptable for now." This is a reasonable call, but the design should add a concrete
+mitigation: set `LC_ALL=C` on btrfs subprocess calls in `btrfs.rs`. This is a one-line
+change that eliminates the locale risk entirely and is standard practice for tools that parse
+subprocess output. The fact that this is not proposed suggests the author did not consider
+the fix, only the problem.
+
+**M3. No versioning or staleness detection for the pattern table.**
+
+As btrfs evolves, patterns may stop matching or match incorrectly. The design has no way to
+detect this. Consider adding a metric or log entry for "pattern table fallthrough rate" --
+if it spikes after a btrfs upgrade, someone knows to update the patterns.
+
+### Minor
+
+**N1. `BtrfsOperation` enum duplicates information already in `OperationOutcome.operation`.**
+
+The design introduces `BtrfsOperation { Snapshot, Send, Receive, Delete }` but
+`OperationOutcome.operation` is a string ("snapshot", "send_full", "send_incremental",
+"delete", "retention"). These should converge. Either `OperationOutcome.operation` becomes
+a typed enum, or `BtrfsOperation` parses from the string. Having both is a maintenance
+hazard.
+
+**N2. The effort estimate of "~1 session" is optimistic if Option A is chosen.**
+
+The string-parsing layer (extracting exit codes, splitting composite errors, handling edge
+cases) will consume more time than estimated. If the design switches to typed context
+propagation, the estimate is more realistic.
+
+### Commendation
+
+**C1. The "no behavior change" invariant is the right call.**
+
+Separating presentation improvement from error-handling logic changes is exactly correct for
+a backup tool. This design can be shipped, tested, and iterated without any risk to the
+backup pipeline itself. The author clearly internalized the catastrophic failure concern.
+
+**C2. The fallthrough handler preserves raw stderr unconditionally.**
+
+The guarantee that unknown patterns produce full technical output means the translation
+layer can never make things worse than today. This is the right default for a safety-critical
+tool.
+
+**C3. Rejected alternatives are well-reasoned.**
+
+The document considers four alternatives and rejects them with clear rationale. The reasoning
+for keeping translation out of `btrfs.rs` (module boundary) and against a separate module
+(coupling) is sound. The only gap is not considering the hybrid option of typed context on
+the error type.
+
+## 6. The Simplicity Question
+
+> Does this design add complexity the user must manage?
+
+No. The user sees better error messages. There is no new configuration, no new commands, no
+new concepts. This passes the CLAUDE.md simplicity test.
+
+> Does this design add complexity the developer must manage?
+
+Option A: Yes. The string-parsing layer is an ongoing maintenance burden -- every change to
+error formatting in `btrfs.rs` must be tested against the parser in `voice.rs`, with no
+compiler help.
+
+Option B: Moderate. Touching 8 construction sites is mechanical but noisy.
+
+**Hybrid option (typed context on `UrdError::Btrfs`):** Lowest ongoing complexity. The
+construction sites change minimally (they already have the data in typed form -- they just
+stop formatting it into a string). The voice layer receives typed input. The compiler
+enforces the contract.
+
+## 7. For the Dev Team (Prioritized Action Items)
+
+1. **Reject Option A. Carry typed context on `UrdError::Btrfs`.**
+   Replace `msg: String` with a `BtrfsErrorContext` struct (or add it alongside `msg`).
+   This eliminates the string-parsing layer, makes the coupling explicit, and is a smaller
+   conceptual change than it appears. The 8 construction sites in `btrfs.rs` already have
+   exit_code, stderr, and operation in local variables -- they just need to populate a struct
+   instead of `format!()`. Keep `Display` for log/debug output. Priority: do this before
+   writing any code.
+
+2. **Split composite send/receive errors.**
+   Whether using typed context or string parsing, the combined "send failed; receive failed"
+   message must be handled as two separate errors for translation. With typed context, carry
+   `send_error: Option<SubprocessError>` and `recv_error: Option<SubprocessError>`
+   separately.
+
+3. **Neutralize Pattern 5's framing.**
+   Change "Snapshot already removed" to "Snapshot not found at expected path" with
+   dual-interpretation remediation advice.
+
+4. **Set `LC_ALL=C` on btrfs subprocess calls.**
+   One-line change in `btrfs.rs` that eliminates the locale parsing risk. Do this regardless
+   of the structured errors work.
+
+5. **Add `BtrfsOperation` as a typed enum to `OperationOutcome`.**
+   Unify with the string `operation` field. This is a good cleanup independent of the
+   structured errors work.
+
+6. **Defer exit codes (as proposed).**
+   The design's recommendation to keep 0/1 is correct. Revisit when the Sentinel needs
+   granular exit discrimination.
+
+## 8. Open Questions
+
+1. **How deep should remediation advice go?** The design includes specific commands
+   (`df -h /run/media/.../WD-18TB`). Should these include actual paths from the config, or
+   generic placeholders? Actual paths are more useful but require the translation function
+   to receive config data, which conflicts with the "pure function, no config access"
+   invariant. The design should resolve this tension explicitly.
+
+2. **Should the translation layer be tested against real btrfs stderr?** The test strategy
+   shows synthetic inputs. Consider capturing real stderr from the observed failures
+   (listed in the Problem section) and using those as golden test inputs. This protects
+   against subtle format assumptions.
+
+3. **What is the interaction with the Sentinel's error handling?** The Sentinel will need
+   to make decisions based on error types (e.g., "drive full" triggers a different awareness
+   state than "permission denied"). Should `BtrfsErrorContext` / `BtrfsErrorDetail` be the
+   shared vocabulary, or does the Sentinel need its own error classification? This should be
+   decided before implementation to avoid a second refactor.
+
+4. **Should the pattern table live in a separate data file (TOML/JSON)?** If pattern
+   updates should not require recompilation (e.g., user-contributed patterns for unusual
+   btrfs builds), an external table would be appropriate. If patterns are always developer-
+   maintained, a Rust array is fine. The current design assumes the latter, which is
+   reasonable for now.

--- a/docs/99-reports/2026-03-26-test-strategy-review.md
+++ b/docs/99-reports/2026-03-26-test-strategy-review.md
@@ -1,0 +1,435 @@
+# Test Strategy Review: Three Design Proposals
+
+> **TL;DR:** The proposed test strategies cover the happy paths and primary edge cases well
+> but share a common blind spot: they under-test the interaction between new features and
+> existing safety mechanisms (pin protection, retention, executor error isolation). The
+> highest-risk gap is in the Protection Promises design — no test verifies that promise-derived
+> retention policies don't accidentally bypass the three-layer pin protection system. The
+> Sentinel design needs circuit breaker state transition tests that would catch the
+> partial-failure cascade. The Structured Errors design is well-covered for a presentation-only
+> feature.
+
+**Date:** 2026-03-26
+**Scope:** Test strategies from three design proposals:
+- Structured Error Messages (`docs/95-ideas/2026-03-26-design-structured-errors.md`)
+- The Sentinel (`docs/95-ideas/2026-03-26-design-sentinel.md`)
+- Protection Promises (`docs/95-ideas/2026-03-26-design-protection-promises.md`)
+
+**Existing test suite:** 251 tests. Strong coverage in plan.rs (31), awareness.rs (24),
+voice.rs (23), executor.rs (17), retention.rs (9). No property-based tests (no proptest).
+MockBtrfs and MockFileSystemState provide excellent test isolation.
+
+---
+
+## Design 1: Structured Error Messages
+
+**Proposed tests:** 15 (8 pattern matching, 3 composite errors, 3 rendering, 1 monitoring)
+**Risk level:** Low — presentation only, no behavior change
+**Verdict:** Adequate. Minor gaps only.
+
+### Coverage Map
+
+| Function | Proposed tests | Risk | Assessment |
+|----------|---------------|------|-----------|
+| `translate_btrfs_error()` | 8 pattern tests + 1 fallthrough | Moderate | Good — one per pattern + fallthrough |
+| Composite send/receive | 3 tests | Moderate | Good — covers both sides |
+| Voice rendering | 3 tests | Low | Adequate |
+| `LC_ALL=C` enforcement | 0 | Moderate | **Gap** |
+
+### Gaps
+
+**Moderate gap: No test for `LC_ALL=C` on subprocess calls.**
+
+The design adds `LC_ALL=C` to all btrfs subprocess calls as a hardening measure. No test
+verifies this. If someone adds a new `Command::new()` for btrfs without the env var, patterns
+break silently on non-English systems.
+
+```
+test_btrfs_commands_set_lc_all_c
+  Setup: Read MockBtrfs call recording, or inspect Command construction
+  Assert: All subprocess calls include LC_ALL=C in environment
+  Why: Patterns depend on English stderr. This is the only guarantee.
+```
+
+Since MockBtrfs doesn't spawn real processes, this needs a code-level assertion — either
+a `#[cfg(test)]` hook that records env vars, or a grep-based test that scans `btrfs.rs` for
+`Command::new` and verifies each has `.env("LC_ALL", "C")`.
+
+**Low gap: No test for `BtrfsErrorContext` round-trip through `Display`.**
+
+The `Display` impl on `UrdError::Btrfs` renders a flat summary from `BtrfsErrorContext`.
+Verify that the flat summary is human-readable and contains the key facts (operation, stderr
+excerpt).
+
+```
+test_btrfs_error_display_contains_operation_and_stderr
+  Setup: BtrfsErrorContext with operation=Send, stderr="No space left"
+  Assert: format!("{}", error) contains "send" and "No space"
+  Why: Logs and non-voice error paths use Display, not the translation layer
+```
+
+**Low gap: No test for `BtrfsOperation` enum parsing from executor's operation types.**
+
+The design unifies `OperationOutcome.operation` as `BtrfsOperation` enum. Test the mapping
+from executor operation types ("send_full", "send_incremental", etc.) to enum variants.
+
+### Recommended additions: +3 tests (total: ~18)
+
+---
+
+## Design 2: The Sentinel
+
+**Proposed tests:** ~50 (7 notification, 9 state machine, 3 integration, ~30 additional
+implied by "~20 state machine" and "~15 active mode")
+**Risk level:** High — introduces concurrent execution, lock contention, auto-triggering
+**Verdict:** Significant gaps in circuit breaker edge cases and lock contention scenarios.
+
+### Coverage Map
+
+| Component | Proposed tests | Risk | Assessment |
+|-----------|---------------|------|-----------|
+| 5a: `compute_notifications()` | 7 pure + 3 integration | Moderate | Good |
+| 5b: `sentinel_transition()` | 9 state machine | High | **Gaps below** |
+| 5c: Circuit breaker | 0 explicit | Critical | **Major gap** |
+| 5c: Lock file | 0 explicit | High | **Gap** |
+| 5a: `BackupOverdue` | 0 | High | **Gap** |
+
+### Gaps
+
+**Critical gap: No circuit breaker state transition tests.**
+
+The circuit breaker is the primary defense against cascade-triggering — the closest
+proximity to Urd's catastrophic failure mode (snapshot congestion from repeated auto-triggers).
+The design defines Closed → Open → HalfOpen transitions with partial-failure semantics,
+but proposes zero tests for this logic.
+
+```
+test_circuit_breaker_closes_after_success
+  Setup: CircuitBreaker in Closed state, failure_count=0
+  Action: Record success
+  Assert: State remains Closed, failure_count=0
+
+test_circuit_breaker_opens_after_max_failures
+  Setup: Closed, failure_count=2, max_failures=3
+  Action: Record failure
+  Assert: State transitions to Open
+
+test_circuit_breaker_half_open_after_backoff
+  Setup: Open, last_failure 2h ago, min_interval=1h
+  Action: Check if trigger allowed
+  Assert: State transitions to HalfOpen, one trigger allowed
+
+test_circuit_breaker_half_open_to_closed_on_success
+  Setup: HalfOpen
+  Action: Record success
+  Assert: State transitions to Closed, failure_count reset
+
+test_circuit_breaker_half_open_to_open_on_failure
+  Setup: HalfOpen
+  Action: Record failure
+  Assert: State transitions to Open, backoff doubles
+
+test_circuit_breaker_partial_success_on_scheduled_run
+  Setup: Closed
+  Action: Record partial success for ScheduledRun trigger
+  Assert: Counts as failure (per design decision)
+
+test_circuit_breaker_partial_success_on_drive_mounted
+  Setup: Closed, trigger=DriveMounted, some sends succeeded
+  Action: Record partial resolution
+  Assert: Counts as resolved, counter reset
+
+test_circuit_breaker_manual_backup_ignores_open_circuit
+  Setup: Open
+  Action: Manual urd backup attempts
+  Assert: Allowed regardless of circuit state
+
+test_circuit_breaker_exponential_backoff_caps_at_24h
+  Setup: Open, failure_count=10
+  Action: Compute next allowed trigger time
+  Assert: Backoff capped at 24h, not 2^10 hours
+```
+
+**These 9 tests are non-negotiable before shipping 5c.** The circuit breaker is the only
+thing between the Sentinel and a repeat of the catastrophic storage failure.
+
+**High gap: No lock file contention tests.**
+
+The lock file prevents concurrent backup runs. No tests verify the contention behavior.
+
+```
+test_lock_acquired_successfully
+  Setup: No existing lock
+  Action: acquire_backup_lock()
+  Assert: Returns Ok(LockGuard), lock file exists
+
+test_lock_contention_returns_error
+  Setup: Hold lock in a thread
+  Action: Second acquire_backup_lock() from main thread
+  Assert: Returns Err indicating lock held
+
+test_lock_released_on_drop
+  Setup: Acquire lock, drop guard
+  Action: Try to acquire again
+  Assert: Succeeds
+
+test_lock_file_contains_pid_and_trigger
+  Setup: Acquire lock with trigger="sentinel"
+  Action: Read lock file contents
+  Assert: Contains PID, timestamp, trigger source
+
+test_lock_survives_process_crash (integration, #[ignore])
+  Setup: Fork, acquire lock, kill child
+  Action: Parent tries to acquire
+  Assert: Succeeds (flock released on process death)
+```
+
+**High gap: No `BackupOverdue` notification tests.**
+
+The `BackupOverdue` event catches hung backups — an important safety mechanism added in
+the review. No test verifies that it fires correctly.
+
+```
+test_backup_overdue_fires_when_stale
+  Setup: Heartbeat with stale_after 2h ago
+  Action: compute_notifications() with current time past stale_after
+  Assert: BackupOverdue event generated with correct age
+
+test_backup_overdue_does_not_fire_when_fresh
+  Setup: Heartbeat with stale_after 1h from now
+  Action: compute_notifications()
+  Assert: No BackupOverdue event
+
+test_backup_overdue_urgency_is_critical
+  Setup: Heartbeat stale by 24h
+  Action: compute_notifications()
+  Assert: BackupOverdue urgency is Critical
+```
+
+**Moderate gap: No adaptive tick interval tests.**
+
+```
+test_adaptive_tick_all_protected → 15 minutes
+test_adaptive_tick_any_at_risk → 5 minutes
+test_adaptive_tick_any_unprotected → 2 minutes
+```
+
+**Moderate gap: No notification deduplication tests.**
+
+```
+test_notifications_dispatched_flag_prevents_resend
+test_notifications_dispatched_false_triggers_resend
+test_sentinel_skips_dispatch_when_flag_true
+```
+
+### Recommended additions: +23 tests (total: ~73)
+
+The Sentinel is the most test-hungry feature. The circuit breaker alone needs 9 tests.
+This is proportional — it's the highest-risk new code in the roadmap.
+
+---
+
+## Design 3: Protection Promises
+
+**Proposed tests:** ~37 (5 derivation, 6 resolution, 7 achievability, 4 drive mapping,
+4 transition safety, 3 awareness integration, 3 run frequency, 3 voice, 2 additional)
+**Risk level:** High — changes retention policy derivation, one step from snapshot deletion
+**Verdict:** Good coverage of the happy path; critical gaps in interaction with existing
+safety mechanisms.
+
+### Coverage Map
+
+| Function | Proposed tests | Risk | Assessment |
+|----------|---------------|------|-----------|
+| `derive_policy()` | 5 | Moderate | Good |
+| `resolve_subvolume()` | 6 | Critical | **Gaps below** |
+| Achievability checks | 7 | Moderate | Good |
+| Drive mapping | 4 | High | Good |
+| Transition safety | 4 | Critical | Good but incomplete |
+| Awareness integration | 2 | Moderate | Thin |
+| Run frequency check | 3 | Moderate | Good |
+
+### Gaps
+
+**Critical gap: No test that promise-derived retention interacts correctly with pin
+protection.**
+
+This is the highest-risk untested scenario in the entire design. The three-layer pin
+protection system (unsent protection in planner, `is_pinned` in retention, re-check in
+executor) is Urd's primary defense against deleting snapshots needed for incremental sends.
+Promise-derived retention policies flow through the same `graduated_retention()` function,
+but no test verifies that the derived policies respect pinned snapshots.
+
+The danger: `derive_policy("guarded")` produces `daily=7, weekly=4`. If a pinned snapshot
+is 8 days old (outside the daily window), does `graduated_retention()` still protect it?
+Yes — the existing retention function has `pinned` as an explicit parameter. But no test
+exercises this with promise-derived retention configs specifically.
+
+```
+test_promise_derived_retention_preserves_pinned_snapshots
+  Setup: Subvolume with protection_level="guarded" (derives daily=7)
+         Pinned snapshot 10 days old (outside daily window)
+  Action: Run graduated_retention() with derived config and pinned set
+  Assert: Pinned snapshot NOT in deletions list
+  Why: Pin protection must survive the promise derivation path. This is one bug
+       away from the catastrophic failure mode.
+
+test_promise_derived_retention_with_space_pressure_preserves_pins
+  Setup: Same as above but with space_pressure=true
+  Action: Run graduated_retention()
+  Assert: Pinned snapshot still NOT deleted even under pressure
+  Why: Space pressure enables more aggressive thinning but must never
+       override pin protection.
+```
+
+**Critical gap: No test for the full pipeline: promise level → derived retention →
+planner → retention decision.**
+
+The design proposes `test_promise_derived_intervals_evaluated_correctly` but this tests
+awareness model evaluation, not the retention/planning pipeline. A full pipeline test:
+
+```
+test_promise_level_to_retention_decision_pipeline
+  Setup: Config with protection_level="protected", active snapshots including
+         some outside derived retention windows, one pinned
+  Action: plan() with MockFileSystemState
+  Assert: Planner's retention operations respect derived retention AND pins
+          AND unsent protection simultaneously
+  Why: The promise layer adds a new indirection between config and retention.
+       Pipeline tests catch integration bugs that unit tests miss.
+```
+
+**High gap: No test for protection level downgrade (resilient → guarded).**
+
+The transition safety tests cover tightening retention. But what about downgrading
+the protection level itself? Switching from `resilient` to `guarded` means
+`send_enabled` goes from `true` to `false`. On the next run:
+- No external sends happen
+- External snapshots become orphaned (no retention runs against them)
+- Pin files reference snapshots that will never be updated
+
+```
+test_downgrade_resilient_to_guarded_disables_sends
+  Setup: Subvolume with protection_level="resilient", existing pin files
+  Action: Change to protection_level="guarded", resolve_subvolume()
+  Assert: send_enabled=false, existing pin files are stale but harmless
+
+test_downgrade_does_not_delete_external_snapshots
+  Setup: External drive has snapshots from previous resilient config
+  Action: Plan with guarded level (send_enabled=false)
+  Assert: No external retention operations planned (we don't delete what
+          we're no longer managing)
+```
+
+**High gap: No test for drives field interaction with planner drive loop.**
+
+The design acknowledges (review M2) that the planner needs to filter drives per subvolume.
+The test strategy includes `test_drives_field_filters_send_targets` but doesn't test
+interaction with the existing planner logic.
+
+```
+test_planner_skips_unmapped_drives_for_subvolume
+  Setup: Config with 3 drives, subvolume maps to ["WD-18TB"] only
+  Action: plan() with all 3 drives mounted
+  Assert: Send operations only for WD-18TB, not for other drives
+
+test_planner_sends_to_all_drives_when_no_mapping
+  Setup: Config with 3 drives, subvolume has drives=None
+  Action: plan() with all 3 drives mounted
+  Assert: Send operations for all 3 drives (backward compatible)
+
+test_planner_drive_mapping_with_uuid_mismatch
+  Setup: Mapped drive has UUID mismatch
+  Action: plan() with MockFileSystemState returning UuidMismatch
+  Assert: Skip with UuidMismatch reason, not "drive not in mapping"
+```
+
+**Moderate gap: No property test for migration path identity.**
+
+The design proposes `test_migration_existing_config_unchanged` as a "property test" but
+describes it as a single example. For a migration guarantee this important, use actual
+property-based testing:
+
+```
+// Using proptest (or manual exhaustive iteration over real config)
+test_migration_identity_property
+  Setup: Generate SubvolumeConfig instances with no protection_level field,
+         various combinations of explicit and default fields
+  Action: Compare sv.resolved(defaults) vs resolve_subvolume(sv, defaults, any_freq)
+  Assert: Identical for every input
+  Why: The migration claim ("zero breaking changes") is load-bearing.
+       A single counterexample invalidates it.
+```
+
+This is one of the best candidates for proptest in the entire codebase — the invariant
+is well-defined, the input space is enumerable, and a violation is catastrophic.
+
+**Moderate gap: No test for voiding override display in status.**
+
+```
+test_status_shows_degraded_promise_when_sends_disabled
+  Setup: protection_level="protected", send_enabled=false
+  Action: Render status
+  Assert: Shows "protected (degraded — no external sends)", not bare "protected"
+```
+
+### Recommended additions: +12 tests (total: ~49)
+
+---
+
+## Cross-Design Test Gaps
+
+### Gap 1: No integration test between Sentinel triggers and existing backup pipeline
+
+When the Sentinel auto-triggers a backup (5c), it calls the same pipeline as manual
+`urd backup`. But the test strategies for the Sentinel and the existing executor tests
+are independent. A test that exercises: Sentinel trigger → lock acquisition → plan →
+execute → heartbeat → notification would catch integration bugs.
+
+**Recommendation:** Add 2 integration tests to the Sentinel design:
+
+```
+test_sentinel_triggered_backup_produces_heartbeat (#[ignore])
+test_sentinel_triggered_backup_respects_lock (#[ignore])
+```
+
+### Gap 2: No test for structured errors rendered in backup summary
+
+The structured errors design produces `BtrfsErrorDetail` for rendering. The voice layer
+renders it in backup summaries. But the backup summary tests (21 existing) were written
+before structured errors exist. When structured errors are implemented, the backup summary
+tests need updating.
+
+**Recommendation:** Add to the structured errors test plan:
+
+```
+test_backup_summary_renders_structured_error_instead_of_raw
+```
+
+### Gap 3: Proptest is absent from the codebase
+
+Three designs would benefit from property-based testing:
+1. Migration identity (promises): `resolve_subvolume` with no `protection_level` = `resolved()`
+2. Pin protection under derived retention: `graduated_retention` never returns pinned snapshots
+3. Translation completeness: `translate_btrfs_error` always produces non-empty summary
+
+**Recommendation:** Add `proptest` to dev-dependencies. The migration identity property alone
+justifies the dependency. Start with one proptest, expand as patterns prove useful.
+
+---
+
+## Summary
+
+| Design | Proposed | Gaps found | Recommended total | Critical gaps |
+|--------|----------|-----------|-------------------|---------------|
+| Structured Errors | 15 | 3 (low) | ~18 | 0 |
+| Sentinel | ~50 | 23 (9 critical) | ~73 | Circuit breaker transitions |
+| Protection Promises | ~37 | 12 (4 critical) | ~49 | Pin protection with derived retention |
+
+**Highest-priority tests to add before implementation:**
+
+1. **Circuit breaker state transitions** (9 tests) — Sentinel's cascade defense
+2. **Promise-derived retention preserves pinned snapshots** (2 tests) — one bug from data loss
+3. **Full pipeline: promise → planner → retention** (1 test) — integration safety
+4. **Lock file contention** (5 tests) — concurrent execution correctness
+5. **Migration identity property** (1 proptest) — zero-breaking-change guarantee


### PR DESCRIPTION
## Summary

- **Three feature designs** spanning Priorities 2e (structured errors), 5 (Sentinel), and the ADR-110 gate (protection promises), each with full module decomposition, type signatures, integration points, test strategies, and rejected alternatives
- **Three arch-adversary reviews** with all findings addressed — key discoveries: rejected string-parsing approach for errors in favor of typed context; defined circuit breaker partial-failure semantics; added retroactive deletion safeguard for promise level transitions
- **Test strategy review** identifying critical gaps: 9 circuit breaker tests, 2 pin-protection-with-derived-retention tests, migration identity proptest

## Documents

| Type | Document |
|------|----------|
| Design | `docs/95-ideas/2026-03-26-design-structured-errors.md` |
| Design | `docs/95-ideas/2026-03-26-design-sentinel.md` |
| Design | `docs/95-ideas/2026-03-26-design-protection-promises.md` |
| Review | `docs/99-reports/2026-03-26-structured-errors-design-review.md` |
| Review | `docs/99-reports/2026-03-26-sentinel-design-review.md` |
| Review | `docs/99-reports/2026-03-26-protection-promises-design-review.md` |
| Test review | `docs/99-reports/2026-03-26-test-strategy-review.md` |

## Testing

- Documentation only — no Rust code changed
- Existing test suite unaffected (251 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)