### PR TITLE
docs: workflow refinements, /grill-me command, and lessons compilation

### DIFF
--- a/.claude/commands/grill-me.md
+++ b/.claude/commands/grill-me.md
@@ -1,0 +1,32 @@
+Interview me relentlessly about every aspect of this plan or design until we reach shared understanding.
+
+Walk down each branch of the decision tree, resolving dependencies between decisions one by one. Earlier decisions constrain later ones — resolve upstream branches before opening downstream ones.
+
+## Rules
+
+1. **One question at a time.** Do not batch questions. Each answer may change what you ask next.
+
+2. **Provide your recommended answer.** For each question, state what you think the answer should be and why — grounded in CLAUDE.md's architectural invariants, the module responsibility table, and the current state in status.md. The user can accept, reject, or refine.
+
+3. **Check the codebase before asking.** If a question can be answered by reading code, reading docs, or checking existing patterns — do that instead of asking. Only ask the user about decisions that require judgment, not facts that are already recorded.
+
+4. **Track resolved branches.** Maintain a running summary of resolved decisions so we can see the tree take shape. When a branch is resolved, name it and move on.
+
+5. **Stop when the tree is resolved.** When all branches that matter for the next step (implementation or design doc) are resolved, summarize the full decision tree and identify the output artifact — whether that's a `/design` doc, an update to an existing plan, or direct implementation.
+
+## What to probe
+
+- Assumptions the plan makes about existing code (verify them)
+- Module boundaries — does this respect CLAUDE.md's responsibility table?
+- ADR gates — does this need a new ADR or touch an existing contract?
+- Error modes — what happens when this fails at 3am unattended?
+- Sequencing — does the order of implementation matter? What depends on what?
+- Scope — what's in, what's explicitly out, and is the boundary clean?
+
+## Output
+
+The interview itself is the output. The resolved decision tree becomes input to whatever comes next in the pipeline — typically `/design` (if the idea is still forming) or direct implementation (if the design is already written and we're stress-testing it).
+
+## Arguments
+
+$ARGUMENTS — The plan, design, or idea to grill. Can be a reference to a doc in docs/95-ideas/, a feature name from status.md, or a free-form description of what you're considering.

--- a/.claude/commands/journal.md
+++ b/.claude/commands/journal.md
@@ -42,6 +42,13 @@ if nothing is open.}
   "Added `translate_btrfs_error()` covering 7 btrfs stderr patterns" is useful.
 - Journals are private — real paths, real output, real mistakes are fine
 - Don't duplicate the commit message. The journal captures context the commit doesn't.
