### PR TITLE
feat: Sentinel Session 2 — I/O runner + CLI

### DIFF
--- a/docs/95-ideas/2026-03-27-design-sentinel-session2.md
+++ b/docs/95-ideas/2026-03-27-design-sentinel-session2.md
@@ -1,0 +1,494 @@
+# Design: Sentinel Session 2 — I/O Runner + CLI
+
+> **TL;DR:** Build the poll-based event loop that connects the Session 1 pure state
+> machine to real-world I/O. Wire up `urd sentinel run` (foreground daemon) and
+> `urd sentinel status`. Passive mode only — no config changes needed. Defers
+> notification deduplication, drive recording, and edge case hardening to Session 3.
+
+**Date:** 2026-03-27
+**Status:** proposed
+**Depends on:** Sentinel Session 1 (COMPLETE — `sentinel.rs`, `lock.rs`)
+**Prior design:** [Implementation plan](2026-03-27-design-sentinel-implementation.md) (Session 2 section)
+
+## Key Simplification from Original Plan
+
+The implementation plan proposed epoll + inotify + timerfd (three nix feature additions)
+for the event loop. This design starts with a **poll-based loop** instead:
+
+- **5-second sleep loop** checks drive mounts, heartbeat changes, and tick deadlines
+- **Zero new dependencies** — no nix feature additions, no new crates
+- **The state machine doesn't care** how events arrive (ADR-108 pattern pays off)
+- **Upgrade path clear** — inotify can replace polling in a future session for instant
+  drive detection, without changing the runner's structure
+
+The arch-adversary review recommended "I/O runner with poll loop first." The implementation
+plan's fallback section says: "Fall back to polling-only. The state machine doesn't care
+how events arrive." This design makes the fallback the primary plan.
+
+**Responsiveness with 5-second polling:**
+- Drive mount detection: within 5 seconds (adequate — user plugs in drive, notification
+  arrives before they sit down)
+- Heartbeat change detection: within 5 seconds (adequate — backup finishes, sentinel
+  picks up within one poll cycle)
+- Assessment tick precision: within 5 seconds of scheduled time (negligible for 2-15
+  minute intervals)
+
+## New Files
+
+| File | Type | Responsibility |
+|------|------|----------------|
+| `src/sentinel_runner.rs` | I/O | Poll loop, event detection, action execution, state file I/O |
+| `src/commands/sentinel.rs` | CLI | `urd sentinel run` and `urd sentinel status` handlers |
+
+## Modified Files
+
+| File | Change | Scope |
+|------|--------|-------|
+| `src/cli.rs` | Add `Sentinel(SentinelArgs)` to `Commands` enum | ~15 lines |
+| `src/commands/mod.rs` | Add `pub mod sentinel;` | 1 line |
+| `src/main.rs` | Add `mod sentinel_runner;`, dispatch sentinel command | ~5 lines |
+| `src/output.rs` | Add `SentinelStatusOutput` struct | ~20 lines |
+| `src/voice.rs` | Add `render_sentinel_status()` | ~40 lines |
+
+**Not modified in Session 2:**
+- `config.rs` — passive mode needs no config. Uses existing `[notifications]` config.
+  The sentinel state file path uses a hardcoded default alongside the heartbeat path.
+- `backup.rs` — notification deduplication deferred to Session 3.
+- `state.rs` — drive connection recording deferred to Session 3.
+
+## Runner Architecture
+
+### Struct
+
+```rust
+pub struct SentinelRunner {
+    config: Config,
+    state: SentinelState,
+    state_file_path: PathBuf,
+    heartbeat_path: PathBuf,
+    last_heartbeat_mtime: Option<SystemTime>,
+    last_assessment_time: Option<Instant>,
+    tick_interval: Duration,
+    events_since_startup: u64,
+    started: NaiveDateTime,
+    shutdown: Arc<AtomicBool>,
+}
+```
+
+### Poll Loop
+
+```
+SentinelRunner::run():
+    register ctrlc handler → sets shutdown AtomicBool
+    initial drive scan → populate state.mounted_drives (no events, just baseline)
+
+    loop:
+        if shutdown.load() → process Shutdown → break
+
+        events = collect_events()    // drive diff, heartbeat mtime, tick check
+        for event in events:
+            (new_state, actions) = sentinel_transition(&state, &event)
+            execute_actions(actions)
+            state = new_state
+            events_since_startup += 1
+
+        sleep(POLL_INTERVAL)         // 5 seconds
+```
+
+### Event Collection
+
+Each poll cycle checks three sources. Events are collected into a `Vec<SentinelEvent>`
+and processed sequentially. Order: drive changes first (they trigger assessments that
+include the new drive state), then heartbeat, then tick.
+
+**Drive detection:**
+```rust
+fn detect_drive_events(&mut self) -> Vec<SentinelEvent> {
+    let current: BTreeSet<String> = self.config.drives.iter()
+        .filter(|d| drives::drive_availability(d) == DriveAvailability::Available)
+        .map(|d| d.label.clone())
+        .collect();
+
+    let mut events = Vec::new();
+    for label in current.difference(&self.state.mounted_drives) {
+        events.push(SentinelEvent::DriveMounted { label: label.clone() });
+    }
+    for label in self.state.mounted_drives.difference(&current) {
+        events.push(SentinelEvent::DriveUnmounted { label: label.clone() });
+    }
+    events
+}
+```
+
+**Heartbeat change detection:**
+```rust
+fn detect_heartbeat_event(&mut self) -> Option<SentinelEvent> {
+    let mtime = std::fs::metadata(&self.heartbeat_path).ok()?.modified().ok()?;
+    if self.last_heartbeat_mtime.map_or(true, |prev| mtime > prev) {
+        self.last_heartbeat_mtime = Some(mtime);
+        // Skip event on first check (just recording baseline mtime)
+        if self.last_heartbeat_mtime.is_some() {
+            return Some(SentinelEvent::BackupCompleted);
+        }
+    }
+    None
+}
+```
+
+On startup, the first mtime read is recorded as baseline — no `BackupCompleted` event
+for the existing heartbeat file. Only subsequent mtime changes generate events.
+
+**Assessment tick:**
+```rust
+fn detect_tick_event(&self) -> Option<SentinelEvent> {
+    match self.last_assessment_time {
+        Some(last) if last.elapsed() >= self.tick_interval => {
+            Some(SentinelEvent::AssessmentTick)
+        }
+        None => Some(SentinelEvent::AssessmentTick), // First tick immediately
+        _ => None,
+    }
+}
+```
+
+### Action Execution
+
+**Assess** (the primary action):
+```rust
+fn execute_assess(&mut self) -> anyhow::Result<()> {
+    let now = chrono::Local::now().naive_local();
+    let state_db = StateDb::open(&self.config.general.state_db).ok();
+    let fs = RealFileSystemState { state: state_db.as_ref() };
+
+    let assessments = awareness::assess(&self.config, now, &fs);
+
+    // Dispatch notifications if promise states changed
+    if self.state.has_initial_assessment
+        && sentinel::has_promise_changes(&self.state.last_promise_states, &assessments)
+    {
+        let notifications = self.build_notifications(&assessments);
+        if !notifications.is_empty() {
+            notify::dispatch(&notifications, &self.config.notifications);
+        }
+    }
+
+    // Update state
+    self.state.last_promise_states = sentinel::snapshot_promises(&assessments);
+    if !self.state.has_initial_assessment {
+        self.state.has_initial_assessment = true;
+        log::info!("Initial assessment complete: {} subvolumes evaluated",
+            assessments.len());
+    }
+
+    // Update adaptive tick
+    self.tick_interval = sentinel::compute_next_tick(&assessments);
+    self.last_assessment_time = Some(Instant::now());
+
+    // Write state file
+    self.write_state_file(now)?;
+
+    Ok(())
+}
+```
+
+**Notification building:** The Sentinel uses `awareness::assess()` directly (not heartbeat-based
+`notify::compute_notifications()`). It builds `Notification` objects from promise state diffs.
+This is a separate path from the backup's heartbeat-based notifications — the two paths
+converge at `notify::dispatch()`. Session 3 adds deduplication so they don't both fire.
+
+For Session 2, this means: if a backup runs while the Sentinel is also running, both may
+dispatch notifications for the same state change. This is acceptable for one session —
+duplicate notifications are a minor UX issue, not a correctness issue.
+
+**LogDriveChange:**
+```rust
+fn execute_log_drive_change(&self, label: &str, mounted: bool) {
+    if mounted {
+        log::info!("Drive mounted: {}", label);
+    } else {
+        log::info!("Drive unmounted: {}", label);
+    }
+    // Session 3: record_drive_event() in SQLite
+}
+```
+
+**Exit:**
+```rust
+fn execute_exit(&self) {
+    log::info!("Sentinel shutting down");
+    // Remove state file to signal "not running"
+    let _ = std::fs::remove_file(&self.state_file_path);
+}
+```
+
+## Sentinel State File
+
+**Path:** `{data_dir}/sentinel-state.json` where `data_dir` is derived from
+`config.general.state_db` parent (same directory as `urd.db` and `heartbeat.json`).
+No config field needed — the location is deterministic.
+
+**Schema:**
+```json
+{
+    "schema_version": 1,
+    "pid": 12345,
+    "started": "2026-03-27T10:00:00",
+    "last_assessment": "2026-03-27T10:15:00",
+    "mounted_drives": ["WD-18TB"],
+    "tick_interval_secs": 900,
+    "events_since_startup": 42,
+    "promise_states": [
+        { "name": "subvol1", "status": "protected" },
+        { "name": "subvol2", "status": "at_risk" }
+    ],
+    "circuit_breaker": {
+        "state": "closed",
+        "failure_count": 0
+    }
+}
+```
+
+Written atomically (temp file + rename), same pattern as `heartbeat::write()`.
+
+Read by `urd sentinel status` to display current state without IPC.
+
+Also serves as a "running" indicator: if the file exists AND the PID within is alive
+(`/proc/{pid}` exists), the Sentinel is running. This is checked by `urd sentinel status`
+and (in Session 3) by `backup.rs` for notification deduplication.
+
+## CLI Structure
+
+```rust
+// cli.rs
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    // ... existing commands ...
+    /// Sentinel daemon — monitors backup health and drive connections
+    Sentinel(SentinelArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct SentinelArgs {
+    #[command(subcommand)]
+    pub command: SentinelCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SentinelCommands {
+    /// Start the Sentinel (foreground, for systemd)
+    Run,
+    /// Show Sentinel status
+    Status,
+}
+```
+
+## Command Handlers
+
+### `urd sentinel run`
+
+```rust
+pub fn run_daemon(config: Config) -> anyhow::Result<()> {
+    let mut runner = SentinelRunner::new(config)?;
+    runner.run()
+}
+```
+
+Runs in foreground. systemd manages lifecycle. Logs to stderr (captured by journald).
+No daemonization.
+
+### `urd sentinel status`
+
+```rust
+pub fn status(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
+    let state_file = sentinel_state_path(&config);
+    let status_output = match SentinelStateFile::read(&state_file) {
+        Some(state) if is_pid_alive(state.pid) => {
+            SentinelStatusOutput::Running(state)
+        }
+        Some(state) => {
+            SentinelStatusOutput::Stale(state) // PID dead, file left behind
+        }
+        None => {
+            SentinelStatusOutput::NotRunning
+        }
+    };
+
+    match output_mode {
+        OutputMode::Interactive => print!("{}", voice::render_sentinel_status(&status_output)),
+        OutputMode::Daemon => println!("{}", serde_json::to_string(&status_output)?),
+    }
+    Ok(())
+}
+```
+
+## Presentation
+
+### Interactive output (running)
+
+```
+SENTINEL — watching
+
+  Running       since 3h ago (PID 12345)
+  Assessment    2m ago (tick: 15m — all promises held)
+  Mounted       WD-18TB
+  Events        42 since startup
+```
+
+### Interactive output (not running)
+
+```
+SENTINEL — not running
+
+  Start with: systemctl --user start urd-sentinel
+  Or: urd sentinel run
+```
+
+### Interactive output (stale state file)
+
+```
+SENTINEL — not running (last seen 3h ago, PID 12345 exited)
+
+  Start with: systemctl --user start urd-sentinel
+```
+
+## Data Flow Summary
+
+```
+                    ┌──────────────────────────┐
+                    │   SentinelRunner (I/O)    │
+                    │                           │
+                    │  5s poll loop:            │
+                    │  ┌─ drives::              │
+                    │  │  drive_availability()  │
+  /proc/mounts ◄───┤  │  → drive diff          │
+                    │  │  → DriveMounted/       │
+                    │  │    DriveUnmounted      │
+                    │  │                        │
+  heartbeat.json ◄──┤  ├─ mtime check          │
+                    │  │  → BackupCompleted     │
+                    │  │                        │
+                    │  ├─ tick deadline check   │
+                    │  │  → AssessmentTick      │
+                    │  │                        │
+  ctrlc signal ◄────┤  └─ shutdown flag         │
+                    │     → Shutdown            │
+                    │                           │
+                    │  for each event:          │
+                    │    sentinel_transition()  │──► pure (sentinel.rs)
+                    │    → execute actions:     │
+                    │      Assess:             │
+                    │        awareness::assess()│──► pure (awareness.rs)
+                    │        has_promise_changes│──► pure (sentinel.rs)
+                    │        notify::dispatch() │──► I/O (notify.rs)
+                    │        write state file   │
+                    │      LogDriveChange:      │
+                    │        log::info!()       │
+                    │      Exit:                │
+                    │        remove state file  │
+                    └──────────────────────────┘
+```
+
+## Dependency on FileSystemState
+
+`awareness::assess()` requires `&dyn FileSystemState`. The trait is defined in `plan.rs`
+(lines 17-68) with 9 required methods. `RealFileSystemState` (plan.rs:623) is the concrete
+implementation, wrapping an optional `&StateDb` for historical send data.
+
+The runner creates `RealFileSystemState` the same way `commands/status.rs` does:
+```rust
+let state_db = StateDb::open(&self.config.general.state_db).ok();
+let fs = RealFileSystemState { state: state_db.as_ref() };
+```
+
+`RealFileSystemState` is currently `pub(crate)` — no visibility change needed.
+
+## What Session 2 Does NOT Include
+
+These are explicitly deferred to keep Session 2 focused on the core pipeline:
+
+1. **Notification deduplication** (Session 3) — backup.rs does not check if Sentinel is
+   running. Both may dispatch for the same state change. Minor UX issue, not a bug.
+
+2. **Drive connection recording** (Session 3) — `LogDriveChange` only logs. No SQLite
+   `drive_connections` table yet.
+
+3. **Edge case hardening** (Session 3) — Missing heartbeat file on startup, LUKS settle
+   debounce, unknown drive labels, SQLite failures during assess.
+
+4. **inotify upgrade** (Session 3+) — Replace 5s polling with instant detection via
+   `nix::sys::inotify` on `/proc/mounts` and heartbeat file.
+
+5. **Config changes** (Session 4) — `[sentinel]` config section for active mode.
+   Passive mode needs no config beyond what already exists.
+
+6. **Active mode / triggers** (Session 4) — `should_trigger_backup()` is callable but
+   the runner doesn't invoke it yet. No subprocess spawning.
+
+## Test Strategy
+
+### Unit tests (~10)
+
+| Test | What it verifies |
+|------|------------------|
+| State file serialization round-trip | `SentinelStateFile` → JSON → parse → fields match |
+| State file read missing file | Returns `None`, doesn't panic |
+| State file read corrupt JSON | Returns `None` |
+| PID alive check (current process) | `is_pid_alive(std::process::id())` returns true |
+| PID alive check (dead PID) | `is_pid_alive(99999999)` returns false |
+| Voice: render running status | Output contains "watching", PID, tick interval |
+| Voice: render not-running status | Output contains "not running" |
+| Voice: render stale status | Output contains "not running", "last seen" |
+| Drive event detection: mount | New drive in available set → `DriveMounted` |
+| Drive event detection: unmount | Drive removed from available set → `DriveUnmounted` |
+
+### What is NOT unit-testable in Session 2
+
+The runner's main loop is inherently I/O-bound. Full integration tests (Session 3+,
+`#[ignore]`) will cover: startup/shutdown lifecycle, real file watching, signal handling.
+Session 2 focuses on testing the seams: serialization, voice rendering, event detection
+logic extracted into testable functions.
+
+## Effort Calibration
+
+**Comparable to:** Heartbeat module (new file + output/voice + integration into backup).
+
+| Component | Lines (estimate) | Complexity |
+|-----------|------------------|------------|
+| `sentinel_runner.rs` | ~200 | Medium — mostly plumbing between pure modules |
+| `commands/sentinel.rs` | ~60 | Low — two handlers, state file read |
+| CLI/main changes | ~30 | Low — mechanical |
+| `output.rs` additions | ~30 | Low — one struct |
+| `voice.rs` additions | ~50 | Low — text rendering |
+| Tests | ~120 | Low — serialization + voice |
+| **Total** | **~490** | |
+
+One session. The poll-based approach eliminates the inotify/epoll complexity that was the
+main implementation risk in the original plan.
+
+## Ready for Review
+
+**For the arch-adversary, focus on:**
+
+1. **Poll interval (5 seconds).** Is this the right balance? Faster wastes CPU on 15-minute
+   tick cycles. Slower delays drive detection. The inotify upgrade (Session 3+) eliminates
+   this trade-off entirely — but is 5s acceptable for the interim?
+
+2. **Duplicate notifications in Session 2.** Both backup and sentinel may dispatch for the
+   same state change. The deduplication (backup checks if sentinel is running) is deferred
+   to Session 3. Is one session of potential duplicates acceptable, or should dedup be
+   in-scope?
+
+3. **Sentinel notification path.** The Sentinel builds notifications from `awareness::assess()`
+   diffs, not from `notify::compute_notifications()` (which is heartbeat-based). These are
+   two independent "did promises change?" implementations that must agree. Is the test
+   coverage in Session 1 (`has_promise_changes`) sufficient, or do we need a cross-path
+   consistency test?
+
+4. **State file as running indicator.** PID + file existence is checked via `/proc/{pid}`.
+   Race: Sentinel crashes between backup reading state file and dispatching notifications.
+   Result: both dispatch (same as no-dedup). Is this the right trade-off vs. a Unix socket
+   or lockfile-based approach?
+
+5. **No config for passive mode.** The sentinel state file path is derived from
+   `config.general.state_db` parent. No `sentinel_state_file` field in config. Is this
+   too implicit, or is the deterministic derivation sufficient?

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -12,9 +12,41 @@ cutover — a conscious risk decision documented in
 [first-night journal](../98-journals/2026-03-25-first-night.md). Monitoring target was
 2026-04-01 (1 week from cutover on 2026-03-25).
 
