### PR TITLE
feat: Sentinel Session 1 — lock extraction + pure state machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ All backup logic flows through: config -> plan -> execute. No exceptions.
 | `drives.rs` | Detect mounted drives, UUID fingerprinting, check space | Mount/unmount drives |
 | `output.rs` | Define structured output types | Render text (voice.rs does that) |
 | `voice.rs` | Render structured output as text (mythic voice) | Perform I/O or compute state |
+| `lock.rs` | Shared advisory lock with metadata (PID, trigger source) | Decide whether to proceed (caller's job) |
+| `sentinel.rs` | Pure state machine for Sentinel daemon (events, actions, circuit breaker) | Perform I/O (sentinel_runner.rs does that) |
 | `error.rs` | Error types, `translate_btrfs_error()` for actionable messages | Recovery logic |
 | `commands/` | CLI subcommand handlers (wire pure modules to I/O) | Core logic (delegate to above) |
 
@@ -139,7 +141,7 @@ See ADR-111 implementation gates for the migration checklist.
 - Integration tests: `tests/integration/`, `#[ignore]` by default. Run: `cargo test -- --ignored`
 - Use `MockBtrfs` and `MockFileSystemState` for anything that would call btrfs or read filesystem
 - Test retention logic exhaustively — it protects against data loss
-- 318 tests, all passing, clippy clean
+- 366 tests, all passing, clippy clean
 
 ## Backward Compatibility (ADR-105)
 
@@ -170,7 +172,7 @@ stringified — prevents shell injection and preserves non-UTF-8 paths.
 ```bash
 cargo build                          # Debug
 cargo build --release                # Release
-cargo test                           # Unit tests (318 tests)
+cargo test                           # Unit tests (366 tests)
 cargo test -- --ignored              # Integration tests (needs drives)
 cargo clippy -- -D warnings          # Lint (all warnings are errors)
 cargo run -- plan                    # Preview backup plan

--- a/docs/95-ideas/2026-03-27-design-sentinel-implementation.md
+++ b/docs/95-ideas/2026-03-27-design-sentinel-implementation.md
@@ -1,0 +1,711 @@
+# Design: Sentinel Implementation Plan (5b + 5c)
+
+> **TL;DR:** Implementation-ready decomposition of the Sentinel event reactor (5b) and
+> active mode (5c) into five sessions. Resolves the open questions from the reviewed
+> design. Extracts the lock to a shared module, builds the pure state machine first,
+> then layers on I/O. The circuit breaker and trigger logic ship behind a config flag
+> (`active = true` in `[sentinel]`) so passive mode proves itself before active mode
+> goes live.
+
+**Date:** 2026-03-27
+**Status:** proposed
+**Depends on:** 5a notification dispatcher (COMPLETE), ADR-110 (accepted), heartbeat (COMPLETE)
+**Prior design:** [Sentinel design](2026-03-26-design-sentinel.md) (reviewed, all findings addressed)
+
+## Problem
+
+5a is done: `urd backup` computes promise state transitions and dispatches notifications.
+But between backup runs (04:00 daily), the system is blind. Drives can be plugged or
+unplugged, promises can degrade, and the user gets no feedback until the next morning.
+
+The Sentinel fills this gap as a long-running daemon that:
+- **5b (passive):** Watches for drive mount/unmount, monitors heartbeat staleness,
+  re-assesses promise states on adaptive ticks, and dispatches notifications.
+- **5c (active):** Auto-triggers `urd backup` when a drive mounts or promises degrade,
+  with a circuit breaker to prevent cascade failures.
+
+## Open Questions Resolved
+
+The prior design left five open questions. Resolving them here before implementation:
+
+### OQ1: HTTP dependency for webhooks → `curl` subprocess
+
+**Decision:** Shell out to `curl`, not `ureq`. Rationale:
+- Urd is dependency-light (no async runtime, no HTTP stack). `ureq` adds ~200KB and a
+  new dependency category.
+- `curl` is available on every target Linux system. 5a already uses subprocesses for
+  `notify-send`.
+- Webhook notifications are fire-and-forget with best-effort delivery. Production-grade
+  HTTP error handling isn't needed.
+- If `curl` is missing, the `Webhook` channel fails and `Log` channel catches it.
+- This decision is already implicit in the current `notify.rs` implementation.
+
+### OQ2: Assessment interval → Adaptive (already resolved in review)
+
+Three tiers: all PROTECTED = 15m, any AT RISK = 5m, any UNPROTECTED = 2m.
+No config needed. Implemented as a pure function of current assessments.
+
+### OQ3: Reminder notifications → Defer
+
+**Decision:** No reminder notifications in v1. Rationale:
+- The notification model is state-transition-based: notify on *change*, not duration.
+- Adding duration-based reminders introduces a timer/counter that duplicates the
+  assessment tick's purpose.
+- The `BackupOverdue` notification (based on heartbeat staleness) already covers the
+  "nothing is happening" case.
+- If the user wants periodic reminders, they can poll `urd status` via cron — the
+  Sentinel shouldn't reinvent cron.
+- **Revisit after operational experience with 5b.**
+
+### OQ4: Config reload → Require restart
+
+**Decision:** No SIGHUP config reload in v1. Rationale:
+- Config changes are rare (setup-time, not runtime).
+- Reloading config mid-loop requires re-validating everything, rebuilding resolved
+  subvolumes, and handling partial reload failures. This is a lot of complexity for
+  a feature that saves one `systemctl restart urd-sentinel`.
+- The systemd unit has `Restart=on-failure`. A manual restart is trivial.
+- SIGHUP can be added later without changing the state machine (the runner reloads
+  config before the next tick, the pure state machine doesn't know about config).
+
+### OQ5: Tray icon / Unix socket → Defer
+
+**Decision:** Heartbeat file + sentinel state file are sufficient for v1.
+- Tray icon reads `heartbeat.json` (already available).
+- `urd sentinel status` reads `sentinel-state.json`.
+- A Unix socket adds daemon lifecycle complexity (bind, accept, serialize) for
+  zero user value until a tray icon client exists.
+- **Revisit when/if a tray icon is built.**
+
+## Module Boundaries
+
+### New modules
+
+| Module | Type | Responsibility |
+|--------|------|----------------|
+| `sentinel.rs` | Pure (ADR-108) | State machine types, `sentinel_transition()`, `compute_next_tick()`, `should_trigger_backup()`, circuit breaker logic |
+| `sentinel_runner.rs` | I/O | Event loop, inotify watches, poll fallback, action execution, signal handling |
+| `lock.rs` | I/O (shared) | `acquire_lock()` with metadata, `LockGuard`, `read_lock_info()` |
+| `commands/sentinel.rs` | CLI | `urd sentinel run`, `urd sentinel status` subcommands |
+
+### Modified modules
+
+| Module | Change | Scope |
+|--------|--------|-------|
+| `commands/backup.rs` | Replace private `acquire_lock()` with shared `lock::acquire_lock()`. Add `trigger_source` parameter. | ~15 lines changed |
+| `config.rs` | Add `[sentinel]` config section (optional, backward-compatible) | ~20 lines |
+| `state.rs` | Add `drive_connections` table creation in `init_tables()` and `record_drive_event()` / `last_drive_connection()` | ~40 lines |
+| `cli.rs` | Add `Sentinel` variant to `Commands` enum with `SentinelArgs` | ~15 lines |
+| `main.rs` | Add `mod sentinel; mod sentinel_runner; mod lock;` and dispatch | ~5 lines |
+| `output.rs` | Add `SentinelStatusOutput` struct | ~15 lines |
+| `voice.rs` | Add `render_sentinel_status()` | ~30 lines |
+
+## Config Extension
+
+```toml
+# Optional — Sentinel features work without this section.
+# When absent, defaults to disabled.
+[sentinel]
+# Enable active mode (auto-trigger backups). Default: false.
+# When false, Sentinel only observes and notifies (passive mode).
+active = false
+# Minimum interval between auto-triggered backups. Default: "1h".
+min_trigger_interval = "1h"
+# Maximum consecutive auto-trigger failures before circuit opens. Default: 3.
+max_trigger_failures = 3
+```
+
+**Design decision:** The `[sentinel]` section controls *active mode behavior only*.
+Passive mode (5b) needs no config — it uses existing `[notifications]` config and
+derives assessment intervals from promise states. This means 5b ships with zero
+config changes if the user already has `[notifications]` configured.
+
+## Data Flow
+
+### 5b: Passive mode
+
+```
+                        ┌──────────────┐
+                        │  Event Sources │
+                        │               │
+                        │ • inotify on  │
+                        │   /proc/mounts│
+                        │ • inotify on  │
+                        │   heartbeat   │
+                        │ • poll timer  │
+                        │ • signals     │
+                        └──────┬───────┘
+                               │ raw I/O events
+                               ▼
+                     ┌─────────────────┐
+                     │ SentinelRunner   │
+                     │ (I/O layer)      │
+                     │                  │
+                     │ translate to     │
+                     │ SentinelEvent    │
+                     └────────┬────────┘
+                              │ SentinelEvent
+                              ▼
+                    ┌──────────────────┐
+                    │sentinel_transition│  ← pure function
+                    │(state, event)     │
+                    │→ (state, actions) │
+                    └────────┬─────────┘
+                             │ Vec<SentinelAction>
+                             ▼
+                    ┌──────────────────┐
+                    │ Action Executor   │
+                    │ (in runner)       │
+                    │                   │
+                    │ Assess:           │
+                    │  → awareness::    │
+                    │    assess()       │
+                    │  → compare with   │
+                    │    last_promise_  │
+                    │    states         │
+                    │  → notify::       │
+                    │    dispatch()     │
+                    │  → write sentinel │
+                    │    state file     │
+                    │                   │
+                    │ LogDriveChange:   │
+                    │  → log::info!     │
+                    │                   │
+                    │ RecordDrive:      │
+                    │  → state.rs       │
+                    │    insert         │
+                    └──────────────────┘
+```
+
+### 5c: Active mode (extends 5b)
+
+```
+sentinel_transition(state, DriveMounted { label })
+    → actions: [Assess, LogDriveChange, RecordDriveConnection]
+
+After Assess completes with new assessments:
+    should_trigger_backup(state, event, config, assessments)
+        → Some(BackupTrigger { reason: DriveMounted, .. })
+
+Runner:
+    → lock::try_acquire_lock()
+    → if acquired: spawn `urd backup --trigger sentinel`
+    → wait for completion (heartbeat inotify)
+    → evaluate result against trigger condition
+    → update circuit breaker
+```
+
+**Key insight:** The Sentinel does NOT import or call backup logic directly. It spawns
+`urd backup` as a subprocess. This maintains the invariant that `urd backup` is the
+single entry point for backup execution. The lock file prevents concurrent runs.
+The Sentinel's trigger is just another way to invoke the same command.
+
+## Session Plan
+
+### Session 1: Lock extraction + State machine (pure)
+
+**Goal:** Extract lock to shared module. Build the pure state machine with full test
+coverage. No I/O, no daemon — just types and functions.
+
+**New files:**
+- `src/lock.rs` — extracted from `backup.rs`, enhanced with metadata
+- `src/sentinel.rs` — pure state machine
+
+**Modified files:**
+- `src/commands/backup.rs` — use `lock::acquire_lock()` instead of private fn
+- `src/main.rs` — add `mod lock; mod sentinel;`
+
+**Lock module (`lock.rs`):**
+```rust
+pub struct LockGuard { /* flock file handle */ }
+pub struct LockInfo { pub pid: u32, pub started: String, pub trigger: String }
+
+pub fn acquire_lock(lock_path: &Path, trigger: &str) -> Result<LockGuard>
+pub fn try_acquire_lock(lock_path: &Path, trigger: &str) -> Result<Option<LockGuard>>
+pub fn read_lock_info(lock_path: &Path) -> Option<LockInfo>
+```
+
+- `acquire_lock()` — blocks on failure with descriptive error (for `urd backup`)
+- `try_acquire_lock()` — returns `None` if held (for Sentinel auto-trigger)
+- Both write PID + timestamp + trigger after acquiring
+- `read_lock_info()` — reads metadata for "who holds the lock?" display
+
+**Sentinel state machine (`sentinel.rs`):**
+```rust
+// Types
+pub enum SentinelEvent { DriveMounted, DriveUnmounted, AssessmentTick, BackupCompleted, Shutdown }
+pub enum SentinelAction { Assess, LogDriveChange, RecordDriveConnection, WriteState, Noop, Exit }
+pub struct SentinelState { mounted_drives, last_assessment, last_promise_states, circuit_breaker }
+pub struct CircuitBreaker { min_interval, last_trigger, failure_count, max_failures, state }
+pub enum CircuitState { Closed, Open, HalfOpen }
+
+// Pure functions
+pub fn sentinel_transition(state: &SentinelState, event: &SentinelEvent) -> (SentinelState, Vec<SentinelAction>)
+pub fn compute_next_tick(assessments: &[SubvolAssessment]) -> Duration
+pub fn should_trigger_backup(state: &SentinelState, event: &SentinelEvent, assessments: &[SubvolAssessment]) -> Option<BackupTrigger>
+pub fn evaluate_trigger_result(circuit: &CircuitBreaker, trigger: &BackupTrigger, result: &TriggerOutcome) -> CircuitBreaker
+
+// Serialization (for sentinel-state.json)
+pub struct SentinelStateFile { /* serializable subset of SentinelState */ }
+```
+
+**Tests (~25):**
+- State machine transitions: 8 tests (one per event type + edge cases)
+- Drive tracking: 3 tests (mount/unmount/duplicate mount)
+- Adaptive tick: 3 tests (all protected, any at-risk, any unprotected)
+- Circuit breaker: 9 tests (close/open/half-open transitions, partial failure, exponential backoff, cap at 24h, manual bypass)
+- Trigger logic: 2 tests (drive mount trigger, promise degradation trigger)
+
+**Effort calibration:** Similar to awareness model (1 new pure module, ~25 tests, one session).
+
+---
+
+### Session 2: I/O runner + CLI scaffolding
+
+**Goal:** Build the event loop that translates real-world events into `SentinelEvent`s
+and executes `SentinelAction`s. Wire up `urd sentinel run` and `urd sentinel status`.
+
+**New files:**
+- `src/sentinel_runner.rs` — I/O event loop
+- `src/commands/sentinel.rs` — CLI handlers
+
+**Modified files:**
+- `src/cli.rs` — add `Sentinel` command with subcommands
+- `src/commands/mod.rs` — add `pub mod sentinel;`
+- `src/main.rs` — add `mod sentinel_runner;`, dispatch sentinel command
+- `src/config.rs` — add `[sentinel]` config section (optional)
+- `src/output.rs` — add `SentinelStatusOutput`
+- `src/voice.rs` — add `render_sentinel_status()`
+
+**Runner architecture:**
+
+The event loop uses `epoll(2)` via `nix::sys::epoll` (already a dependency) to
+multiplex:
+1. `inotify` fd for `/proc/mounts` changes
+2. `inotify` fd for heartbeat file changes
+3. `timerfd` for assessment tick (adaptive interval)
+4. Signal pipe for SIGTERM/SIGINT (via `ctrlc` crate, already a dependency)
+
+```rust
+pub struct SentinelRunner {
+    config: Config,
+    state: SentinelState,
+    // epoll fd
+    epoll_fd: OwnedFd,
+    // inotify fd for /proc/mounts
+    mount_watch: inotify::Inotify,
+    // inotify fd for heartbeat file
+    heartbeat_watch: inotify::Inotify,
+    // timerfd for assessment tick
+    tick_timer: OwnedFd,
+}
+
+impl SentinelRunner {
+    pub fn new(config: Config) -> Result<Self>
+    pub fn run(&mut self) -> Result<()>   // blocks until shutdown
+    fn wait_for_event(&self) -> Result<SentinelEvent>
+    fn execute_actions(&mut self, actions: Vec<SentinelAction>) -> Result<()>
+    fn execute_assess(&mut self) -> Result<()>
+    fn write_state_file(&self) -> Result<()>
+}
+```
+
+**Dependency decision: `inotify` crate vs raw `nix`.**
+
+Use raw `nix::sys::inotify` — it's already available through the `nix` dependency
+(add `"inotify"` to the nix features list). No new crate needed. The API is:
+```rust
+nix::sys::inotify::Inotify::init(InitFlags::IN_NONBLOCK)?;
+inotify.add_watch(path, AddWatchFlags::IN_MODIFY | IN_CLOSE_WRITE)?;
+```
+
+Similarly, use `nix::sys::timerfd` for the adaptive tick timer (add `"time"` feature).
+And `nix::sys::epoll` for multiplexing (add `"event"` feature).
+
+**Nix feature additions:** `"inotify"`, `"time"`, `"event"` added to `nix` in `Cargo.toml`.
+These are feature flags on an existing dependency, not new crates.
+
+**CLI structure:**
+```rust
+// In cli.rs
+Sentinel(SentinelArgs),
+
+pub struct SentinelArgs {
+    #[command(subcommand)]
+    pub action: SentinelAction,
+}
+
+pub enum SentinelAction {
+    /// Start the Sentinel daemon (foreground)
+    Run,
+    /// Show Sentinel status (reads sentinel-state.json)
+    Status,
+}
+```
+
+**Drive detection from /proc/mounts:**
+
+On each inotify event on `/proc/mounts`:
+1. Wait 500ms (LUKS settle debounce)
+2. Read current mounts
+3. For each configured drive, call `drives::drive_availability()`
+4. Compare against `state.mounted_drives`
+5. Emit `DriveMounted` or `DriveUnmounted` for changes
+
+The polling fallback runs every 60 seconds via the same timerfd (second timer) or
+by including a 60s sweep in the main tick logic when no inotify events arrive.
+
+**Sentinel state file (`~/.local/share/urd/sentinel-state.json`):**
+```json
+{
+    "schema_version": 1,
+    "pid": 12345,
+    "started": "2026-03-27T10:00:00",
+    "last_assessment": "2026-03-27T10:15:00",
+    "mounted_drives": ["WD-18TB"],
+    "tick_interval_secs": 900,
+    "events_since_startup": 42,
+    "circuit_breaker": {
+        "state": "closed",
+        "failure_count": 0,
+        "last_trigger": null
+    }
+}
+```
+
+Written atomically (temp + rename, same pattern as heartbeat). Read by
+`urd sentinel status`. Also serves as a "Sentinel is running" indicator —
+if the file exists and PID is alive, the Sentinel is running. `urd backup`
+checks for this to decide whether to defer notification dispatch to the Sentinel.
+
+**5a/5b notification deduplication:**
+
+When the Sentinel is running:
+- `urd backup` writes heartbeat with `notifications_dispatched: false`
+- Sentinel detects heartbeat change via inotify, reads it, dispatches notifications
+  if flag is false, then calls `heartbeat::mark_dispatched()`
+
+Detection: backup.rs checks if sentinel-state.json exists AND the PID within is
+alive (`kill(pid, 0)` or `/proc/{pid}/` exists). If so, skip notification dispatch
+(the Sentinel will handle it). If not, dispatch normally (5a standalone behavior).
+
+```rust
+// In backup.rs
+fn sentinel_is_running(config: &Config) -> bool {
+    // Read sentinel-state.json, check PID is alive
+}
+```
+
+**Tests (~10):**
+- CLI parsing: 2 tests (run, status)
+- State file serialization round-trip: 2 tests
+- Sentinel detection (PID check): 2 tests
+- Voice rendering for sentinel status: 2 tests
+- Config parsing with/without `[sentinel]` section: 2 tests
+
+**Integration tests (~5, #[ignore]):**
+- inotify detects file modification
+- timerfd fires at expected interval
+- Sentinel starts and shuts down on SIGTERM
+- Sentinel survives missing heartbeat file
+- Drive detection matches `drives::drive_availability()`
+
+**Effort calibration:** More complex than awareness model due to I/O and OS integration.
+Comparable to the heartbeat + notification work combined (~1.5 sessions if clean, budget 1 session).
+
+---
+
+### Session 3: Drive connection tracking + integration hardening
+
+**Goal:** Add drive connection history to SQLite, harden the event loop with real-world
+edge cases, wire up the 5a/5b notification deduplication.
+
+**Modified files:**
+- `src/state.rs` — `drive_connections` table, `record_drive_event()`, query functions
+- `src/sentinel_runner.rs` — execute `RecordDriveConnection` actions, handle edge cases
+- `src/commands/backup.rs` — sentinel detection for notification deduplication
+
+**Drive connections table:**
+```sql
+CREATE TABLE IF NOT EXISTS drive_connections (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    drive_label TEXT NOT NULL,
+    event_type TEXT NOT NULL,  -- 'mounted' or 'unmounted'
+    timestamp TEXT NOT NULL,   -- ISO 8601
+    detected_by TEXT NOT NULL  -- 'sentinel', 'backup', 'manual'
+);
+```
+
+**State module additions:**
+```rust
+pub fn record_drive_event(&self, label: &str, event: &str, detected_by: &str) -> Result<()>
+pub fn last_drive_connection(&self, label: &str) -> Result<Option<String>>  // ISO 8601 timestamp
+pub fn drive_connection_count(&self, label: &str, since: &str) -> Result<u32>
+```
+
+**Edge cases to handle:**
+1. Heartbeat file doesn't exist yet (first run) — Sentinel creates inotify watch on
+   the parent directory, re-watches file when it appears
+2. `/proc/mounts` inotify race with LUKS — 500ms debounce already designed; implement
+   and test
+3. Drive label not in config — log and ignore (don't crash)
+4. SQLite open failure — log warning, skip drive recording (ADR-102: SQLite failures
+   don't block operation)
+5. Heartbeat read failure — log warning, skip notification dispatch for this tick
+6. Multiple rapid mount events — debounce: only process if 500ms since last mount event
+
+**Tests (~8):**
+- Drive event recording: 3 tests (mount, unmount, query)
+- Notification deduplication: 3 tests (sentinel running, not running, stale PID)
+- Edge cases: 2 tests (missing heartbeat, unknown drive label)
+
+**Effort calibration:** Low complexity, mostly wiring. Similar to pre-flight checks (~0.5-1 session).
+
+---
+
+### Session 4: Active mode — trigger + circuit breaker
+
+**Goal:** Implement 5c trigger logic and circuit breaker. The Sentinel can now
+auto-trigger `urd backup` when conditions are met.
+
+**Modified files:**
+- `src/sentinel.rs` — `should_trigger_backup()` uses real assessment data, `evaluate_trigger_result()`
+- `src/sentinel_runner.rs` — backup subprocess spawning, result evaluation
+- `src/lock.rs` — `try_acquire_lock()` for non-blocking attempt
+- `src/config.rs` — parse `[sentinel]` active mode fields
+
+**Trigger execution in runner:**
+```rust
+fn execute_trigger(&mut self, trigger: BackupTrigger) -> Result<TriggerOutcome> {
+    // 1. Check circuit breaker allows trigger
+    // 2. try_acquire_lock() — if held, skip (expected during timer overlap)
+    // 3. Spawn: urd backup --trigger sentinel [--subvolume X if scoped]
+    //    Inherit stdout/stderr to journald
+    // 4. Wait for process exit
+    // 5. Read new heartbeat
+    // 6. Evaluate: did the trigger condition improve?
+    // 7. Return TriggerOutcome for circuit breaker update
+}
+```
+
+**Subprocess invocation:**
+```rust
+let status = std::process::Command::new(std::env::current_exe()?)
+    .arg("backup")
+    .arg("--trigger")
+    .arg("sentinel")
+    .status()?;
+```
+
+Wait — `--trigger` is a new flag on `urd backup`. It serves two purposes:
+1. Lock metadata: the lock file says `"trigger": "sentinel"` instead of `"manual"`
+2. Logging: backup log messages note they were Sentinel-triggered
+
+This is a simple string passthrough, not a behavioral change. `urd backup` runs
+identically regardless of trigger source.
+
+**The timer overlap problem:** Sentinel triggers at 03:58, timer fires at 04:00.
+The lock prevents concurrent runs. The timer's `urd backup` gets "Another backup
+is running" and exits with code 4. systemd reports the unit as failed. This is
+cosmetically bad. Mitigation:
+- The Sentinel avoids triggering within 30 minutes of the configured timer time
+  (read from `run_frequency` config). This is a soft heuristic, not a guarantee.
+- Actually, this is over-engineering. The timer unit should have
+  `SuccessExitStatus=4` so that "lock held" exits don't count as failures.
+  Document this in the systemd unit update.
+
+**Circuit breaker update in runner:**
+```rust
+fn handle_trigger_result(&mut self, trigger: &BackupTrigger, outcome: TriggerOutcome) {
+    self.state.circuit_breaker = sentinel::evaluate_trigger_result(
+        &self.state.circuit_breaker,
+        trigger,
+        &outcome,
+    );
+    self.write_state_file(); // persist circuit breaker state
+}
+```
+
+**Config additions:**
+```rust
+#[derive(Debug, Deserialize)]
+pub struct SentinelConfig {
+    #[serde(default)]
+    pub active: bool,
+    #[serde(default = "default_min_trigger_interval")]
+    pub min_trigger_interval: Interval,
+    #[serde(default = "default_max_trigger_failures")]
+    pub max_trigger_failures: u32,
+}
+```
+
+**Tests (~12):**
+- Trigger conditions: 4 tests (drive mount with needs, drive mount without needs,
+  promise degradation, assessment tick does NOT trigger)
+- Circuit breaker integration: 4 tests (trigger allowed, blocked by open circuit,
+  half-open retry, backoff timing)
+- Trigger evaluation: 4 tests (drive send success, drive send failure,
+  partial failure on scheduled run, manual backup doesn't affect circuit)
+
+**Effort calibration:** Similar to protection promises session 1 (~1 session).
+
+---
+
+### Session 5: systemd integration + observability + deployment
+
+**Goal:** Ship it. systemd units, operational documentation, deployment verification.
+
+**New files:**
+- `systemd/urd-sentinel.service` — systemd unit
+- Update `systemd/urd-backup.service` — add `SuccessExitStatus=4`
+
+**Modified files:**
+- `src/commands/sentinel.rs` — flesh out `urd sentinel status` display
+- `src/voice.rs` — `render_sentinel_status()` with mythic voice
+- `src/output.rs` — `SentinelStatusOutput` struct
+
+**`urd sentinel status` output:**
+
+```
+SENTINEL — watching
+
+  Assessment    2m ago (tick: 15m — all promises held)
+  Mounted       WD-18TB (since 2h ago)
+  Circuit       closed (0 failures)
+  Events        42 since startup (3h ago)
+  Active mode   disabled
+```
+
+When not running:
+```
+SENTINEL — not running
+
+  Last seen     3h ago (PID 12345, exited)
+  Use: systemctl --user start urd-sentinel
+```
+
+**systemd unit:**
+```ini
+[Unit]
+Description=Urd Sentinel — backup awareness daemon
+Documentation=man:urd(1)
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=%h/.cargo/bin/urd sentinel run
+Restart=on-failure
+RestartSec=30
+# Same resource limits as backup service
+Nice=19
+IOSchedulingClass=idle
+
+[Install]
+WantedBy=default.target
+```
+
+**Deployment verification tests (manual, in journal):**
+1. Start Sentinel: `systemctl --user start urd-sentinel`
+2. Check status: `urd sentinel status` → shows "watching"
+3. Plug in drive → desktop notification within 30s
+4. Run `urd backup` manually → Sentinel detects heartbeat change, no duplicate notification
+5. `journalctl --user -u urd-sentinel` → clean logs, no errors
+6. `systemctl --user stop urd-sentinel` → clean shutdown
+7. `urd sentinel status` → shows "not running"
+8. `urd backup` → dispatches notifications directly (5a standalone mode)
+
+**Tests (~5):**
+- Voice rendering: 3 tests (running, not running, active mode display)
+- Status output serialization: 2 tests
+
+**Effort calibration:** Low code, mostly integration. ~0.5 session.
+
+## Risk Sequencing
+
+Session 1 (pure state machine) is lowest risk — it's all testable without I/O.
+Session 2 (I/O runner) is highest risk — inotify/epoll/timerfd integration has the
+most unknowns. Session 3 (hardening) follows to catch edge cases exposed by session 2.
+Session 4 (active mode) is highest *consequence* risk (cascade potential), but the
+circuit breaker is already designed and tested in session 1. Session 5 is deployment.
+
+**If session 2 reveals inotify problems:** Fall back to polling-only. The state machine
+doesn't care how events arrive. The runner can use a simple 5-second poll loop instead
+of epoll+inotify. This is less responsive but fully functional.
+
+## New Dependencies
+
+**None.** All OS primitives (`inotify`, `epoll`, `timerfd`) are available through
+`nix` with additional feature flags. No new crates.
+
+```toml
+# Cargo.toml change:
+nix = { version = "0.29", features = ["fs", "inotify", "time", "event", "signal"] }
+```
+
+## Backward Compatibility
+
+### New on-disk artifacts
+
+| Artifact | Path | Contract |
+|----------|------|----------|
+| Lock file | `~/.local/share/urd/urd.db.lock` | Already exists (backup.rs). Gains JSON metadata. |
+| Sentinel state | `~/.local/share/urd/sentinel-state.json` | New. Schema v1. Read by `urd sentinel status`. |
+| Drive connections table | `urd.db` | New SQLite table. No migration needed (CREATE IF NOT EXISTS). |
+
+**ADR needed?** No. The lock file's location is already established. The sentinel state
+file follows the heartbeat pattern (JSON, atomic writes, versioned schema). The SQLite
+table follows ADR-102 (history, not truth). None of these artifacts are consumed by
+external tools with backward-compat expectations.
+
+## Assumptions
+
+1. **`nix` crate's inotify/timerfd/epoll APIs are stable.** Version 0.29 is current.
+   These are thin wrappers around Linux syscalls — low breakage risk.
+2. **Single-machine only.** The flock, inotify, and PID checking all assume local
+   operation. This is already true for all of Urd.
+3. **User-level systemd.** The Sentinel runs as a user service, same as the timer.
+   Sudo for btrfs operations is handled by the spawned `urd backup` subprocess,
+   not the Sentinel itself.
+4. **`/proc/mounts` inotify works on the target system.** The polling fallback
+   handles cases where it doesn't, but the primary path assumes standard Linux.
+
+## Effort Summary
+
+| Session | Focus | New files | Tests | Effort |
+|---------|-------|-----------|-------|--------|
+| 1 | Lock + state machine (pure) | `lock.rs`, `sentinel.rs` | ~25 | 1 session |
+| 2 | I/O runner + CLI | `sentinel_runner.rs`, `commands/sentinel.rs` | ~15 | 1 session |
+| 3 | Drive tracking + hardening | — | ~8 | 0.5–1 session |
+| 4 | Active mode (trigger + circuit breaker) | — | ~12 | 1 session |
+| 5 | systemd + observability + deploy | systemd unit | ~5 | 0.5 session |
+| **Total** | | **4 new files** | **~65** | **4–4.5 sessions** |
+
+The prior design estimated 4–5 sessions for 5b+5c. This plan comes in at the low end
+because:
+- The lock module is a straightforward extraction
+- The state machine is well-specified from the reviewed design
+- Active mode is a thin extension of the passive event loop
+- No new crate dependencies
+
+## Ready for Review
+
+**For the arch-adversary, focus on:**
+
+1. **The subprocess approach for active mode.** The Sentinel spawns `urd backup` as a
+   child process rather than calling backup logic directly. This maintains separation
+   but adds process coordination complexity. Is this the right trade-off?
+
+2. **Polling fallback granularity.** The design says 60s polling sweep. Is this too
+   slow for drive detection? Too fast for battery? Should it be adaptive too?
+
+3. **Sentinel detection via PID check.** Backup.rs checks if the Sentinel PID (from
+   state file) is alive to decide whether to defer notifications. Race condition:
+   Sentinel crashes between backup reading state file and backup dispatching. Consequence:
+   notifications dispatched by backup AND by next Sentinel startup (if it re-sends for
+   `notifications_dispatched: false`). Is this acceptable?
+
+4. **No config reload.** Is requiring a restart for config changes a real operational
+   burden, or is this the right simplicity trade-off for v1?
+
+5. **`SuccessExitStatus=4` for timer overlap.** Is there a cleaner way to handle the
+   timer/Sentinel near-miss than making exit code 4 "not a failure"?

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -12,9 +12,33 @@ cutover — a conscious risk decision documented in
 [first-night journal](../98-journals/2026-03-25-first-night.md). Monitoring target was
 2026-04-01 (1 week from cutover on 2026-03-25).
 
-**318 tests. All pass. Clippy clean.**
+**366 tests. All pass. Clippy clean.**
 
-### Recent development (2026-03-27, session 4)
+### Recent development (2026-03-27, session 5)
+
+**Sentinel Session 1: Lock extraction + pure state machine.** Built the Sentinel's core
+pure module (`sentinel.rs`) and extracted the backup lock to a shared module (`lock.rs`).
+[Journal](../98-journals/2026-03-27-sentinel-session1.md)
+
+New modules:
+- `lock.rs` — shared advisory lock with `LockGuard`, `LockInfo` metadata (PID, timestamp,
+  trigger source), `acquire_lock()`, `try_acquire_lock()`, `read_lock_info()`. Handles empty,
+  corrupt, and missing lock files gracefully.
+- `sentinel.rs` — pure state machine (ADR-108 pattern). `sentinel_transition()` maps events
+  to actions. Adaptive tick (15m/5m/2m by worst promise status). Circuit breaker with
+  exponential backoff (15m initial, 24h cap). `TriggerPermission` enum for explicit
+  Open→HalfOpen protocol. `should_trigger_backup()` as runner-level decision (not state
+  machine). First-assessment notification suppression.
+
+**Arch-adversary review** found and fixed: `File::create` truncation race in lock acquisition,
+implicit HalfOpen protocol replaced with `TriggerPermission` enum, `LockHeld` no longer
+consumes min_interval cooldown, `DriveMounted` guarded against pre-initial-assessment triggers.
+[Review](../99-reports/2026-03-27-sentinel-session1-review.md)
+
+32 sentinel tests + 8 lock tests. Modified `backup.rs` to use shared lock module (one-line
+change). Session 2 will build the I/O runner with poll loop first (per review recommendation).
+
+### Earlier development (2026-03-27, session 4)
 
 **Config system design review.** Systematic review of the configuration system through 11
 design questions. Identified five structural problems (two-masters override semantics,
@@ -325,15 +349,15 @@ The Sentinel is three independent systems that compose. Build and test them sepa
 | # | Component | Depends On | Notes |
 |---|-----------|------------|-------|
 | 5a | ~~**Notification dispatcher**~~ | ~~Awareness model (3a)~~ | **COMPLETE.** `notify.rs`: `compute_notifications()` pure function, 4 channel types (Desktop/Webhook/Command/Log), urgency filtering. Heartbeat gains `notifications_dispatched` for crash recovery. `[notifications]` config section. Integrated into `backup.rs`. 18 tests. |
-| 5b | **Event reactor** | Awareness model (3a), heartbeat (3b) | udev drive events, timer management. Long-running daemon. Start passive (no auto-trigger). |
-| 5c | **Active mode** | Event reactor (5b) | Auto-trigger backups to meet promises. Circuit breaker (no cascade on error). Lock contention with manual `urd backup` resolved. |
+| 5b | **Event reactor** | Awareness model (3a), heartbeat (3b) | Session 1 complete: pure state machine (`sentinel.rs`), shared lock (`lock.rs`), circuit breaker, adaptive tick. Session 2 next: I/O runner + CLI. [Design](../95-ideas/2026-03-27-design-sentinel-implementation.md) |
+| 5c | **Active mode** | Event reactor (5b) | Auto-trigger logic designed in Session 1: `should_trigger_backup()`, `TriggerPermission`, `evaluate_trigger_result()`. Implementation in Session 4. |
 
 Architectural gates:
 - [x] Awareness model works independently (tested, no Sentinel dependency)
 - [x] Heartbeat works independently (written by `urd backup`, read by Sentinel)
-- [ ] Event/action types defined as enums (testable state machine)
-- [ ] Lock contention with manual `urd backup` designed
-- [ ] Circuit breaker designed (min interval between auto-triggers)
+- [x] Event/action types defined as enums (testable state machine) — `sentinel.rs` Session 1
+- [x] Lock contention with manual `urd backup` designed — `lock.rs` shared module
+- [x] Circuit breaker designed (min interval between auto-triggers) — `CircuitBreaker` with `TriggerPermission`
 - [ ] Passive mode ships and works before active mode is attempted
 - [ ] Sentinel can be killed without affecting promise state computation
 
@@ -537,7 +561,7 @@ timestamp staleness handling, space check deduplication, ANSI line clearing.
 - [x] **Phase 5** — Architectural foundation: awareness model, heartbeat, presentation layer, `urd get`, voice migration (8/8 commands), structured errors
 - [x] **Phase 5 gate** — ADR-110: protection promise design (retention mappings, config conflicts, migration)
 - [x] **Phase 6** — Protection promises: types, derivation, config resolution, preflight checks, planner drive filtering, `--confirm-retention-change`, status display. Config deployed with promises.
-- [ ] **Phase 7** — Sentinel: ~~notification dispatcher~~ (5a done) → event reactor → active mode
+- [ ] **Phase 7** — Sentinel: ~~notification dispatcher~~ (5a done) → ~~state machine + lock~~ (Session 1 done) → I/O runner → active mode
 - [ ] **Phase 8** — Expansion: completions, smart defaults, setup wizard, drive lifecycle
 
 ## Active Work — Operational Cutover
@@ -654,8 +678,9 @@ for the graduation rationale.
 | Vision architecture review | [2026-03-23 Architectural criteria for vision](../99-reports/2026-03-23-vision-architecture-review.md) |
 | Protection promises design | [ADR-110](../00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md) + [Design](../95-ideas/2026-03-26-design-protection-promises.md) |
 | Sentinel design (5a/5b/5c) | [Sentinel design](../95-ideas/2026-03-26-design-sentinel.md) |
+| Sentinel implementation plan (5b+5c) | [Implementation plan](../95-ideas/2026-03-27-design-sentinel-implementation.md) |
 | Session 3 deployment + verification tests | [Session 3 journal](../98-journals/2026-03-27-session3-deployment.md) |
-| Latest adversary review | [2026-03-26 Preflight implementation review](../99-reports/2026-03-26-preflight-implementation-review.md) |
+| Latest adversary review | [Sentinel Session 1 review](../99-reports/2026-03-27-sentinel-session1-review.md) |
 | Code conventions & architecture | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 

--- a/docs/99-reports/2026-03-27-sentinel-implementation-design-review.md
+++ b/docs/99-reports/2026-03-27-sentinel-implementation-design-review.md
@@ -1,0 +1,228 @@
+# Arch-Adversary Review: Sentinel Implementation Plan (5b + 5c)
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-27
+**Scope:** Design proposal — `docs/95-ideas/2026-03-27-design-sentinel-implementation.md`
+**Review type:** Design review (pre-implementation)
+**Prior review:** `docs/99-reports/2026-03-26-sentinel-design-review.md` (addressed all findings)
+**Commit:** 5dedec7 (master)
+**Reviewer:** Claude (arch-adversary)
+
+---
+
+## 1. Executive Summary
+
+The implementation plan is well-sequenced and makes disciplined choices — subprocess spawning for active mode, no new crate dependencies, polling fallback for unreliable inotify. But the design has a structural gap in the Sentinel's `Assess` action: it calls `awareness::assess()` which requires a `&dyn FileSystemState`, which in production requires `RealFileSystemState` which takes an optional `&StateDb` reference. The Sentinel runner will need to hold a `StateDb` connection open for the lifetime of the daemon — that's an open database connection for hours or days. The design doesn't discuss this, and it has implications for lock contention with `urd backup` (which also opens `StateDb`). The circuit breaker and notification deduplication are correctly designed. The session sequencing is sound.
+
+## 2. What Kills You (Catastrophic Failure Proximity)
+
+The catastrophic failure mode for Urd is **silent data loss**. For the Sentinel specifically:
+
+**Cascade-triggering that exhausts disk space** — The circuit breaker design correctly addresses this, including the hardest case (partial failures on `ScheduledRun` count as failures). The catastrophic storage failure history is clearly shaping these decisions. **Distance: 3+ bugs away.** The circuit breaker would need to fail, the min_interval would need to be bypassed, AND space estimation would need to fail. This is well-defended.
+
+**Lock contention preventing legitimate backups** — The subprocess approach makes this safer: the Sentinel never holds the backup lock itself. It only spawns `urd backup`, which acquires and releases the lock normally. The Sentinel can't accidentally hold the lock forever. **Distance: not reachable.** This is a good consequence of the subprocess decision.
+
+**False confidence from a dead Sentinel** — The Sentinel crashes, the state file goes stale, but the user believes it's still watching. `urd backup` then defers notification dispatch because `sentinel_is_running()` reads the stale state file and finds the PID alive (but it's been reassigned to a different process). Notifications are lost. **Distance: 2 bugs away.** This is the closest thing to a live wire in this design.
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4 | Pure state machine is well-bounded. Circuit breaker semantics resolved. The `FileSystemState` lifetime question is a real gap but solvable. |
+| **Security** | 4 | Subprocess spawning avoids giving the Sentinel sudo. No new attack surface beyond what `urd backup` already has. Lock metadata is advisory, not security-critical. |
+| **Architectural Excellence** | 4 | Clean separation of pure state machine from I/O runner. Subprocess approach maintains the single-entry-point invariant for backup execution. Module boundaries are right. One concern: `sentinel.rs` mixes state machine logic and circuit breaker logic — these are independently testable and might warrant separation if the file grows. |
+| **Systems Design** | 3 | Session 2 underestimates the difficulty of epoll+inotify+timerfd multiplexing. The design names the OS primitives but doesn't address the interaction patterns (what if two inotify events arrive in the same epoll_wait? what ordering guarantees exist?). The PID-based Sentinel detection has a known race condition that the design acknowledges but doesn't resolve. |
+
+## 4. Design Tensions
+
+### Tension 1: Subprocess vs. In-Process Backup Triggering
+
+The design spawns `urd backup` as a subprocess for active mode rather than calling `commands::backup::run()` directly. This is the right call for three reasons:
+
+1. **sudo isolation** — the Sentinel runs as a user daemon without special privileges. `urd backup` has its own sudoers configuration for btrfs operations. In-process execution would require the Sentinel to inherit sudo context.
+2. **Single entry point** — all backup execution flows through `urd backup`, regardless of trigger source. Testing, logging, and lock acquisition all use the same code path.
+3. **Crash isolation** — if the backup panics or gets killed by OOM, the Sentinel survives. In-process execution would bring down the entire daemon.
+
+**The cost** is process coordination: the Sentinel must wait for the subprocess, read the heartbeat to evaluate results, and handle cases where the process exits abnormally. But this cost is well-bounded and the benefits clearly outweigh it.
+
+### Tension 2: epoll Complexity vs. Simple Polling
+
+The design proposes epoll+inotify+timerfd multiplexing — three distinct Linux kernel APIs wired together through a fourth. This is the "correct" architecture for a daemon, but it's also the highest-risk session in the plan. The alternative — a simple `loop { sleep(5); check_everything(); }` — is crude but trivially correct and testable.
+
+The design acknowledges this with "If session 2 reveals inotify problems: Fall back to polling-only." This is good risk awareness. But the fallback should be the *starting* implementation, not the contingency. Build the simple poll loop first, prove everything works, then add inotify as an optimization. The state machine doesn't care how events arrive — that's the whole point of the pure/impure separation.
+
+**Recommendation:** Session 2 should implement a poll loop first. inotify+epoll becomes Session 2b or gets folded into Session 3's "hardening" scope. This de-risks the highest-uncertainty session.
+
+### Tension 3: PID-Based Sentinel Detection vs. Explicit Protocol
+
+Backup.rs checks if the Sentinel is running by reading `sentinel-state.json` and verifying the PID is alive. This is a heuristic, not a protocol. The race conditions are real: PID reuse (a different process now has that PID), file staleness (Sentinel wrote the file then crashed, systemd hasn't restarted it yet), and timing (Sentinel is between state file writes when backup checks).
+
+The alternative is explicit coordination: a Unix socket, a shared flag file with flock, or simply making the decision static via config (`sentinel_manages_notifications = true`). The last option is the simplest and has no race conditions — if the user has enabled the Sentinel, backup always defers notifications. The Sentinel is responsible for dispatching even if it was briefly down (it re-sends on startup for `notifications_dispatched: false` heartbeats).
+
+### Tension 4: Drive Connections Table — Consumer-Driven vs. Speculative
+
+The prior review flagged this as "borderline premature." This implementation plan puts it in Session 3 without adding a consumer. The table records events that nothing queries. The counter-argument (cheap to record, expensive to retrofit) is valid *if* the consumer is on the roadmap. It is — drive topology constraints and promise achievability are listed in status.md's Priority 3d gate. But "on the roadmap" and "designed" are different things. The recording side can't be tested end-to-end without the query side.
+
+**Recommendation:** Implement the recording, but add one concrete query to prove the schema works: `urd sentinel status` should show "WD-18TB: last connected 5 days ago" using `last_drive_connection()`. That's a real consumer that exercises the table and provides immediate user value.
+
+## 5. Findings
+
+### Significant
+
+**S1. The Sentinel's `Assess` action requires `FileSystemState`, which requires `StateDb`.**
+
+The `awareness::assess()` function takes `&dyn FileSystemState`. In production, this is `RealFileSystemState<'a>` which holds an `Option<&'a StateDb>`. The Sentinel runner calls `assess()` on every tick (potentially every 2 minutes). This means either:
+
+(a) The runner holds a `StateDb` connection open for the daemon's lifetime, or
+(b) The runner opens and closes `StateDb` on every assess tick.
+
+Option (a) risks SQLite lock contention with `urd backup` (which also opens `StateDb`). SQLite's default locking (journal mode = delete) allows concurrent readers but only one writer. If the Sentinel is reading while backup is writing, that's fine. But if both try to write simultaneously (Sentinel recording drive events, backup recording operations), one will get SQLITE_BUSY.
+
+Option (b) has overhead but avoids contention. Given that assess ticks are at most every 2 minutes and the DB open is <1ms, this is the safer choice.
+
+*Consequence:* If ignored, the Sentinel could intermittently fail to record drive events or (worse) cause `urd backup` to fail a state DB write. Per ADR-102, SQLite failures don't prevent backups, so the blast radius is contained — but it's still a source of spurious warnings.
+
+*Recommendation:* Design decision needed before Session 2. Document that the runner opens `StateDb` per-tick (option b), not on startup. For the `drive_connections` insert (Session 3), use a short-lived connection: open, insert, close. This follows the "SQLite is history, not truth" principle — a failed insert is logged and dropped.
+
+**S2. PID reuse makes `sentinel_is_running()` unreliable for notification deduplication.**
+
+Linux PIDs are reused after a process dies. On a system with moderate process churn, a PID can be reassigned within seconds. The scenario:
+
+1. Sentinel writes `sentinel-state.json` with PID 12345
+2. Sentinel crashes
+3. systemd hasn't restarted it yet (RestartSec=30)
+4. Some unrelated process starts with PID 12345
+5. `urd backup` reads state file, checks `kill(12345, 0)` → alive
+6. Backup defers notification dispatch to a Sentinel that doesn't exist
+7. Notifications are lost for this run
+
+The prior design's `notifications_dispatched` field mitigates this: the *next* Sentinel startup will re-send for `notifications_dispatched: false`. But between the crash and the restart (up to 30 seconds), any backup run loses its notifications.
+
+*Consequence:* Up to one backup run's notifications are lost per Sentinel crash. Not catastrophic, but undermines the "impossible to miss failures" UX principle.
+
+*Recommendation:* Replace PID detection with a **config-driven decision**: add `notifications.dispatch_by = "backup"` (default, current 5a behavior) vs `"sentinel"`. When the user enables the Sentinel, they set `dispatch_by = "sentinel"`. No race condition, no PID checking, no stale state files. The trade-off is that the user must edit config — but they already edit config to enable the Sentinel. This could be a single field on the `[sentinel]` section rather than a separate notifications field: if `[sentinel]` exists and the daemon is meant to be running, backup defers. The "meant to be running" part is a config declaration, not a runtime detection.
+
+**S3. `should_trigger_backup()` needs assessments that the state machine doesn't have.**
+
+The data flow for active mode (5c) has a sequencing problem:
+
+```
+sentinel_transition(state, DriveMounted) → actions: [Assess, LogDriveChange, ...]
+                                                      ↓
+runner.execute_assess() → calls awareness::assess() → gets assessments
+                                                      ↓
+should_trigger_backup(state, event, assessments) → trigger decision
+```
+
+But `should_trigger_backup()` is listed as a pure function in `sentinel.rs` (Session 1), while the assessments it needs are only available after the runner executes the `Assess` action (Session 2+). The function is defined in Session 1 but can't be meaningfully tested until the runner provides real assessments.
+
+More importantly, the trigger decision happens *after* the state machine transition returns. This means the trigger is not part of the state machine — it's a second decision layer in the runner. This is fine architecturally, but the design presents it as if it's part of the pure state machine when it's actually part of the impure runner.
+
+*Recommendation:* Make this explicit in Session 1's scope. `should_trigger_backup()` belongs in `sentinel.rs` as a pure function, but it's not called by `sentinel_transition()` — it's called by the runner after executing the `Assess` action. Tests in Session 1 can exercise it with synthetic assessment data. The design doc should clarify this is a runner-level decision, not a state machine transition.
+
+### Moderate
+
+**M1. Session 2 underestimates epoll+inotify+timerfd complexity.**
+
+The design budgets Session 2 as "1 session" and compares it to "heartbeat + notification work combined." But the I/O multiplexing layer has different complexity characteristics:
+
+- inotify returns *raw event buffers* that must be parsed. Events for different watches arrive in the same buffer.
+- epoll can return multiple ready fds in a single `epoll_wait()` call. The design doesn't discuss event batching or ordering.
+- timerfd needs `TFD_TIMER_ABSTIME` for predictable scheduling. The nix crate's timerfd API has footguns around `TimerSpec` construction.
+- Signal handling via `ctrlc` crate is callback-based, which doesn't compose cleanly with epoll's fd-based model. The design may need `signalfd` instead (another nix feature).
+
+None of these are blockers, but together they represent significantly more syscall-level debugging than any prior Urd session.
+
+*Recommendation:* Either (a) budget Session 2 as 1.5–2 sessions, or (b) start with a poll loop as recommended in Tension 2 and add inotify optimization later. Option (b) is strongly preferred — it lets the Sentinel ship and stabilize with polling while inotify becomes a performance improvement, not a launch blocker.
+
+**M2. Lock file metadata write is not atomic with lock acquisition.**
+
+The design says: "Both write PID + timestamp + trigger after acquiring." But there's a window between acquiring the flock and writing the metadata. If the process crashes in that window, the lock file exists (empty or with stale data) and another process reading `read_lock_info()` gets garbage.
+
+*Consequence:* `urd backup`'s "Another backup is running" message shows wrong or missing metadata. Not dangerous — the lock itself (flock) is correct — but the UX degrades.
+
+*Recommendation:* `read_lock_info()` must handle: empty file, invalid JSON, and valid JSON with a PID that no longer exists. All three should produce a reasonable message: "Another backup may be running (lock held, details unavailable)." This is a test case, not a redesign.
+
+**M3. The design doesn't address Sentinel startup initialization.**
+
+When the Sentinel starts, it needs to:
+1. Scan currently mounted drives (initial `mounted_drives` state)
+2. Read the current heartbeat (to establish `last_promise_states` baseline)
+3. Load persisted circuit breaker state from `sentinel-state.json`
+4. Create inotify watches (which may fail if paths don't exist yet)
+
+If the heartbeat doesn't exist (fresh installation, first run before any backup), `last_promise_states` is empty. The first assessment tick will compute promise states and compare against an empty map — every subvolume will appear to have "transitioned" from nothing to its current state. This triggers spurious notifications on Sentinel startup.
+
+*Consequence:* User gets a flood of notifications every time the Sentinel starts or restarts.
+
+*Recommendation:* On first assessment (when `last_promise_states` is empty), populate the map from the assessment results *without* dispatching notifications. This is the same logic as `compute_notifications(None, current)` — when there's no previous state, don't notify. But the Sentinel's notification path doesn't go through `compute_notifications()` — it compares `last_promise_states` directly. The runner must replicate this "first run = no notifications" logic. Add an explicit test: `test_first_assessment_after_startup_no_notifications`.
+
+**M4. `SuccessExitStatus=4` in the timer unit is fragile.**
+
+The design proposes making exit code 4 a success in the systemd timer unit to handle lock contention. But exit code 4 is currently `urd backup`'s code for "lock held" — it's an application-level convention, not a standard. If any other error path accidentally returns exit code 4, systemd will silently swallow it. And the user must remember to add this to their service unit — it's not in the existing `urd-backup.service`.
+
+*Recommendation:* Instead of `SuccessExitStatus=4`, have `urd backup` distinguish "lock held by Sentinel" (which is expected and fine) from "lock held by unknown" (which might be a real problem). When the lock is held and `read_lock_info()` returns `trigger: "sentinel"`, exit 0 with a message "Backup already in progress (Sentinel-triggered), skipping." When the lock is held by anything else, exit 4 as today. This way, timer+Sentinel overlap produces a clean exit without requiring systemd unit changes.
+
+### Commendation
+
+**C1. Subprocess spawning for active mode is the right call.**
+
+This was the first question in the "Ready for Review" section, and the answer is clearly yes. The design correctly identifies the three benefits (sudo isolation, single entry point, crash isolation) and the costs are bounded. In the prior review, "lock contention preventing legitimate backups" was identified as a catastrophic risk. The subprocess approach eliminates it entirely — the Sentinel never holds the backup lock. This is a design choice that makes an entire failure category unreachable.
+
+**C2. No new crate dependencies.**
+
+Adding `nix` feature flags instead of new crates is disciplined. The project has 12 dependencies (counting Cargo.toml); each new one adds supply chain risk, compile time, and API surface to learn. Using `nix::sys::inotify` instead of the `inotify` crate means one fewer dependency to audit and one fewer API to learn. The `curl` subprocess decision follows the same principle.
+
+**C3. The fallback strategy is honest.**
+
+"If session 2 reveals inotify problems: Fall back to polling-only" is the kind of sentence that makes a design trustworthy. It acknowledges uncertainty without hand-waving. The state machine's indifference to event sources makes this fallback structurally sound, not just aspirational.
+
+**C4. Open questions are genuinely resolved, not deferred with new names.**
+
+The five open questions from the prior design are each resolved with a clear decision and rationale. "Require restart" for config reload is the right v1 choice. "Defer" for tray icon/Unix socket avoids building infrastructure without a consumer. These are the simplicity decisions that keep the project moving.
+
+## 6. The Simplicity Question
+
+> **What could be removed?**
+
+**The `drive_connections` table (Session 3)** has no consumer in this design. The recording infrastructure is ~60 lines of code (schema + insert + queries) that exercises no production code path. If the table is implemented, it should have at least one visible consumer (`urd sentinel status` showing last connection time, as recommended in Tension 4).
+
+**`WriteState` as a separate action** — the state file write happens on every Assess action, and only on Assess actions. It's not a decision the state machine makes; it's a consequence of assessment. The runner can write the state file as part of `execute_assess()` rather than as a separate action. This removes an enum variant and simplifies the transition function.
+
+> **What's earning its keep?**
+
+**The pure state machine** (`sentinel_transition`) is earning its keep. It makes the hardest part of the daemon — "what should happen in response to this event?" — testable without inotify, epoll, or timers. This is the same pattern as the planner/executor separation, which has proven itself across 318 tests.
+
+**The circuit breaker** is earning its keep despite being 5c infrastructure built in Session 1. The partial-failure semantics (evaluate against the trigger condition, not global pass/fail) are the kind of detail that only surfaces in design review and would be a bug in production.
+
+## 7. For the Dev Team (Prioritized Action Items)
+
+1. **Decide on `StateDb` connection lifetime for the Sentinel runner** (S1). Document that the runner opens `StateDb` per-tick, not on startup. This avoids SQLite lock contention with concurrent `urd backup` runs. This is a design decision, not a code change — document it in the implementation plan before Session 2.
+
+2. **Replace PID-based `sentinel_is_running()` with a config-driven approach** (S2). Add `notifications.dispatch_by = "backup" | "sentinel"` (or a field on `[sentinel]` that implies notification ownership). This eliminates the PID reuse race condition. The trade-off (user must edit config) is acceptable because users already edit config to enable the Sentinel.
+
+3. **Start Session 2 with a poll loop, not epoll** (M1, Tension 2). Implement `loop { sleep(adaptive_tick); check_mounts(); check_heartbeat(); }` first. Prove the runner works. Add inotify+epoll as an optimization in Session 3 or later. This de-risks the highest-uncertainty session and lets passive mode ship sooner.
+
+4. **Handle Sentinel startup without spurious notifications** (M3). On first assessment after startup (when `last_promise_states` is empty), populate the map without dispatching. Add test: `test_first_assessment_after_startup_no_notifications`.
+
+5. **Make `should_trigger_backup()` explicitly a runner-level decision** (S3). The function lives in `sentinel.rs` (pure), but it's called by the runner after executing `Assess`, not by `sentinel_transition()`. Clarify this boundary in the design and in code comments. Session 1 tests use synthetic assessment data; Session 4 tests use the full flow.
+
+6. **Handle lock metadata gracefully** (M2). `read_lock_info()` must handle empty file, invalid JSON, and stale PID. Tests: `test_read_lock_info_empty_file`, `test_read_lock_info_corrupt_json`, `test_read_lock_info_dead_pid`.
+
+7. **Use exit code 0 for "lock held by Sentinel"** instead of `SuccessExitStatus=4` (M4). When `read_lock_info()` returns `trigger: "sentinel"`, `urd backup` exits 0 with a message. This avoids fragile systemd unit configuration.
+
+8. **Wire `last_drive_connection()` into `urd sentinel status`** (Tension 4). Gives the `drive_connections` table a real consumer and provides immediate user value.
+
+9. **Consider removing `WriteState` from `SentinelAction` enum** (Simplicity). The state file write is always a consequence of `Assess`, never an independent action. The runner writes it as part of `execute_assess()`.
+
+## 8. Open Questions
+
+1. **SQLite WAL mode.** If both the Sentinel and `urd backup` open `StateDb` (even briefly and non-overlapping), should Urd switch to WAL mode for better concurrent read/write behavior? WAL mode is a one-line change (`PRAGMA journal_mode=WAL`) but changes the on-disk format (`.db-wal` and `.db-shm` files appear). This is a backward-compatibility consideration per ADR-105. Probably the right move, but needs a conscious decision.
+
+2. **Sentinel state file and heartbeat file atomicity.** Both use temp+rename for atomic writes. But the Sentinel reads the heartbeat and writes its own state file. If the Sentinel crashes between reading the heartbeat and acting on it, is there a consistency gap? Specifically: if `urd backup` writes a heartbeat with `notifications_dispatched: false` and the Sentinel reads it but crashes before dispatching, the next Sentinel startup should re-dispatch. Does the current design handle this? (Answer: yes, because on startup the Sentinel reads the heartbeat fresh and dispatches if `notifications_dispatched: false`. But this should be an explicit test.)
+
+3. **What happens if `std::env::current_exe()` fails?** The Sentinel spawns `urd backup` via `current_exe()`. On some Linux systems with non-standard `/proc` configurations, this can return an error. The design should have a fallback (config-specified binary path, or just hardcode `"urd"`).
+
+---
+
+*Review conducted as architectural adversary. Findings reflect design-phase analysis; implementation may resolve or introduce additional concerns.*

--- a/docs/99-reports/2026-03-27-sentinel-session1-review.md
+++ b/docs/99-reports/2026-03-27-sentinel-session1-review.md
@@ -1,0 +1,180 @@
+# Arch-Adversary Review: Sentinel Session 1 — Lock Extraction + Pure State Machine
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-27
+**Scope:** Implementation review — `src/lock.rs` (new), `src/sentinel.rs` (new), `src/commands/backup.rs` (modified), `src/main.rs` (modified)
+**Review type:** Implementation review (post-implementation)
+**Prior review:** `docs/99-reports/2026-03-27-sentinel-implementation-design-review.md`
+**Commit:** uncommitted (working tree on master, 5dedec7)
+**Reviewer:** Claude (arch-adversary)
+
+---
+
+## 1. Executive Summary
+
+This is a clean Session 1 delivery. The lock extraction is correct and the state machine is well-structured. The circuit breaker has one logic gap that will manifest as a surprising behavioral asymmetry in production. The code addresses the prior design review's action items faithfully. The main risk is in lock.rs — a `File::create` call that truncates the lock file before attempting to acquire it, which can destroy metadata that a concurrent reader needs.
+
+## 2. What Kills You (Catastrophic Failure Proximity)
+
+The catastrophic failure mode for Urd is **silent data loss**. For Session 1 specifically:
+
+**Can the Sentinel cause silent data loss?** No. Session 1 contains zero I/O paths to btrfs. The state machine is pure. The lock module wraps existing `flock(2)` behavior that was already in production. The Sentinel's active mode will spawn `urd backup` as a subprocess — it can't delete snapshots directly. **Distance: not reachable from this code.**
+
+**Can the lock extraction break existing backups?** The behavioral change is small: the trigger string changes from absent to `"timer"`, and lock metadata is now written after acquisition. The lock mechanism itself is identical (`Flock::lock` with `LockExclusiveNonblock`). The only risk is the `File::create` truncation issue described in S1 below. **Distance: 2 bugs away** — requires concurrent lock-contention read during the create-truncation window AND the user to make a decision based on the corrupted metadata.
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4 | State machine logic is sound. Circuit breaker has one asymmetry (S2). Lock extraction preserves existing behavior. 30 sentinel tests + 6 lock tests cover the important cases. |
+| **Security** | 5 | No new attack surface. Lock module doesn't touch sudo paths. Sentinel types don't handle external input. No new dependencies. |
+| **Architectural Excellence** | 4 | Clean pure/impure separation. Module boundaries follow established patterns. One concern: `sentinel_transition` clones the entire state on every call — fine now, could matter if state grows. |
+| **Systems Design** | 3 | The `File::create` truncation race (S1) is a real systems-level issue. The circuit breaker's Open→Closed transition has no HalfOpen step (S2), which breaks the standard pattern. |
+| **Rust Idioms** | 4 | Clean use of `BTreeSet`, `#[must_use]`, pattern matching. `chrono::Duration::from_std().unwrap_or(MAX)` is correct defensive coding. One structural concern: `CircuitBreakerConfig` is cloned into `CircuitBreaker` rather than referenced — fine for this size, but unusual. |
+| **Code Quality** | 4 | Well-commented. Tests are readable and cover the stated design cases. Module header comments explain the architecture clearly. |
+
+## 4. Design Tensions
+
+### Tension 1: State cloning vs. mutation in sentinel_transition
+
+`sentinel_transition` takes `&SentinelState` and returns a new `(SentinelState, Vec<SentinelAction>)`. This clones the entire state on every event. The alternative is `&mut SentinelState` with in-place mutation.
+
+The clone approach is the right call for a pure state machine — it makes the function referentially transparent and enables the runner to compare old and new state without manual bookkeeping. The cost (cloning a `BTreeSet<String>` and a `Vec<PromiseSnapshot>`) is negligible for the event frequencies involved (seconds to minutes between events). This only becomes wrong if `SentinelState` grows to contain large data — unlikely given the design.
+
+### Tension 2: `has_promise_changes` vs. reusing `notify::compute_notifications`
+
+The Sentinel has its own promise-change detection (`has_promise_changes`) rather than reusing the existing `notify::compute_notifications()` from 5a. These do related but different things — `compute_notifications` takes heartbeats and produces `Notification` objects, while `has_promise_changes` takes promise snapshots and returns a bool.
+
+This is the right split. The Sentinel's notification path will call `awareness::assess()` directly (not via heartbeat), so it needs its own comparison logic operating on assessments, not heartbeat structs. The two paths converge at `notify::dispatch()`, which is shared. But this means there are now **two independent implementations of "did promise states change?"** — one in `notify::compute_notifications` (heartbeat-based) and one in `sentinel::has_promise_changes` (assessment-based). They must agree. There's no test that exercises both paths with the same scenario to verify they produce consistent results. This is a Session 2 integration concern, not a Session 1 bug.
+
+## 5. Findings
+
+### Significant
+
+**S1. `File::create` in `acquire_lock` and `try_acquire_lock` truncates the lock file before locking.**
+
+```rust
+let file = File::create(lock_path)?;  // ← truncates to zero bytes
+match nix::fcntl::Flock::lock(file, ...) {
+```
+
+`File::create` opens with `O_CREAT | O_WRONLY | O_TRUNC`. The truncation happens *before* the `Flock::lock` call. This means:
+
+1. Process A holds the lock with metadata `{"pid": 100, "trigger": "sentinel"}`
+2. Process B calls `acquire_lock` → `File::create` truncates the file to 0 bytes
+3. Process B calls `Flock::lock` → gets `EWOULDBLOCK`
+4. Process B calls `read_lock_info(lock_path)` → reads the now-empty file → returns `None`
+5. Process B reports "Another urd backup is already running (lock file: ...)" with no metadata
+
+The metadata that Process A wrote is gone. Process A still holds the lock (flock is fd-based, not file-content-based), but any subsequent `read_lock_info` call by anyone will get `None` until Process A rewrites. But Process A never rewrites — it wrote once on acquisition.
+
+*Consequence:* The lock contention error message falls back to the no-metadata format. Not dangerous — the lock still works — but the metadata feature (PID, trigger source, timestamp) is unreliable. Specifically, `urd backup` checking "is the holder the Sentinel?" via `read_lock_info` will get `None` instead of the Sentinel's metadata, breaking the review item M4 logic (exit 0 for Sentinel-held locks).
+
+*Fix:* Use `OpenOptions::new().create(true).read(true).write(true).open(lock_path)` instead of `File::create`. This opens with `O_CREAT | O_RDWR` without `O_TRUNC`. The metadata write (`write_lock_metadata`) already truncates via `ftruncate` after acquiring the lock, so the initial truncation is unnecessary.
+
+**S2. Circuit breaker has no explicit Open→HalfOpen transition — `allows_trigger` silently permits it.**
+
+The standard circuit breaker pattern is: Open → (backoff elapses) → HalfOpen → (trial succeeds) → Closed, or (trial fails) → Open. In this implementation:
+
+- `allows_trigger` returns `true` when Open + backoff elapsed (line 177), but it doesn't transition the state to HalfOpen.
+- `evaluate_trigger_result` checks `circuit.state == CircuitState::HalfOpen` to decide whether to double backoff on failure.
+- The runner must manually set `cb.state = CircuitState::HalfOpen` between calling `allows_trigger` (which says "go ahead") and `evaluate_trigger_result` (which checks the state).
+
+This creates an implicit protocol: the runner must know to set HalfOpen between these two pure function calls. If it doesn't, a failure after an open-circuit backoff elapses will be treated as a closed-circuit failure (incrementing `failure_count` but not doubling backoff), because `evaluate_trigger_result` sees `Closed`, not `HalfOpen`.
+
+The tests work around this by manually setting `cb.state = CircuitState::HalfOpen` (lines 855, 881), which proves the protocol exists but doesn't enforce it.
+
+*Consequence:* If the runner forgets the intermediate HalfOpen set, the circuit breaker's backoff escalation is broken. The breaker still *opens* (failure_count accumulates), but it never doubles the backoff, so it retries every 15 minutes forever instead of backing off to 30m, 1h, 2h, etc.
+
+*Fix:* Either (a) make `allows_trigger` return an enum (`Allowed`, `Blocked`, `HalfOpenTrial`) so the runner knows what state the trigger is in, or (b) add a `prepare_trigger(&mut self, now)` method that transitions Open→HalfOpen and returns whether the trigger is allowed. Option (a) is cleaner and stays pure:
+
+```rust
+pub enum TriggerPermission { Allowed, Blocked, HalfOpenTrial }
+pub fn check_trigger(&self, now: NaiveDateTime) -> TriggerPermission
+```
+
+Then `evaluate_trigger_result` takes `TriggerPermission` instead of checking `circuit.state`.
+
+### Moderate
+
+**M1. `LockHeld` outcome updates `last_trigger` timestamp, which affects min_interval gating.**
+
+```rust
+TriggerOutcome::LockHeld => {
+    // Not a real failure — ... Don't change circuit state or increment failure count.
+}
+```
+
+But `new.last_trigger = Some(trigger.triggered_at)` is set unconditionally at line 432, *before* the match. So a `LockHeld` result still updates `last_trigger`. The next real trigger will be blocked by `min_interval` counting from the LockHeld event, even though no backup actually ran.
+
+Scenario: Sentinel triggers at 10:00, lock is held → LockHeld. Drive unmounts and remounts at 10:15. Sentinel wants to trigger but `min_interval` (1h) blocks it because `last_trigger` is 10:00. The user unplugs the drive at 10:30. No backup was sent.
+
+*Consequence:* `LockHeld` events eat the min_interval cooldown as if a real trigger occurred. This reduces responsiveness after timer/sentinel overlap.
+
+*Fix:* Move `new.last_trigger = Some(trigger.triggered_at)` into the `Success` and `Failure` arms only.
+
+**M2. `should_trigger_backup` for `DriveMounted` doesn't check `has_initial_assessment`.**
+
+The `AssessmentTick` arm correctly returns `None` when `!state.has_initial_assessment`. But the `DriveMounted` arm doesn't check this flag. If a drive mounts before the first assessment completes, the function receives the just-computed assessments and may trigger a backup based on stale-by-default external drive status (every drive starts "unprotected" because no sends exist yet from the Sentinel's perspective).
+
+*Consequence:* On Sentinel startup, if a drive is already mounted, the first `DriveMounted` event could trigger an unnecessary backup before the Sentinel has established baseline state. Not harmful (the backup itself is correct), but wastes resources and could trigger the circuit breaker if the backup "fails" for unrelated reasons.
+
+*Fix:* Add `if !state.has_initial_assessment { return None; }` at the top of `should_trigger_backup`, before the match. Or check it in the `DriveMounted` arm.
+
+**M3. `has_promise_changes` and `has_promise_degradation` are near-duplicates with subtly different semantics.**
+
+Both iterate `previous` vs. `current` assessments. `has_promise_degradation` only checks one direction (current < previous). `has_promise_changes` checks both directions plus added/removed subvolumes. They share no code. If the comparison logic needs to change (e.g., to handle assessment errors), both must be updated independently.
+
+*Consequence:* Maintenance burden. The divergence between "any change" (notification) and "degradation only" (trigger) is a real semantic distinction, but the implementation duplicates the iteration and lookup logic.
+
+*Fix:* Extract the common comparison into a helper that returns a richer result (e.g., `Vec<(name, old_status, new_status)>`), then let each consumer filter. Not urgent — the current code is small enough that duplication is manageable.
+
+### Commendation
+
+**C1. The state machine is genuinely pure and well-tested.**
+
+`sentinel_transition` takes `(&SentinelState, &SentinelEvent)` and returns `(SentinelState, Vec<SentinelAction>)` with no side effects. This follows the same pattern as the planner and awareness model, which have proven their value across 300+ tests. The 30 sentinel tests exercise every event type, drive tracking edge cases, circuit breaker state transitions, and trigger conditions. The `first_assessment_after_startup_no_notifications` test directly validates the prior review's M3 finding.
+
+**C2. Lock extraction is minimal and correct.**
+
+The diff to backup.rs is exactly 6 insertions and 27 deletions. The lock mechanism is identical — same `Flock::lock` call, same `EWOULDBLOCK` handling. The new metadata feature is additive and best-effort (failures don't affect the lock). The `read_lock_info` edge case handling (empty, corrupt, missing) is tested. This is a textbook extraction — same behavior, new capabilities, no regressions.
+
+**C3. The trigger/circuit-breaker separation is clean.**
+
+`should_trigger_backup` decides *whether* to trigger. `evaluate_trigger_result` decides *how the circuit breaker responds*. The runner sits between them. This separation means the trigger logic and the circuit breaker can be tested independently with different scenarios, which the tests demonstrate. The `TriggerOutcome::LockHeld` variant correctly distinguishes "couldn't trigger because of contention" from "triggered and failed", preventing false circuit-breaker opens.
+
+## 6. The Simplicity Question
+
+> **What could be removed?**
+
+**`SentinelStateFile` and `CircuitBreakerState`** are defined but unused. They're serialization types for Session 2's state file. Having them here means they'll need to stay in sync with the actual state types as those evolve. If they drift, the Session 2 author will discover the mismatch only when wiring serialization. Consider removing them until Session 2 and generating them from the actual types then — or add a test that round-trips `SentinelState` → `SentinelStateFile` → fields to catch drift.
+
+**`last_assessment` field on `SentinelState`** is declared but never read (compiler warns). It's intended for the runner to track timing, but `sentinel_transition` doesn't set it (it doesn't know the current time — correct for a pure function). Either remove it from `SentinelState` and let the runner track it separately, or accept that it's runner-managed state that happens to live in the state struct for serialization convenience.
+
+> **What's earning its keep?**
+
+**The adaptive tick function** (`compute_next_tick`) is three lines of pattern matching that encode a real operational insight: poll faster when things are worse. Simple, correct, and the tests document the exact intervals.
+
+**The `has_promise_changes` first-assessment guard** (line 492-494) prevents a known failure mode (spurious notification flood on Sentinel restart) with two lines. Directly traces to a specific review finding.
+
+## 7. For the Dev Team (Prioritized Action Items)
+
+1. **Fix `File::create` truncation in lock.rs** (S1). Replace `File::create(lock_path)` with `OpenOptions::new().create(true).read(true).write(true).open(lock_path)` in both `acquire_lock` and `try_acquire_lock`. This preserves existing metadata during contention. The test `acquire_and_try_acquire_contention` should verify that metadata remains readable after a failed acquire attempt.
+
+2. **Make the HalfOpen transition explicit** (S2). Change `allows_trigger` to return `TriggerPermission { Allowed, Blocked, HalfOpenTrial }`. Update `evaluate_trigger_result` to accept the permission rather than checking `circuit.state`. This eliminates the implicit protocol between the two functions. Update circuit breaker tests to use the new API.
+
+3. **Move `last_trigger` update into Success/Failure arms only** (M1). Line 432 sets `new.last_trigger` unconditionally. Move it into the `Success` and `Failure` match arms so `LockHeld` doesn't consume the min_interval cooldown. Add test: `circuit_lock_held_does_not_consume_min_interval`.
+
+4. **Guard `DriveMounted` trigger against pre-initial-assessment** (M2). Add `has_initial_assessment` check to the `DriveMounted` arm of `should_trigger_backup`. Add test: `no_trigger_on_drive_mount_before_initial_assessment`.
+
+5. **Remove or test `SentinelStateFile`/`CircuitBreakerState`** (Simplicity). Either delete them (Session 2 will create them when needed) or add a round-trip test that catches structural drift.
+
+## 8. Open Questions
+
+1. **Should `lock::acquire_lock` return a richer error for "held by Sentinel" vs. "held by other"?** The current implementation puts the distinction in the error *message* string. Session 2 needs this distinction programmatically (to decide exit code 0 vs. 4). A structured error type (or a separate `is_sentinel_held(lock_path)` function) would be cleaner than string-matching.
+
+2. **Who sets `has_initial_assessment = true`?** The state machine doesn't — it's a pure function that doesn't know which assessment is "first." The runner must set this flag after the first `Assess` action completes. This is implied by the design but not documented in the code. A comment on the field would help the Session 2 implementer.
+
+---
+
+*Review conducted as architectural adversary. Findings reflect implementation-phase analysis of Session 1 artifacts.*

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::fs::File;
 use std::io::IsTerminal;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -14,6 +13,7 @@ use crate::config::Config;
 use crate::drives;
 use crate::executor::{ExecutionResult, Executor, OpResult, RunResult};
 use crate::heartbeat;
+use crate::lock;
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
 use crate::output::{
     BackupSummary, OutputMode, SendSummary, SkippedSubvolume, StatusAssessment, StructuredError,
@@ -82,7 +82,8 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     }
 
     // Acquire advisory lock to prevent concurrent backup runs
-    let _lock = acquire_lock(&config)?;
+    let lock_path = config.general.state_db.with_extension("lock");
+    let _lock = lock::acquire_lock(&lock_path, "timer")?;
 
     if backup_plan.is_empty() && backup_plan.skipped.is_empty() {
         println!("{}", "Nothing to do.".dimmed());
@@ -315,31 +316,6 @@ fn build_backup_summary(
             .map(StatusAssessment::from_assessment)
             .collect(),
         warnings,
-    }
-}
-
-/// Acquire an advisory lock to prevent concurrent backup runs.
-/// Returns the lock file (lock is held until dropped).
-fn acquire_lock(config: &Config) -> anyhow::Result<nix::fcntl::Flock<File>> {
-    let lock_path = config.general.state_db.with_extension("lock");
-
-    if let Some(parent) = lock_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-
-    let file = File::create(&lock_path)?;
-
-    match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
-        Ok(lock) => Ok(lock),
-        Err((_, errno)) if errno == nix::errno::Errno::EWOULDBLOCK => {
-            anyhow::bail!(
-                "Another urd backup is already running (lock file: {})",
-                lock_path.display()
-            );
-        }
-        Err((_, errno)) => {
-            anyhow::bail!("Failed to acquire lock {}: {errno}", lock_path.display());
-        }
     }
 }
 

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,0 +1,254 @@
+// Lock module — shared advisory lock for preventing concurrent backup runs.
+//
+// Extracted from backup.rs to be shared between `urd backup` and the Sentinel.
+// The lock file uses flock(2) for the actual lock and writes JSON metadata
+// (PID, timestamp, trigger source) after acquisition.
+
+use std::fs::{File, OpenOptions};
+use std::io::Read;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Metadata written to the lock file after acquisition.
+/// Read by `read_lock_info()` to display "who holds the lock?" information.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LockInfo {
+    pub pid: u32,
+    pub started: String,
+    pub trigger: String,
+}
+
+/// RAII guard that holds the flock. Lock is released when dropped.
+#[derive(Debug)]
+pub struct LockGuard {
+    _flock: nix::fcntl::Flock<File>,
+}
+
+/// Acquire an exclusive advisory lock, blocking-error on failure.
+///
+/// Used by `urd backup` — if the lock is held, returns an error with
+/// context about who holds it (if readable).
+pub fn acquire_lock(lock_path: &Path, trigger: &str) -> anyhow::Result<LockGuard> {
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // S1 fix: .truncate(false) preserves existing metadata so concurrent
+    // readers see the holder's info during contention.
+    // write_lock_metadata truncates via ftruncate *after* acquiring the lock.
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(lock_path)?;
+
+    match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
+        Ok(flock) => {
+            write_lock_metadata(&flock, trigger);
+            Ok(LockGuard { _flock: flock })
+        }
+        Err((_, errno)) if errno == nix::errno::Errno::EWOULDBLOCK => {
+            let holder = read_lock_info(lock_path);
+            let detail = match holder {
+                Some(info) if info.trigger == "sentinel" => {
+                    format!(
+                        "Backup already in progress (Sentinel-triggered, PID {}, started {})",
+                        info.pid, info.started
+                    )
+                }
+                Some(info) => {
+                    format!(
+                        "Another urd backup is already running (PID {}, trigger: {}, started {})",
+                        info.pid, info.trigger, info.started
+                    )
+                }
+                None => format!(
+                    "Another urd backup is already running (lock file: {})",
+                    lock_path.display()
+                ),
+            };
+            anyhow::bail!("{detail}");
+        }
+        Err((_, errno)) => {
+            anyhow::bail!("Failed to acquire lock {}: {errno}", lock_path.display());
+        }
+    }
+}
+
+/// Try to acquire the lock without blocking. Returns `None` if already held.
+///
+/// Used by the Sentinel for auto-triggered backups — if another backup is
+/// running, the Sentinel simply skips the trigger (expected during timer overlap).
+#[allow(dead_code)] // Used by sentinel_runner (Session 2)
+pub fn try_acquire_lock(lock_path: &Path, trigger: &str) -> anyhow::Result<Option<LockGuard>> {
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    // S1 fix: explicitly .truncate(false) — preserves existing metadata so
+    // concurrent readers see the holder's info during contention.
+    // write_lock_metadata truncates via ftruncate *after* acquiring the lock.
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(lock_path)?;
+
+    match nix::fcntl::Flock::lock(file, nix::fcntl::FlockArg::LockExclusiveNonblock) {
+        Ok(flock) => {
+            write_lock_metadata(&flock, trigger);
+            Ok(Some(LockGuard { _flock: flock }))
+        }
+        Err((_, errno)) if errno == nix::errno::Errno::EWOULDBLOCK => Ok(None),
+        Err((_, errno)) => {
+            anyhow::bail!("Failed to acquire lock {}: {errno}", lock_path.display());
+        }
+    }
+}
+
+/// Read lock metadata from the lock file. Returns `None` if the file doesn't
+/// exist, is empty, or contains invalid JSON.
+///
+/// This reads the metadata only — the actual lock state is determined by flock(2).
+/// A readable LockInfo with a dead PID means the lock was released but the file
+/// wasn't cleaned up (normal — flock releases on close, file persists).
+pub fn read_lock_info(lock_path: &Path) -> Option<LockInfo> {
+    let mut file = File::open(lock_path).ok()?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).ok()?;
+    if contents.is_empty() {
+        return None;
+    }
+    serde_json::from_str(&contents).ok()
+}
+
+/// Write PID + timestamp + trigger to the lock file after acquisition.
+/// Best-effort — failure to write metadata doesn't affect the lock itself.
+fn write_lock_metadata(file: &File, trigger: &str) {
+    let info = LockInfo {
+        pid: std::process::id(),
+        started: chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string(),
+        trigger: trigger.to_string(),
+    };
+    // Write to the same file handle that holds the flock.
+    let Ok(mut writer) = file.try_clone() else {
+        return;
+    };
+    // Truncate and rewrite
+    if nix::unistd::ftruncate(&writer, 0).is_ok() {
+        use std::io::Seek;
+        let _ = writer.seek(std::io::SeekFrom::Start(0));
+        let _ = serde_json::to_writer(&mut writer, &info);
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as IoWrite;
+
+    #[test]
+    fn read_lock_info_valid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        let info = LockInfo {
+            pid: 12345,
+            started: "2026-03-27T10:00:00".to_string(),
+            trigger: "manual".to_string(),
+        };
+        let mut f = File::create(&path).unwrap();
+        serde_json::to_writer(&mut f, &info).unwrap();
+        f.flush().unwrap();
+        drop(f);
+
+        let read = read_lock_info(&path).unwrap();
+        assert_eq!(read.pid, 12345);
+        assert_eq!(read.trigger, "manual");
+    }
+
+    #[test]
+    fn read_lock_info_empty_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        File::create(&path).unwrap();
+
+        assert!(read_lock_info(&path).is_none());
+    }
+
+    #[test]
+    fn read_lock_info_corrupt_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+        let mut f = File::create(&path).unwrap();
+        f.write_all(b"not valid json {{{").unwrap();
+        drop(f);
+
+        assert!(read_lock_info(&path).is_none());
+    }
+
+    #[test]
+    fn read_lock_info_missing_file() {
+        let path = Path::new("/tmp/urd-test-nonexistent-lock-file.lock");
+        assert!(read_lock_info(path).is_none());
+    }
+
+    #[test]
+    fn acquire_and_try_acquire_contention() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let guard = acquire_lock(&path, "test").unwrap();
+
+        // try_acquire should return None (lock held)
+        let try_result = try_acquire_lock(&path, "test2").unwrap();
+        assert!(try_result.is_none());
+
+        // acquire should fail with an error
+        let err = acquire_lock(&path, "test3").unwrap_err();
+        assert!(err.to_string().contains("already running"));
+
+        drop(guard);
+
+        // Now it should succeed
+        let guard2 = try_acquire_lock(&path, "test4").unwrap();
+        assert!(guard2.is_some());
+    }
+
+    #[test]
+    fn metadata_survives_contention() {
+        // S1 fix: a failed acquire must not truncate the holder's metadata.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let _guard = acquire_lock(&path, "sentinel").unwrap();
+
+        // Contending acquire fails — but metadata should still be readable
+        let err = acquire_lock(&path, "other").unwrap_err();
+        assert!(
+            err.to_string().contains("Sentinel-triggered"),
+            "contention error should contain holder's trigger info, got: {}",
+            err
+        );
+
+        // Direct read should also succeed
+        let info = read_lock_info(&path).unwrap();
+        assert_eq!(info.trigger, "sentinel");
+    }
+
+    #[test]
+    fn lock_writes_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.lock");
+
+        let _guard = acquire_lock(&path, "sentinel").unwrap();
+
+        let info = read_lock_info(&path).unwrap();
+        assert_eq!(info.pid, std::process::id());
+        assert_eq!(info.trigger, "sentinel");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,12 +8,15 @@ mod drives;
 mod error;
 mod executor;
 mod heartbeat;
