### PR TITLE
feat: two-axis status display with operational health (VFM-A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Drive session tokens for hardware swap detection (`.urd-drive-token` identity files)
 - Chain health computation in awareness model (incremental chain intact/broken per drive)
+- Two-axis status display: data safety (OK/aging/gap) + operational health (healthy/degraded/blocked)
+- Temporal context in status table: snapshot counts show age (e.g., "47 (30m)", "12 (2h)")
+- Unmounted drives shown as "away" in status table when they have send history
 
 ### Changed
 - README rewritten for public repository

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,14 +8,15 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-416 tests, all passing, clippy clean. Current version: v0.3.0.
+436 tests, all passing, clippy clean. Current version: v0.3.0.
 
 ## In Progress
 
-- **HSD-A complete** (2026-03-29). Drive session tokens + chain health as awareness input.
-  Token infrastructure built, tested, reviewed. Token verification dormant until HSD-B wires it.
-  Chain health moved from status command into pure awareness module.
-  [Implementation review](../99-reports/2026-03-29-hsd-a-implementation-review.md)
+- **VFM-A complete** (2026-03-29). OperationalHealth enum + two-axis CLI rendering.
+  `compute_health()` pure function checks chain health, space pressure (local + external),
+  drive availability. CLI shows SAFETY + HEALTH columns, summary line, temporal context.
+  Reviewed, simplified, post-review fixes applied.
+  [Implementation review](../99-reports/2026-03-29-vfm-a-implementation-review.md)
 
 ## Build Queue
 
@@ -23,18 +24,13 @@ Seven-step sequence resolved 2026-03-29. See [roadmap.md Priority 5.5](roadmap.m
 full details, design decisions, and review findings.
 
 1. ~~**HSD-A**~~ — drive session tokens + chain health as awareness input. **Done.**
-2. **VFM-A** — `OperationalHealth` enum, two-axis CLI rendering.
-   Fixes false reassurance problem. [Design](../95-ideas/2026-03-28-design-visual-feedback-model.md) ← **start here**
+2. ~~**VFM-A**~~ — `OperationalHealth` enum, two-axis CLI rendering. **Done.** ← **start here**
 3. **Sentinel Session 3** — hardening + notification deduplication.
    Needed by HSD-B and VFM-B, not by earlier steps.
 4. **HSD-B** — sentinel chain-break detection + full-send gate (Norman escalation, never auto-proceed).
 5. **VFM-B** — sentinel visual state in state file + health notifications.
 6. **Transient snapshots** — `local_retention = "transient"` for NVMe space pressure.
 7. **Tray icon (Spindle)** — reads sentinel-state.json, 4 static icons.
-
-Key design decisions already resolved:
-- Chain health: facade pattern — callers pre-compute, awareness is single health facade
-- Full-send gate: never auto-proceed, escalate notification urgency (Norman principles)
 
 **Later:** Config system migration (ADR-111), shell completions (6a).
 
@@ -47,7 +43,7 @@ Key design decisions already resolved:
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Latest journals | `docs/98-journals/` (local only, gitignored) |
-| Latest reviews | [HSD-A impl review](../99-reports/2026-03-29-hsd-a-implementation-review.md), [HSD design review](../99-reports/2026-03-28-hardware-swap-defenses-design-review.md) |
+| Latest reviews | [VFM-A review](../99-reports/2026-03-29-vfm-a-implementation-review.md), [HSD-A review](../99-reports/2026-03-29-hsd-a-implementation-review.md) |
 
 ## Known Issues
 
@@ -58,5 +54,6 @@ Key design decisions already resolved:
 - WD-18TB UUID needs adding to config when drive is next mounted
 - Orphaned snapshot `20250422-multimedia` on WD-18TB1 — clean up or let crash recovery handle
 - Per-drive pin protection for external retention: all-drives-union is conservative but suboptimal for space
+- Stringly-typed output boundary: three independent status-ranking implementations across notify.rs and voice.rs
 
 See [roadmap.md](roadmap.md) for the full tech debt list and dropped features.

--- a/docs/99-reports/2026-03-29-vfm-a-implementation-review.md
+++ b/docs/99-reports/2026-03-29-vfm-a-implementation-review.md
@@ -1,0 +1,274 @@
+# VFM-A Implementation Review
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-29
+**Scope:** VFM-A (Session A) — `OperationalHealth` enum and two-axis CLI rendering
+**Reviewer:** arch-adversary
+**Commit:** unstaged (working tree changes)
+**Files reviewed:** `awareness.rs`, `output.rs`, `voice.rs`, `commands/status.rs`, `sentinel.rs`, `sentinel_runner.rs`, `heartbeat.rs`, `commands/backup.rs`
+**Design doc:** `docs/95-ideas/2026-03-28-design-visual-feedback-model.md`
+
+---
+
+## Executive Summary
+
+VFM-A adds a second assessment axis (operational health) to the awareness model and updates the
+CLI to display it. The implementation is clean, well-scoped, and respects the pure-function
+module pattern. The primary concern is a false-reassurance gap in `compute_health` where local
+filesystem pressure is invisible — the function reports `Healthy` for local-only health even when
+the NVMe is near its space guard threshold. This is not a data-loss risk but it is exactly the
+false reassurance this feature was built to eliminate.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — deleting snapshots that shouldn't be deleted.
+
+**Distance from VFM-A changes:** Far. VFM-A is read-only advisory code. `compute_health` and
+`render_summary_line` compute and display information. They don't influence the planner, executor,
+or retention decisions. Nothing in this changeset can cause a snapshot to be created, deleted,
+or sent. The blast radius of a bug here is wrong status text, not data loss.
+
+**Catastrophic failure checklist:**
+1. Silent data loss — **not applicable.** No write operations.
+2. Path traversal — **not applicable.** No path construction for btrfs.
+3. Pinned snapshot deletion — **not applicable.** Advisory only.
+4. Space exhaustion — **not applicable.** Reads space, doesn't consume it.
+5. Config orphaning — **not applicable.** No config writes.
+6. TOCTOU — **not applicable.** No privileged actions.
+
+This is the safest kind of feature to ship: it observes but doesn't act.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | Health computation covers the drive-swap scenario correctly. One gap: local-only health blind spot. |
+| 2 | Security | 5 | Pure advisory code. No privilege escalation surface. |
+| 3 | Architectural Excellence | 4 | Follows the pure-function module pattern exactly. Clean separation awareness→output→voice. |
+| 4 | Systems Design | 3 | Space estimation uses `calibrated_size` fallback chain — but calibration data is rarely available. The 7-day "away" threshold is hardcoded where it should be configurable (or at least a named constant). |
+| 5 | Rust Idioms | 4 | Good use of `PartialOrd` for min-aggregation. `strip_ansi_len` is hand-rolled where a crate could help, but acceptable for a single use. |
+| 6 | Code Quality | 4 | Readable, well-structured. The stringly-typed boundary is pre-existing tech debt, not introduced here. |
+
+## Design Tensions
+
+### 1. "Healthy" for send_enabled=false — simplicity vs. completeness
+
+**Trade-off:** `compute_health` returns `Healthy` immediately when `send_enabled=false`. This
+trades completeness (local space pressure is real) for simplicity (the health model is about
+external sends).
+
+**Assessment:** Defensible for Session A. The design doc scopes operational health to "can the
+next backup succeed efficiently?" — and for local-only subvolumes, the planner's space guard
+handles this. But the user looking at `urd status` sees `OK healthy` for a subvolume whose NVMe
+is 95% full. The known issue list already calls out NVMe accumulation above 10GB threshold.
+This tension will surface in production. **Right call for now, but document the gap.**
+
+### 2. Stringly-typed output boundary — serialization cleanliness vs. fragility
+
+**Trade-off:** Enums are converted to strings at the output.rs boundary. Voice.rs matches on
+string literals. This keeps the serialization boundary clean (JSON output is just strings) but
+creates a fragile contract between Display impls and match arms.
+
+**Assessment:** This is pre-existing tech debt. VFM-A follows the established pattern correctly.
+Fixing it (keeping enums through to voice.rs) would be a broader refactor touching notify.rs,
+sentinel, and heartbeat. Not VFM-A's problem to solve. **No action needed in this PR.**
+
+### 3. Chain health on unmounted drives — what you can't see
+
+**Trade-off:** Chain health is only computed for mounted drives (because reading external snapshots
+requires the drive to be present). This means an unmounted drive with broken chains gets no
+`Degraded` signal until you mount it.
+
+**Assessment:** This is a physical constraint, not a design flaw. You can't read a drive that
+isn't there. The `last_send_age > 7 days` degradation partially compensates — if a drive is
+gone long enough, health degrades anyway. The sentinel (Session B) will add mount-time chain
+health checks. **Correct trade-off.**
+
+### 4. Showing all drives as columns — information density vs. noise
+
+**Trade-off:** The table now shows all configured drives as columns (not just mounted ones),
+with "away" for unmounted drives that have send history. This gives the user a complete picture
+but widens the table.
+
+**Assessment:** Good call. The previous behavior (hiding unmounted columns) erased information.
+The "away" indicator is exactly what's needed — it answers "has this drive ever been used?" at a
+glance. **Right decision.**
+
+## Findings
+
+### Finding 1: Local filesystem health blind spot (Moderate)
+
+**What:** `compute_health` returns `Healthy` immediately for `send_enabled=false` subvolumes
+and doesn't check local space pressure for any subvolume. A subvolume can be `OK healthy` while
+its snapshot root filesystem is within 5% of `min_free_bytes`.
+
+**Consequence:** The user sees "All data safe" with a green summary while the next scheduled
+snapshot will be blocked by the space guard. This is the same class of false reassurance the
+VFM design was created to fix — just on the local axis instead of external.
+
+**Suggested fix:** Add a local space pressure check before the `send_enabled` early return:
+
+```rust
+// Check local space pressure regardless of send_enabled
+if let Some(min_free) = config.root_min_free_bytes(subvol_name) {
+    if min_free > 0 {
+        if let Ok(free) = fs.filesystem_free_bytes(local_snapshot_dir) {
+            let tight = min_free + min_free / 5;
+            if free < tight {
+                reasons.push("local space tight".to_string());
+                worst = worst.min(OperationalHealth::Degraded);
+            }
+        }
+    }
+}
+```
+
+This requires threading `snapshot_root` and `config` into `compute_health`. Alternatively, compute
+it in the `assess` loop before calling `compute_health` and pass a pre-computed local health signal.
+
+**Distance from catastrophic failure:** Far — advisory only. But this is the primary false
+reassurance the user asked VFM-A to fix, now on the local axis.
+
+### Finding 2: Space estimation fallback rarely has data (Moderate)
+
+**What:** The "blocked: insufficient space" check uses a fallback chain: `calibrated_size` →
+`last_send_size(incremental)` → `last_send_size(full)`. In practice, `calibrated_size` requires
+running `urd calibrate` (rarely done), and `last_send_size` requires a prior successful send to
+that drive. For a fresh drive or after a chain break, all three return `None`, and the check
+silently skips (fail-open).
+
+**Consequence:** The space-blocked check effectively does nothing until the user has at least one
+successful send to each drive. First sends are the most likely to fail from space exhaustion
+(because they're full sends, the largest operations). The check is most absent when it's most
+needed.
+
+**Suggested fix:** When all size estimates are `None` and a chain is broken (implying a full
+send is needed), use a conservative heuristic — e.g., check if `free - min_free` is at least
+some configured minimum or a percentage of the drive. Or: explicitly flag the uncertainty in
+`health_reasons` ("space unknown — no send history for {drive}") at `Degraded` rather than
+silently skipping. This respects ADR-107 (fail open for backups) while surfacing the uncertainty.
+
+### Finding 3: Hardcoded 7-day threshold (Minor)
+
+**What:** The "drive away" degradation threshold is hardcoded as `age.num_days() > 7` at
+awareness.rs:598. The 20% space tight margin is also hardcoded (line 585: `min_free / 5`).
+
+**Consequence:** These are operational tuning parameters that different users will want different
+values for. A user with an offsite drive they rotate monthly doesn't want degradation warnings
+after 7 days. A user with tight NVMe space might want the space margin at 30%.
+
+**Suggested fix:** Define named constants at the top of `compute_health` (like the existing
+`LOCAL_AT_RISK_MULTIPLIER` pattern). Not config fields — constants are fine for now, but they
+should be grep-able and documented:
+
+```rust
+const DRIVE_AWAY_DEGRADED_DAYS: i64 = 7;
+const SPACE_TIGHT_MARGIN_PERCENT: u64 = 20;
+```
+
+### Finding 4: Summary line conflates safety and health "attention" (Minor)
+
+**What:** The summary line can read: `"1 of 4 safe. htpc-root needs attention. 2 need attention
+— chain broken on WD-18TB."` — two different "needs attention" clauses with different meanings.
+The first is safety (data freshness), the second is health (operational readiness).
+
+**Consequence:** The summary line was designed to answer two questions in order: (1) is my data
+safe? (2) is anything off? But when both axes have issues, the sentence structure blurs them.
+
+**Suggested fix:** Differentiate the clauses: `"1 of 4 safe. 2 degraded — chain broken on
+WD-18TB."` — drop the word "attention" from the health part and use the health vocabulary
+directly. The safety part already communicates urgency through the count.
+
+### Finding 5: Commendation — compute_health is a pure function with correct fail-open semantics
+
+**What:** `compute_health` follows the project's pure-function module pattern perfectly: all
+inputs arrive through parameters, no I/O is performed directly, and it returns a value. The
+`FileSystemState` trait is the I/O boundary, consistent with every other pure module.
+
+More importantly, the space check fails open — when `filesystem_free_bytes` returns an error,
+it falls back to `u64::MAX` (unlimited). When no size estimate exists, the drive is assumed
+unblocked. This honors ADR-107 (backups fail open) in the advisory layer. The function never
+prevents a backup from happening; it only advises the user.
+
+### Finding 6: Commendation — scope discipline
+
+**What:** VFM-A implements exactly Session A from the design doc and nothing more. The sentinel
+state file is untouched (schema_version stays at 1). No notification events were added. No
+`visual_state` block. All downstream construction sites (sentinel, heartbeat, backup) add the
+health fields only in `#[cfg(test)]` blocks. Production code in these modules doesn't access
+the new fields.
+
+This is the kind of scope discipline that prevents feature creep from breaking things. The
+sentinel (Session B) can be built independently because Session A didn't leak into it.
+
+## Also Noted
+
+- The `strip_ansi_len` function is a minimal hand-rolled ANSI parser. Fine for now; if ANSI
+  handling gets more complex, consider the `strip-ansi-escapes` crate.
+- Three duration formatters exist in the codebase (`humanize_duration`, `format_duration_secs`,
+  `format_duration_short`). They serve different purposes. Low priority to consolidate.
+- `color_and_pad` is called with `cell.len()` as `visible_len` for safety/health columns.
+  Since these cells don't contain ANSI codes at that point, `cell.len()` is correct. But if
+  pre-colored cells are ever passed to these columns, the padding will break.
+
+## The Simplicity Question
+
+**What's earning its keep:**
+- `OperationalHealth` enum — necessary. The whole point of VFM-A.
+- `compute_health` — necessary. Central logic, pure function, well-tested.
+- `safety_label()` — necessary. Vocabulary translation for the two-axis model.
+- `render_summary_line()` — necessary. Answers "is my data safe?" in one glance.
+- `humanize_duration()` — necessary. Temporal context is the single most valuable UX addition.
+- `strip_ansi_len()` — necessary. Pre-colored cells need ANSI-aware width calculation.
+
+**What could be simpler:**
+- The `format_status_table` / `format_table` split could be eliminated by always passing
+  `Option<usize>` for colored columns. The generic `format_table` wrapper is one line, but it's
+  an extra indirection that exists only because the backup summary table doesn't want coloring.
+  Consider making the backup summary use `format_status_table` directly with `None, None`.
+
+**Nothing should be deleted.** The implementation is lean. ~120 lines of new production code
+in `compute_health`, ~100 in voice.rs rendering, ~20 in output.rs types. The rest is tests.
+
+## For the Dev Team
+
+Priority-ordered action items:
+
+1. **Add local space pressure to health computation** (Finding 1)
+   - File: `src/awareness.rs`, `compute_health()` function
+   - What: Before the `send_enabled` early return, check local snapshot root space against
+     `min_free_bytes`. Thread `snapshot_root` path through or pre-compute in the `assess` loop.
+   - Why: The feature was built to eliminate false reassurance. A blind spot on local space
+     is the same class of problem on a different axis.
+
+2. **Surface space estimation uncertainty** (Finding 2)
+   - File: `src/awareness.rs`, `compute_health()` space-blocked check
+   - What: When all size estimates are `None` and chain is broken (full send pending), add a
+     `Degraded` reason: "space estimate unknown for {drive} — full send size unpredictable".
+   - Why: Silent skip on first sends (the riskiest operations) undermines the check.
+
+3. **Extract hardcoded thresholds to named constants** (Finding 3)
+   - File: `src/awareness.rs`, top of file near existing threshold constants
+   - What: `DRIVE_AWAY_DEGRADED_DAYS = 7`, `SPACE_TIGHT_MARGIN_PERCENT = 20`
+   - Why: Grep-able, documented, consistent with existing `LOCAL_AT_RISK_MULTIPLIER` pattern.
+
+4. **Differentiate summary line clauses** (Finding 4)
+   - File: `src/voice.rs`, `render_summary_line()`
+   - What: Change health clause from "N need attention" to "N degraded" / "N blocked" to
+     avoid echoing the safety clause's "needs attention" wording.
+   - Why: When both axes have issues, the current wording is confusing.
+
+## Open Questions
+
+1. Should `OperationalHealth::Blocked` suppress the green "All data safe." in the summary line?
+   Currently, `OK blocked` shows "All data safe." followed by "1 needs attention — no backup
+   drives connected." The green text could be misleading when backups literally can't happen.
+
+2. The design doc proposes temporal context on external drive columns too (`"7 (18h)"`), and
+   the implementation delivers this. But for unmounted drives showing "away", should the age of
+   the last send be shown? E.g., `"away (13d)"` would be more informative than just `"away"`.
+
+3. How should this interact with the heartbeat? The heartbeat currently doesn't carry health
+   fields. When the monitoring stack reads `promise_status: "PROTECTED"`, it can't distinguish
+   "protected and healthy" from "protected but degraded." Is this a gap that needs closing
+   before VFM-B, or is the heartbeat solely about data safety?

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -29,6 +29,13 @@ const EXTERNAL_AT_RISK_MULTIPLIER: f64 = 1.5;
 /// External send freshness: UNPROTECTED if age > 3× interval.
 const EXTERNAL_UNPROTECTED_MULTIPLIER: f64 = 3.0;
 
+/// Operational health: space is "tight" when free bytes are within this percentage
+/// of the min_free_bytes threshold. Applies to both local and external drives.
+const SPACE_TIGHT_MARGIN_PERCENT: u64 = 20;
+
+/// Operational health: an unmounted drive degrades health after this many days.
+const DRIVE_AWAY_DEGRADED_DAYS: i64 = 7;
+
 // ── Types ──────────────────────────────────────────────────────────────
 
 /// Promise status for a subvolume or assessment dimension.
@@ -50,11 +57,37 @@ impl std::fmt::Display for PromiseStatus {
     }
 }
 
+/// Operational health — can the next backup succeed efficiently?
+/// Ordered worst-to-best so `min()` yields the worst health.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum OperationalHealth {
+    /// Something will prevent or severely impair the next backup.
+    Blocked,
+    /// Next backup will work but suboptimally (e.g., full send required).
+    Degraded,
+    /// Everything normal — incremental chains healthy, space adequate.
+    Healthy,
+}
+
+impl std::fmt::Display for OperationalHealth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Blocked => write!(f, "blocked"),
+            Self::Degraded => write!(f, "degraded"),
+            Self::Healthy => write!(f, "healthy"),
+        }
+    }
+}
+
 /// Complete assessment for a single subvolume.
 #[derive(Debug)]
 pub struct SubvolAssessment {
     pub name: String,
     pub status: PromiseStatus,
+    /// Operational health — can the next backup succeed efficiently?
+    pub health: OperationalHealth,
+    /// Reasons for non-Healthy operational health (empty when Healthy).
+    pub health_reasons: Vec<String>,
     pub local: LocalAssessment,
     pub external: Vec<DriveAssessment>,
     /// Chain health per mounted, send-enabled drive.
@@ -121,7 +154,6 @@ impl std::fmt::Display for ChainBreakReason {
 pub struct LocalAssessment {
     pub status: PromiseStatus,
     pub snapshot_count: usize,
-    #[allow(dead_code)] // consumed by verbose status display (future)
     pub newest_age: Option<Duration>,
     #[allow(dead_code)] // consumed by verbose status display (future)
     pub configured_interval: Interval,
@@ -134,7 +166,6 @@ pub struct DriveAssessment {
     pub status: PromiseStatus,
     pub mounted: bool,
     pub snapshot_count: Option<usize>,
-    #[allow(dead_code)] // consumed by verbose status display (future)
     pub last_send_age: Option<Duration>,
     #[allow(dead_code)] // consumed by verbose status display (future)
     pub configured_interval: Interval,
@@ -164,6 +195,8 @@ pub fn assess(
             assessments.push(SubvolAssessment {
                 name: subvol.name.clone(),
                 status: PromiseStatus::Unprotected,
+                health: OperationalHealth::Blocked,
+                health_reasons: vec!["no snapshot root configured".to_string()],
                 local: LocalAssessment {
                     status: PromiseStatus::Unprotected,
                     snapshot_count: 0,
@@ -280,9 +313,38 @@ pub fn assess(
         // ── Overall status ──────────────────────────────────────────
         let overall = compute_overall_status(&local, &drive_assessments);
 
+        // ── Operational health ─────────────────────────────────────
+        // Pre-compute local space pressure (needs config access not available in compute_health)
+        let local_space_tight = config
+            .root_min_free_bytes(&subvol.name)
+            .filter(|&min_free| min_free > 0)
+            .and_then(|min_free| {
+                let local_dir = snapshot_root.join(&subvol.name);
+                fs.filesystem_free_bytes(&local_dir).ok().and_then(|free| {
+                    let tight_threshold = min_free + min_free / (100 / SPACE_TIGHT_MARGIN_PERCENT);
+                    if free < tight_threshold {
+                        Some(free)
+                    } else {
+                        None
+                    }
+                })
+            });
+
+        let (health, health_reasons) = compute_health(
+            subvol.send_enabled,
+            &chain_health_entries,
+            &drive_assessments,
+            &config.drives,
+            fs,
+            &subvol.name,
+            local_space_tight.is_some(),
+        );
+
         assessments.push(SubvolAssessment {
             name: subvol.name.clone(),
             status: overall,
+            health,
+            health_reasons,
             local,
             external: drive_assessments,
             chain_health: chain_health_entries,
@@ -455,6 +517,149 @@ fn assess_chain_health(
     }
 }
 
+/// Compute operational health for a subvolume.
+///
+/// Pure function: chain health + drive state + space info in, health out.
+/// Checks (in priority order): blocked conditions, then degraded conditions.
+fn compute_health(
+    send_enabled: bool,
+    chain_health: &[DriveChainHealth],
+    drive_assessments: &[DriveAssessment],
+    drives_config: &[DriveConfig],
+    fs: &dyn FileSystemState,
+    subvol_name: &str,
+    local_space_tight: bool,
+) -> (OperationalHealth, Vec<String>) {
+    let mut reasons: Vec<String> = Vec::new();
+    let mut worst = OperationalHealth::Healthy;
+
+    // ── Degraded: local snapshot root space tight ──────────────────
+    if local_space_tight {
+        reasons.push("local snapshot space tight".to_string());
+        worst = worst.min(OperationalHealth::Degraded);
+    }
+
+    if !send_enabled {
+        return (worst, reasons);
+    }
+
+    let mounted_drives: Vec<&DriveAssessment> =
+        drive_assessments.iter().filter(|d| d.mounted).collect();
+
+    // ── Blocked: no drives connected ───────────────────────────────
+    if !drives_config.is_empty() && mounted_drives.is_empty() {
+        reasons.push("no backup drives connected".to_string());
+        worst = worst.min(OperationalHealth::Blocked);
+    }
+
+    // ── Blocked: insufficient space on ALL connected drives ────────
+    if !mounted_drives.is_empty() {
+        let mut all_space_blocked = true;
+        for da in &mounted_drives {
+            let drive_cfg = drives_config.iter().find(|d| d.label == da.drive_label);
+            let Some(cfg) = drive_cfg else {
+                all_space_blocked = false;
+                continue;
+            };
+
+            let free = fs.filesystem_free_bytes(&cfg.mount_path).unwrap_or(u64::MAX);
+            let min_free = cfg.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
+
+            // Estimate next send size: calibrated > last send > skip
+            let est_size = fs
+                .calibrated_size(subvol_name)
+                .map(|(bytes, _)| bytes)
+                .or_else(|| fs.last_send_size(subvol_name, &da.drive_label, "incremental"))
+                .or_else(|| fs.last_send_size(subvol_name, &da.drive_label, "full"));
+
+            // Check if chain is broken on this drive (full send will be needed)
+            let chain_broken = chain_health
+                .iter()
+                .any(|ch| ch.drive_label == da.drive_label && matches!(&ch.status, ChainStatus::Broken { reason, .. } if *reason != ChainBreakReason::NoDriveData));
+
+            match est_size {
+                Some(size) if free.saturating_sub(min_free) < size => {
+                    // This drive can't fit the next send
+                }
+                None if chain_broken => {
+                    // Chain broken (full send needed) but no size estimate —
+                    // can't verify space. Fail open but surface the uncertainty.
+                    all_space_blocked = false;
+                }
+                _ => {
+                    // Either enough space or no estimate with intact chain (fail open)
+                    all_space_blocked = false;
+                }
+            }
+        }
+
+        if all_space_blocked {
+            reasons.push("insufficient space on all connected drives".to_string());
+            worst = worst.min(OperationalHealth::Blocked);
+        }
+    }
+
+    // ── Degraded: chain broken on any connected drive ──────────────
+    for ch in chain_health {
+        if let ChainStatus::Broken { reason, .. } = &ch.status
+            && *reason != ChainBreakReason::NoDriveData
+        {
+            reasons.push(format!(
+                "chain broken on {} \u{2014} next send will be full",
+                ch.drive_label
+            ));
+            worst = worst.min(OperationalHealth::Degraded);
+
+            // Surface uncertainty: chain broken means full send, but no size estimate
+            let has_estimate = fs
+                .calibrated_size(subvol_name)
+                .is_some()
+                || fs.last_send_size(subvol_name, &ch.drive_label, "full").is_some();
+            if !has_estimate {
+                reasons.push(format!(
+                    "full send size unknown for {} \u{2014} space check unavailable",
+                    ch.drive_label
+                ));
+            }
+        }
+    }
+
+    // ── Degraded: space tight on any connected drive ───────────────
+    for da in &mounted_drives {
+        if let Some(cfg) = drives_config.iter().find(|d| d.label == da.drive_label)
+            && let Some(min_free_bytes) = cfg.min_free_bytes
+        {
+            let min_free = min_free_bytes.bytes();
+            if min_free > 0 {
+                let free = fs.filesystem_free_bytes(&cfg.mount_path).unwrap_or(u64::MAX);
+                let tight_threshold =
+                    min_free + min_free / (100 / SPACE_TIGHT_MARGIN_PERCENT);
+                if free < tight_threshold {
+                    reasons.push(format!("space tight on {}", da.drive_label));
+                    worst = worst.min(OperationalHealth::Degraded);
+                }
+            }
+        }
+    }
+
+    // ── Degraded: configured drive unmounted >7 days ───────────────
+    for da in drive_assessments {
+        if !da.mounted
+            && let Some(age) = da.last_send_age
+            && age.num_days() > DRIVE_AWAY_DEGRADED_DAYS
+        {
+            reasons.push(format!(
+                "{} away for {} days",
+                da.drive_label,
+                age.num_days()
+            ));
+            worst = worst.min(OperationalHealth::Degraded);
+        }
+    }
+
+    (worst, reasons)
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -519,6 +724,98 @@ source = "/data/sv2"
 
     fn snap(datetime: NaiveDateTime, name: &str) -> SnapshotName {
         SnapshotName::new(datetime, name)
+    }
+
+    /// Test config with one drive and min_free_bytes set.
+    fn test_config_with_min_free() -> Config {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/mnt/wd"
+snapshot_root = ".snapshots"
+role = "primary"
+min_free_bytes = "100GB"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "sv1"
+source = "/data/sv1"
+"#;
+        toml::from_str(toml_str).expect("test config with min_free should parse")
+    }
+
+    /// Test config with two drives.
+    fn test_config_two_drives() -> Config {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "primary"
+min_free_bytes = "100GB"
+
+[[drives]]
+label = "D2"
+mount_path = "/mnt/d2"
+snapshot_root = ".snapshots"
+role = "offsite"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "sv1"
+source = "/data/sv1"
+"#;
+        toml::from_str(toml_str).expect("test config two drives should parse")
     }
 
     // ── Test 1: All protected ──────────────────────────────────────
@@ -1549,6 +1846,422 @@ source = "/data/sv1"
                 reason: ChainBreakReason::PinReadError,
                 pin_parent: None,
             }
+        );
+    }
+
+    // ── Operational health tests ───────────────────────────────────
+
+    #[test]
+    fn health_all_chains_intact_is_healthy() {
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        let pin_snap = snap(dt(2026, 3, 23, 12, 0), "sv1");
+        // Fresh local snapshots — must include the pin parent
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                pin_snap.clone(),
+                snap(dt(2026, 3, 23, 13, 30), "sv1"),
+            ],
+        );
+        // Drive mounted with snapshots and intact chain
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv1".to_string()),
+            vec![pin_snap.clone()],
+        );
+        fs.pin_files.insert(
+            (
+                std::path::PathBuf::from("/snap/sv1"),
+                "WD-18TB".to_string(),
+            ),
+            pin_snap,
+        );
+        fs.send_times.insert(
+            ("sv1".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        // Adequate free space
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Healthy);
+        assert!(results[0].health_reasons.is_empty());
+    }
+
+    #[test]
+    fn health_chain_broken_is_degraded() {
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv1".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "sv1")],
+        );
+        // No pin file — chain broken
+        fs.send_times.insert(
+            ("sv1".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Degraded);
+        assert!(results[0].health_reasons[0].contains("chain broken"));
+        assert!(results[0].health_reasons[0].contains("WD-18TB"));
+    }
+
+    #[test]
+    fn health_no_drives_mounted_send_enabled_is_blocked() {
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        // No drives mounted, send_enabled=true (default in test config)
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Blocked);
+        assert!(results[0].health_reasons[0].contains("no backup drives connected"));
+    }
+
+    #[test]
+    fn health_send_disabled_no_drives_is_healthy() {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/mnt/wd"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "sv1"
+source = "/data/sv1"
+send_enabled = false
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        // No drives mounted — but send_enabled=false, so health should be Healthy
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Healthy);
+    }
+
+    #[test]
+    fn health_space_tight_is_degraded() {
+        let config = test_config_with_min_free();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv1".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "sv1")],
+        );
+        fs.pin_files.insert(
+            (
+                std::path::PathBuf::from("/snap/sv1"),
+                "WD-18TB".to_string(),
+            ),
+            snap(dt(2026, 3, 23, 12, 0), "sv1"),
+        );
+        fs.send_times.insert(
+            ("sv1".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        // Free space: 105GB. min_free = 100GB. tight_threshold = 120GB. 105 < 120 → degraded
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 105_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Degraded);
+        assert!(results[0].health_reasons.iter().any(|r| r.contains("space tight")));
+    }
+
+    #[test]
+    fn health_space_blocked_all_drives() {
+        let config = test_config_with_min_free();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv1".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "sv1")],
+        );
+        fs.pin_files.insert(
+            (
+                std::path::PathBuf::from("/snap/sv1"),
+                "WD-18TB".to_string(),
+            ),
+            snap(dt(2026, 3, 23, 12, 0), "sv1"),
+        );
+        fs.send_times.insert(
+            ("sv1".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        // Free: 150GB, min_free: 100GB, available: 50GB, last send: 60GB → blocked
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 150_000_000_000);
+        fs.send_sizes.insert(
+            ("sv1".to_string(), "WD-18TB".to_string(), "incremental".to_string()),
+            60_000_000_000,
+        );
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Blocked);
+        assert!(results[0].health_reasons.iter().any(|r| r.contains("insufficient space")));
+    }
+
+    #[test]
+    fn health_drive_away_long_is_degraded() {
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        // Drive NOT mounted but has send history >7 days ago
+        fs.send_times.insert(
+            ("sv1".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 10, 12, 0), // 13 days ago
+        );
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Blocked);
+        // Blocked because no drives mounted (primary check), plus degraded for away >7d
+        assert!(results[0].health_reasons.iter().any(|r| r.contains("no backup drives connected")));
+    }
+
+    #[test]
+    fn health_drive_away_recent_other_mounted() {
+        let config = test_config_two_drives();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        let pin_snap = snap(dt(2026, 3, 23, 12, 0), "sv1");
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                pin_snap.clone(),
+                snap(dt(2026, 3, 23, 13, 30), "sv1"),
+            ],
+        );
+        // D1 mounted and healthy
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![pin_snap.clone()],
+        );
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "D1".to_string()),
+            pin_snap,
+        );
+        fs.send_times.insert(
+            ("sv1".to_string(), "D1".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        // D2 unmounted, last send 2 days ago (< 7 days)
+        fs.send_times.insert(
+            ("sv1".to_string(), "D2".to_string()),
+            dt(2026, 3, 21, 12, 0),
+        );
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/d1"), 1_000_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Healthy, "health_reasons: {:?}", results[0].health_reasons);
+        assert!(results[0].health_reasons.is_empty());
+    }
+
+    #[test]
+    fn health_multiple_reasons_collected() {
+        let config = test_config_two_drives();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        // D1 mounted, chain broken, space tight
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "sv1")],
+        );
+        // No pin file → chain broken
+        fs.send_times.insert(
+            ("sv1".to_string(), "D1".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        // Space tight: 105GB free, 100GB min
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/d1"), 105_000_000_000);
+        // D2 unmounted, >7 days
+        fs.send_times.insert(
+            ("sv1".to_string(), "D2".to_string()),
+            dt(2026, 3, 10, 12, 0),
+        );
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Degraded);
+        assert!(results[0].health_reasons.len() >= 2, "expected multiple reasons, got: {:?}", results[0].health_reasons);
+        assert!(results[0].health_reasons.iter().any(|r| r.contains("chain broken")));
+        // Either space tight or drive away, depending on config
+    }
+
+    #[test]
+    fn health_worst_wins() {
+        // OperationalHealth ordering: Blocked < Degraded < Healthy
+        assert!(OperationalHealth::Blocked < OperationalHealth::Degraded);
+        assert!(OperationalHealth::Degraded < OperationalHealth::Healthy);
+        assert_eq!(
+            OperationalHealth::Blocked.min(OperationalHealth::Healthy),
+            OperationalHealth::Blocked
+        );
+    }
+
+    #[test]
+    fn health_local_space_tight_degrades() {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"], min_free_bytes = "10GB" }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = false
+enabled = true
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/mnt/wd"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "sv1"
+source = "/data/sv1"
+send_enabled = false
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        // Local space: 11GB free, 10GB min → tight_threshold = 12GB → 11 < 12 → degraded
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/snap/sv1"), 11_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Degraded);
+        assert!(results[0].health_reasons.iter().any(|r| r.contains("local snapshot space tight")));
+    }
+
+    #[test]
+    fn health_chain_broken_no_estimate_surfaces_uncertainty() {
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv1".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "sv1")],
+        );
+        // No pin file → chain broken. No send sizes → no estimate.
+        fs.send_times.insert(
+            ("sv1".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].health, OperationalHealth::Degraded);
+        assert!(
+            results[0].health_reasons.iter().any(|r| r.contains("full send size unknown")),
+            "expected uncertainty reason, got: {:?}", results[0].health_reasons
         );
     }
 }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -615,7 +615,7 @@ fn filter_promise_retention(config: &Config, plan: &mut BackupPlan) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::awareness::{LocalAssessment, PromiseStatus, SubvolAssessment};
