### PR TITLE
feat: estimated send sizes in plan output with three-tier fallback (UX-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Estimated send sizes in `urd plan` output with three-tier fallback (same-drive > cross-drive > calibrated)
+- Qualified summary totals: `"6 sends (~623 GB total)"` or `"estimated for 4 of 6"` when partial
 - Cross-drive fallback for send size estimation (covers drive swap scenarios)
 - Structural headings in `urd plan` output (operations and skipped sections)
 - Collapsed skip reasons: grouped by category instead of 20+ individual lines
 - `SkipCategory` enum with structured classification in JSON daemon output
+
+### Fixed
+- Planner space check now uses cross-drive fallback (previously only same-drive history)
 
 ## [0.4.0] - 2026-03-29
 

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,13 +8,14 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-470 tests, all passing, clippy clean. Current version: v0.4.0.
+488 tests, all passing, clippy clean. Current version: v0.4.0.
 
 ## In Progress
 
-- **UX-1 complete, uncommitted** (2026-03-30). `SkipCategory` enum in output.rs, grouped
-  plan rendering in voice.rs (D5 structural headings + D1 collapsed skips). Arch-adversary
-  review complete, all findings addressed. Ready for `/commit-push-pr`.
+- **UX-2 complete, uncommitted** (2026-03-30). Three-tier size estimation fallback in
+  plan_cmd.rs, structured `estimated_bytes` + `is_full_send` on `PlanOperationEntry`,
+  voice.rs renders size annotations and qualified summary totals. Post-review addressed
+  cross-drive fallback divergence in planner space check. Ready for `/commit-push-pr`.
 
 ## Build Queue
 
@@ -25,8 +26,8 @@ full details, design decisions, and review findings.
 2. ~~**VFM-A**~~ — `OperationalHealth` enum, two-axis CLI rendering. **Done.**
 3. ~~**Sentinel Session 3**~~ — hardening + notification deduplication. **Done.**
 4. ~~**UX-1**~~ — plan output: structural headings (D5) + collapsed skips (D1). **Done.**
-5. **UX-2** — plan output: estimated send sizes (D2+D3), cross-drive fallback (S1 fix). **start here**
-6. **UX-3** — progress display: rich context (P1) + ETA (P3).
+5. ~~**UX-2**~~ — plan output: estimated send sizes (D2+D3), cross-drive fallback (S1 fix). **Done.**
+6. **UX-3** — plan output: progress display: rich context (P1) + ETA (P3). **start here**
 7. **HSD-B** — sentinel chain-break detection + full-send gate (Norman escalation).
    - Reference incident: `docs/98-journals/2026-03-29-clone-drive-incident-analysis.md`
 8. **VFM-B** — sentinel visual state in state file + health notifications.
@@ -34,9 +35,7 @@ full details, design decisions, and review findings.
 10. **Tray icon (Spindle)** — reads sentinel-state.json, 4 static icons.
 
 Designs: `docs/95-ideas/2026-03-29-design-*.md`.
-Review: `docs/99-reports/2026-03-29-progress-display-design-review.md`.
-Post-review: `docs/99-reports/2026-03-29-post-review-cross-drive-fallback-review.md`.
-UX-1 review: `docs/99-reports/2026-03-30-ux1-plan-output-review.md`.
+Reviews: `docs/99-reports/2026-03-30-ux2-estimated-sizes-review.md`.
 
 **Later:** Config system migration (ADR-111), shell completions (6a).
 
@@ -49,7 +48,7 @@ UX-1 review: `docs/99-reports/2026-03-30-ux1-plan-output-review.md`.
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Latest journals | `docs/98-journals/` (local only, gitignored) |
-| Latest reviews | [UX-1 review](../99-reports/2026-03-30-ux1-plan-output-review.md), [Design review](../99-reports/2026-03-29-progress-display-design-review.md) |
+| Latest reviews | [UX-2 review](../99-reports/2026-03-30-ux2-estimated-sizes-review.md), [UX-1 review](../99-reports/2026-03-30-ux1-plan-output-review.md) |
 
 ## Known Issues
 

--- a/docs/99-reports/2026-03-30-ux2-estimated-sizes-review.md
+++ b/docs/99-reports/2026-03-30-ux2-estimated-sizes-review.md
@@ -1,0 +1,184 @@
+# Arch-Adversary Review: UX-2 Estimated Send Sizes
+
+**Project:** Urd
+**Date:** 2026-03-30
+**Scope:** Implementation review — `git diff` of 5 files (517 insertions, 10 deletions)
+**Base commit:** `b4b9ae3` (master, clean)
+**Files:** `src/output.rs`, `src/commands/plan_cmd.rs`, `src/commands/backup.rs`, `src/voice.rs`, `src/plan.rs`
+
+---
+
+## Executive Summary
+
+A clean, well-scoped presentation-layer feature that threads existing size data through the
+output layer. No proximity to catastrophic failure — this is pure display code. The simplify
+pass correctly moved size formatting from plan_cmd.rs to voice.rs, respecting the architecture.
+One moderate finding (space estimation divergence with the planner) and one minor cosmetic issue.
+
+## What Kills You
+
+**Catastrophic failure for Urd: silent data loss** — deleting snapshots that shouldn't be deleted,
+or failing to create backups without visible notification.
+
+**Distance from this change: infinite.** This is a read-only display feature. It queries SQLite
+for historical sizes and renders them in plan output. It cannot modify snapshots, cannot influence
+the planner's decisions, and cannot cause data loss. The `FileSystemState` trait methods are
+read-only by design. The worst this change can do is display a wrong number.
+
+Catastrophic failure checklist — all clear:
+1. Silent data loss — not possible (read-only display)
+2. Path traversal — no new path construction to btrfs
+3. Pinned snapshot deletion — no interaction with pins
+4. Space exhaustion — no influence on backup decisions
+5. Config orphaning — no config interaction
+6. TOCTOU — no privilege boundary crossing
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | Three-tier fallback chain is correct; one divergence with planner's space estimator (moderate, not a bug in *this* code) |
+| 2 | Security | 5 | No new trust boundaries, no path construction, pure display |
+| 3 | Architectural Excellence | 4 | Clean separation after simplify pass — data in output types, rendering in voice.rs. `is_full_send` is slightly awkward but functional |
+| 4 | Systems Design | 4 | Handles all edge cases (no data, partial data, all data). Summary qualification communicates uncertainty |
+| 5 | Rust Idioms | 4 | Good use of `or_else()` chains, `Option` throughout, `skip_serializing_if` |
+| 6 | Code Quality | 4 | 17 new tests cover the matrix well. One minor indentation issue in an existing test |
+
+**Overall: 4/5 — solid implementation with minor issues only.**
+
+## Design Tensions
+
+### 1. Display estimates vs. planner estimates (conscious trade-off, needs alignment)
+
+The plan_cmd.rs display uses a three-tier fallback (same-drive > cross-drive > calibrated) while
+the planner's space check at `plan.rs:481` uses only two tiers (same-drive > calibrated, no
+cross-drive). This means a send can show `~50 GB` in the plan output (from cross-drive history)
+but not be space-checked against that same figure. The user sees an estimate but the planner
+doesn't use it for the space guard.
+
+This is not a bug in UX-2 — the planner was written before cross-drive fallback existed. But
+now that both consumers exist, the divergence is a maintenance trap. Someone reading the plan
+output will assume the planner "knows" that estimate.
+
+### 2. `is_full_send: Option<bool>` vs. an operation type enum (pragmatic, acceptable)
+
+The `is_full_send` field on `PlanOperationEntry` encodes send type as `Some(true)` / `Some(false)`
+/ `None`. An enum (`SendType::Full | Incremental`) would be more precise, but would be the third
+parallel operation-type vocabulary (alongside `PlannedOperation` and the stringly-typed DB layer).
+The `Option<bool>` is ugly but minimal — it adds one field instead of a new type and all the
+associated plumbing. Acceptable for a display-only field.
+
+### 3. `estimated_total_bytes` as pre-computed vs. derived (acceptable)
+
+The total is stored in `PlanSummaryOutput` rather than computed on demand. This creates a
+redundant state that could drift from `operations`. In practice the construction is co-located
+(same function, 10 lines apart) and the JSON serialization benefits from having the value
+pre-computed. Acceptable trade-off.
+
+## Findings
+
+### S1: Space estimator missing cross-drive fallback (Significant)
+
+**What:** `plan.rs:481` uses `last_send_size()` (same-drive only) for space checks. If a user
+plugs in a new drive with no same-drive history, the space guard falls through to calibrated
+data (or nothing for incrementals). Meanwhile, `plan_cmd.rs` would show a cross-drive estimate
+for the same operation.
+
+**Consequence:** A send to a new drive shows `~50 GB` in plan output but isn't space-checked
+against that 50 GB. If the drive has 40 GB free, the planner won't skip it, the executor will
+start the send, and it will fail ~80% through — leaving a partial snapshot that needs cleanup.
+The executor handles this (cleans up partials), but the user experiences a failed backup that
+the plan output implied would work.
+
+**Distance from catastrophic:** Three steps — the executor cleans up, the next run retries,
+and no data is lost. But it's a UX promise violation: "the plan showed an estimate, why didn't
+it catch this?"
+
+**Fix:** Add cross-drive fallback as Tier 2 in the planner's space estimation at `plan.rs:481`:
+```
+if let Some(last_size) = fs.last_send_size(&subvol.name, &drive.label, send_type_str)
+    .or_else(|| fs.last_send_size_any_drive(&subvol.name, send_type_str))
+{
+```
+This is a one-line change. File a separate issue or add to UX-3 scope.
+
+### M1: Indentation inconsistency in test (Minor)
+
+**What:** `voice.rs:2163` has `is_full_send: None` indented with 20 spaces instead of 16,
+inside the `plan_structural_headings_present` test. The automated `is_full_send` insertion
+picked up wrong indentation from the surrounding `estimated_bytes` field that was already
+at incorrect depth.
+
+**Fix:** Align to 16 spaces (same as other fields in the struct literal).
+
+### C1: Clean separation of data and presentation (Commendation)
+
+The simplify pass correctly identified that embedding formatted sizes in the `detail` string
+violated the architecture (output types carry data, voice renders). Moving size formatting to
+voice.rs and adding `estimated_bytes` + `is_full_send` as structured fields is the right call.
+This means:
+- JSON consumers get raw bytes (machine-readable)
+- Interactive rendering controls formatting (human-readable)
+- Future changes to size display (precision, placement, wording) touch only voice.rs
+
+### C2: Three-tier fallback chain (Commendation)
+
+The `or_else()` chain is clean and readable:
+```rust
+fs_state.last_send_size(subvolume_name, drive_label, "send_full")
+    .or_else(|| fs_state.last_send_size_any_drive(subvolume_name, "send_full"))
+    .or_else(|| fs_state.calibrated_size(subvolume_name).map(|(bytes, _)| bytes));
+```
+Each tier is one line. The incremental chain deliberately omits the calibrated tier with a
+comment explaining why. This is easy to understand, easy to extend, and easy to test.
+
+### C3: Qualified summary format (Commendation)
+
+The partial-coverage format `"6 sends (~623 GB estimated for 4 of 6)"` is a genuinely good UX
+decision. It communicates uncertainty without hiding the data. The user knows exactly how much
+of the estimate is backed by data. This is the kind of precision that builds trust in a backup
+tool's output.
+
+## The Simplicity Question
+
+**What's earning its keep:**
+- The `estimated_bytes` field — structured data for JSON consumers and rendering
+- The three-tier fallback — correct priority order, handles drive swaps
+- The qualified summary — communicates partial data honestly
+- The tests — 17 new tests cover the full matrix (8 lookup + 3 aggregation + 6 rendering)
+
+**What could be simpler:**
+- `is_full_send: Option<bool>` is the weakest field. It exists solely so voice.rs can choose
+  between `~53 GB` and `last: ~5.5 MB`. If incrementals used the same prefix, this field
+  disappears. But the design doc specifies different labels, and the rationale (incremental sizes
+  vary widely, "last:" communicates this) is sound. So it earns its keep, barely.
+- `estimated_total_bytes` is derivable but convenient for JSON. Acceptable.
+
+**Nothing should be deleted.** The change is minimal for what it does.
+
+## For the Dev Team
+
+Priority order:
+
+1. **S1 — Add cross-drive fallback to planner space check** (`src/plan.rs:481`)
+   Change: `fs.last_send_size(...)` → `fs.last_send_size(...).or_else(|| fs.last_send_size_any_drive(...))`
+   Why: Aligns planner space estimation with display estimates. Without this, the plan can show
+   a size estimate while not space-checking against it. File separately — not a blocker for this PR.
+
+2. **M1 — Fix indentation** (`src/voice.rs:2163`)
+   Change: Align `is_full_send: None` to 16-space indent.
+   Why: Cosmetic, but it's in the diff and should be clean.
+
+## Open Questions
+
+1. **Should cross-drive estimates be visually distinguished?** Currently, same-drive history and
+   cross-drive fallback both render as `~53 GB` with no indication of source. The design doc
+   says "label with same ~ confidence" which is correct for v1. But if a user is confused about
+   why an estimate seems wrong, there's no way to tell it came from a different drive. Consider
+   adding a `(cross-drive)` qualifier in a future pass if users report confusion.
+
+2. **Summary line order change.** The summary changed from `"N snapshots, N sends, N deletions,
+   N skipped"` to `"N sends (...), N snapshots, N deletions, N skipped"`. Sends moved to front.
+   This is reasonable (sends are the most information-rich item), but it's a visible change to
+   existing output that scripts or muscle memory might depend on. The daemon mode JSON structure
+   is unchanged, so only interactive output is affected.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -76,7 +76,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 
     // Dry run: print plan and exit (no lock needed)
     if args.dry_run {
-        let plan_output = crate::commands::plan_cmd::build_plan_output(&backup_plan);
+        let plan_output = crate::commands::plan_cmd::build_plan_output(&backup_plan, &fs_state);
         let mode = crate::output::OutputMode::detect();
         print!("{}", crate::voice::render_plan(&plan_output, mode));
         return Ok(());

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -5,7 +5,7 @@ use crate::output::{
     OutputMode, PlanOperationEntry, PlanOutput, PlanSummaryOutput, SkipCategory,
     SkippedSubvolume,
 };
-use crate::plan::{self, PlanFilters, RealFileSystemState};
+use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
 use crate::state::StateDb;
 use crate::types::PlannedOperation;
 use crate::voice;
@@ -28,7 +28,7 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
     // Warn about drives without UUID fingerprinting
     drives::warn_missing_uuids(&config.drives);
 
-    let output = build_plan_output(&backup_plan);
+    let output = build_plan_output(&backup_plan, &fs_state);
     print!("{}", voice::render_plan(&output, mode));
 
     Ok(())
@@ -36,13 +36,16 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
 
 /// Build PlanOutput from a BackupPlan. Shared by `urd plan` and `urd backup --dry-run`.
 #[must_use]
-pub fn build_plan_output(backup_plan: &crate::types::BackupPlan) -> PlanOutput {
+pub fn build_plan_output(
+    backup_plan: &crate::types::BackupPlan,
+    fs_state: &dyn FileSystemState,
+) -> PlanOutput {
     let summary = backup_plan.summary();
 
     let operations: Vec<PlanOperationEntry> = backup_plan
         .operations
         .iter()
-        .map(build_operation_entry)
+        .map(|op| build_operation_entry(op, fs_state))
         .collect();
 
     let skipped: Vec<SkippedSubvolume> = backup_plan
@@ -55,6 +58,17 @@ pub fn build_plan_output(backup_plan: &crate::types::BackupPlan) -> PlanOutput {
         })
         .collect();
 
+    // Aggregate estimated bytes across all sends with estimates.
+    let estimated_total: u64 = operations
+        .iter()
+        .filter_map(|op| op.estimated_bytes)
+        .sum();
+    let estimated_total_bytes = if estimated_total > 0 {
+        Some(estimated_total)
+    } else {
+        None
+    };
+
     PlanOutput {
         timestamp: backup_plan.timestamp.format("%Y-%m-%d %H:%M").to_string(),
         operations,
@@ -64,11 +78,215 @@ pub fn build_plan_output(backup_plan: &crate::types::BackupPlan) -> PlanOutput {
             sends: summary.sends,
             deletions: summary.deletions,
             skipped: summary.skipped,
+            estimated_total_bytes,
         },
     }
 }
 
-fn build_operation_entry(op: &PlannedOperation) -> PlanOperationEntry {
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::MockFileSystemState;
+    use crate::types::SnapshotName;
+    use std::path::PathBuf;
+
+    fn dummy_snap(subvol: &str) -> SnapshotName {
+        SnapshotName::parse(&format!("20260329-0404-{subvol}")).unwrap()
+    }
+
+    fn mock_send_full(subvol: &str, drive: &str) -> PlannedOperation {
+        PlannedOperation::SendFull {
+            snapshot: PathBuf::from(format!("/snapshots/{subvol}/20260329-0404-{subvol}")),
+            dest_dir: PathBuf::from(format!("/mnt/{drive}/{subvol}")),
+            drive_label: drive.to_string(),
+            pin_on_success: Some((
+                PathBuf::from(format!("/snapshots/{subvol}/.last-external-parent-{drive}")),
+                dummy_snap(subvol),
+            )),
+            subvolume_name: subvol.to_string(),
+        }
+    }
+
+    fn mock_send_incremental(subvol: &str, drive: &str) -> PlannedOperation {
+        PlannedOperation::SendIncremental {
+            snapshot: PathBuf::from(format!("/snapshots/{subvol}/20260329-0404-{subvol}")),
+            parent: PathBuf::from(format!("/snapshots/{subvol}/20260328-0404-{subvol}")),
+            dest_dir: PathBuf::from(format!("/mnt/{drive}/{subvol}")),
+            drive_label: drive.to_string(),
+            pin_on_success: Some((
+                PathBuf::from(format!("/snapshots/{subvol}/.last-external-parent-{drive}")),
+                dummy_snap(subvol),
+            )),
+            subvolume_name: subvol.to_string(),
+        }
+    }
+
+    // ── Size lookup tests ─────────────────────────────────────────────
+
+    #[test]
+    fn full_send_same_drive_history() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes.insert(
+            ("htpc-home".into(), "WD-18TB".into(), "send_full".into()),
+            53_000_000_000,
+        );
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        assert_eq!(entry.estimated_bytes, Some(53_000_000_000));
+        assert_eq!(entry.is_full_send, Some(true));
+        // Size is NOT in detail — voice.rs renders it from estimated_bytes.
+        assert!(!entry.detail.contains('~'), "size should not be in detail");
+        assert!(entry.detail.contains("(full)"), "detail: {}", entry.detail);
+    }
+
+    #[test]
+    fn full_send_cross_drive_fallback() {
+        let mut fs = MockFileSystemState::new();
+        // History on different drive, not on target drive
+        fs.send_sizes.insert(
+            ("htpc-home".into(), "OTHER-DRIVE".into(), "send_full".into()),
+            50_000_000_000,
+        );
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        assert_eq!(entry.estimated_bytes, Some(50_000_000_000));
+    }
+
+    #[test]
+    fn full_send_calibrated_fallback() {
+        let mut fs = MockFileSystemState::new();
+        fs.calibrated_sizes.insert(
+            "htpc-home".into(),
+            (45_000_000_000, "2026-03-28".into()),
+        );
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        assert_eq!(entry.estimated_bytes, Some(45_000_000_000));
+    }
+
+    #[test]
+    fn full_send_same_drive_wins_over_cross_drive() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes.insert(
+            ("htpc-home".into(), "WD-18TB".into(), "send_full".into()),
+            53_000_000_000,
+        );
+        fs.send_sizes.insert(
+            ("htpc-home".into(), "OTHER".into(), "send_full".into()),
+            50_000_000_000,
+        );
+        fs.calibrated_sizes.insert(
+            "htpc-home".into(),
+            (45_000_000_000, "2026-03-28".into()),
+        );
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        assert_eq!(entry.estimated_bytes, Some(53_000_000_000));
+    }
+
+    #[test]
+    fn full_send_no_data() {
+        let fs = MockFileSystemState::new();
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        assert_eq!(entry.estimated_bytes, None);
+        assert!(entry.detail.contains("(full)"), "detail: {}", entry.detail);
+        assert!(!entry.detail.contains('~'), "should not have size annotation");
+    }
+
+    #[test]
+    fn incremental_send_same_drive_history() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes.insert(
+            ("htpc-home".into(), "WD-18TB".into(), "send_incremental".into()),
+            5_500_000,
+        );
+        let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs);
+        assert_eq!(entry.estimated_bytes, Some(5_500_000));
+        assert_eq!(entry.is_full_send, Some(false));
+        // Size is NOT in detail — voice.rs renders it from estimated_bytes.
+        assert!(!entry.detail.contains('~'), "size should not be in detail");
+    }
+
+    #[test]
+    fn incremental_send_cross_drive_fallback() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes.insert(
+            ("htpc-home".into(), "OTHER".into(), "send_incremental".into()),
+            3_000_000,
+        );
+        let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs);
+        assert_eq!(entry.estimated_bytes, Some(3_000_000));
+    }
+
+    #[test]
+    fn incremental_send_no_calibrated_fallback() {
+        let mut fs = MockFileSystemState::new();
+        // Only calibration data — should NOT be used for incrementals
+        fs.calibrated_sizes.insert(
+            "htpc-home".into(),
+            (45_000_000_000, "2026-03-28".into()),
+        );
+        let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs);
+        assert_eq!(entry.estimated_bytes, None);
+    }
+
+    // ── Summary aggregation tests ─────────────────────────────────────
+
+    #[test]
+    fn summary_aggregates_all_estimates() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes.insert(
+            ("htpc-home".into(), "WD-18TB".into(), "send_full".into()),
+            53_000_000_000,
+        );
+        fs.send_sizes.insert(
+            ("htpc-docs".into(), "WD-18TB".into(), "send_full".into()),
+            1_200_000_000,
+        );
+        let plan = crate::types::BackupPlan {
+            timestamp: chrono::NaiveDateTime::default(),
+            operations: vec![
+                mock_send_full("htpc-home", "WD-18TB"),
+                mock_send_full("htpc-docs", "WD-18TB"),
+            ],
+            skipped: vec![],
+        };
+        let output = build_plan_output(&plan, &fs);
+        assert_eq!(output.summary.estimated_total_bytes, Some(54_200_000_000));
+    }
+
+    #[test]
+    fn summary_partial_estimates() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes.insert(
+            ("htpc-home".into(), "WD-18TB".into(), "send_full".into()),
+            53_000_000_000,
+        );
+        let plan = crate::types::BackupPlan {
+            timestamp: chrono::NaiveDateTime::default(),
+            operations: vec![
+                mock_send_full("htpc-home", "WD-18TB"),
+                mock_send_full("htpc-docs", "WD-18TB"), // no estimate
+            ],
+            skipped: vec![],
+        };
+        let output = build_plan_output(&plan, &fs);
+        assert_eq!(output.summary.estimated_total_bytes, Some(53_000_000_000));
+    }
+
+    #[test]
+    fn summary_no_estimates_is_none() {
+        let fs = MockFileSystemState::new();
+        let plan = crate::types::BackupPlan {
+            timestamp: chrono::NaiveDateTime::default(),
+            operations: vec![mock_send_full("htpc-home", "WD-18TB")],
+            skipped: vec![],
+        };
+        let output = build_plan_output(&plan, &fs);
+        assert_eq!(output.summary.estimated_total_bytes, None);
+    }
+}
+
+fn build_operation_entry(
+    op: &PlannedOperation,
+    fs_state: &dyn FileSystemState,
+) -> PlanOperationEntry {
     match op {
         PlannedOperation::CreateSnapshot {
             source,
@@ -78,6 +296,8 @@ fn build_operation_entry(op: &PlannedOperation) -> PlanOperationEntry {
             subvolume: subvolume_name.clone(),
             operation: "create".to_string(),
             detail: format!("{} -> {}", source.display(), dest.display()),
+            estimated_bytes: None,
+            is_full_send: None,
         },
         PlannedOperation::SendIncremental {
             snapshot,
@@ -94,12 +314,23 @@ fn build_operation_entry(op: &PlannedOperation) -> PlanOperationEntry {
             } else {
                 ""
             };
+
+            // Two-tier fallback: same-drive history, then cross-drive.
+            // No calibrated fallback for incrementals (calibration measures full subvolume).
+            let estimated_bytes = fs_state
+                .last_send_size(subvolume_name, drive_label, "send_incremental")
+                .or_else(|| {
+                    fs_state.last_send_size_any_drive(subvolume_name, "send_incremental")
+                });
+
             PlanOperationEntry {
                 subvolume: subvolume_name.clone(),
                 operation: "send".to_string(),
                 detail: format!(
                     "{snap_name} -> {drive_label} (incremental, parent: {parent_name}){pin_suffix}"
                 ),
+                estimated_bytes,
+                is_full_send: Some(false),
             }
         }
         PlannedOperation::SendFull {
@@ -115,10 +346,19 @@ fn build_operation_entry(op: &PlannedOperation) -> PlanOperationEntry {
             } else {
                 ""
             };
+
+            // Three-tier fallback: same-drive, cross-drive, calibrated.
+            let estimated_bytes = fs_state
+                .last_send_size(subvolume_name, drive_label, "send_full")
+                .or_else(|| fs_state.last_send_size_any_drive(subvolume_name, "send_full"))
+                .or_else(|| fs_state.calibrated_size(subvolume_name).map(|(bytes, _)| bytes));
+
             PlanOperationEntry {
                 subvolume: subvolume_name.clone(),
                 operation: "send".to_string(),
                 detail: format!("{snap_name} -> {drive_label} (full){pin_suffix}"),
+                estimated_bytes,
+                is_full_send: Some(true),
             }
         }
         PlannedOperation::DeleteSnapshot {
@@ -131,6 +371,8 @@ fn build_operation_entry(op: &PlannedOperation) -> PlanOperationEntry {
                 subvolume: subvolume_name.clone(),
                 operation: "delete".to_string(),
                 detail: format!("{snap_name} ({reason})"),
+                estimated_bytes: None,
+                is_full_send: None,
             }
         }
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -363,6 +363,13 @@ pub struct PlanOperationEntry {
     pub subvolume: String,
     pub operation: String,
     pub detail: String,
+    /// Estimated bytes for send operations (from history or calibration).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub estimated_bytes: Option<u64>,
+    /// Whether this is a full or incremental send (for size label formatting).
+    /// Only set for send operations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_full_send: Option<bool>,
 }
 
 /// Summary counts for a backup plan.
@@ -372,6 +379,9 @@ pub struct PlanSummaryOutput {
     pub sends: usize,
     pub deletions: usize,
     pub skipped: usize,
+    /// Aggregated estimated bytes across all sends with estimates.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub estimated_total_bytes: Option<u64>,
 }
 
 // ── HistoryOutput ──────────────────────────────────────────────────────

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -56,7 +56,6 @@ pub trait FileSystemState {
 
     /// Get the bytes_transferred from the most recent successful send of a given type
     /// across **all** drives. Cross-drive fallback for drive swap scenarios.
-    #[allow(dead_code)]
     fn last_send_size_any_drive(&self, subvol_name: &str, send_type: &str) -> Option<u64>;
 
     /// Get a calibrated size estimate for a subvolume (from `urd calibrate`).
@@ -473,14 +472,17 @@ fn plan_external_send(
     };
 
     // Space estimation: skip if estimated send size exceeds available space.
-    // Tier 1: Historical send data (most accurate). Tier 3: Calibrated sizes (fallback for full sends).
+    // Three-tier fallback: same-drive history > cross-drive history > calibrated (full only).
     let send_type_str = if is_incremental {
         "send_incremental"
     } else {
         "send_full"
     };
-    if let Some(last_size) = fs.last_send_size(&subvol.name, &drive.label, send_type_str) {
-        // Tier 1: historical data from previous sends (successful or failed)
+    if let Some(last_size) = fs
+        .last_send_size(&subvol.name, &drive.label, send_type_str)
+        .or_else(|| fs.last_send_size_any_drive(&subvol.name, send_type_str))
+    {
+        // Tier 1/2: historical data from same drive or cross-drive fallback
         if let Some((estimated, available, free, min_free)) =
             exceeds_available_space(last_size, &ext_dir, drive, fs)
         {
@@ -1644,6 +1646,42 @@ send_enabled = false
             sends.len(),
             1,
             "First-ever send should proceed without history or calibration"
+        );
+    }
+
+    #[test]
+    fn cross_drive_fallback_space_check() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.mounted_drives.insert("D1".to_string());
+        // No same-drive history, but cross-drive history says 1TB
+        fs.send_sizes.insert(
+            ("sv1".to_string(), "OTHER-DRIVE".to_string(), "send_full".to_string()),
+            1_000_000_000_000,
+        );
+        // Drive has only 500GB free
+        fs.free_bytes
+            .insert(PathBuf::from("/mnt/d1"), 500_000_000_000);
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::SendFull { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(
+            sends.len(),
+            0,
+            "Cross-drive fallback should space-check and skip when too large"
+        );
+        assert!(
+            result
+                .skipped
+                .iter()
+                .any(|(name, reason)| name == "sv1" && reason.contains("estimated")),
+            "Skip reason should mention estimated size"
         );
     }
 

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -800,7 +800,12 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
                 "delete" => "[DELETE]".yellow().to_string(),
                 other => format!("[{other}]"),
             };
-            writeln!(out, "  {:<10} {}", label, entry.detail).ok();
+            let size_annotation = match (entry.estimated_bytes, entry.is_full_send) {
+                (Some(bytes), Some(true)) => format!(" ~{}", ByteSize(bytes)),
+                (Some(bytes), Some(false)) => format!(" last: ~{}", ByteSize(bytes)),
+                _ => String::new(),
+            };
+            writeln!(out, "  {:<10} {}{}", label, entry.detail, size_annotation.dimmed()).ok();
         }
         writeln!(out).ok();
     } else {
@@ -820,13 +825,38 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
     }
 
     writeln!(out).ok();
+
+    // Build sends portion of summary, with estimated total if available.
+    let sends_str = if data.summary.sends == 0 {
+        "0 sends".to_string()
+    } else if let Some(total) = data.summary.estimated_total_bytes {
+        let sends_with_estimates = data
+            .operations
+            .iter()
+            .filter(|op| op.operation == "send" && op.estimated_bytes.is_some())
+            .count();
+        if sends_with_estimates == data.summary.sends {
+            format!("{} sends (~{} total)", data.summary.sends, ByteSize(total))
+        } else {
+            format!(
+                "{} sends (~{} estimated for {} of {})",
+                data.summary.sends,
+                ByteSize(total),
+                sends_with_estimates,
+                data.summary.sends
+            )
+        }
+    } else {
+        format!("{} sends", data.summary.sends)
+    };
+
     writeln!(
         out,
         "{}",
         format!(
-            "Summary: {} snapshots, {} sends, {} deletions, {} skipped",
+            "Summary: {}, {} snapshots, {} deletions, {} skipped",
+            sends_str,
             data.summary.snapshots,
-            data.summary.sends,
             data.summary.deletions,
             data.summary.skipped
         )
@@ -2073,11 +2103,15 @@ mod tests {
                     subvolume: "htpc-home".to_string(),
                     operation: "create".to_string(),
                     detail: "/home -> /snapshots/htpc-home/20260326-0400-home".to_string(),
+                    estimated_bytes: None,
+                    is_full_send: None,
                 },
                 PlanOperationEntry {
                     subvolume: "htpc-home".to_string(),
                     operation: "send".to_string(),
                     detail: "20260326-0400-home -> WD-18TB (incremental, parent: 20260325-0400-home) + pin".to_string(),
+                    estimated_bytes: None,
+                    is_full_send: None,
                 },
             ],
             skipped: vec![],
@@ -2086,6 +2120,7 @@ mod tests {
                 sends: 1,
                 deletions: 0,
                 skipped: 0,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2105,6 +2140,7 @@ mod tests {
                 sends: 0,
                 deletions: 0,
                 skipped: 0,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Daemon);
@@ -2123,6 +2159,8 @@ mod tests {
                 subvolume: "htpc-home".to_string(),
                 operation: "send".to_string(),
                 detail: "20260329-0404-htpc-home -> WD-18TB (full) + pin".to_string(),
+                estimated_bytes: None,
+                is_full_send: None,
             }],
             skipped: vec![SkippedSubvolume {
                 name: "htpc-docs".to_string(),
@@ -2134,6 +2172,7 @@ mod tests {
                 sends: 1,
                 deletions: 0,
                 skipped: 1,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2160,6 +2199,7 @@ mod tests {
                 sends: 0,
                 deletions: 0,
                 skipped: 1,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2201,6 +2241,7 @@ mod tests {
                 sends: 0,
                 deletions: 0,
                 skipped: 3,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2253,6 +2294,7 @@ mod tests {
                 sends: 0,
                 deletions: 0,
                 skipped: 3,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2294,6 +2336,7 @@ mod tests {
                 sends: 0,
                 deletions: 0,
                 skipped: 2,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2332,6 +2375,7 @@ mod tests {
                 sends: 0,
                 deletions: 0,
                 skipped: 3,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2362,6 +2406,7 @@ mod tests {
                 sends: 0,
                 deletions: 0,
                 skipped: 1,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2403,6 +2448,7 @@ mod tests {
                 sends: 0,
                 deletions: 0,
                 skipped: 3,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
@@ -2434,6 +2480,7 @@ mod tests {
                 sends: 0,
                 deletions: 0,
                 skipped: 1,
+                estimated_total_bytes: None,
             },
         };
         let output = render_plan(&data, OutputMode::Daemon);
@@ -2442,6 +2489,215 @@ mod tests {
             .as_str()
             .expect("category field missing");
         assert_eq!(category, "disabled");
+    }
+
+    // ── Plan estimated size rendering tests ─────────────────────────────
+
+    #[test]
+    fn plan_summary_with_total_estimate() {
+        colored::control::set_override(false);
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![
+                PlanOperationEntry {
+                    subvolume: "htpc-home".to_string(),
+                    operation: "send".to_string(),
+                    detail: "snap -> WD-18TB (full)".to_string(),
+                    estimated_bytes: Some(53_000_000_000),
+                    is_full_send: Some(true),
+                },
+                PlanOperationEntry {
+                    subvolume: "htpc-docs".to_string(),
+                    operation: "send".to_string(),
+                    detail: "snap -> WD-18TB (full)".to_string(),
+                    estimated_bytes: Some(1_200_000_000),
+                    is_full_send: Some(true),
+                },
+            ],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 2,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: Some(54_200_000_000),
+            },
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("2 sends (~54.2GB total)"),
+            "summary should show total estimate: {output}"
+        );
+        // Size annotation rendered by voice, not embedded in detail
+        assert!(
+            output.contains("~53.0GB"),
+            "should render full send size annotation: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_incremental_send_size_annotation() {
+        colored::control::set_override(false);
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![PlanOperationEntry {
+                subvolume: "htpc-home".to_string(),
+                operation: "send".to_string(),
+                detail: "snap -> WD-18TB (incremental, parent: prev)".to_string(),
+                estimated_bytes: Some(5_500_000),
+                is_full_send: Some(false),
+            }],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 1,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: Some(5_500_000),
+            },
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("last: ~5.5MB"),
+            "should render incremental size with 'last:' prefix: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_summary_partial_estimates_qualified() {
+        colored::control::set_override(false);
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![
+                PlanOperationEntry {
+                    subvolume: "htpc-home".to_string(),
+                    operation: "send".to_string(),
+                    detail: "snap -> WD-18TB (full)".to_string(),
+                    estimated_bytes: Some(53_000_000_000),
+                    is_full_send: Some(true),
+                },
+                PlanOperationEntry {
+                    subvolume: "htpc-docs".to_string(),
+                    operation: "send".to_string(),
+                    detail: "snap -> WD-18TB (full)".to_string(),
+                    estimated_bytes: None,
+                    is_full_send: Some(true),
+                },
+            ],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 2,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: Some(53_000_000_000),
+            },
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("2 sends (~53.0GB estimated for 1 of 2)"),
+            "partial estimates should be qualified: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_summary_no_estimates_no_size() {
+        colored::control::set_override(false);
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![PlanOperationEntry {
+                subvolume: "htpc-home".to_string(),
+                operation: "send".to_string(),
+                detail: "snap -> WD-18TB (full)".to_string(),
+                estimated_bytes: None,
+                is_full_send: None,
+            }],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 1,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: None,
+            },
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("1 sends,"),
+            "no estimates should just show count: {output}"
+        );
+        assert!(
+            !output.contains("total"),
+            "should not mention total without estimates: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_daemon_json_includes_estimated_bytes() {
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![PlanOperationEntry {
+                subvolume: "htpc-home".to_string(),
+                operation: "send".to_string(),
+                detail: "snap -> WD-18TB (full)".to_string(),
+                estimated_bytes: Some(53_000_000_000),
+                is_full_send: Some(true),
+            }],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 1,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: Some(53_000_000_000),
+            },
+        };
+        let output = render_plan(&data, OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        assert_eq!(
+            parsed["operations"][0]["estimated_bytes"].as_u64(),
+            Some(53_000_000_000)
+        );
+        assert_eq!(
+            parsed["summary"]["estimated_total_bytes"].as_u64(),
+            Some(53_000_000_000)
+        );
+    }
+
+    #[test]
+    fn plan_daemon_json_omits_null_estimated_bytes() {
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![PlanOperationEntry {
+                subvolume: "htpc-home".to_string(),
+                operation: "send".to_string(),
+                detail: "snap -> WD-18TB (full)".to_string(),
+                estimated_bytes: None,
+                is_full_send: None,
+            }],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 1,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: None,
+            },
+        };
+        let output = render_plan(&data, OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        assert!(
+            parsed["operations"][0].get("estimated_bytes").is_none(),
+            "null estimated_bytes should be omitted from JSON"
+        );
+        assert!(
+            parsed["summary"].get("estimated_total_bytes").is_none(),
+            "null estimated_total_bytes should be omitted from JSON"
+        );
+        assert!(
+            parsed["operations"][0].get("is_full_send").is_none(),
+            "null is_full_send should be omitted from JSON"
+        );
     }
 
     // ── History tests ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Surfaces estimated send sizes in `urd plan` and `urd backup --dry-run` output using a three-tier fallback chain: same-drive history > cross-drive history > calibrated measurement
- Full sends show `~53.0GB`, incrementals show `last: ~5.5MB` — size annotations rendered by voice.rs from structured `estimated_bytes` field
- Summary line leads with sends and aggregate total: `6 sends (~623 GB total)` or qualified `estimated for 4 of 6` when partial
- Planner space check now uses cross-drive fallback (post-review fix: aligns space estimation with display estimates)

## Testing

- cargo clippy: pass (zero warnings)
- cargo test: 488 tests, all pass (+18 new)
- Integration tests: not applicable (presentation layer only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)