### PR TITLE
feat: cross-drive fallback for send size estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Cross-drive fallback for send size estimation (covers drive swap scenarios)
+
 ## [0.4.0] - 2026-03-29
 
 ### Added

--- a/docs/95-ideas/2026-03-29-design-d1-collapsed-skip-reasons.md
+++ b/docs/95-ideas/2026-03-29-design-d1-collapsed-skip-reasons.md
@@ -35,16 +35,17 @@ After:
 #[serde(rename_all = "snake_case")]
 pub enum SkipCategory {
     DriveNotMounted,
-    IntervalNotElapsed,
-    SendIntervalNotElapsed,
-    Disabled,
-    SendDisabled,
-    SpaceExceeded,
-    AlreadyOnDrive,
-    SnapshotExists,
-    Other,
+    IntervalNotElapsed,  // includes send interval not due
+    Disabled,            // includes send disabled
+    SpaceExceeded,       // both historical and calibrated estimates
+    Other,               // UUID/token issues, already on drive, snapshot exists
 }
 ```
+
+**Rationale (arch-adversary S2+M1):** Real-world data shows 5 categories cover 100% of
+observed output. `SendDisabled` merges into `Disabled` (user doesn't care about the
+distinction in a summary). `SendIntervalNotElapsed` merges into `IntervalNotElapsed`.
+UUID/token mismatch, already-on-drive, and snapshot-exists are rare enough for `Other`.
 
 Add `category: SkipCategory` to `SkippedSubvolume`. The `reason` field stays for detail.
 
@@ -53,17 +54,24 @@ Add `category: SkipCategory` to `SkippedSubvolume`. The `reason` field stays for
 Add `classify_skip_reason(reason: &str) -> SkipCategory` that parses known prefixes
 from plan.rs skip reasons:
 
-| Pattern | Category |
-|---------|----------|
-| `"drive " + " not mounted"` | `DriveNotMounted` |
-| `"interval not elapsed"` | `IntervalNotElapsed` |
-| `"send to " + " not due"` | `SendIntervalNotElapsed` |
-| `"disabled"` | `Disabled` |
-| `"send disabled"` | `SendDisabled` |
-| starts with `"send to "` + contains `"skipped"` | `SpaceExceeded` |
-| contains `"already on"` | `AlreadyOnDrive` |
-| `"snapshot already exists"` | `SnapshotExists` |
-| anything else | `Other` |
+All 14 plan.rs skip patterns (verified by grep) mapped to 5 categories:
+
+| # | Pattern | Category |
+|---|---------|----------|
+| 1 | `"disabled"` | `Disabled` |
+| 2 | `"drive {label} not mounted"` | `DriveNotMounted` |
+| 3 | `"drive {label} UUID mismatch …"` | `Other` |
+| 4 | `"drive {label} UUID check failed: …"` | `Other` |
+| 5 | `"drive {label} token mismatch …"` | `Other` |
+| 6 | `"send disabled"` | `Disabled` |
+| 7 | `"local filesystem low on space …"` | `SpaceExceeded` |
+| 8 | `"snapshot already exists"` | `Other` |
+| 9 | `"interval not elapsed (next in ~…)"` | `IntervalNotElapsed` |
+| 10 | `"send to {label} not due (next in ~…)"` | `IntervalNotElapsed` |
+| 11 | `"no local snapshots to send"` | `Other` |
+| 12 | `"{snap} already on {label}"` | `Other` |
+| 13 | `"send to {label} skipped: estimated ~… exceeds …"` | `SpaceExceeded` |
+| 14 | `"send to {label} skipped: calibrated size ~… exceeds …"` | `SpaceExceeded` |
 
 Update `build_plan_output()` to call this when constructing `SkippedSubvolume`.
 
@@ -94,11 +102,17 @@ Replace flat skip loop (lines 802-817) with grouping logic:
 
 ## Test Strategy
 
-- **`classify_skip_reason`:** One test per known pattern + unknown→Other. ~10 tests.
+- **`classify_skip_reason`:** One test per known pattern + unknown→Other. ~5 tests (one per
+  category, plus Other).
+- **Completeness test (arch-adversary S2):** A single test that exercises all 14 plan.rs skip
+  patterns against the classifier. Each pattern must classify to its expected category. This
+  catches silent regressions when new skip reasons are added to plan.rs — any unhandled
+  pattern falls to `Other`, and the test documents which patterns are intentionally `Other`
+  vs accidentally missed.
 - **Grouping/rendering:** PlanOutput with mixed categories, verify collapsed output. ~6 tests.
 - **JSON regression:** Verify daemon output serializes all entries with categories. ~1 test.
 
-**Estimated: 17-18 tests.**
+**Estimated: 13-15 tests.**
 
 ## Effort Estimate
 

--- a/docs/95-ideas/2026-03-29-design-d2-estimated-sizes.md
+++ b/docs/95-ideas/2026-03-29-design-d2-estimated-sizes.md
@@ -33,11 +33,23 @@ Both `Option` for cases where no estimate is available (first-ever send, no cali
 Expand signature: `build_plan_output(plan: &BackupPlan, fs_state: &dyn FileSystemState)`.
 Both callers (`plan_cmd::run` and `backup::run`) already have `fs_state` in scope.
 
-In `build_operation_entry`, query for each send:
-- **SendFull:** Try `last_send_size(subvol, drive, "send_full")` first (most accurate —
-  actual transfer bytes), fall back to `calibrated_size(subvol)`.
-- **SendIncremental:** Try `last_send_size(subvol, drive, "send_incremental")`. Label as
-  "last:" rather than "~" since incremental sizes vary widely by delta.
+In `build_operation_entry`, query for each send using a three-tier fallback chain
+(arch-adversary S1 — cross-drive fallback for drive swap scenarios):
+
+- **SendFull:**
+  1. `last_send_size(subvol, drive, "send_full")` — same drive history (most accurate)
+  2. `last_send_size_any_drive(subvol, "send_full")` — cross-drive history (covers drive swaps)
+  3. `calibrated_size(subvol)` — `du -sb` measurement (full sends only)
+- **SendIncremental:**
+  1. `last_send_size(subvol, drive, "send_incremental")` — same drive
+  2. `last_send_size_any_drive(subvol, "send_incremental")` — cross-drive
+  3. No calibrated fallback (calibration measures full subvolume, not incremental delta)
+
+Label same-drive history as `~`, cross-drive as `~` (same confidence), calibrated as `~`
+with `(est)` qualifier. Incrementals use `last:` prefix since sizes vary widely by delta.
+
+The `last_send_size_any_drive()` infrastructure is already implemented in `state.rs` and
+the `FileSystemState` trait in `plan.rs`.
 
 Summary: sum all non-None `estimated_bytes`. If some sends lack estimates, render
 qualified: `6 sends (~623 GB estimated for 4 of 6)`.
@@ -58,7 +70,7 @@ Update to pass `&fs_state` to `build_plan_output()`.
 ## Data Flow
 
 1. `plan_cmd::run()` / `backup::run()` both have `fs_state: RealFileSystemState`.
-2. `build_plan_output(plan, &fs_state)` queries `last_send_size()` and `calibrated_size()`
+2. `build_plan_output(plan, &fs_state)` queries size using the three-tier fallback chain
    for each send operation.
 3. Populates `PlanOperationEntry.estimated_bytes`.
 4. Aggregates to `PlanSummaryOutput.estimated_total_bytes`.
@@ -66,9 +78,11 @@ Update to pass `&fs_state` to `build_plan_output()`.
 
 ## Test Strategy
 
-- **Size lookup:** Mock `FileSystemState` returning known sizes. Cases: full with history,
-  full with calibrated only, full with both (history wins), incremental with history,
-  send with no data. ~6 tests.
+- **Size lookup:** Mock `FileSystemState` returning known sizes. Cases: full with same-drive
+  history, full with cross-drive fallback only, full with calibrated only, full with all
+  three (same-drive wins), incremental with history, incremental with cross-drive fallback,
+  send with no data. ~8 tests. Cross-drive fallback infrastructure already tested in
+  `state.rs`.
 - **Summary aggregation:** Partial data, all-None, all-present. ~3 tests.
 - **Rendering:** Output includes `~53 GB`, `last: 5.5 MB`, no annotation for None. ~6 tests.
 - **JSON serialization:** `estimated_bytes` as integer or null. ~1 test.
@@ -84,6 +98,22 @@ backup.rs trivially). `FileSystemState` already in scope at both call sites. **O
 
 None for implementation. Feature 4 (ETA) reuses the same size lookup logic — extract
 to shared helper if both are implemented.
+
+## Known Limitations
+
+**Calibration size gap (arch-adversary open question 1):** `urd calibrate` uses `du -sb`
+which measures filesystem apparent size, not btrfs send stream size. The send stream is
+~10% larger due to btrfs metadata overhead. Real data from run #15:
+
+| Subvolume | Calibrated (`du -sb`) | Actual send | Gap |
+|-----------|----------------------|-------------|-----|
+| subvol3-opptak | 3.1 TB | 3.4 TB | +9.7% |
+| subvol5-music | 1.0 TB | 1.1 TB | +10% |
+
+This is acceptable for v1: all sizes use `~` prefix communicating approximation, and
+the existing 1.2x safety margin in space checks (plan.rs) partially compensates. A
+future improvement would be to calibrate via `btrfs send --dry-run` (measures actual
+stream size) instead of `du -sb`, but this is more complex and not needed now.
 
 ## Risks
 

--- a/docs/95-ideas/2026-03-29-design-p1-rich-progress-display.md
+++ b/docs/95-ideas/2026-03-29-design-p1-rich-progress-display.md
@@ -26,29 +26,40 @@ Target display:
 Define a module-private `ProgressContext` struct:
 
 ```rust
