### PR TITLE
feat: grouped plan output with structural headings and skip categories (UX-1)

### DIFF
--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,23 +8,37 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-462 tests, all passing, clippy clean. Current version: v0.4.0.
+470 tests, all passing, clippy clean. Current version: v0.4.0.
 
 ## In Progress
 
-- **UX-1 complete, uncommitted.** Structural headings (D5) + collapsed skip reasons (D1)
-  in `urd plan` output. `SkipCategory` enum in output.rs, grouped rendering in voice.rs,
-  JSON daemon output enriched with category field. Ready to commit.
-- **Cross-drive fallback infrastructure** (from previous session) also uncommitted in
-  `state.rs`/`plan.rs` — methods not yet called, built for UX-2.
+- **UX-1 complete, uncommitted** (2026-03-30). `SkipCategory` enum in output.rs, grouped
+  plan rendering in voice.rs (D5 structural headings + D1 collapsed skips). Arch-adversary
+  review complete, all findings addressed. Ready for `/commit-push-pr`.
 
-## Next Up
+## Build Queue
 
-1. **Commit UX-1 + cross-drive fallback** — all changes are uncommitted, tests pass.
-2. **UX-2** — estimated send sizes in plan output (D2+D3), uses cross-drive fallback.
-   Design: `docs/95-ideas/2026-03-29-design-d2-estimated-sizes.md`.
-3. **UX-3** — rich progress display (P1) + ETA (P3).
-   Design: `docs/95-ideas/2026-03-29-design-p1-rich-progress-display.md`.
+Seven-step sequence resolved 2026-03-29. See [roadmap.md Priority 5.5](roadmap.md) for
+full details, design decisions, and review findings.
+
+1. ~~**HSD-A**~~ — drive session tokens + chain health as awareness input. **Done.**
+2. ~~**VFM-A**~~ — `OperationalHealth` enum, two-axis CLI rendering. **Done.**
+3. ~~**Sentinel Session 3**~~ — hardening + notification deduplication. **Done.**
+4. ~~**UX-1**~~ — plan output: structural headings (D5) + collapsed skips (D1). **Done.**
+5. **UX-2** — plan output: estimated send sizes (D2+D3), cross-drive fallback (S1 fix). **start here**
+6. **UX-3** — progress display: rich context (P1) + ETA (P3).
+7. **HSD-B** — sentinel chain-break detection + full-send gate (Norman escalation).
+   - Reference incident: `docs/98-journals/2026-03-29-clone-drive-incident-analysis.md`
+8. **VFM-B** — sentinel visual state in state file + health notifications.
+9. **Transient snapshots** — `local_retention = "transient"` for NVMe space pressure.
+10. **Tray icon (Spindle)** — reads sentinel-state.json, 4 static icons.
+
+Designs: `docs/95-ideas/2026-03-29-design-*.md`.
+Review: `docs/99-reports/2026-03-29-progress-display-design-review.md`.
+Post-review: `docs/99-reports/2026-03-29-post-review-cross-drive-fallback-review.md`.
+UX-1 review: `docs/99-reports/2026-03-30-ux1-plan-output-review.md`.
+
+**Later:** Config system migration (ADR-111), shell completions (6a).
 
 ## Key Links
 
