### PR TITLE
feat: sentinel chain-break detection + full-send gate (HSD-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Sentinel detects simultaneous chain breaks on a drive and notifies (hardware swap signal)
+- `FullSendReason` annotation on full sends: `first send`, `chain broken`, or `no pin`
+- Full-send gate in autonomous mode: chain-break sends are blocked unless `--force-full` is passed
+- Drive token verification wired into backup path (filters sends to token-mismatched drives)
+
 ## [0.4.1] - 2026-03-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-03-30
+
 ### Added
 - Sentinel detects simultaneous chain breaks on a drive and notifies (hardware swap signal)
 - `FullSendReason` annotation on full sends: `first send`, `chain broken`, or `no pin`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,12 +8,12 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-507 tests, all passing, clippy clean. Current version: v0.4.0.
+521 tests, all passing, clippy clean. Current version: v0.4.2.
 
 ## In Progress
 
-- **UX-3 complete, PR #44 open** (2026-03-30). Rich progress display during backup:
-  subvolume context, send counter, completion trail, ETA for full sends. Ready to merge.
+- **HSD-B complete, PR #45 open** (2026-03-30). Chain-break detection, full-send gate,
+  drive token verification wired into backup path. Reviewed, released as v0.4.2.
 
 ## Build Queue
 
@@ -23,17 +23,16 @@ full details, design decisions, and review findings.
 1. ~~**HSD-A**~~ — drive session tokens + chain health as awareness input. **Done.**
 2. ~~**VFM-A**~~ — `OperationalHealth` enum, two-axis CLI rendering. **Done.**
 3. ~~**Sentinel Session 3**~~ — hardening + notification deduplication. **Done.**
-4. ~~**UX-1**~~ — plan output: structural headings (D5) + collapsed skips (D1). **Done.**
-5. ~~**UX-2**~~ — plan output: estimated send sizes (D2+D3), cross-drive fallback (S1 fix). **Done.**
-6. ~~**UX-3**~~ — plan output: progress display: rich context (P1) + ETA (P3). **Done (PR #44).**
-7. **HSD-B** — sentinel chain-break detection + full-send gate (Norman escalation). **start here**
-   - Reference incident: `docs/98-journals/2026-03-29-clone-drive-incident-analysis.md`
-8. **VFM-B** — sentinel visual state in state file + health notifications.
+4. ~~**UX-1**~~ — plan output: structural headings + collapsed skips. **Done.**
+5. ~~**UX-2**~~ — plan output: estimated send sizes, cross-drive fallback. **Done.**
+6. ~~**UX-3**~~ — plan output: rich progress display + ETA. **Done.**
+7. ~~**HSD-B**~~ — sentinel chain-break detection + full-send gate. **Done (PR #45).**
+8. **VFM-B** — sentinel visual state in state file + health notifications. **Start here.**
 9. **Transient snapshots** — `local_retention = "transient"` for NVMe space pressure.
 10. **Tray icon (Spindle)** — reads sentinel-state.json, 4 static icons.
 
 Designs: `docs/95-ideas/2026-03-29-design-*.md`.
-Reviews: `docs/99-reports/2026-03-30-ux3-progress-display-review.md`.
+Reviews: `docs/99-reports/2026-03-30-hsd-b-chain-break-detection-review.md`.
 
 **Later:** Config system migration (ADR-111), shell completions (6a).
 
@@ -46,7 +45,7 @@ Reviews: `docs/99-reports/2026-03-30-ux3-progress-display-review.md`.
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Latest journals | `docs/98-journals/` (local only, gitignored) |
-| Latest reviews | [UX-3 review](../99-reports/2026-03-30-ux3-progress-display-review.md), [UX-2 review](../99-reports/2026-03-30-ux2-estimated-sizes-review.md) |
+| Latest reviews | [HSD-B review](../99-reports/2026-03-30-hsd-b-chain-break-detection-review.md), [UX-3 review](../99-reports/2026-03-30-ux3-progress-display-review.md) |
 
 ## Known Issues
 
@@ -60,5 +59,6 @@ Reviews: `docs/99-reports/2026-03-30-ux3-progress-display-review.md`.
 - `drive_connections` table has no retention policy (negligible for years at ~1000 rows/year)
 - `render_skipped_block` (backup summary) uses ad-hoc string grouping; could adopt `SkipCategory`
 - Progress completion line byte count lags true total by up to one poll interval (~45 MB at USB3 speeds)
+- `OpResult::Skipped` is overloaded: four distinct semantics (prior failure, optimization, safety guard, safety gate)
 
 See [roadmap.md](roadmap.md) for the full tech debt list and dropped features.

--- a/docs/99-reports/2026-03-30-hsd-b-chain-break-detection-review.md
+++ b/docs/99-reports/2026-03-30-hsd-b-chain-break-detection-review.md
@@ -1,0 +1,262 @@
+# Arch-Adversary Review: HSD-B Chain-Break Detection + Full-Send Gate
+
+**Project:** Urd
+**Date:** 2026-03-30
+**Scope:** Implementation review of HSD-B (13 files, +583/-31 lines, 14 new tests)
+**Base commit:** `bd0aa51` (v0.4.1), uncommitted changes on master
+**Reviewer:** arch-adversary
+
+---
+
+## Executive Summary
+
+HSD-B is well-structured work that adds three independent safety layers (sentinel
+detection, plan annotation, executor gate) with clean separation of concerns. The
+pure-function core in `sentinel.rs` is correct, well-tested, and structurally debounced
+without timer complexity. Two findings need attention before shipping: a gated
+chain-break send silently reports as success in heartbeat/metrics (significant — masks
+the condition it was designed to surface), and progress counters are computed before
+token filtering (moderate — cosmetic but confusing under the exact conditions where the
+user is already investigating a problem).
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — deleting snapshots that shouldn't be
+deleted, or sending data to a wrong/swapped drive.
+
+**Proximity of this change:** The full-send gate is a *defense* against the catastrophic
+mode, not a vector toward it. The gate errs on the side of caution (skip and notify
+rather than proceed). Token verification similarly blocks sends to suspicious drives.
+The closest this change gets to the catastrophic failure mode is through the **false
+negative** path: if `detect_simultaneous_chain_breaks` fails to fire, a swap goes
+undetected. The >= 2 threshold and mounted-drive filter are both correct design choices
+that could mask a swap only in the single-subvolume case, which is documented.
+
+**Distance:** 2+ bugs away from catastrophic failure. This is defensive code that
+*reduces* proximity to the failure mode.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | Gate logic is correct, but Skipped-as-success masks the gated condition downstream |
+| 2 | Security | 4 | Token verification is fail-open by design (ADR-107), threat model is documented |
+| 3 | Architectural Excellence | 5 | Pure functions with structural debounce, clean module boundaries, no new I/O in core |
+| 4 | Systems Design | 4 | INVOCATION_ID is a good systemd convention; progress counter ordering needs fixing |
+| 5 | Rust Idioms | 4 | Clean pattern matching, proper use of `#[must_use]`, strong types throughout |
+| 6 | Code Quality | 4 | Well-tested (14 new tests), good coverage of edge cases, clear naming |
+
+## Design Tensions
+
+### 1. Structural debounce vs. explicit timer — resolved correctly
+
+The design doc proposed debouncing chain-break notifications. The implementation
+realized that state-transition comparison is inherently debounced: once chains are
+broken, `last_chain_health` reflects the new state, so the next tick sees no transition.
+This eliminates an entire class of bugs (timer reset on restart, timer granularity
+choices, timer interaction with circuit breaker). The right call.
+
+### 2. Plan mutation vs. planner awareness for token filtering — resolved correctly
+
+Token verification filters the plan post-hoc rather than teaching the planner about
+tokens. This preserves the planner as a pure function (ADR-108) and keeps the token
+concept at the I/O boundary where it belongs. The trade-off: wasted computation in the
+planner for operations that will be filtered. This is negligible — plan construction is
+microseconds, not the bottleneck. The bigger issue is that progress counters are
+computed from the pre-filtered plan (see Finding 2).
+
+### 3. `INVOCATION_ID` coarseness vs. explicit `--autonomous` flag — acceptable trade-off
+
+Any systemd invocation (including `systemctl --user start urd-backup`) gets the gate.
+The journal's Finding 3 correctly identifies this. The trade-off favors safety: a user
+who manually triggers via systemd probably *doesn't* want to silently send gigabytes
+to a potentially-wrong drive. The escape hatch (`--force-full`) is discoverable from
+the skip message. This is the right default.
+
+### 4. `Skipped` as an OpResult vs. a dedicated gate result — needs resolution
+
+`OpResult::Skipped` is overloaded. It means "snapshot creation failed so send was
+skipped" (line 394), "space recovered, deletion skipped" (line 597), "snapshot is
+pinned" (line 623), and now "chain-break full send gated" (line 262). These have
+very different semantic meanings downstream. The gated send is the only case where
+skipping is *intentional safety behavior* rather than a consequence of a prior failure
+or an optimization. See Finding 1.
+
+## Findings
+
+### Finding 1 — Significant: Gated chain-break send reports as success
+
+**What:** When `FullSendPolicy::SkipAndNotify` gates a chain-break full send, the
+outcome is `OpResult::Skipped`. The executor only sets `subvol_success = false` on
+`OpResult::Failure` (line 300). So the subvolume reports `success: true`, which flows
+into `heartbeat.backup_success = Some(true)`, which means `compute_notifications()`
+never fires `BackupFailures` for this subvolume.
+
+**Consequence:** The user's monitoring shows the backup as successful. The heartbeat
+is not stale (it was just written). The notification for the anomaly comes from the
+sentinel (if running), but the backup path itself is silent about the gate. In the
+exact scenario HSD-B is designed for (drive swap, autonomous mode, sentinel not yet
+running), the gated send is invisible: no notification, no failure in metrics, no
+heartbeat staleness.
+
+**Suggested fix:** Either:
+- (a) Treat gated sends as `OpResult::Failure` with a distinctive error message. This
+  is the simplest fix and makes the gate visible in all downstream consumers.
+- (b) Add a dedicated `OpResult::Gated` variant that heartbeat/metrics can interpret
+  distinctly. More precise but wider blast radius.
+- (c) At minimum, emit a `BackupFailures` or a new `ChainBreakGated` notification
+  from the backup path in `commands/backup.rs` when any operations were gated.
+
+Option (a) is recommended — it's one line change (`subvol_success = false` branch to
+include `OpResult::Skipped` when the error contains "chain-break"), but option (c) is
+cleaner if you want Skipped to remain non-failure for other skip reasons.
+
+### Finding 2 — Moderate: Progress counter computed before token filtering
+
+**What:** `total_sends` is computed at line 125 (`backup_plan.summary().sends`),
+then token filtering removes operations at lines 167-174, but `total_sends` is
+not recalculated.
+
+**Consequence:** If a drive is token-filtered, the progress display shows e.g.
+"Send 2/4" and never reaches 4/4. This happens precisely when the user is already
+dealing with a suspicious drive situation — the confusing progress display compounds
+the confusion. The fix is mechanical: move `total_sends` computation after the token
+filtering block, or recompute it.
+
+**Suggested fix:** Move lines 125-126 (total_sends, size_estimates) to after line 177
+(end of token filtering).
+
+### Finding 3 — Moderate: Token verification and full-send gate are independent checks with no coordination
+
+**What:** Token verification (backup.rs:157-177) removes all sends to a mismatched
+drive. The full-send gate (executor.rs:251-268) skips chain-break full sends. These
+are independent: a drive can fail token verification AND have chain-break sends.
+
+**Consequence:** No incorrect behavior — token filtering runs first and removes the
+operations before the executor ever sees them. But the log messages don't coordinate:
+the user sees "skipping sends to this drive" (token) without context about whether
+those sends were also chain-break sends. In a real swap scenario, both signals fire
+independently. Consider logging the intersection: "Drive X: token mismatch AND
+chain breaks detected — strong swap signal."
+
+**Suggested fix:** This is enhancement territory, not a bug. Note for VFM-B when
+sentinel health signals are consolidated.
+
+### Finding 4 — Moderate: `DriveAnomaly.broken_count` reports total chains, not broken chains
+
+**What:** In `detect_simultaneous_chain_breaks()` (sentinel.rs:656), `broken_count`
+is set to `curr_total` (total chains on the drive in the current tick), not the count
+of chains that actually broke. Since the anomaly only fires when ALL chains break
+(0 intact), these are numerically equal. But the field name and the notification body
+say "broken_count" / "All {broken_count} chains broke" — the semantics are correct
+by coincidence, not by construction.
+
+**Consequence:** If the detection threshold is ever relaxed (e.g., fire when >50%
+break instead of all), `broken_count` would report total chains, not broken ones.
+Latent bug.
+
+**Suggested fix:** Rename to `total_chains` or compute as `curr_total - curr_intact`
+explicitly. Either makes the semantics self-documenting.
+
+### Finding 5 — Minor: `--force-full` applies globally, not per-subvolume
+
+**What:** The `--force-full` flag on `BackupArgs` sets `FullSendPolicy::Allow` for
+the entire executor. The skip message suggests `urd backup --force-full --subvolume X`,
+implying per-subvolume granularity, but `--force-full` forces all chain-break sends
+on all drives.
+
+**Consequence:** If subvolume A has a legitimate chain break (drive swap) and
+subvolume B has a legitimate chain break (pin file corruption), `--force-full` forces
+both. The user can't selectively approve. Acceptable for now — the `--subvolume` flag
+limits execution scope, so the combination works as documented.
+
+**Suggested fix:** No code change needed. The hint message is correct: `--subvolume`
+provides the scoping. Document this interaction in the man page or `--help` when it's
+written.
+
+### Finding 6 — Commendation: Structural debounce eliminates a class of bugs
+
+The insight that state-transition comparison is inherently debounced — once
+`last_chain_health` reflects broken chains, `detect_simultaneous_chain_breaks()`
+returns empty because `prev_intact` is 0 — is excellent. This eliminates timer state,
+restart edge cases, and the "debounce window too short/too long" tuning problem. The
+sentinel's event-driven architecture makes this natural: it's not suppressing repeated
+signals, it's correctly modeling state transitions. This is the kind of design decision
+that prevents future bugs.
+
+### Finding 7 — Commendation: FullSendReason piggybacks on existing planner state
+
+The reason determination (plan.rs:552-558) derives `FullSendReason` from state the
+planner already computed (`pin.is_some()`, `ext_snaps.is_empty()`). No new I/O, no new
+trait methods, no new filesystem queries. The type is simple (3 variants, no data), the
+Display impl is clean, and the plumbing through to the executor is mechanical. This is
+the right amount of machinery for the problem.
+
+### Finding 8 — Commendation: Token verification preserves planner purity
+
+The decision to filter the plan post-hoc in `backup.rs` rather than teaching the
+planner about tokens is architecturally clean. It keeps the planner as a pure function
+of config + filesystem state (ADR-108), keeps token concerns at the I/O boundary, and
+uses a simple `retain()` that's easy to audit. The fail-open self-healing path
+(drive has token, SQLite doesn't, store it) is the right call for a system that must
+never prevent backups (ADR-107).
+
+## The Simplicity Question
+
+**What's earning its keep:**
+- `FullSendReason` — 3-variant enum, no data, used for both display and gating. Minimal.
+- `ChainSnapshot` / `DriveAnomaly` — purpose-built types for a specific detection.
+  No over-engineering.
+- `FullSendPolicy` — 2-variant enum on the executor. Clean toggle.
+- Structural debounce — zero additional state, zero timers.
+
+**What could be simpler:**
+- The `DriveAnomaly` type in the design doc had a `detail: String` field. The
+  implementation dropped it (good — the notification builds its own body). The design
+  doc can be updated to match.
+- The notification construction in `sentinel_runner.rs:282-294` is inline rather than
+  a helper. At 13 lines it's fine, but if more anomaly types are added in VFM-B,
+  extract a builder. Not now.
+
+**Nothing needs removing.** The machinery is proportional to the problem.
+
+## For the Dev Team
+
+Priority order:
+
+1. **Fix gated-send-as-success (Finding 1).** In `commands/backup.rs`, after executor
+   returns, scan `result.subvolume_results` for operations with `OpResult::Skipped`
+   and error containing "chain-break". If any exist, emit a notification (new
+   `NotificationEvent::ChainBreakGated` variant or reuse `BackupFailures`). Also
+   consider whether those subvolumes should have `success: false`. File:
+   `src/executor.rs:299-301` and `src/commands/backup.rs` post-execution block.
+
+2. **Move progress counter after token filtering (Finding 2).** In
+   `src/commands/backup.rs`, move lines 125-126 to after line 177. Mechanical fix,
+   no test changes needed (progress display isn't unit-tested).
+
+3. **Rename `broken_count` to `total_chains` (Finding 4).** In `src/sentinel.rs`,
+   `DriveAnomaly` struct and all references. Update notification body in
+   `sentinel_runner.rs` to say "All {total_chains} chains" for clarity. Also update
+   tests.
+
+## Open Questions
+
+1. **Should the heartbeat include a "gated" state?** Currently gated sends are
+   invisible in the heartbeat. A `chain_break_gated: bool` field on
+   `SubvolumeHeartbeat` would make the state observable without changing the
+   success/failure semantics. Worth deciding before VFM-B adds health signals.
+
+2. **What happens when both drives are token-mismatched?** If both WD-18TB and
+   WD-18TB1 fail token verification, all sends are filtered. The executor runs
+   with no send operations — snapshot creation succeeds, heartbeat shows success,
+   but no data leaves the machine. This is correct (fail-open for backups means
+   "don't crash," not "send anyway"), but the user gets no signal except a log
+   warning. The sentinel's chain-break detection would catch this on the next
+   assessment cycle — but only if sentinel is running.
+
+3. **The `--force-full` flag's interaction with `--dry-run`.** If a user runs
+   `urd backup --dry-run` in a systemd context, chain-break sends appear as
+   "would skip" (because SkipAndNotify is set). But `--dry-run --force-full`
+   shows "would send." Is this the right UX for dry-run, or should dry-run always
+   show what *would* happen without the gate?

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,6 +98,11 @@ pub struct BackupArgs {
     /// Without this flag, retention is skipped for promise-level subvolumes (fail-closed).
     #[arg(long)]
     pub confirm_retention_change: bool,
+
+    /// Force full sends even when incremental chains are broken.
+    /// Without this flag, chain-break full sends are skipped in autonomous mode (systemd).
+    #[arg(long)]
+    pub force_full: bool,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -11,7 +11,7 @@ use crate::btrfs::RealBtrfs;
 use crate::cli::BackupArgs;
 use crate::config::Config;
 use crate::drives;
-use crate::executor::{ExecutionResult, Executor, OpResult, RunResult, SendType};
+use crate::executor::{ExecutionResult, Executor, FullSendPolicy, OpResult, RunResult, SendType};
 use crate::heartbeat;
 use crate::lock;
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
@@ -121,7 +121,48 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let bytes_counter = Arc::new(AtomicU64::new(0));
     let btrfs = RealBtrfs::new(&config.general.btrfs_path, bytes_counter.clone());
 
-    // Build progress context for rich display
+    let mut executor = Executor::new(&btrfs, state_db.as_ref(), &config, &shutdown);
+
+    // In autonomous mode (systemd), gate chain-break full sends unless --force-full.
+    if !args.force_full && std::env::var("INVOCATION_ID").is_ok() {
+        executor.set_full_send_policy(FullSendPolicy::SkipAndNotify);
+    }
+
+    // Verify drive tokens: collect mismatched drives, then filter in one pass.
+    if let Some(ref db) = state_db {
+        let mismatched: std::collections::BTreeSet<String> = config
+            .drives
+            .iter()
+            .filter(|d| drives::is_drive_mounted(d))
+            .filter_map(|drive| {
+                if let drives::DriveAvailability::TokenMismatch { expected, found } =
+                    drives::verify_drive_token(drive, db)
+                {
+                    log::warn!(
+                        "Drive {} has a token mismatch (expected {}, found {}) — \
+                         skipping sends to this drive",
+                        drive.label, expected, found,
+                    );
+                    Some(drive.label.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if !mismatched.is_empty() {
+            backup_plan.operations.retain(|op| {
+                !matches!(
+                    op,
+                    PlannedOperation::SendFull { drive_label, .. }
+                    | PlannedOperation::SendIncremental { drive_label, .. }
+                    if mismatched.contains(drive_label)
+                )
+            });
+        }
+    }
+
+    // Build progress context after token filtering so counters reflect actual work.
     let total_sends = backup_plan.summary().sends as u32;
     let size_estimates = build_size_estimates(&backup_plan, &fs_state);
     let progress_ctx = Arc::new(Mutex::new(ProgressContext {
@@ -146,7 +187,6 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         None
     };
 
-    let mut executor = Executor::new(&btrfs, state_db.as_ref(), &config, &shutdown);
     executor.set_progress(progress_ctx, size_estimates);
     let exec_start = Instant::now();
     let result = executor.execute(&backup_plan, mode);
@@ -877,7 +917,7 @@ mod tests {
         ExecutionResult, OpResult, OperationOutcome, RunResult, SendType, SubvolumeResult,
     };
     use crate::types::Interval;
-    use crate::types::PlannedOperation;
+    use crate::types::{FullSendReason, PlannedOperation};
     use std::path::PathBuf;
 
     fn make_outcome(
@@ -1451,6 +1491,7 @@ mod tests {
                     drive_label: "WD-18TB".to_string(),
                     subvolume_name: "sv1".to_string(),
                     pin_on_success: None,
+                    reason: FullSendReason::FirstSend,
                 },
                 PlannedOperation::SendIncremental {
                     parent: PathBuf::from("/snaps/sv2/20260328-0400-sv2"),
@@ -1507,6 +1548,7 @@ mod tests {
                 drive_label: "new-drive".to_string(),
                 subvolume_name: "sv1".to_string(),
                 pin_on_success: None,
+                reason: FullSendReason::FirstSend,
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
@@ -1532,6 +1574,7 @@ mod tests {
                 drive_label: "new-drive".to_string(),
                 subvolume_name: "sv1".to_string(),
                 pin_on_success: None,
+                reason: FullSendReason::FirstSend,
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
@@ -1567,6 +1610,7 @@ mod tests {
                 drive_label: "d1".to_string(),
                 subvolume_name: "sv1".to_string(),
                 pin_on_success: None,
+                reason: FullSendReason::FirstSend,
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -104,6 +104,7 @@ mod tests {
                 dummy_snap(subvol),
             )),
             subvolume_name: subvol.to_string(),
+            reason: crate::types::FullSendReason::FirstSend,
         }
     }
 
@@ -135,7 +136,7 @@ mod tests {
         assert_eq!(entry.is_full_send, Some(true));
         // Size is NOT in detail — voice.rs renders it from estimated_bytes.
         assert!(!entry.detail.contains('~'), "size should not be in detail");
-        assert!(entry.detail.contains("(full)"), "detail: {}", entry.detail);
+        assert!(entry.detail.contains("(full"), "detail: {}", entry.detail);
     }
 
     #[test]
@@ -185,7 +186,7 @@ mod tests {
         let fs = MockFileSystemState::new();
         let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
         assert_eq!(entry.estimated_bytes, None);
-        assert!(entry.detail.contains("(full)"), "detail: {}", entry.detail);
+        assert!(entry.detail.contains("(full"), "detail: {}", entry.detail);
         assert!(!entry.detail.contains('~'), "should not have size annotation");
     }
 
@@ -298,6 +299,7 @@ fn build_operation_entry(
             detail: format!("{} -> {}", source.display(), dest.display()),
             estimated_bytes: None,
             is_full_send: None,
+            full_send_reason: None,
         },
         PlannedOperation::SendIncremental {
             snapshot,
@@ -331,6 +333,7 @@ fn build_operation_entry(
                 ),
                 estimated_bytes,
                 is_full_send: Some(false),
+                full_send_reason: None,
             }
         }
         PlannedOperation::SendFull {
@@ -338,6 +341,7 @@ fn build_operation_entry(
             drive_label,
             pin_on_success,
             subvolume_name,
+            reason,
             ..
         } => {
             let snap_name = snapshot.file_name().unwrap_or_default().to_string_lossy();
@@ -356,9 +360,12 @@ fn build_operation_entry(
             PlanOperationEntry {
                 subvolume: subvolume_name.clone(),
                 operation: "send".to_string(),
-                detail: format!("{snap_name} -> {drive_label} (full){pin_suffix}"),
+                detail: format!(
+                    "{snap_name} -> {drive_label} (full \u{2014} {reason}){pin_suffix}"
+                ),
                 estimated_bytes,
                 is_full_send: Some(true),
+                full_send_reason: Some(reason.to_string()),
             }
         }
         PlannedOperation::DeleteSnapshot {
@@ -373,6 +380,7 @@ fn build_operation_entry(
                 detail: format!("{snap_name} ({reason})"),
                 estimated_bytes: None,
                 is_full_send: None,
+                full_send_reason: None,
             }
         }
     }

--- a/src/drives.rs
+++ b/src/drives.rs
@@ -27,11 +27,9 @@ pub enum DriveAvailability {
     /// NOTE: The drive session token is an identity signal, not a security
     /// control. A user who copies the token file to a different drive can
     /// defeat verification. Threat model: accidental hardware swaps.
-    #[allow(dead_code)] // constructed by verify_drive_token(); wired in HSD-B
     TokenMismatch { expected: String, found: String },
     /// Drive is mounted and UUID matches, but no token file exists on the drive.
     /// Normal for drives that have not completed their first Urd send.
-    #[allow(dead_code)] // constructed by verify_drive_token(); wired in HSD-B
     TokenMissing,
 }
 
@@ -290,7 +288,6 @@ pub fn generate_drive_token() -> String {
 /// - `TokenMissing` if no token file on drive (benign, sends proceed).
 /// - `TokenMismatch` if tokens differ (sends should be blocked).
 #[must_use]
-#[allow(dead_code)] // wired into sentinel_runner and commands/backup in HSD-B
 pub fn verify_drive_token(drive: &DriveConfig, state: &StateDb) -> DriveAvailability {
     let drive_token = match read_drive_token(drive) {
         Ok(Some(t)) => t,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -11,7 +11,7 @@ use crate::config::Config;
 use crate::drives;
 use crate::error::BtrfsOperation;
 use crate::state::{OperationRecord, StateDb};
-use crate::types::{BackupPlan, PlannedOperation};
+use crate::types::{BackupPlan, FullSendReason, PlannedOperation};
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -59,6 +59,15 @@ pub enum OpResult {
     Skipped,
 }
 
+/// Policy for handling chain-break full sends.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FullSendPolicy {
+    /// Proceed on all full sends regardless of reason (interactive default).
+    Allow,
+    /// Skip chain-break full sends and log a warning (autonomous/systemd default).
+    SkipAndNotify,
+}
+
 #[derive(Debug)]
 pub struct OperationOutcome {
     pub operation: String,
@@ -101,6 +110,7 @@ pub struct Executor<'a> {
     shutdown: &'a AtomicBool,
     progress_context: Option<Arc<Mutex<ProgressContext>>>,
     size_estimates: Option<SizeEstimates>,
+    full_send_policy: FullSendPolicy,
 }
 
 impl<'a> Executor<'a> {
@@ -118,7 +128,13 @@ impl<'a> Executor<'a> {
             shutdown,
             progress_context: None,
             size_estimates: None,
+            full_send_policy: FullSendPolicy::Allow,
         }
+    }
+
+    /// Set the full-send policy for chain-break gating.
+    pub fn set_full_send_policy(&mut self, policy: FullSendPolicy) {
+        self.full_send_policy = policy;
     }
 
     /// Set progress context for rich progress display.
@@ -228,24 +244,50 @@ impl<'a> Executor<'a> {
                     dest_dir,
                     drive_label,
                     pin_on_success,
+                    reason,
                     ..
                 } => {
-                    let (result, pin_failed) = self.execute_send(
-                        snapshot,
-                        None,
-                        dest_dir,
-                        drive_label,
-                        pin_on_success.as_ref(),
-                        &failed_creates,
-                        subvol_name,
-                    );
-                    if result.result == OpResult::Success {
-                        send_type = SendType::Full;
+                    // Gate chain-break full sends in autonomous mode.
+                    if *reason == FullSendReason::ChainBroken
+                        && self.full_send_policy == FullSendPolicy::SkipAndNotify
+                    {
+                        log::warn!(
+                            "Skipping chain-break full send for {} to {}: \
+                             use `urd backup --force-full` to override",
+                            subvol_name, drive_label,
+                        );
+                        OperationOutcome {
+                            operation: "send_full".to_string(),
+                            drive_label: Some(drive_label.clone()),
+                            result: OpResult::Failure,
+                            duration: std::time::Duration::ZERO,
+                            error: Some(format!(
+                                "chain-break full send gated — run \
+                                 `urd backup --force-full --subvolume {}` to proceed",
+                                subvol_name,
+                            )),
+                            bytes_transferred: None,
+                            btrfs_operation: None,
+                            btrfs_stderr: None,
+                        }
+                    } else {
+                        let (result, pin_failed) = self.execute_send(
+                            snapshot,
+                            None,
+                            dest_dir,
+                            drive_label,
+                            pin_on_success.as_ref(),
+                            &failed_creates,
+                            subvol_name,
+                        );
+                        if result.result == OpResult::Success {
+                            send_type = SendType::Full;
+                        }
+                        if pin_failed {
+                            pin_failures += 1;
+                        }
+                        result
                     }
-                    if pin_failed {
-                        pin_failures += 1;
-                    }
-                    result
                 }
                 PlannedOperation::DeleteSnapshot {
                     path,
@@ -971,6 +1013,7 @@ source = "/data/b"
                     drive_label: "TEST-DRIVE".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     pin_on_success: None,
+                    reason: FullSendReason::FirstSend,
                 },
             ],
             timestamp: ts,
@@ -1019,6 +1062,7 @@ source = "/data/b"
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
                 pin_on_success: Some((pin_path.clone(), snap_name)),
+                reason: FullSendReason::FirstSend,
             }],
             timestamp: ts,
             skipped: vec![],
@@ -1179,6 +1223,7 @@ source = "/data/b"
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
                 pin_on_success: None,
+                reason: FullSendReason::FirstSend,
             }],
             timestamp: ts,
             skipped: vec![],
@@ -1359,6 +1404,7 @@ source = "/data/b"
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
                 pin_on_success: Some((pin_path, snap_name)),
+                reason: FullSendReason::FirstSend,
             }],
             timestamp: ts,
             skipped: vec![],
@@ -1500,6 +1546,7 @@ source = "/data/b"
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
                 pin_on_success: None,
+                reason: FullSendReason::FirstSend,
             }],
             timestamp: ts,
             skipped: vec![],
@@ -1554,6 +1601,7 @@ source = "/data/b"
                     drive_label: "TEST-DRIVE".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     pin_on_success: None,
+                    reason: FullSendReason::FirstSend,
                 },
             ],
             timestamp: ts,
@@ -1600,6 +1648,7 @@ source = "/data/b"
                     drive_label: "TEST-DRIVE".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     pin_on_success: None,
+                    reason: FullSendReason::FirstSend,
                 },
             ],
             timestamp: ts,
@@ -1712,5 +1761,91 @@ source = "/data/sv1"
 
         // Should not panic for unknown drive label
         executor.maybe_write_drive_token("NONEXISTENT-DRIVE");
+    }
+
+    // ── Full-send gate tests ──────────────────────────────────────────
+
+    fn chain_broken_plan() -> BackupPlan {
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        BackupPlan {
+            operations: vec![PlannedOperation::SendFull {
+                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
+                drive_label: "TEST-DRIVE".to_string(),
+                subvolume_name: "sv-a".to_string(),
+                pin_on_success: None,
+                reason: FullSendReason::ChainBroken,
+            }],
+            timestamp: ts,
+            skipped: vec![],
+        }
+    }
+
+    #[test]
+    fn skip_and_notify_gates_chain_broken() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_full_send_policy(FullSendPolicy::SkipAndNotify);
+
+        let result = executor.execute(&chain_broken_plan(), "full");
+
+        assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Failure);
+        assert!(!result.subvolume_results[0].success, "subvolume should report failure");
+        assert_eq!(result.overall, RunResult::Failure);
+        assert!(mock.calls().is_empty(), "btrfs should not be called");
+        assert!(
+            result.subvolume_results[0].operations[0]
+                .error
+                .as_ref()
+                .unwrap()
+                .contains("chain-break full send gated"),
+            "error message should indicate gating"
+        );
+    }
+
+    #[test]
+    fn skip_and_notify_allows_first_send() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_full_send_policy(FullSendPolicy::SkipAndNotify);
+
+        let plan = simple_plan(); // uses FirstSend reason
+        let result = executor.execute(&plan, "full");
+
+        assert_eq!(result.overall, RunResult::Success);
+    }
+
+    #[test]
+    fn allow_proceeds_on_chain_broken() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+        // Default policy is Allow
+
+        let result = executor.execute(&chain_broken_plan(), "full");
+
+        assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Success);
+        assert!(!mock.calls().is_empty(), "btrfs should be called");
+    }
+
+    #[test]
+    fn force_full_overrides_skip_and_notify() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_full_send_policy(FullSendPolicy::Allow); // --force-full sets Allow
+
+        let result = executor.execute(&chain_broken_plan(), "full");
+
+        assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Success);
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -52,6 +52,12 @@ pub enum NotificationEvent {
         last_heartbeat_age_hours: u64,
         stale_after_hours: u64,
     },
