### PR TITLE
feat: sentinel session 3 + v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-03-29
+
 ### Added
 - Drive session tokens for hardware swap detection (`.urd-drive-token` identity files)
 - Chain health computation in awareness model (incremental chain intact/broken per drive)
 - Two-axis status display: data safety (OK/aging/gap) + operational health (healthy/degraded/blocked)
 - Temporal context in status table: snapshot counts show age (e.g., "47 (30m)", "12 (2h)")
 - Unmounted drives shown as "away" in status table when they have send history
+- Notification deduplication: backup defers to sentinel when daemon is running
+- Drive connection recording in SQLite (mount/unmount events with typed enums)
 
 ### Changed
 - README rewritten for public repository
 - Status command derives chain health from awareness assessment instead of recomputing
+- `SentinelStateFile::read()` moved from output.rs to sentinel_runner.rs (ADR-108)
+- Sentinel initial assessment log differentiates missing heartbeat (first-run)
 
 ## [0.3.0] - 2026-03-27
 
@@ -72,7 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/vonrobak/urd/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/vonrobak/urd/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/vonrobak/urd/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/vonrobak/urd/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,15 +8,15 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-436 tests, all passing, clippy clean. Current version: v0.3.0.
+444 tests, all passing, clippy clean. Current version: v0.3.0.
 
 ## In Progress
 
-- **VFM-A complete** (2026-03-29). OperationalHealth enum + two-axis CLI rendering.
-  `compute_health()` pure function checks chain health, space pressure (local + external),
-  drive availability. CLI shows SAFETY + HEALTH columns, summary line, temporal context.
-  Reviewed, simplified, post-review fixes applied.
-  [Implementation review](../99-reports/2026-03-29-vfm-a-implementation-review.md)
+- **Sentinel Session 3 complete** (2026-03-29). Notification deduplication between backup
+  command and sentinel daemon. Drive connection recording in SQLite. `SentinelStateFile::read()`
+  moved out of pure-types module (ADR-108). Post-review: heartbeat dispatched flag preserved
+  on deferral. Reviewed, simplified, post-review fixes applied.
+  [Implementation review](../99-reports/2026-03-29-sentinel-session3-implementation-review.md)
 
 ## Build Queue
 