+use crate::executor::SendType;
+
 struct ProgressContext {
     subvolume_name: String,
     drive_label: String,
-    send_type: &'static str,    // "full" or "incremental"
+    send_type: SendType,        // Full or Incremental (from executor.rs)
     send_index: u32,            // 1-based, updated by executor before each send
     total_sends: u32,           // computed from plan before execution
 }
 ```
 
+**Note (arch-adversary P1 item 3):** Uses the existing `SendType` enum from `executor.rs`
+(`Full`, `Incremental`, `NoSend`) instead of a raw `&'static str`. The `NoSend` variant
+is never set in `ProgressContext` since the progress display only activates during sends.
+
 Create `Arc<Mutex<ProgressContext>>` alongside existing `bytes_counter`. Pass clone to
 progress thread and to `Executor`. Rewrite `progress_display_loop` to read from both
 the atomic counter and the mutex-protected context.
 
-**State machine in progress thread (three states):**
+**State machine in progress thread (four states):**
 1. **Idle:** Counter is 0, no active send. Continue polling.
 2. **Active:** Counter > 0. On 0→non-zero transition, read `ProgressContext` via mutex,
    store locally. Display live progress line with `\r` overwrite.
 3. **Completing:** Counter resets to 0 after having been non-zero (next send starting).
    Print permanent completion line via `eprintln!`, then transition back to idle/active.