+    /// All incremental chains on a drive broke simultaneously.
+    /// Strong signal for drive swap or mass pin file loss.
+    DriveAnomalyDetected {
+        drive_label: String,
+        total_chains: usize,
+    },
 }
 
 // ── Urgency ────────────────────────────────────────────────────────────

--- a/src/output.rs
+++ b/src/output.rs
@@ -370,6 +370,10 @@ pub struct PlanOperationEntry {
     /// Only set for send operations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_full_send: Option<bool>,
+    /// Why a full send was chosen (e.g., "first send", "chain broken", "no pin").
+    /// Only set for full send operations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub full_send_reason: Option<String>,
 }
 
 /// Summary counts for a backup plan.

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -9,7 +9,7 @@ use crate::config::{Config, DriveConfig, ResolvedSubvolume};
 use crate::drives::DriveAvailability;
 use crate::error::UrdError;
 use crate::retention;
-use crate::types::{BackupPlan, PlannedOperation, SnapshotName};
+use crate::types::{BackupPlan, FullSendReason, PlannedOperation, SnapshotName};
 
 // ── FileSystemState trait ───────────────────────────────────────────────
 
@@ -549,12 +549,21 @@ fn plan_external_send(
             pin_on_success: pin_info,
         });
     } else {
+        let reason = if pin.is_some() {
+            // Pin exists but parent not found on drive/locally → chain broke
+            FullSendReason::ChainBroken
+        } else if ext_snaps.is_empty() {
+            FullSendReason::FirstSend
+        } else {
+            FullSendReason::NoPinFile
+        };
         operations.push(PlannedOperation::SendFull {
             snapshot: snap_path,
             dest_dir: ext_dir,
             drive_label: drive.label.clone(),
             subvolume_name: subvol.name.clone(),
             pin_on_success: pin_info,
+            reason,
         });
     }
 }