@@ -24,10 +24,9 @@ Seven-step sequence resolved 2026-03-29. See [roadmap.md Priority 5.5](roadmap.m
 full details, design decisions, and review findings.
 
 1. ~~**HSD-A**~~ — drive session tokens + chain health as awareness input. **Done.**
-2. ~~**VFM-A**~~ — `OperationalHealth` enum, two-axis CLI rendering. **Done.** ← **start here**
-3. **Sentinel Session 3** — hardening + notification deduplication.
-   Needed by HSD-B and VFM-B, not by earlier steps.
-4. **HSD-B** — sentinel chain-break detection + full-send gate (Norman escalation, never auto-proceed).
+2. ~~**VFM-A**~~ — `OperationalHealth` enum, two-axis CLI rendering. **Done.**
+3. ~~**Sentinel Session 3**~~ — hardening + notification deduplication. **Done.** ← **completed**
+4. **HSD-B** — sentinel chain-break detection + full-send gate (Norman escalation, never auto-proceed). ← **start here**
 5. **VFM-B** — sentinel visual state in state file + health notifications.
 6. **Transient snapshots** — `local_retention = "transient"` for NVMe space pressure.
 7. **Tray icon (Spindle)** — reads sentinel-state.json, 4 static icons.
@@ -43,7 +42,7 @@ full details, design decisions, and review findings.
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Latest journals | `docs/98-journals/` (local only, gitignored) |
-| Latest reviews | [VFM-A review](../99-reports/2026-03-29-vfm-a-implementation-review.md), [HSD-A review](../99-reports/2026-03-29-hsd-a-implementation-review.md) |
+| Latest reviews | [Session 3 review](../99-reports/2026-03-29-sentinel-session3-implementation-review.md), [VFM-A review](../99-reports/2026-03-29-vfm-a-implementation-review.md) |
 
 ## Known Issues
 
@@ -55,5 +54,6 @@ full details, design decisions, and review findings.
 - Orphaned snapshot `20250422-multimedia` on WD-18TB1 — clean up or let crash recovery handle
 - Per-drive pin protection for external retention: all-drives-union is conservative but suboptimal for space
 - Stringly-typed output boundary: three independent status-ranking implementations across notify.rs and voice.rs
+- `drive_connections` table has no retention policy (negligible for years at ~1000 rows/year)
 
 See [roadmap.md](roadmap.md) for the full tech debt list and dropped features.

--- a/docs/99-reports/2026-03-29-sentinel-session3-implementation-review.md
+++ b/docs/99-reports/2026-03-29-sentinel-session3-implementation-review.md
@@ -1,0 +1,228 @@
+# Sentinel Session 3 Implementation Review
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-03-29
+**Scope:** Sentinel Session 3 — notification deduplication, drive connection recording, edge case hardening
+**Base commit:** 7de2c32 (unstaged diff)
+**Test count:** 444 (8 new), clippy clean
+**Files reviewed:** `src/commands/backup.rs`, `src/commands/sentinel.rs`, `src/output.rs`, `src/sentinel_runner.rs`, `src/state.rs`
+
+---
+
+## 1. Executive Summary
+
+Solid session. The notification deduplication is correctly fail-open, the drive connection
+recording follows established patterns, and the `SentinelStateFile::read()` move resolves
+a real ADR-108 violation. One significant finding: when backup defers notification dispatch
+to the sentinel, the heartbeat's `notifications_dispatched` flag is left in an ambiguous
+state that could cause the sentinel to skip notifications it was supposed to handle.
+
+## 2. What Kills You
+
+**Catastrophic failure mode:** Silent data loss — deleting snapshots that shouldn't be deleted.
+
+**Proximity:** This session is **far from the catastrophic failure mode**. Notification
+deduplication, drive event recording, and log improvements are all observability-layer
+changes. No code path in this diff touches retention, pin protection, or btrfs operations.
+The worst outcome is missed or duplicate notifications — annoying, not destructive.
+
+**Secondary failure mode for this session:** Missed notifications when the sentinel is
+supposed to handle them but doesn't. This is the scenario to scrutinize.
+
+## 3. Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 3 | One real gap in the dedup handoff (S1). Logic otherwise sound. |
+| 2 | Security | 5 | No new privilege boundaries. PID check is /proc, not kill(). |
+| 3 | Architectural Excellence | 4 | Clean module boundaries. `sentinel_is_running` correctly placed. |
+| 4 | Systems Design | 3 | Heartbeat dispatched-flag ambiguity needs resolution (S1). |
+| 5 | Rust Idioms | 4 | Enums for event types, `#[must_use]`, proper error handling. |
+| 6 | Code Quality | 4 | Consistent with existing patterns. Tests cover the right things. |
+
+## 4. Design Tensions
+
+### Tension 1: Heartbeat-based vs. assessment-based notification paths
+
+The backup command computes notifications from heartbeat transitions
+(`notify::compute_notifications`). The sentinel computes notifications from assessment
+diffs (`build_notifications`). These are two independent implementations of "did promises
+change?" that must agree. The deduplication design says "when sentinel is running, let
+sentinel handle it" — but the sentinel's notification path is fundamentally different from
+backup's.
+
+**Resolution:** Correct. The sentinel's assessment-based path is more authoritative (it
+runs `awareness::assess()` directly). When backup defers, the sentinel picks up the
+heartbeat mtime change via `detect_heartbeat_event()`, triggers `BackupCompleted`,
+which triggers `Assess`, which runs the full assessment pipeline. The sentinel doesn't
+use the heartbeat's `notifications_dispatched` flag at all for its assessment-based
+notifications — it uses its own `last_promise_states` diff. This is the right design:
+the sentinel is the authority when it's running.
+
+### Tension 2: Fail-open dedup vs. notification reliability
+
+`sentinel_is_running` is fail-open: any I/O error returns false, causing backup to
+dispatch normally. This means: worst case on detection failure = duplicate notifications.
+Worst case on false positive (sentinel just died) = missed notifications for one run.
+
+**Resolution:** Correct trade-off. Duplicates are annoying; missed notifications self-heal
+on the next backup run (sentinel is detected as dead). The one-run window is acceptable
+for a system with nightly backups and 2-15 minute assessment ticks.
+
+### Tension 3: SQLite open per drive event vs. persistent connection
+
+The runner opens a fresh SQLite connection for each drive mount/unmount event, while
+`execute_assess()` opens its own connection per assessment tick. This means the runner
+never holds a persistent connection.
+
+**Resolution:** Correct for a daemon. Drive events are rare (a few per day). Assessment
+ticks are every 2-15 minutes. The short-lived connection pattern avoids WAL checkpoint
+accumulation and stale-handle concerns that plague long-running daemons with persistent
+SQLite connections. The cost (~1ms per open) is invisible against the 5-second poll
+interval.
+
+## 5. Findings
+
+### S1. Heartbeat `notifications_dispatched` flag left `false` when backup defers to sentinel
+
+**Severity: Significant**
+
+When `sentinel_is_running()` returns true, backup skips `dispatch_notifications()` entirely.
+This means `heartbeat::mark_dispatched()` is never called. The heartbeat on disk has
+`notifications_dispatched: false`.
+
+The sentinel's current notification path doesn't read this flag — it uses its own
+assessment diff via `build_notifications()`. So today, this works. The sentinel detects
+the heartbeat mtime change, fires `BackupCompleted → Assess`, runs its own assessment,
+and dispatches based on promise state changes.
+
+**But the flag was designed for crash recovery.** The doc comment on the field says:
+"Used for crash recovery: if false on next read, re-compute and re-send." If a future
+session implements crash recovery by reading `notifications_dispatched`, it will find
+`false` after every deferred-to-sentinel run and re-dispatch — even though the sentinel
+already handled it. The flag's semantic contract ("false means notifications weren't
+sent") is now violated: false means "either not sent, or sent by sentinel."
+
+**Consequence:** No immediate bug. But a latent semantic mismatch that will cause
+duplicate notifications if anyone implements the crash recovery path documented in the
+field's own comment. This is one feature away from a real bug.
+
+**Fix:** When deferring to sentinel, still call `heartbeat::mark_dispatched()`. The
+sentinel doesn't use this flag for its assessment-based path — it will do its own
+dispatch regardless. Marking it dispatched prevents the crash-recovery path from
+double-firing. The backup is saying "I chose not to dispatch, and that's intentional"
+rather than "I failed to dispatch." Alternative: add a third state
+(`dispatched_by_sentinel`) but that's over-engineering for the current system.
+
+### M1. `sentinel_is_running` does not check `schema_version`
+
+**Severity: Moderate**
+
+`read_sentinel_state_file` deserializes whatever JSON it finds. If a future sentinel
+version changes the state file schema (adds required fields, changes semantics),
+the old `sentinel_is_running` could parse a v2 file and misinterpret the PID field.
+
+More concretely: if the state file is corrupt or from an incompatible version,
+`serde_json::from_str` silently fails and returns `None`, which is the right behavior
+(fail-open). But if it parses successfully with wrong semantics (unlikely but possible
+with schema drift), the PID check could affirm a dead sentinel.
+
+**Consequence:** Extremely unlikely with the current simple schema. But the pattern of
+"parse JSON, trust the fields" without version checking is something to be aware of as
+the state file evolves (VFM-B will add `visual_state`).
+
+**Fix:** No code change needed now. Note for VFM-B: when `schema_version` increments,
+add a version check to `read_sentinel_state_file` and return `None` for unknown versions.
+
+### M2. `drive_connections` table grows unbounded
+
+**Severity: Moderate**
+
+The `drive_connections` table has no retention policy. Every mount and unmount event is
+recorded forever. At a few events per day, this is ~1000 rows/year — negligible for
+SQLite. But the table has no consumer that would notice if it grew large, and no cleanup
+mechanism.
+
+**Consequence:** No practical impact for years. But unlike the `operations` table (which
+has `recent_runs(limit)` patterns suggesting bounded queries), `drive_connections` has a
+`count(..., since)` query that scans the whole table if `since` is old enough.
+
+**Fix:** Add a `PRAGMA` or periodic cleanup in a future session (e.g., delete events
+older than 90 days during `init_schema` or `urd verify`). Not urgent.
+
+### Minor. Stale blank line in backup.rs
+
+`src/commands/backup.rs` line 583: extra blank line after `dispatch_notifications`.
+Cosmetic.
+
+### Commendation: C1. The `sentinel_is_running` placement is right
+
+Moving this from backup.rs to sentinel_runner.rs (during simplify pass) was the correct
+call. The function composes three sentinel-internal details (`sentinel_state_path`,
+`read_sentinel_state_file`, `is_pid_alive`) into one intention-revealing API. Callers
+don't need to know how liveness detection works — they ask a yes/no question. This is
+the right abstraction level for a module boundary.
+
+### Commendation: C2. Typed enums for drive events
+
+`DriveEventType` and `DriveEventSource` replace raw strings for the SQLite layer. This
+follows the project's "strong types over primitives" convention (CLAUDE.md) and prevents
+a real class of bugs (swapped string parameters in a 3-`&str` function). The `as_str()`
+pattern for SQLite serialization is clean and consistent.
+
+### Commendation: C3. The dedup is genuinely fail-open
+
+The `sentinel_is_running` function's error handling is correct at every level:
+- File not found → `None` → false (no sentinel)
+- Corrupt JSON → `None` → false (dispatch normally)
+- Dead PID → false (stale file, dispatch normally)
+- PID race → at worst, one run's notifications deferred to dead sentinel → self-heals next run
+
+This matches ADR-107's "fail-open for backups" philosophy applied to the notification layer.
+
+## 6. The Simplicity Question
+
+**What could be removed?** The `drive_connection_count()` method has no consumer outside
+tests. Its `since` parameter suggests a query pattern that doesn't exist yet. If sentinel
+status doesn't need it, it's speculative. `last_drive_connection()` is also unused outside
+tests but is the obvious query for a future `urd sentinel status` enhancement — more
+defensible.
+
+**What's earning its keep?** Everything else. The notification deduplication is ~15 lines
+of meaningful code (the `sentinel_is_running` function + two guard clauses). The drive
+recording is ~30 lines of wiring in the runner. The state.rs additions follow established
+patterns exactly. The first-run heartbeat log is 8 lines that improve diagnostics. There's
+no premature abstraction or speculative machinery.
+
+## 7. For the Dev Team (Prioritized Action Items)
+
+1. **Mark heartbeat dispatched when deferring to sentinel** (S1). In both guard clauses
+   in `backup.rs` (lines 99-103 and 159-163), when `sentinel_is_running` is true, call
+   `heartbeat::mark_dispatched()` before the log message. This preserves the flag's
+   semantic contract ("false means no one handled notifications") and prevents the
+   crash-recovery path from double-firing. ~4 lines added.
+
+2. **Remove extra blank line** at `backup.rs:583`. Cosmetic.
+
+3. **Consider removing `drive_connection_count`** if no consumer is planned for the near
+   term. The `#[allow(dead_code)]` comment says "future" but doesn't name the feature.
+   If it's for `urd sentinel status`, keep it. If it's speculative, delete it — it can be
+   re-added in 30 seconds when needed.
+
+## 8. Open Questions
+
+1. **Should the sentinel mark `notifications_dispatched = true` after its assessment-based
+   dispatch?** Currently the sentinel never writes to the heartbeat. If it did, the flag
+   would be authoritative for both paths. But this adds a write dependency from sentinel
+   to heartbeat that doesn't exist today. The simpler fix (S1: backup marks dispatched
+   when deferring) avoids this coupling.
+
+2. **Should `urd sentinel status` show last drive connection times?** The data is now
+   being recorded. The `last_drive_connection()` method exists. Wiring it into the status
+   display would give the feature a consumer and justify the `#[allow(dead_code)]`.
+   Natural pairing with VFM-B.
+
+---
+
+*Reviewer: arch-adversary skill*
+*Coverage: all changed files, 444 tests passing*

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -21,6 +21,7 @@ use crate::output::{
 };
 use crate::notify;
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
+use crate::sentinel_runner;
 use crate::preflight;
 use crate::state::StateDb;
 use crate::types::{BackupPlan, ByteSize, PlannedOperation, ProtectionLevel};
