### PR TITLE
feat: sentinel health tracking, visual state, and health notifications (VFM-B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-03-30
+
 ### Added
 - Sentinel tracks health transitions and fires HealthDegraded/HealthRecovered notifications
 - `visual_state` block in sentinel-state.json: icon state and safety/health counts for tray icon consumers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Sentinel tracks health transitions and fires HealthDegraded/HealthRecovered notifications
+- `visual_state` block in sentinel-state.json: icon state and safety/health counts for tray icon consumers
+- Per-subvolume health and health_reasons in sentinel state file promise states
+- Sentinel state file schema version 2 (backward-compatible with v1)
+
+### Changed
+- Generic `NamedSnapshot` trait replaces duplicated change-detection logic for promise and health axes
+- All-blocked health escalates to Critical icon (was Warning)
+
 ## [0.4.2] - 2026-03-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,12 +8,13 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-521 tests, all passing, clippy clean. Current version: v0.4.2.
+542 tests, all passing, clippy clean. Current version: v0.4.2.
 
 ## In Progress
 
-- **HSD-B complete, PR #45 open** (2026-03-30). Chain-break detection, full-send gate,
-  drive token verification wired into backup path. Reviewed, released as v0.4.2.
+- **VFM-B complete, needs PR** (2026-03-30). Sentinel health tracking, visual state in
+  state file (schema v2), HealthDegraded/HealthRecovered notifications, NamedSnapshot
+  trait refactor. Reviewed. 7 files changed, +653/-35 lines, 21 new tests.
 
 ## Build Queue
 
@@ -26,13 +27,13 @@ full details, design decisions, and review findings.
 4. ~~**UX-1**~~ — plan output: structural headings + collapsed skips. **Done.**
 5. ~~**UX-2**~~ — plan output: estimated send sizes, cross-drive fallback. **Done.**
 6. ~~**UX-3**~~ — plan output: rich progress display + ETA. **Done.**
-7. ~~**HSD-B**~~ — sentinel chain-break detection + full-send gate. **Done (PR #45).**
-8. **VFM-B** — sentinel visual state in state file + health notifications. **Start here.**
-9. **Transient snapshots** — `local_retention = "transient"` for NVMe space pressure.
+7. ~~**HSD-B**~~ — sentinel chain-break detection + full-send gate. **Done (v0.4.2).**
+8. ~~**VFM-B**~~ — sentinel visual state + health notifications. **Done, needs PR.**
+9. **Transient snapshots** — `local_retention = "transient"` for NVMe space pressure. **Start here.**
 10. **Tray icon (Spindle)** — reads sentinel-state.json, 4 static icons.
 
 Designs: `docs/95-ideas/2026-03-29-design-*.md`.
-Reviews: `docs/99-reports/2026-03-30-hsd-b-chain-break-detection-review.md`.
+Reviews: `docs/99-reports/2026-03-30-vfm-b-visual-state-review.md`.
 
 **Later:** Config system migration (ADR-111), shell completions (6a).
 
@@ -45,7 +46,7 @@ Reviews: `docs/99-reports/2026-03-30-hsd-b-chain-break-detection-review.md`.
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Latest journals | `docs/98-journals/` (local only, gitignored) |
-| Latest reviews | [HSD-B review](../99-reports/2026-03-30-hsd-b-chain-break-detection-review.md), [UX-3 review](../99-reports/2026-03-30-ux3-progress-display-review.md) |
+| Latest reviews | [VFM-B review](../99-reports/2026-03-30-vfm-b-visual-state-review.md), [HSD-B review](../99-reports/2026-03-30-hsd-b-chain-break-detection-review.md) |
 
 ## Known Issues
 
@@ -60,5 +61,6 @@ Reviews: `docs/99-reports/2026-03-30-hsd-b-chain-break-detection-review.md`.
 - `render_skipped_block` (backup summary) uses ad-hoc string grouping; could adopt `SkipCategory`
 - Progress completion line byte count lags true total by up to one poll interval (~45 MB at USB3 speeds)
 - `OpResult::Skipped` is overloaded: four distinct semantics (prior failure, optimization, safety guard, safety gate)
+- `urd sentinel status` interactive mode doesn't render health/visual_state fields yet
 
 See [roadmap.md](roadmap.md) for the full tech debt list and dropped features.

--- a/docs/99-reports/2026-03-30-vfm-b-visual-state-review.md
+++ b/docs/99-reports/2026-03-30-vfm-b-visual-state-review.md
@@ -1,0 +1,195 @@
+# VFM-B Implementation Review
+
+**Project:** Urd -- BTRFS Time Machine for Linux
+**Date:** 2026-03-30
+**Scope:** VFM-B (Session B) -- Sentinel health tracking, visual state, and health notifications
+**Reviewer:** arch-adversary
+**Commit:** unstaged (working tree changes against base 2d14b67)
+**Files reviewed:** `sentinel.rs`, `sentinel_runner.rs`, `output.rs`, `notify.rs`, `commands/sentinel.rs`, `commands/backup.rs`, `voice.rs`
+**Design doc:** `docs/95-ideas/2026-03-28-design-visual-feedback-model.md` (Session B, lines 452-458)
+**Prior review:** `docs/99-reports/2026-03-29-vfm-a-implementation-review.md`
+
+---
+
+## Executive Summary
+
+VFM-B adds health transition detection and a visual state block to the sentinel daemon's state
+file. The implementation is clean, well-scoped, and maintains the pure-function module pattern
+throughout. The `NamedSnapshot` trait refactor is a genuine simplification that eliminates code
+duplication between promise and health change detection. The primary concern is an icon logic
+condition that maps `Blocked` health to `Warning` rather than `Critical`, which may
+under-communicate the severity of a state where backups literally cannot run. No data-safety
+risk exists -- this is entirely advisory/observational code.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss -- deleting snapshots that shouldn't be deleted.
+
+**Distance from VFM-B changes:** Far. VFM-B is advisory/observational code in the sentinel
+daemon. `compute_visual_state()`, `snapshot_health()`, `has_health_changes()`, and
+`build_health_notifications()` are all pure functions that observe state and produce structured
+output. They do not influence the planner, executor, retention, or any write path. The sentinel
+runner's `execute_assess()` writes a state file and dispatches notifications -- neither of which
+affects backup operations.
+
+**Catastrophic failure checklist:**
+1. Silent data loss -- **not applicable.** No write operations on snapshots.
+2. Path traversal -- **not applicable.** No path construction for btrfs.
+3. Pinned snapshot deletion -- **not applicable.** Advisory only.
+4. Space exhaustion -- **not applicable.** Writes one small JSON state file.
+5. Config orphaning -- **not applicable.** No config writes.
+6. TOCTOU -- **not applicable.** No privileged actions.
+
+This is the same class of safety as VFM-A: it observes but doesn't act.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | Health transition detection, visual state computation, and backward-compatible deserialization all work correctly. One icon logic subtlety (Blocked mapped to Warning, not Critical). |
+| 2 | Security | 5 | Pure advisory code. No privilege escalation surface. No new I/O paths. |
+| 3 | Architectural Excellence | 5 | Follows the pure-function module pattern exactly. The `NamedSnapshot` trait generalization is a clean simplification. Schema version bump with backward-compatible defaults is textbook. |
+| 4 | Systems Design | 4 | Health notifications at `Urgency::Info` is a defensible choice that respects the safety/health distinction. The `worst_safety`/`worst_health` fields as strings in `VisualState` carry the stringly-typed tech debt forward. |
+| 5 | Rust Idioms | 4 | Good use of trait-based generics for `has_changes`. The `NamedSnapshot` trait is minimal and purpose-built. `Box<SentinelStateFile>` in the enum variant is a reasonable size optimization. |
+| 6 | Code Quality | 4 | Well-tested: 17+ new tests covering health snapshots, visual state computation, health notifications, backward compatibility, and JSON serialization. Clear naming throughout. |
+
+## Design Tensions
+
+### 1. Health notifications at Info urgency -- underweight or correct?
+
+**Trade-off:** All health transitions (including `Blocked`) fire at `Urgency::Info`. This means
+a health degradation from `Healthy` to `Blocked` -- where backups literally cannot proceed --
+produces the same urgency as a recovery notification. Users with `min_urgency: warning` (the
+default) will never see health notifications through any channel.
+
+**Assessment:** Defensible. Health is explicitly "operational readiness, not data safety." If
+backups are blocked long enough, the promise state will degrade to AT RISK or UNPROTECTED,
+which fires at Warning/Critical. Health notifications are an early warning; promise notifications
+are the alarm. The separation is correct in principle. But a user who has `min_urgency: warning`
+and whose drives are both unmounted will see nothing until their promises degrade -- which could
+be days. **Right call for v1, but consider elevating `Blocked` transitions to `Warning` in a
+future pass.**
+
+### 2. Stringly-typed worst_safety/worst_health in VisualState
+
+**Trade-off:** `VisualState` stores `worst_safety: String` and `worst_health: String` rather
+than the typed enums. This matches the existing pattern in `SentinelPromiseState` (where `status`
+and `health` are strings) and keeps the serialization boundary clean.
+
+**Assessment:** Consistent with existing patterns. The stringly-typed boundary is pre-existing
+tech debt inherited from the `SentinelPromiseState` design. VFM-B follows the established
+convention. Fixing it would mean either making the output types depend on the awareness enums
+(violating the current output/awareness separation) or introducing a parallel enum in
+`output.rs`. Neither is worth doing for this PR. **No action needed.**
+
+### 3. Schema version bump from 1 to 2 -- clean break vs. incremental
+
+**Trade-off:** The version jumps from 1 to 2. Old consumers reading a v2 file get the new
+fields. New code reading a v1 file gets `visual_state: None` and `health: "healthy"` (via
+`#[serde(default)]`). There's no reader-side logic that checks `schema_version` to decide
+behavior -- the defaults handle it implicitly.
+
+**Assessment:** This is the right approach. Explicit version-checking dispatch would be premature
+for two versions with clean backward-compatible defaults. The `#[serde(default)]` annotations do
+the right thing: missing fields get safe defaults. The test `state_file_v1_backward_compat_
+deserialization` validates this directly. **Good decision.**
+
+## Findings
+
+### Finding 1: Icon logic maps Blocked health to Warning, not Critical (Minor)
+
+**What:** In `compute_visual_state()` at sentinel.rs, the icon logic is:
+- `Unprotected` safety -> `Critical`
+- `AtRisk` safety OR `Degraded`/`Blocked` health -> `Warning`
+- Everything else -> `Ok`
+
+This means a system where all subvolumes are `Protected` but `Blocked` (no backup drives
+connected, all chains broken) shows a yellow `Warning` icon, not a red `Critical`.
+
+**Consequence:** The visual state understates the operational severity. `Blocked` means
+backups cannot run at all. A tray icon consumer showing yellow for "backups literally
+cannot happen" may give insufficient urgency.
+
+**Suggested fix:** This is a UX judgment call. Consider whether all-Blocked health
+(`health_counts.blocked == assessments.len()`) should escalate to `Critical`, paralleling
+the `AllUnprotected` pattern for safety.
+
+**Distance from catastrophic failure:** None -- purely visual.
+
+### Finding 2: Health notification body only includes first reason (Minor)
+
+**What:** In `build_health_notifications()`, the notification body includes only
+`health_reasons.first()`. If a subvolume has multiple health reasons, only the first
+is shown.
+
+**Consequence:** The notification may omit context that helps the user diagnose the issue.
+
+**Suggested fix:** Replace `.first().map(|s| s.as_str()).unwrap_or("")` with
+`health_reasons.join("; ")`, and consider adding "Run `urd status` for details." suffix.
+
+### Finding 3: Commendation -- NamedSnapshot trait is a genuine simplification
+
+**What:** The `NamedSnapshot` trait and `has_changes<T>` generic function replace what would
+have been a copy-paste of `has_promise_changes` for health detection. The trait has two
+methods, each implemented in 3-4 lines. The convenience aliases maintain the existing API.
+
+This is the kind of refactor that pays for itself immediately: health change detection came
+for free, and any future axis would be a one-trait-impl addition.
+
+### Finding 4: Commendation -- backward compatibility is thorough
+
+**What:** The schema v2 transition handles backward compatibility at three levels:
+1. `visual_state` is `Option` with `#[serde(default, skip_serializing_if)]`
+2. `health` has `#[serde(default = "default_healthy")]`
+3. `health_reasons` has `#[serde(default, skip_serializing_if = "Vec::is_empty")]`
+
+The test `state_file_v1_backward_compat_deserialization` validates deserialization of an
+actual v1 JSON string. The test `state_file_health_reasons_omitted_when_empty` validates
+the output contract.
+
+### Finding 5: Commendation -- scope discipline matches VFM-A
+
+**What:** VFM-B implements exactly Session B from the design doc. `DriveAnomalyDetected`
+from HSD-B is not duplicated. The `Active` icon variant is declared but documented as
+reserved. No voice.rs rendering changes beyond test fixtures. No CLI surface changes
+beyond the `Box::new(state)` size optimization.
+
+## The Simplicity Question
+
+**What's earning its keep:**
+- `HealthSnapshot` + `snapshot_health()` -- necessary for delta comparison across ticks.
+- `NamedSnapshot` trait + `has_changes<T>()` -- eliminates duplication, pays for itself.
+- `compute_visual_state()` -- central logic for the tray icon contract.
+- `build_health_notifications()` -- parallel notification path for health transitions.
+- `VisualState` and friends -- necessary structured data for external consumers.
+- Schema v2 backward compatibility -- `#[serde(default)]` annotations are necessary.
+
+**Nothing should be deleted.** The implementation adds ~325 lines of new production code
+with ~315 lines of new tests. The ratio is healthy.
+
+## For the Dev Team
+
+Priority-ordered action items:
+
+1. **Consider elevating all-Blocked health to Critical icon** (Finding 1)
+   - File: `src/sentinel.rs`, `compute_visual_state()` function
+   - What: After icon logic, check if all subvolumes are Blocked -- if so, escalate to Critical
+   - Why: Yellow icon for "backups cannot run at all" may not convey enough urgency
+
+2. **Include all health reasons in notification body** (Finding 2)
+   - File: `src/sentinel_runner.rs`, `build_health_notifications()` function
+   - What: Replace `.first()` with `.join("; ")` and add "Run `urd status` for details." suffix
+   - Why: Multiple reasons provide better diagnostic context
+
+## Open Questions
+
+1. **Should `VisualIcon::Active` be produced during backup execution?** The variant is declared
+   and reserved. Detecting backup start would require a lock file check or separate signal. Is
+   this planned for a future session or deferred indefinitely?
+
+2. **Should health notifications be suppressed when caused by drive unmount?** The user just
+   unplugged the drive -- they know. Health transitions from drive unmount may feel noisy. The
+   tick interval provides natural debounce but doesn't suppress the initial notification.
+
+3. **How should `urd sentinel status` render the new health fields?** The interactive rendering
+   doesn't show visual_state yet. Is this intentional (consumer-facing only) or a gap to fill?

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1323,7 +1323,7 @@ mod tests {
 
     fn write_sentinel_state_file(path: &std::path::Path, pid: u32) {
         let state = crate::output::SentinelStateFile {
-            schema_version: 1,
+            schema_version: 2,
             pid,
             started: "2026-03-29T10:00:00".to_string(),
             last_assessment: None,
@@ -1334,6 +1334,7 @@ mod tests {
                 state: "closed".to_string(),
                 failure_count: 0,
             },
+            visual_state: None,
         };
         let content = serde_json::to_string_pretty(&state).unwrap();
         std::fs::write(path, content).unwrap();

--- a/src/commands/sentinel.rs
+++ b/src/commands/sentinel.rs
@@ -18,7 +18,7 @@ pub fn status(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     let status_output = match read_sentinel_state_file(&state_path) {
         Some(state) if is_pid_alive(state.pid) => {
             let uptime = format_uptime(&state.started);
-            SentinelStatusOutput::Running { state, uptime }
+            SentinelStatusOutput::Running { state: Box::new(state), uptime }
         }
         Some(state) => {
             // Stale state file — PID is dead. Clean up and report as not running.

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -52,6 +52,21 @@ pub enum NotificationEvent {
         last_heartbeat_age_hours: u64,
         stale_after_hours: u64,
     },
+    /// A subvolume's operational health worsened (e.g., Healthy -> Degraded).
+    /// Separate from PromiseDegraded — health is operational readiness, not data safety.
+    #[allow(dead_code)] // Constructed by Sentinel (VFM-B), not backup command
+    HealthDegraded {
+        subvolume: String,
+        from: String,
+        to: String,
+    },
+    /// A subvolume's operational health improved.
+    #[allow(dead_code)] // Constructed by Sentinel (VFM-B), not backup command
+    HealthRecovered {
+        subvolume: String,
+        from: String,
+        to: String,
+    },
     /// All incremental chains on a drive broke simultaneously.
     /// Strong signal for drive swap or mass pin file loss.
     DriveAnomalyDetected {

--- a/src/output.rs
+++ b/src/output.rs
@@ -582,6 +582,51 @@ pub struct InitSnapshotCount {
     pub external_counts: Vec<(String, usize)>,
 }
 
+// ── Visual state types (VFM-B) ──────────────────────────────────────────
+
+/// Icon state for tray icon consumers. Four states, each maps to a static
+/// SVG icon file. The tray applet selects by name: `urd-icon-ok.svg`, etc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum VisualIcon {
+    /// All safe, all healthy.
+    Ok,
+    /// Safety ok but health degraded, or safety aging.
+    Warning,
+    /// Data gap exists (any subvolume UNPROTECTED).
+    Critical,
+    /// Backup currently running (reserved, not yet produced).
+    Active,
+}
+
+/// Safety axis counts using tray-friendly vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SafetyCounts {
+    pub ok: usize,
+    pub aging: usize,
+    pub gap: usize,
+}
+
+/// Health axis counts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthCounts {
+    pub healthy: usize,
+    pub degraded: usize,
+    pub blocked: usize,
+}
+
+/// Structured visual state for tray icon and external consumers.
+/// No pre-computed text — consumers render their own tooltips/summaries
+/// from this structured data (design review S2).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VisualState {
+    pub icon: VisualIcon,
+    pub worst_safety: String,
+    pub worst_health: String,
+    pub safety_counts: SafetyCounts,
+    pub health_counts: HealthCounts,
+}
+
 // ── SentinelStatusOutput ─────────────────────────────────────────────────
 
 /// Sentinel state file schema — written atomically by the runner, read by
@@ -596,6 +641,10 @@ pub struct SentinelStateFile {
     pub tick_interval_secs: u64,
     pub promise_states: Vec<SentinelPromiseState>,
     pub circuit_breaker: SentinelCircuitState,
+    /// Visual state for tray icon and external consumers (VFM-B, schema v2+).
+    /// `None` when reading schema v1 files for backward compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub visual_state: Option<VisualState>,
 }
 
 /// Per-subvolume promise state in the sentinel state file.
@@ -603,6 +652,16 @@ pub struct SentinelStateFile {
 pub struct SentinelPromiseState {
     pub name: String,
     pub status: String,
+    /// Operational health (VFM-B, schema v2+). Defaults to "healthy" for v1 files.
+    #[serde(default = "default_healthy")]
+    pub health: String,
+    /// Reasons for non-healthy status. Omitted from JSON when empty.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub health_reasons: Vec<String>,
+}
+
+fn default_healthy() -> String {
+    "healthy".to_string()
 }
 
 /// Circuit breaker summary in the sentinel state file.
@@ -619,7 +678,7 @@ pub enum SentinelStatusOutput {
     /// Sentinel is running (PID alive, state file present).
     #[serde(rename = "running")]
     Running {
-        state: SentinelStateFile,
+        state: Box<SentinelStateFile>,
         /// Human-readable uptime (e.g., "3h 12m").
         uptime: String,
     },

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
-use crate::awareness::{ChainStatus, PromiseStatus, SubvolAssessment};
+use crate::awareness::{ChainStatus, OperationalHealth, PromiseStatus, SubvolAssessment};
 
 // ── Events ──────────────────────────────────────────────────────────────
 
@@ -76,6 +76,9 @@ pub struct SentinelState {
     /// Chain health per (subvolume, drive) from the last assessment.
     /// Used by `detect_simultaneous_chain_breaks()` to compare across ticks.
     pub last_chain_health: Vec<ChainSnapshot>,
+    /// Operational health per subvolume from the last assessment.
+    /// Used by health transition detection to fire HealthDegraded/Recovered.
+    pub last_health_states: Vec<HealthSnapshot>,
     /// Circuit breaker state (active mode only, but tracked always).
     pub circuit_breaker: CircuitBreaker,
 }
@@ -97,6 +100,7 @@ impl SentinelState {
             last_promise_states: Vec::new(),
             has_initial_assessment: false,
             last_chain_health: Vec::new(),
+            last_health_states: Vec::new(),
             circuit_breaker: CircuitBreaker::new(circuit_breaker_config),
         }
     }
@@ -523,7 +527,83 @@ pub fn evaluate_trigger_result(
     new
 }
 
-// ── Promise snapshot helpers ────────────────────────────────────────────
+// ── Snapshot change detection ──────────────────────────────────────────
+
+/// Trait for snapshot types that can be compared against assessments.
+/// Enables generic change detection across promise and health axes.
+pub trait NamedSnapshot {
+    fn name(&self) -> &str;
+    fn changed(&self, assessment: &SubvolAssessment) -> bool;
+}
+
+impl NamedSnapshot for PromiseSnapshot {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn changed(&self, assessment: &SubvolAssessment) -> bool {
+        self.status != assessment.status
+    }
+}
+
+impl NamedSnapshot for HealthSnapshot {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn changed(&self, assessment: &SubvolAssessment) -> bool {
+        self.health != assessment.health
+    }
+}
+
+/// Determine whether snapshot state transitions warrant notifications.
+/// Returns true if any subvolume's tracked state changed, appeared, or disappeared.
+///
+/// Special case: when `previous` is empty (first assessment after startup),
+/// returns false to suppress spurious notifications (review item M3).
+#[must_use]
+pub fn has_changes<T: NamedSnapshot>(
+    previous: &[T],
+    current: &[SubvolAssessment],
+) -> bool {
+    if previous.is_empty() {
+        return false;
+    }
+
+    for assess in current {
+        match previous.iter().find(|p| p.name() == assess.name) {
+            Some(prev) if prev.changed(assess) => return true,
+            None => return true,
+            _ => {}
+        }
+    }
+
+    for prev in previous {
+        if !current.iter().any(|a| a.name == prev.name()) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Convenience alias: detect promise state changes.
+#[must_use]
+pub fn has_promise_changes(
+    previous: &[PromiseSnapshot],
+    current: &[SubvolAssessment],
+) -> bool {
+    has_changes(previous, current)
+}
+
+/// Convenience alias: detect health state changes.
+#[must_use]
+pub fn has_health_changes(
+    previous: &[HealthSnapshot],
+    current: &[SubvolAssessment],
+) -> bool {
+    has_changes(previous, current)
+}
+
+// ── Snapshot extractors ───────────────────────────────────────────────
 
 /// Extract promise snapshots from assessments for state storage.
 #[must_use]
@@ -537,36 +617,96 @@ pub fn snapshot_promises(assessments: &[SubvolAssessment]) -> Vec<PromiseSnapsho
         .collect()
 }
 
-/// Determine whether promise state transitions warrant notifications.
-/// Returns true if any subvolume's promise status changed.
-///
-/// Special case: when `previous` is empty (first assessment after startup),
-/// returns false to suppress spurious notifications (review item M3).
+/// A snapshot of operational health from a single assessment, for
+/// comparing health transitions to decide notifications.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HealthSnapshot {
+    pub name: String,
+    pub health: OperationalHealth,
+    pub health_reasons: Vec<String>,
+}
+
+/// Extract health snapshots from assessments for state storage.
 #[must_use]
-pub fn has_promise_changes(
-    previous: &[PromiseSnapshot],
-    current: &[SubvolAssessment],
-) -> bool {
-    if previous.is_empty() {
-        return false;
-    }
+pub fn snapshot_health(assessments: &[SubvolAssessment]) -> Vec<HealthSnapshot> {
+    assessments
+        .iter()
+        .map(|a| HealthSnapshot {
+            name: a.name.clone(),
+            health: a.health,
+            health_reasons: a.health_reasons.clone(),
+        })
+        .collect()
+}
 
-    for assess in current {
-        match previous.iter().find(|p| p.name == assess.name) {
-            Some(prev) if prev.status != assess.status => return true,
-            None => return true, // new subvolume appeared
-            _ => {}
+// ── Visual state computation (VFM-B) ──────────────────────────────────
+
+/// Compute the visual state from the current assessment.
+/// Pure function: assessments in, visual state out.
+///
+/// Icon priority: Critical (any Unprotected) > Warning (any AtRisk or
+/// any Degraded/Blocked) > Ok (all Protected and all Healthy).
+/// The `Active` state is reserved for backup-in-progress detection (future).
+#[must_use]
+pub fn compute_visual_state(assessments: &[SubvolAssessment]) -> crate::output::VisualState {
+    use crate::output::{HealthCounts, SafetyCounts, VisualIcon, VisualState};
+
+    let mut safety_counts = SafetyCounts {
+        ok: 0,
+        aging: 0,
+        gap: 0,
+    };
+    let mut health_counts = HealthCounts {
+        healthy: 0,
+        degraded: 0,
+        blocked: 0,
+    };
+
+    for a in assessments {
+        match a.status {
+            PromiseStatus::Protected => safety_counts.ok += 1,
+            PromiseStatus::AtRisk => safety_counts.aging += 1,
+            PromiseStatus::Unprotected => safety_counts.gap += 1,
+        }
+        match a.health {
+            OperationalHealth::Healthy => health_counts.healthy += 1,
+            OperationalHealth::Degraded => health_counts.degraded += 1,
+            OperationalHealth::Blocked => health_counts.blocked += 1,
         }
     }
 
-    // Check for subvolumes that disappeared
-    for prev in previous {
-        if !current.iter().any(|a| a.name == prev.name) {
-            return true;
-        }
-    }
+    let worst_safety = assessments
+        .iter()
+        .map(|a| a.status)
+        .min()
+        .unwrap_or(PromiseStatus::Protected);
 
-    false
+    let worst_health = assessments
+        .iter()
+        .map(|a| a.health)
+        .min()
+        .unwrap_or(OperationalHealth::Healthy);
+
+    let all_blocked =
+        !assessments.is_empty() && assessments.iter().all(|a| a.health == OperationalHealth::Blocked);
+
+    let icon = if worst_safety == PromiseStatus::Unprotected || all_blocked {
+        VisualIcon::Critical
+    } else if worst_safety == PromiseStatus::AtRisk
+        || worst_health <= OperationalHealth::Degraded
+    {
+        VisualIcon::Warning
+    } else {
+        VisualIcon::Ok
+    };
+
+    VisualState {
+        icon,
+        worst_safety: worst_safety.to_string(),
+        worst_health: worst_health.to_string(),
+        safety_counts,
+        health_counts,
+    }
 }
 
 // ── Chain-break detection (HSD-B) ──────────────────────────────────────
@@ -1484,5 +1624,160 @@ mod tests {
         let anomalies = detect_simultaneous_chain_breaks(&prev, &curr);
         assert_eq!(anomalies.len(), 1);
         assert_eq!(anomalies[0].drive_label, "D1");
+    }
+
+    // ── Health snapshot tests (VFM-B) ──────────────────────────────────
+
+    #[test]
+    fn snapshot_health_extracts_from_assessments() {
+        let assessments = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            {
+                let mut a = make_assessment("sv2", PromiseStatus::Protected);
+                a.health = OperationalHealth::Degraded;
+                a
+            },
+        ];
+        let snaps = snapshot_health(&assessments);
+        assert_eq!(snaps.len(), 2);
+        assert_eq!(snaps[0].name, "sv1");
+        assert_eq!(snaps[0].health, OperationalHealth::Healthy);
+        assert_eq!(snaps[1].name, "sv2");
+        assert_eq!(snaps[1].health, OperationalHealth::Degraded);
+    }
+
+    #[test]
+    fn has_health_changes_empty_previous_returns_false() {
+        let assessments = vec![make_assessment("sv1", PromiseStatus::Protected)];
+        assert!(!has_health_changes(&[], &assessments));
+    }
+
+    #[test]
+    fn has_health_changes_no_change_returns_false() {
+        let prev = vec![HealthSnapshot {
+            name: "sv1".into(),
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
+        }];
+        let curr = vec![make_assessment("sv1", PromiseStatus::Protected)];
+        assert!(!has_health_changes(&prev, &curr));
+    }
+
+    #[test]
+    fn has_health_changes_worsened_returns_true() {
+        let prev = vec![HealthSnapshot {
+            name: "sv1".into(),
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
+        }];
+        let mut a = make_assessment("sv1", PromiseStatus::Protected);
+        a.health = OperationalHealth::Degraded;
+        assert!(has_health_changes(&prev, &[a]));
+    }
+
+    #[test]
+    fn has_health_changes_improved_returns_true() {
+        let prev = vec![HealthSnapshot {
+            name: "sv1".into(),
+            health: OperationalHealth::Blocked,
+            health_reasons: vec![],
+        }];
+        let curr = vec![make_assessment("sv1", PromiseStatus::Protected)];
+        assert!(has_health_changes(&prev, &curr));
+    }
+
+    // ── Visual state tests (VFM-B) ───────────────────────────────────
+
+    #[test]
+    fn visual_state_all_healthy_protected_is_ok() {
+        let assessments = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            make_assessment("sv2", PromiseStatus::Protected),
+        ];
+        let vs = compute_visual_state(&assessments);
+        assert_eq!(vs.icon, crate::output::VisualIcon::Ok);
+        assert_eq!(vs.safety_counts.ok, 2);
+        assert_eq!(vs.health_counts.healthy, 2);
+    }
+
+    #[test]
+    fn visual_state_any_at_risk_is_warning() {
+        let assessments = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            make_assessment("sv2", PromiseStatus::AtRisk),
+        ];
+        let vs = compute_visual_state(&assessments);
+        assert_eq!(vs.icon, crate::output::VisualIcon::Warning);
+        assert_eq!(vs.safety_counts.aging, 1);
+        assert_eq!(vs.worst_safety, "AT RISK");
+    }
+
+    #[test]
+    fn visual_state_any_unprotected_is_critical() {
+        let assessments = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            make_assessment("sv2", PromiseStatus::Unprotected),
+        ];
+        let vs = compute_visual_state(&assessments);
+        assert_eq!(vs.icon, crate::output::VisualIcon::Critical);
+        assert_eq!(vs.safety_counts.gap, 1);
+    }
+
+    #[test]
+    fn visual_state_protected_but_degraded_is_warning() {
+        let mut a = make_assessment("sv1", PromiseStatus::Protected);
+        a.health = OperationalHealth::Degraded;
+        let vs = compute_visual_state(&[a]);
+        assert_eq!(vs.icon, crate::output::VisualIcon::Warning);
+        assert_eq!(vs.worst_health, "degraded");
+        assert_eq!(vs.health_counts.degraded, 1);
+    }
+
+    #[test]
+    fn visual_state_all_blocked_is_critical() {
+        let mut a = make_assessment("sv1", PromiseStatus::Protected);
+        a.health = OperationalHealth::Blocked;
+        let vs = compute_visual_state(&[a]);
+        assert_eq!(vs.icon, crate::output::VisualIcon::Critical);
+        assert_eq!(vs.health_counts.blocked, 1);
+    }
+
+    #[test]
+    fn visual_state_some_blocked_some_healthy_is_warning() {
+        let mut a1 = make_assessment("sv1", PromiseStatus::Protected);
+        a1.health = OperationalHealth::Blocked;
+        let a2 = make_assessment("sv2", PromiseStatus::Protected);
+        let vs = compute_visual_state(&[a1, a2]);
+        assert_eq!(vs.icon, crate::output::VisualIcon::Warning);
+    }
+
+    #[test]
+    fn visual_state_empty_assessments_is_ok() {
+        let vs = compute_visual_state(&[]);
+        assert_eq!(vs.icon, crate::output::VisualIcon::Ok);
+        assert_eq!(vs.safety_counts.ok, 0);
+        assert_eq!(vs.health_counts.healthy, 0);
+    }
+
+    #[test]
+    fn visual_state_unprotected_trumps_degraded() {
+        let mut a1 = make_assessment("sv1", PromiseStatus::Unprotected);
+        a1.health = OperationalHealth::Degraded;
+        let vs = compute_visual_state(&[a1]);
+        assert_eq!(vs.icon, crate::output::VisualIcon::Critical);
+    }
+
+    #[test]
+    fn has_health_changes_new_subvolume_returns_true() {
+        let prev = vec![HealthSnapshot {
+            name: "sv1".into(),
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
+        }];
+        let curr = vec![
+            make_assessment("sv1", PromiseStatus::Protected),
+            make_assessment("sv2", PromiseStatus::Protected),
+        ];
+        assert!(has_health_changes(&prev, &curr));
     }
 }

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -246,6 +246,16 @@ impl SentinelRunner {
             ));
         }
 
+        // 1b. Health state changes (VFM-B, skip first assessment).
+        if self.state.has_initial_assessment
+            && sentinel::has_health_changes(&self.state.last_health_states, &assessments)
+        {
+            notifications.extend(build_health_notifications(
+                &self.state.last_health_states,
+                &assessments,
+            ));
+        }
+
         // 2. BackupOverdue — independent of promise changes (S1 fix).
         //    Debounced: don't re-send within OVERDUE_DEBOUNCE (M2 fix).
         let debounce_ok = self.state.has_initial_assessment
@@ -303,6 +313,7 @@ impl SentinelRunner {
 
         // Update state.
         self.state.last_promise_states = sentinel::snapshot_promises(&assessments);
+        self.state.last_health_states = sentinel::snapshot_health(&assessments);
         if !self.state.has_initial_assessment {
             self.state.has_initial_assessment = true;
             // Populate chain health baseline so the next tick can detect transitions.
@@ -327,7 +338,7 @@ impl SentinelRunner {
         self.last_assessment_time = Some(Instant::now());
 
         // Write state file.
-        self.write_state_file(now)?;
+        self.write_state_file(now, &assessments)?;
 
         Ok(())
     }
@@ -365,9 +376,13 @@ impl SentinelRunner {
 
     // ── State file I/O ──────────────────────────────────────────────────
 
-    fn write_state_file(&self, now: NaiveDateTime) -> anyhow::Result<()> {
+    fn write_state_file(
+        &self,
+        now: NaiveDateTime,
+        assessments: &[SubvolAssessment],
+    ) -> anyhow::Result<()> {
         let state_file = SentinelStateFile {
-            schema_version: 1,
+            schema_version: 2,
             pid: std::process::id(),
             started: self.started.format("%Y-%m-%dT%H:%M:%S").to_string(),
             last_assessment: Some(now.format("%Y-%m-%dT%H:%M:%S").to_string()),
@@ -377,15 +392,29 @@ impl SentinelRunner {
                 .state
                 .last_promise_states
                 .iter()
-                .map(|p| SentinelPromiseState {
-                    name: p.name.clone(),
-                    status: p.status.to_string(),
+                .map(|p| {
+                    let health_snap = self
+                        .state
+                        .last_health_states
+                        .iter()
+                        .find(|h| h.name == p.name);
+                    SentinelPromiseState {
+                        name: p.name.clone(),
+                        status: p.status.to_string(),
+                        health: health_snap
+                            .map(|h| h.health.to_string())
+                            .unwrap_or_else(|| "healthy".to_string()),
+                        health_reasons: health_snap
+                            .map(|h| h.health_reasons.clone())
+                            .unwrap_or_default(),
+                    }
                 })
                 .collect(),
             circuit_breaker: SentinelCircuitState {
                 state: self.state.circuit_breaker.state.to_string(),
                 failure_count: self.state.circuit_breaker.failure_count,
             },
+            visual_state: Some(sentinel::compute_visual_state(assessments)),
         };
 
         let content = serde_json::to_string_pretty(&state_file)?;
@@ -524,6 +553,70 @@ pub fn check_backup_overdue(
     })
 }
 
+// ── Health notification building (VFM-B) ───────────────────────────────
+
+/// Build notifications from Sentinel-observed health state changes.
+///
+/// Pure function: previous health snapshots + current assessments → notifications.
+/// Parallel to `build_notifications()` for promise changes.
+///
+/// Urgency: Info (health is operational readiness, not data safety).
+pub fn build_health_notifications(
+    previous: &[sentinel::HealthSnapshot],
+    current: &[SubvolAssessment],
+) -> Vec<Notification> {
+    let mut notifications = Vec::new();
+
+    for assess in current {
+        if let Some(prev) = previous.iter().find(|p| p.name == assess.name)
+            && assess.health != prev.health
+        {
+            let from = prev.health.to_string();
+            let to = assess.health.to_string();
+
+            if assess.health < prev.health {
+                let reasons = if assess.health_reasons.is_empty() {
+                    String::new()
+                } else {
+                    format!(
+                        " {} Run `urd status` for details.",
+                        assess.health_reasons.join("; ")
+                    )
+                };
+                notifications.push(Notification {
+                    event: NotificationEvent::HealthDegraded {
+                        subvolume: assess.name.clone(),
+                        from: from.clone(),
+                        to: to.clone(),
+                    },
+                    urgency: Urgency::Info,
+                    title: format!("Urd: {} health now {}", assess.name, to),
+                    body: format!(
+                        "The loom for {} reports {} — was {}.{}",
+                        assess.name, to, from, reasons
+                    ),
+                });
+            } else {
+                notifications.push(Notification {
+                    event: NotificationEvent::HealthRecovered {
+                        subvolume: assess.name.clone(),
+                        from: from.clone(),
+                        to: to.clone(),
+                    },
+                    urgency: Urgency::Info,
+                    title: format!("Urd: {} health restored to {}", assess.name, to),
+                    body: format!(
+                        "The loom for {} is running smoothly again — restored from {} to {}.",
+                        assess.name, from, to
+                    ),
+                });
+            }
+        }
+    }
+
+    notifications
+}
+
 // ── Helpers ─────────────────────────────────────────────────────────────
 
 /// Derive sentinel state file path from config (same directory as state_db).
@@ -597,7 +690,7 @@ mod tests {
     #[test]
     fn state_file_serialization_roundtrip() {
         let state = SentinelStateFile {
-            schema_version: 1,
+            schema_version: 2,
             pid: 12345,
             started: "2026-03-27T10:00:00".to_string(),
             last_assessment: Some("2026-03-27T10:15:00".to_string()),
@@ -606,23 +699,47 @@ mod tests {
             promise_states: vec![SentinelPromiseState {
                 name: "home".to_string(),
                 status: "PROTECTED".to_string(),
+                health: "degraded".to_string(),
+                health_reasons: vec!["chain broken on WD-18TB".to_string()],
             }],
             circuit_breaker: SentinelCircuitState {
                 state: "closed".to_string(),
                 failure_count: 0,
             },
+            visual_state: Some(crate::output::VisualState {
+                icon: crate::output::VisualIcon::Warning,
+                worst_safety: "PROTECTED".to_string(),
+                worst_health: "degraded".to_string(),
+                safety_counts: crate::output::SafetyCounts {
+                    ok: 1,
+                    aging: 0,
+                    gap: 0,
+                },
+                health_counts: crate::output::HealthCounts {
+                    healthy: 0,
+                    degraded: 1,
+                    blocked: 0,
+                },
+            }),
         };
 
         let json = serde_json::to_string_pretty(&state).unwrap();
         let parsed: SentinelStateFile = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed.schema_version, 1);
+        assert_eq!(parsed.schema_version, 2);
         assert_eq!(parsed.pid, 12345);
         assert_eq!(parsed.started, "2026-03-27T10:00:00");
         assert_eq!(parsed.mounted_drives, vec!["WD-18TB"]);
         assert_eq!(parsed.promise_states.len(), 1);
         assert_eq!(parsed.promise_states[0].name, "home");
+        assert_eq!(parsed.promise_states[0].health, "degraded");
+        assert_eq!(parsed.promise_states[0].health_reasons.len(), 1);
         assert_eq!(parsed.circuit_breaker.state, "closed");
+        assert!(parsed.visual_state.is_some());
+        assert_eq!(
+            parsed.visual_state.unwrap().icon,
+            crate::output::VisualIcon::Warning
+        );
     }
 
     #[test]
@@ -647,7 +764,7 @@ mod tests {
         let path = dir.path().join("sentinel-state.json");
 
         let state = SentinelStateFile {
-            schema_version: 1,
+            schema_version: 2,
             pid: std::process::id(),
             started: "2026-03-27T10:00:00".to_string(),
             last_assessment: None,
@@ -658,6 +775,7 @@ mod tests {
                 state: "closed".to_string(),
                 failure_count: 0,
             },
+            visual_state: None,
         };
 
         let content = serde_json::to_string_pretty(&state).unwrap();
@@ -665,6 +783,55 @@ mod tests {
 
         let read_back = read_sentinel_state_file(&path).unwrap();
         assert_eq!(read_back.pid, std::process::id());
+    }
+
+    #[test]
+    fn state_file_v1_backward_compat_deserialization() {
+        // Schema v1 files lack visual_state and health fields — must deserialize cleanly.
+        let v1_json = r#"{
+            "schema_version": 1,
+            "pid": 99999,
+            "started": "2026-03-27T10:00:00",
+            "last_assessment": null,
+            "mounted_drives": [],
+            "tick_interval_secs": 120,
+            "promise_states": [
+                { "name": "home", "status": "PROTECTED" }
+            ],
+            "circuit_breaker": { "state": "closed", "failure_count": 0 }
+        }"#;
+
+        let parsed: SentinelStateFile = serde_json::from_str(v1_json).unwrap();
+        assert_eq!(parsed.schema_version, 1);
+        assert!(parsed.visual_state.is_none());
+        assert_eq!(parsed.promise_states[0].health, "healthy"); // default
+        assert!(parsed.promise_states[0].health_reasons.is_empty()); // default
+    }
+
+    #[test]
+    fn state_file_health_reasons_omitted_when_empty() {
+        let state = SentinelStateFile {
+            schema_version: 2,
+            pid: 1,
+            started: "2026-03-27T10:00:00".to_string(),
+            last_assessment: None,
+            mounted_drives: vec![],
+            tick_interval_secs: 120,
+            promise_states: vec![SentinelPromiseState {
+                name: "home".to_string(),
+                status: "PROTECTED".to_string(),
+                health: "healthy".to_string(),
+                health_reasons: vec![],
+            }],
+            circuit_breaker: SentinelCircuitState {
+                state: "closed".to_string(),
+                failure_count: 0,
+            },
+            visual_state: None,
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        assert!(!json.contains("health_reasons"));
     }
 
     // ── PID alive check ─────────────────────────────────────────────
@@ -845,5 +1012,83 @@ mod tests {
         let hb = make_heartbeat("2026-03-27T04:00:00", "2026-03-27T06:00:00");
         let now = dt("2026-03-27T06:00:00");
         assert!(check_backup_overdue(&hb, now).is_none());
+    }
+
+    // ── Health notification tests (VFM-B) ──────────────────────────────
+
+    fn make_health_snapshot(name: &str, health: OperationalHealth) -> sentinel::HealthSnapshot {
+        sentinel::HealthSnapshot {
+            name: name.to_string(),
+            health,
+            health_reasons: vec![],
+        }
+    }
+
+    #[test]
+    fn health_degraded_produces_notification() {
+        let prev = vec![make_health_snapshot("sv1", OperationalHealth::Healthy)];
+        let mut a = make_assessment("sv1", PromiseStatus::Protected);
+        a.health = OperationalHealth::Degraded;
+        a.health_reasons = vec!["chain broken on WD-18TB".to_string()];
+
+        let notifs = build_health_notifications(&prev, &[a]);
+        assert_eq!(notifs.len(), 1);
+        assert!(matches!(
+            &notifs[0].event,
+            NotificationEvent::HealthDegraded { subvolume, from, to }
+            if subvolume == "sv1" && from == "healthy" && to == "degraded"
+        ));
+        assert_eq!(notifs[0].urgency, Urgency::Info);
+    }
+
+    #[test]
+    fn health_recovered_produces_notification() {
+        let prev = vec![make_health_snapshot("sv1", OperationalHealth::Degraded)];
+        let a = make_assessment("sv1", PromiseStatus::Protected);
+
+        let notifs = build_health_notifications(&prev, &[a]);
+        assert_eq!(notifs.len(), 1);
+        assert!(matches!(
+            &notifs[0].event,
+            NotificationEvent::HealthRecovered { subvolume, from, to }
+            if subvolume == "sv1" && from == "degraded" && to == "healthy"
+        ));
+    }
+
+    #[test]
+    fn health_blocked_produces_degraded_notification() {
+        let prev = vec![make_health_snapshot("sv1", OperationalHealth::Healthy)];
+        let mut a = make_assessment("sv1", PromiseStatus::Protected);
+        a.health = OperationalHealth::Blocked;
+
+        let notifs = build_health_notifications(&prev, &[a]);
+        assert_eq!(notifs.len(), 1);
+        assert!(matches!(
+            &notifs[0].event,
+            NotificationEvent::HealthDegraded { to, .. } if to == "blocked"
+        ));
+    }
+
+    #[test]
+    fn health_no_change_produces_nothing() {
+        let prev = vec![make_health_snapshot("sv1", OperationalHealth::Healthy)];
+        let a = make_assessment("sv1", PromiseStatus::Protected);
+        assert!(build_health_notifications(&prev, &[a]).is_empty());
+    }
+
+    #[test]
+    fn health_mixed_transitions() {
+        let prev = vec![
+            make_health_snapshot("sv1", OperationalHealth::Healthy),
+            make_health_snapshot("sv2", OperationalHealth::Degraded),
+        ];
+        let mut a1 = make_assessment("sv1", PromiseStatus::Protected);
+        a1.health = OperationalHealth::Degraded;
+        let a2 = make_assessment("sv2", PromiseStatus::Protected);
+
+        let notifs = build_health_notifications(&prev, &[a1, a2]);
+        assert_eq!(notifs.len(), 2);
+        assert!(matches!(&notifs[0].event, NotificationEvent::HealthDegraded { subvolume, .. } if subvolume == "sv1"));
+        assert!(matches!(&notifs[1].event, NotificationEvent::HealthRecovered { subvolume, .. } if subvolume == "sv2"));
     }
 }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -2901,7 +2901,7 @@ mod tests {
 
     fn test_sentinel_running() -> SentinelStatusOutput {
         SentinelStatusOutput::Running {
-            state: SentinelStateFile {
+            state: Box::new(SentinelStateFile {
                 schema_version: 1,
                 pid: 12345,
                 started: "2026-03-27T10:00:00".to_string(),
@@ -2911,12 +2911,15 @@ mod tests {
                 promise_states: vec![SentinelPromiseState {
                     name: "home".to_string(),
                     status: "PROTECTED".to_string(),
+                    health: "healthy".to_string(),
+                    health_reasons: vec![],
                 }],
                 circuit_breaker: SentinelCircuitState {
                     state: "closed".to_string(),
                     failure_count: 0,
                 },
-            },
+                visual_state: None,
+            }),
             uptime: "3h 12m".to_string(),
         }
     }


### PR DESCRIPTION
## Summary

- **Health transition detection**: Sentinel tracks operational health across ticks and fires `HealthDegraded`/`HealthRecovered` notifications (`Urgency::Info`) when health changes
- **Visual state in state file**: `visual_state` block with icon state (`ok`/`warning`/`critical`/`active`), worst safety/health, and per-axis counts — the tray icon contract (structured data, no pre-computed text)
- **State file schema v2**: `SentinelPromiseState` extended with `health` and `health_reasons` fields; backward-compatible with v1 via `#[serde(default)]`
- **NamedSnapshot trait**: Generic change-detection algorithm replaces duplicated promise/health comparison logic
- **All-blocked escalation**: When every subvolume is `Blocked`, icon escalates to `Critical` (parallels `AllUnprotected` pattern)

Design doc: `docs/95-ideas/2026-03-28-design-visual-feedback-model.md` (Session B)
Review: `docs/99-reports/2026-03-30-vfm-b-visual-state-review.md` (scores 4-5/5)

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 542 tests pass (21 new)
- Integration tests: not applicable (advisory code, no btrfs I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)