@@ -1151,6 +1160,11 @@ priority = 2
             .filter(|op| matches!(op, PlannedOperation::SendFull { .. }))
             .collect();
         assert_eq!(sends.len(), 1);
+        // No pin file + no external snapshots → FirstSend
+        assert!(matches!(
+            sends[0],
+            PlannedOperation::SendFull { reason: FullSendReason::FirstSend, .. }
+        ));
     }
 
     #[test]
@@ -1179,6 +1193,11 @@ priority = 2
             .filter(|op| matches!(op, PlannedOperation::SendFull { .. }))
             .collect();
         assert_eq!(sends.len(), 1);
+        // Pin exists but parent missing on drive → ChainBroken
+        assert!(matches!(
+            sends[0],
+            PlannedOperation::SendFull { reason: FullSendReason::ChainBroken, .. }
+        ));
     }
 
     #[test]

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
-use crate::awareness::{PromiseStatus, SubvolAssessment};
+use crate::awareness::{ChainStatus, PromiseStatus, SubvolAssessment};
 
 // ── Events ──────────────────────────────────────────────────────────────
 
@@ -73,6 +73,9 @@ pub struct SentinelState {
     /// completes. The state machine doesn't set it — it's a pure function
     /// that doesn't know which assessment is "first."
     pub has_initial_assessment: bool,
+    /// Chain health per (subvolume, drive) from the last assessment.
+    /// Used by `detect_simultaneous_chain_breaks()` to compare across ticks.
+    pub last_chain_health: Vec<ChainSnapshot>,
     /// Circuit breaker state (active mode only, but tracked always).
     pub circuit_breaker: CircuitBreaker,
 }