@@ -95,7 +96,14 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         if let Err(e) = heartbeat::write(&config.general.heartbeat_file, &hb) {
             log::warn!("Failed to write heartbeat: {e}");
         }
-        dispatch_notifications(previous_hb.as_ref(), &hb, &config);
+        if sentinel_runner::sentinel_is_running(&config) {
+            log::info!("Sentinel is running — deferring notification dispatch");
+            if let Err(e) = heartbeat::mark_dispatched(&config.general.heartbeat_file) {
+                log::warn!("Failed to update heartbeat dispatched flag: {e}");
+            }
+        } else {
+            dispatch_notifications(previous_hb.as_ref(), &hb, &config);
+        }
         return Ok(());
     }
 
@@ -150,8 +158,15 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         log::warn!("Failed to write heartbeat: {e}");
     }
 
-    // Dispatch notifications for promise state changes
-    dispatch_notifications(previous_hb.as_ref(), &hb, &config);
+    // Dispatch notifications for promise state changes (unless Sentinel handles it).
+    if sentinel_runner::sentinel_is_running(&config) {
+        log::info!("Sentinel is running — deferring notification dispatch");
+        if let Err(e) = heartbeat::mark_dispatched(&config.general.heartbeat_file) {
+            log::warn!("Failed to update heartbeat dispatched flag: {e}");
+        }
+    } else {
+        dispatch_notifications(previous_hb.as_ref(), &hb, &config);
+    }
 
     // Build and render structured summary
     let summary = build_backup_summary(
@@ -995,5 +1010,93 @@ mod tests {
         assert!(summary.subvolumes[0].errors.is_empty());
         // And should not appear in sends list (it failed)
         assert!(summary.subvolumes[0].sends.is_empty());
+    }
+
+    // ── Sentinel detection tests ────────────────────────────────────
+
+    #[test]
+    fn sentinel_is_running_no_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_state_db(dir.path());
+        assert!(!crate::sentinel_runner::sentinel_is_running(&config));
+    }
+
+    #[test]
+    fn sentinel_is_running_stale_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_state_db(dir.path());
+        let state_path = crate::sentinel_runner::sentinel_state_path(&config);
+        write_sentinel_state_file(&state_path, 99_999_999);
+        assert!(!crate::sentinel_runner::sentinel_is_running(&config));
+    }
+
+    #[test]
+    fn sentinel_is_running_live_pid() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = config_with_state_db(dir.path());
+        let state_path = crate::sentinel_runner::sentinel_state_path(&config);
+        write_sentinel_state_file(&state_path, std::process::id());
+        assert!(crate::sentinel_runner::sentinel_is_running(&config));
+    }
+
+    fn write_sentinel_state_file(path: &std::path::Path, pid: u32) {
+        let state = crate::output::SentinelStateFile {
+            schema_version: 1,
+            pid,
+            started: "2026-03-29T10:00:00".to_string(),
+            last_assessment: None,
+            mounted_drives: vec![],
+            tick_interval_secs: 120,
+            promise_states: vec![],
+            circuit_breaker: crate::output::SentinelCircuitState {
+                state: "closed".to_string(),
+                failure_count: 0,
+            },
+        };
+        let content = serde_json::to_string_pretty(&state).unwrap();
+        std::fs::write(path, content).unwrap();
+    }
+
+    /// Build a minimal Config with state_db pointing into the given directory.
+    fn config_with_state_db(dir: &std::path::Path) -> Config {
+        use crate::config::{DefaultsConfig, GeneralConfig, LocalSnapshotsConfig};
+        use crate::types::RunFrequency;
+        use crate::notify::NotificationConfig;
+        use crate::types::{GraduatedRetention, Interval};
+
+        Config {
+            general: GeneralConfig {
+                state_db: dir.join("urd.db"),
+                metrics_file: dir.join("test.prom"),
+                log_dir: dir.to_path_buf(),
+                btrfs_path: "/usr/sbin/btrfs".to_string(),
+                heartbeat_file: dir.join("heartbeat.json"),
+                run_frequency: RunFrequency::Timer {
+                    interval: Interval::days(1),
+                },
+            },
+            local_snapshots: LocalSnapshotsConfig { roots: vec![] },
+            drives: vec![],
+            defaults: DefaultsConfig {
+                snapshot_interval: "1h".parse().unwrap(),
+                send_interval: "4h".parse().unwrap(),
+                send_enabled: true,
+                enabled: true,
+                local_retention: GraduatedRetention {
+                    hourly: Some(24),
+                    daily: Some(30),
+                    weekly: Some(26),
+                    monthly: Some(12),
+                },
+                external_retention: GraduatedRetention {
+                    hourly: None,
+                    daily: Some(30),
+                    weekly: Some(26),
+                    monthly: Some(0),
+                },
+            },
+            subvolumes: vec![],
+            notifications: NotificationConfig::default(),
+        }
     }
 }