+    use crate::awareness::{LocalAssessment, OperationalHealth, PromiseStatus, SubvolAssessment};
     use crate::executor::{
         ExecutionResult, OpResult, OperationOutcome, RunResult, SendType, SubvolumeResult,
     };
@@ -667,6 +667,8 @@ mod tests {
         vec![SubvolAssessment {
             name: "htpc-home".to_string(),
             status: PromiseStatus::Protected,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
             local: LocalAssessment {
                 status: PromiseStatus::Protected,
                 snapshot_count: 10,

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -202,7 +202,7 @@ pub fn mark_dispatched(path: &Path) -> crate::error::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::awareness::{DriveAssessment, LocalAssessment, PromiseStatus};
+    use crate::awareness::{DriveAssessment, LocalAssessment, OperationalHealth, PromiseStatus};
     use crate::config::{
         Config, DefaultsConfig, GeneralConfig, LocalSnapshotsConfig, SnapshotRoot, SubvolumeConfig,
     };
@@ -276,6 +276,8 @@ mod tests {
             SubvolAssessment {
                 name: "home".to_string(),
                 status: PromiseStatus::Protected,
+                health: OperationalHealth::Healthy,
+                health_reasons: vec![],
                 local: LocalAssessment {
                     status: PromiseStatus::Protected,
                     snapshot_count: 24,
@@ -297,6 +299,8 @@ mod tests {
             SubvolAssessment {
                 name: "docs".to_string(),
                 status: PromiseStatus::AtRisk,
+                health: OperationalHealth::Healthy,
+                health_reasons: vec![],
                 local: LocalAssessment {
                     status: PromiseStatus::AtRisk,
                     snapshot_count: 5,

--- a/src/output.rs
+++ b/src/output.rs
@@ -98,10 +98,18 @@ pub struct StatusOutput {
 pub struct StatusAssessment {
     pub name: String,
     pub status: String,
+    /// Operational health: "healthy", "degraded", or "blocked".
+    pub health: String,
+    /// Reasons for non-healthy operational health (empty when healthy).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub health_reasons: Vec<String>,
     /// Promise level from config (e.g., "protected", "resilient"), or None for custom/unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub promise_level: Option<String>,
     pub local_snapshot_count: usize,
+    /// Age of newest local snapshot in seconds, if available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_newest_age_secs: Option<i64>,
     pub local_status: String,
     pub external: Vec<StatusDriveAssessment>,
     pub advisories: Vec<String>,
@@ -114,8 +122,11 @@ impl StatusAssessment {
         Self {
             name: a.name.clone(),
             status: a.status.to_string(),
+            health: a.health.to_string(),
+            health_reasons: a.health_reasons.clone(),
             promise_level: None,
             local_snapshot_count: a.local.snapshot_count,
+            local_newest_age_secs: a.local.newest_age.map(|d| d.num_seconds()),
             local_status: a.local.status.to_string(),
             external: a
                 .external
@@ -135,6 +146,9 @@ pub struct StatusDriveAssessment {
     pub status: String,
     pub mounted: bool,
     pub snapshot_count: Option<usize>,
+    /// Age of last send in seconds, if available (even when unmounted).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_send_age_secs: Option<i64>,
 }
 
 impl StatusDriveAssessment {
@@ -145,6 +159,7 @@ impl StatusDriveAssessment {
             status: a.status.to_string(),
             mounted: a.mounted,
             snapshot_count: a.snapshot_count,
+            last_send_age_secs: a.last_send_age.map(|d| d.num_seconds()),
         }
     }
 }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -570,7 +570,7 @@ pub fn has_promise_changes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::awareness::{DriveAssessment, LocalAssessment};
+    use crate::awareness::{DriveAssessment, LocalAssessment, OperationalHealth};
     use crate::types::Interval;
 
     fn dt(s: &str) -> NaiveDateTime {
@@ -585,6 +585,8 @@ mod tests {
         SubvolAssessment {
             name: name.to_string(),
             status,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
             local: LocalAssessment {
                 status,
                 snapshot_count: 5,
@@ -607,6 +609,8 @@ mod tests {
         SubvolAssessment {
             name: name.to_string(),
             status,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
             local: LocalAssessment {
                 status: PromiseStatus::Protected,
                 snapshot_count: 5,

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -482,13 +482,15 @@ pub fn is_pid_alive(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::awareness::{LocalAssessment, PromiseStatus};
+    use crate::awareness::{LocalAssessment, OperationalHealth, PromiseStatus};
     use crate::types::Interval;
 
     fn make_assessment(name: &str, status: PromiseStatus) -> SubvolAssessment {
         SubvolAssessment {
             name: name.to_string(),
             status,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
             local: LocalAssessment {
                 status,
                 snapshot_count: 5,

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -36,6 +36,9 @@ fn render_status_daemon(data: &StatusOutput) -> String {
 fn render_status_interactive(data: &StatusOutput) -> String {
     let mut out = String::new();
 
+    // ── Summary line ────────────────────────────────────────────────
+    render_summary_line(data, &mut out);
+
     // ── Per-subvolume table ──────────────────────────────────────────
     render_subvolume_table(data, &mut out);
 
@@ -62,39 +65,116 @@ fn render_status_interactive(data: &StatusOutput) -> String {
     out
 }
 
+fn render_summary_line(data: &StatusOutput, out: &mut String) {
+    if data.assessments.is_empty() {
+        return;
+    }
+
+    let total = data.assessments.len();
+    let safe_count = data
+        .assessments
+        .iter()
+        .filter(|a| a.status == "PROTECTED")
+        .count();
+    let has_health_issues = data.assessments.iter().any(|a| a.health != "healthy");
+
+    let safety_part = if safe_count == total {
+        "All data safe.".green().to_string()
+    } else {
+        let unsafe_names: Vec<&str> = data
+            .assessments
+            .iter()
+            .filter(|a| a.status != "PROTECTED")
+            .map(|a| a.name.as_str())
+            .collect();
+        format!(
+            "{} of {} safe. {} {} attention.",
+            safe_count,
+            total,
+            unsafe_names.join(", "),
+            if unsafe_names.len() == 1 { "needs" } else { "need" },
+        )
+        .yellow()
+        .to_string()
+    };
+
+    let health_part = if has_health_issues {
+        let blocked_count = data
+            .assessments
+            .iter()
+            .filter(|a| a.health == "blocked")
+            .count();
+        let degraded_count = data
+            .assessments
+            .iter()
+            .filter(|a| a.health == "degraded")
+            .count();
+        // Pick the first reason from the worst non-healthy subvolume
+        let first_reason = data
+            .assessments
+            .iter()
+            .find(|a| a.health != "healthy")
+            .and_then(|a| a.health_reasons.first())
+            .map(|r| format!(" \u{2014} {r}"))
+            .unwrap_or_default();
+        let mut parts = Vec::new();
+        if blocked_count > 0 {
+            parts.push(format!("{blocked_count} blocked"));
+        }
+        if degraded_count > 0 {
+            parts.push(format!("{degraded_count} degraded"));
+        }
+        format!(" {}{first_reason}.", parts.join(", "))
+    } else {
+        String::new()
+    };
+
+    writeln!(out, "{safety_part}{health_part}").ok();
+}
+
 fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
     if data.assessments.is_empty() {
         writeln!(out, "{}", "No subvolumes configured.".dimmed()).ok();
         return;
     }
 
-    // Collect mounted drive labels for column headers
-    let mounted_drives: Vec<&str> = data
-        .drives
-        .iter()
-        .filter(|d| d.mounted)
-        .map(|d| d.label.as_str())
-        .collect();
+    // Collect all configured drive labels for column headers (not just mounted)
+    let drive_labels: Vec<&str> = data.drives.iter().map(|d| d.label.as_str()).collect();
 
     // Check if any assessment has a promise level — only show column if so
     let has_promises = data.assessments.iter().any(|a| a.promise_level.is_some());
+    // Only show HEALTH column when at least one subvolume is non-healthy
+    let show_health = data.assessments.iter().any(|a| a.health != "healthy");
 
-    // Build headers: STATUS  [PROMISE]  SUBVOLUME  LOCAL  [DRIVE1]  [DRIVE2]  CHAIN
-    let mut headers: Vec<String> = vec!["STATUS".to_string()];
+    // Build headers: SAFETY  [HEALTH]  [PROMISE]  SUBVOLUME  LOCAL  [DRIVES...]  CHAIN
+    let mut headers: Vec<String> = vec!["SAFETY".to_string()];
+    if show_health {
+        headers.push("HEALTH".to_string());
+    }
     if has_promises {
         headers.push("PROMISE".to_string());
     }
     headers.push("SUBVOLUME".to_string());
     headers.push("LOCAL".to_string());
-    for label in &mounted_drives {
+    for label in &drive_labels {
         headers.push(label.to_string());
     }
     headers.push("CHAIN".to_string());
 
+    // Track which columns need coloring
+    let safety_col = Some(0usize);
+    let health_col = if show_health { Some(1usize) } else { None };
+
     // Build rows
     let mut rows: Vec<Vec<String>> = Vec::new();
     for assessment in &data.assessments {
-        let mut row = vec![assessment.status.clone()];
+        // Safety column — new vocabulary
+        let safety = safety_label(&assessment.status);
+        let mut row = vec![safety];
+
+        if show_health {
+            row.push(assessment.health.clone());
+        }
         if has_promises {
             row.push(
                 assessment
@@ -104,19 +184,33 @@ fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
             );
         }
         row.push(assessment.name.clone());
-        row.push(assessment.local_snapshot_count.to_string());
 
-        // Per-drive external snapshot count
-        for label in &mounted_drives {
-            let count = assessment
+        // LOCAL column with temporal context
+        let local_cell = format_count_with_age(
+            assessment.local_snapshot_count,
+            assessment.local_newest_age_secs,
+        );
+        row.push(local_cell);
+
+        // Per-drive columns (all configured drives, not just mounted)
+        for label in &drive_labels {
+            let ext = assessment
                 .external
                 .iter()
-                .find(|e| e.drive_label == *label)
-                .and_then(|e| e.snapshot_count);
-            row.push(match count {
-                Some(c) if c > 0 => c.to_string(),
-                _ => "\u{2014}".to_string(), // em dash
-            });
+                .find(|e| e.drive_label == *label);
+            let cell = match ext {
+                Some(e) if e.mounted => {
+                    let count = e.snapshot_count.unwrap_or(0);
+                    if count > 0 {
+                        format_count_with_age(count, e.last_send_age_secs)
+                    } else {
+                        "\u{2014}".to_string()
+                    }
+                }
+                Some(e) if e.last_send_age_secs.is_some() => "away".dimmed().to_string(),
+                _ => "\u{2014}".to_string(),
+            };
+            row.push(cell);
         }
 
         // Chain health
@@ -131,7 +225,38 @@ fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
         rows.push(row);
     }
 
-    format_table(&headers, &rows, out);
+    format_status_table(&headers, &rows, safety_col, health_col, out);
+}
+
+/// Map legacy status strings to new vocabulary.
+fn safety_label(status: &str) -> String {
+    match status {
+        "PROTECTED" => "OK".to_string(),
+        "AT RISK" => "aging".to_string(),
+        "UNPROTECTED" => "gap".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Format a snapshot count with optional age: "10 (2h)" or just "10".
+fn format_count_with_age(count: usize, age_secs: Option<i64>) -> String {
+    match age_secs {
+        Some(secs) if secs >= 0 => format!("{} ({})", count, humanize_duration(secs)),
+        _ => count.to_string(),
+    }
+}
+
+/// Humanize seconds into a compact duration string.
+fn humanize_duration(secs: i64) -> String {
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else if secs < 86400 {
+        format!("{}h", secs / 3600)
+    } else {
+        format!("{}d", secs / 86400)
+    }
 }
 
 fn render_advisories(data: &StatusOutput, out: &mut String) {
@@ -213,13 +338,20 @@ fn render_last_run(data: &StatusOutput, out: &mut String) {
 
 // ── Table formatter ─────────────────────────────────────────────────────
 
-fn format_table(headers: &[String], rows: &[Vec<String>], out: &mut String) {
+/// Format status table with optional colored SAFETY and HEALTH columns.
+fn format_status_table(
+    headers: &[String],
+    rows: &[Vec<String>],
+    safety_col: Option<usize>,
+    health_col: Option<usize>,
+    out: &mut String,
+) {
     let cols = headers.len();
     let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
     for row in rows {
         for (i, cell) in row.iter().enumerate() {
             if i < cols {
-                widths[i] = widths[i].max(cell.len());
+                widths[i] = widths[i].max(strip_ansi_len(cell));
             }
         }
     }
@@ -232,20 +364,22 @@ fn format_table(headers: &[String], rows: &[Vec<String>], out: &mut String) {
         .collect();
     writeln!(out, "{}", header_line.join("  ").bold()).ok();
 
-    // Rows — color the STATUS column
+    // Rows — color SAFETY and HEALTH columns
     for row in rows {
         let line: Vec<String> = row
             .iter()
             .enumerate()
             .map(|(i, cell)| {
                 let w = widths.get(i).copied().unwrap_or(cell.len());
-                if i == 0 {
-                    // STATUS column — apply color
-                    let colored = color_status_str(cell);
-                    // Pad after coloring (colored strings have invisible ANSI bytes)
-                    let visible_len = cell.len();
+                let visible_len = strip_ansi_len(cell);
+                if safety_col == Some(i) {
+                    color_and_pad(&color_safety_str(cell), cell.len(), w)
+                } else if health_col == Some(i) {
+                    color_and_pad(&color_health_str(cell), cell.len(), w)
+                } else if visible_len != cell.len() {
+                    // Cell already contains ANSI codes (pre-colored) — pad by visible width
                     let padding = w.saturating_sub(visible_len);
-                    format!("{colored}{:padding$}", "", padding = padding)
+                    format!("{cell}{:padding$}", "", padding = padding)
                 } else {
                     format!("{:<width$}", cell, width = w)
                 }
@@ -255,13 +389,52 @@ fn format_table(headers: &[String], rows: &[Vec<String>], out: &mut String) {
     }
 }
 
+/// Generic table formatter (no column coloring). Used by backup summary.
+fn format_table(headers: &[String], rows: &[Vec<String>], out: &mut String) {
+    format_status_table(headers, rows, None, None, out);
+}
+
+/// Get visible (non-ANSI) length of a string.
+fn strip_ansi_len(s: &str) -> usize {
+    // ANSI escape sequences: ESC[ ... m
+    let mut len = 0;
+    let mut in_escape = false;
+    for c in s.chars() {
+        if in_escape {
+            if c == 'm' {
+                in_escape = false;
+            }
+        } else if c == '\x1b' {
+            in_escape = true;
+        } else {
+            len += 1;
+        }
+    }
+    len
+}
+
+/// Apply color then pad to column width (ANSI codes are invisible bytes).
+fn color_and_pad(colored: &str, visible_len: usize, width: usize) -> String {
+    let padding = width.saturating_sub(visible_len);
+    format!("{colored}{:padding$}", "", padding = padding)
+}
+
 // ── Color helpers ───────────────────────────────────────────────────────
 
-fn color_status_str(status: &str) -> String {
-    match status {
-        "PROTECTED" => "PROTECTED".green().to_string(),
-        "AT RISK" => "AT RISK".yellow().to_string(),
-        "UNPROTECTED" => "UNPROTECTED".red().to_string(),
+fn color_safety_str(safety: &str) -> String {
+    match safety {
+        "OK" => "OK".green().to_string(),
+        "aging" => "aging".yellow().to_string(),
+        "gap" => "gap".red().to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn color_health_str(health: &str) -> String {
+    match health {
+        "healthy" => "healthy".dimmed().to_string(),
+        "degraded" => "degraded".yellow().to_string(),
+        "blocked" => "blocked".red().to_string(),
         other => other.to_string(),
     }
 }
@@ -1290,14 +1463,18 @@ mod tests {
                 StatusAssessment {
                     name: "htpc-home".to_string(),
                     status: "PROTECTED".to_string(),
+                    health: "healthy".to_string(),
+                    health_reasons: vec![],
                     promise_level: None,
                     local_snapshot_count: 47,
+                    local_newest_age_secs: Some(1800),
                     local_status: "PROTECTED".to_string(),
                     external: vec![StatusDriveAssessment {
                         drive_label: "WD-18TB".to_string(),
                         status: "PROTECTED".to_string(),
                         mounted: true,
                         snapshot_count: Some(12),
+                        last_send_age_secs: Some(7200),
                     }],
                     advisories: vec![],
                     errors: vec![],
@@ -1305,14 +1482,20 @@ mod tests {
                 StatusAssessment {
                     name: "htpc-docs".to_string(),
                     status: "AT RISK".to_string(),
+                    health: "degraded".to_string(),
+                    health_reasons: vec![
+                        "chain broken on WD-18TB \u{2014} next send will be full".to_string(),
+                    ],
                     promise_level: None,
                     local_snapshot_count: 5,
+                    local_newest_age_secs: Some(10800),
                     local_status: "AT RISK".to_string(),
                     external: vec![StatusDriveAssessment {
                         drive_label: "WD-18TB".to_string(),
                         status: "UNPROTECTED".to_string(),
                         mounted: true,
                         snapshot_count: Some(0),
+                        last_send_age_secs: None,
                     }],
                     advisories: vec![],
                     errors: vec![],
@@ -1359,11 +1542,11 @@ mod tests {
     }
 
     #[test]
-    fn interactive_contains_promise_statuses() {
+    fn interactive_contains_safety_vocabulary() {
         colored::control::set_override(false);
         let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("PROTECTED"), "missing PROTECTED");
-        assert!(output.contains("AT RISK"), "missing AT RISK");
+        assert!(output.contains("OK"), "missing OK safety label");
+        assert!(output.contains("aging"), "missing aging safety label");
     }
 
     #[test]
@@ -1553,8 +1736,11 @@ mod tests {
             assessments: vec![StatusAssessment {
                 name: "htpc-home".to_string(),
                 status: "PROTECTED".to_string(),
+                health: "healthy".to_string(),
+                health_reasons: vec![],
                 promise_level: None,
                 local_snapshot_count: 12,
+                local_newest_age_secs: None,
                 local_status: "PROTECTED".to_string(),
                 external: vec![],
                 advisories: vec![],
@@ -2082,5 +2268,104 @@ mod tests {
             serde_json::from_str(&output).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{output}"));
         assert_eq!(parsed["status"], "running");
         assert_eq!(parsed["state"]["pid"], 12345);
+    }
+
+    // ── Two-axis rendering tests ───────────────────────────────────
+
+    #[test]
+    fn summary_line_all_safe_all_healthy() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        // Make all assessments safe and healthy
+        for a in &mut data.assessments {
+            a.status = "PROTECTED".to_string();
+            a.health = "healthy".to_string();
+            a.health_reasons = vec![];
+        }
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(output.contains("All data safe"), "missing summary line, got: {output}");
+    }
+
+    #[test]
+    fn summary_line_all_safe_degraded() {
+        colored::control::set_override(false);
+        let data = test_status_output(); // htpc-docs is degraded
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("degraded"),
+            "missing health degraded in summary, got: {output}"
+        );
+    }
+
+    #[test]
+    fn safety_column_uses_new_vocabulary() {
+        colored::control::set_override(false);
+        let data = test_status_output();
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(output.contains("OK"), "missing OK label");
+        assert!(output.contains("aging"), "missing aging label");
+        assert!(!output.contains("PROTECTED"), "should not contain legacy PROTECTED");
+        assert!(!output.contains("AT RISK"), "should not contain legacy AT RISK");
+    }
+
+    #[test]
+    fn health_column_hidden_when_all_healthy() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        for a in &mut data.assessments {
+            a.health = "healthy".to_string();
+            a.health_reasons = vec![];
+        }
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(!output.contains("HEALTH"), "HEALTH column should be hidden when all healthy");
+    }
+
+    #[test]
+    fn health_column_shown_when_degraded() {
+        colored::control::set_override(false);
+        let data = test_status_output(); // htpc-docs is degraded
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(output.contains("HEALTH"), "HEALTH column should be visible");
+        assert!(output.contains("degraded"), "missing degraded value");
+    }
+
+    #[test]
+    fn temporal_context_in_local_column() {
+        colored::control::set_override(false);
+        let data = test_status_output();
+        let output = render_status(&data, OutputMode::Interactive);
+        // htpc-home has local_newest_age_secs = 1800 (30m)
+        assert!(output.contains("47 (30m)"), "missing temporal context '47 (30m)' in: {output}");
+    }
+
+    #[test]
+    fn unmounted_drive_shows_away() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        // Add an unmounted drive with send history to one assessment
+        data.assessments[0].external.push(StatusDriveAssessment {
+            drive_label: "Offsite-4TB".to_string(),
+            status: "PROTECTED".to_string(),
+            mounted: false,
+            snapshot_count: None,
+            last_send_age_secs: Some(172800), // 2 days
+        });
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(output.contains("away"), "unmounted drive with history should show 'away': {output}");
+    }
+
+    #[test]
+    fn daemon_json_includes_health_fields() {
+        let data = test_status_output();
+        let output = render_status(&data, OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed["assessments"][0]["health"], "healthy");
+        assert_eq!(parsed["assessments"][1]["health"], "degraded");
+        assert!(
+            parsed["assessments"][1]["health_reasons"][0]
+                .as_str()
+                .unwrap()
+                .contains("chain broken"),
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Two-axis awareness model:** `OperationalHealth` enum (Blocked/Degraded/Blocked) added alongside existing `PromiseStatus`, separating "is my data safe?" from "can the next backup succeed?"
- **CLI rendering:** SAFETY column (OK/aging/gap) + conditional HEALTH column, summary line answering both questions at a glance, temporal context in snapshot counts
- **Health computation:** Pure function checking chain integrity, space pressure (local + external), drive availability, with named threshold constants
- **Arch-adversary reviewed:** Local space blind spot fixed, space estimation uncertainty surfaced, summary line wording differentiated

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 436 tests, all pass (20 new)
- cargo build --release: pass
- Integration tests: not applicable (advisory-only changes, no btrfs operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)