+4. **Shutdown (arch-adversary M2):** Shutdown flag is set. If `last_display_bytes > 0`,
+   immediately print the final completion line with last known context before thread exit.
+   This handles the last send, whose counter never resets to 0. The executor signals
+   shutdown after all sends complete; the progress thread must not wait for a counter
+   reset that will never come.
 
-**Last-send handling:** The final send's counter never resets to 0 — the thread exits
-via shutdown flag. During shutdown cleanup, print the final completion line using the
-last observed bytes and elapsed time.
+The ~1s gap between sends (snapshot creation time) is acceptable: the progress thread
+shows the previous send's final byte count as a stale line briefly, then detects the
+reset when the next `send_receive()` starts.
 
 Extract formatting into pure functions for testability:
 - `format_progress_line(ctx, bytes, rate, elapsed) -> String`

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,15 +8,13 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-444 tests, all passing, clippy clean. Current version: v0.4.0.
+448 tests, all passing, clippy clean. Current version: v0.4.0.
 
 ## In Progress
 
-- **Sentinel Session 3 complete** (2026-03-29). Notification deduplication between backup
-  command and sentinel daemon. Drive connection recording in SQLite. `SentinelStateFile::read()`
-  moved out of pure-types module (ADR-108). Post-review: heartbeat dispatched flag preserved
-  on deferral. Reviewed, simplified, post-review fixes applied.
-  [Implementation review](../99-reports/2026-03-29-sentinel-session3-implementation-review.md)
+- **UX design post-review complete** (2026-03-30). Cross-drive fallback infrastructure
+  built in `state.rs`/`plan.rs` (S1 fix). Design docs D1, D2, P1 updated with review
+  findings. All changes uncommitted — ready to commit with UX-1 or separately.
 
 ## Build Queue
 