@@ -35,9 +49,7 @@ Sentinel daemon deployed (passive monitoring, drive detection, backup overdue al
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Latest journals | `docs/98-journals/` (local only, gitignored) |
-| Design review | [Progress display design review](../99-reports/2026-03-29-progress-display-design-review.md) |
-| Post-review | [Cross-drive fallback review](../99-reports/2026-03-29-post-review-cross-drive-fallback-review.md) |
-| UX designs | `docs/95-ideas/2026-03-29-design-{d1,d2,d5,p1,p3}.md` |
+| Latest reviews | [UX-1 review](../99-reports/2026-03-30-ux1-plan-output-review.md), [Design review](../99-reports/2026-03-29-progress-display-design-review.md) |
 
 ## Known Issues
 
@@ -45,8 +57,10 @@ Sentinel daemon deployed (passive monitoring, drive detection, backup overdue al
 - Journal persistence gap: journald may purge user-unit logs; heartbeat partially compensates
 - `FileSystemState` trait (11 methods) outgrowing its name — consider rename to `SystemState`
 - `urd get` doesn't support directory restore (files only in v1)
-- Calibrated sizes use `du -sb` but btrfs send streams are ~10% larger — affects size estimates
+- Calibrated sizes use `du -sb` but btrfs send streams are ~10% larger — affects size estimates (review Open Q1)
+- Per-drive pin protection for external retention: all-drives-union is conservative but suboptimal for space
 - Stringly-typed output boundary: three independent status-ranking implementations across notify.rs and voice.rs
-- `parse_duration_to_minutes` lacks unit test for cross-unit comparisons (d vs h)
+- `drive_connections` table has no retention policy (negligible for years at ~1000 rows/year)
+- `render_skipped_block` (backup summary) uses ad-hoc string grouping; could adopt `SkipCategory`
 
 See [roadmap.md](roadmap.md) for the full tech debt list and dropped features.

--- a/docs/99-reports/2026-03-30-ux1-plan-output-review.md
+++ b/docs/99-reports/2026-03-30-ux1-plan-output-review.md
@@ -1,0 +1,193 @@
+# Architectural Review: UX-1 Plan Output Improvements (D5 + D1)
+
+**Project:** Urd
+**Date:** 2026-03-30
+**Scope:** Implementation review of uncommitted changes in `src/output.rs`, `src/voice.rs`, `src/commands/plan_cmd.rs`, `src/commands/backup.rs`
+**Base commit:** `3b6301c`
+**Reviewer:** arch-adversary
+
+---
+
+## Executive summary
+
+Clean, well-scoped presentation-layer change. The implementation adds a `SkipCategory` enum
+to classify skip reasons for grouped rendering in `urd plan` output and enriched JSON for
+daemon consumers. No proximity to catastrophic failure modes — this touches only the
+rendering pipeline, not the planner, executor, or btrfs layer. Two findings worth addressing:
+a silent coupling between classification and rendering that will break on new skip patterns,
+and duplicated duration formatting logic.
+
+## What kills you
+
+**Catastrophic failure mode:** Silent data loss via incorrect snapshot deletion.
+
+**Distance from this change:** Not reachable. This change operates entirely in the
+presentation layer (output.rs types, voice.rs rendering). It cannot influence which
+snapshots are created, sent, retained, or deleted. The planner's skip reasons remain
+free-text strings in plan.rs — this change only classifies them after the fact for display.
+No backup decisions depend on `SkipCategory`.
+
+**Verdict:** Safe. No catastrophic failure checklist items triggered.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | All 14 patterns classified correctly with completeness test. One edge case in rendering (S1). |
+| 2 | Security | 5 | No security surface — pure presentation, no privileged operations. |
+| 3 | Architectural Excellence | 4 | Clean separation: enum in output.rs, rendering in voice.rs, classification at boundary. |
+| 4 | Systems Design | 4 | JSON enrichment is additive/non-breaking. Duration parsing handles all `format_duration_short` outputs. |
+| 5 | Rust Idioms | 4 | Good use of iterators, `#[must_use]`, serde rename. Minor: could use `IndexMap` but array iteration is fine. |
+| 6 | Code Quality | 4 | 22 new tests, clear function decomposition, good doc comments. |
+
+## Design tensions
+
+### 1. Stringly-typed classification vs structured skip reasons
+
+**Trade-off:** `from_reason()` classifies free-text reason strings rather than plan.rs
+producing structured `(SkipCategory, String)` tuples directly.
+
+**Why this was chosen:** Avoids touching plan.rs, keeps the output boundary as the
+classification point, and plan.rs remains a pure planner that doesn't know about presentation
+concerns.
+
+**Verdict:** Right call for now. The coupling is one-directional (output.rs reads plan.rs
+patterns) and the completeness test catches drift. If plan.rs grows past ~20 skip patterns,
+consider making the planner emit structured skip types — but that's a larger refactor that
+should wait for ADR-111 config migration when plan.rs will change anyway.
+
+### 2. Coexistence of two grouping approaches
+
+**Trade-off:** `render_skipped_block` (backup summary) still uses ad-hoc string pattern
+matching for "drive not mounted" grouping. The new `render_plan_skipped_grouped` uses the
+`SkipCategory` enum. Both coexist.
+
+**Why:** Different rendering requirements (backup summary shows send counts, plan output
+shows subvolume counts per drive). Unifying would require refactoring backup summary
+rendering — out of scope.
+
+**Verdict:** Acceptable. The journal correctly flagged this as future work. The backup
+summary could adopt `SkipCategory` later, but the current ad-hoc approach works and
+touching it would expand scope for no functional gain.
+
+## Findings
+
+### S1 — Significant: `render_drive_not_mounted_group` re-parses reason strings after classification
+
+**What:** `render_drive_not_mounted_group` (voice.rs:868-888) extracts drive labels by
+parsing the reason string again with `strip_prefix("drive ").strip_suffix(" not mounted")`.
+If `from_reason()` classifies a reason as `DriveNotMounted` but the reason format changes
+slightly (e.g., "drive WD-18TB is not mounted"), the category would still match but label
+extraction would fail, falling back to `"unknown"`.
+
+**Consequence:** The output would show `Not mounted: unknown (6 subvolumes)` — confusing
+but not dangerous. The user loses the drive label information that makes the grouped output
+useful.
+
+**Why this matters:** The category classifier and the label extractor parse the same string
+with different patterns but no shared logic. They can drift independently.
+
+**Suggested fix:** Extract the drive label during classification and store it. Either:
+- (a) Add a `drive_label()` method on `SkippedSubvolume` that extracts the label (single
+  source of truth for the parsing logic), or
+- (b) Accept the current approach but add a test in voice.rs that verifies label extraction
+  succeeds for a `DriveNotMounted`-classified reason — this catches drift without adding
+  a new type.
+
+Option (b) is simpler and sufficient.
+
+### M1 — Moderate: Duplicated duration formatting logic
+
+**What:** `render_interval_group` (voice.rs:898-906) re-implements `format_duration_short`
+from plan.rs (plan.rs:596-604) to convert minutes back to a human string. The two
+implementations must stay in sync.
+
+**Consequence:** If `format_duration_short` changes (e.g., adds hours+minutes for >1 day
+durations like "1d2h"), the rendering would produce a different format than what the planner
+emits, creating visual inconsistency.
+
+**Suggested fix:** Either:
+- (a) Make `format_duration_short` public in plan.rs and call it from voice.rs, or
+- (b) Move the formatting function to a shared location (types.rs or output.rs).
+
+Option (a) is one line: `pub fn format_duration_short`.
+
+### M2 — Moderate: Completeness test is pattern-level, not source-level
+
+**What:** The `classify_all_14_patterns` test (output.rs) hardcodes 14 representative
+reason strings. When someone adds a 15th skip reason in plan.rs, the test still passes
+with 14 assertions — there's no mechanism to detect the gap.
+
+**Consequence:** New skip patterns silently fall to `Other` until someone notices the
+plan output doesn't group them. Not dangerous (Other renders correctly), but defeats the
+purpose of the completeness test.
+
+**Suggested fix:** Add a comment in plan.rs at each `skipped.push()` call site referencing
+the completeness test: `// NOTE: new patterns must be added to output::tests::classify_all_14_patterns`.
+Alternatively, grep for `skipped.push` in plan.rs from the test and assert the count matches,
+though that's fragile.
+
+### Minor — "1 subvolumes" grammar
+
+**What:** `render_drive_not_mounted_group` always uses "subvolumes" (plural), even when
+count is 1: `"2TB-backup (1 subvolumes)"`. The test
+`plan_grouped_drive_not_mounted` even asserts this incorrect grammar.
+
+**Suggested fix:** `if count == 1 { "subvolume" } else { "subvolumes" }`.
+
+### Commendation — Duration parsing with cross-unit test
+
+The `parse_duration_to_minutes` function and the cross-unit comparison test
+(`parse_duration_cross_unit_comparison`) directly address the bug caught in the simplify
+pass. The test name and doc comment explain *why* this test exists — it's not obvious that
+"9d" vs "2h30m" comparison is a real failure mode. This is exactly the kind of test that
+prevents regression: it encodes a discovered bug, not a specification.
+
+### Commendation — Classification at the output boundary
+
+Placing `from_reason()` on `SkipCategory` in output.rs — rather than in plan.rs or voice.rs —
+respects the module boundaries cleanly. Plan.rs stays a pure planner (doesn't know about
+presentation). Voice.rs stays a pure renderer (doesn't parse business logic). Output.rs is the
+translation layer between them, which is where classification belongs. This is the right module
+boundary.
+
+## The simplicity question
+
+**What's earning its keep:** The `SkipCategory` enum justifies itself — it collapses 20+ lines
+into ~4 and enriches JSON output. The 5 variants match real-world skip distributions well. The
+category renderers are short, single-purpose functions.
+
+**What could be simpler:** The duration re-formatting in `render_interval_group` duplicates
+plan.rs logic (see M1). One public function eliminates the duplication.
+
+**What could be removed:** Nothing. The implementation is minimal for the design requirements.
+
+## For the Dev Team
+
+Priority order:
+
+1. **[Minor] Fix "1 subvolumes" grammar** — `src/voice.rs:render_drive_not_mounted_group`.
+   Use `if count == 1 { "subvolume" } else { "subvolumes" }`. Update the test assertion too.
+
+2. **[S1] Add label extraction test** — `src/voice.rs` tests. Add a test that constructs a
+   `DriveNotMounted` skip, renders it via `render_plan_interactive`, and asserts the actual
+   drive label (not "unknown") appears in the output. This catches drift between the
+   classifier and the label extractor.
+
+3. **[M1] Deduplicate duration formatting** — Make `format_duration_short` in
+   `src/plan.rs:596` public. Import and call it from `render_interval_group` in voice.rs
+   instead of reimplementing.
+
+4. **[M2] Add skip pattern breadcrumb** — Add a comment at each `skipped.push()` site in
+   `src/plan.rs` noting the completeness test in output.rs.
+
+## Open questions
+
+- **Backup summary unification:** The journal and design review both noted that
+  `render_skipped_block` could adopt `SkipCategory`. Is this planned for UX-2 or deferred
+  further? Having two grouping approaches is fine short-term but creates a maintenance
+  surface if someone changes skip reason wording.
+
+- **Sentinel daemon consumption:** The JSON `category` field is documented as non-breaking
+  and additive. Does the sentinel or any downstream consumer currently parse skip reasons
+  from JSON? If so, they could switch to using the `category` field instead.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -17,8 +17,7 @@ use crate::lock;
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
 use crate::output::{
     BackupSummary, OutputMode, SendSummary, SkipCategory, SkippedSubvolume, StatusAssessment,
-    StructuredError,
-    SubvolumeSummary,
+    StructuredError, SubvolumeSummary,
 };
 use crate::notify;
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};

--- a/src/output.rs
+++ b/src/output.rs
@@ -257,7 +257,13 @@ pub struct SendSummary {
     pub bytes_transferred: Option<u64>,
 }
 
-/// Skip reason category for grouped rendering and structured JSON output.
+// ── SkipCategory ──────────────────────────────────────────────────────
+
+/// Classification of why a subvolume/send was skipped.
+///
+/// Used for grouped rendering in plan output and structured JSON for daemon consumers.
+/// Classification happens at the output boundary via `from_reason()`, keeping plan.rs
+/// skip reasons as free-text strings.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SkipCategory {
@@ -269,24 +275,26 @@ pub enum SkipCategory {
 }
 
 impl SkipCategory {
-    /// Classify a free-text skip reason from `plan.rs` into a category.
+    /// Classify a skip reason string into a category.
     ///
-    /// Covers all 14 known skip patterns. Unknown patterns fall to `Other`.
+    /// Matches against the 14 known patterns from plan.rs. Unknown patterns
+    /// fall to `Other`. A completeness test in the test module ensures all
+    /// known patterns classify correctly.
     #[must_use]
     pub fn from_reason(reason: &str) -> Self {
-        if reason
-            .strip_prefix("drive ")
-            .is_some_and(|r| r.ends_with(" not mounted"))
+        if reason == "disabled" || reason == "send disabled" {
+            Self::Disabled
+        } else if reason.starts_with("drive ")
+            && reason.ends_with(" not mounted")
         {
             Self::DriveNotMounted
-        } else if reason == "disabled" || reason == "send disabled" {
-            Self::Disabled
         } else if reason.starts_with("interval not elapsed")
             || reason.contains("not due (next in")
         {
             Self::IntervalNotElapsed
         } else if reason.starts_with("local filesystem low on space")
-            || (reason.contains("skipped:") && reason.contains("exceeds"))
+            || reason.contains("skipped: estimated ~")
+            || reason.contains("skipped: calibrated size ~")
         {
             Self::SpaceExceeded
         } else {
@@ -295,12 +303,47 @@ impl SkipCategory {
     }
 }
 
-/// A planner-skipped subvolume/send with reason and category.
+/// Parse a duration string (produced by `format_duration_short` in plan.rs) to minutes.
+///
+/// Handles three formats: `"45m"`, `"2h30m"`, `"3d"`.
+/// When embedded in a reason string, extracts the text between `~` and `)`.
+/// Returns `None` if no parseable duration is found.
+#[must_use]
+pub fn parse_duration_to_minutes(reason: &str) -> Option<u64> {
+    // Extract duration substring: text between '~' and ')'
+    let duration_str = if let Some(start) = reason.find('~') {
+        let after_tilde = &reason[start + 1..];
+        if let Some(end) = after_tilde.find(')') {
+            &after_tilde[..end]
+        } else {
+            after_tilde.trim()
+        }
+    } else {
+        reason.trim()
+    };
+
+    // Parse: "Nd", "NhMm", "Nm"
+    if let Some(d) = duration_str.strip_suffix('d') {
+        d.parse::<u64>().ok().map(|v| v * 1440)
+    } else if let Some(rest) = duration_str.strip_suffix('m') {
+        if let Some(h_pos) = rest.find('h') {
+            let hours = rest[..h_pos].parse::<u64>().ok()?;
+            let mins = rest[h_pos + 1..].parse::<u64>().ok()?;
+            Some(hours * 60 + mins)
+        } else {
+            rest.parse::<u64>().ok()
+        }
+    } else {
+        None
+    }
+}
+
+/// A planner-skipped subvolume/send with reason.
 #[derive(Debug, Serialize)]
 pub struct SkippedSubvolume {
     pub name: String,
-    pub category: SkipCategory,
     pub reason: String,
+    pub category: SkipCategory,
 }
 
 // ── PlanOutput ─────────────────────────────────────────────────────────
@@ -623,19 +666,7 @@ mod tests {
         assert!(matches!(result, ChainHealth::Full(_)));
     }
 
-    // ── SkipCategory classification ────────────────────────────────────
-
-    #[test]
-    fn classify_drive_not_mounted() {
-        assert_eq!(
-            SkipCategory::from_reason("drive WD-18TB1 not mounted"),
-            SkipCategory::DriveNotMounted
-        );
-        assert_eq!(
-            SkipCategory::from_reason("drive 2TB-backup not mounted"),
-            SkipCategory::DriveNotMounted
-        );
-    }
+    // ── SkipCategory classification tests ──────────────────────────────
 
     #[test]
     fn classify_disabled() {
@@ -643,6 +674,18 @@ mod tests {
         assert_eq!(
             SkipCategory::from_reason("send disabled"),
             SkipCategory::Disabled
+        );
+    }
+
+    #[test]
+    fn classify_drive_not_mounted() {
+        assert_eq!(
+            SkipCategory::from_reason("drive WD-18TB not mounted"),
+            SkipCategory::DriveNotMounted
+        );
+        assert_eq!(
+            SkipCategory::from_reason("drive 2TB-backup not mounted"),
+            SkipCategory::DriveNotMounted
         );
     }
 
@@ -662,19 +705,19 @@ mod tests {
     fn classify_space_exceeded() {
         assert_eq!(
             SkipCategory::from_reason(
-                "local filesystem low on space (5.0 GB free, 10.0 GB required)"
+                "local filesystem low on space (1.2 GB free, 5.0 GB required)"
             ),
             SkipCategory::SpaceExceeded
         );
         assert_eq!(
             SkipCategory::from_reason(
-                "send to WD-18TB skipped: estimated ~4.1 TB exceeds 2.0 TB available (free: 2.5 TB, min_free: 500.0 GB)"
+                "send to WD-18TB skipped: estimated ~4.5 GB exceeds WD-18TB available (free: 2.1 GB, min_free: 50.0 GB)"
             ),
             SkipCategory::SpaceExceeded
         );
         assert_eq!(
             SkipCategory::from_reason(
-                "send to WD-18TB skipped: calibrated size ~4.1 TB exceeds 2.0 TB available"
+                "send to WD-18TB skipped: calibrated size ~4.5 GB exceeds WD-18TB available"
             ),
             SkipCategory::SpaceExceeded
         );
@@ -682,18 +725,6 @@ mod tests {
 
     #[test]
     fn classify_other() {
-        assert_eq!(
-            SkipCategory::from_reason("snapshot already exists"),
-            SkipCategory::Other
-        );
-        assert_eq!(
-            SkipCategory::from_reason("no local snapshots to send"),
-            SkipCategory::Other
-        );
-        assert_eq!(
-            SkipCategory::from_reason("20260329-0400-home already on WD-18TB"),
-            SkipCategory::Other
-        );
         assert_eq!(
             SkipCategory::from_reason(
                 "drive WD-18TB UUID mismatch (expected abc, found def)"
@@ -710,13 +741,35 @@ mod tests {
             ),
             SkipCategory::Other
         );
+        assert_eq!(
+            SkipCategory::from_reason("snapshot already exists"),
+            SkipCategory::Other
+        );
+        assert_eq!(
+            SkipCategory::from_reason("no local snapshots to send"),
+            SkipCategory::Other
+        );
+        assert_eq!(
+            SkipCategory::from_reason("20260329-0404-htpc-home already on WD-18TB"),
+            SkipCategory::Other
+        );
     }
 
-    /// Completeness test: all 14 known plan.rs skip patterns classified correctly.
+    #[test]
+    fn classify_unknown_falls_to_other() {
+        assert_eq!(
+            SkipCategory::from_reason("some completely unknown reason"),
+            SkipCategory::Other
+        );
+    }
+
+    /// Completeness test: all 14 known plan.rs skip patterns classify to their
+    /// expected category. Prevents silent regressions when new patterns are added.
     #[test]
     fn classify_all_14_patterns() {
-        let patterns = [
+        let patterns = vec![
             ("disabled", SkipCategory::Disabled),
+            ("send disabled", SkipCategory::Disabled),
             ("drive WD-18TB not mounted", SkipCategory::DriveNotMounted),
             (
                 "drive WD-18TB UUID mismatch (expected abc, found def)",
@@ -730,9 +783,8 @@ mod tests {
                 "drive WD-18TB token mismatch (expected abc, found def) — possible drive swap",
                 SkipCategory::Other,
             ),
-            ("send disabled", SkipCategory::Disabled),
             (
-                "local filesystem low on space (5.0 GB free, 10.0 GB required)",
+                "local filesystem low on space (1.2 GB free, 5.0 GB required)",
                 SkipCategory::SpaceExceeded,
             ),
             ("snapshot already exists", SkipCategory::Other),
@@ -746,24 +798,68 @@ mod tests {
             ),
             ("no local snapshots to send", SkipCategory::Other),
             (
-                "20260329-0400-home already on WD-18TB",
+                "20260329-0404-htpc-home already on WD-18TB",
                 SkipCategory::Other,
             ),
             (
-                "send to WD-18TB skipped: estimated ~4.1 TB exceeds 2.0 TB available (free: 2.5 TB, min_free: 500.0 GB)",
+                "send to WD-18TB skipped: estimated ~4.5 GB exceeds WD-18TB available (free: 2.1 GB, min_free: 50.0 GB)",
                 SkipCategory::SpaceExceeded,
             ),
             (
-                "send to WD-18TB skipped: calibrated size ~4.1 TB exceeds 2.0 TB available",
+                "send to WD-18TB skipped: calibrated size ~4.5 GB exceeds WD-18TB available",
                 SkipCategory::SpaceExceeded,
             ),
         ];
-        for (reason, expected) in &patterns {
+
+        for (reason, expected) in patterns {
             assert_eq!(
                 SkipCategory::from_reason(reason),
-                *expected,
-                "pattern {reason:?} should classify as {expected:?}"
+                expected,
+                "pattern: {reason}"
             );
         }
+    }
+
+    // ── parse_duration_to_minutes tests ────────────────────────────────
+
+    #[test]
+    fn parse_duration_minutes_only() {
+        assert_eq!(parse_duration_to_minutes("~45m"), Some(45));
+    }
+
+    #[test]
+    fn parse_duration_hours_minutes() {
+        assert_eq!(parse_duration_to_minutes("~2h30m"), Some(150));
+    }
+
+    #[test]
+    fn parse_duration_days() {
+        assert_eq!(parse_duration_to_minutes("~3d"), Some(4320));
+    }
+
+    #[test]
+    fn parse_duration_embedded_in_reason() {
+        assert_eq!(
+            parse_duration_to_minutes("interval not elapsed (next in ~14h6m)"),
+            Some(846)
+        );
+        assert_eq!(
+            parse_duration_to_minutes("send to WD-18TB not due (next in ~2h30m)"),
+            Some(150)
+        );
+    }
+
+    #[test]
+    fn parse_duration_no_duration() {
+        assert_eq!(parse_duration_to_minutes("disabled"), None);
+    }
+
+    /// Cross-unit comparison: ensures days > hours even though "9d" is shorter
+    /// than "2h30m" as a string. This caught a real bug in the simplify pass.
+    #[test]
+    fn parse_duration_cross_unit_comparison() {
+        let days = parse_duration_to_minutes("~9d").unwrap();
+        let hours = parse_duration_to_minutes("~2h30m").unwrap();
+        assert!(days > hours, "9d ({days}m) should be > 2h30m ({hours}m)");
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -92,6 +92,8 @@ pub fn plan(
     fs: &dyn FileSystemState,
 ) -> crate::error::Result<BackupPlan> {
     let mut operations = Vec::new();
+    // Skip reason strings are classified by output::SkipCategory::from_reason().
+    // When adding new patterns, update output::tests::classify_all_14_patterns.
     let mut skipped = Vec::new();
 
     let resolved = config.resolved_subvolumes();
@@ -593,7 +595,12 @@ fn plan_external_retention(
     }
 }
 
-fn format_duration_short(minutes: i64) -> String {
+/// Format a duration in minutes to a short human-readable string.
+///
+/// Used by the planner for skip reasons and by voice.rs for grouped rendering.
+/// Produces: `"45m"`, `"2h30m"`, `"3d"`.
+#[must_use]
+pub fn format_duration_short(minutes: i64) -> String {
     if minutes < 60 {
         format!("{minutes}m")
     } else if minutes < 1440 {

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -13,9 +13,11 @@ use colored::Colorize;
 
 use crate::output::{
     BackupSummary, CalibrateOutput, CalibrateResult, FailuresOutput, GetOutput, HistoryOutput,
-    InitOutput, InitStatus, OutputMode, PlanOutput, SentinelStatusOutput, StatusOutput,
-    SubvolumeHistoryOutput, VerifyOutput,
+    InitOutput, InitStatus, OutputMode, PlanOutput, SentinelStatusOutput, SkipCategory,
+    SkippedSubvolume, StatusOutput, SubvolumeHistoryOutput, VerifyOutput,
+    parse_duration_to_minutes,
 };
+use crate::plan::format_duration_short;
 use crate::types::ByteSize;
 
 // ── Status ──────────────────────────────────────────────────────────────
@@ -800,13 +802,14 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
             };
             writeln!(out, "  {:<10} {}", label, entry.detail).ok();
         }
+        writeln!(out).ok();
     } else {
         writeln!(out, "{}", "No operations planned.".dimmed()).ok();
+        writeln!(out).ok();
     }
 
     // === Skipped (N) ===
     if !data.skipped.is_empty() {
-        writeln!(out).ok();
         writeln!(
             out,
             "{}",
@@ -834,148 +837,103 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
     out
 }
 
-/// Render plan skip entries grouped by category.
-fn render_plan_skipped_grouped(
-    skipped: &[crate::output::SkippedSubvolume],
-    out: &mut String,
-) {
-    use crate::output::SkipCategory;
-    use std::collections::BTreeMap;
+/// Render skipped subvolumes grouped by category for plan output.
+fn render_plan_skipped_grouped(skipped: &[SkippedSubvolume], out: &mut String) {
+    // Collect by category in defined render order.
+    let categories = [
+        SkipCategory::DriveNotMounted,
+        SkipCategory::IntervalNotElapsed,
+        SkipCategory::Disabled,
+        SkipCategory::SpaceExceeded,
+        SkipCategory::Other,
+    ];
 
-    // BTreeMap keyed by display order ensures categories render in a fixed sequence.
-    let mut groups: BTreeMap<usize, Vec<&crate::output::SkippedSubvolume>> = BTreeMap::new();
-    for skip in skipped {
-        let idx = match skip.category {
-            SkipCategory::DriveNotMounted => 0,
-            SkipCategory::IntervalNotElapsed => 1,
-            SkipCategory::Disabled => 2,
-            SkipCategory::SpaceExceeded => 3,
-            SkipCategory::Other => 4,
-        };
-        groups.entry(idx).or_default().push(skip);
-    }
-
-    for (idx, entries) in &groups {
-        match idx {
-            0 => render_drive_not_mounted_group(entries, out),
-            1 => render_interval_group(entries, out),
-            2 => render_disabled_group(entries, out),
-            _ => {
-                for entry in entries {
-                    writeln!(out, "  {}: {}", entry.name, entry.reason.dimmed()).ok();
-                }
+    for cat in &categories {
+        let items: Vec<&SkippedSubvolume> =
+            skipped.iter().filter(|s| &s.category == cat).collect();
+        if items.is_empty() {
+            continue;
+        }
+        match cat {
+            SkipCategory::DriveNotMounted => render_drive_not_mounted_group(&items, out),
+            SkipCategory::IntervalNotElapsed => render_interval_group(&items, out),
+            SkipCategory::Disabled => render_disabled_group(&items, out),
+            SkipCategory::SpaceExceeded | SkipCategory::Other => {
+                render_individual_skips(&items, cat, out);
             }
         }
     }
 }
 
-/// Render "Not mounted: DriveA (N subvolumes), DriveB (M subvolumes)"
-fn render_drive_not_mounted_group(
-    entries: &[&crate::output::SkippedSubvolume],
-    out: &mut String,
-) {
-    let mut drives: Vec<(String, Vec<String>)> = Vec::new();
-    for entry in entries {
-        let label = entry
+/// Render DriveNotMounted skips, sub-grouped by drive label with subvolume counts.
+fn render_drive_not_mounted_group(items: &[&SkippedSubvolume], out: &mut String) {
+    // Extract drive label from reason: "drive {label} not mounted"
+    let mut drives: Vec<(String, usize)> = Vec::new();
+    for item in items {
+        let label = item
             .reason
             .strip_prefix("drive ")
             .and_then(|r| r.strip_suffix(" not mounted"))
             .unwrap_or("unknown")
             .to_string();
-        if let Some((_, subvols)) = drives.iter_mut().find(|(l, _)| *l == label) {
-            if !subvols.contains(&entry.name) {
-                subvols.push(entry.name.clone());
-            }
+        if let Some(entry) = drives.iter_mut().find(|(l, _)| *l == label) {
+            entry.1 += 1;
         } else {
-            drives.push((label, vec![entry.name.clone()]));
+            drives.push((label, 1));
         }
     }
-
     let parts: Vec<String> = drives
         .iter()
-        .map(|(label, subvols)| {
-            let n = subvols.len();
-            if n == 1 {
-                format!("{label} (1 subvolume)")
-            } else {
-                format!("{label} ({n} subvolumes)")
-            }
+        .map(|(label, count)| {
+            let noun = if *count == 1 { "subvolume" } else { "subvolumes" };
+            format!("{label} ({count} {noun})")
         })
         .collect();
-    writeln!(out, "  {}: {}", "Not mounted".dimmed(), parts.join(", ")).ok();
+    writeln!(out, "  {} {}", "Not mounted:".dimmed(), parts.join(", ")).ok();
 }
 
-/// Render "Interval not elapsed: N subvolumes (next in ~Xh)"
-fn render_interval_group(entries: &[&crate::output::SkippedSubvolume], out: &mut String) {
-    let mut names: Vec<&str> = Vec::new();
-    let mut shortest_minutes = i64::MAX;
-    let mut shortest_text: Option<&str> = None;
+/// Render IntervalNotElapsed skips as a single line with count and shortest duration.
+fn render_interval_group(items: &[&SkippedSubvolume], out: &mut String) {
+    let shortest = items
+        .iter()
+        .filter_map(|s| parse_duration_to_minutes(&s.reason))
+        .min();
 
-    for entry in entries {
-        if !names.contains(&entry.name.as_str()) {
-            names.push(&entry.name);
-        }
-        if let Some(pos) = entry.reason.find("next in ~") {
-            let duration_part = &entry.reason[pos + 9..];
-            let duration = duration_part.trim_end_matches(')');
-            let minutes = parse_duration_to_minutes(duration);
-            if minutes < shortest_minutes {
-                shortest_minutes = minutes;
-                shortest_text = Some(duration);
-            }
-        }
-    }
-
-    let n = names.len();
-    let count_str = if n == 1 {
-        "1 subvolume".to_string()
+    let suffix = if let Some(mins) = shortest {
+        format!(" (next in ~{})", format_duration_short(mins as i64))
     } else {
-        format!("{n} subvolumes")
+        String::new()
     };
-    let suffix = match shortest_text {
-        Some(d) => format!(" (next in ~{d})"),
-        None => String::new(),
-    };
+
     writeln!(
         out,
-        "  {}: {}{}",
-        "Interval not elapsed".dimmed(),
-        count_str,
-        suffix
+        "  {} {} subvolumes{}",
+        "Interval not elapsed:".dimmed(),
+        items.len(),
+        suffix,
     )
     .ok();
 }
 
-/// Parse a short duration string (e.g. "14h6m", "5d", "30m") to minutes.
-fn parse_duration_to_minutes(s: &str) -> i64 {
-    let mut total: i64 = 0;
-    let mut num = String::new();
-    for ch in s.chars() {
-        if ch.is_ascii_digit() {
-            num.push(ch);
-        } else {
-            let n: i64 = num.parse().unwrap_or(0);
-            match ch {
-                'd' => total += n * 1440,
-                'h' => total += n * 60,
-                'm' => total += n,
-                _ => {}
-            }
-            num.clear();
-        }
-    }
-    total
+/// Render Disabled skips as an inline comma-separated name list.
+fn render_disabled_group(items: &[&SkippedSubvolume], out: &mut String) {
+    let names: Vec<&str> = items.iter().map(|s| s.name.as_str()).collect();
+    writeln!(out, "  {} {}", "Disabled:".dimmed(), names.join(", ")).ok();
 }
 
-/// Render "Disabled: name1, name2, name3"
-fn render_disabled_group(entries: &[&crate::output::SkippedSubvolume], out: &mut String) {
-    let mut names: Vec<&str> = Vec::new();
-    for entry in entries {
-        if !names.contains(&entry.name.as_str()) {
-            names.push(&entry.name);
-        }
+/// Render SpaceExceeded or Other skips as individual lines (detail matters).
+fn render_individual_skips(
+    items: &[&SkippedSubvolume],
+    category: &SkipCategory,
+    out: &mut String,
+) {
+    let tag = match category {
+        SkipCategory::SpaceExceeded => "[SPACE]".yellow().to_string(),
+        _ => "[SKIP]".dimmed().to_string(),
+    };
+    for item in items {
+        writeln!(out, "  {} {}: {}", tag, item.name, item.reason.dimmed()).ok();
     }
-    writeln!(out, "  {}: {}", "Disabled".dimmed(), names.join(", ")).ok();
 }
 
 // ── History ─────────────────────────────────────────────────────────────
@@ -1597,9 +1555,8 @@ mod tests {
         ChainHealthEntry, DriveInfo, HistoryOutput, HistoryRun, InitCheck, InitDriveStatus,
         InitOutput, InitPinFile, InitSnapshotCount, InitStatus, LastRunInfo, PlanOperationEntry,
         PlanOutput, PlanSummaryOutput, SendSummary, SkipCategory, SkippedSubvolume,
-        StatusAssessment,
-        StatusDriveAssessment, SubvolumeSummary, VerifyCheck, VerifyDrive, VerifyOutput,
-        VerifySubvolume,
+        StatusAssessment, StatusDriveAssessment, SubvolumeSummary, VerifyCheck, VerifyDrive,
+        VerifyOutput, VerifySubvolume,
     };
 
     fn test_status_output() -> StatusOutput {
@@ -1871,13 +1828,13 @@ mod tests {
             skipped: vec![
                 SkippedSubvolume {
                     name: "htpc-home".to_string(),
-                    category: SkipCategory::DriveNotMounted,
                     reason: "drive 2TB-backup not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
                 },
                 SkippedSubvolume {
                     name: "htpc-docs".to_string(),
-                    category: SkipCategory::DriveNotMounted,
                     reason: "drive 2TB-backup not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
                 },
             ],
             assessments: vec![StatusAssessment {
@@ -1947,13 +1904,13 @@ mod tests {
         data.skipped = vec![
             SkippedSubvolume {
                 name: "htpc-home".to_string(),
-                category: SkipCategory::DriveNotMounted,
                 reason: "drive WD-18TB not mounted".to_string(),
+                category: SkipCategory::DriveNotMounted,
             },
             SkippedSubvolume {
                 name: "htpc-home".to_string(),
-                category: SkipCategory::Other,
                 reason: "drive 2TB-backup UUID mismatch (expected abc, found def)".to_string(),
+                category: SkipCategory::Other,
             },
         ];
         let output = render_backup_summary(&data, OutputMode::Interactive);
@@ -2067,23 +2024,23 @@ mod tests {
             skipped: vec![
                 SkippedSubvolume {
                     name: "htpc-home".to_string(),
-                    category: SkipCategory::DriveNotMounted,
                     reason: "drive WD-18TB not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
                 },
                 SkippedSubvolume {
                     name: "htpc-docs".to_string(),
-                    category: SkipCategory::DriveNotMounted,
                     reason: "drive WD-18TB not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
                 },
                 SkippedSubvolume {
                     name: "htpc-home".to_string(),
-                    category: SkipCategory::DriveNotMounted,
                     reason: "drive 2TB-backup not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
                 },
                 SkippedSubvolume {
                     name: "htpc-docs".to_string(),
-                    category: SkipCategory::DriveNotMounted,
                     reason: "drive 2TB-backup not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
                 },
             ],
             assessments: vec![],
@@ -2155,22 +2112,28 @@ mod tests {
         assert!(parsed.get("timestamp").is_some());
     }
 
+    // ── Plan grouped rendering tests ──────────────────────────────────
+
     #[test]
-    fn plan_shows_operations_heading() {
+    fn plan_structural_headings_present() {
         colored::control::set_override(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![PlanOperationEntry {
                 subvolume: "htpc-home".to_string(),
                 operation: "send".to_string(),
-                detail: "20260329-0404-home -> WD-18TB (full) + pin".to_string(),
+                detail: "20260329-0404-htpc-home -> WD-18TB (full) + pin".to_string(),
             }],
-            skipped: vec![],
+            skipped: vec![SkippedSubvolume {
+                name: "htpc-docs".to_string(),
+                reason: "disabled".to_string(),
+                category: SkipCategory::Disabled,
+            }],
             summary: PlanSummaryOutput {
                 snapshots: 0,
                 sends: 1,
                 deletions: 0,
-                skipped: 0,
+                skipped: 1,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2178,62 +2141,19 @@ mod tests {
             output.contains("=== Planned operations ==="),
             "missing operations heading"
         );
-        assert!(
-            !output.contains("=== Skipped"),
-            "skipped heading should not appear when no skips"
-        );
+        assert!(output.contains("=== Skipped (1) ==="), "missing skipped heading");
     }
 
     #[test]
-    fn plan_shows_skipped_heading_with_count() {
-        colored::control::set_override(false);
-        let data = PlanOutput {
-            timestamp: "2026-03-29 13:57".to_string(),
-            operations: vec![PlanOperationEntry {
-                subvolume: "htpc-home".to_string(),
-                operation: "send".to_string(),
-                detail: "20260329-0404-home -> WD-18TB (full) + pin".to_string(),
-            }],
-            skipped: vec![
-                SkippedSubvolume {
-                    name: "htpc-docs".to_string(),
-                    category: SkipCategory::DriveNotMounted,
-                    reason: "drive 2TB-backup not mounted".to_string(),
-                },
-                SkippedSubvolume {
-                    name: "htpc-pics".to_string(),
-                    category: SkipCategory::DriveNotMounted,
-                    reason: "drive 2TB-backup not mounted".to_string(),
-                },
-            ],
-            summary: PlanSummaryOutput {
-                snapshots: 0,
-                sends: 1,
-                deletions: 0,
-                skipped: 2,
-            },
-        };
-        let output = render_plan(&data, OutputMode::Interactive);
-        assert!(
-            output.contains("=== Planned operations ==="),
-            "missing operations heading"
-        );
-        assert!(
-            output.contains("=== Skipped (2) ==="),
-            "missing skipped heading with count"
-        );
-    }
-
-    #[test]
-    fn plan_skips_only_no_operations_heading() {
+    fn plan_no_operations_shows_message() {
         colored::control::set_override(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
             skipped: vec![SkippedSubvolume {
-                name: "htpc-home".to_string(),
-                category: SkipCategory::Disabled,
+                name: "htpc-docs".to_string(),
                 reason: "disabled".to_string(),
+                category: SkipCategory::Disabled,
             }],
             summary: PlanSummaryOutput {
                 snapshots: 0,
@@ -2244,21 +2164,17 @@ mod tests {
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
-            !output.contains("=== Planned operations ==="),
-            "operations heading should not appear when no operations"
-        );
-        assert!(
             output.contains("No operations planned."),
-            "missing 'no operations' note"
+            "missing no-ops message"
         );
         assert!(
-            output.contains("=== Skipped (1) ==="),
-            "missing skipped heading"
+            !output.contains("=== Planned operations ==="),
+            "should not show operations heading when empty"
         );
     }
 
     #[test]
-    fn plan_groups_not_mounted_by_drive() {
+    fn plan_grouped_drive_not_mounted() {
         colored::control::set_override(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
@@ -2266,18 +2182,18 @@ mod tests {
             skipped: vec![
                 SkippedSubvolume {
                     name: "htpc-home".to_string(),
-                    category: SkipCategory::DriveNotMounted,
                     reason: "drive WD-18TB1 not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
                 },
                 SkippedSubvolume {
                     name: "htpc-docs".to_string(),
-                    category: SkipCategory::DriveNotMounted,
                     reason: "drive WD-18TB1 not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
                 },
                 SkippedSubvolume {
                     name: "htpc-home".to_string(),
-                    category: SkipCategory::DriveNotMounted,
                     reason: "drive 2TB-backup not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
                 },
             ],
             summary: PlanSummaryOutput {
@@ -2289,26 +2205,28 @@ mod tests {
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
-            output.contains("Not mounted"),
-            "missing 'Not mounted' group label"
+            output.contains("Not mounted:"),
+            "missing grouped not-mounted line"
         );
         assert!(
             output.contains("WD-18TB1 (2 subvolumes)"),
-            "missing drive count for WD-18TB1"
+            "missing WD-18TB1 drive group"
         );
         assert!(
             output.contains("2TB-backup (1 subvolume)"),
-            "missing drive count for 2TB-backup"
+            "missing 2TB-backup drive group"
         );
-        // Should NOT contain individual [SKIP] lines
+        // Should NOT have individual [SKIP] lines for these
+        assert!(!output.contains("[SKIP]"), "should not show individual skip lines");
+        // Label extraction must succeed — "unknown" means classifier and extractor drifted
         assert!(
-            !output.contains("[SKIP]"),
-            "grouped skips should not show individual [SKIP] labels"
+            !output.contains("unknown"),
+            "drive label extraction failed — classifier/extractor drift"
         );
     }
 
     #[test]
-    fn plan_groups_interval_with_count() {
+    fn plan_grouped_interval_shows_shortest() {
         colored::control::set_override(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
@@ -2316,18 +2234,18 @@ mod tests {
             skipped: vec![
                 SkippedSubvolume {
                     name: "htpc-home".to_string(),
-                    category: SkipCategory::IntervalNotElapsed,
                     reason: "interval not elapsed (next in ~14h6m)".to_string(),
+                    category: SkipCategory::IntervalNotElapsed,
                 },
                 SkippedSubvolume {
                     name: "htpc-docs".to_string(),
+                    reason: "interval not elapsed (next in ~2h30m)".to_string(),
                     category: SkipCategory::IntervalNotElapsed,
-                    reason: "send to WD-18TB not due (next in ~2h30m)".to_string(),
                 },
                 SkippedSubvolume {
-                    name: "htpc-pics".to_string(),
+                    name: "htpc-tmp".to_string(),
+                    reason: "send to WD-18TB not due (next in ~20h0m)".to_string(),
                     category: SkipCategory::IntervalNotElapsed,
-                    reason: "interval not elapsed (next in ~20h)".to_string(),
                 },
             ],
             summary: PlanSummaryOutput {
@@ -2339,21 +2257,55 @@ mod tests {
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
-            output.contains("Interval not elapsed"),
-            "missing interval group label"
+            output.contains("Interval not elapsed:"),
+            "missing interval group"
         );
         assert!(
             output.contains("3 subvolumes"),
-            "missing subvolume count in interval group"
+            "missing subvolume count"
         );
+        // Shortest is 2h30m = 150 minutes
         assert!(
-            output.contains("next in ~"),
-            "missing 'next in' duration hint"
+            output.contains("(next in ~2h30m)"),
+            "should show shortest duration: {output}"
         );
     }
 
     #[test]
-    fn plan_groups_disabled_inline() {
+    fn plan_grouped_interval_days_vs_hours() {
+        colored::control::set_override(false);
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![],
+            skipped: vec![
+                SkippedSubvolume {
+                    name: "subvol-a".to_string(),
+                    reason: "interval not elapsed (next in ~9d)".to_string(),
+                    category: SkipCategory::IntervalNotElapsed,
+                },
+                SkippedSubvolume {
+                    name: "subvol-b".to_string(),
+                    reason: "interval not elapsed (next in ~2h30m)".to_string(),
+                    category: SkipCategory::IntervalNotElapsed,
+                },
+            ],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 0,
+                deletions: 0,
+                skipped: 2,
+            },
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        // 2h30m (150 min) < 9d (12960 min) — must show 2h30m as shortest, not 9d
+        assert!(
+            output.contains("(next in ~2h30m)"),
+            "should pick 2h30m over 9d: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_grouped_disabled_comma_list() {
         colored::control::set_override(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
@@ -2361,18 +2313,18 @@ mod tests {
             skipped: vec![
                 SkippedSubvolume {
                     name: "htpc-root".to_string(),
-                    category: SkipCategory::Disabled,
                     reason: "disabled".to_string(),
+                    category: SkipCategory::Disabled,
                 },
                 SkippedSubvolume {
-                    name: "htpc-multimedia".to_string(),
+                    name: "subvol4-multimedia".to_string(),
+                    reason: "disabled".to_string(),
                     category: SkipCategory::Disabled,
+                },
+                SkippedSubvolume {
+                    name: "subvol6-tmp".to_string(),
                     reason: "send disabled".to_string(),
-                },
-                SkippedSubvolume {
-                    name: "htpc-tmp".to_string(),
                     category: SkipCategory::Disabled,
-                    reason: "disabled".to_string(),
                 },
             ],
             summary: PlanSummaryOutput {
@@ -2384,94 +2336,112 @@ mod tests {
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
-            output.contains("Disabled"),
-            "missing disabled group label"
+            output.contains("Disabled:"),
+            "missing disabled group"
         );
         assert!(
-            output.contains("htpc-root"),
-            "missing first disabled subvolume"
-        );
-        assert!(
-            output.contains("htpc-tmp"),
-            "missing last disabled subvolume"
+            output.contains("htpc-root, subvol4-multimedia, subvol6-tmp"),
+            "names should be comma-separated: {output}"
         );
     }
 
     #[test]
-    fn plan_other_skips_shown_individually() {
+    fn plan_space_exceeded_individual_lines() {
+        colored::control::set_override(false);
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![],
+            skipped: vec![SkippedSubvolume {
+                name: "htpc-home".to_string(),
+                reason: "send to WD-18TB skipped: estimated ~4.5 GB exceeds WD-18TB available"
+                    .to_string(),
+                category: SkipCategory::SpaceExceeded,
+            }],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 0,
+                deletions: 0,
+                skipped: 1,
+            },
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("[SPACE]"),
+            "space exceeded should use [SPACE] tag"
+        );
+        assert!(
+            output.contains("htpc-home"),
+            "should show subvolume name"
+        );
+    }
+
+    #[test]
+    fn plan_mixed_categories_render_order() {
         colored::control::set_override(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
             skipped: vec![
                 SkippedSubvolume {
-                    name: "htpc-home".to_string(),
-                    category: SkipCategory::Other,
-                    reason: "snapshot already exists".to_string(),
+                    name: "sub-a".to_string(),
+                    reason: "disabled".to_string(),
+                    category: SkipCategory::Disabled,
                 },
                 SkippedSubvolume {
-                    name: "htpc-docs".to_string(),
-                    category: SkipCategory::Other,
-                    reason: "no local snapshots to send".to_string(),
+                    name: "sub-b".to_string(),
+                    reason: "drive WD-18TB not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
+                },
+                SkippedSubvolume {
+                    name: "sub-c".to_string(),
+                    reason: "interval not elapsed (next in ~5m)".to_string(),
+                    category: SkipCategory::IntervalNotElapsed,
                 },
             ],
             summary: PlanSummaryOutput {
                 snapshots: 0,
                 sends: 0,
                 deletions: 0,
-                skipped: 2,
+                skipped: 3,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
+        let not_mounted_pos = output.find("Not mounted:").expect("missing Not mounted");
+        let interval_pos = output.find("Interval not elapsed:").expect("missing Interval");
+        let disabled_pos = output.find("Disabled:").expect("missing Disabled");
         assert!(
-            output.contains("htpc-home: snapshot already exists"),
-            "Other skips should render individually"
+            not_mounted_pos < interval_pos,
+            "DriveNotMounted should render before IntervalNotElapsed"
         );
         assert!(
-            output.contains("htpc-docs: no local snapshots to send"),
-            "Other skips should render individually"
+            interval_pos < disabled_pos,
+            "IntervalNotElapsed should render before Disabled"
         );
     }
 
     #[test]
-    fn plan_daemon_includes_skip_categories() {
+    fn plan_daemon_json_includes_category() {
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
-            skipped: vec![
-                SkippedSubvolume {
-                    name: "htpc-home".to_string(),
-                    category: SkipCategory::DriveNotMounted,
-                    reason: "drive WD-18TB not mounted".to_string(),
-                },
-                SkippedSubvolume {
-                    name: "htpc-docs".to_string(),
-                    category: SkipCategory::Disabled,
-                    reason: "disabled".to_string(),
-                },
-            ],
+            skipped: vec![SkippedSubvolume {
+                name: "htpc-home".to_string(),
+                reason: "disabled".to_string(),
+                category: SkipCategory::Disabled,
+            }],
             summary: PlanSummaryOutput {
                 snapshots: 0,
                 sends: 0,
                 deletions: 0,
-                skipped: 2,
+                skipped: 1,
             },
         };
         let output = render_plan(&data, OutputMode::Daemon);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
-        let skipped = parsed.get("skipped").expect("missing skipped array");
-        let first = &skipped[0];
-        assert_eq!(
-            first.get("category").and_then(|v| v.as_str()),
-            Some("drive_not_mounted"),
-            "JSON should include snake_case category"
-        );
-        let second = &skipped[1];
-        assert_eq!(
-            second.get("category").and_then(|v| v.as_str()),
-            Some("disabled"),
-            "JSON should include category for disabled"
-        );
+        let category = parsed["skipped"][0]["category"]
+            .as_str()
+            .expect("category field missing");
+        assert_eq!(category, "disabled");
     }
 
     // ── History tests ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **D5 structural headings:** `=== Planned operations ===` and `=== Skipped (N) ===` section headers for `urd plan` output
- **D1 collapsed skip reasons:** `SkipCategory` enum (5 variants) classifies all 14 plan.rs skip patterns into grouped rendering — drive labels with counts, interval summary with shortest duration, disabled name list, individual detail for space/other
- **JSON enrichment:** additive `category` field in daemon output for structured skip classification
- **Arch-adversary review:** 4 findings addressed — label extraction drift test, deduplicated `format_duration_short`, completeness breadcrumb, grammar fix

## Testing

- cargo clippy: pass (zero warnings)
- cargo test: 470 tests, all passing (+22 new)
- cargo build --release: pass
- Integration tests: not applicable (presentation layer only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)