+mod lock;
 mod metrics;
 mod notify;
 mod output;
 mod plan;
 mod preflight;
 mod retention;
+#[allow(dead_code)] // Session 2 (sentinel_runner) will consume this module
+mod sentinel;
 mod state;
 mod types;
 mod voice;

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -1,0 +1,1183 @@
+// Sentinel — pure state machine for the Urd backup awareness daemon.
+//
+// This module contains only types and pure functions. No I/O. The runner
+// (sentinel_runner.rs, Session 2) translates real-world events into
+// SentinelEvents and executes the SentinelActions returned by transitions.
+//
+// Design: follows ADR-108 (pure-function module pattern), same as planner,
+// awareness, and retention. The state machine is indifferent to how events
+// arrive — inotify, polling, or test harness.
+
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+use crate::awareness::{PromiseStatus, SubvolAssessment};
+
+// ── Events ──────────────────────────────────────────────────────────────
+
+/// Events that the runner translates from raw I/O into domain terms.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SentinelEvent {
+    /// A configured drive was mounted (label from drive config).
+    DriveMounted { label: String },
+    /// A configured drive was unmounted.
+    DriveUnmounted { label: String },
+    /// Adaptive tick fired — time to re-assess promise states.
+    AssessmentTick,
+    /// A backup run completed (detected via heartbeat change).
+    BackupCompleted,
+    /// Graceful shutdown requested (SIGTERM/SIGINT).
+    Shutdown,
+}
+
+// ── Actions ─────────────────────────────────────────────────────────────
+
+/// Actions the runner must execute after a state transition.
+///
+/// Per review item 9: WriteState is folded into Assess — the runner writes
+/// the state file as part of execute_assess(), not as a separate action.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SentinelAction {
+    /// Re-assess promise states, compare with previous, dispatch notifications
+    /// if changed, and write the sentinel state file. This is the primary tick.
+    Assess,
+    /// Log a drive mount/unmount event. The runner logs and (in Session 3)
+    /// records the event in the drive_connections table.
+    LogDriveChange {
+        label: String,
+        mounted: bool,
+    },
+    /// Clean exit.
+    Exit,
+}
+
+// ── State ───────────────────────────────────────────────────────────────
+
+/// The sentinel's in-memory state. Passed to pure functions, updated by
+/// the runner after executing actions.
+#[derive(Debug, Clone)]
+pub struct SentinelState {
+    /// Currently mounted configured drives (by label).
+    pub mounted_drives: BTreeSet<String>,
+    /// Promise status per subvolume from the last assessment.
+    /// Empty on startup — the first assessment populates without notifying.
+    pub last_promise_states: Vec<PromiseSnapshot>,
+    /// Whether the first assessment has been performed since startup.
+    /// Used to suppress spurious notifications (review item M3) and prevent
+    /// premature triggers (M2).
+    ///
+    /// The runner must set this to `true` after the first `Assess` action
+    /// completes. The state machine doesn't set it — it's a pure function
+    /// that doesn't know which assessment is "first."
+    pub has_initial_assessment: bool,
+    /// Circuit breaker state (active mode only, but tracked always).
+    pub circuit_breaker: CircuitBreaker,
+}
+
+/// A snapshot of promise states from a single assessment, used for
+/// comparing state transitions to decide notifications.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromiseSnapshot {
+    pub name: String,
+    pub status: PromiseStatus,
+}
+
+impl SentinelState {
+    /// Create initial state for a fresh sentinel startup.
+    #[must_use]
+    pub fn new(circuit_breaker_config: CircuitBreakerConfig) -> Self {
+        Self {
+            mounted_drives: BTreeSet::new(),
+            last_promise_states: Vec::new(),
+            has_initial_assessment: false,
+            circuit_breaker: CircuitBreaker::new(circuit_breaker_config),
+        }
+    }
+}
+
+// ── Circuit Breaker ─────────────────────────────────────────────────────
+
+/// Configuration for the circuit breaker (from config or defaults).
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    /// Minimum interval between auto-triggered backups.
+    pub min_interval: Duration,
+    /// Maximum consecutive failures before the circuit opens.
+    pub max_failures: u32,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            min_interval: Duration::from_secs(3600), // 1h
+            max_failures: 3,
+        }
+    }
+}
+
+/// Circuit breaker preventing cascade failures from auto-triggered backups.
+///
+/// States:
+/// - Closed: triggers allowed, failure counter tracks consecutive failures.
+/// - Open: triggers blocked, exponential backoff before half-open attempt.
+/// - HalfOpen: one trial trigger allowed — success closes, failure re-opens.
+#[derive(Debug, Clone)]
+pub struct CircuitBreaker {
+    pub config: CircuitBreakerConfig,
+    pub state: CircuitState,
+    pub failure_count: u32,
+    pub last_trigger: Option<NaiveDateTime>,
+    /// Current backoff duration (doubles on each failure, capped at 24h).
+    pub backoff: Duration,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CircuitState {
+    Closed,
+    Open,
+    HalfOpen,
+}
+
+impl std::fmt::Display for CircuitState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Closed => write!(f, "closed"),
+            Self::Open => write!(f, "open"),
+            Self::HalfOpen => write!(f, "half-open"),
+        }
+    }
+}
+
+/// Maximum backoff duration: 24 hours.
+const MAX_BACKOFF: Duration = Duration::from_secs(24 * 3600);
+/// Initial backoff after first circuit open: 15 minutes.
+const INITIAL_BACKOFF: Duration = Duration::from_secs(15 * 60);
+
+impl CircuitBreaker {
+    #[must_use]
+    pub fn new(config: CircuitBreakerConfig) -> Self {
+        Self {
+            config,
+            state: CircuitState::Closed,
+            failure_count: 0,
+            last_trigger: None,
+            backoff: INITIAL_BACKOFF,
+        }
+    }
+
+    /// Check whether a trigger is allowed and what kind of trigger it is.
+    ///
+    /// Returns `Allowed` for normal closed-circuit triggers, `HalfOpenTrial`
+    /// when the circuit is open but backoff has elapsed (the runner should
+    /// treat the result as a trial), or `Blocked` when the trigger is not
+    /// permitted. The runner passes the returned permission to
+    /// `evaluate_trigger_result` so the circuit breaker knows whether to
+    /// apply half-open semantics — no implicit protocol.
+    #[must_use]
+    pub fn check_trigger(&self, now: NaiveDateTime) -> TriggerPermission {
+        match self.state {
+            CircuitState::Open => {
+                // Check if backoff has elapsed → half-open trial
+                let elapsed_ok = match self.last_trigger {
+                    Some(last) => {
+                        let elapsed = now.signed_duration_since(last);
+                        elapsed >= chrono::Duration::from_std(self.backoff)
+                            .unwrap_or(chrono::Duration::MAX)
+                    }
+                    None => true,
+                };
+                if elapsed_ok {
+                    TriggerPermission::HalfOpenTrial
+                } else {
+                    TriggerPermission::Blocked
+                }
+            }
+            CircuitState::HalfOpen => TriggerPermission::HalfOpenTrial,
+            CircuitState::Closed => {
+                // Respect min_interval
+                let interval_ok = match self.last_trigger {
+                    Some(last) => {
+                        let elapsed = now.signed_duration_since(last);
+                        elapsed >= chrono::Duration::from_std(self.config.min_interval)
+                            .unwrap_or(chrono::Duration::MAX)
+                    }
+                    None => true,
+                };
+                if interval_ok {
+                    TriggerPermission::Allowed
+                } else {
+                    TriggerPermission::Blocked
+                }
+            }
+        }
+    }
+}
+
+// ── Trigger types ───────────────────────────────────────────────────────
+
+/// Result of `CircuitBreaker::check_trigger` — tells the runner what kind
+/// of trigger this is, so `evaluate_trigger_result` can apply the correct
+/// circuit breaker semantics without an implicit protocol.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriggerPermission {
+    /// Normal trigger (circuit closed, min_interval elapsed).
+    Allowed,
+    /// Circuit is open but backoff elapsed — this is a trial. If it fails,
+    /// backoff doubles. If it succeeds, circuit closes.
+    HalfOpenTrial,
+    /// Trigger not permitted (circuit open during backoff, or min_interval
+    /// not elapsed).
+    Blocked,
+}
+
+impl TriggerPermission {
+    /// Whether this permission allows a trigger to proceed.
+    #[must_use]
+    pub fn is_allowed(self) -> bool {
+        matches!(self, Self::Allowed | Self::HalfOpenTrial)
+    }
+}
+
+/// Why the sentinel wants to trigger a backup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TriggerReason {
+    /// A drive was mounted that has pending sends.
+    DriveMounted { label: String },
+    /// Promise states degraded (something went from Protected to worse).
+    PromiseDegraded,
+}
+
+/// A decision to trigger a backup, with context for result evaluation.
+#[derive(Debug, Clone)]
+pub struct BackupTrigger {
+    pub reason: TriggerReason,
+    pub triggered_at: NaiveDateTime,
+    /// How the circuit breaker permitted this trigger — passed through to
+    /// `evaluate_trigger_result` so it knows whether to apply half-open
+    /// semantics. Eliminates the implicit protocol (review item S2).
+    pub permission: TriggerPermission,
+}
+
+/// Outcome of a triggered backup, for circuit breaker evaluation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TriggerOutcome {
+    /// Backup succeeded (exit 0, or heartbeat shows improvement).
+    Success,
+    /// Backup failed or the trigger condition didn't improve.
+    Failure,
+    /// Lock was held — another backup was already running. Not a failure.
+    LockHeld,
+}
+
+// ── Adaptive tick ───────────────────────────────────────────────────────
+
+/// Compute the next assessment tick interval based on current promise states.
+///
+/// - All PROTECTED: 15 minutes (low urgency, battery-friendly)
+/// - Any AT RISK: 5 minutes (something needs attention)
+/// - Any UNPROTECTED: 2 minutes (urgent — data may be at risk)
+/// - No assessments (startup): 2 minutes (need initial state fast)
+#[must_use]
+pub fn compute_next_tick(assessments: &[SubvolAssessment]) -> Duration {
+    if assessments.is_empty() {
+        return Duration::from_secs(2 * 60);
+    }
+
+    let worst = assessments
+        .iter()
+        .map(|a| a.status)
+        .min() // PromiseStatus is ordered worst-to-best
+        .unwrap_or(PromiseStatus::Protected);
+
+    match worst {
+        PromiseStatus::Unprotected => Duration::from_secs(2 * 60),
+        PromiseStatus::AtRisk => Duration::from_secs(5 * 60),
+        PromiseStatus::Protected => Duration::from_secs(15 * 60),
+    }
+}
+
+// ── State machine transition ────────────────────────────────────────────
+
+/// Pure state machine: given current state and an event, compute the new
+/// state and the actions the runner should execute.
+///
+/// The runner calls this, executes the actions, then stores the new state.
+/// This function never performs I/O.
+#[must_use]
+pub fn sentinel_transition(
+    state: &SentinelState,
+    event: &SentinelEvent,
+) -> (SentinelState, Vec<SentinelAction>) {
+    let mut new_state = state.clone();
+    let mut actions = Vec::new();
+
+    match event {
+        SentinelEvent::DriveMounted { label } => {
+            let is_new = new_state.mounted_drives.insert(label.clone());
+            if is_new {
+                actions.push(SentinelAction::LogDriveChange {
+                    label: label.clone(),
+                    mounted: true,
+                });
+                actions.push(SentinelAction::Assess);
+            }
+            // Duplicate mount events are ignored (idempotent).
+        }
+
+        SentinelEvent::DriveUnmounted { label } => {
+            let was_present = new_state.mounted_drives.remove(label);
+            if was_present {
+                actions.push(SentinelAction::LogDriveChange {
+                    label: label.clone(),
+                    mounted: false,
+                });
+                actions.push(SentinelAction::Assess);
+            }
+        }
+
+        SentinelEvent::AssessmentTick => {
+            actions.push(SentinelAction::Assess);
+        }
+
+        SentinelEvent::BackupCompleted => {
+            // A backup just finished — re-assess to pick up new promise states
+            // and dispatch any notifications the backup left undispatched.
+            actions.push(SentinelAction::Assess);
+        }
+
+        SentinelEvent::Shutdown => {
+            actions.push(SentinelAction::Exit);
+        }
+    }
+
+    (new_state, actions)
+}
+
+// ── Trigger decision (runner-level) ─────────────────────────────────────
+
+/// Decide whether to auto-trigger a backup based on the event, current
+/// assessments, and sentinel state.
+///
+/// This is a pure function that lives in sentinel.rs, but it is called by
+/// the **runner** after executing the Assess action — NOT by
+/// sentinel_transition(). The runner provides the assessments from the
+/// just-completed assessment. (Review item S3: runner-level decision.)
+///
+/// Only relevant when active mode is enabled (`[sentinel] active = true`).
+#[must_use]
+pub fn should_trigger_backup(
+    state: &SentinelState,
+    event: &SentinelEvent,
+    assessments: &[SubvolAssessment],
+    now: NaiveDateTime,
+) -> Option<BackupTrigger> {
+    // Check circuit breaker permission once — shared by all trigger paths.
+    let permission = state.circuit_breaker.check_trigger(now);
+    if !permission.is_allowed() {
+        return None;
+    }
+
+    // Only DriveMounted and AssessmentTick (with degradation) can trigger.
+    match event {
+        SentinelEvent::DriveMounted { label } => {
+            if !state.has_initial_assessment {
+                return None; // M2: don't trigger before baseline is established
+            }
+
+            // Trigger if any subvolume needs a send to this drive.
+            let drive_needs_send = assessments.iter().any(|a| {
+                a.external.iter().any(|d| {
+                    d.drive_label == *label && d.status != PromiseStatus::Protected
+                })
+            });
+
+            if drive_needs_send {
+                Some(BackupTrigger {
+                    reason: TriggerReason::DriveMounted {
+                        label: label.clone(),
+                    },
+                    triggered_at: now,
+                    permission,
+                })
+            } else {
+                None
+            }
+        }
+
+        SentinelEvent::AssessmentTick => {
+            if !state.has_initial_assessment {
+                return None; // Don't trigger on the very first assessment
+            }
+
+            let degraded = has_promise_degradation(&state.last_promise_states, assessments);
+            if degraded {
+                Some(BackupTrigger {
+                    reason: TriggerReason::PromiseDegraded,
+                    triggered_at: now,
+                    permission,
+                })
+            } else {
+                None
+            }
+        }
+
+        // BackupCompleted, DriveUnmounted, Shutdown — never trigger.
+        _ => None,
+    }
+}
+
+/// Check if any subvolume's promise status degraded (got worse) between
+/// the previous snapshot and current assessments.
+fn has_promise_degradation(
+    previous: &[PromiseSnapshot],
+    current: &[SubvolAssessment],
+) -> bool {
+    for assess in current {
+        if let Some(prev) = previous.iter().find(|p| p.name == assess.name) {
+            // PromiseStatus is ordered Unprotected < AtRisk < Protected,
+            // so degradation means current < previous.
+            if assess.status < prev.status {
+                return true;
+            }
+        }
+        // New subvolumes (not in previous) don't count as degradation.
+    }
+    false
+}
+
+// ── Circuit breaker evaluation ──────────────────────────────────────────
+
+/// Evaluate a trigger result and return the updated circuit breaker state.
+///
+/// Pure function — the runner calls this after a triggered backup completes
+/// and stores the result.
+#[must_use]
+pub fn evaluate_trigger_result(
+    circuit: &CircuitBreaker,
+    trigger: &BackupTrigger,
+    result: &TriggerOutcome,
+) -> CircuitBreaker {
+    let mut new = circuit.clone();
+
+    match result {
+        TriggerOutcome::Success => {
+            new.last_trigger = Some(trigger.triggered_at);
+            new.state = CircuitState::Closed;
+            new.failure_count = 0;
+            new.backoff = INITIAL_BACKOFF;
+        }
+
+        TriggerOutcome::Failure => {
+            new.last_trigger = Some(trigger.triggered_at);
+            new.failure_count += 1;
+
+            // Use the permission carried on the trigger to determine
+            // whether this was a half-open trial — no implicit protocol
+            // between check_trigger and evaluate_trigger_result (S2 fix).
+            if trigger.permission == TriggerPermission::HalfOpenTrial {
+                // Half-open trial failed — re-open with doubled backoff
+                new.state = CircuitState::Open;
+                new.backoff = circuit
+                    .backoff
+                    .checked_mul(2)
+                    .map(|d| d.min(MAX_BACKOFF))
+                    .unwrap_or(MAX_BACKOFF);
+            } else if new.failure_count >= new.config.max_failures {
+                // Closed circuit hit max failures — open with initial backoff
+                new.state = CircuitState::Open;
+                new.backoff = INITIAL_BACKOFF;
+            }
+        }
+
+        TriggerOutcome::LockHeld => {
+            // M1 fix: Not a real trigger — don't update last_trigger,
+            // don't change circuit state, don't increment failure count.
+            // This avoids consuming the min_interval cooldown.
+        }
+    }
+
+    new
+}
+
+// ── Promise snapshot helpers ────────────────────────────────────────────
+
+/// Extract promise snapshots from assessments for state storage.
+#[must_use]
+pub fn snapshot_promises(assessments: &[SubvolAssessment]) -> Vec<PromiseSnapshot> {
+    assessments
+        .iter()
+        .map(|a| PromiseSnapshot {
+            name: a.name.clone(),
+            status: a.status,
+        })
+        .collect()
+}
+
+/// Determine whether promise state transitions warrant notifications.
+/// Returns true if any subvolume's promise status changed.
+///
+/// Special case: when `previous` is empty (first assessment after startup),
+/// returns false to suppress spurious notifications (review item M3).
+#[must_use]
+pub fn has_promise_changes(
+    previous: &[PromiseSnapshot],
+    current: &[SubvolAssessment],
+) -> bool {
+    if previous.is_empty() {
+        return false;
+    }
+
+    for assess in current {
+        match previous.iter().find(|p| p.name == assess.name) {
+            Some(prev) if prev.status != assess.status => return true,
+            None => return true, // new subvolume appeared
+            _ => {}
+        }
+    }
+
+    // Check for subvolumes that disappeared
+    for prev in previous {
+        if !current.iter().any(|a| a.name == prev.name) {
+            return true;
+        }
+    }
+
+    false
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::awareness::{DriveAssessment, LocalAssessment};
+    use crate::types::Interval;
+
+    fn dt(s: &str) -> NaiveDateTime {
+        NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M").unwrap()
+    }
+
+    fn fresh_state() -> SentinelState {
+        SentinelState::new(CircuitBreakerConfig::default())
+    }
+
+    fn make_assessment(name: &str, status: PromiseStatus) -> SubvolAssessment {
+        SubvolAssessment {
+            name: name.to_string(),
+            status,
+            local: LocalAssessment {
+                status,
+                snapshot_count: 5,
+                newest_age: None,
+                configured_interval: Interval::hours(1),
+            },
+            external: vec![],
+            advisories: vec![],
+            errors: vec![],
+        }
+    }
+
+    fn make_assessment_with_drive(
+        name: &str,
+        status: PromiseStatus,
+        drive_label: &str,
+        drive_status: PromiseStatus,
+    ) -> SubvolAssessment {
+        SubvolAssessment {
+            name: name.to_string(),
+            status,
+            local: LocalAssessment {
+                status: PromiseStatus::Protected,
+                snapshot_count: 5,
+                newest_age: None,
+                configured_interval: Interval::hours(1),
+            },
+            external: vec![DriveAssessment {
+                drive_label: drive_label.to_string(),
+                status: drive_status,
+                mounted: true,
+                snapshot_count: Some(3),
+                last_send_age: None,
+                configured_interval: Interval::hours(24),
+            }],
+            advisories: vec![],
+            errors: vec![],
+        }
+    }
+
+    // ── State machine transitions ───────────────────────────────────────
+
+    #[test]
+    fn transition_drive_mounted_adds_to_set() {
+        let state = fresh_state();
+        let event = SentinelEvent::DriveMounted {
+            label: "WD-18TB".to_string(),
+        };
+
+        let (new_state, actions) = sentinel_transition(&state, &event);
+
+        assert!(new_state.mounted_drives.contains("WD-18TB"));
+        assert_eq!(actions.len(), 2);
+        assert_eq!(
+            actions[0],
+            SentinelAction::LogDriveChange {
+                label: "WD-18TB".to_string(),
+                mounted: true,
+            }
+        );
+        assert_eq!(actions[1], SentinelAction::Assess);
+    }
+
+    #[test]
+    fn transition_drive_unmounted_removes_from_set() {
+        let mut state = fresh_state();
+        state.mounted_drives.insert("WD-18TB".to_string());
+
+        let event = SentinelEvent::DriveUnmounted {
+            label: "WD-18TB".to_string(),
+        };
+        let (new_state, actions) = sentinel_transition(&state, &event);
+
+        assert!(!new_state.mounted_drives.contains("WD-18TB"));
+        assert_eq!(actions.len(), 2);
+        assert_eq!(
+            actions[0],
+            SentinelAction::LogDriveChange {
+                label: "WD-18TB".to_string(),
+                mounted: false,
+            }
+        );
+        assert_eq!(actions[1], SentinelAction::Assess);
+    }
+
+    #[test]
+    fn transition_assessment_tick_triggers_assess() {
+        let state = fresh_state();
+        let (_, actions) = sentinel_transition(&state, &SentinelEvent::AssessmentTick);
+
+        assert_eq!(actions, vec![SentinelAction::Assess]);
+    }
+
+    #[test]
+    fn transition_backup_completed_triggers_assess() {
+        let state = fresh_state();
+        let (_, actions) = sentinel_transition(&state, &SentinelEvent::BackupCompleted);
+
+        assert_eq!(actions, vec![SentinelAction::Assess]);
+    }
+
+    #[test]
+    fn transition_shutdown_triggers_exit() {
+        let state = fresh_state();
+        let (_, actions) = sentinel_transition(&state, &SentinelEvent::Shutdown);
+
+        assert_eq!(actions, vec![SentinelAction::Exit]);
+    }
+
+    // ── Drive tracking ──────────────────────────────────────────────────
+
+    #[test]
+    fn duplicate_mount_is_idempotent() {
+        let mut state = fresh_state();
+        state.mounted_drives.insert("WD-18TB".to_string());
+
+        let event = SentinelEvent::DriveMounted {
+            label: "WD-18TB".to_string(),
+        };
+        let (new_state, actions) = sentinel_transition(&state, &event);
+
+        assert_eq!(new_state.mounted_drives.len(), 1);
+        assert!(actions.is_empty(), "duplicate mount should produce no actions");
+    }
+
+    #[test]
+    fn unmount_unknown_drive_is_no_op() {
+        let state = fresh_state();
+        let event = SentinelEvent::DriveUnmounted {
+            label: "unknown".to_string(),
+        };
+        let (_, actions) = sentinel_transition(&state, &event);
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn multiple_drives_tracked_independently() {
+        let state = fresh_state();
+
+        let (state, _) = sentinel_transition(
+            &state,
+            &SentinelEvent::DriveMounted {
+                label: "WD-18TB".to_string(),
+            },
+        );
+        let (state, _) = sentinel_transition(
+            &state,
+            &SentinelEvent::DriveMounted {
+                label: "2TB-backup".to_string(),
+            },
+        );
+
+        assert_eq!(state.mounted_drives.len(), 2);
+        assert!(state.mounted_drives.contains("WD-18TB"));
+        assert!(state.mounted_drives.contains("2TB-backup"));
+
+        let (state, actions) = sentinel_transition(
+            &state,
+            &SentinelEvent::DriveUnmounted {
+                label: "WD-18TB".to_string(),
+            },
+        );
+
+        assert_eq!(state.mounted_drives.len(), 1);
+        assert!(state.mounted_drives.contains("2TB-backup"));
+        assert!(!actions.is_empty());
+    }
+
+    // ── Adaptive tick ───────────────────────────────────────────────────
+
+    #[test]
+    fn tick_all_protected_is_15_minutes() {
+        let assessments = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            make_assessment("sv2", PromiseStatus::Protected),
+        ];
+        assert_eq!(compute_next_tick(&assessments), Duration::from_secs(15 * 60));
+    }
+
+    #[test]
+    fn tick_any_at_risk_is_5_minutes() {
+        let assessments = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            make_assessment("sv2", PromiseStatus::AtRisk),
+        ];
+        assert_eq!(compute_next_tick(&assessments), Duration::from_secs(5 * 60));
+    }
+
+    #[test]
+    fn tick_any_unprotected_is_2_minutes() {
+        let assessments = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            make_assessment("sv2", PromiseStatus::Unprotected),
+        ];
+        assert_eq!(compute_next_tick(&assessments), Duration::from_secs(2 * 60));
+    }
+
+    #[test]
+    fn tick_empty_assessments_is_2_minutes() {
+        assert_eq!(compute_next_tick(&[]), Duration::from_secs(2 * 60));
+    }
+
+    // ── Circuit breaker ─────────────────────────────────────────────────
+
+    /// Helper to build a trigger with a given permission.
+    fn make_trigger(at: &str, permission: TriggerPermission) -> BackupTrigger {
+        BackupTrigger {
+            reason: TriggerReason::PromiseDegraded,
+            triggered_at: dt(at),
+            permission,
+        }
+    }
+
+    #[test]
+    fn circuit_starts_closed() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig::default());
+        assert_eq!(cb.state, CircuitState::Closed);
+        assert_eq!(cb.failure_count, 0);
+    }
+
+    #[test]
+    fn circuit_stays_closed_on_success() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig::default());
+        let trigger = make_trigger("2026-03-27 10:00", TriggerPermission::Allowed);
+
+        let cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::Success);
+        assert_eq!(cb.state, CircuitState::Closed);
+        assert_eq!(cb.failure_count, 0);
+    }
+
+    #[test]
+    fn circuit_opens_after_max_failures() {
+        let config = CircuitBreakerConfig {
+            max_failures: 3,
+            ..Default::default()
+        };
+        let mut cb = CircuitBreaker::new(config);
+        let now = dt("2026-03-27 10:00");
+
+        for i in 0..3 {
+            let trigger = BackupTrigger {
+                reason: TriggerReason::PromiseDegraded,
+                triggered_at: now + chrono::Duration::minutes(i),
+                permission: TriggerPermission::Allowed,
+            };
+            cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::Failure);
+        }
+
+        assert_eq!(cb.state, CircuitState::Open);
+        assert_eq!(cb.failure_count, 3);
+    }
+
+    #[test]
+    fn circuit_does_not_open_below_max_failures() {
+        let config = CircuitBreakerConfig {
+            max_failures: 3,
+            ..Default::default()
+        };
+        let mut cb = CircuitBreaker::new(config);
+
+        for i in 0..2 {
+            let trigger = BackupTrigger {
+                reason: TriggerReason::PromiseDegraded,
+                triggered_at: dt("2026-03-27 10:00") + chrono::Duration::minutes(i),
+                permission: TriggerPermission::Allowed,
+            };
+            cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::Failure);
+        }
+
+        assert_eq!(cb.state, CircuitState::Closed);
+        assert_eq!(cb.failure_count, 2);
+    }
+
+    #[test]
+    fn circuit_open_blocks_trigger_during_backoff() {
+        let config = CircuitBreakerConfig {
+            max_failures: 1,
+            min_interval: Duration::from_secs(60),
+        };
+        let mut cb = CircuitBreaker::new(config);
+        let trigger = make_trigger("2026-03-27 10:00", TriggerPermission::Allowed);
+        cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::Failure);
+        assert_eq!(cb.state, CircuitState::Open);
+
+        // 5 minutes later — still within backoff (15 min initial)
+        assert_eq!(cb.check_trigger(dt("2026-03-27 10:05")), TriggerPermission::Blocked);
+    }
+
+    #[test]
+    fn circuit_open_returns_half_open_trial_after_backoff() {
+        let config = CircuitBreakerConfig {
+            max_failures: 1,
+            min_interval: Duration::from_secs(60),
+        };
+        let mut cb = CircuitBreaker::new(config);
+        let trigger = make_trigger("2026-03-27 10:00", TriggerPermission::Allowed);
+        cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::Failure);
+
+        // 20 minutes later — past initial 15-min backoff → HalfOpenTrial
+        assert_eq!(
+            cb.check_trigger(dt("2026-03-27 10:20")),
+            TriggerPermission::HalfOpenTrial
+        );
+    }
+
+    #[test]
+    fn circuit_half_open_trial_failure_reopens_with_doubled_backoff() {
+        let config = CircuitBreakerConfig {
+            max_failures: 1,
+            min_interval: Duration::from_secs(60),
+        };
+        let mut cb = CircuitBreaker::new(config);
+
+        // Open circuit with Allowed trigger
+        let trigger = make_trigger("2026-03-27 10:00", TriggerPermission::Allowed);
+        cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::Failure);
+        assert_eq!(cb.state, CircuitState::Open);
+
+        // Half-open trial fails — S2: permission carries the context, no manual state set
+        let trial = make_trigger("2026-03-27 10:20", TriggerPermission::HalfOpenTrial);
+        let cb = evaluate_trigger_result(&cb, &trial, &TriggerOutcome::Failure);
+        assert_eq!(cb.state, CircuitState::Open);
+        assert!(cb.backoff > INITIAL_BACKOFF, "backoff should double on half-open failure");
+    }
+
+    #[test]
+    fn circuit_half_open_trial_success_closes() {
+        let config = CircuitBreakerConfig {
+            max_failures: 1,
+            min_interval: Duration::from_secs(60),
+        };
+        let mut cb = CircuitBreaker::new(config);
+
+        // Open circuit
+        let trigger = make_trigger("2026-03-27 10:00", TriggerPermission::Allowed);
+        cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::Failure);
+
+        // Half-open trial succeeds — back to closed
+        let trial = make_trigger("2026-03-27 10:20", TriggerPermission::HalfOpenTrial);
+        let cb = evaluate_trigger_result(&cb, &trial, &TriggerOutcome::Success);
+        assert_eq!(cb.state, CircuitState::Closed);
+        assert_eq!(cb.failure_count, 0);
+        assert_eq!(cb.backoff, INITIAL_BACKOFF);
+    }
+
+    #[test]
+    fn circuit_lock_held_does_not_count_as_failure() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig::default());
+        let trigger = BackupTrigger {
+            reason: TriggerReason::DriveMounted {
+                label: "WD-18TB".to_string(),
+            },
+            triggered_at: dt("2026-03-27 10:00"),
+            permission: TriggerPermission::Allowed,
+        };
+
+        let cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::LockHeld);
+        assert_eq!(cb.state, CircuitState::Closed);
+        assert_eq!(cb.failure_count, 0);
+    }
+
+    #[test]
+    fn circuit_lock_held_does_not_consume_min_interval() {
+        // M1 fix: LockHeld should not update last_trigger, so the next
+        // real trigger is not blocked by min_interval.
+        let config = CircuitBreakerConfig {
+            min_interval: Duration::from_secs(3600),
+            max_failures: 3,
+        };
+        let cb = CircuitBreaker::new(config);
+
+        let trigger = BackupTrigger {
+            reason: TriggerReason::DriveMounted {
+                label: "WD-18TB".to_string(),
+            },
+            triggered_at: dt("2026-03-27 10:00"),
+            permission: TriggerPermission::Allowed,
+        };
+        let cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::LockHeld);
+
+        // Immediately after — should still be allowed (last_trigger not set)
+        assert_eq!(
+            cb.check_trigger(dt("2026-03-27 10:01")),
+            TriggerPermission::Allowed
+        );
+    }
+
+    #[test]
+    fn circuit_backoff_capped_at_24h() {
+        let config = CircuitBreakerConfig {
+            max_failures: 1,
+            min_interval: Duration::from_secs(60),
+        };
+        let mut cb = CircuitBreaker::new(config);
+        cb.backoff = Duration::from_secs(20 * 3600); // 20h
+
+        // Half-open trial with doubled backoff should cap at 24h
+        let trigger = make_trigger("2026-03-27 10:00", TriggerPermission::HalfOpenTrial);
+        let cb = evaluate_trigger_result(&cb, &trigger, &TriggerOutcome::Failure);
+
+        assert_eq!(cb.backoff, MAX_BACKOFF);
+    }
+
+    #[test]
+    fn circuit_closed_respects_min_interval() {
+        let config = CircuitBreakerConfig {
+            min_interval: Duration::from_secs(3600), // 1h
+            max_failures: 3,
+        };
+        let mut cb = CircuitBreaker::new(config);
+        cb.last_trigger = Some(dt("2026-03-27 10:00"));
+
+        // 30 minutes later — too soon
+        assert_eq!(cb.check_trigger(dt("2026-03-27 10:30")), TriggerPermission::Blocked);
+        // 61 minutes later — ok
+        assert_eq!(cb.check_trigger(dt("2026-03-27 11:01")), TriggerPermission::Allowed);
+    }
+
+    // ── Trigger logic ───────────────────────────────────────────────────
+
+    #[test]
+    fn trigger_on_drive_mount_with_pending_sends() {
+        let mut state = fresh_state();
+        state.has_initial_assessment = true;
+
+        let assessments = vec![make_assessment_with_drive(
+            "sv1",
+            PromiseStatus::AtRisk,
+            "WD-18TB",
+            PromiseStatus::Unprotected,
+        )];
+
+        let event = SentinelEvent::DriveMounted {
+            label: "WD-18TB".to_string(),
+        };
+        let now = dt("2026-03-27 10:00");
+
+        let trigger = should_trigger_backup(&state, &event, &assessments, now);
+        assert!(trigger.is_some());
+        assert_eq!(
+            trigger.unwrap().reason,
+            TriggerReason::DriveMounted {
+                label: "WD-18TB".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn no_trigger_on_drive_mount_when_all_protected() {
+        let mut state = fresh_state();
+        state.has_initial_assessment = true;
+
+        let assessments = vec![make_assessment_with_drive(
+            "sv1",
+            PromiseStatus::Protected,
+            "WD-18TB",
+            PromiseStatus::Protected,
+        )];
+
+        let event = SentinelEvent::DriveMounted {
+            label: "WD-18TB".to_string(),
+        };
+        let now = dt("2026-03-27 10:00");
+
+        assert!(should_trigger_backup(&state, &event, &assessments, now).is_none());
+    }
+
+    #[test]
+    fn trigger_on_promise_degradation() {
+        let mut state = fresh_state();
+        state.has_initial_assessment = true;
+        state.last_promise_states = vec![PromiseSnapshot {
+            name: "sv1".to_string(),
+            status: PromiseStatus::Protected,
+        }];
+
+        let assessments = vec![make_assessment("sv1", PromiseStatus::AtRisk)];
+        let now = dt("2026-03-27 10:00");
+
+        let trigger =
+            should_trigger_backup(&state, &SentinelEvent::AssessmentTick, &assessments, now);
+        assert!(trigger.is_some());
+        assert_eq!(trigger.unwrap().reason, TriggerReason::PromiseDegraded);
+    }
+
+    #[test]
+    fn no_trigger_on_first_assessment() {
+        let state = fresh_state(); // has_initial_assessment = false
+
+        let assessments = vec![make_assessment("sv1", PromiseStatus::Unprotected)];
+        let now = dt("2026-03-27 10:00");
+
+        assert!(
+            should_trigger_backup(&state, &SentinelEvent::AssessmentTick, &assessments, now)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn no_trigger_on_drive_mount_before_initial_assessment() {
+        // M2 fix: DriveMounted before baseline is established should not trigger.
+        let state = fresh_state(); // has_initial_assessment = false
+
+        let assessments = vec![make_assessment_with_drive(
+            "sv1",
+            PromiseStatus::AtRisk,
+            "WD-18TB",
+            PromiseStatus::Unprotected,
+        )];
+
+        let event = SentinelEvent::DriveMounted {
+            label: "WD-18TB".to_string(),
+        };
+        let now = dt("2026-03-27 10:00");
+
+        assert!(should_trigger_backup(&state, &event, &assessments, now).is_none());
+    }
+
+    #[test]
+    fn no_trigger_on_backup_completed() {
+        let mut state = fresh_state();
+        state.has_initial_assessment = true;
+
+        let assessments = vec![make_assessment("sv1", PromiseStatus::Unprotected)];
+        let now = dt("2026-03-27 10:00");
+
+        assert!(
+            should_trigger_backup(&state, &SentinelEvent::BackupCompleted, &assessments, now)
+                .is_none()
+        );
+    }
+
+    // ── Promise change detection ────────────────────────────────────────
+
+    #[test]
+    fn first_assessment_after_startup_no_notifications() {
+        // Review item M3: empty previous → no notifications
+        let previous: Vec<PromiseSnapshot> = vec![];
+        let current = vec![make_assessment("sv1", PromiseStatus::Protected)];
+
+        assert!(!has_promise_changes(&previous, &current));
+    }
+
+    #[test]
+    fn promise_change_detected() {
+        let previous = vec![PromiseSnapshot {
+            name: "sv1".to_string(),
+            status: PromiseStatus::Protected,
+        }];
+        let current = vec![make_assessment("sv1", PromiseStatus::AtRisk)];
+
+        assert!(has_promise_changes(&previous, &current));
+    }
+
+    #[test]
+    fn no_change_when_status_same() {
+        let previous = vec![PromiseSnapshot {
+            name: "sv1".to_string(),
+            status: PromiseStatus::Protected,
+        }];
+        let current = vec![make_assessment("sv1", PromiseStatus::Protected)];
+
+        assert!(!has_promise_changes(&previous, &current));
+    }
+
+    #[test]
+    fn new_subvolume_is_a_change() {
+        let previous = vec![PromiseSnapshot {
+            name: "sv1".to_string(),
+            status: PromiseStatus::Protected,
+        }];
+        let current = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            make_assessment("sv2", PromiseStatus::Protected),
+        ];
+
+        assert!(has_promise_changes(&previous, &current));
+    }
+
+    #[test]
+    fn removed_subvolume_is_a_change() {
+        let previous = vec![
+            PromiseSnapshot {
+                name: "sv1".to_string(),
+                status: PromiseStatus::Protected,
+            },
+            PromiseSnapshot {
+                name: "sv2".to_string(),
+                status: PromiseStatus::Protected,
+            },
+        ];
+        let current = vec![make_assessment("sv1", PromiseStatus::Protected)];
+
+        assert!(has_promise_changes(&previous, &current));
+    }
+
+    #[test]
+    fn snapshot_promises_roundtrip() {
+        let assessments = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            make_assessment("sv2", PromiseStatus::AtRisk),
+        ];
+
+        let snaps = snapshot_promises(&assessments);
+        assert_eq!(snaps.len(), 2);
+        assert_eq!(snaps[0].name, "sv1");
+        assert_eq!(snaps[0].status, PromiseStatus::Protected);
+        assert_eq!(snaps[1].name, "sv2");
+        assert_eq!(snaps[1].status, PromiseStatus::AtRisk);
+    }
+}


### PR DESCRIPTION
## Summary

- **New `lock.rs` module**: Extracted advisory lock from `backup.rs` into shared module with `LockGuard`, `LockInfo` metadata (PID, timestamp, trigger source), `try_acquire_lock()` for Sentinel, and graceful handling of empty/corrupt/missing lock files
- **New `sentinel.rs` module**: Pure state machine (ADR-108 pattern) with event/action enums, `sentinel_transition()`, adaptive tick intervals (15m/5m/2m), circuit breaker with exponential backoff, `TriggerPermission` enum for explicit half-open protocol, and first-assessment notification suppression
- **Two arch-adversary reviews** with all findings addressed: `File::create` truncation race, implicit HalfOpen protocol, LockHeld cooldown consumption, pre-initial-assessment trigger guard
- **Design documents**: Implementation plan (5 sessions) and implementation plan review

## Testing

- cargo clippy: pass (zero warnings, `-D warnings`)
- cargo test: 366 tests, all pass (was 318, +48 new)
- Integration tests: not applicable (pure modules, no I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)