@@ -25,7 +23,7 @@ full details, design decisions, and review findings.
 
 1. ~~**HSD-A**~~ — drive session tokens + chain health as awareness input. **Done.**
 2. ~~**VFM-A**~~ — `OperationalHealth` enum, two-axis CLI rendering. **Done.**
-3. ~~**Sentinel Session 3**~~ — hardening + notification deduplication. **Done.** ← **completed**
+3. ~~**Sentinel Session 3**~~ — hardening + notification deduplication. **Done.**
 4. **UX-1** — plan output: structural headings (D5) + collapsed skips (D1). ← **start here**
 5. **UX-2** — plan output: estimated send sizes (D2+D3), cross-drive fallback (S1 fix).
 6. **UX-3** — progress display: rich context (P1) + ETA (P3).
@@ -37,6 +35,7 @@ full details, design decisions, and review findings.
 
 Designs: `docs/95-ideas/2026-03-29-design-*.md`.
 Review: `docs/99-reports/2026-03-29-progress-display-design-review.md`.
+Post-review: `docs/99-reports/2026-03-29-post-review-cross-drive-fallback-review.md`.
 
 **Later:** Config system migration (ADR-111), shell completions (6a).
 
@@ -49,15 +48,15 @@ Review: `docs/99-reports/2026-03-29-progress-display-design-review.md`.
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Latest journals | `docs/98-journals/` (local only, gitignored) |
-| Latest reviews | [Session 3 review](../99-reports/2026-03-29-sentinel-session3-implementation-review.md), [VFM-A review](../99-reports/2026-03-29-vfm-a-implementation-review.md) |
+| Latest reviews | [Post-review](../99-reports/2026-03-29-post-review-cross-drive-fallback-review.md), [Design review](../99-reports/2026-03-29-progress-display-design-review.md) |
 
 ## Known Issues
 
 - NVMe snapshot accumulation: space guard prevents catastrophic exhaustion but gradual accumulation above 10GB threshold not gated
 - Journal persistence gap: journald may purge user-unit logs; heartbeat partially compensates
-- `FileSystemState` trait (10 methods) outgrowing its name — consider rename to `SystemState`
+- `FileSystemState` trait (11 methods) outgrowing its name — consider rename to `SystemState`
 - `urd get` doesn't support directory restore (files only in v1)
-- Urd config: consolidate WD-18TB / WD-18TB1 drive entries (same UUID, mount point resolved to `/run/media/patriark/WD-18TB`)
+- Urd config: consolidate WD-18TB / WD-18TB1 drive entries (same UUID, mount point resolved to `/run/media/<user>/WD-18TB`)
 - Calibrated sizes use `du -sb` but btrfs send streams are ~10% larger — affects size estimates (review Open Q1)
 - Per-drive pin protection for external retention: all-drives-union is conservative but suboptimal for space
 - Stringly-typed output boundary: three independent status-ranking implementations across notify.rs and voice.rs