@@ -93,6 +96,7 @@ impl SentinelState {
             mounted_drives: BTreeSet::new(),
             last_promise_states: Vec::new(),
             has_initial_assessment: false,
+            last_chain_health: Vec::new(),
             circuit_breaker: CircuitBreaker::new(circuit_breaker_config),
         }
     }
@@ -565,12 +569,110 @@ pub fn has_promise_changes(
     false
 }
 
+// ── Chain-break detection (HSD-B) ──────────────────────────────────────
+
+/// Chain health from a single assessment tick, for delta comparison.
+/// Built from `SubvolAssessment::chain_health` by `build_chain_snapshots()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChainSnapshot {
+    pub subvolume: String,
+    pub drive_label: String,
+    /// true = incremental chain intact (pin exists, parent found on drive).
+    pub chain_intact: bool,
+}
+
+/// A drive where all incremental chains broke simultaneously.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriveAnomaly {
+    pub drive_label: String,
+    /// Total number of chains on this drive (all of which broke).
+    pub total_chains: usize,
+}
+
+/// Extract chain snapshots from assessments for mounted drives only.
+///
+/// Pure function: reads `SubvolAssessment::chain_health` (populated by
+/// `awareness::assess()`) and filters to chains for drives in
+/// `mounted_drives`. Unmounted drives are excluded because chain health
+/// cannot be assessed without reading the drive's snapshots.
+#[must_use]
+pub fn build_chain_snapshots(
+    assessments: &[SubvolAssessment],
+    mounted_drives: &BTreeSet<String>,
+) -> Vec<ChainSnapshot> {
+    let mut snapshots = Vec::new();
+    for assessment in assessments {
+        for ch in &assessment.chain_health {
+            if mounted_drives.contains(&ch.drive_label) {
+                snapshots.push(ChainSnapshot {
+                    subvolume: assessment.name.clone(),
+                    drive_label: ch.drive_label.clone(),
+                    chain_intact: matches!(ch.status, ChainStatus::Intact { .. }),
+                });
+            }
+        }
+    }
+    snapshots
+}
+
+/// Detect drives where all incremental chains broke simultaneously.
+///
+/// Compares chain snapshots from two consecutive assessment ticks. Returns
+/// anomalies for drives where:
+/// - The previous tick had >= 2 intact chains on the drive, AND
+/// - The current tick has 0 intact chains on the drive.
+///
+/// The >= 2 threshold prevents false positives from single-subvolume drives
+/// (a single chain break is a normal operational event). This is the
+/// strongest heuristic signal for a drive swap or mass pin file loss.
+#[must_use]
+pub fn detect_simultaneous_chain_breaks(
+    previous: &[ChainSnapshot],
+    current: &[ChainSnapshot],
+) -> Vec<DriveAnomaly> {
+    use std::collections::BTreeMap;
+
+    // Count intact chains per drive in previous state
+    let mut prev_intact: BTreeMap<&str, usize> = BTreeMap::new();
+    for snap in previous {
+        if snap.chain_intact {
+            *prev_intact.entry(&snap.drive_label).or_insert(0) += 1;
+        }
+    }
+
+    // Count intact and total chains per drive in current state
+    let mut curr: BTreeMap<&str, (usize, usize)> = BTreeMap::new(); // (intact, total)
+    for snap in current {
+        let entry = curr.entry(&snap.drive_label).or_insert((0, 0));
+        entry.1 += 1;
+        if snap.chain_intact {
+            entry.0 += 1;
+        }
+    }
+
+    let mut anomalies = Vec::new();
+    for (drive, &prev_count) in &prev_intact {
+        let &(intact, total) = curr.get(drive).unwrap_or(&(0, 0));
+        // Drive had >= 2 intact chains before, and now has 0
+        if prev_count >= 2 && intact == 0 {
+            anomalies.push(DriveAnomaly {
+                drive_label: drive.to_string(),
+                total_chains: total,
+            });
+        }
+    }
+
+    anomalies
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::awareness::{DriveAssessment, LocalAssessment, OperationalHealth};
+    use crate::awareness::{
+        DriveAssessment, DriveChainHealth, LocalAssessment, OperationalHealth,
+    };
     use crate::types::Interval;
 
     fn dt(s: &str) -> NaiveDateTime {
@@ -1201,5 +1303,186 @@ mod tests {
         assert_eq!(snaps[0].status, PromiseStatus::Protected);
         assert_eq!(snaps[1].name, "sv2");
         assert_eq!(snaps[1].status, PromiseStatus::AtRisk);
+    }
+
+    // ── Chain snapshot + anomaly detection tests ───────────────────────
+
+    fn make_assessment_with_chains(
+        name: &str,
+        chains: Vec<(&str, bool)>,
+    ) -> SubvolAssessment {
+        let chain_health = chains
+            .into_iter()
+            .map(|(drive, intact)| DriveChainHealth {
+                drive_label: drive.to_string(),
+                status: if intact {
+                    ChainStatus::Intact {
+                        pin_parent: format!("20260329-1000-{name}"),
+                    }
+                } else {
+                    ChainStatus::Broken {
+                        reason: crate::awareness::ChainBreakReason::PinMissingOnDrive,
+                        pin_parent: Some(format!("20260329-1000-{name}")),
+                    }
+                },
+            })
+            .collect();
+        SubvolAssessment {
+            name: name.to_string(),
+            status: PromiseStatus::Protected,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
+            local: LocalAssessment {
+                status: PromiseStatus::Protected,
+                snapshot_count: 5,
+                newest_age: None,
+                configured_interval: Interval::hours(1),
+            },
+            external: vec![],
+            chain_health,
+            advisories: vec![],
+            errors: vec![],
+        }
+    }
+
+    #[test]
+    fn build_chain_snapshots_filters_mounted_drives() {
+        let mut mounted = BTreeSet::new();
+        mounted.insert("WD-18TB".to_string());
+        // WD-18TB1 is NOT mounted
+
+        let assessments = vec![make_assessment_with_chains(
+            "sv1",
+            vec![("WD-18TB", true), ("WD-18TB1", false)],
+        )];
+
+        let snaps = build_chain_snapshots(&assessments, &mounted);
+        assert_eq!(snaps.len(), 1);
+        assert_eq!(snaps[0].drive_label, "WD-18TB");
+        assert!(snaps[0].chain_intact);
+    }
+
+    #[test]
+    fn build_chain_snapshots_intact_and_broken() {
+        let mut mounted = BTreeSet::new();
+        mounted.insert("D1".to_string());
+
+        let assessments = vec![
+            make_assessment_with_chains("sv1", vec![("D1", true)]),
+            make_assessment_with_chains("sv2", vec![("D1", false)]),
+        ];
+
+        let snaps = build_chain_snapshots(&assessments, &mounted);
+        assert_eq!(snaps.len(), 2);
+        assert!(snaps[0].chain_intact);
+        assert!(!snaps[1].chain_intact);
+    }
+
+    #[test]
+    fn build_chain_snapshots_empty_assessments() {
+        let mounted = BTreeSet::new();
+        let snaps = build_chain_snapshots(&[], &mounted);
+        assert!(snaps.is_empty());
+    }
+
+    #[test]
+    fn build_chain_snapshots_no_mounted_drives() {
+        let mounted = BTreeSet::new();
+        let assessments = vec![make_assessment_with_chains("sv1", vec![("D1", true)])];
+        let snaps = build_chain_snapshots(&assessments, &mounted);
+        assert!(snaps.is_empty());
+    }
+
+    #[test]
+    fn detect_chain_breaks_all_intact_no_anomaly() {
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+        let curr = prev.clone();
+
+        assert!(detect_simultaneous_chain_breaks(&prev, &curr).is_empty());
+    }
+
+    #[test]
+    fn detect_chain_breaks_single_break_no_anomaly() {
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+        let curr = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: false },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+
+        assert!(detect_simultaneous_chain_breaks(&prev, &curr).is_empty());
+    }
+
+    #[test]
+    fn detect_chain_breaks_all_break_is_anomaly() {
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+        let curr = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: false },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: false },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: false },
+        ];
+
+        let anomalies = detect_simultaneous_chain_breaks(&prev, &curr);
+        assert_eq!(anomalies.len(), 1);
+        assert_eq!(anomalies[0].drive_label, "D1");
+        assert_eq!(anomalies[0].total_chains, 3);
+    }
+
+    #[test]
+    fn detect_chain_breaks_single_subvolume_no_anomaly() {
+        // Threshold is >= 2 intact chains previously — single subvolume can't trigger
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+        let curr = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: false },
+        ];
+
+        assert!(detect_simultaneous_chain_breaks(&prev, &curr).is_empty());
+    }
+
+    #[test]
+    fn detect_chain_breaks_new_drive_no_anomaly() {
+        // Drive not in previous state — no anomaly (first assessment)
+        let prev = vec![];
+        let curr = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: false },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: false },
+        ];
+
+        assert!(detect_simultaneous_chain_breaks(&prev, &curr).is_empty());
+    }
+
+    #[test]
+    fn detect_chain_breaks_multiple_drives_independent() {
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D2".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D2".into(), chain_intact: true },
+        ];
+        let curr = vec![
+            // D1: all broken
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: false },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: false },
+            // D2: still intact
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D2".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D2".into(), chain_intact: true },
+        ];
+
+        let anomalies = detect_simultaneous_chain_breaks(&prev, &curr);
+        assert_eq!(anomalies.len(), 1);
+        assert_eq!(anomalies[0].drive_label, "D1");
     }
 }

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -261,6 +261,42 @@ impl SentinelRunner {
             self.last_overdue_notified = Some(Instant::now());
         }
 
