### PR TITLE
docs: config system design review and ADR suite update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,94 +4,68 @@
 
 **Urd** (Old Norse: Urðr) — a BTRFS Time Machine for Linux, written in Rust.
 
-Urd is the norn who tends the Well of Urðr and knows all that has passed. She preserves your
-filesystem history silently and faithfully. When you invoke her, the encounter should be
-pleasant and clear. When she demands your attention, you should be glad she did.
+Urd preserves filesystem history silently and faithfully. When invoked, the encounter
+should be pleasant and clear. When Urd demands attention, the user should be glad it did.
 
 **Design north star:** Every feature must pass two tests: (1) does it make the user's data
 safer? (2) does it reduce the attention the user needs to spend on backups? If a feature
 adds complexity the user must manage, it needs a very strong justification.
 
 **Two modes of existence:**
-- **The invisible worker.** Urd runs autonomously — systemd timer, Sentinel daemon, tray icon.
-  Silence is a good sign. The user should trust that if Urd is quiet, their data is safe.
-- **The invoked norn.** When the user calls `urd status`, `urd restore`, or any command, they
-  are consulting Urd. She speaks with authority and clarity, guiding decisions about their data.
-  When Urd surfaces a problem unbidden (notification, broken promise), it's because it matters.
+- **The invisible worker.** Runs autonomously via systemd timer (nightly at ~04:00).
+  Silence means data is safe. Future: Sentinel daemon for sub-hourly cadence.
+- **The invoked norn.** `urd status`, `urd get`, `urd restore` — the user is consulting Urd.
+  Speaks with authority and clarity. Surfaces problems only when they matter.
 
-**The mythic voice.** Urd's text-based interactions carry the character of the norn — evocative,
-wise, grounding. Not cosplay or gimmick, but a consistent tone that makes the experience of
-managing backups feel considered and trustworthy. "Your recordings are woven into the well"
-rather than "backup completed: success." Apply this voice to status output, setup conversation,
-recovery contracts, and notifications. Technical details remain precise; the framing is mythic.
+**The mythic voice.** Urd's presentation layer carries the character of the norn — evocative
+and grounding. Not cosplay, but a consistent tone. The voice belongs entirely in the
+presentation layer (`voice.rs`), never in config or data structures. Technical details
+remain precise; the framing is mythic.
 
-**Protection promises.** Urd thinks in promises, not operations. The user declares what matters
-("protect my home directory," "keep my recordings resilient") and Urd derives the operations.
-Anchor promises to the user's actual data: documents, photos, recordings, projects — not
-subvolume IDs. Promise states (PROTECTED / AT RISK / UNPROTECTED) are the universal language
-of the app.
+**Protection promises.** Urd thinks in promises, not operations. The user declares what
+matters; Urd derives the operations. Promise states (PROTECTED / AT RISK / UNPROTECTED)
+are the universal language. Current taxonomy (guarded/protected/resilient) is provisional
+and needs rework — see ADR-110 maturity model.
 
 ## Orient Yourself
 
-Read `docs/96-project-supervisor/status.md` first — it has current state, priorities, and
-links to everything else. See `CONTRIBUTING.md` for documentation standards.
+Read `docs/96-project-supervisor/status.md` first — current state, priorities, and links.
+See `CONTRIBUTING.md` for documentation structure and conventions.
 
 ## Architecture
 
-### Core Invariant: Planner/Executor Separation
+### Core Flow
 
-The planner (`plan.rs`) is a **pure function**: config + filesystem state in, `BackupPlan` out.
-It never modifies anything. The executor (`executor.rs`) takes a plan and runs it.
+```
+config  -->  plan (pure function)  -->  execute (I/O)
+                                           |
+                                      btrfs (sudo)
+```
 
-This is the most important architectural property. Do not bypass it. All backup logic flows
-through: config -> plan -> execute.
-
-### BtrfsOps Trait
-
-`btrfs.rs` defines `BtrfsOps`. `RealBtrfs` shells out to `sudo btrfs`; `MockBtrfs` records
-calls for testing. This is the **only module that calls btrfs**. Everything else uses the trait.
+All backup logic flows through: config -> plan -> execute. No exceptions.
 
 ### Module Responsibilities
 
 | Module | Does | Does NOT |
 |--------|------|----------|