--- a/docs/99-reports/2026-03-29-post-review-cross-drive-fallback-review.md
+++ b/docs/99-reports/2026-03-29-post-review-cross-drive-fallback-review.md
@@ -1,0 +1,185 @@
+# Architectural Review: Post-Review — Cross-Drive Fallback & Design Updates
+
+**Project:** Urd
+**Date:** 2026-03-29
+**Scope:** Implementation review of post-review changes addressing the progress display design review findings (S1, S2, M1, M2, P1 items). 5 files changed, +290/-36 lines.
+**Review type:** Implementation review
+**Commit:** uncommitted changes on `master` (base: `90110a6`)
+**Artifact:** `git diff` of `src/state.rs`, `src/plan.rs`, and three design docs in `docs/95-ideas/`
+
+## Executive Summary
+
+Clean, low-risk implementation. The code changes are purely additive infrastructure
+(4 query methods, 1 trait method, 4 tests) that don't touch any execution path. The design
+doc updates are well-targeted. One moderate finding about mock/real semantic divergence
+that should be noted before D2 implementation relies on the mock. One minor design
+classification concern worth revisiting.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss via incorrect retention or path construction.
+
+**Distance:** These changes are maximally far from it. The new `_any_drive` methods are
+read-only queries on SQLite history. They don't influence any backup, retention, or deletion
+decision. The trait method is `#[allow(dead_code)]` — literally no production code path
+calls it yet. The design doc changes are text files. **Nothing here can cause data loss.**
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | SQL queries are correct. One mock/real semantic gap (M1). |
+| Security | 5 | Read-only queries, no privilege interaction. |
+| Architecture | 5 | Follows existing patterns exactly. Trait extension is minimal. |
+| Systems Design | 4 | Infrastructure is well-positioned. One test coverage gap (M1). |
+| Rust Idioms | 5 | Identical patterns to adjacent methods. Nothing to critique. |
+| Code Quality | 4 | Clean mechanical extension. Moderate duplication (noted, acceptable). |
+
+## Design Tensions
+
+### 1. Code duplication vs. parameterized query (D1)
+
+The four `_any_drive` methods are near-identical copies of the four drive-specific methods,
+differing only in whether `AND drive_label = ?N` appears in the SQL. An alternative would
+be a single internal method that optionally includes the drive filter.
+
+**Verdict: duplication is the right call.** Each method is ~20 lines, self-contained, and
+independently testable. A parameterized helper would save ~30 lines but add a branch and
+make the SQL harder to read. The duplication cost is low — if the query shape changes, you
+change two methods instead of one. The readability gain outweighs the DRY violation. This
+is the "three similar functions are better than one premature abstraction" principle applied
+correctly.
+
+### 2. Infrastructure-first vs. just-in-time (D2)
+
+The cross-drive fallback is implemented as infrastructure before any consumer exists. The
+alternative would be to add it when D2 is built, ensuring the API matches what the consumer
+actually needs.
+
+**Verdict: infrastructure-first is reasonable here.** The API surface is small (one trait
+method with an obvious signature), the implementation is mechanical, and having it in place
+lets D2 focus on the presentation layer without detours. The risk — building the wrong API —
+is low because the method signature mirrors the existing drive-specific method minus one
+parameter. If D2 needs something different, the change is trivial.
+
+## Findings
+
+### M1 — Moderate: Mock returns max-by-value; real returns most-recent-by-time
+
+**What:** `MockFileSystemState::last_send_size_any_drive` filters by subvol+type and
+returns `.max()` — the **largest** byte value across all drives. `RealFileSystemState`
+returns `ORDER BY id DESC LIMIT 1` — the **most recent** entry by insertion order.
+
+```rust
+// Mock (plan.rs:901-906): returns largest
+self.send_sizes.iter()
+    .filter(|((sv, _, st), _)| sv == subvol_name && st == send_type)
+    .map(|(_, &bytes)| bytes)
+    .max()
+
+// Real (state.rs:380): returns most recent
+"ORDER BY id DESC LIMIT 1"
+```
+
+**Consequence:** A test that inserts data for DriveA (100 GB, older) and DriveB (50 GB,
+newer) would get 100 GB from the mock but 50 GB from the real implementation. Tests
+using this mock could pass while the real behavior differs. This doesn't matter now
+(no consumer exists), but when D2 is implemented, a test verifying "cross-drive fallback
+returns the right estimate" could be testing the wrong invariant.
+
+**Suggested fix:** This is acceptable for now — note it as a known divergence for the
+D2 implementer. When D2 adds tests using this mock method, the implementer should verify
+the test asserts the *right* thing (most recent, not largest). Alternatively, add a
+comment to the mock: `// Note: returns max by value, not most-recent. Real impl uses recency.`
+
+**Why not fix now:** The mock's `send_sizes` HashMap has no concept of insertion order
+(it's keyed by `(subvol, drive, type)` tuples). Matching real recency semantics would
+require adding an ordering field or switching to a `Vec`, which is unnecessary churn
+for an unused method.
+
+### Minor — D1 classification groups local and external space under one category
+
+The updated D1 design maps "local filesystem low on space" (pattern 7) to `SpaceExceeded`
+alongside the external drive space patterns (13, 14). These are different failure domains:
+
+- Local space low prevents **snapshot creation** (user action: free local space)
+- External space exceeded prevents **sends** (user action: free drive space or use another drive)
+
+Collapsed together — "Space exceeded: subvol3 (local), htpc-home (WD-18TB)" — the user
+sees one group but needs two different responses. For v1 with 5 categories this is fine
+(local space issues are rare in practice), but if it causes confusion, `LocalSpaceLow`
+could be split out later.
+
+### Minor — Commendation: Trait method doc says "successful" but implementation uses max(successful, failed)
+
+The `last_send_size_any_drive` doc comment says "most recent successful send" but
+`RealFileSystemState` returns `max(successful, failed)`. This is a **pre-existing
+inconsistency** — the drive-specific `last_send_size` trait method has the same gap
+(doc says successful, impl uses both). The new code correctly mirrors the existing
+pattern, which is the right choice. The conservative `max()` approach is intentional:
+a failed send that transferred 80 GB before dying proves the actual size is at least
+80 GB, which is useful for space estimation.
+
+Not filing as a finding since it's pre-existing and consistent. The trait-level docs
+could be updated in a future cleanup to say "most recent send data (successful or
+failed, whichever is larger)" but this is low priority.
+
+### Minor — Commendation: Design doc updates are surgical and traceable
+
+Each design doc change cites the specific arch-adversary finding it addresses (e.g.,
+"arch-adversary S1", "arch-adversary S2+M1", "arch-adversary M2"). This makes the
+design evolution traceable — someone reading D2 can find the original review finding
+that prompted the cross-drive fallback. The Known Limitations section in D2 with real
+run data (3.1 TB calibrated vs 3.4 TB actual) is particularly good — it documents a
+known inaccuracy with measured bounds rather than hand-waving.
+
+### Minor — Commendation: `#[allow(dead_code)]` on trait method, not implementations
+
+Placing the suppress on the trait definition rather than each implementation is correct —
+it suppresses the warning for all three (trait + two impls) with one annotation. When D2
+consumes the method, removing the single `#[allow(dead_code)]` enables the compiler to
+verify all implementations exist.
+
+## Also Noted
+
+- The four new StateDb tests cover the important cases well. Could add one test for
+  `send_type` isolation (e.g., `send_full` data doesn't appear in `send_incremental`
+  query), but the SQL is clear and this is low risk.
+- The D2 design's "cross-drive as `~` (same confidence)" labeling is debatable — cross-drive
+  data may be from a different snapshot and thus less accurate. But the `~` already
+  communicates approximation, so this is fine for v1.
+
+## The Simplicity Question
+
+**What could be removed?** Nothing. The code changes are the minimum viable infrastructure
+for the cross-drive fallback. The design doc changes are text-only updates.
+
+**What's earning its keep?** The four StateDb methods are mechanical but necessary — the
+SQL must be written somewhere, and these follow the established pattern perfectly. The
+trait method is a single line that enables clean composition in D2.
+
+**Duplication assessment:** The four `_any_drive` methods share ~90% of their code with
+their drive-specific counterparts. This duplication is acceptable per the design tension
+analysis above. If the pattern continues to grow (e.g., adding `_any_send_type` variants),
+it would warrant refactoring into a query builder — but for two variants, copy-paste is
+simpler and more readable.
+
+## For the Dev Team
+
+1. **Before D2 implementation:** Add a one-line comment to `MockFileSystemState::last_send_size_any_drive`
+   noting that it returns max-by-value, not most-recent-by-time (differs from real impl).
+   This prevents a future test from asserting the wrong invariant. **File:** `src/plan.rs:901`.
+
+2. **During D1 implementation:** Consider whether "local filesystem low on space" should
+   remain under `SpaceExceeded` or get its own rendering treatment. The current classification
+   is correct for the enum but may produce confusing collapsed output. Decide during D1
+   implementation when you can see the actual rendered text.
+
+## Open Questions
+
+1. **Should the planner also use cross-drive fallback for space checks?** Currently `plan.rs:480`
+   uses `last_send_size()` (drive-specific) for space estimation. If you switch from WD-18TB1
+   to WD-18TB, the planner has no history and proceeds with the send (fails open per ADR-107).
+   The cross-drive fallback could provide a better space estimate, but it changes the planner's
+   conservatism: data from a different drive might not reflect the target drive's space
+   constraints accurately. This is a design question for the D2 session, not a code bug.

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -54,6 +54,11 @@ pub trait FileSystemState {
     /// Returns None if no history exists (e.g., first-ever send).
     fn last_send_size(&self, subvol_name: &str, drive_label: &str, send_type: &str) -> Option<u64>;
 
+    /// Get the bytes_transferred from the most recent successful send of a given type
+    /// across **all** drives. Cross-drive fallback for drive swap scenarios.
+    #[allow(dead_code)]
+    fn last_send_size_any_drive(&self, subvol_name: &str, send_type: &str) -> Option<u64>;
+
     /// Get a calibrated size estimate for a subvolume (from `urd calibrate`).
     /// Returns `(estimated_bytes, measured_at)` or None if not calibrated.
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)>;
@@ -693,6 +698,23 @@ impl FileSystemState for RealFileSystemState<'_> {
         })
     }
 