+- **Forward-looking handoff is encouraged** — "When you return" sections with verification
+  steps, things to watch for, and context the next session needs are high-value. This is a
+  core function of the journal.
+- **Exception: git workflow state.** Don't write "PR #45 is open" or "merge branch X" as
+  pending actions — these decay within minutes. Record PRs as deliverables ("Opened PR #45
+  for HSD-B"), not as tasks. A fresh session checks `git log`, `gh pr list`, and
+  `git branch` for actual git state.
 
 ## Output 2: Update status.md
 
@@ -61,6 +68,9 @@ document (~50 lines) that a fresh session reads first.
 - Update test count, version, and "In Progress" to reflect this session's outcomes
 - "Next Up" should reflect what the user would likely work on in the next session
 - Use PII placeholders for any tracked paths (status.md is tracked, not gitignored)
+- **Git state is checked, not recorded.** Write "HSD-B complete" not "PR #45 open."
+  Status.md tells the next session *what was built and what to build next*. The session
+  checks `git log`, `gh pr list`, `git branch` for actual branch/PR state.
 
 ## Arguments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ safer? (2) does it reduce the attention the user needs to spend on backups? If a
 adds complexity the user must manage, it needs a very strong justification.
 
 **Two modes of existence:**
-- **The invisible worker.** Runs autonomously via systemd timer (nightly at ~04:00).
-  Silence means data is safe. Future: Sentinel daemon for sub-hourly cadence.
+- **The invisible worker.** Runs autonomously via systemd timer (nightly at ~04:00) and
+  Sentinel daemon (sub-hourly monitoring, drive detection, backup overdue alerts).
+  Silence means data is safe.
 - **The invoked norn.** `urd status`, `urd get`, `urd restore` — the user is consulting Urd.
   Speaks with authority and clarity. Surfaces problems only when they matter.
 
@@ -86,22 +87,11 @@ Each references an ADR in `docs/00-foundation/decisions/` with full rationale.
 9. **Backward compatibility contracts are sacred.** Snapshot names, pin files, Prometheus metrics — on-disk data format changes require an ADR with migration plan. Config schema changes use `urd migrate`. (ADR-105, ADR-111)
 10. **Named protection levels are opaque or they don't exist.** No per-field overrides on named levels. Custom is first-class. Named levels must earn opaque status through operational track record. (ADR-110, ADR-111)
 
-### Config System (ADR-111 — target architecture, not yet implemented)
+### Config System (ADR-111)
 
-The config system is undergoing a redesign. Key principles:
-
-- **Config files are complete, self-describing artifacts.** Each subvolume block is readable
-  in isolation. No hidden inheritance, no cross-section joins.
-- **Two modes: named level or custom.** Named levels derive all operational parameters
-  (opaque, no overrides). Custom subvolumes specify all parameters explicitly.
-- **Templates scaffold; they don't govern.** One-time generation at setup, not runtime inheritance.
-- **`[defaults]` section is being removed.** Hardcoded fallbacks in the binary for omitted fields.
-- **Explicit drive routing.** Every subvolume names its target drives. No implicit "all drives."
-- **Space constraints are a filesystem concern.** `[[space_constraints]]` section on paths.
-- **One schema version at a time.** `config_version` field, `urd migrate` for transitions.
-
-Current implementation still uses the legacy schema (`[defaults]`, `[local_snapshots]`).
-See ADR-111 implementation gates for the migration checklist.
+Current implementation uses the legacy schema (`[defaults]`, `[local_snapshots]`). ADR-111
+defines the target architecture: explicit drive routing, no inheritance, named levels are
+opaque, templates scaffold rather than govern. See ADR-111 for full design and migration gates.
 
 ### Error Handling
 
@@ -121,8 +111,9 @@ See ADR-111 implementation gates for the migration checklist.
   Fewer errors, not better errors.
 - **Precision in config, voice in presentation.** Config layer is mechanical and explicit.
   Mythic voice belongs entirely in `voice.rs` and notifications.
-- **The Sentinel is the integration layer.** Event-driven state machine (future) that
-  reacts to events, updates promise states, and drives notifications.
+- **The Sentinel is the integration layer.** Event-driven state machine that reacts to
+  drive events, updates promise states, and drives notifications. Deployed as a systemd
+  user service.
 
 ## Coding Conventions
 
@@ -134,6 +125,8 @@ See ADR-111 implementation gates for the migration checklist.
 - Derive `Debug` on all types; `Clone`, `PartialEq`, `Eq` where sensible
 - No `unsafe` — no need for it in this project
 - No `unwrap()` / `expect()` in library code — only in tests and `main.rs`
+- Fallback values must be *safe*, not just *convenient*. `unwrap_or(0)` is wrong when 0 is in-range but semantically meaningless (e.g., bytes transferred, age in days). Use `Option` to represent absence.
+- Daemon code (sentinel): lifecycle events use `warn!()` to be visible at default log levels
 - Doc filenames: lowercase kebab-case (exceptions: CLAUDE.md, README.md, CONTRIBUTING.md)
 
 ## Testing
@@ -141,8 +134,10 @@ See ADR-111 implementation gates for the migration checklist.
 - Unit tests: `#[cfg(test)] mod tests` in same file. Run: `cargo test`
 - Integration tests: `tests/integration/`, `#[ignore]` by default. Run: `cargo test -- --ignored`
 - Use `MockBtrfs` and `MockFileSystemState` for anything that would call btrfs or read filesystem
+- Code using path-constructing functions (`external_snapshot_dir()`, `local_snapshot_dir()`) should also have `tempfile::TempDir` tests — mocks are blind to filesystem preconditions like missing parent directories
 - Test retention logic exhaustively — it protects against data loss
-- 389+ tests, all passing, clippy clean
+- When building features, use vertical slicing: write one test, implement to pass, repeat. Never write all tests first then all implementation.
+- 521+ tests, all passing, clippy clean
 
 ## Backward Compatibility (ADR-105)
 
@@ -199,7 +194,7 @@ stringified — prevents shell injection and preserves non-UTF-8 paths.
 ```bash
 cargo build                          # Debug
 cargo build --release                # Release
-cargo test                           # Unit tests (389+ tests)
+cargo test                           # Unit tests (521+ tests)
 cargo test -- --ignored              # Integration tests (needs drives)
 cargo clippy -- -D warnings          # Lint (all warnings are errors)
 cargo run -- plan                    # Preview backup plan
@@ -238,13 +233,14 @@ cargo run -- get FILE --at DATE      # Restore file from snapshot
 Guideline, not rigid procedure. Skip steps that don't apply to the current work.
 
 ```
-/brainstorm → /design → [build] → /simplify → arch-adversary → /post-review → /check → /journal → /commit-push-pr
+/brainstorm → /design → /grill-me → [build] → /simplify → arch-adversary → /post-review → /check → /journal → /commit-push-pr
 ```
 
 | Tool | Phase | What it does |
 |------|-------|--------------|
 | `/brainstorm` | Ideation | Divergent thinking, no scoring. Output: `docs/95-ideas/` |
 | `/design` | Design | Module decomposition, ADR gate identification |
+| `/grill-me` | Stress-test | Socratic interview, resolve decision tree branches |
 | `/simplify` | Post-build | Simplification pass: abstractions, types, control flow |
 | `arch-adversary` | Review | Severity-ranked findings with catastrophic failure checklist |
 | `/post-review` | Rework | Systematic fix of review findings, structured disagreement |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,10 +123,12 @@ follow links to roadmap.md for the full picture.
 **97-plans** — Implementation plans. Each plan is a dated snapshot of intent — what we're
 going to build and how. When scope changes significantly, write a new plan.
 
-**98-journals** — Session logs capturing the development journey (gitignored — local only).
-Write freely here: real command output, real paths, real mistakes. This is your private
-working memory. Distill key learnings into tracked docs (status.md, ADRs) so the public
-record stays useful without exposing personal details.
+**98-journals** — Session logs and handoff documents (gitignored — local only). Each
+journal serves two functions: (1) historical record of what was done and learned, and
+(2) handoff to the next session — verification steps, things to watch for, context that
+git history alone can't provide. Write freely: real command output, real paths, real
+mistakes. Distill key learnings into tracked docs (status.md, ADRs) so the public record
+stays useful without exposing personal details.
 
 **99-reports** — Analysis and review output. Arch-adversary reviews, automated reports,
 progress assessments. Each report is tied to a specific point in time and scope.
@@ -226,6 +228,15 @@ type should have. Add sections as needed.
 ## What was done
 
 ## What was learned
+
+## When you return
+
+{Verification steps, things to check, context the next session needs to pick up
+efficiently. This is the handoff — what would you tell the next session before it
+reads the code? Do NOT include git workflow state (PR open/closed, branch needs
+merging) — the next session checks git directly. DO include: operational checks
+(did the timer run?), things to verify about the work, context that git can't provide.
+Remove this section if nothing needs handoff.}
 
 ## Open questions
 ```
@@ -330,9 +341,10 @@ The adversary review reviews the proposal before implementation begins.
 
 ### Before starting new work
 
-1. Read `96-project-supervisor/status.md` for current state
-2. Follow links to relevant plans, recent journals, and open issues
-3. Check `95-ideas/` if exploring options for what to build next
+1. Read `96-project-supervisor/status.md` for current state and what to build next
+2. Read the most recent journal in `98-journals/` — especially "When you return"
+3. Check actual git state: `git log --oneline -5`, `gh pr list`, `git branch`
+4. Follow links to relevant plans, reports, and ideas as needed
 
 ### When you have a rough idea
 

--- a/docs/96-project-supervisor/2026-03-30-lessons.md
+++ b/docs/96-project-supervisor/2026-03-30-lessons.md
@@ -1,0 +1,274 @@
+# Lessons Learned: Urd Development (2026-03-22 to 2026-03-30)
+
+> **TL;DR:** Compiled from 52 journal entries across 9 days of development. Lessons cluster
+> around five themes: safety-critical design patterns, the value of pre-implementation review,
+> pure-function architecture benefits, operational reality vs. test assumptions, and workflow
+> discipline. The most consequential lesson: code that works after the first successful run
+> but fails on bootstrap is the dominant bug class.
+
+**Date:** 2026-03-30
+**Source:** `docs/98-journals/2026-03-22-*` through `docs/98-journals/2026-03-30-*`
+
+---
+
+## 1. Safety-Critical Design Patterns
+
+### 1.1 A safety mechanism that doesn't gate creation is not a safety mechanism
+The `min_free_bytes` config field existed, was set, and was wired in — but to the wrong
+function. It accelerated cleanup without preventing the snapshot that fills the filesystem.
+**Corollary to ADR-107:** "fail open" does not mean "let a backup operation compromise the
+system it runs on."
+*Source: [local-space-exhaustion-postmortem](../98-journals/2026-03-24-local-space-exhaustion-postmortem.md)*
+
+### 1.2 `unwrap_or(0)` is a smell in estimation code
+Two bugs (calibrate storing 0 bytes, calibration_age_days returning 0) shared the same
+root cause: 0 is within the valid range of the type but outside the valid range of the
+domain. When writing fallback values, ask "is this default *safe* or just *convenient*?"
+*Source: [post-implementation-review-fixes](../98-journals/2026-03-23-post-implementation-review-fixes.md)*
+
+### 1.3 Retention and send scheduling are coupled
+Retention can destroy the precondition for incremental sends. The planner checks at plan
+time, but retention runs independently. Pre-flight validation should catch
+retention/send-interval incompatibility.
+*Source: [operational-evaluation](../98-journals/2026-03-26-operational-evaluation.md)*
+
+### 1.4 When adding a new semantic to an existing enum variant, trace every downstream consumer
+`OpResult::Skipped` means four different things: prior failure, optimization, safety guard,
+and safety gate. The fourth (chain break blocking a send) is a genuine failure, but
+downstream consumers (heartbeat, notifications) treat all `Skipped` as non-failures.
+*Source: [hsd-b-review-and-release](../98-journals/2026-03-30-hsd-b-review-and-release.md)*
+
+### 1.5 Pinned snapshot deletion has three independent layers for a reason
+Unsent protection in planner, exclusion in retention, re-check in executor. Each layer
+catches what the previous might miss. The defense-in-depth is not redundancy — it's
+protection against different failure modes at different stages.
+*Source: [CLAUDE.md ADR-106, validated across multiple reviews]*
+
+### 1.6 Space guards prevented catastrophe in production
+After a drive swap, `urd plan` correctly blocked two full sends that would have exceeded
+available space (4.1TB estimated, 1.1TB available). Without these guards, the nightly run
+would have triggered the same ENOSPC failure from Urd's history.
+*Source: [sentinel-hardware-swap-test](../98-journals/2026-03-28-sentinel-hardware-swap-test.md)*
+
+---
+
+## 2. The Bootstrap Bug Class
+
+### 2.1 Code that works after first successful run but fails on bootstrap is the dominant bug class
+Two bugs shared the same root cause: assuming per-subvolume directories exist on external
+drives before the first send. The executor assumed it for `btrfs receive` (mkdir fix), the
+planner assumed it for `statvfs` (mount path fix). Both were invisible in tests because
+mocks don't model real filesystem presence.
+*Source: [pre-cutover-hardening](../98-journals/2026-03-24-pre-cutover-hardening.md)*
+
+### 2.2 `btrfs receive` does not create parent directories
+Every first-send to a new drive, or first-send of a new subvolume to any drive, would have
+failed without the mkdir fix. The bash script apparently handled this (or the directories
+were created manually at some point).
+*Source: [pre-cutover-hardening](../98-journals/2026-03-24-pre-cutover-hardening.md)*
+
+### 2.3 Tests using fake paths won't exercise filesystem preconditions
+MockBtrfs is excellent for testing logic but blind to filesystem assumptions. The
+`tempfile::TempDir` approach is the right pattern for testing code that touches the
+real filesystem. Any code using `external_snapshot_dir()` or `local_snapshot_dir()`
+should have filesystem tests.
+*Source: [pre-cutover-hardening](../98-journals/2026-03-24-pre-cutover-hardening.md)*
+
+### 2.4 Chain health baseline must be set on first assessment
+Without populating `last_chain_health` during the first assessment, the second assessment
+compares against an empty vector and never detects anomalies. Bootstrap state matters.
+*Source: [hsd-b-chain-break-detection](../98-journals/2026-03-30-hsd-b-chain-break-detection.md)*
+
+---
+
+## 3. Pre-Implementation Review Value
+
+### 3.1 Design-review-before-implementation is the highest-ROI practice
+Across all features, the pre-implementation design review caught the most impactful bugs:
+clock skew in awareness model, mkdir precondition in executor, legacy pin false positives.
+Estimated cost: 4-6 hours per feature. Payoff: 2-4 hours of rework prevented plus bugs
+that would have shipped.
+*Source: [development-cycle-skills](../98-journals/2026-03-24-development-cycle-skills.md)*
+
+### 3.2 The two-review pattern works: design review catches policy, implementation review catches bugs
+The design review caught policy-level issues (multiplier asymmetry, drive aggregation
+semantics). The implementation review caught code-level bugs the design couldn't predict
+(clock skew, progress timer reuse). Different phases, different findings.
+*Source: [awareness-model](../98-journals/2026-03-23-awareness-model.md), [uuid-drive-fingerprinting](../98-journals/2026-03-24-uuid-drive-fingerprinting.md)*
+
+### 3.3 The adversary review found what manual review didn't
+The progress timer bug only manifests during multi-subvolume runs — exactly the production
+case. The code looked correct for single-subvolume testing. Systematic stress-testing
+("what happens on the 2nd+ send?") caught what unit tests missed.
+*Source: [post-implementation-review-fixes](../98-journals/2026-03-23-post-implementation-review-fixes.md)*
+
+### 3.4 Reviews should trace actual code flow, not infer from design doc placement
+The UX-3 review's S2 finding was wrong — the reviewer assumed `send_index` was incremented
+before early returns, but the implementation already had it after. A good reminder that
+reviews need to read the code, not just the design.
+*Source: [ux3-rich-progress-display](../98-journals/2026-03-30-ux3-rich-progress-display.md)*
+
+### 3.5 Simplify and arch-adversary are complementary lenses
+Simplify catches redundancies, type-level issues, and abstraction audit failures.
+Arch-adversary catches semantic contract violations and catastrophic-failure proximity.
+The pipeline (`/simplify` -> `arch-adversary` -> `/post-review`) catches things a single
+pass would miss.
+*Source: [vfm-a-implementation](../98-journals/2026-03-29-vfm-a-implementation.md), [sentinel-session3](../98-journals/2026-03-29-sentinel-session3.md)*
+
+---
+
+## 4. Pure-Function Architecture Benefits
+
+### 4.1 Pure functions slot in cleanly
+The awareness model's `assess(&config, now, &fs_state)` works with all three arguments
+available at every call site — no new plumbing needed. Pure-function design (ADR-108)
+means new consumers don't need the executor, the database, or any special setup.
+*Source: [heartbeat-file](../98-journals/2026-03-24-heartbeat-file.md)*
+
+### 4.2 Impure functions in a pure-function codebase are a code smell
+The original `build_notifications` took `&Config` and did I/O — the only impure function in
+the notification pipeline. Making it pure immediately made it testable, which immediately
+revealed the BackupOverdue path had no test coverage.
+*Source: [sentinel-session2](../98-journals/2026-03-27-sentinel-session2.md)*
+
+### 4.3 Gate bugs are invisible without trace-through
+The `has_promise_changes` gate was correct for promise notifications but silently
+suppressed BackupOverdue. When a function is called inside a conditional, ask "what else
+does this function produce that shouldn't be inside this gate?"
+*Source: [sentinel-session2](../98-journals/2026-03-27-sentinel-session2.md)*
+
+### 4.4 Implicit protocols between pure functions are a design smell
+The original `allows_trigger` + `evaluate_trigger_result` pair required the runner to set
+intermediate state. Carrying the permission on the trigger struct makes the contract
+explicit and testable without manual state manipulation.
+*Source: [sentinel-session1](../98-journals/2026-03-27-sentinel-session1.md)*
+
+---
+
+## 5. Operational Reality vs. Test Assumptions
+
+### 5.1 Cloned drives share BTRFS UUIDs — Urd can't distinguish them
+After swapping in a cloned drive, UUID verification passed, the sentinel reported no
+change, but all incremental chains broke, snapshot counts changed silently, and free space
+dropped 1.1TB. The config compounds the problem: one drive has no UUID configured at all.
+Observable signals exist (free space delta, snapshot set mismatch, simultaneous chain
+breaks) but aren't yet wired.
+*Source: [sentinel-hardware-swap-test](../98-journals/2026-03-28-sentinel-hardware-swap-test.md), [clone-drive-incident-analysis](../98-journals/2026-03-29-clone-drive-incident-analysis.md)*
+
+### 5.2 Awareness model needs truthful inputs
+A pure function computing states from config is only as useful as the config's alignment
+with operational reality. Crying wolf is worse than no awareness. Config intervals must
+match the actual timer schedule.
+*Source: [operational-evaluation](../98-journals/2026-03-26-operational-evaluation.md)*
+
+### 5.3 Journal persistence is a real operational gap
+Successful runs happened but `journalctl` lost the evidence. For unattended operation,
+the heartbeat partially compensates, but systemd journal retention for user units is
+unreliable.
+*Source: [operational-evaluation](../98-journals/2026-03-26-operational-evaluation.md)*
+
+### 5.4 The "nothing to do" run validates the architecture
+Run 11 at 22 seconds proves the planner's skip logic is efficient. In a daily-timer world,
+most runs should look like this. The system costs almost nothing when idle.
+*Source: [operational-evaluation](../98-journals/2026-03-26-operational-evaluation.md)*
+
+### 5.5 `findmnt` is the right abstraction for UUID detection
+LUKS encryption adds a layer: `/proc/mounts` shows the mapper device UUID, not the
+filesystem UUID. `findmnt` abstracts this away regardless of the storage stack underneath.
+Using the wrong UUID would cause false mismatches.
+*Source: [uuid-drive-fingerprinting](../98-journals/2026-03-24-uuid-drive-fingerprinting.md)*
+
+---
+
+## 6. Architecture and Design Decisions
+
+### 6.1 Configuration inheritance creates cognitive overhead
+`[defaults]` sections and implicit fallbacks feel helpful when writing a config but create
+cognitive overhead when reading one. For a backup tool where the operator must trust the
+system does what they expect, explicitness wins.
+*Source: [config-design-review](../98-journals/2026-03-27-config-design-review.md)*
+
+### 6.2 The drive routing semantic inversion
+Protected subvolumes getting more drive coverage than resilient ones demonstrated that
+implicit behaviors ("send to all drives" as the default) create surprising outcomes.
+Explicit is better than implicit, even when more verbose.
+*Source: [config-design-review](../98-journals/2026-03-27-config-design-review.md)*
+
+### 6.3 Enum-over-trait for presentation modes
+`render_status()` is 5 lines: a match with two arms calling private functions. No
+`Box<dyn>`, no vtable, no indirection. Adding a new mode is a new match arm. The
+serializable wrapper types keep serialization concerns out of the domain model.
+*Source: [presentation-layer](../98-journals/2026-03-24-presentation-layer.md)*
+
+### 6.4 `CREATE TABLE IF NOT EXISTS` is sufficient migration for a single-user tool
+For a simple schema with only table additions (no column alterations), this eliminates
+migration machinery entirely.
+*Source: [post-cutover-features](../98-journals/2026-03-23-post-cutover-features.md)*
+
+### 6.5 stdout/stderr separation enables composition
+`urd get` sends file content to stdout and metadata to stderr, enabling piping, diffing,
+and redirecting without flags.
+*Source: [urd-get](../98-journals/2026-03-24-urd-get.md)*
+
+### 6.6 Copy-not-symlink for backup infrastructure systemd units
+A stale copy still runs; a broken symlink silently stops backups. For a system protecting
+data on a pool with no redundancy, reliability wins.
+*Source: [documentation-system](../98-journals/2026-03-23-documentation-system.md)*
+
+---
+
+## 7. Workflow and Tooling
+
+### 7.1 A skill earns its context cost when it imposes a methodology Claude wouldn't naturally follow
+Scorecards, severity frameworks, risk-proportional coverage tiers warrant skills. When the
+skill just says "follow CLAUDE.md," it's a command, not a skill.
+*Source: [development-cycle-skills](../98-journals/2026-03-24-development-cycle-skills.md)*
+
+### 7.2 Quantitative scoring frameworks for brainstorming are unreliable for LLMs
+75% arithmetic errors in composite scores. Editorial judgment in sequencing was consistently
+better than the computed scores. Use qualitative tier placement with explicit reasoning.
+*Source: [vision-and-roadmap](../98-journals/2026-03-23-vision-and-roadmap.md)*
+
+### 7.3 status.md was a documentation anti-pattern
+A living document that accumulates history eventually requires reading the whole history to
+update. Fix: split by update frequency — status.md (per-session), roadmap.md (when
+priorities shift), journals (accumulate).
+*Source: [workflow-and-documentation-rework](../98-journals/2026-03-28-workflow-and-documentation-rework.md)*
+
+### 7.4 The three-fixes rule is the most discriminating debugging skill feature
+Without-skill responses consistently proposed fix #4 when given a "three failed attempts"
+scenario. With-skill responses stopped and reset to investigation. The clearest behavioral
+change systematic-debugging produces.
+*Source: [workflow-and-documentation-rework](../98-journals/2026-03-28-workflow-and-documentation-rework.md)*
+
+### 7.5 Dry run -> manual run -> verify is a solid pre-flight pattern
+The dry run matched the actual run exactly. Predictable behavior is what matters.
+*Source: [test-run-and-skill-ecosystem](../98-journals/2026-03-25-test-run-and-skill-ecosystem.md)*
+
+### 7.6 Duration string comparison is treacherous
+"5d" (len 2) looks shorter than "2h30m" (len 5) but is 48x longer. Always parse durations
+to a common unit before comparing.
+*Source: [ux1-plan-output-improvements](../98-journals/2026-03-30-ux1-plan-output-improvements.md)*
+
+### 7.7 Daemon log levels need different defaults than CLI tools
+`info!()` is appropriate for CLI verbose output. For a daemon, lifecycle events need
+`warn!()` to be visible at default log levels.
+*Source: [sentinel-session2](../98-journals/2026-03-27-sentinel-session2.md)*
+
+---
+
+## 8. Stringly-Typed Boundaries (Recurring Theme)
+
+Three independent status-ranking implementations exist across notify.rs and voice.rs.
+The enum-to-string-to-matching pipeline is load-bearing tech debt that doubles in surface
+area with each new enum routed through it. Observed in:
+
+- VFM-A: OperationalHealth routed through the same pipeline as PromiseStatus
+- UX-1: `format_duration_short` duplicated between plan.rs and voice.rs
+- UX-1: SkipCategory classification at the output boundary
+
+The pattern is always the same: a well-typed enum crosses a module boundary through
+`to_string()`, and the receiver does string matching to reconstruct meaning. Each instance
+is small. Together they form a systemic weakness.
+
+*Sources: [vfm-a-implementation](../98-journals/2026-03-29-vfm-a-implementation.md), [ux1-plan-output-grouped-skips](../98-journals/2026-03-30-ux1-plan-output-grouped-skips.md)*


### PR DESCRIPTION
## Summary

- Evaluated mattpocock/skills repo — added `/grill-me` command (Socratic interview for stress-testing plans), confirmed existing tools cover the rest
- Compiled lessons learned from all 52 journal entries into `docs/96-project-supervisor/2026-03-30-lessons.md` — 40+ lessons organized by theme (safety patterns, bootstrap bugs, review value, pure-function benefits, operational reality, workflow)
- Updated CLAUDE.md: fixed stale sentinel/test-count references, compressed config system section (-12 lines), added three coding conventions from lessons review (unwrap_or smell, tempfile tests, daemon log levels)
- Refined journal command: forward-looking handoff sections encouraged, git workflow state (PR open/closed) explicitly excluded to prevent stale-state confusion in next-session pickup
- Updated CONTRIBUTING.md: journal template gains "When you return" section, session-start workflow checks git state directly

## Testing

- cargo clippy: not applicable (docs only)
- cargo test: not applicable (docs only)
- Integration tests: not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)