-**366 tests. All pass. Clippy clean.**
+**389 tests. All pass. Clippy clean.**
 
-### Recent development (2026-03-27, session 5)
+### Recent development (2026-03-27, session 6)
+
+**Sentinel Session 2: I/O runner + CLI.** Built the poll-based event loop (`sentinel_runner.rs`)
+and CLI scaffolding (`urd sentinel run`, `urd sentinel status`). The runner connects Session 1's
+pure state machine to real I/O: 5-second poll loop detects drive mounts, heartbeat changes, and
+tick deadlines. Events feed through `sentinel_transition()`, actions execute (assess, log, exit).
+[Journal](../98-journals/2026-03-27-sentinel-session2.md)
+
+New modules:
+- `sentinel_runner.rs` — I/O runner with poll loop, event detection, action execution (assess
+  coalescing, initial drive scan through state machine), state file I/O (atomic write),
+  `build_notifications()` pure function, `check_backup_overdue()` pure function with 4h debounce.
+- `commands/sentinel.rs` — CLI handlers for `run` (foreground daemon) and `status` (reads state
+  file, checks PID liveness, cleans up stale files).
+
+Voice rendering for `urd sentinel status`: interactive mode shows uptime, PID, assessment timing,
+mounted drives, promise summary. Daemon mode outputs JSON.
+
+**Design review** (pre-implementation): 2 significant + 2 moderate findings, all addressed in
+implementation: heartbeat baseline S1 fix, notification contract S2 specification, assess
+coalescing M1, initial drive scan routing M2.
+[Design review](../99-reports/2026-03-27-sentinel-session2-design-review.md)
+
+**Implementation review** found and fixed: BackupOverdue was gated behind `has_promise_changes()`
+(would never fire for silent backup failures — the most common overdue scenario). Extracted
+`check_backup_overdue()` as pure function with independent evaluation. Lifecycle logs promoted to
+`warn!()` for journald visibility. BackupOverdue debounced at 4h to prevent notification spam.
+[Implementation review](../99-reports/2026-03-27-sentinel-session2-implementation-review.md)
+
+23 new tests (state file I/O, PID checks, promise notifications, BackupOverdue pure function,
+voice rendering). Session 3 next: hardening + notification deduplication.
+
+### Earlier development (2026-03-27, session 5)
 
 **Sentinel Session 1: Lock extraction + pure state machine.** Built the Sentinel's core
 pure module (`sentinel.rs`) and extracted the backup lock to a shared module (`lock.rs`).
@@ -349,7 +381,7 @@ The Sentinel is three independent systems that compose. Build and test them sepa
 | # | Component | Depends On | Notes |
 |---|-----------|------------|-------|
 | 5a | ~~**Notification dispatcher**~~ | ~~Awareness model (3a)~~ | **COMPLETE.** `notify.rs`: `compute_notifications()` pure function, 4 channel types (Desktop/Webhook/Command/Log), urgency filtering. Heartbeat gains `notifications_dispatched` for crash recovery. `[notifications]` config section. Integrated into `backup.rs`. 18 tests. |
-| 5b | **Event reactor** | Awareness model (3a), heartbeat (3b) | Session 1 complete: pure state machine (`sentinel.rs`), shared lock (`lock.rs`), circuit breaker, adaptive tick. Session 2 next: I/O runner + CLI. [Design](../95-ideas/2026-03-27-design-sentinel-implementation.md) |
+| 5b | **Event reactor** | Awareness model (3a), heartbeat (3b) | Session 1 complete: pure state machine. Session 2 complete: I/O runner (`sentinel_runner.rs`), CLI (`urd sentinel run/status`), passive monitoring with BackupOverdue detection + 4h debounce. Session 3 next: hardening + notification deduplication. [Design](../95-ideas/2026-03-27-design-sentinel-implementation.md) |
 | 5c | **Active mode** | Event reactor (5b) | Auto-trigger logic designed in Session 1: `should_trigger_backup()`, `TriggerPermission`, `evaluate_trigger_result()`. Implementation in Session 4. |
 
 Architectural gates:
@@ -358,8 +390,8 @@ Architectural gates:
 - [x] Event/action types defined as enums (testable state machine) — `sentinel.rs` Session 1
 - [x] Lock contention with manual `urd backup` designed — `lock.rs` shared module
 - [x] Circuit breaker designed (min interval between auto-triggers) — `CircuitBreaker` with `TriggerPermission`
-- [ ] Passive mode ships and works before active mode is attempted
-- [ ] Sentinel can be killed without affecting promise state computation
+- [x] Passive mode ships and works before active mode is attempted — Session 2: `urd sentinel run` polls, assesses, notifies
+- [x] Sentinel can be killed without affecting promise state computation — ctrlc handler, state file cleanup on exit
 
 ### Priority 6: Core Expansion
 
@@ -561,7 +593,7 @@ timestamp staleness handling, space check deduplication, ANSI line clearing.
 - [x] **Phase 5** — Architectural foundation: awareness model, heartbeat, presentation layer, `urd get`, voice migration (8/8 commands), structured errors
 - [x] **Phase 5 gate** — ADR-110: protection promise design (retention mappings, config conflicts, migration)
 - [x] **Phase 6** — Protection promises: types, derivation, config resolution, preflight checks, planner drive filtering, `--confirm-retention-change`, status display. Config deployed with promises.
-- [ ] **Phase 7** — Sentinel: ~~notification dispatcher~~ (5a done) → ~~state machine + lock~~ (Session 1 done) → I/O runner → active mode
+- [ ] **Phase 7** — Sentinel: ~~notification dispatcher~~ (5a done) → ~~state machine + lock~~ (Session 1 done) → ~~I/O runner + CLI~~ (Session 2 done) → hardening/dedup (Session 3) → active mode (Session 4)
 - [ ] **Phase 8** — Expansion: completions, smart defaults, setup wizard, drive lifecycle
 
 ## Active Work — Operational Cutover
@@ -680,7 +712,8 @@ for the graduation rationale.
 | Sentinel design (5a/5b/5c) | [Sentinel design](../95-ideas/2026-03-26-design-sentinel.md) |
 | Sentinel implementation plan (5b+5c) | [Implementation plan](../95-ideas/2026-03-27-design-sentinel-implementation.md) |
 | Session 3 deployment + verification tests | [Session 3 journal](../98-journals/2026-03-27-session3-deployment.md) |
-| Latest adversary review | [Sentinel Session 1 review](../99-reports/2026-03-27-sentinel-session1-review.md) |
+| Sentinel Session 2 design + reviews | [Design](../95-ideas/2026-03-27-design-sentinel-session2.md), [design review](../99-reports/2026-03-27-sentinel-session2-design-review.md), [impl review](../99-reports/2026-03-27-sentinel-session2-implementation-review.md) |
+| Latest adversary review | [Sentinel Session 2 implementation review](../99-reports/2026-03-27-sentinel-session2-implementation-review.md) |
 | Code conventions & architecture | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 
@@ -692,7 +725,7 @@ for the graduation rationale.
 - Successful sends could update `subvolume_sizes` table to keep calibration fresh, but pipe bytes ≠ `du -sb` bytes (method mixing concern)
 - `FileSystemState` trait (10 methods, including `drive_availability`) is outgrowing its name — consider renaming to `SystemState` if more methods are added
 - `SubvolumeResult.send_type` in executor.rs records only the last send type when a subvolume is sent to multiple drives — the per-operation data in `OperationOutcome` is correct, but the summary field is misleading. The backup summary works around this by extracting from operations directly