+    fn last_send_size_any_drive(&self, subvol_name: &str, send_type: &str) -> Option<u64> {
+        self.state.and_then(|db| {
+            let successful = db
+                .last_successful_send_size_any_drive(subvol_name, send_type)
+                .ok()
+                .flatten();
+            let failed = db
+                .last_failed_send_size_any_drive(subvol_name, send_type)
+                .ok()
+                .flatten();
+            match (successful, failed) {
+                (Some(s), Some(f)) => Some(s.max(f)),
+                (s, f) => s.or(f),
+            }
+        })
+    }
+
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)> {
         self.state
             .and_then(|db| db.calibrated_size(subvol_name).ok().flatten())
@@ -874,6 +896,17 @@ impl FileSystemState for MockFileSystemState {
                 send_type.to_string(),
             ))
             .copied()
+    }
+
+    fn last_send_size_any_drive(&self, subvol_name: &str, send_type: &str) -> Option<u64> {
+        // Note: returns max by value, not most-recent-by-time.
+        // Real impl uses recency (ORDER BY id DESC). The mock has no
+        // insertion ordering, so max-by-value is the best approximation.
+        self.send_sizes
+            .iter()
+            .filter(|((sv, _, st), _)| sv == subvol_name && st == send_type)
+            .map(|(_, &bytes)| bytes)
+            .max()
     }
 
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -365,6 +365,38 @@ impl StateDb {
         }
     }
 