+        // 3. Simultaneous chain-break detection (HSD-B).
+        //    Only after initial assessment (same suppression as promise changes).
+        //    Debounce is structural: anomalies only fire on state transition
+        //    (previous had intact chains, current doesn't). Persistent broken
+        //    state produces no further notifications.
+        if self.state.has_initial_assessment {
+            let current_chains =
+                sentinel::build_chain_snapshots(&assessments, &self.state.mounted_drives);
+            let anomalies = sentinel::detect_simultaneous_chain_breaks(
+                &self.state.last_chain_health,
+                &current_chains,
+            );
+            for anomaly in &anomalies {
+                log::warn!(
+                    "Drive anomaly: all {} chains broke on {} simultaneously",
+                    anomaly.total_chains,
+                    anomaly.drive_label,
+                );
+                notifications.push(Notification {
+                    event: NotificationEvent::DriveAnomalyDetected {
+                        drive_label: anomaly.drive_label.clone(),
+                        total_chains: anomaly.total_chains,
+                    },
+                    urgency: Urgency::Warning,
+                    title: format!("Drive anomaly on {}", anomaly.drive_label),
+                    body: format!(
+                        "All {} incremental chains on {} broke simultaneously. \
+                         The drive may have been swapped or cloned. \
+                         Run `urd status` to inspect chain health.",
+                        anomaly.total_chains, anomaly.drive_label,
+                    ),
+                });
+            }
+            self.state.last_chain_health = current_chains;
+        }
+
         if !notifications.is_empty() {
             notify::dispatch(&notifications, &self.config.notifications);
         }