-| `config.rs` | Parse TOML, validate, expand paths | Touch filesystem beyond path checks |
-| `types.rs` | Define domain types, parsing, Display | Contain business logic |
-| `plan.rs` | Decide what operations to run | Execute anything or call btrfs |
-| `executor.rs` | Execute planned operations | Decide what to do (planner's job) |
-| `btrfs.rs` | Wrap btrfs subprocess calls | Know about retention, plans, config |
-| `retention.rs` | Compute which snapshots to keep/delete | Delete anything (returns lists) |
+| `config.rs` | Parse TOML, validate, expand paths, resolve subvolumes | Touch filesystem beyond path checks |
+| `types.rs` | Domain types, parsing, Display, `derive_policy()` | Contain business logic |
+| `plan.rs` | Decide what operations to run (pure function) | Execute anything or call btrfs |
+| `executor.rs` | Execute planned operations, error isolation | Decide what to do (planner's job) |
+| `btrfs.rs` | Wrap `sudo btrfs` subprocess calls via `BtrfsOps` trait | Know about retention, plans, config |
+| `retention.rs` | Compute which snapshots to keep/delete (pure) | Delete anything (returns lists) |
+| `awareness.rs` | Compute promise states per subvolume (pure) | Perform I/O |
 | `chain.rs` | Track incremental chain parents (pin files) | Send snapshots |
 | `state.rs` | Record history in SQLite | Influence backup decisions |
-| `metrics.rs` | Write Prometheus .prom files | Read metrics |
-| `drives.rs` | Detect mounted drives, check space | Mount/unmount drives |
-| `commands/` | CLI subcommand handlers | Core logic (delegate to above) |
-
-### Error Handling
-
-- `thiserror` for types in `error.rs`; `anyhow` in `main.rs` / CLI layer
-- Individual subvolume failures must NOT abort the entire backup run
-- Failed sends must clean up partial snapshots at the destination
-- SQLite failures must NOT prevent backups (log warning, continue)
-
-### UX Principles
-
-These encode design decisions from the Norman UX analysis and user feedback:
-
-- **Invisible worker, invoked norn.** Two interaction modes (see Vision above). Autonomous
-  operation is silent; invoked interaction is rich, guided, and carries the mythic voice.
-  Failures and broken promises are always impossible to miss, regardless of mode.
-- **Answer "is my data safe?"** Every user-facing surface should answer this in human terms
-  — promise states, plain language, data types the user cares about (not subvolume IDs).
-- **Guide through affordances, not error messages.** The interface should lead users toward
-  correct choices so errors don't happen. Smart defaults, setup guidance, and promise-level
-  config are better than post-hoc warnings. The goal is fewer errors, not better errors.
-- **Flexibility only earns its keep if it's easy to operate.** A powerful feature behind a
-  confusing interface is a feature nobody uses. When in doubt, choose the simpler design.
-  Power users interact with config files directly — don't over-build the config UI for them.
-- **The Sentinel is the integration layer.** An event-driven state machine that holds the
-  awareness model, reacts to events (drive plug, timer, backup result), updates promise
-  states, and drives notifications. Other features subscribe to its event stream.
+| `preflight.rs` | Validate config achievability (pure) | Block backups (advisory only) |
+| `heartbeat.rs` | Write JSON health signal after each run | Block backups on failure |
+| `metrics.rs` | Write Prometheus `.prom` files | Read metrics |
+| `notify.rs` | Compute and dispatch notifications | Decide promise states (uses awareness) |
+| `drives.rs` | Detect mounted drives, UUID fingerprinting, check space | Mount/unmount drives |
+| `output.rs` | Define structured output types | Render text (voice.rs does that) |
+| `voice.rs` | Render structured output as text (mythic voice) | Perform I/O or compute state |
+| `error.rs` | Error types, `translate_btrfs_error()` for actionable messages | Recovery logic |
+| `commands/` | CLI subcommand handlers (wire pure modules to I/O) | Core logic (delegate to above) |
 
 ### Architectural Invariants
 
@@ -103,10 +77,49 @@ Each references an ADR in `docs/00-foundation/decisions/` with full rationale.
 3. **Filesystem is truth, SQLite is history.** Pin files and snapshot dirs are authoritative. SQLite failures never prevent backups. (ADR-102)
 4. **Individual subvolume failures never abort the run.** The executor isolates errors per subvolume. (ADR-100)
 5. **Retention never deletes pinned snapshots.** Three independent layers: unsent protection, planner exclusion, executor re-check. (ADR-106)
-6. **Backups fail open; deletions fail closed.** Missing data means proceed and clean up, never refuse to back up. But never delete a snapshot you can't confirm is safe to remove. (ADR-107)
+6. **Backups fail open; deletions fail closed.** Proceed on missing data, never delete what can't be confirmed safe. (ADR-107)
 7. **Core logic modules are pure functions.** Planner, awareness, retention, voice — inputs in, outputs out, no I/O. (ADR-108)
-8. **Validate at config boundary, trust afterward.** Paths and names validated once at load; no re-validation in hot paths. (ADR-109)
-9. **Backward compatibility contracts are sacred.** Snapshot names, pin files, Prometheus metrics — changes require an ADR with migration plan. (ADR-105)
+8. **Validate structure at load time; isolate failures at runtime.** Structural config errors refuse to start. Runtime conditions (unmounted drive, full filesystem) skip per-unit and report. (ADR-109, ADR-111)
+9. **Backward compatibility contracts are sacred.** Snapshot names, pin files, Prometheus metrics — on-disk data format changes require an ADR with migration plan. Config schema changes use `urd migrate`. (ADR-105, ADR-111)
+10. **Named protection levels are opaque or they don't exist.** No per-field overrides on named levels. Custom is first-class. Named levels must earn opaque status through operational track record. (ADR-110, ADR-111)
+
+### Config System (ADR-111 — target architecture, not yet implemented)
+
+The config system is undergoing a redesign. Key principles:
+
+- **Config files are complete, self-describing artifacts.** Each subvolume block is readable
+  in isolation. No hidden inheritance, no cross-section joins.
+- **Two modes: named level or custom.** Named levels derive all operational parameters
+  (opaque, no overrides). Custom subvolumes specify all parameters explicitly.
+- **Templates scaffold; they don't govern.** One-time generation at setup, not runtime inheritance.
+- **`[defaults]` section is being removed.** Hardcoded fallbacks in the binary for omitted fields.
+- **Explicit drive routing.** Every subvolume names its target drives. No implicit "all drives."
+- **Space constraints are a filesystem concern.** `[[space_constraints]]` section on paths.
+- **One schema version at a time.** `config_version` field, `urd migrate` for transitions.
+
+Current implementation still uses the legacy schema (`[defaults]`, `[local_snapshots]`).
+See ADR-111 implementation gates for the migration checklist.
+
+### Error Handling
+
+- `thiserror` for types in `error.rs`; `anyhow` in `main.rs` / CLI layer
+- Individual subvolume failures must NOT abort the entire backup run
+- Failed sends must clean up partial snapshots at the destination
+- SQLite failures must NOT prevent backups (log warning, continue)
+- `translate_btrfs_error()` converts btrfs stderr into actionable `BtrfsErrorDetail`
+
+### UX Principles
+
+- **Invisible worker, invoked norn.** Autonomous operation is silent; invoked interaction
+  is rich and guided. Failures are always impossible to miss.
+- **Answer "is my data safe?"** Every surface should answer this in promise states and
+  plain language — not subvolume IDs.
+- **Guide through affordances, not error messages.** Lead users toward correct choices.
+  Fewer errors, not better errors.
+- **Precision in config, voice in presentation.** Config layer is mechanical and explicit.
+  Mythic voice belongs entirely in `voice.rs` and notifications.
+- **The Sentinel is the integration layer.** Event-driven state machine (future) that
+  reacts to events, updates promise states, and drives notifications.
 
 ## Coding Conventions
 
@@ -124,17 +137,20 @@ Each references an ADR in `docs/00-foundation/decisions/` with full rationale.
 
 - Unit tests: `#[cfg(test)] mod tests` in same file. Run: `cargo test`
 - Integration tests: `tests/integration/`, `#[ignore]` by default. Run: `cargo test -- --ignored`
-- Use `MockBtrfs` for anything that would call btrfs
+- Use `MockBtrfs` and `MockFileSystemState` for anything that would call btrfs or read filesystem
 - Test retention logic exhaustively — it protects against data loss
+- 318 tests, all passing, clippy clean
 
-## Backward Compatibility
+## Backward Compatibility (ADR-105)
 
-These formats are **load-bearing** — existing snapshots, monitoring, and pin files depend on them:
+These **on-disk data formats** are load-bearing — existing snapshots, monitoring, and pin
+files depend on them. Config schema has separate versioning (ADR-111).
 
-1. **Snapshot names:** Legacy `YYYYMMDD-<name>` (read-only, parsed as midnight) and current
-   `YYYYMMDD-HHMM-<name>` (all new snapshots). Both coexist; ordering by datetime, not string.
-2. **Snapshot dirs:** `<snapshot_root>/<subvolume_name>/`
-3. **Pin files:** `.last-external-parent-<DRIVE_LABEL>` in local snapshot dir
+1. **Snapshot names:** Legacy `YYYYMMDD-{short_name}` (read-only, parsed as midnight) and
+   current `YYYYMMDD-HHMM-{short_name}` (all new snapshots). Ordering by datetime, not string.
+2. **Snapshot dirs:** `{snapshot_root}/{name}/` — `name` is the directory, `short_name` is
+   in the snapshot name. Both are on-disk contracts.
+3. **Pin files:** `.last-external-parent-{DRIVE_LABEL}` in local snapshot dir
 4. **Prometheus metrics:** exact names, labels, and value semantics must be preserved
 
 ## BTRFS Commands
@@ -145,27 +161,47 @@ All operations require `sudo` (scoped via sudoers). The `BtrfsOps` trait wraps:
 snapshot -r, send [-p parent], receive, subvolume delete, subvolume show, filesystem show
 ```
 
-The send|receive pipeline must capture stderr from both sides, check both exit codes, and
-clean up partial snapshots on failure.
+The send|receive pipeline captures stderr from both sides, checks both exit codes, and
+cleans up partial snapshots on failure. Paths passed as `&Path` to `Command::arg()`, never
+stringified — prevents shell injection and preserves non-UTF-8 paths.
 
 ## Build & Run
 
 ```bash
 cargo build                          # Debug
 cargo build --release                # Release
-cargo test                           # Unit tests
+cargo test                           # Unit tests (318 tests)
 cargo test -- --ignored              # Integration tests (needs drives)
-cargo clippy -- -D warnings          # Lint
+cargo clippy -- -D warnings          # Lint (all warnings are errors)
 cargo run -- plan                    # Preview backup plan
 cargo run -- backup --dry-run        # Dry-run
-cargo run -- status                  # Current state
+cargo run -- status                  # Current promise states
+cargo run -- get FILE --at DATE      # Restore file from snapshot
 ```
 
 ## Configuration
 
 - Config: `~/.config/urd/urd.toml` (override: `--config`)
 - State DB: `~/.local/share/urd/urd.db`
+- Heartbeat: `~/.local/share/urd/heartbeat.json`
 - Example: `config/urd.toml.example`
+
+## ADR Index
+
+| ADR | Title | Scope |
+|-----|-------|-------|
+| 100 | Planner/executor separation | Core architecture |
+| 101 | BtrfsOps trait | Btrfs abstraction |
+| 102 | Filesystem truth, SQLite history | State management |
+| 103 | Interval-based scheduling | Snapshot/send timing |
+| 104 | Graduated retention | Snapshot lifecycle |
+| 105 | Backward compatibility contracts | On-disk data formats |
+| 106 | Defense-in-depth data integrity | Pin protection layers |
+| 107 | Fail-open backups, fail-closed deletions | Error philosophy |
+| 108 | Pure-function module pattern | Module design |
+| 109 | Config-boundary validation | Security/correctness |
+| 110 | Protection promises | Promise semantics, maturity model |
+| 111 | Config system architecture | Config structure, versioning (target, not yet implemented) |
 
 ## Project State
 

--- a/docs/00-foundation/decisions/2026-03-24-ADR-103-interval-scheduling.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-103-interval-scheduling.md
@@ -35,8 +35,9 @@ The planner checks whether enough time has elapsed since the last snapshot/send 
 subvolume. If not, the operation is skipped with a "next in ~Xh" message. This makes the
 plan idempotent and safe to run repeatedly.
 
-Per-subvolume overrides inherit from `[defaults]`. Most subvolumes share the same policy;
-only those with different needs specify their own intervals.
+Per-subvolume intervals come from either a named protection level (opaque — see ADR-110) or
+explicit values on the subvolume (custom policy). See ADR-111 for the config inheritance
+model — there is no `[defaults]` section; configs are self-describing artifacts.
 
 ## Consequences
 
@@ -46,7 +47,7 @@ only those with different needs specify their own intervals.
 - Per-subvolume cadences let critical data (home directory) snapshot more frequently than
   stable data (music collection)
 - Decoupled snapshot/send intervals reduce unnecessary external I/O
-- The `[defaults]` inheritance model means most config is 3 lines, not repeated per subvolume
+- Templates provide starting points for common policies, reducing config verbosity (ADR-111)
 
 ### Negative
 
@@ -60,9 +61,9 @@ only those with different needs specify their own intervals.
 
 - Snapshot naming includes time (`YYYYMMDD-HHMM-shortname`) to support sub-daily snapshots.
   Legacy `YYYYMMDD-shortname` names are parsed as midnight for backward compatibility.
-- The systemd timer fires at a fixed time (02:00 daily). Interval-based scheduling means
-  "at least this much time between operations," not "run at this exact time." The timer
-  is the trigger; the intervals are the filter.
+- The systemd timer fires at a fixed daily time. Interval-based scheduling means "at least
+  this much time between operations," not "run at this exact time." The timer is the
+  trigger; the intervals are the filter.
 
 ## Related
 

--- a/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
@@ -24,19 +24,25 @@ retention model must handle both.
 
 ### Local retention: graduated time windows
 
+A typical graduated retention policy:
+
 ```toml
-[defaults.local_retention]
-hourly = 24      # keep 24 hourly snapshots (1 day of hourly granularity)
-daily = 30       # then 30 daily (1 per day, newest in each day)
-weekly = 26      # then 26 weekly (1 per ISO week)
-monthly = 12     # then 12 monthly (1 per calendar month)
+# Per-subvolume (custom policy) or derived from a named protection level
+local_retention = { hourly = 24, daily = 30, weekly = 26, monthly = 12 }
 ```
+
+- `hourly = 24` — keep 24 hourly snapshots (1 day of hourly granularity)
+- `daily = 30` — then 30 daily (1 per day, newest in each day)
+- `weekly = 26` — then 26 weekly (1 per ISO week)
+- `monthly = 12` — then 12 monthly (1 per calendar month)
 
 Within each window, keep the *newest* snapshot per time period. This produces ~92 snapshots
 covering ~18 months, with fine granularity for recent data and coarse granularity for old.
 
-Per-subvolume overrides use `Option<u32>` fields that merge with defaults. A subvolume can
-override `daily = 7` without restating all four windows.
+Per-subvolume retention comes from either a named protection level (opaque — see ADR-110)
+or explicit values on the subvolume (custom policy). There is no `[defaults]` merge — configs
+are self-describing artifacts (ADR-111). Custom subvolumes specify their full retention;
+omitted fields use hardcoded fallbacks in the binary.
 
 ### Space pressure mode
 

--- a/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
@@ -57,6 +57,13 @@ pin file format breaks incremental sends).
   Per-drive metrics may be added later but must not replace the global ones.
 - Written atomically (temp file + rename) to prevent partial reads by node exporter.
 
+### Scope: data formats, not config schema
+
+These contracts govern **on-disk data formats** — snapshot names, directory structure, pin
+files, and Prometheus metrics. The config file schema has its own versioning contract
+(ADR-111) and is not subject to these backward-compatibility rules. Config schema changes
+are handled by `urd migrate`; data format changes require a migration plan and a new ADR.
+
 ## Consequences
 
 ### Positive

--- a/docs/00-foundation/decisions/2026-03-24-ADR-109-config-boundary-validation.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-109-config-boundary-validation.md
@@ -44,6 +44,19 @@ This means validation is for **correctness** (catching typos, malformed paths), 
 **security against the config author**. The security boundary is between the config and
 the system — validated paths are safe to pass to sudo commands.
 
+### Structural vs runtime errors
+
+Config validation catches **structural errors** — authoring mistakes that make the config
+meaningless. These are hard failures: Urd refuses to start.
+
+**Runtime conditions** (drive not mounted, filesystem below `min_free_bytes`, source path
+missing) are not config errors — the config is correct but the world isn't ready. These
+are handled at runtime by the executor, which isolates failures per-unit and produces a
+structured result describing what was skipped and why (ADR-111).
+
+The distinction: "this config is *wrong*" vs "this config is *right but the world isn't
+ready*." Config validation owns the first; the executor owns the second.
+
 ### No re-validation in hot paths
 
 After `Config::validate()` succeeds, modules that consume config values (planner, executor,
@@ -89,6 +102,7 @@ are separate from config validation because they come from a different trust bou
 ## Related
 
 - ADR-101: BtrfsOps trait (the module where validated paths reach sudo commands)
+- ADR-111: Config system architecture (structural vs runtime error distinction, new fields)
 - [Phase 1 hardening review](../../99-reports/2026-03-22-phase1-hardening-review.md) —
   path validation introduced
 - [Phase 3.5 adversary review](../../99-reports/2026-03-22-arch-adversary-phase35.md) —

--- a/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
+++ b/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
@@ -1,15 +1,18 @@
 # ADR-110: Protection Promises
 
-> **TL;DR:** Protection promises are named levels (`guarded`, `protected`, `resilient`, `custom`)
-> that map to concrete retention and interval policies. The user declares intent; Urd derives
-> operations. Existing configs continue to work as implicit `custom` with zero breaking changes.
-> Promise derivation is a pure function at config resolution time — the planner, executor, and
-> awareness model are unchanged.
+> **TL;DR:** Protection promises are named levels that map to concrete operational policies.
+> The user declares intent; Urd derives operations. Named levels are opaque — no per-field
+> overrides. `Custom` means the user manages all parameters explicitly. Named levels must
+> earn opaque status through operational track record; the current taxonomy
+> (guarded/protected/resilient) is provisional and subject to rework.
 
-**Date:** 2026-03-26
-**Status:** Accepted
+**Date:** 2026-03-26 (revised 2026-03-27)
+**Status:** Accepted (taxonomy provisional — see Maturity Model)
 **Depends on:** ADR-100 (planner/executor separation), ADR-108 (pure function modules),
-ADR-109 (config boundary validation)
+ADR-109 (config boundary validation), ADR-111 (config system architecture)
+**Ownership:** This ADR is authoritative for protection promise *semantics* — what levels
+mean, how they derive policy, the maturity model, and the opacity rule. ADR-111 is
+authoritative for config *structure* — what fields exist, how validation works, versioning.
 
 ## Context
 
@@ -26,23 +29,56 @@ describes *desired cadence* without reference to *actual run frequency*.
 
 Protection promises bridge this gap: the user declares what they want; Urd derives what to do.
 
+A subsequent design review (2026-03-27) found that the original override semantics
+(voiding/weakening overrides on named levels) created contradictory configs and noisy
+preflight warnings. The review also found the current three-level taxonomy insufficiently
+mature — "guarded" vs "protected" are near-synonyms that don't communicate the operational
+axis (local-only vs external copies). These findings led to the revised design below.
+
 ## Decision
 
-### Four promise levels
+### Named levels are opaque
+
+When `protection_level` is set to a named level, the level's derived parameters are the
+final values. There are no per-field overrides. The level is a sealed policy — the user
+trusts Urd to deliver it.
+
+If the user needs different parameters from what a named level provides, they omit
+`protection_level` and specify all values explicitly (custom policy). There is no middle
+ground. This eliminates the override resolution complexity, the voiding/weakening
+distinction, and preflight warnings from intentional deviations.
+
+### Custom is first-class
+
+`Custom` is not a fallback or inferior mode. It means the operator owns the full policy.
+No code path treats it as lesser. It is the appropriate — and currently recommended —
+choice when named levels haven't earned their keep through operational evidence.
+
+### Current taxonomy (provisional)
+
+The current named levels are:
 
 ```rust
 pub enum ProtectionLevel {
     Guarded,    // Local snapshots only. For: temp data, caches, build artifacts.
     Protected,  // Local + at least one external drive current. For: documents, photos.
     Resilient,  // Local + multiple external drives current. For: irreplaceable data.
-    Custom,     // User manages all parameters manually. Default for migration.
+    Custom,     // User manages all parameters manually.
 }
 ```
 
-No `archival` level. Retention depth is orthogonal to protection freshness — a subvolume can
-be `protected` (current copies exist) and have deep retention (keep monthly snapshots
-indefinitely). Conflating them creates confusing semantics. If archival becomes needed, it
-should be a separate `retention_profile`.
+**This taxonomy is provisional.** The design review identified that:
+
+- "Guarded" and "protected" are near-synonyms that don't communicate the actual
+  operational difference (local-only vs external copies).
+- "Protected" and "resilient" are operationally identical except for `min_external_drives`.
+  This may be insufficient to justify two distinct opaque levels.
+- Level names should communicate operational meaning to the user — the naming axis should
+  make the promise legible without reading documentation.
+
+The taxonomy will be reworked in a future design session once more operational experience
+exists. Until then, `custom` with explicit parameters is the recommended approach for
+production configs.
 
 ### Outcome targets per level
 
@@ -59,12 +95,12 @@ frequencies. These targets are primary policy, defensible independent of awarene
 ### Pure derivation function
 
 ```rust
-pub fn derive_policy(level: ProtectionLevel, run_frequency: RunFrequency) -> DerivedPolicy
+pub fn derive_policy(level: ProtectionLevel, run_frequency: RunFrequency) -> Option<DerivedPolicy>
 ```
 
 This is a pure function (ADR-108) that maps a promise level + run frequency to concrete
 operational parameters: snapshot_interval, send_interval, send_enabled, local_retention,
-external_retention, min_external_drives.
+external_retention, min_external_drives. Returns `None` for `Custom`.
 
 Run frequency is an explicit config field, not inferred:
 
@@ -75,37 +111,36 @@ pub enum RunFrequency {
 }
 ```
 
-### Config schema
+### Config interaction
+
+Named levels produce all operational parameters. The subvolume config for a named level
+contains only identity and the level itself:
 
 ```toml
-[general]
-run_frequency = "daily"
-
 [[subvolumes]]
 name = "subvol3-opptak"
+source = "/mnt/btrfs-pool/subvol3-opptak"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
 protection_level = "resilient"
-drives = ["WD-18TB"]  # Which drives serve this promise
-
-[[subvolumes]]
-name = "subvol6-tmp"
-# No protection_level -> implicit "custom"
-snapshot_interval = "1d"
-send_enabled = false
+drives = ["WD-18TB", "WD-18TB1"]
 ```
 
-### Override resolution
+Operational fields (`snapshot_interval`, `send_interval`, `local_retention`,
+`external_retention`) are **not permitted** alongside a named protection level. If present,
+config validation rejects the file as a structural error (ADR-111). This is the enforcement
+mechanism for opacity.
 
-When `protection_level` is set, the promise derives default values. Explicit overrides replace
-the derived values. The preflight module warns when overrides weaken or void the promise.
+For custom policies, all operational fields are specified explicitly:
 
-**Voiding overrides** (structurally incompatible — status shows degradation marker):
-- `send_enabled = false` on `protected` or `resilient`
-- `drives = []` on levels requiring external copies
-
-**Weakening overrides** (warning in preflight, status shows promise level normally):
-- `snapshot_interval` longer than derived
-- `send_interval` longer than derived
-- `local_retention` tighter than derived
+```toml
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+snapshot_interval = "1w"
+send_enabled = false
+local_retention = { daily = 3, weekly = 2 }
+```
 
 ### Transition safety
 
@@ -115,67 +150,91 @@ if the derived retention is tighter than the previous explicit retention. Mitiga
 Without it, backups proceed but retention is skipped for affected subvolumes (fail open,
 ADR-107).
 
-### Migration path
-
-Zero breaking changes. Every existing config continues to work identically:
-
-1. No `protection_level` field -> implicit `custom`
-2. `custom` means: user's explicit values, same resolution as today
-3. No `drives` field on subvolume -> send to all drives (current behavior)
-4. No `run_frequency` field -> default `daily` (24h timer)
-
-Property test required: for all configs without `protection_level`, the new resolution path
-must produce byte-identical output to the current `SubvolumeConfig::resolved()`.
-
 ### Achievability validation
 
 A promise is achievable if the derived policy can be fulfilled given run frequency, drive
-topology, and retention alignment. Achievability is checked by the preflight module — advisory
-(warnings), not blocking (errors). ADR-107: fail open.
+topology, and retention alignment. Achievability has two tiers:
 
-### Subvolume-to-drive mapping
+**Structural unachievability (hard error — refuse to start):** The config makes it
+impossible to fulfill the promise. Examples: a `resilient` subvolume with only 1 drive
+in its `drives` list (needs 2), or a named level with `drives` omitted when the level
+requires external sends. These are authoring mistakes, not runtime conditions — the
+config is wrong. Caught by `Config::validate()` (ADR-109, ADR-111).
 
-New optional `drives` field on subvolume config. `None` = send to all drives (current
-behavior). `Some(["WD-18TB"])` = send only to listed drives. Validated against configured
-drives at config load time.
+**Runtime unachievability (advisory warning — fail open):** The config is correct but the
+world isn't ready. Examples: a drive is configured but not mounted, or a filesystem is
+temporarily below `min_free_bytes`. The backup runs what it can and reports what was
+skipped (ADR-107, ADR-111 structural vs runtime distinction).
+
+## Maturity Model
+
+Named levels earn opaque status through a two-phase trajectory:
+
+### Phase 1: Custom-first (current)
+
+Custom is the recommended default. Named levels exist in the codebase but are understood
+to be provisional. Templates based on named level parameters help operators scaffold
+custom configs — the template is guidance, the resulting custom config is the policy.
+
+### Phase 2: Named levels graduate
+
+A named level graduates to production-ready opaque status when it has:
+
+1. **Operational track record** — run as a template-based custom policy in production for
+   a meaningful period without the operator needing to intervene or override.
+2. **Distinct operational identity** — parameters that are meaningfully different from
+   every other level. If two levels are identical except for one field, they may not
+   justify separate names.
+3. **Self-explanatory name** — the operator can infer what the level does from its name
+   without reading documentation. The naming axis should communicate operational meaning
+   (where copies exist, what failures the data survives).
+4. **ADR documentation** — rationale for the level's specific parameter choices, grounded
+   in operational evidence from Phase 1.
+
+Design completeness alone (tests, docs, ADR) is necessary but insufficient. Graduation
+requires data and operational understanding — you can't design a battle-tested level at a
+desk.
 
 ## Consequences
 
 ### Positive
 
 - Users express intent, not operations — "protect my recordings" instead of interval math
-- Config validation catches unachievable promises at load time
+- No override complexity — levels are sealed, custom is explicit
+- Config validation catches structural errors (operational fields mixed with named levels)
 - Status output answers "is my data safe?" in promise-level terms
 - The awareness model is completely unchanged — promises affect inputs, not evaluation
-- Zero migration burden for existing users
+- The maturity model prevents premature promotion of untested levels
 
 ### Negative
 
-- Config resolution has two paths (`custom` vs named level) — must be tested for equivalence
-- Override interactions create a combinatorial space for preflight warnings
-- `--confirm-retention-change` is a speed bump for legitimate config changes
+- Operators cannot make small adjustments to named levels — they must go fully custom for
+  any deviation. Templates mitigate this by providing a starting point.
+- The provisional taxonomy means named levels are not yet recommended for production use.
+  This is honest but means the promise model's full value is deferred.
+- Taxonomy rework will require a config schema version bump and `urd migrate` (ADR-111).
 
 ### Risks
 
 - **Retroactive deletion on level change** — mitigated by `--confirm-retention-change` flag
-  and fail-open retention skip. Two critical safety tests required:
-  `test_promise_derived_retention_preserves_pinned_snapshots` and
-  `test_promise_derived_retention_with_space_pressure_preserves_pins`.
+  and fail-open retention skip.
 - **Promise-derived retention bypassing pin protection** — one bug from silent data loss.
-  The three-layer pin protection (ADR-106) is the safety net. Test required:
-  `test_promise_level_to_retention_decision_pipeline`.
+  The three-layer pin protection (ADR-106) is the safety net.
+- **Permanent deferral** — if graduation criteria are too strict, named levels never mature
+  and custom remains the permanent reality. Mitigation: the criteria are evidence-based
+  (operational track record), not process-based (committee approval).
 
 ## Invariants
 
-1. **Promises derive operations; they don't bypass the planner.** Config resolution happens
+1. **Named levels are opaque.** When set, derived parameters are final. No overrides.
+   Operational fields alongside a named level are a config validation error. (ADR-111)
+2. **Custom is first-class.** No code path treats it as inferior. It means "the operator's
+   config is the policy." (ADR-111)
+3. **Promises derive operations; they don't bypass the planner.** Config resolution happens
    before the planner runs. The planner receives `ResolvedSubvolume` with concrete values,
    never `ProtectionLevel`. (ADR-100)
-2. **`custom` is first-class.** No code path treats it as inferior. It means "the user's
-   config is the policy." (ADR-109)
-3. **Promise derivation is a pure function.** `derive_policy()` has no I/O, no state, no
+4. **Promise derivation is a pure function.** `derive_policy()` has no I/O, no state, no
    side effects. (ADR-108)
-4. **Existing configs don't break.** All new fields are optional with backward-compatible
-   defaults. No migration script needed. (ADR-105)
 5. **Achievability is advisory, not blocking.** Warnings, not errors. The user may be in
    transition. (ADR-107)
 6. **The awareness model is unchanged.** Promise levels affect what intervals are configured,
@@ -187,8 +246,8 @@ This ADR is considered implemented when:
 
 - [ ] `ProtectionLevel` enum and `derive_policy()` exist in `types.rs`
 - [ ] `protection_level`, `drives`, `run_frequency` config fields are parsed and validated
+- [ ] Config validation rejects operational fields alongside named protection levels
 - [ ] `resolve_subvolume()` branches on protection level with custom fallthrough
-- [ ] Migration identity property test passes
 - [ ] Achievability preflight checks are active
 - [ ] `--confirm-retention-change` flag gates retention tightening
 - [ ] `urd status` shows promise level column
@@ -196,6 +255,8 @@ This ADR is considered implemented when:
 
 ## Related
 
+- ADR-111: Config system architecture (governs config structure, versioning, validation)
 - Design: `docs/95-ideas/2026-03-26-design-protection-promises.md`
 - Design review: `docs/99-reports/2026-03-26-protection-promises-design-review.md`
+- Config design review: `docs/98-journals/2026-03-27-config-design-review.md`
 - Test strategy review: `docs/99-reports/2026-03-26-test-strategy-review.md`

--- a/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
+++ b/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
@@ -1,0 +1,296 @@
+# ADR-111: Config System Architecture
+
+> **TL;DR:** The config file is a complete, self-describing artifact with no hidden inheritance.
+> Each subvolume block contains all its operational parameters. Templates scaffold configs at
+> setup time; they don't govern runtime behavior. Named protection levels are opaque (no
+> overrides) but must earn that status through operational evidence. Until then, custom policies
+> with explicit parameters are the honest default.
+
+**Date:** 2026-03-27
+**Status:** Accepted — not yet implemented (see Implementation Gates)
+**Depends on:** ADR-108 (pure function modules), ADR-109 (config boundary validation)
+**Partially supersedes:** ADR-110 (override semantics replaced; see ADR-110 revision)
+**Modifies:** ADR-103 (defaults inheritance removed), ADR-104 (defaults inheritance removed)
+**Ownership:** This ADR is authoritative for config *structure* — what fields exist, what
+sections the file has, how validation works, how versioning works. ADR-110 is authoritative
+for protection promise *semantics* — what levels mean, how they derive policy, the maturity
+model. Where both ADRs touch the same topic (e.g., "named levels are opaque"), ADR-110
+defines the rule and this ADR references it.
+
+## Context
+
+The config system evolved organically during Urd's development: a `[defaults]` section
+provided fallback values, protection levels derived parameters but allowed overrides, and
+subvolume-to-snapshot-root mapping lived in a separate section. A design review
+(2026-03-27, journal) identified five structural problems:
+
+1. **Two masters.** Protection levels declared intent, but operational overrides could
+   contradict them. A `guarded` subvolume with `snapshot_interval = "1w"` claimed guarded
+   protection while operating below the guarded baseline. Preflight warned every run.
+
+2. **Vestigial `[defaults]`.** All subvolumes had protection levels, so the defaults section
+   never influenced any resolved value. Dead config that implied it was doing something.
+
+3. **Semantic inversion.** Protected subvolumes (no explicit `drives`) sent to all 3 drives.
+   Resilient subvolumes (explicit list) sent to 2. The level names suggested resilient had
+   more redundancy, but the topology was inverted.
+
+4. **Cross-reference fragility.** `[local_snapshots]` mapped subvolume names to snapshot
+   roots. A rename in `[[subvolumes]]` without updating `[local_snapshots]` broke silently.
+
+5. **Over-specified identity.** Three required identifiers per subvolume (`name`,
+   `short_name`, `source`) where two would suffice for most cases.
+
+These problems shared a root cause: the config was a composition of layers (defaults,
+derived values, overrides, cross-references) rather than an explicit artifact.
+
+## Decision
+
+### Principle: config as complete, self-describing artifact
+
+Each section and each subvolume block is readable in isolation. No hidden inheritance,
+no cross-section joins, no implicit defaults that change behavior at a distance. The
+operator reads the config and knows what Urd will do.
+
+### Subvolume identity
+
+Each subvolume block carries all its own identity and location:
+
+```toml
+[[subvolumes]]
+name = "subvol1-docs"                        # Required. On-disk contract (snapshot dirs).
+source = "/mnt/btrfs-pool/subvol1-docs"      # Required. Path to the live subvolume.
+snapshot_root = "/mnt/btrfs-pool/.snapshots"  # Required. Where local snapshots are stored.
+short_name = "docs"                           # Optional. Display/snapshot name. Defaults to name.
+priority = 2                                  # Optional. Execution order. Hardcoded default: 2.
+```
+
+- `name` is a backward-compatibility contract (ADR-105). Snapshot directories on disk are
+  `{snapshot_root}/{name}/{snapshot_name}`. It must be explicit, never derived.
+- `short_name` defaults to `name` when omitted. Only specified when the operator wants a
+  shorter label for snapshots and display.
+- **On-disk roles:** `name` is the directory component: `{snapshot_root}/{name}/` (ADR-105
+  Contract 2). `short_name` is the snapshot name suffix: `YYYYMMDD-HHMM-{short_name}`
+  (ADR-105 Contract 1). Both are backward-compatibility contracts — changing either for an
+  existing subvolume orphans its snapshots.
+- The `[local_snapshots]` section is eliminated. No cross-referencing between sections.
+
+### Space constraints
+
+Free-space thresholds are a filesystem-level concern, not a subvolume property:
+
+```toml
+[[space_constraints]]
+path = "~/.snapshots"
+min_free_bytes = "10GB"
+
+[[space_constraints]]
+path = "/mnt/btrfs-pool/.snapshots"
+min_free_bytes = "50GB"
+```
+
+When free space on a snapshot root's filesystem drops below its threshold, Urd skips
+snapshot creation on that root. This prevents filesystem exhaustion and congestion — a
+first-class safety mechanism, not a subvolume-level detail.
+
+### No `[defaults]` section
+
+The `[defaults]` section is removed. Subvolume parameters come from one of two sources:
+
+1. **Named protection level** — opaque, all parameters derived (see ADR-110 revision).
+2. **Explicit values** — the operator specifies all parameters directly (custom policy).
+
+When a custom subvolume omits a field, hardcoded fallbacks in the binary provide sensible
+values. These are documented but not user-editable at runtime. The config file is the
+primary artifact; hardcoded fallbacks are a safety net, not a configuration mechanism.
+
+### Templates as scaffolding
+
+Templates generate complete config blocks at setup time (e.g., via `urd init`). The
+resulting config is self-contained — changes to templates don't affect existing configs.
+Templates are a development-time tool, not a runtime inheritance layer.
+
+### Named levels are opaque
+
+Named protection levels are opaque sealed policies (ADR-110 is authoritative for this rule).
+When `protection_level` is set to a named level, operational fields (`snapshot_interval`,
+`send_interval`, `local_retention`, `external_retention`) are **not permitted** — config
+validation rejects them as structural errors. The level derives all operational parameters.
+
+See ADR-110 for the maturity model governing when named levels become available.
+
+### Explicit drive routing
+
+Every subvolume that sends externally must name its target drives:
+
+```toml
+[[subvolumes]]
+name = "subvol3-opptak"
+drives = ["WD-18TB", "WD-18TB1"]
+```
+
+If `drives` is omitted, no external sends occur (regardless of `send_enabled`). There is
+no implicit "send to all drives" behavior. This prevents the semantic inversion where
+unnamed drive lists produce more redundancy than explicitly listed ones.
+
+Long-term trajectory: intent-based routing where the planner resolves the mapping from
+protection level + drive topology. Explicit lists are the honest foundation that makes
+this possible later.
+
+### `send_enabled` as pause button
+
+The `drives` list defines *where* to send. `send_enabled` controls *whether* to send.
+Setting it to `false` pauses external sends without losing the drive configuration — the
+operator can resume by flipping one field.
+
+**Resolution rules:** `send_enabled` is `Option<bool>` in the parsed config. During config
+resolution: `Some(true)` or `Some(false)` = explicit operator choice. `None` = derived as
+`true` if `drives` is non-empty, `false` otherwise. `send_enabled` is only meaningful when
+`drives` is non-empty — without drives, no sends occur regardless of `send_enabled`.
+Specifying `send_enabled` without `drives` is not a validation error, just irrelevant.
+
+Templates don't include `send_enabled`. It only appears in the config when the operator
+actively uses it as a pause mechanism.
+
+### Structural vs runtime validation
+
+Config validation distinguishes two error categories (extends ADR-109):
+
+**Hard errors (refuse to start):**
+- TOML syntax errors, missing required fields, invalid types
+- Structural contradictions (drive name in `drives` that doesn't exist in `[[drives]]`)
+- Config version mismatch (see versioning below)
+
+**Soft errors (run what you can, report clearly):**
+- Drive not mounted — skip sends to that drive
+- Filesystem below `min_free_bytes` — skip snapshots on that root
+- Source path doesn't exist — skip that subvolume
+
+The executor produces a structured run result describing what succeeded, what was skipped,
+and why. This feeds into heartbeat, metrics, and status output. The principle: validate
+structure at load time, isolate failures at runtime, always produce a structured result
+that makes partial outcomes legible.
+
+### Config versioning
+
+The config file carries a version field:
+
+```toml
+[general]
+config_version = 1
+```
+
+Urd only reads the current schema version. An older version produces a clear error
+directing the operator to run `urd migrate`. The `migrate` command transforms old configs
+to the current schema. No runtime support for old versions — one schema version at a time.
+
+This keeps the config parser clean (one code path, not accumulated version branches) at
+the cost of requiring the operator to run `migrate` after updates that change the schema.
+The trade-off is appropriate: Urd is in active development with a hands-on operator, and
+existing snapshots provide the safety net.
+
+Note: this versioning applies to the config schema only. On-disk data formats (snapshot
+names, pin files, metrics) follow ADR-105's backward compatibility contracts separately.
+
+### Format
+
+TOML. Standard in the Rust ecosystem, human-editable, explicit typing, supports comments.
+No reason to change.
+
+## Consequences
+
+### Positive
+
+- The operator reads one subvolume block and knows everything about it — no mental joins
+- `[defaults]` removal eliminates action-at-a-distance config changes
+- Explicit drive lists prevent semantic inversions in redundancy topology
+- Structural/runtime error split means config mistakes are caught early while transient
+  conditions don't block healthy operations
+- One schema version keeps the parser clean
+
+### Negative
+
+- More verbose configs — each custom subvolume must specify all parameters rather than
+  inheriting from defaults. Templates mitigate this at setup time.
+- Removing `[local_snapshots]` means `snapshot_root` is repeated for subvolumes sharing
+  a root. This is intentional — repetition in config is preferable to cross-referencing.
+- Strict versioning means the operator must run `urd migrate` after schema-changing
+  updates. A stale config prevents backups until migrated.
+
+### Constraints
+
+- New config fields that become path components or command arguments must be added to
+  `Config::validate()` (ADR-109).
+- `name` is an on-disk contract — it must never be derived or defaulted (ADR-105).
+- Schema changes require incrementing `config_version` and updating `urd migrate`.
+- Hardcoded fallback values must be documented in `urd --help` or `urd config show`.
+
+## Implementation Gates
+
+This ADR describes a **target architecture**. The current implementation uses the legacy
+config schema. This ADR is considered implemented when:
+
+- [ ] `config_version` field added to `[general]`; parser checks version before proceeding
+- [ ] `urd migrate` command transforms old config schema to current version
+- [ ] `snapshot_root` field added to `[[subvolumes]]`; subvolume block is self-describing
+- [ ] `[local_snapshots]` section eliminated; `snapshot_root_for()` reads from subvolume config
+- [ ] `[[space_constraints]]` section added; `min_free_bytes` checked per filesystem path
+- [ ] `[defaults]` section removed; custom subvolumes specify all parameters or use hardcoded
+      fallbacks
+- [ ] `short_name` made optional with default-to-`name` behavior
+- [ ] Config validation rejects operational fields alongside named protection levels (ADR-110)
+- [ ] `send_enabled` resolved as `Option<bool>` per resolution rules above
+- [ ] Existing tests updated to use new config schema
+- [ ] Hardcoded fallback values documented in `urd --help` or `urd config show`
+
+### Required vs optional fields for custom subvolumes
+
+| Field | Required? | Hardcoded fallback |
+|-------|-----------|-------------------|
+| `name` | Required | — |
+| `source` | Required | — |
+| `snapshot_root` | Required | — |
+| `short_name` | Optional | Defaults to `name` |
+| `priority` | Optional | `2` |
+| `snapshot_interval` | Optional | `1d` |
+| `send_interval` | Optional | `1d` |
+| `send_enabled` | Optional | `true` if `drives` non-empty, `false` otherwise |
+| `local_retention` | Optional | `{ daily = 7, weekly = 4 }` |
+| `external_retention` | Optional | `{ daily = 30, weekly = 26 }` |
+| `drives` | Optional | `[]` (no external sends) |
+
+For named protection levels, only identity fields (`name`, `source`, `snapshot_root`,
+`short_name`, `priority`) and `drives` are permitted. All operational fields are derived.
+
+## Principles
+
+These govern future config system decisions:
+
+1. **Named levels are opaque or they don't exist.** No overrides, no weakening, no partial
+   application. If not mature enough to be sealed, use templates instead.
+2. **Custom is first-class, not a fallback.** The operator owns the policy. It's the
+   appropriate choice when named levels haven't earned their keep.
+3. **Config files are complete, self-describing artifacts.** Each block readable in
+   isolation. No hidden inheritance, no cross-section joins.
+4. **Templates scaffold; they don't govern.** One-time generation, not runtime inheritance.
+5. **Graduation requires operational evidence.** Named levels earn opaque status through
+   production track record, not design documents alone.
+6. **Validate structure at load time; isolate failures at runtime.** Authoring mistakes are
+   hard errors. World-state problems are per-unit soft errors.
+7. **Always produce structured results.** Every run produces a data object describing
+   outcomes. Foundation for all feedback surfaces.
+8. **Precision in config, voice in presentation.** Config is mechanical and explicit. The
+   mythic voice belongs in the presentation layer.
+9. **One schema version at a time.** `urd migrate` handles transitions. Tidiness over
+   grace periods.
+10. **Space constraints are a filesystem concern.** Free-space thresholds on paths, not on
+    subvolumes. A first-class safety mechanism.
+
+## Related
+
+- ADR-103: Interval scheduling (defaults inheritance removed)
+- ADR-104: Graduated retention (defaults inheritance removed)
+- ADR-105: Backward compatibility (scoped to data formats, not config schema)
+- ADR-109: Config boundary validation (extended with structural/runtime distinction)
+- ADR-110: Protection promises (override semantics superseded; maturity model added)
+- Journal: `docs/98-journals/2026-03-27-config-design-review.md` — full design discussion

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -14,7 +14,48 @@ cutover — a conscious risk decision documented in
 
 **318 tests. All pass. Clippy clean.**
 
-### Recent development (2026-03-27, session 3)
+### Recent development (2026-03-27, session 4)
+
+**Config system design review.** Systematic review of the configuration system through 11
+design questions. Identified five structural problems (two-masters override semantics,
+vestigial defaults, semantic inversion in drive routing, cross-reference fragility,
+over-specified identity) and established 10 design principles.
+[Journal](../98-journals/2026-03-27-config-design-review.md)
+
+Key decisions:
+- Named protection levels must be opaque (no per-field overrides) — or use `custom`
+- Current taxonomy (guarded/protected/resilient) is provisional, needs rework
+- `custom` with templates is the honest default until levels earn opaque status
+- Config files must be complete, self-describing artifacts (no `[defaults]` inheritance)
+- Templates scaffold configs at setup time; they don't govern runtime behavior
+- Explicit drive routing per subvolume (no implicit "all drives" behavior)
+- Structural config errors are hard failures; runtime conditions are per-unit soft errors
+
+**ADR-111: Config System Architecture** written. Describes the target config schema:
+subvolume carries `snapshot_root`, `[local_snapshots]` eliminated, `[[space_constraints]]`
+as first-class section, `config_version` field with `urd migrate`, required vs optional
+field table for custom subvolumes. Status: Accepted — not yet implemented.
+[ADR-111](../00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md)
+
+**ADR-110 revised.** Override semantics replaced with opaque-only rule. Maturity model
+added (two-phase: custom-first → named levels graduate through operational evidence).
+Achievability split into structural (hard error) and runtime (advisory warning).
+Ownership boundary clarified: ADR-110 owns promise semantics, ADR-111 owns config structure.
+
+**Four ADRs updated** for cross-ADR consistency: ADR-103, ADR-104 (defaults references
+removed), ADR-105 (scoped to on-disk data formats), ADR-109 (structural vs runtime
+error distinction added).
+
+**ADR suite adversary review** — limited review focused on cross-ADR consistency, precision,
+and gaps. 3 significant + 4 moderate findings, all fixed. Key fixes: implementation gates
+added to ADR-111, achievability tightened for opaque levels, `name`/`short_name` on-disk
+roles clarified, `send_enabled`/`drives` interaction specified.
+[Review](../99-reports/2026-03-27-adr-suite-consistency-review.md)
+
+**CLAUDE.md rewritten.** Updated to reflect current module structure (18 modules), all 11
+ADRs, config system transition state, and 10 architectural invariants.
+
+### Earlier development (2026-03-27, session 3)
 
 **Notification dispatcher** (Priority 5a) implemented. `notify.rs` module with
 `compute_notifications()` pure function (heartbeat state transition → notifications),
@@ -246,21 +287,29 @@ filter, added `--output` overwrite protection, removed dead_code allow on `local
 - [x] Path validation (normalize + no `..` + starts_with defense-in-depth)
 - [x] Read-only operation, no sudo needed
 
-**Gate before Priority 4:** ~~Write ADR for protection promises~~ — **COMPLETE (ADR-110).**
+**Gate before Priority 4:** ~~Write ADR for protection promises~~ — **COMPLETE (ADR-110, revised 2026-03-27).**
 - [x] Exact retention/interval derivations for each promise level
-- [x] Config conflict resolution: what if promise + manual intervals both set?
+- [x] ~~Config conflict resolution: what if promise + manual intervals both set?~~ **Superseded:** ADR-110 revision makes named levels opaque — no per-field overrides. Operational fields alongside a named level are a config validation error (ADR-111).
 - [x] Migration path for existing configs (implicit `custom`)
 - [x] Promise validation: "this promise is unachievable given your drive connection pattern"
 - [x] `custom` designed as first-class, not afterthought
 - [x] Timer frequency as input to achievability — `RunFrequency` is explicit input to `derive_policy()`
-- [ ] Drive topology constraints — subvolumes that exceed drive capacity cannot have external promises on those drives (subvol3-opptak at ~3.4TB vs 2TB-backup at ~1.1TB). Not yet implemented — preflight checks cover drive count but not capacity.
+- [ ] Drive topology constraints — subvolumes that exceed drive capacity cannot have external promises on those drives. Not yet implemented — preflight checks cover drive count but not capacity. Better suited for Sentinel (5b).
 - [ ] Awareness threshold mode — thresholds still use fixed multipliers regardless of run frequency. Deferred to Sentinel work.
+- [ ] **Config schema migration (ADR-111)** — target architecture defined but not yet implemented. Current code uses legacy schema (`[defaults]`, `[local_snapshots]`, override merging). Implement incrementally alongside other work; do not rush — taxonomy rework may change the schema again.
+- [ ] **Protection level taxonomy rework** — current names (guarded/protected/resilient) are provisional. Needs operational experience before redesign. Collect data from production runs first.
 
 ### Priority 4: Protection Promises (score: 10) — SUBSTANTIALLY COMPLETE
 
 Config extension: optional `protection_level` per subvolume. Planner derives intervals
-and retention from promise level. Existing operation-focused configs continue to work
-as implicit `custom`. The awareness model (3a) evaluates whether promises are being kept.
+and retention from promise level. `custom` is the recommended default until named levels
+earn opaque status through operational evidence (ADR-110 maturity model). The awareness
+model (3a) evaluates whether promises are being kept.
+
+**Design review (2026-03-27):** Named levels must be opaque (no overrides) or use `custom`.
+Current taxonomy is provisional — names don't communicate operational meaning well enough.
+Config system redesign documented in ADR-111 (target architecture, not yet implemented).
+See [config design review journal](../98-journals/2026-03-27-config-design-review.md).
 
 | # | Feature | Effort | Notes |
 |---|---------|--------|-------|

--- a/docs/99-reports/2026-03-27-adr-suite-consistency-review.md
+++ b/docs/99-reports/2026-03-27-adr-suite-consistency-review.md
@@ -1,0 +1,306 @@
+# ADR Suite Consistency Review
+
+> **TL;DR:** The ADR suite is structurally sound and the foundational ADRs (100-102, 106-108)
+> are excellent. The new ADRs (110, 111) are well-reasoned but contain cross-ADR contradictions,
+> under-specified decisions, and a circular dependency that need targeted fixes. Three findings
+> are significant; the rest are moderate. No catastrophic-proximity issues.
+
+**Date:** 2026-03-27
+**Scope:** All 11 ADRs in `docs/00-foundation/decisions/`, with focus on ADR-110 and ADR-111
+**Reviewer:** Architectural adversary (limited review — cross-ADR consistency, precision, gaps)
+**Base commit:** `e3c1ff2`
+
+## What kills you
+
+For a backup tool running `sudo btrfs`, silent data loss is the catastrophic failure mode. The
+ADR suite's primary job is to prevent it by giving future sessions clear, unambiguous rules.
+
+The foundational ADRs (100, 101, 102, 106) are **excellent** on this front. The three-layer
+defense (ADR-106), filesystem-as-truth (ADR-102), and planner/executor separation (ADR-100) are
+precisely stated, independently testable, and well-connected. A fresh Claude Code session reading
+these would make the right decisions.
+
+The new ADRs (110, 111) are further from the catastrophic failure mode — they govern config
+structure, not deletion logic. But imprecision here can cause a future session to implement
+config resolution incorrectly, which feeds wrong values into the planner, which could affect
+retention decisions. The distance is real but not negligible.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | Decisions are sound; some under-specification in edge cases |
+| 2 | Security | 4 | ADR-109's validation model is solid; new fields need coverage |
+| 3 | Architectural Excellence | 4 | Clean separation of concerns; circular dependency in 110/111 |
+| 4 | Systems Design | 3 | ADR-111 describes a future state without migration path from current |
+
+## Design Tensions
+
+### 1. ADR-110 and ADR-111 have a circular dependency
+
+ADR-110 says `Depends on: ... ADR-111`. ADR-111 says `Partially supersedes: ADR-110`. ADR-110
+also says `Depends on: ADR-109`, and ADR-111 says `Depends on: ADR-109`. Both ADRs define
+overlapping rules about protection level opacity, custom-first policy, and config validation.
+
+This creates ambiguity for a future session: which ADR is authoritative for protection level
+config behavior? If they disagree, which wins?
+
+**Resolution:** ADR-111 should be the authority for config structure (what fields exist, how
+they're validated, what sections the file has). ADR-110 should be the authority for protection
+promise semantics (what levels mean, how they derive policy, the maturity model). Currently
+both ADRs define "named levels are opaque" — this rule should live in one place with the other
+referencing it.
+
+### 2. Aspirational architecture vs current implementation
+
+ADR-111 describes a target config schema (subvolume carries `snapshot_root`, no `[defaults]`,
+no `[local_snapshots]`, `[[space_constraints]]` section, `config_version` field). The current
+codebase implements none of this — it has `[local_snapshots]`, `[defaults]`, no
+`config_version`, and `snapshot_root_for()` based on the old cross-reference model.
+
+The ADR doesn't state whether it describes the *current* or *target* state, or what the
+migration sequence is. A fresh session reading ADR-111 could reasonably try to implement the
+target schema and break the existing config.
+
+**Resolution:** ADR-111 should explicitly mark its status as a target architecture and include
+a migration sequence section, or — if the intent is to implement it now — the implementation
+gates should reflect the full delta from current state.
+
+### 3. Hardcoded fallbacks vs "complete artifact"
+
+ADR-111 principle 3 says configs are "complete, self-describing artifacts." ADR-111 also says
+"when a custom subvolume omits a field, hardcoded fallbacks in the binary provide sensible
+values." These are in tension: a config that relies on hardcoded fallbacks is not self-describing
+— the operator must read docs or run `urd config show` to know what they'll get.
+
+This tension is acknowledged (the fallbacks are called "a safety net, not a configuration
+mechanism") but the boundary is imprecise. Which fields can be omitted? All of them? Only some?
+
+**Resolution:** ADR-111 should specify which fields are required for custom subvolumes and
+which have hardcoded fallbacks. A table would eliminate ambiguity.
+
+## Findings
+
+### Finding 1: ADR-110 config example contradicts ADR-111 drive routing rules (Significant)
+
+ADR-110 shows a custom subvolume example (line 130-140):
+
+```toml
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+snapshot_interval = "1w"
+send_enabled = false
+local_retention = { daily = 3, weekly = 2 }
+```
+
+This custom subvolume has no `drives` field. ADR-111 says "if `drives` is omitted, no external
+sends occur (regardless of `send_enabled`)." But it also has `send_enabled = false`, which is
+redundant if missing `drives` already means no sends.
+
+More importantly: if `send_enabled = false` is the "pause button" (ADR-111), and missing
+`drives` means no sends, then what does `send_enabled = false` *without* `drives` mean? Is it
+a config error? Is it redundant? A future session implementing validation needs to know.
+
+**Consequence:** Ambiguous validation rules lead to inconsistent config rejection/acceptance
+across sessions.
+
+**Fix:** ADR-111 should specify the interaction explicitly: `send_enabled` is only meaningful
+when `drives` is present. Without `drives`, `send_enabled` is ignored (not an error — just
+irrelevant). Add this to the drive routing or `send_enabled` section.
+
+### Finding 2: ADR-104 TOML example still shows `[defaults.local_retention]` (Significant)
+
+ADR-104 lines 27-33 still contain:
+
+```toml
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+```
+
+The prose below (lines 38-41) was updated to reference ADR-111 and say "there is no `[defaults]`
+merge." But the TOML example directly above still uses the `[defaults]` section header. A fresh
+session reading ADR-104 sees a code example showing `[defaults.local_retention]` followed by
+prose saying defaults don't exist.
+
+**Consequence:** A future session implementing retention config may reintroduce `[defaults]`
+because the TOML example shows it.
+
+**Fix:** Change the TOML example to show a standalone retention block or a per-subvolume
+example, with a note that these values are representative of a typical graduated retention
+policy.
+
+### Finding 3: ADR-111 implementation gates are missing (Significant)
+
+ADR-110 has implementation gates (checklist of what "implemented" means). ADR-111 has none.
+For a design ADR of this scope — new config schema, eliminated sections, new `config_version`
+field, new `[[space_constraints]]` section, moved `snapshot_root` field — the absence of
+implementation gates means a future session has no way to determine whether ADR-111 is
+implemented, partially implemented, or not started.
+
+**Consequence:** A future session might assume ADR-111 is implemented (status says "Accepted")
+and write code against the target schema that doesn't match current reality.
+
+**Fix:** Add an implementation gates section to ADR-111 listing the concrete changes needed:
+`config_version` field, `[[space_constraints]]` section, `snapshot_root` on subvolume,
+`[local_snapshots]` removal, `[defaults]` removal, `urd migrate` command, validation of
+operational fields alongside named levels.
+
+### Finding 4: ADR-103 timer time is stale (Moderate)
+
+ADR-103 line 64: "The systemd timer fires at a fixed time (02:00 daily)." The actual timer
+fires at 04:04. This is a minor factual error but in an ADR that's meant to be authoritative.
+Future sessions may use this detail for scheduling assumptions.
+
+**Fix:** Change to a general statement ("The systemd timer fires at a fixed time daily") rather
+than specifying the exact time, which is an operational detail that can change.
+
+### Finding 5: ADR-110 achievability section is under-specified for opaque levels (Moderate)
+
+ADR-110 says achievability is "advisory (warnings), not blocking (errors). ADR-107: fail open."
+But ADR-110 also says named levels are opaque and produce all operational parameters. If
+achievability is just a warning, a `resilient` subvolume with only 1 drive configured would
+run with derived `min_external_drives = 2` and silently fail to meet its promise every run.
+
+For opaque levels where the user trusts Urd to deliver, an unachievable promise shouldn't be
+a quiet warning — it should be a structural error. The fail-open philosophy (ADR-107) governs
+runtime conditions (drive not mounted), not structural impossibilities (only 1 drive configured
+for a 2-drive promise).
+
+**Consequence:** A future session implementing achievability may make it too lenient for
+opaque levels, allowing configs that can never fulfill their promise.
+
+**Fix:** ADR-110 should distinguish: achievability for *named levels* is a **structural
+validation error** (the config is wrong — you promised resilient but only configured 1 drive).
+Achievability for *runtime conditions* (drive configured but not mounted) is a warning
+(ADR-107 fail-open). This aligns with ADR-111's structural vs runtime error distinction.
+
+### Finding 6: ADR-105 `name` contract needs ADR-111 alignment (Moderate)
+
+ADR-105 Contract 2 says: `<snapshot_root>/<subvolume_name>/<snapshot_name>`. ADR-111 introduces
+`short_name` (defaults to `name`) and states `short_name` is used for "display/snapshot name."
+The snapshot naming contract in ADR-105 uses `shortname` in the format
+`YYYYMMDD-HHMM-shortname` (Contract 1).
+
+This means `name` governs the directory path and `short_name` governs the snapshot name within
+that directory. If `short_name` defaults to `name`, the snapshot name contains the full
+subvolume name (e.g., `20260327-0404-subvol1-docs`). The current system uses `short_name` in
+snapshot names (e.g., `20260327-0404-docs`).
+
+The relationship is: `{snapshot_root}/{name}/YYYYMMDD-HHMM-{short_name}`.
+
+ADR-105 doesn't state this dual-name relationship. ADR-111 doesn't clarify which name appears
+where.
+
+**Consequence:** A future session may use `name` in snapshot names or `short_name` in directory
+paths, breaking backward compatibility.
+
+**Fix:** ADR-111 should explicitly state: `name` = directory component (on-disk contract per
+ADR-105 Contract 2). `short_name` = snapshot name suffix (on-disk contract per ADR-105
+Contract 1). Reference both contracts.
+
+### Finding 7: The foundational ADRs are excellent (Commendation)
+
+ADRs 100, 101, 102, 106, 107, and 108 form a remarkably coherent foundation. Specific
+qualities worth preserving:
+
+- **ADR-100** states both what the planner does and what it does NOT do. The negative
+  constraints ("never calls btrfs, writes files, modifies state") are as precise as the
+  positive ones. This is exactly what a future session needs.
+- **ADR-106** defines three independently sufficient layers. The "silent data loss requires
+  all three to fail simultaneously" framing is the right way to communicate defense-in-depth.
+- **ADR-107** names its exception explicitly (clock-skew clamping). ADRs that state their own
+  exceptions are more trustworthy than those that don't.
+- **ADR-108** lists which modules follow the pattern AND which intentionally don't, with
+  reasons. This prevents a future session from over-applying the pattern.
+
+These ADRs demonstrate the quality bar the newer ADRs should match.
+
+### Finding 8: ADR-111 `send_enabled` default behavior is implicit (Moderate)
+
+ADR-111 says `send_enabled` "default is `true` when drives are present." But TOML
+deserialization doesn't condition defaults on other fields. This means the *hardcoded* default
+for `send_enabled` is either always-true or always-false, and the conditional behavior
+("true when drives are present") must be implemented in config resolution logic.
+
+A future session implementing this might set the serde default to `true`, which would mean
+`send_enabled` is `true` even when no drives are listed — contradicting the "pause button"
+semantics.
+
+**Fix:** Clarify that `send_enabled` has no serde default — it is `Option<bool>` in the
+parsed config, resolved during config resolution: `Some(true)` or `Some(false)` = explicit;
+`None` = derived as `true` if `drives` is non-empty, `false` otherwise.
+
+## The Simplicity Question
+
+**What's earning its keep:** The planner/executor separation (ADR-100), BtrfsOps trait
+(ADR-101), filesystem-as-truth (ADR-102), and defense-in-depth (ADR-106) are load-bearing
+and precisely stated. They should not be simplified.
+
+**What could be simpler:** ADR-110 and ADR-111 overlap significantly in their coverage of
+protection levels, config validation, and custom-first policy. The overlap isn't contradictory
+(yet) but it means a future session must read both ADRs and mentally merge them to understand
+the config system. These should have clearer ownership boundaries.
+
+**What's not yet earning its keep:** The 10 principles at the end of ADR-111 partly duplicate
+decisions stated earlier in the same ADR. Principles 1, 2, 6, and 9 are precise enough to
+guide decisions. Principles 3, 4, 7, and 8 are aspirational statements that don't constrain
+behavior — a future session can't use "always produce structured results" to make a concrete
+code decision without more specifics. Consider trimming to the principles that are actionable.
+
+## For the Dev Team
+
+Priority-ordered fixes:
+
+1. **ADR-111: Add implementation gates section.** List every concrete change needed: add
+   `config_version` field, add `[[space_constraints]]` section, move `snapshot_root` to
+   subvolume, remove `[local_snapshots]`, remove `[defaults]`, add `urd migrate`, validate
+   operational fields alongside named levels, specify required vs optional fields for custom
+   subvolumes. Without this, the ADR's "Accepted" status is misleading.
+
+2. **ADR-111: Add current-vs-target state marker.** Either add a note at the top ("This ADR
+   describes the target config architecture. The current implementation uses the legacy schema.
+   See implementation gates for the delta.") or change the status to "Accepted — not yet
+   implemented."
+
+3. **ADR-110: Tighten achievability for opaque levels.** Change "advisory (warnings), not
+   blocking (errors)" to: "For named levels, structural unachievability (insufficient drives
+   configured) is a hard validation error. For runtime conditions (drives configured but not
+   mounted), achievability is advisory (ADR-107 fail-open)."
+
+4. **ADR-104: Fix the TOML example.** Replace `[defaults.local_retention]` with a standalone
+   or per-subvolume example that doesn't reference the removed `[defaults]` section.
+
+5. **ADR-111: Specify `send_enabled` / `drives` interaction.** Add: "`send_enabled` is only
+   meaningful when `drives` is non-empty. When `drives` is omitted or empty, no sends occur
+   regardless of `send_enabled`. `send_enabled` is `Option<bool>` — resolved to `true` when
+   drives are present and not explicitly set to `false`."
+
+6. **ADR-111: Clarify `name` vs `short_name` on-disk roles.** Add: "`name` is the directory
+   component: `{snapshot_root}/{name}/` (ADR-105 Contract 2). `short_name` is the snapshot
+   name suffix: `YYYYMMDD-HHMM-{short_name}` (ADR-105 Contract 1)."
+
+7. **ADR-110/111: Resolve circular dependency.** Add ownership note to each: ADR-111 is
+   authoritative for config *structure* (fields, sections, validation). ADR-110 is authoritative
+   for protection promise *semantics* (what levels mean, derivation function, maturity model).
+   Shared rules (e.g., "named levels are opaque") should be defined in ADR-110 and referenced
+   from ADR-111.
+
+8. **ADR-103: Remove specific timer time.** Change "02:00 daily" to "a fixed daily time" to
+   avoid stale operational details.
+
+## Open Questions
+
+1. **Should ADR-111 have a "Not yet implemented" status?** The ADR convention elsewhere uses
+   "Accepted" to mean the decision is made. But for an ADR that describes a significantly
+   different schema from what exists, the status is ambiguous. Consider adding a "Maturity"
+   field: `Decision: Accepted | Implementation: Pending`.
+
+2. **Are the 10 principles in ADR-111 the right artifact?** If they're meant to guide future
+   sessions, they might be better placed in CLAUDE.md (which is always loaded) rather than in
+   an ADR (which must be explicitly read). The foundational ADRs succeed because their rules
+   are in CLAUDE.md's "Architectural Invariants" section.


### PR DESCRIPTION
## Summary

- **ADR-111 (new):** Config System Architecture — target config schema with self-describing artifacts, no defaults inheritance, explicit drive routing, space constraints, config versioning. Not yet implemented.
- **ADR-110 (revised):** Protection promises reworked — opaque levels only (no overrides), maturity model for level graduation, provisional taxonomy, structural vs runtime achievability.
- **ADRs 103, 104, 105, 109 updated** for cross-ADR consistency (removed stale defaults references, scoped backward compat to data formats, added error distinction).
- **ADR suite adversary review:** 3 significant + 4 moderate findings identified and fixed.
- **CLAUDE.md rewritten:** All 18 modules, 10 invariants, config transition state, ADR index.
- **status.md updated** to reflect design decisions and ADR revisions.

Design review journal at `docs/98-journals/2026-03-27-config-design-review.md` (gitignored, local only).

## Testing

- No Rust code changed — documentation only
- cargo clippy: not applicable
- cargo test: not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)