+    /// Get the bytes_transferred from the most recent successful send of a given type
+    /// for a subvolume across **all** drives. Returns None if no matching history exists.
+    /// Used as a cross-drive fallback when the target drive has no history (e.g., drive swap).
+    pub fn last_successful_send_size_any_drive(
+        &self,
+        subvol: &str,
+        send_type: &str,
+    ) -> crate::error::Result<Option<u64>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT bytes_transferred FROM operations
+                 WHERE subvolume = ?1 AND operation = ?2
+                   AND result = 'success' AND bytes_transferred IS NOT NULL
+                 ORDER BY id DESC LIMIT 1",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut rows = stmt
+            .query_map(rusqlite::params![subvol, send_type], |row| {
+                let bytes: i64 = row.get(0)?;
+                Ok(bytes as u64)
+            })
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        match rows.next() {
+            Some(Ok(size)) => Ok(Some(size)),
+            Some(Err(e)) => Err(UrdError::State(format!("failed to read send size: {e}"))),
+            None => Ok(None),
+        }
+    }
+
     /// Get the timestamp of the most recent successful send (full or incremental)
     /// for a subvolume to a specific drive. Returns the run's started_at timestamp.
     #[allow(dead_code)]
@@ -534,6 +566,38 @@ impl StateDb {
 
         let mut rows = stmt
             .query_map(rusqlite::params![subvol, drive, send_type], |row| {
+                let bytes: i64 = row.get(0)?;
+                Ok(bytes as u64)
+            })
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        match rows.next() {
+            Some(Ok(size)) => Ok(Some(size)),
+            Some(Err(e)) => Err(UrdError::State(format!("failed to read send size: {e}"))),
+            None => Ok(None),
+        }
+    }
+
+    /// Get the bytes_transferred from the most recent failed send of a given type
+    /// for a subvolume across **all** drives, where partial bytes were recorded.
+    /// Cross-drive fallback counterpart of `last_failed_send_size()`.
+    pub fn last_failed_send_size_any_drive(
+        &self,
+        subvol: &str,
+        send_type: &str,
+    ) -> crate::error::Result<Option<u64>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT bytes_transferred FROM operations
+                 WHERE subvolume = ?1 AND operation = ?2
+                   AND result = 'failure' AND bytes_transferred IS NOT NULL
+                 ORDER BY id DESC LIMIT 1",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut rows = stmt
+            .query_map(rusqlite::params![subvol, send_type], |row| {
                 let bytes: i64 = row.get(0)?;
                 Ok(bytes as u64)
             })