@@ -269,6 +305,9 @@ impl SentinelRunner {
         self.state.last_promise_states = sentinel::snapshot_promises(&assessments);
         if !self.state.has_initial_assessment {
             self.state.has_initial_assessment = true;
+            // Populate chain health baseline so the next tick can detect transitions.
+            self.state.last_chain_health =
+                sentinel::build_chain_snapshots(&assessments, &self.state.mounted_drives);
             if self.heartbeat_path.exists() {
                 log::info!(
                     "Initial assessment complete: {} subvolumes evaluated",

--- a/src/state.rs
+++ b/src/state.rs
@@ -515,7 +515,6 @@ impl StateDb {
 
     /// Look up a stored drive session token by drive label.
     /// Returns None if no token is stored for this drive.
-    #[allow(dead_code)] // used by verify_drive_token(); wired in HSD-B
     pub fn get_drive_token(&self, label: &str) -> crate::error::Result<Option<String>> {
         let mut stmt = self
             .conn
@@ -534,7 +533,6 @@ impl StateDb {
     }
 
     /// Update the last_verified timestamp for a drive token.
-    #[allow(dead_code)] // used by verify_drive_token(); wired in HSD-B
     pub fn touch_drive_token(&self, label: &str, now: &str) -> crate::error::Result<()> {
         self.conn
             .execute(

--- a/src/types.rs
+++ b/src/types.rs
@@ -501,6 +501,28 @@ pub struct ResolvedGraduatedRetention {
 
 // ── PlannedOperation ────────────────────────────────────────────────────
 
+/// Why a full send was planned instead of an incremental send.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FullSendReason {
+    /// First send to this drive for this subvolume (no external snapshots). Normal.
+    FirstSend,
+    /// Pin file exists but the parent snapshot is missing on the drive.
+    /// The chain broke — this is a red flag that warrants attention.
+    ChainBroken,
+    /// Pin file doesn't exist. Could be first send or pin was lost.
+    NoPinFile,
+}
+
+impl fmt::Display for FullSendReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FirstSend => write!(f, "first send"),
+            Self::ChainBroken => write!(f, "chain broken"),
+            Self::NoPinFile => write!(f, "no pin"),
+        }
+    }
+}
+
 /// An operation the backup planner has decided to perform.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlannedOperation {
@@ -525,6 +547,8 @@ pub enum PlannedOperation {
         subvolume_name: String,
         /// Pin file to write on successful send: (pin_file_path, snapshot_name_to_write)
         pin_on_success: Option<(PathBuf, SnapshotName)>,
+        /// Why this is a full send instead of incremental.
+        reason: FullSendReason,
     },
     DeleteSnapshot {
         path: PathBuf,
@@ -563,6 +587,7 @@ impl fmt::Display for PlannedOperation {
                 snapshot,
                 drive_label,
                 pin_on_success,
+                reason,
                 ..
             } => {
                 let pin_suffix = if pin_on_success.is_some() {
@@ -572,7 +597,7 @@ impl fmt::Display for PlannedOperation {
                 };
                 write!(
                     f,
-                    "SEND    {} -> {} (full){pin_suffix}",
+                    "SEND    {} -> {} (full \u{2014} {reason}){pin_suffix}",
                     snapshot.display(),
                     drive_label
                 )

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -2105,6 +2105,7 @@ mod tests {
                     detail: "/home -> /snapshots/htpc-home/20260326-0400-home".to_string(),
                     estimated_bytes: None,
                     is_full_send: None,
+                    full_send_reason: None,
                 },
                 PlanOperationEntry {
                     subvolume: "htpc-home".to_string(),
@@ -2112,6 +2113,7 @@ mod tests {
                     detail: "20260326-0400-home -> WD-18TB (incremental, parent: 20260325-0400-home) + pin".to_string(),
                     estimated_bytes: None,
                     is_full_send: None,
+                    full_send_reason: None,
                 },
             ],
             skipped: vec![],
@@ -2161,6 +2163,7 @@ mod tests {
                 detail: "20260329-0404-htpc-home -> WD-18TB (full) + pin".to_string(),
                 estimated_bytes: None,
                 is_full_send: None,
+                full_send_reason: None,
             }],
             skipped: vec![SkippedSubvolume {
                 name: "htpc-docs".to_string(),
@@ -2505,6 +2508,7 @@ mod tests {
                     detail: "snap -> WD-18TB (full)".to_string(),
                     estimated_bytes: Some(53_000_000_000),
                     is_full_send: Some(true),
+                    full_send_reason: None,
                 },
                 PlanOperationEntry {
                     subvolume: "htpc-docs".to_string(),
@@ -2512,6 +2516,7 @@ mod tests {
                     detail: "snap -> WD-18TB (full)".to_string(),
                     estimated_bytes: Some(1_200_000_000),
                     is_full_send: Some(true),
+                    full_send_reason: None,
                 },
             ],
             skipped: vec![],
@@ -2546,6 +2551,7 @@ mod tests {
                 detail: "snap -> WD-18TB (incremental, parent: prev)".to_string(),
                 estimated_bytes: Some(5_500_000),
                 is_full_send: Some(false),
+                full_send_reason: None,
             }],
             skipped: vec![],
             summary: PlanSummaryOutput {
@@ -2575,6 +2581,7 @@ mod tests {
                     detail: "snap -> WD-18TB (full)".to_string(),
                     estimated_bytes: Some(53_000_000_000),
                     is_full_send: Some(true),
+                    full_send_reason: None,
                 },
                 PlanOperationEntry {
                     subvolume: "htpc-docs".to_string(),
@@ -2582,6 +2589,7 @@ mod tests {
                     detail: "snap -> WD-18TB (full)".to_string(),
                     estimated_bytes: None,
                     is_full_send: Some(true),
+                    full_send_reason: None,
                 },
             ],
             skipped: vec![],
@@ -2611,6 +2619,7 @@ mod tests {
                 detail: "snap -> WD-18TB (full)".to_string(),
                 estimated_bytes: None,
                 is_full_send: None,
+                full_send_reason: None,
             }],
             skipped: vec![],
             summary: PlanSummaryOutput {
@@ -2642,6 +2651,7 @@ mod tests {
                 detail: "snap -> WD-18TB (full)".to_string(),
                 estimated_bytes: Some(53_000_000_000),
                 is_full_send: Some(true),
+                full_send_reason: None,
             }],
             skipped: vec![],
             summary: PlanSummaryOutput {
@@ -2674,6 +2684,7 @@ mod tests {
                 detail: "snap -> WD-18TB (full)".to_string(),
                 estimated_bytes: None,
                 is_full_send: None,
+                full_send_reason: None,
             }],
             skipped: vec![],
             summary: PlanSummaryOutput {


### PR DESCRIPTION
## Summary

- **Sentinel chain-break detection:** pure functions detect when all incremental chains on a drive break simultaneously — strongest heuristic for a hardware swap. Structural debounce via state-transition comparison (no timers).
- **FullSendReason annotation:** planner tags full sends with reason (FirstSend / ChainBroken / NoPinFile). Plan display and JSON output surface the reason.
- **Full-send gate:** autonomous mode (systemd) blocks chain-break full sends as `Failure` unless `--force-full` is passed. Visible in heartbeat, metrics, and notifications.
- **Drive token verification:** `verify_drive_token()` wired into backup path. Token-mismatched drives have sends filtered in a single pass. Fail-open per ADR-107.

Post-review fixes from arch-adversary + simplify passes: gated sends report as Failure (not Skipped), progress counters after token filtering, `broken_count` → `total_chains`, mount guard on token verification, single-pass retain.

Design: `docs/95-ideas/2026-03-28-design-hardware-swap-defenses.md` (Session B)
Review: `docs/99-reports/2026-03-30-hsd-b-chain-break-detection-review.md`

## Testing

- cargo clippy: pass (warnings as errors)
- cargo test: 521 tests, all passing
- cargo build --release: pass
- Integration tests: not applicable (no drive-dependent changes to test paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)