-- `heartbeat::read()` returns `Option` — cannot distinguish missing file from corrupt JSON (upgrade to `Result<Option>` when Sentinel is built)
+- `heartbeat::read()` returns `Option` — cannot distinguish missing file from corrupt JSON. Sentinel's `check_backup_overdue()` handles this gracefully (returns `None` on any parse failure), but a `Result<Option>` upgrade would allow logging corrupt heartbeat files
 - ~~`init` command still uses direct `println!`~~ — resolved: migrated to voice layer (session 3)
 - Per-drive pin protection for external retention — current all-drives-union is conservative but suboptimal for space
 - `urd get` normalizes paths without filesystem access (no `canonicalize`) — symlinked paths won't match subvolume sources. Documented limitation; correct behavior (use canonical paths)

--- a/docs/99-reports/2026-03-27-sentinel-session2-design-review.md
+++ b/docs/99-reports/2026-03-27-sentinel-session2-design-review.md
@@ -1,0 +1,368 @@
+# Arch-Adversary Review: Sentinel Session 2 Design — I/O Runner + CLI
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-27
+**Scope:** Design review — `docs/95-ideas/2026-03-27-design-sentinel-session2.md`
+**Review type:** Design review (pre-implementation)
+**Prior artifacts:** Session 1 implementation (`sentinel.rs`, `lock.rs`), Session 1 review
+**Reviewer:** Claude (arch-adversary)
+
+---
+
+## 1. Executive Summary
+
+The design is sound and well-scoped. The poll-first simplification is the right call — it
+eliminates the highest-risk component (inotify/epoll integration) from Session 2 while
+delivering the full event→transition→action pipeline. One significant finding: the design
+introduces a second, independent notification path that can produce semantically different
+notifications than the existing backup path for identical state changes. This divergence
+must be designed carefully now or it will produce confusing user-facing behavior. The rest
+is solid plumbing with clear module boundaries.
+
+## 2. What Kills You (Catastrophic Failure Proximity)
+
+**Can the Sentinel cause silent data loss?** No. The Sentinel in passive mode performs
+zero btrfs operations. It reads filesystem state (snapshot directories, mount points) and
+dispatches notifications. It cannot delete, create, or modify snapshots. The closest it
+comes to a dangerous path is `awareness::assess()`, which is a pure function that reads
+through `FileSystemState` — the same code path that `urd status` uses. **Distance: not
+reachable from this design.**
+
+**Can the Sentinel interfere with running backups?** No. The Sentinel doesn't acquire
+the backup lock in passive mode. It reads the heartbeat file (which is written atomically)
+and the filesystem (which is read-only from the Sentinel's perspective). The only shared
+mutable state is the sentinel state file, which only the Sentinel writes and only
+`urd sentinel status` reads.
+
+**Can a Sentinel bug cause the user to believe data is safe when it isn't?** Yes — this
+is the relevant catastrophic mode for a monitoring daemon. If the Sentinel suppresses
+notifications it should send, or sends "all clear" when promises are degraded, the user
+loses the early warning that is the Sentinel's entire purpose. **Distance: 1 bug in the
+notification building logic.** This makes the notification path the highest-scrutiny area
+of this review.
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4 | Poll loop is straightforward. Event→transition→action pipeline reuses tested pure functions. One gap: heartbeat baseline detection has a logic bug (S1). Notification path is under-specified (S2). |
+| **Security** | 5 | No new attack surface. No privilege escalation. No external input parsing beyond existing config. PID check via `/proc` is standard and safe. |
+| **Architectural Excellence** | 4 | Clean module boundaries. Runner is pure plumbing between tested pure modules. The poll-first approach is a good simplification. One structural concern: `build_notifications()` is a new function that duplicates existing notification logic (T1). |
+| **Systems Design** | 4 | Poll interval is fine for v1. Graceful shutdown via AtomicBool is the right pattern. State file as running indicator is adequate. StateDb open-per-assessment is the safe choice (S3). |
+
+## 4. Design Tensions
+
+### Tension 1: Two notification paths (heartbeat-based vs. assessment-based)
+
+The backup command uses `notify::compute_notifications(previous_heartbeat, current_heartbeat)`
+to determine what to notify about. The Sentinel uses `sentinel::has_promise_changes()` +
+a new `build_notifications()` method to determine notifications from raw assessments.
+
+These are two independent implementations of "did promise states change, and what should
+the user hear about it?" The backup path compares heartbeat string fields
+(`prev_sv.promise_status != current_sv.promise_status`). The Sentinel path compares
+`PromiseStatus` enum values. They should agree, but they operate on different data
+representations — one is `String` (heartbeat JSON), the other is `PromiseStatus` (typed
+enum).
+
+More concerning: `compute_notifications` generates specific notification types beyond
+promise changes — `BackupFailures`, `AllUnprotected`, `PinWriteFailures`. The Sentinel's
+`has_promise_changes` only detects promise status changes. This means the backup path
+notifies on failure events that the Sentinel path cannot detect, because the Sentinel
+doesn't see backup execution results (only heartbeat changes).
+
+**This tension is resolved correctly by the design's Session 3 plan** — the Sentinel
+will detect heartbeat changes and can use `compute_notifications` for backup-sourced
+events. But Session 2 ships with the gap, and `build_notifications()` must be designed
+to produce the right subset (promise changes only) without creating an expectation that
+it covers everything.
+
+**Verdict:** The two-path approach is the right architecture (the Sentinel and backup have
+genuinely different information available), but `build_notifications()` needs a clear
+contract: it produces *Sentinel-observed* notifications (promise transitions, drive events,
+heartbeat staleness), NOT backup-execution notifications (failures, pin issues). The backup
+path handles those. Document this split explicitly.
+
+### Tension 2: Assessment frequency vs. resource cost
+
+The Sentinel opens `StateDb` and calls `awareness::assess()` every tick (2-15 minutes).
+Each assessment reads snapshot directories, checks drive mounts, and queries SQLite.
+On a system with 9 subvolumes and 2 drives, this means ~20 filesystem stat calls and
+several SQLite queries per tick.
+
+At 15-minute ticks, this is negligible. At 2-minute ticks (UNPROTECTED state), it's still
+lightweight but now running on a system that's already under stress (something is wrong
+enough to be UNPROTECTED). The design correctly avoids keeping the StateDb connection open
+between ticks, which prevents lock contention with `urd backup`.
+
+**Verdict:** Right trade-off for v1. The resource cost is trivially small. Opening StateDb
+per-assessment is the safe choice (avoids stale connections and lock contention).
+
+## 5. Findings
+
+### Significant
+
+**S1. Heartbeat baseline detection has a logic bug — will fire spurious BackupCompleted on startup.**
+
+```rust
+fn detect_heartbeat_event(&mut self) -> Option<SentinelEvent> {
+    let mtime = std::fs::metadata(&self.heartbeat_path).ok()?.modified().ok()?;
+    if self.last_heartbeat_mtime.map_or(true, |prev| mtime > prev) {
+        self.last_heartbeat_mtime = Some(mtime);
+        // Skip event on first check (just recording baseline mtime)
+        if self.last_heartbeat_mtime.is_some() {
+            return Some(SentinelEvent::BackupCompleted);
+        }
+    }
+    None
+}
+```
+
+The comment says "skip event on first check" but the code doesn't skip it.
+`self.last_heartbeat_mtime` is set to `Some(mtime)` two lines above, so the
+`if self.last_heartbeat_mtime.is_some()` check is *always true* after the
+assignment. The "first check" baseline skip never happens.
+
+*Consequence:* On every Sentinel startup, a spurious `BackupCompleted` event fires
+immediately. This triggers an `Assess` action (via `sentinel_transition`), which is
+actually harmless for Session 2 — the first assessment was going to happen anyway via
+the tick. But it violates the stated design intent and would cause a real problem in
+Session 4 when `BackupCompleted` might have different semantics.
+
+*Fix:* Use a separate `is_first_check` flag, or initialize `last_heartbeat_mtime` in
+`SentinelRunner::new()` by reading the current mtime (establishing baseline before
+the loop starts). The latter is simpler:
+
+```rust
+// In SentinelRunner::new():
+let last_heartbeat_mtime = std::fs::metadata(&heartbeat_path)
+    .ok()
+    .and_then(|m| m.modified().ok());
+
+// In detect_heartbeat_event():
+fn detect_heartbeat_event(&mut self) -> Option<SentinelEvent> {
+    let mtime = std::fs::metadata(&self.heartbeat_path).ok()?.modified().ok()?;
+    match self.last_heartbeat_mtime {
+        Some(prev) if mtime > prev => {
+            self.last_heartbeat_mtime = Some(mtime);
+            Some(SentinelEvent::BackupCompleted)
+        }
+        None => {
+            // First observation — record baseline, no event
+            self.last_heartbeat_mtime = Some(mtime);
+            None
+        }
+        _ => None,
+    }
+}
+```
+
+**S2. `build_notifications()` is under-specified — the design's most critical new function has no definition.**
+
+The design says:
+
+> **Notification building:** The Sentinel uses `awareness::assess()` directly (not
+> heartbeat-based `notify::compute_notifications()`). It builds `Notification` objects
+> from promise state diffs.
+
+But `build_notifications()` is never defined. It's called in `execute_assess()` as
+`self.build_notifications(&assessments)`, but the design doesn't specify:
+
+1. What `Notification` events it produces (which `NotificationEvent` variants?)
+2. How it maps promise state diffs to urgency levels
+3. Whether it handles the `BackupOverdue` event (heartbeat staleness — the one
+   `NotificationEvent` variant explicitly marked `#[allow(dead_code)]` with a comment
+   "Constructed by Sentinel (5b)")
+4. How its output compares to `compute_notifications()` for the same state change
+
+This is the function closest to the "false sense of safety" catastrophic mode. A bug
+here means the user doesn't get notified when they should.
+
+*Fix:* Specify `build_notifications()` in the design:
+- Input: previous `Vec<PromiseSnapshot>` + current `Vec<SubvolAssessment>`
+- Output: `Vec<Notification>` containing `PromiseDegraded` and `PromiseRecovered` events
+- Urgency mapping: degradation = Warning (same as `compute_notifications`), recovery = Info
+- `BackupOverdue`: check heartbeat `stale_after` field — this IS the Sentinel's job
+- `AllUnprotected`: emit when every subvolume is Unprotected — Critical urgency
+- `BackupFailures` and `PinWriteFailures`: NOT produced by this path (backup-only events)
+
+### Moderate
+
+**M1. Drive event ordering creates redundant assessments.**
+
+The design says: "Order: drive changes first (they trigger assessments that include the
+new drive state), then heartbeat, then tick."
+
+If a drive mounts AND the tick is due in the same poll cycle, the event sequence is:
+`DriveMounted` → `AssessmentTick`. Both produce `Assess` actions (via
+`sentinel_transition`). Two assessments run back-to-back in the same 5-second window,
+with the second producing identical results.
+
+*Consequence:* Wasted work. On a 2-minute tick with a drive mount, you get two full
+assessments (filesystem reads + SQLite) within milliseconds of each other.
+
+*Fix:* After processing all events in a cycle, deduplicate the action list — if multiple
+`Assess` actions are queued, execute only one. Simple filter: `actions.dedup()` (since
+`SentinelAction` derives `PartialEq`). Or process events in a batch and coalesce:
+
+```rust
+let events = self.collect_events();
+let mut need_assess = false;
+for event in &events {
+    let (new_state, actions) = sentinel_transition(&self.state, event);
+    self.state = new_state;
+    for action in actions {
+        match action {
+            SentinelAction::Assess => need_assess = true,
+            other => self.execute_action(other)?,
+        }
+    }
+}
+if need_assess {
+    self.execute_assess()?;
+}
+```
+
+This is cleaner and handles the N-events-per-cycle case efficiently.
+
+**M2. Initial drive scan should use `sentinel_transition`, not bypass it.**
+
+The design says: "initial drive scan → populate state.mounted_drives (no events, just
+baseline)."
+
+But the state machine already handles this correctly — `DriveMounted` events add drives
+to the set. If you bypass the state machine for the initial scan, you lose the
+`LogDriveChange` actions and create a code path that isn't tested by the state machine's
+unit tests.
+
+*Fix:* Run the initial drive scan through the event pipeline, but with a flag or
+by running it *before* `has_initial_assessment` is set. The state machine's `DriveMounted`
+handler will add the drives and emit `Assess` + `LogDriveChange`. The `LogDriveChange` on
+startup is actually useful ("Sentinel starting, detected drives: WD-18TB"). The `Assess`
+action will be the initial assessment — combine the two startup steps into one.
+
+However — there's a subtlety: if you process mount events for all pre-mounted drives,
+you get N `Assess` actions (one per drive). With the M1 coalescing fix, this becomes one
+assessment. Without it, you run N redundant assessments on startup. **M1 and M2 should be
+addressed together.**
+
+**M3. State file deletion on exit is racy with `urd sentinel status`.**
+
+The design says `execute_exit` removes the state file. If `urd sentinel status` reads
+the file between the Sentinel deciding to exit and the file being removed, it sees a
+"running" Sentinel that's about to die.
+
+*Consequence:* Cosmetic — `urd sentinel status` briefly shows "running" for a dying
+Sentinel. The next check shows "not running" (file gone) or "stale" (PID dead). No
+functional impact.
+
+*Recommendation:* Accept this. The race window is microseconds. Not worth adding
+complexity for. Just noting it for completeness.
+
+### Commendation
+
+**C1. The poll-first simplification is the right engineering judgment.**
+
+The original design proposed epoll + inotify + timerfd — three Linux syscall families
+with their own failure modes, edge cases, and testing difficulties. The poll-based
+approach eliminates all of that complexity while delivering identical functionality with
+at most 5 seconds of latency. For a monitoring daemon where the fastest action cycle is
+2 minutes, 5 seconds of detection delay is noise.
+
+More importantly, the design correctly identifies the upgrade path: inotify can replace
+polling later without changing the runner's structure, because the state machine is
+event-source agnostic. This is the ADR-108 pattern paying dividends — the investment in
+a pure state machine means the I/O layer is replaceable.
+
+**C2. Scoping is disciplined — the deferred items list is honest.**
+
+Six items are explicitly deferred with clear session assignments. Each deferral includes
+the consequence of not having it ("duplicate notifications are a minor UX issue, not a
+correctness issue"). This is the right way to manage scope — not by pretending deferred
+items don't matter, but by stating what the user will experience and when it gets fixed.
+
+**C3. FileSystemState reuse is correct.**
+
+The runner creates `RealFileSystemState` the same way `commands/status.rs` does. This
+means the Sentinel's view of filesystem state is identical to what `urd status` would
+show. No new trait implementation, no new filesystem access patterns, no new code that
+could disagree with the rest of the system.
+
+## 6. The Simplicity Question
+
+> **What could be removed?**
+
+**The `events_since_startup` counter** is included in the state file and displayed in
+`urd sentinel status`. It has no operational value — it doesn't affect behavior, doesn't
+help debugging (log timestamps do that), and isn't consumed by any other component. It's
+a vanity metric. Remove it unless there's a concrete use case. If the user wants to know
+if the Sentinel is active, the `last_assessment` timestamp and the PID are sufficient.
+
+**The `Stale` variant of `SentinelStatusOutput`** (PID dead, file left behind). The
+distinction between "not running" and "stale state file" is cosmetic. Both mean "the
+Sentinel isn't running." The stale case adds a code path, a voice rendering variant, and
+a test — for a message that means the same thing as "not running" but with slightly more
+information. Consider collapsing to two states: Running / NotRunning. If the state file
+exists but PID is dead, clean it up and show NotRunning.
+
+> **What's earning its keep?**
+
+**The `detect_drive_events` / `detect_heartbeat_event` / `detect_tick_event` separation.**
+Three small functions, each testable independently, each responsible for exactly one event
+source. This is the right granularity — easy to replace any one with an inotify-based
+version later.
+
+**The state file as running indicator.** No IPC, no socket, no lockfile dance. One JSON
+file, one PID check. Simple and sufficient for v1.
+
+## 7. For the Dev Team (Prioritized Action Items)
+
+1. **Fix heartbeat baseline detection** (S1). Initialize `last_heartbeat_mtime` in
+   `SentinelRunner::new()` by reading the current file mtime. In `detect_heartbeat_event`,
+   only fire `BackupCompleted` when `Some(prev)` exists and `mtime > prev`. Don't use
+   the set-then-check pattern in the design pseudocode.
+
+2. **Specify `build_notifications()` contract** (S2). Define explicitly: which
+   `NotificationEvent` variants it produces (`PromiseDegraded`, `PromiseRecovered`,
+   `AllUnprotected`, `BackupOverdue`), how it maps urgency, and what it does NOT produce
+   (`BackupFailures`, `PinWriteFailures` — those are backup-path-only). This is the
+   function closest to the monitoring catastrophic mode — under-specification here is a
+   risk.
+
+3. **Coalesce Assess actions per poll cycle** (M1). Don't execute multiple assessments
+   when N events in the same cycle all produce Assess. Collect actions, deduplicate, then
+   execute. This naturally handles the startup case (M2) where all pre-mounted drives
+   generate events simultaneously.
+
+4. **Route initial drive scan through the state machine** (M2). Don't bypass
+   `sentinel_transition` for the startup drive scan. Process `DriveMounted` events
+   for each initially-detected drive, let the state machine handle them, coalesce the
+   resulting Assess actions (per M1), and execute one initial assessment. This
+   eliminates a bypass code path and produces useful startup log messages.
+
+5. **Consider removing `events_since_startup`** (Simplicity). If no consumer needs it,
+   it's dead weight in the state file schema.
+
+## 8. Open Questions
+
+1. **Should `build_notifications` handle `BackupOverdue`?** The `NotificationEvent`
+   variant exists and is annotated "Constructed by Sentinel (5b)." The heartbeat has a
+   `stale_after` field. The Sentinel can check `now > stale_after` and emit this
+   notification. Is this in scope for Session 2 (it's a natural fit) or Session 3 (with
+   the rest of the hardening)?
+
+2. **What happens when `awareness::assess()` errors?** The design shows
+   `assessments = awareness::assess(&config, now, &fs)` but the function returns
+   `Vec<SubvolAssessment>`, not `Result`. Per-subvolume errors are captured in
+   `SubvolAssessment.errors`. Should the Sentinel log these? Surface them in
+   notifications? Or just pass them through to the state file?
+
+3. **Should `urd sentinel status` clean up stale state files?** The current design shows
+   three states (Running/Stale/NotRunning). If `urd sentinel status` detects a stale
+   file (PID dead), should it remove it? This would simplify the "is the Sentinel running?"
+   check in Session 3 (backup.rs) — if the file exists, the Sentinel is running, period.
+
+---
+
+*Review conducted as architectural adversary. Findings reflect design-phase analysis of
+the Session 2 proposal.*

--- a/docs/99-reports/2026-03-27-sentinel-session2-implementation-review.md
+++ b/docs/99-reports/2026-03-27-sentinel-session2-implementation-review.md
@@ -1,0 +1,331 @@
+# Arch-Adversary Review: Sentinel Session 2 Implementation
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-27
+**Scope:** Implementation review — `sentinel_runner.rs`, `commands/sentinel.rs`, output/voice/cli additions
+**Review type:** Implementation review (post-implementation)
+**Prior artifacts:** Session 2 design, Session 2 design review, Session 1 implementation
+**Reviewer:** Claude (arch-adversary)
+
+---
+
+## 1. Executive Summary
+
+The implementation is clean, well-scoped, and faithfully addresses all four findings from the
+design review. The code is pure plumbing between tested pure modules — exactly what it should
+be. One significant finding: `BackupOverdue` fires on *every* assessment cycle once the
+heartbeat is stale, not just on the transition from fresh to stale. This will produce
+repeated notifications every 2-15 minutes until a backup runs. One moderate finding: the
+`build_notifications` function reads `chrono::Local::now()` internally, making it impure
+and untestable for the BackupOverdue path. The rest is solid.
+
+## 2. What Kills You (Catastrophic Failure Proximity)
+
+**Can the Sentinel cause silent data loss?** No. The Sentinel performs zero btrfs operations.
+It reads filesystem state, compares promise snapshots, and dispatches notifications. No path
+exists from this code to snapshot deletion or modification. **Distance: not reachable.**
+
+**Can the Sentinel cause the user to believe data is safe when it isn't?** The relevant
+catastrophic mode for a monitoring daemon. Two paths:
+
+1. **Suppressed notification** — `has_promise_changes()` returns false when it should return
+   true. This function has 6 unit tests from Session 1 covering same, changed, new, and
+   removed subvolumes. The `has_initial_assessment` guard correctly suppresses only the first
+   assessment. **Distance: 2 bugs** (would need both `has_promise_changes` and
+   `build_notifications` to independently miss the same transition).
+
+2. **BackupOverdue never fires** — if the heartbeat file parse fails silently, the user never
+   gets the staleness warning. The code uses `heartbeat::read()` which returns `None` on
+   parse failure, and the `if let Some(heartbeat)` chain silently skips. This is the correct
+   behavior (fail open on monitoring, don't crash), but it means a corrupted heartbeat file
+   *also* suppresses the overdue warning. **Distance: 1 filesystem corruption event.**
+   Acceptable — a corrupted heartbeat is a genuine problem that will surface through other
+   channels (the backup itself writes the heartbeat, so the next successful backup resets it).
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4 | All design review findings addressed correctly. One gap: BackupOverdue repeats on every tick (S1). BackupOverdue path is impure and untested (S2). |
+| **Security** | 5 | No new attack surface. State file is in the same data directory as the existing heartbeat and SQLite database. No privilege escalation. PID check via `/proc` is the standard Linux pattern. |
+| **Architectural Excellence** | 5 | The runner is pure plumbing. Every decision lives in a tested pure module. Action coalescing is clean. The state machine boundary is respected everywhere. |
+| **Systems Design** | 4 | Poll loop is correct. Atomic writes are correct. One concern: the Sentinel logs at `Warn` default level but all its log messages use `info!` — it will be silent unless `--verbose` or `RUST_LOG` is set (M1). |
+| **Rust Idioms** | 4 | Clean use of `let` chains, proper `BTreeSet` diff for drive detection, `Arc<AtomicBool>` for shutdown. One minor: `Serde` derive on `Deserialize` was missing from `output.rs` import — mechanical fix, but reveals this wasn't caught by incremental compilation during development. |
+| **Code Quality** | 4 | Clear module structure, good comments, tests cover the seams. The `test_config()` helper is duplicated from `heartbeat.rs` tests — not ideal but acceptable for test isolation. |
+
+## 4. Design Tensions
+
+### Tension 1: BackupOverdue evaluated every tick vs. on transition only
+
+The `build_notifications` function checks `now > stale_after` on every call. Since
+`execute_assess()` calls it whenever promise states change AND the heartbeat is stale, the
+BackupOverdue notification will fire alongside every promise-change notification once the
+heartbeat goes stale.
+
+But there's a subtler issue: BackupOverdue is computed *inside* `build_notifications`, which
+is only called when `has_promise_changes()` returns true. If the heartbeat goes stale but
+promise states haven't changed (the common case — nothing is happening, that's why it's
+stale), **BackupOverdue will never fire.**
+
+This is a real gap. The stale heartbeat should be detected independently of promise state
+changes.
+
+**Verdict:** This needs a fix. The BackupOverdue check should be in `execute_assess()`,
+not gated by `has_promise_changes()`.
+
+### Tension 2: `build_notifications` purity vs. convenience
+
+The function takes `&Config` to read the heartbeat file for BackupOverdue. This means it
+performs I/O (filesystem read) and calls `chrono::Local::now()`. The rest of the notification
+logic is pure (previous + current assessments → notifications). The BackupOverdue check is
+the outlier.
+
+**Verdict:** Right trade-off for v1 — the alternative is threading heartbeat data through
+the caller, adding parameters to a function that's already clear. The impurity is isolated
+to one code path and documented. But it makes the BackupOverdue path untested by unit tests.
+
+## 5. Findings
+
+### Significant
+
+**S1. BackupOverdue is gated by `has_promise_changes()` — will never fire in the common case.**
+
+In `execute_assess()` (line 231):
+
+```rust
+if self.state.has_initial_assessment
+    && sentinel::has_promise_changes(&self.state.last_promise_states, &assessments)
+{
+    let notifications =
+        build_notifications(&self.state.last_promise_states, &assessments, &self.config);
+    // ...
+}
+```
+
+The BackupOverdue check inside `build_notifications` only runs when promise states change.
+But the scenario where BackupOverdue matters most is: backups have stopped, nothing is
+changing, the heartbeat is stale. In that case, `has_promise_changes()` returns false (promise
+states are stable at whatever level they were), and `build_notifications` is never called.
+
+The user doesn't get the "no backup in Xh" notification that is the Sentinel's primary
+value proposition for this failure mode.
+
+*Consequence:* The Sentinel detects drive changes and promise transitions correctly, but
+fails to detect the "nothing is happening and it should be" case — which is arguably the
+most important thing a monitoring daemon does.
+
+*Fix:* Extract BackupOverdue into a separate check in `execute_assess()`, outside the
+`has_promise_changes` gate:
+
+```rust
+// Always check for stale heartbeat, regardless of promise changes.
+let mut notifications = Vec::new();
+
+if self.state.has_initial_assessment
+    && sentinel::has_promise_changes(&self.state.last_promise_states, &assessments)
+{
+    notifications.extend(
+        build_notifications(&self.state.last_promise_states, &assessments, &self.config)
+    );
+}
+
+// BackupOverdue is independent of promise changes.
+if self.state.has_initial_assessment {
+    notifications.extend(check_backup_overdue(&self.config));
+}
+
+if !notifications.is_empty() {
+    notify::dispatch(&notifications, &self.config.notifications);
+}
+```
+
+This also resolves the "repeated every tick" concern — you'll want a
+`last_overdue_notification` timestamp to debounce it (notify once, then again at increasing
+intervals, like 1h / 4h / 12h).
+
+**S2. BackupOverdue path is impure and has zero test coverage.**
+
+`build_notifications` calls `heartbeat::read()` and `chrono::Local::now()` internally,
+making the BackupOverdue path impossible to test without a real heartbeat file on disk.
+All 5 `build_notifications` tests use a `test_config()` with a nonexistent heartbeat path,
+which means every test implicitly skips the BackupOverdue branch.
+
+This is the notification closest to the monitoring catastrophic mode ("Sentinel fails to
+alert when backups have stopped"), and it has no test coverage.
+
+*Consequence:* If the stale_after comparison logic has a bug (e.g., timestamp format mismatch,
+timezone issue), it won't be caught until production.
+
+*Fix:* When you extract BackupOverdue per S1, make `check_backup_overdue` take the heartbeat
+data and `now` as parameters (pure function pattern), and test it directly:
+
+```rust
+fn check_backup_overdue(heartbeat: &Heartbeat, now: NaiveDateTime) -> Option<Notification>
+```
+
+### Moderate
+
+**M1. All Sentinel log messages use `log::info!()` but the default log level is `Warn`.**
+
+In `main.rs` (line 41):
+```rust
+.filter_level(if cli.verbose {
+    log::LevelFilter::Debug
+} else {
+    log::LevelFilter::Warn
+})
+```
+
+Every log message in the runner uses `info!`:
+- "Sentinel starting" (line 80)
+- "Initial assessment complete" (line 246)
+- "Drive mounted: {label}" (line 263)
+- "Drive unmounted: {label}" (line 265)
+- "Sentinel shutting down" (line 270)
+
+None of these will appear in journald unless the user runs `urd sentinel run --verbose`
+or sets `RUST_LOG=info`. A daemon that's completely silent even on startup and shutdown is
+disorienting — the user will `journalctl -u urd-sentinel` and see nothing.
+
+*Consequence:* The Sentinel appears broken or not running because there's no log output to
+confirm it started. The user has to check `urd sentinel status` or add `--verbose` to the
+systemd unit.
+
+*Fix:* Use `log::warn!` for lifecycle events (start, shutdown, assessment failures) that the
+user should see without `--verbose`. Keep `info!` for routine events (drive mount/unmount,
+assessment complete) that are useful for debugging but noisy in normal operation. The
+assessment failure path already uses `log::error!` — that's correct.
+
+Alternatively, consider adding `--verbose` to the recommended systemd unit invocation, since
+daemons are expected to log more than CLI tools.
+
+**M2. No debounce on BackupOverdue — will fire repeatedly once stale.**
+
+Even after fixing S1, every assessment tick (2-15 minutes) will re-evaluate the heartbeat
+staleness. If the heartbeat is stale for 6 hours, the user gets ~24-180 repeated
+BackupOverdue notifications depending on the tick interval. This turns a useful alert into
+spam that trains the user to ignore notifications.
+
+*Consequence:* Notification fatigue degrades the Sentinel's value as a monitoring system.
+
+*Fix:* Track `last_overdue_notified: Option<Instant>` in the runner. Only fire BackupOverdue
+if it hasn't been sent in the last N hours (suggest: 4h, matching the typical send interval).
+Or: fire once, then again at doubling intervals (1h, 2h, 4h, 8h) similar to the circuit
+breaker backoff. This is a natural Session 3 item but worth noting now because S1's fix
+will expose this immediately.
+
+### Commendation
+
+**C1. The Assess coalescing is exactly right.**
+
+```rust
+fn execute_actions(&mut self, actions: &[SentinelAction]) {
+    let mut need_assess = false;
+    for action in actions {
+        match action {
+            SentinelAction::Assess => need_assess = true,
+            // ...
+        }
+    }
+    if need_assess && let Err(e) = self.execute_assess() { ... }
+}
+```
+
+This is the M1 fix from the design review, implemented cleanly. A `DriveMounted` + tick
+in the same cycle produces one assessment, not two. The M2 fix (initial drive scan through
+state machine) composes naturally with this — 5 pre-mounted drives produce 5 events, 5
+`Assess` actions, and one actual assessment. No special-case code, no bypass.
+
+**C2. The S1 heartbeat baseline fix is correct and minimal.**
+
+```rust
+// In new():
+let last_heartbeat_mtime = std::fs::metadata(&heartbeat_path)
+    .ok()
+    .and_then(|m| m.modified().ok());
+
+// In detect_heartbeat_event():
+match self.last_heartbeat_mtime {
+    Some(prev) if mtime > prev => { ... Some(BackupCompleted) }
+    None => { self.last_heartbeat_mtime = Some(mtime); None }
+    _ => None,
+}
+```
+
+The design's pseudocode had a set-then-check bug. This implementation avoids it entirely
+by initializing the baseline in `new()` and using a clean match in the detector. The `None`
+arm handles the edge case where the heartbeat file didn't exist at startup but appears
+later — records baseline, no event. Correct.
+
+**C3. The `build_notifications` contract is explicit and enforced by tests.**
+
+The `notifications_never_produces_backup_only_events` test explicitly asserts that
+`BackupFailures` and `PinWriteFailures` are never produced. This isn't just a negative test
+for completeness — it's the documented contract from S2 of the design review, encoded as
+a test. If someone later adds a heartbeat-reading path that produces backup-only events,
+this test catches it.
+
+## 6. The Simplicity Question
+
+> **What could be removed?**
+
+**The `SentinelStateFile` type lives in `output.rs` but has I/O methods.** The `read()` method
+performs filesystem I/O, which violates the output module's role as a pure type definitions
+module. The type is fine in `output.rs` (it's a structured output type), but `read()` should
+either live in `sentinel_runner.rs` or be a free function. This is minor — it works, it's
+tested, and the violation is documented. But it's the kind of thing that accumulates.
+
+> **What's earning its keep?**
+
+**Everything else.** The runner is ~310 lines including tests. The CLI handler is 62 lines.
+The voice rendering is ~60 lines. There's no premature abstraction, no generic parameters,
+no trait objects. The most complex function (`build_notifications`) is 90 lines and reads
+top-to-bottom. The `format_tick_description` helper in voice.rs is a clean extraction that
+keeps the match arm readable.
+
+## 7. For the Dev Team (Prioritized Action Items)
+
+1. **Move BackupOverdue out of the `has_promise_changes` gate** (S1). In `execute_assess()`,
+   check heartbeat staleness independently of promise state changes. This is a 10-line
+   restructuring of `execute_assess()`. Without this fix, the Sentinel cannot detect the
+   most common failure mode (backups silently stopped).
+
+2. **Make BackupOverdue testable** (S2). Extract the stale-heartbeat check into a pure
+   function that takes `&Heartbeat` and `NaiveDateTime`, returns `Option<Notification>`.
+   Write 3 tests: not stale (returns None), stale (returns Some with correct hours),
+   corrupt timestamps (returns None). This covers the one notification path that currently
+   has zero test coverage.
+
+3. **Add debounce for BackupOverdue** (M2). Track when the last overdue notification was
+   sent. Don't re-send within 4 hours. This prevents notification spam when backups are
+   down for extended periods. Natural pairing with S1.
+
+4. **Promote lifecycle log messages to `warn!` level** (M1). Change "Sentinel starting"
+   and "Sentinel shutting down" to `log::warn!()` so they appear in journald without
+   `--verbose`. Keep routine events (drive changes, assessments) at `info!`.
+
+## 8. Open Questions
+
+1. **Should the Sentinel write to the heartbeat file?** Currently it only reads it for
+   BackupOverdue. But the heartbeat's `notifications_dispatched` field exists for crash
+   recovery — "if false on next read, re-compute and re-send." The Sentinel is now a second
+   consumer of this field. Should it set `notifications_dispatched = true` after dispatching
+   Sentinel-sourced notifications? Or is that a Session 3 concern (notification deduplication)?
+
+2. **Should `urd sentinel status` show the last assessment's promise states?** The state
+   file contains `promise_states` but the voice rendering doesn't display them. For a user
+   running `urd sentinel status` to check if the Sentinel is watching, the current output
+   is sufficient. But for diagnosing "why did I get this notification?", showing per-subvolume
+   promise states would be useful. Consider adding this to the interactive rendering.
+
+3. **Should the Sentinel gate on config validity?** Currently `urd sentinel run` loads the
+   config and starts the loop. If the config has structural errors (invalid paths, missing
+   fields), `Config::load()` fails and the process exits. But if the config is structurally
+   valid but semantically wrong (e.g., references a drive that doesn't exist), the Sentinel
+   starts and produces assessments that may be confusing. Should it run preflight checks on
+   startup and log warnings?
+
+---
+
+*Review conducted as architectural adversary. Findings reflect implementation-phase analysis
+of the Session 2 code.*

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,6 +35,22 @@ pub enum Commands {
     Calibrate(CalibrateArgs),
     /// Retrieve a file from a past snapshot
     Get(GetArgs),
+    /// Sentinel daemon — monitors backup health and drive connections
+    Sentinel(SentinelArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct SentinelArgs {
+    #[command(subcommand)]
+    pub command: SentinelCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SentinelCommands {
+    /// Start the Sentinel (foreground, for systemd)
+    Run,
+    /// Show Sentinel status
+    Status,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -5,4 +5,5 @@ pub mod history;
 pub mod init;
 pub mod plan_cmd;
 pub mod status;
+pub mod sentinel;
 pub mod verify;

--- a/src/commands/sentinel.rs
+++ b/src/commands/sentinel.rs
@@ -1,0 +1,62 @@
+// CLI handlers for `urd sentinel run` and `urd sentinel status`.
+
+use crate::config::Config;
+use crate::output::{OutputMode, SentinelStateFile, SentinelStatusOutput};
+use crate::sentinel_runner::{self, is_pid_alive, sentinel_state_path};
+use crate::voice;
+
+/// Start the sentinel daemon (foreground, for systemd).
+pub fn run_daemon(config: Config) -> anyhow::Result<()> {
+    let mut runner = sentinel_runner::SentinelRunner::new(config)?;
+    runner.run()
+}
+
+/// Show sentinel status.
+pub fn status(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
+    let state_path = sentinel_state_path(&config);
+
+    let status_output = match SentinelStateFile::read(&state_path) {
+        Some(state) if is_pid_alive(state.pid) => {
+            let uptime = format_uptime(&state.started);
+            SentinelStatusOutput::Running { state, uptime }
+        }
+        Some(state) => {
+            // Stale state file — PID is dead. Clean up and report as not running.
+            let last_seen = Some(state.started.clone());
+            let _ = std::fs::remove_file(&state_path);
+            SentinelStatusOutput::NotRunning { last_seen }
+        }
+        None => SentinelStatusOutput::NotRunning { last_seen: None },
+    };
+
+    let rendered = voice::render_sentinel_status(&status_output, output_mode);
+    print!("{rendered}");
+
+    Ok(())
+}
+
+/// Format uptime from a started timestamp string to a human-readable duration.
+fn format_uptime(started: &str) -> String {
+    let Ok(started_dt) =
+        chrono::NaiveDateTime::parse_from_str(started, "%Y-%m-%dT%H:%M:%S")
+    else {
+        return "unknown".to_string();
+    };
+
+    let now = chrono::Local::now().naive_local();
+    let elapsed = now.signed_duration_since(started_dt);
+
+    let total_minutes = elapsed.num_minutes();
+    if total_minutes < 1 {
+        return "just started".to_string();
+    }
+
+    let hours = total_minutes / 60;
+    let minutes = total_minutes % 60;
+
+    if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else {
+        format!("{minutes}m")
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ mod output;
 mod plan;
 mod preflight;
 mod retention;
-#[allow(dead_code)] // Session 2 (sentinel_runner) will consume this module
 mod sentinel;
+mod sentinel_runner;
 mod state;
 mod types;
 mod voice;
@@ -57,5 +57,9 @@ fn main() -> anyhow::Result<()> {
         Commands::History(args) => commands::history::run(config, args, output_mode),
         Commands::Verify(args) => commands::verify::run(config, args, output_mode),
         Commands::Get(args) => commands::get::run(config, args, output_mode),
+        Commands::Sentinel(args) => match args.command {
+            cli::SentinelCommands::Run => commands::sentinel::run_daemon(config),
+            cli::SentinelCommands::Status => commands::sentinel::status(config, output_mode),
+        },
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -5,7 +5,7 @@
 
 use std::io::IsTerminal;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::awareness::{DriveAssessment, SubvolAssessment};
 
@@ -469,6 +469,64 @@ pub struct InitSnapshotCount {
     pub subvolume: String,
     pub local_count: usize,
     pub external_counts: Vec<(String, usize)>,
+}
+
+// ── SentinelStatusOutput ─────────────────────────────────────────────────
+
+/// Sentinel state file schema — written atomically by the runner, read by
+/// `urd sentinel status`. Also serves as a "running" indicator (PID check).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SentinelStateFile {
+    pub schema_version: u32,
+    pub pid: u32,
+    pub started: String,
+    pub last_assessment: Option<String>,
+    pub mounted_drives: Vec<String>,
+    pub tick_interval_secs: u64,
+    pub promise_states: Vec<SentinelPromiseState>,
+    pub circuit_breaker: SentinelCircuitState,
+}
+
+/// Per-subvolume promise state in the sentinel state file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SentinelPromiseState {
+    pub name: String,
+    pub status: String,
+}
+
+/// Circuit breaker summary in the sentinel state file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SentinelCircuitState {
+    pub state: String,
+    pub failure_count: u32,
+}
+
+/// Structured output for `urd sentinel status`.
+#[derive(Debug, Serialize)]
+#[serde(tag = "status")]
+pub enum SentinelStatusOutput {
+    /// Sentinel is running (PID alive, state file present).
+    #[serde(rename = "running")]
+    Running {
+        state: SentinelStateFile,
+        /// Human-readable uptime (e.g., "3h 12m").
+        uptime: String,
+    },
+    /// Sentinel is not running (no state file, or stale file cleaned up).
+    #[serde(rename = "not_running")]
+    NotRunning {
+        /// If a stale state file was found, when the sentinel was last seen.
+        last_seen: Option<String>,
+    },
+}
+
+impl SentinelStateFile {
+    /// Read and parse a sentinel state file. Returns `None` if missing or corrupt.
+    #[must_use]
+    pub fn read(path: &std::path::Path) -> Option<Self> {
+        let content = std::fs::read_to_string(path).ok()?;
+        serde_json::from_str(&content).ok()
+    }
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -104,8 +104,10 @@ impl SentinelState {
 #[derive(Debug, Clone)]
 pub struct CircuitBreakerConfig {
     /// Minimum interval between auto-triggered backups.
+    #[allow(dead_code)] // Session 4: active mode
     pub min_interval: Duration,
     /// Maximum consecutive failures before the circuit opens.
+    #[allow(dead_code)] // Session 4: active mode
     pub max_failures: u32,
 }
 
@@ -126,11 +128,14 @@ impl Default for CircuitBreakerConfig {
 /// - HalfOpen: one trial trigger allowed — success closes, failure re-opens.
 #[derive(Debug, Clone)]
 pub struct CircuitBreaker {
+    #[allow(dead_code)] // Session 4: active mode
     pub config: CircuitBreakerConfig,
     pub state: CircuitState,
     pub failure_count: u32,
+    #[allow(dead_code)] // Session 4: active mode
     pub last_trigger: Option<NaiveDateTime>,
     /// Current backoff duration (doubles on each failure, capped at 24h).
+    #[allow(dead_code)] // Session 4: active mode
     pub backoff: Duration,
 }
 
@@ -153,8 +158,10 @@ impl std::fmt::Display for CircuitState {
 }
 
 /// Maximum backoff duration: 24 hours.
+#[allow(dead_code)] // Session 4: active mode
 const MAX_BACKOFF: Duration = Duration::from_secs(24 * 3600);
 /// Initial backoff after first circuit open: 15 minutes.
+#[allow(dead_code)] // Session 4: active mode
 const INITIAL_BACKOFF: Duration = Duration::from_secs(15 * 60);
 
 impl CircuitBreaker {
@@ -178,6 +185,7 @@ impl CircuitBreaker {
     /// `evaluate_trigger_result` so the circuit breaker knows whether to
     /// apply half-open semantics — no implicit protocol.
     #[must_use]
+    #[allow(dead_code)] // Session 4: active mode
     pub fn check_trigger(&self, now: NaiveDateTime) -> TriggerPermission {
         match self.state {
             CircuitState::Open => {
@@ -223,6 +231,7 @@ impl CircuitBreaker {
 /// of trigger this is, so `evaluate_trigger_result` can apply the correct
 /// circuit breaker semantics without an implicit protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Session 4: active mode
 pub enum TriggerPermission {
     /// Normal trigger (circuit closed, min_interval elapsed).
     Allowed,
@@ -234,6 +243,7 @@ pub enum TriggerPermission {
     Blocked,
 }
 
+#[allow(dead_code)] // Session 4: active mode
 impl TriggerPermission {
     /// Whether this permission allows a trigger to proceed.
     #[must_use]
@@ -244,6 +254,7 @@ impl TriggerPermission {
 
 /// Why the sentinel wants to trigger a backup.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // Session 4: active mode
 pub enum TriggerReason {
     /// A drive was mounted that has pending sends.
     DriveMounted { label: String },
@@ -253,6 +264,7 @@ pub enum TriggerReason {
 
 /// A decision to trigger a backup, with context for result evaluation.
 #[derive(Debug, Clone)]
+#[allow(dead_code)] // Session 4: active mode
 pub struct BackupTrigger {
     pub reason: TriggerReason,
     pub triggered_at: NaiveDateTime,
@@ -264,6 +276,7 @@ pub struct BackupTrigger {
 
 /// Outcome of a triggered backup, for circuit breaker evaluation.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // Session 4: active mode
 pub enum TriggerOutcome {
     /// Backup succeeded (exit 0, or heartbeat shows improvement).
     Success,
@@ -369,6 +382,7 @@ pub fn sentinel_transition(
 ///
 /// Only relevant when active mode is enabled (`[sentinel] active = true`).
 #[must_use]
+#[allow(dead_code)] // Session 4: active mode
 pub fn should_trigger_backup(
     state: &SentinelState,
     event: &SentinelEvent,
@@ -432,6 +446,7 @@ pub fn should_trigger_backup(
 
 /// Check if any subvolume's promise status degraded (got worse) between
 /// the previous snapshot and current assessments.
+#[allow(dead_code)] // Session 4: active mode (used by should_trigger_backup)
 fn has_promise_degradation(
     previous: &[PromiseSnapshot],
     current: &[SubvolAssessment],
@@ -456,6 +471,7 @@ fn has_promise_degradation(
 /// Pure function — the runner calls this after a triggered backup completes
 /// and stores the result.
 #[must_use]
+#[allow(dead_code)] // Session 4: active mode
 pub fn evaluate_trigger_result(
     circuit: &CircuitBreaker,
     trigger: &BackupTrigger,

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -1,0 +1,758 @@
+// Sentinel runner — I/O layer that connects the pure state machine (sentinel.rs)
+// to real-world events via a poll-based loop.
+//
+// Responsibilities: detect drive mounts, heartbeat changes, and tick deadlines;
+// feed events to sentinel_transition(); execute resulting actions (assess, notify,
+// write state file). No business logic lives here — it's pure plumbing.
+//
+// Design: docs/95-ideas/2026-03-27-design-sentinel-session2.md
+// Review: docs/99-reports/2026-03-27-sentinel-session2-design-review.md
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime};
+
+use chrono::NaiveDateTime;
+
+use crate::awareness::{self, PromiseStatus, SubvolAssessment};
+use crate::config::Config;
+use crate::drives::{self, DriveAvailability};
+use crate::heartbeat;
+use crate::notify::{self, Notification, NotificationEvent, Urgency};
+use crate::output::{SentinelCircuitState, SentinelPromiseState, SentinelStateFile};
+use crate::plan::RealFileSystemState;
+use crate::sentinel::{
+    self, SentinelAction, SentinelEvent, SentinelState, CircuitBreakerConfig, PromiseSnapshot,
+};
+use crate::state::StateDb;
+
+/// Poll interval: how often the runner checks for events.
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Minimum interval between BackupOverdue notifications (M2 debounce).
+const OVERDUE_DEBOUNCE: Duration = Duration::from_secs(4 * 3600);
+
+pub struct SentinelRunner {
+    config: Config,
+    state: SentinelState,
+    state_file_path: PathBuf,
+    heartbeat_path: PathBuf,
+    /// Baseline mtime — initialized in new() to avoid spurious BackupCompleted on startup (S1 fix).
+    last_heartbeat_mtime: Option<SystemTime>,
+    last_assessment_time: Option<Instant>,
+    tick_interval: Duration,
+    started: NaiveDateTime,
+    shutdown: Arc<AtomicBool>,
+    /// When the last BackupOverdue notification was sent (M2 debounce).
+    last_overdue_notified: Option<Instant>,
+}
+
+impl SentinelRunner {
+    pub fn new(config: Config) -> anyhow::Result<Self> {
+        let state_file_path = sentinel_state_path(&config);
+        let heartbeat_path = config.general.heartbeat_file.clone();
+
+        // S1 fix: read current heartbeat mtime as baseline — no event on startup.
+        let last_heartbeat_mtime = std::fs::metadata(&heartbeat_path)
+            .ok()
+            .and_then(|m| m.modified().ok());
+
+        let state = SentinelState::new(CircuitBreakerConfig::default());
+        let started = chrono::Local::now().naive_local();
+
+        Ok(Self {
+            config,
+            state,
+            state_file_path,
+            heartbeat_path,
+            last_heartbeat_mtime,
+            last_assessment_time: None,
+            tick_interval: Duration::from_secs(2 * 60), // startup: 2 minutes
+            started,
+            shutdown: Arc::new(AtomicBool::new(false)),
+            last_overdue_notified: None,
+        })
+    }
+
+    pub fn run(&mut self) -> anyhow::Result<()> {
+        // Register ctrlc handler.
+        let shutdown = Arc::clone(&self.shutdown);
+        ctrlc::set_handler(move || {
+            shutdown.store(true, Ordering::SeqCst);
+        })?;
+
+        log::warn!("Sentinel starting");
+
+        // M2 fix: route initial drive scan through the state machine.
+        let initial_events = self.detect_drive_events();
+        self.process_events(initial_events);
+
+        // Main poll loop.
+        loop {
+            if self.shutdown.load(Ordering::SeqCst) {
+                let (new_state, actions) =
+                    sentinel::sentinel_transition(&self.state, &SentinelEvent::Shutdown);
+                self.state = new_state;
+                self.execute_actions(&actions);
+                break;
+            }
+
+            let events = self.collect_events();
+            if !events.is_empty() {
+                self.process_events(events);
+            }
+
+            std::thread::sleep(POLL_INTERVAL);
+        }
+
+        Ok(())
+    }
+
+    /// Collect events from all sources. Order: drives first, then heartbeat, then tick.
+    fn collect_events(&mut self) -> Vec<SentinelEvent> {
+        let mut events = self.detect_drive_events();
+
+        if let Some(event) = self.detect_heartbeat_event() {
+            events.push(event);
+        }
+
+        if let Some(event) = self.detect_tick_event() {
+            events.push(event);
+        }
+
+        events
+    }
+
+    /// Process events through the state machine, coalescing Assess actions (M1 fix).
+    fn process_events(&mut self, events: Vec<SentinelEvent>) {
+        let mut all_actions = Vec::new();
+
+        for event in &events {
+            let (new_state, actions) = sentinel::sentinel_transition(&self.state, event);
+            self.state = new_state;
+            all_actions.extend(actions);
+        }
+
+        self.execute_actions(&all_actions);
+    }
+
+    /// Execute actions with Assess coalescing (M1 fix): if multiple Assess actions
+    /// are queued, execute only one. LogDriveChange and Exit run individually.
+    fn execute_actions(&mut self, actions: &[SentinelAction]) {
+        let mut need_assess = false;
+
+        for action in actions {
+            match action {
+                SentinelAction::Assess => need_assess = true,
+                SentinelAction::LogDriveChange { label, mounted } => {
+                    self.execute_log_drive_change(label, *mounted);
+                }
+                SentinelAction::Exit => {
+                    self.execute_exit();
+                }
+            }
+        }
+
+        if need_assess
+            && let Err(e) = self.execute_assess()
+        {
+            log::error!("Assessment failed: {e}");
+        }
+    }
+
+    // ── Event detection ─────────────────────────────────────────────────
+
+    fn detect_drive_events(&self) -> Vec<SentinelEvent> {
+        let current: BTreeSet<String> = self
+            .config
+            .drives
+            .iter()
+            .filter(|d| drives::drive_availability(d) == DriveAvailability::Available)
+            .map(|d| d.label.clone())
+            .collect();
+
+        let mut events = Vec::new();
+        for label in current.difference(&self.state.mounted_drives) {
+            events.push(SentinelEvent::DriveMounted {
+                label: label.clone(),
+            });
+        }
+        for label in self.state.mounted_drives.difference(&current) {
+            events.push(SentinelEvent::DriveUnmounted {
+                label: label.clone(),
+            });
+        }
+        events
+    }
+
+    /// S1 fix: baseline mtime is set in new(). Only fires BackupCompleted when
+    /// a previous mtime exists and the current mtime is newer.
+    fn detect_heartbeat_event(&mut self) -> Option<SentinelEvent> {
+        let mtime = std::fs::metadata(&self.heartbeat_path)
+            .ok()?
+            .modified()
+            .ok()?;
+        match self.last_heartbeat_mtime {
+            Some(prev) if mtime > prev => {
+                self.last_heartbeat_mtime = Some(mtime);
+                Some(SentinelEvent::BackupCompleted)
+            }
+            None => {
+                // First observation (heartbeat appeared after startup) — record baseline.
+                self.last_heartbeat_mtime = Some(mtime);
+                None
+            }
+            _ => None,
+        }
+    }
+
+    fn detect_tick_event(&self) -> Option<SentinelEvent> {
+        match self.last_assessment_time {
+            Some(last) if last.elapsed() >= self.tick_interval => {
+                Some(SentinelEvent::AssessmentTick)
+            }
+            None => Some(SentinelEvent::AssessmentTick), // First tick immediately
+            _ => None,
+        }
+    }
+
+    // ── Action execution ────────────────────────────────────────────────
+
+    fn execute_assess(&mut self) -> anyhow::Result<()> {
+        let now = chrono::Local::now().naive_local();
+        let state_db = if self.config.general.state_db.exists() {
+            StateDb::open(&self.config.general.state_db).ok()
+        } else {
+            None
+        };
+        let fs = RealFileSystemState {
+            state: state_db.as_ref(),
+        };
+
+        let assessments = awareness::assess(&self.config, now, &fs);
+
+        // Collect notifications from two independent sources.
+        let mut notifications = Vec::new();
+
+        // 1. Promise state changes (skip first assessment).
+        if self.state.has_initial_assessment
+            && sentinel::has_promise_changes(&self.state.last_promise_states, &assessments)
+        {
+            notifications.extend(build_notifications(
+                &self.state.last_promise_states,
+                &assessments,
+            ));
+        }
+
+        // 2. BackupOverdue — independent of promise changes (S1 fix).
+        //    Debounced: don't re-send within OVERDUE_DEBOUNCE (M2 fix).
+        let debounce_ok = self.state.has_initial_assessment
+            && self
+                .last_overdue_notified
+                .is_none_or(|last| last.elapsed() >= OVERDUE_DEBOUNCE);
+
+        if debounce_ok
+            && let Some(heartbeat) = heartbeat::read(&self.config.general.heartbeat_file)
+            && let Some(n) = check_backup_overdue(&heartbeat, now)
+        {
+            notifications.push(n);
+            self.last_overdue_notified = Some(Instant::now());
+        }
+
+        if !notifications.is_empty() {
+            notify::dispatch(&notifications, &self.config.notifications);
+        }
+
+        // Update state.
+        self.state.last_promise_states = sentinel::snapshot_promises(&assessments);
+        if !self.state.has_initial_assessment {
+            self.state.has_initial_assessment = true;
+            log::info!(
+                "Initial assessment complete: {} subvolumes evaluated",
+                assessments.len()
+            );
+        }
+
+        // Update adaptive tick.
+        self.tick_interval = sentinel::compute_next_tick(&assessments);
+        self.last_assessment_time = Some(Instant::now());
+
+        // Write state file.
+        self.write_state_file(now)?;
+
+        Ok(())
+    }
+
+    fn execute_log_drive_change(&self, label: &str, mounted: bool) {
+        if mounted {
+            log::info!("Drive mounted: {label}");
+        } else {
+            log::info!("Drive unmounted: {label}");
+        }
+    }
+
+    fn execute_exit(&self) {
+        log::warn!("Sentinel shutting down");
+        let _ = std::fs::remove_file(&self.state_file_path);
+    }
+
+    // ── State file I/O ──────────────────────────────────────────────────
+
+    fn write_state_file(&self, now: NaiveDateTime) -> anyhow::Result<()> {
+        let state_file = SentinelStateFile {
+            schema_version: 1,
+            pid: std::process::id(),
+            started: self.started.format("%Y-%m-%dT%H:%M:%S").to_string(),
+            last_assessment: Some(now.format("%Y-%m-%dT%H:%M:%S").to_string()),
+            mounted_drives: self.state.mounted_drives.iter().cloned().collect(),
+            tick_interval_secs: self.tick_interval.as_secs(),
+            promise_states: self
+                .state
+                .last_promise_states
+                .iter()
+                .map(|p| SentinelPromiseState {
+                    name: p.name.clone(),
+                    status: p.status.to_string(),
+                })
+                .collect(),
+            circuit_breaker: SentinelCircuitState {
+                state: self.state.circuit_breaker.state.to_string(),
+                failure_count: self.state.circuit_breaker.failure_count,
+            },
+        };
+
+        let content = serde_json::to_string_pretty(&state_file)?;
+
+        if let Some(parent) = self.state_file_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        // Atomic write: temp file + rename.
+        let tmp_path = self.state_file_path.with_extension("json.tmp");
+        std::fs::write(&tmp_path, &content)?;
+        std::fs::rename(&tmp_path, &self.state_file_path)?;
+
+        Ok(())
+    }
+}
+
+// ── Notification building (S2 fix) ──────────────────────────────────────
+
+/// Build notifications from Sentinel-observed promise state changes.
+///
+/// Pure function: previous promise snapshots + current assessments → notifications.
+///
+/// Contract:
+/// - Produces: PromiseDegraded, PromiseRecovered, AllUnprotected
+/// - Does NOT produce: BackupFailures, PinWriteFailures (backup-path-only events)
+/// - BackupOverdue is handled separately by `check_backup_overdue()` (S1 fix)
+/// - Urgency: degradation = Warning, recovery = Info, AllUnprotected = Critical
+///
+/// This is a separate path from `notify::compute_notifications()`, which operates
+/// on heartbeat data. The two paths converge at `notify::dispatch()`.
+pub fn build_notifications(
+    previous: &[PromiseSnapshot],
+    current: &[SubvolAssessment],
+) -> Vec<Notification> {
+    let mut notifications = Vec::new();
+
+    // ── Promise state transitions ──────────────────────────────────
+    for assess in current {
+        if let Some(prev) = previous.iter().find(|p| p.name == assess.name)
+            && assess.status != prev.status
+        {
+            let from = prev.status.to_string();
+            let to = assess.status.to_string();
+
+            if assess.status < prev.status {
+                // Degradation
+                notifications.push(Notification {
+                    event: NotificationEvent::PromiseDegraded {
+                        subvolume: assess.name.clone(),
+                        from: from.clone(),
+                        to: to.clone(),
+                    },
+                    urgency: Urgency::Warning,
+                    title: format!("Urd: {} is now {}", assess.name, to),
+                    body: format!(
+                        "The thread of {} has frayed — it was {}, now {}. \
+                         The well remembers, but the weave grows thin.",
+                        assess.name, from, to
+                    ),
+                });
+            } else {
+                // Recovery
+                notifications.push(Notification {
+                    event: NotificationEvent::PromiseRecovered {
+                        subvolume: assess.name.clone(),
+                        from: from.clone(),
+                        to: to.clone(),
+                    },
+                    urgency: Urgency::Info,
+                    title: format!("Urd: {} restored to {}", assess.name, to),
+                    body: format!(
+                        "The thread of {} is rewoven — restored from {} to {}.",
+                        assess.name, from, to
+                    ),
+                });
+            }
+        }
+    }
+
+    // ── All unprotected ────────────────────────────────────────────
+    let all_unprotected = !current.is_empty()
+        && current
+            .iter()
+            .all(|a| a.status == PromiseStatus::Unprotected);
+
+    if all_unprotected {
+        notifications.push(Notification {
+            event: NotificationEvent::AllUnprotected,
+            urgency: Urgency::Critical,
+            title: "Urd: all promises broken".to_string(),
+            body: "Every thread in the well has snapped. No subvolume is protected. \
+                   Attend to this — your data stands unguarded."
+                .to_string(),
+        });
+    }
+
+    notifications
+}
+
+/// Check whether the heartbeat is stale and a BackupOverdue notification is needed.
+///
+/// Pure function (S2 fix): takes heartbeat data and current time, returns notification.
+/// Called independently from promise-change notifications so it fires even when
+/// promise states are stable (S1 fix). Debouncing is the caller's responsibility (M2).
+#[must_use]
+pub fn check_backup_overdue(
+    heartbeat: &heartbeat::Heartbeat,
+    now: NaiveDateTime,
+) -> Option<Notification> {
+    let stale_after =
+        NaiveDateTime::parse_from_str(&heartbeat.stale_after, "%Y-%m-%dT%H:%M:%S").ok()?;
+
+    if now <= stale_after {
+        return None;
+    }
+
+    let timestamp =
+        NaiveDateTime::parse_from_str(&heartbeat.timestamp, "%Y-%m-%dT%H:%M:%S").ok()?;
+
+    let age_hours = (now.signed_duration_since(timestamp).num_minutes() as u64 + 30) / 60;
+    let stale_hours =
+        (stale_after.signed_duration_since(timestamp).num_minutes() as u64 + 30) / 60;
+
+    Some(Notification {
+        event: NotificationEvent::BackupOverdue {
+            last_heartbeat_age_hours: age_hours,
+            stale_after_hours: stale_hours,
+        },
+        urgency: Urgency::Warning,
+        title: format!("Urd: no backup in {age_hours}h"),
+        body: format!(
+            "The last weaving was {age_hours}h ago — expected within {stale_hours}h. \
+             The loom sits idle. Check that the timer is running."
+        ),
+    })
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+/// Derive sentinel state file path from config (same directory as state_db).
+pub fn sentinel_state_path(config: &Config) -> PathBuf {
+    config
+        .general
+        .state_db
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .join("sentinel-state.json")
+}
+
+/// Check if a process is alive by probing /proc/{pid}.
+#[must_use]
+pub fn is_pid_alive(pid: u32) -> bool {
+    std::path::Path::new(&format!("/proc/{pid}")).exists()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::awareness::{LocalAssessment, PromiseStatus};
+    use crate::types::Interval;
+
+    fn make_assessment(name: &str, status: PromiseStatus) -> SubvolAssessment {
+        SubvolAssessment {
+            name: name.to_string(),
+            status,
+            local: LocalAssessment {
+                status,
+                snapshot_count: 5,
+                newest_age: None,
+                configured_interval: Interval::hours(1),
+            },
+            external: vec![],
+            advisories: vec![],
+            errors: vec![],
+        }
+    }
+
+    // ── State file I/O ──────────────────────────────────────────────
+
+    #[test]
+    fn state_file_serialization_roundtrip() {
+        let state = SentinelStateFile {
+            schema_version: 1,
+            pid: 12345,
+            started: "2026-03-27T10:00:00".to_string(),
+            last_assessment: Some("2026-03-27T10:15:00".to_string()),
+            mounted_drives: vec!["WD-18TB".to_string()],
+            tick_interval_secs: 900,
+            promise_states: vec![SentinelPromiseState {
+                name: "home".to_string(),
+                status: "PROTECTED".to_string(),
+            }],
+            circuit_breaker: SentinelCircuitState {
+                state: "closed".to_string(),
+                failure_count: 0,
+            },
+        };
+
+        let json = serde_json::to_string_pretty(&state).unwrap();
+        let parsed: SentinelStateFile = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.schema_version, 1);
+        assert_eq!(parsed.pid, 12345);
+        assert_eq!(parsed.started, "2026-03-27T10:00:00");
+        assert_eq!(parsed.mounted_drives, vec!["WD-18TB"]);
+        assert_eq!(parsed.promise_states.len(), 1);
+        assert_eq!(parsed.promise_states[0].name, "home");
+        assert_eq!(parsed.circuit_breaker.state, "closed");
+    }
+
+    #[test]
+    fn state_file_read_missing_returns_none() {
+        assert!(SentinelStateFile::read(std::path::Path::new(
+            "/tmp/nonexistent-sentinel-state-test.json"
+        ))
+        .is_none());
+    }
+
+    #[test]
+    fn state_file_read_corrupt_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sentinel-state.json");
+        std::fs::write(&path, "not json").unwrap();
+        assert!(SentinelStateFile::read(&path).is_none());
+    }
+
+    #[test]
+    fn state_file_write_and_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sentinel-state.json");
+
+        let state = SentinelStateFile {
+            schema_version: 1,
+            pid: std::process::id(),
+            started: "2026-03-27T10:00:00".to_string(),
+            last_assessment: None,
+            mounted_drives: vec![],
+            tick_interval_secs: 120,
+            promise_states: vec![],
+            circuit_breaker: SentinelCircuitState {
+                state: "closed".to_string(),
+                failure_count: 0,
+            },
+        };
+
+        let content = serde_json::to_string_pretty(&state).unwrap();
+        std::fs::write(&path, &content).unwrap();
+
+        let read_back = SentinelStateFile::read(&path).unwrap();
+        assert_eq!(read_back.pid, std::process::id());
+    }
+
+    // ── PID alive check ─────────────────────────────────────────────
+
+    #[test]
+    fn pid_alive_current_process() {
+        assert!(is_pid_alive(std::process::id()));
+    }
+
+    #[test]
+    fn pid_alive_dead_process() {
+        assert!(!is_pid_alive(99_999_999));
+    }
+
+    // ── build_notifications ─────────────────────────────────────────
+
+    #[test]
+    fn notifications_degradation_produces_warning() {
+        let previous = vec![PromiseSnapshot {
+            name: "home".to_string(),
+            status: PromiseStatus::Protected,
+        }];
+        let current = vec![make_assessment("home", PromiseStatus::AtRisk)];
+
+        let notifications = build_notifications(&previous, &current);
+
+        let degraded: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::PromiseDegraded { .. }))
+            .collect();
+        assert_eq!(degraded.len(), 1);
+        assert_eq!(degraded[0].urgency, Urgency::Warning);
+        assert!(degraded[0].title.contains("AT RISK"));
+    }
+
+    #[test]
+    fn notifications_recovery_produces_info() {
+        let previous = vec![PromiseSnapshot {
+            name: "home".to_string(),
+            status: PromiseStatus::AtRisk,
+        }];
+        let current = vec![make_assessment("home", PromiseStatus::Protected)];
+
+        let notifications = build_notifications(&previous, &current);
+
+        let recovered: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::PromiseRecovered { .. }))
+            .collect();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].urgency, Urgency::Info);
+    }
+
+    #[test]
+    fn notifications_all_unprotected_is_critical() {
+        let previous = vec![
+            PromiseSnapshot {
+                name: "home".to_string(),
+                status: PromiseStatus::Protected,
+            },
+            PromiseSnapshot {
+                name: "docs".to_string(),
+                status: PromiseStatus::Protected,
+            },
+        ];
+        let current = vec![
+            make_assessment("home", PromiseStatus::Unprotected),
+            make_assessment("docs", PromiseStatus::Unprotected),
+        ];
+
+        let notifications = build_notifications(&previous, &current);
+
+        let all_unprot: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::AllUnprotected))
+            .collect();
+        assert_eq!(all_unprot.len(), 1);
+        assert_eq!(all_unprot[0].urgency, Urgency::Critical);
+    }
+
+    #[test]
+    fn notifications_never_produces_backup_only_events() {
+        let previous = vec![PromiseSnapshot {
+            name: "home".to_string(),
+            status: PromiseStatus::Protected,
+        }];
+        let current = vec![make_assessment("home", PromiseStatus::Unprotected)];
+
+        let notifications = build_notifications(&previous, &current);
+
+        for n in &notifications {
+            assert!(
+                !matches!(n.event, NotificationEvent::BackupFailures { .. }),
+                "Sentinel must not produce BackupFailures"
+            );
+            assert!(
+                !matches!(n.event, NotificationEvent::PinWriteFailures { .. }),
+                "Sentinel must not produce PinWriteFailures"
+            );
+        }
+    }
+
+    #[test]
+    fn notifications_no_change_produces_empty() {
+        let previous = vec![PromiseSnapshot {
+            name: "home".to_string(),
+            status: PromiseStatus::Protected,
+        }];
+        let current = vec![make_assessment("home", PromiseStatus::Protected)];
+
+        let notifications = build_notifications(&previous, &current);
+        assert!(notifications.is_empty());
+    }
+
+    // ── check_backup_overdue (S2: pure function with tests) ─────────
+
+    fn dt(s: &str) -> NaiveDateTime {
+        NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").unwrap()
+    }
+
+    fn make_heartbeat(timestamp: &str, stale_after: &str) -> heartbeat::Heartbeat {
+        heartbeat::Heartbeat {
+            schema_version: 1,
+            timestamp: timestamp.to_string(),
+            stale_after: stale_after.to_string(),
+            run_result: "success".to_string(),
+            run_id: Some(1),
+            notifications_dispatched: true,
+            subvolumes: vec![],
+        }
+    }
+
+    #[test]
+    fn overdue_not_stale_returns_none() {
+        // Heartbeat at 04:00, stale after 06:00, now is 05:00 → not stale.
+        let hb = make_heartbeat("2026-03-27T04:00:00", "2026-03-27T06:00:00");
+        let now = dt("2026-03-27T05:00:00");
+        assert!(check_backup_overdue(&hb, now).is_none());
+    }
+
+    #[test]
+    fn overdue_stale_returns_notification() {
+        // Heartbeat at 04:00, stale after 06:00, now is 10:00 → 6h overdue.
+        let hb = make_heartbeat("2026-03-27T04:00:00", "2026-03-27T06:00:00");
+        let now = dt("2026-03-27T10:00:00");
+        let notification = check_backup_overdue(&hb, now).expect("should fire");
+
+        assert_eq!(notification.urgency, Urgency::Warning);
+        match notification.event {
+            NotificationEvent::BackupOverdue {
+                last_heartbeat_age_hours,
+                stale_after_hours,
+            } => {
+                assert_eq!(last_heartbeat_age_hours, 6);
+                assert_eq!(stale_after_hours, 2);
+            }
+            _ => panic!("expected BackupOverdue event"),
+        }
+    }
+
+    #[test]
+    fn overdue_corrupt_timestamps_returns_none() {
+        let hb = make_heartbeat("not-a-timestamp", "also-not-a-timestamp");
+        let now = dt("2026-03-27T10:00:00");
+        assert!(check_backup_overdue(&hb, now).is_none());
+    }
+
+    #[test]
+    fn overdue_corrupt_stale_after_only_returns_none() {
+        let hb = make_heartbeat("2026-03-27T04:00:00", "corrupt");
+        let now = dt("2026-03-27T10:00:00");
+        assert!(check_backup_overdue(&hb, now).is_none());
+    }
+
+    #[test]
+    fn overdue_exactly_at_stale_boundary_returns_none() {
+        // now == stale_after → not overdue (need to be strictly past).
+        let hb = make_heartbeat("2026-03-27T04:00:00", "2026-03-27T06:00:00");
+        let now = dt("2026-03-27T06:00:00");
+        assert!(check_backup_overdue(&hb, now).is_none());
+    }
+}

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -13,8 +13,8 @@ use colored::Colorize;
 
 use crate::output::{
     BackupSummary, CalibrateOutput, CalibrateResult, FailuresOutput, GetOutput, HistoryOutput,
-    InitOutput, InitStatus, OutputMode, PlanOutput, StatusOutput, SubvolumeHistoryOutput,
-    VerifyOutput,
+    InitOutput, InitStatus, OutputMode, PlanOutput, SentinelStatusOutput, StatusOutput,
+    SubvolumeHistoryOutput, VerifyOutput,
 };
 use crate::types::ByteSize;
 
@@ -1182,6 +1182,94 @@ fn format_init_status(status: InitStatus) -> String {
     }
 }
 
+// ── Sentinel Status ──────────────────────────────────────────────────────
+
+/// Render sentinel status output according to the given mode.
+#[must_use]
+pub fn render_sentinel_status(data: &SentinelStatusOutput, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => render_sentinel_status_interactive(data),
+        OutputMode::Daemon => {
+            serde_json::to_string_pretty(data)
+                .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
+        }
+    }
+}
+
+fn render_sentinel_status_interactive(data: &SentinelStatusOutput) -> String {
+    let mut out = String::new();
+
+    match data {
+        SentinelStatusOutput::Running { state, uptime } => {
+            writeln!(out, "{}", "SENTINEL — watching".bold()).ok();
+            writeln!(out).ok();
+            writeln!(
+                out,
+                "  {:<14}since {} (PID {})",
+                "Running", uptime, state.pid
+            )
+            .ok();
+
+            // Assessment timing
+            if let Some(ref last) = state.last_assessment {
+                let tick_desc = format_tick_description(state.tick_interval_secs, &state.promise_states);
+                writeln!(out, "  {:<14}{} (tick: {})", "Assessment", last, tick_desc).ok();
+            }
+
+            // Mounted drives
+            if state.mounted_drives.is_empty() {
+                writeln!(out, "  {:<14}{}", "Mounted", "none".dimmed()).ok();
+            } else {
+                writeln!(out, "  {:<14}{}", "Mounted", state.mounted_drives.join(", ")).ok();
+            }
+        }
+        SentinelStatusOutput::NotRunning { last_seen } => {
+            if let Some(seen) = last_seen {
+                writeln!(
+                    out,
+                    "{}",
+                    format!("SENTINEL — not running (last seen {seen})").bold()
+                )
+                .ok();
+            } else {
+                writeln!(out, "{}", "SENTINEL — not running".bold()).ok();
+            }
+            writeln!(out).ok();
+            writeln!(out, "  Start with: {}", "systemctl --user start urd-sentinel".dimmed()).ok();
+            writeln!(out, "  Or: {}", "urd sentinel run".dimmed()).ok();
+        }
+    }
+
+    out
+}
+
+fn format_tick_description(tick_secs: u64, promise_states: &[crate::output::SentinelPromiseState]) -> String {
+    let tick_str = if tick_secs >= 60 {
+        format!("{}m", tick_secs / 60)
+    } else {
+        format!("{tick_secs}s")
+    };
+
+    let worst = promise_states
+        .iter()
+        .map(|p| p.status.as_str())
+        .min_by_key(|s| match *s {
+            "UNPROTECTED" => 0,
+            "AT RISK" => 1,
+            "PROTECTED" => 2,
+            _ => 0,
+        });
+
+    let state_desc = match worst {
+        Some("PROTECTED") | None => "all promises held",
+        Some("AT RISK") => "promises at risk",
+        Some("UNPROTECTED") => "promises broken",
+        Some(_) => "assessing",
+    };
+
+    format!("{tick_str} — {state_desc}")
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1910,5 +1998,89 @@ mod tests {
         };
         let output = render_init(&data, OutputMode::Daemon);
         let _: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+    }
+
+    // ── Sentinel status tests ──────────────────────────────────────────
+
+    use crate::output::{SentinelCircuitState, SentinelPromiseState, SentinelStateFile};
+
+    fn test_sentinel_running() -> SentinelStatusOutput {
+        SentinelStatusOutput::Running {
+            state: SentinelStateFile {
+                schema_version: 1,
+                pid: 12345,
+                started: "2026-03-27T10:00:00".to_string(),
+                last_assessment: Some("2026-03-27T13:12:00".to_string()),
+                mounted_drives: vec!["WD-18TB".to_string()],
+                tick_interval_secs: 900,
+                promise_states: vec![SentinelPromiseState {
+                    name: "home".to_string(),
+                    status: "PROTECTED".to_string(),
+                }],
+                circuit_breaker: SentinelCircuitState {
+                    state: "closed".to_string(),
+                    failure_count: 0,
+                },
+            },
+            uptime: "3h 12m".to_string(),
+        }
+    }
+
+    #[test]
+    fn sentinel_running_contains_watching() {
+        colored::control::set_override(false);
+        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
+        assert!(output.contains("watching"), "missing 'watching'");
+    }
+
+    #[test]
+    fn sentinel_running_contains_pid() {
+        colored::control::set_override(false);
+        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
+        assert!(output.contains("12345"), "missing PID");
+    }
+
+    #[test]
+    fn sentinel_running_contains_tick() {
+        colored::control::set_override(false);
+        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
+        assert!(output.contains("15m"), "missing tick interval");
+        assert!(output.contains("all promises held"), "missing promise summary");
+    }
+
+    #[test]
+    fn sentinel_running_contains_drive() {
+        colored::control::set_override(false);
+        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
+        assert!(output.contains("WD-18TB"), "missing drive label");
+    }
+
+    #[test]
+    fn sentinel_not_running_shows_message() {
+        colored::control::set_override(false);
+        let data = SentinelStatusOutput::NotRunning { last_seen: None };
+        let output = render_sentinel_status(&data, OutputMode::Interactive);
+        assert!(output.contains("not running"), "missing 'not running'");
+        assert!(output.contains("urd sentinel run"), "missing start hint");
+    }
+
+    #[test]
+    fn sentinel_not_running_with_last_seen() {
+        colored::control::set_override(false);
+        let data = SentinelStatusOutput::NotRunning {
+            last_seen: Some("2026-03-27T10:00:00".to_string()),
+        };
+        let output = render_sentinel_status(&data, OutputMode::Interactive);
+        assert!(output.contains("not running"), "missing 'not running'");
+        assert!(output.contains("2026-03-27T10:00:00"), "missing last seen timestamp");
+    }
+
+    #[test]
+    fn sentinel_daemon_produces_valid_json() {
+        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Daemon);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&output).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{output}"));
+        assert_eq!(parsed["status"], "running");
+        assert_eq!(parsed["state"]["pid"], 12345);
     }
 }


### PR DESCRIPTION
## Summary

- **New: `sentinel_runner.rs`** — poll-based I/O runner connecting Session 1's pure state machine to real-world events (drive mounts, heartbeat changes, tick deadlines). Assess coalescing, initial drive scan through state machine, atomic state file writes.
- **New: `commands/sentinel.rs`** — CLI handlers for `urd sentinel run` (foreground daemon) and `urd sentinel status` (PID-based liveness check, stale file cleanup).
- **Notification pipeline** — `build_notifications()` and `check_backup_overdue()` as pure functions. BackupOverdue fires independently of promise changes with 4h debounce.
- **Design + implementation reviews** — addressed all 4 design review findings and all 4 implementation review findings (BackupOverdue gate bug, impure function extraction, log level visibility, notification spam).

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 389 tests, all passing (was 366, +23 new)
- Integration tests: not applicable (passive monitoring, no btrfs operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)