@@ -1068,6 +1132,111 @@ mod tests {
         assert_eq!(
             db.last_failed_send_size("sv1", "D", "send_full").unwrap(),
             None
+        );
+    }
+
+    // ── cross-drive fallback tests ────────────────────────────────────
+
+    #[test]
+    fn any_drive_returns_most_recent_successful() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        // Record send to drive A
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("DriveA".to_string()),
+            duration_secs: Some(10.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(100_000),
+        })
+        .unwrap();
+
+        // Record send to drive B (more recent, higher id)
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("DriveB".to_string()),
+            duration_secs: Some(20.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(200_000),
+        })
+        .unwrap();
+
+        // Cross-drive query returns most recent (DriveB)
+        assert_eq!(
+            db.last_successful_send_size_any_drive("sv1", "send_full")
+                .unwrap(),
+            Some(200_000)
+        );
+    }
+
+    #[test]
+    fn any_drive_returns_none_when_no_history() {
+        let db = StateDb::open_memory().unwrap();
+        assert_eq!(
+            db.last_successful_send_size_any_drive("sv1", "send_full")
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            db.last_failed_send_size_any_drive("sv1", "send_full")
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn any_drive_isolates_by_subvolume() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("D".to_string()),
+            duration_secs: Some(10.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(500_000),
+        })
+        .unwrap();
+
+        // Different subvolume should not see sv1's data
+        assert_eq!(
+            db.last_successful_send_size_any_drive("sv2", "send_full")
+                .unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn any_drive_failed_returns_partial_bytes() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("DriveA".to_string()),
+            duration_secs: Some(5.0),
+            result: "failure".to_string(),
+            error_message: Some("IO error".to_string()),
+            bytes_transferred: Some(75_000),
+        })
+        .unwrap();
+
+        assert_eq!(
+            db.last_failed_send_size_any_drive("sv1", "send_full")
+                .unwrap(),
+            Some(75_000)
         );
     }
 


### PR DESCRIPTION
## Summary

- Add `last_send_size_any_drive()` infrastructure to `StateDb` and `FileSystemState` trait — enables send size estimation when switching drives (addresses arch-adversary S1 finding)
- Update D1 design: reduce `SkipCategory` from 9 to 5 variants, add completeness test requirement for all 14 plan.rs skip patterns (S2+M1)
- Update D2 design: three-tier fallback chain (same-drive → any-drive → calibrated), document ~10% `du -sb` vs send stream size gap with real data (Open Q1)
- Update P1 design: use `SendType` enum instead of raw string, explicit Shutdown state in progress thread state machine (M2, P1 items)

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 448 tests, all passing
- Integration tests: not applicable (no btrfs interaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)