--- a/src/commands/sentinel.rs
+++ b/src/commands/sentinel.rs
@@ -1,8 +1,8 @@
 // CLI handlers for `urd sentinel run` and `urd sentinel status`.
 
 use crate::config::Config;
-use crate::output::{OutputMode, SentinelStateFile, SentinelStatusOutput};
-use crate::sentinel_runner::{self, is_pid_alive, sentinel_state_path};
+use crate::output::{OutputMode, SentinelStatusOutput};
+use crate::sentinel_runner::{self, is_pid_alive, read_sentinel_state_file, sentinel_state_path};
 use crate::voice;
 
 /// Start the sentinel daemon (foreground, for systemd).
@@ -15,7 +15,7 @@ pub fn run_daemon(config: Config) -> anyhow::Result<()> {
 pub fn status(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     let state_path = sentinel_state_path(&config);
 
-    let status_output = match SentinelStateFile::read(&state_path) {
+    let status_output = match read_sentinel_state_file(&state_path) {
         Some(state) if is_pid_alive(state.pid) => {
             let uptime = format_uptime(&state.started);
             SentinelStatusOutput::Running { state, uptime }

--- a/src/output.rs
+++ b/src/output.rs
@@ -535,15 +535,6 @@ pub enum SentinelStatusOutput {
     },
 }
 
-impl SentinelStateFile {
-    /// Read and parse a sentinel state file. Returns `None` if missing or corrupt.
-    #[must_use]
-    pub fn read(path: &std::path::Path) -> Option<Self> {
-        let content = std::fs::read_to_string(path).ok()?;
-        serde_json::from_str(&content).ok()
-    }
-}
-
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -269,10 +269,18 @@ impl SentinelRunner {
         self.state.last_promise_states = sentinel::snapshot_promises(&assessments);
         if !self.state.has_initial_assessment {
             self.state.has_initial_assessment = true;
-            log::info!(
-                "Initial assessment complete: {} subvolumes evaluated",
-                assessments.len()
-            );
+            if self.heartbeat_path.exists() {
+                log::info!(
+                    "Initial assessment complete: {} subvolumes evaluated",
+                    assessments.len()
+                );
+            } else {
+                log::info!(
+                    "Initial assessment complete: {} subvolumes evaluated \
+                     (no heartbeat file yet — awaiting first backup)",
+                    assessments.len()
+                );
+            }
         }
 
         // Update adaptive tick.
@@ -286,10 +294,28 @@ impl SentinelRunner {
     }
 
     fn execute_log_drive_change(&self, label: &str, mounted: bool) {
-        if mounted {
-            log::info!("Drive mounted: {label}");
+        use crate::state::{DriveEventSource, DriveEventType};
+
+        let event_type = if mounted {
+            DriveEventType::Mounted
         } else {
-            log::info!("Drive unmounted: {label}");
+            DriveEventType::Unmounted
+        };
+        let verb = if mounted { "mounted" } else { "unmounted" };
+        log::info!("Drive {verb}: {label}");
+
+        // Record in SQLite. ADR-102: failure never prevents operation.
+        match StateDb::open(&self.config.general.state_db) {
+            Ok(db) => {
+                if let Err(e) =
+                    db.record_drive_event(label, event_type, DriveEventSource::Sentinel)
+                {
+                    log::warn!("Failed to record drive event: {e}");
+                }
+            }
+            Err(e) => {
+                log::warn!("Failed to open state DB for drive event: {e}");
+            }
         }
     }
 
@@ -477,6 +503,29 @@ pub fn is_pid_alive(pid: u32) -> bool {
     std::path::Path::new(&format!("/proc/{pid}")).exists()
 }
 
+/// Read and parse a sentinel state file. Returns `None` if missing or corrupt.
+///
+/// Free function rather than impl method on `SentinelStateFile` because it
+/// performs I/O, and `output.rs` (where the type lives) is a pure-types module.
+#[must_use]
+pub fn read_sentinel_state_file(path: &std::path::Path) -> Option<SentinelStateFile> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Check if the Sentinel daemon is currently running.
+///
+/// Reads sentinel-state.json and verifies the PID is alive.
+/// Fail-open: returns false on any I/O error (callers dispatch normally).
+#[must_use]
+pub fn sentinel_is_running(config: &Config) -> bool {
+    let state_path = sentinel_state_path(config);
+    let Some(state) = read_sentinel_state_file(&state_path) else {
+        return false;
+    };
+    is_pid_alive(state.pid)
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -539,7 +588,7 @@ mod tests {
 
     #[test]
     fn state_file_read_missing_returns_none() {
-        assert!(SentinelStateFile::read(std::path::Path::new(
+        assert!(read_sentinel_state_file(std::path::Path::new(
             "/tmp/nonexistent-sentinel-state-test.json"
         ))
         .is_none());
@@ -550,7 +599,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("sentinel-state.json");
         std::fs::write(&path, "not json").unwrap();
-        assert!(SentinelStateFile::read(&path).is_none());
+        assert!(read_sentinel_state_file(&path).is_none());
     }
 
     #[test]
@@ -575,7 +624,7 @@ mod tests {
         let content = serde_json::to_string_pretty(&state).unwrap();
         std::fs::write(&path, &content).unwrap();
 
-        let read_back = SentinelStateFile::read(&path).unwrap();
+        let read_back = read_sentinel_state_file(&path).unwrap();
         assert_eq!(read_back.pid, std::process::id());
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -32,6 +32,50 @@ pub struct RunRecord {
     pub result: String,
 }
 
+/// Whether a drive was mounted or unmounted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriveEventType {
+    Mounted,
+    Unmounted,
+}
+
+impl DriveEventType {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Mounted => "mounted",
+            Self::Unmounted => "unmounted",
+        }
+    }
+}
+
+/// What detected the drive event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // Backup variant wired when backup records drive events
+pub enum DriveEventSource {
+    Sentinel,
+    Backup,
+}
+
+impl DriveEventSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Sentinel => "sentinel",
+            Self::Backup => "backup",
+        }
+    }
+}
+
+/// A drive connection event returned from database queries.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct DriveConnectionRecord {
+    pub id: i64,
+    pub drive_label: String,
+    pub event_type: String,
+    pub timestamp: String,
+    pub detected_by: String,
+}
+
 /// An operation record returned from database queries.
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -117,6 +161,14 @@ impl StateDb {
                     token TEXT NOT NULL,
                     first_seen TEXT NOT NULL,
                     last_verified TEXT NOT NULL
+                );
+
+                CREATE TABLE IF NOT EXISTS drive_connections (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    drive_label TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    detected_by TEXT NOT NULL
                 );",
             )
             .map_err(|e| UrdError::State(format!("failed to create schema: {e}")))?;
@@ -492,6 +544,81 @@ impl StateDb {
             Some(Err(e)) => Err(UrdError::State(format!("failed to read send size: {e}"))),
             None => Ok(None),
         }
+    }
+
+    // ── Drive connection methods ─────────────────────────────────────
+
+    /// Record a drive mount or unmount event.
+    pub fn record_drive_event(
+        &self,
+        drive_label: &str,
+        event_type: DriveEventType,
+        detected_by: DriveEventSource,
+    ) -> crate::error::Result<()> {
+        let now = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+        self.conn
+            .execute(
+                "INSERT INTO drive_connections (drive_label, event_type, timestamp, detected_by)
+                 VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![drive_label, event_type.as_str(), now, detected_by.as_str()],
+            )
+            .map_err(|e| UrdError::State(format!("failed to record drive event: {e}")))?;
+        Ok(())
+    }
+
+    /// Get the most recent connection event for a drive, if any.
+    #[allow(dead_code)] // consumed by urd sentinel status (future) and tests
+    pub fn last_drive_connection(
+        &self,
+        drive_label: &str,
+    ) -> crate::error::Result<Option<DriveConnectionRecord>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, drive_label, event_type, timestamp, detected_by
+                 FROM drive_connections WHERE drive_label = ?1
+                 ORDER BY id DESC LIMIT 1",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut rows = stmt
+            .query_map(rusqlite::params![drive_label], |row| {
+                Ok(DriveConnectionRecord {
+                    id: row.get(0)?,
+                    drive_label: row.get(1)?,
+                    event_type: row.get(2)?,
+                    timestamp: row.get(3)?,
+                    detected_by: row.get(4)?,
+                })
+            })
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        match rows.next() {
+            Some(Ok(record)) => Ok(Some(record)),
+            Some(Err(e)) => Err(UrdError::State(format!(
+                "failed to read drive connection: {e}"
+            ))),
+            None => Ok(None),
+        }
+    }
+
+    /// Count drive connection events for a drive since a given ISO 8601 timestamp.
+    #[allow(dead_code)] // consumed by urd sentinel status (future) and tests
+    pub fn drive_connection_count(
+        &self,
+        drive_label: &str,
+        since: &str,
+    ) -> crate::error::Result<u64> {
+        let count: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM drive_connections
+                 WHERE drive_label = ?1 AND timestamp >= ?2",
+                rusqlite::params![drive_label, since],
+                |row| row.get(0),
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+        Ok(count as u64)
     }
 
     fn map_operation_row(row: &rusqlite::Row) -> rusqlite::Result<OperationRow> {
@@ -1035,5 +1162,70 @@ mod tests {
             )
             .unwrap();
         assert_eq!(last_verified, "2026-03-29T12:00:00");
+    }
+
+    // ── Drive connection tests ──────────────────────────────────────
+
+    #[test]
+    fn record_drive_mount_event() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_drive_event("WD-18TB", DriveEventType::Mounted, DriveEventSource::Sentinel)
+            .unwrap();
+
+        let record = db.last_drive_connection("WD-18TB").unwrap().unwrap();
+        assert_eq!(record.drive_label, "WD-18TB");
+        assert_eq!(record.event_type, "mounted");
+        assert_eq!(record.detected_by, "sentinel");
+        assert!(!record.timestamp.is_empty());
+    }
+
+    #[test]
+    fn record_drive_unmount_event() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_drive_event("WD-18TB1", DriveEventType::Unmounted, DriveEventSource::Sentinel)
+            .unwrap();
+
+        let record = db.last_drive_connection("WD-18TB1").unwrap().unwrap();
+        assert_eq!(record.event_type, "unmounted");
+    }
+
+    #[test]
+    fn last_drive_connection_returns_most_recent() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_drive_event("WD-18TB", DriveEventType::Mounted, DriveEventSource::Sentinel)
+            .unwrap();
+        db.record_drive_event("WD-18TB", DriveEventType::Unmounted, DriveEventSource::Sentinel)
+            .unwrap();
+
+        let record = db.last_drive_connection("WD-18TB").unwrap().unwrap();
+        assert_eq!(record.event_type, "unmounted");
+    }
+
+    #[test]
+    fn last_drive_connection_none_for_unknown() {
+        let db = StateDb::open_memory().unwrap();
+        assert!(db.last_drive_connection("nonexistent").unwrap().is_none());
+    }
+
+    #[test]
+    fn drive_connection_count() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_drive_event("WD-18TB", DriveEventType::Mounted, DriveEventSource::Sentinel)
+            .unwrap();
+        db.record_drive_event("WD-18TB", DriveEventType::Unmounted, DriveEventSource::Sentinel)
+            .unwrap();
+        db.record_drive_event("WD-18TB", DriveEventType::Mounted, DriveEventSource::Backup)
+            .unwrap();
+
+        let count = db
+            .drive_connection_count("WD-18TB", "2000-01-01T00:00:00")
+            .unwrap();
+        assert_eq!(count, 3);
+
+        // Different drive has zero events.
+        let count = db
+            .drive_connection_count("other", "2000-01-01T00:00:00")
+            .unwrap();
+        assert_eq!(count, 0);
     }
 }


### PR DESCRIPTION
## Summary

- **Notification deduplication:** backup defers notification dispatch to sentinel when daemon is running. Fail-open semantics — detection failure falls back to normal dispatch. Heartbeat dispatched flag preserved on deferral (arch-adversary S1 fix).
- **Drive connection recording:** new `drive_connections` SQLite table with typed `DriveEventType`/`DriveEventSource` enums. Sentinel records mount/unmount events with ADR-102 error isolation.
- **ADR-108 cleanup:** `SentinelStateFile::read()` moved from pure-types `output.rs` to `sentinel_runner.rs` as a free function.
- **Release v0.4.0:** Includes HSD-A, VFM-A, and Session 3. Version bump, changelog, annotated tag.

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 444 tests, all passing
- Integration tests: not applicable (no btrfs operations changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)