### PR TITLE
feat: transient local retention for space-constrained volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Transient local retention mode (`local_retention = "transient"`): delete local snapshots after external send, keep only pinned chain parents for incremental sends
+- Preflight checks for transient misconfiguration (transient without send, transient with named protection level)
+
 ## [0.4.3] - 2026-03-30
 
 ### Added

--- a/config/urd.toml.example
+++ b/config/urd.toml.example
@@ -175,15 +175,21 @@ source = "/mnt/btrfs-pool/subvol5-music"
 priority = 3
 protection_level = "protected"
 
-# ─── Guarded: local snapshots only ────────────────────────────────────
+# ─── Transient: send to external, don't keep local history ───────────
+# Transient retention keeps only the pinned snapshot needed for incremental
+# chains. Ideal for subvolumes on space-constrained volumes (NVMe root)
+# where you want external backups but can't afford local snapshot history.
 
 [[subvolumes]]
 name = "htpc-root"
 short_name = "htpc-root"
 source = "/"
 priority = 3
-protection_level = "guarded"
-local_retention = { daily = 7 }    # Override: root changes rarely, keep less
+local_retention = "transient"      # Delete local after send, keep only chain parent
+send_interval = "1d"
+drives = ["WD-18TB1"]              # Send to offsite drive only
+
+# ─── Guarded: local snapshots only ────────────────────────────────────
 
 [[subvolumes]]
 name = "subvol4-multimedia"

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,13 +8,14 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-542 tests, all passing, clippy clean. Current version: v0.4.2.
+556 tests, all passing, clippy clean. Current version: v0.4.3.
 
 ## In Progress
 
-- **VFM-B complete, needs PR** (2026-03-30). Sentinel health tracking, visual state in
-  state file (schema v2), HealthDegraded/HealthRecovered notifications, NamedSnapshot
-  trait refactor. Reviewed. 7 files changed, +653/-35 lines, 21 new tests.
+- **Transient snapshots** (2026-03-30). `local_retention = "transient"` — delete local
+  snapshots after external send, keep only pinned chain parents. For space-constrained
+  NVMe volumes (htpc-root). New types, config integration, planner branch, preflight
+  checks. 5 files changed, 14 new tests.
 
 ## Build Queue
 
@@ -28,8 +29,8 @@ full details, design decisions, and review findings.
 5. ~~**UX-2**~~ — plan output: estimated send sizes, cross-drive fallback. **Done.**
 6. ~~**UX-3**~~ — plan output: rich progress display + ETA. **Done.**
 7. ~~**HSD-B**~~ — sentinel chain-break detection + full-send gate. **Done (v0.4.2).**
-8. ~~**VFM-B**~~ — sentinel visual state + health notifications. **Done, needs PR.**
-9. **Transient snapshots** — `local_retention = "transient"` for NVMe space pressure. **Start here.**
+8. ~~**VFM-B**~~ — sentinel visual state + health notifications. **Done (v0.4.3).**
+9. **Transient snapshots** — `local_retention = "transient"` for NVMe space pressure. **In progress.**
 10. **Tray icon (Spindle)** — reads sentinel-state.json, 4 static icons.
 
 Designs: `docs/95-ideas/2026-03-29-design-*.md`.

--- a/docs/99-reports/2026-03-30-transient-snapshots-review.md
+++ b/docs/99-reports/2026-03-30-transient-snapshots-review.md
@@ -1,0 +1,238 @@
+# Architectural Review: Transient Snapshots Implementation
+
+**Project:** Urd
+**Date:** 2026-03-30
+**Scope:** Implementation review of transient snapshots feature (`local_retention = "transient"`)
+**Base commit:** `b0d0117` (v0.4.3)
+**Files reviewed:** `src/types.rs`, `src/config.rs`, `src/plan.rs`, `src/preflight.rs`, `config/urd.toml.example`
+**Mode:** Implementation review (6 dimensions)
+
+---
+
+## Executive Summary
+
+Clean, disciplined implementation that correctly reuses the existing unsent-snapshot
+protection and three-layer pin defense. The core insight — that transient retention
+is just "delete everything not in the protected set" — is exactly right and leverages
+existing planner infrastructure. Two findings matter: one significant (awareness reports
+UNPROTECTED when there are 0 local snapshots between send cycles, which will be the
+normal transient state), one moderate (missing test for the multi-drive pin interaction
+that is the most subtle correctness property of this feature).
+
+---
+
+## What Kills You
+
+The catastrophic failure mode is **deleting the last local copy of a snapshot before it
+reaches any external drive**. This is silent data loss — the user thinks they're protected,
+but the transient cleanup deleted data that was never sent.
+
+Distance from catastrophe: **three independent layers prevent this.** (1) The planner's
+unsent-snapshot protection expands the protected set to include everything newer than the
+oldest pin. (2) Transient retention only deletes snapshots outside the protected set. (3)
+The executor's defense-in-depth re-reads pin files from disk before every delete. All three
+layers are reused from existing code, not newly written. The implementation is well-distanced
+from catastrophe.
+
+---
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | **Correctness** | 4 | Core deletion logic is correct. Unsent protection correctly inherited. One awareness gap (S1). |
+| 2 | **Security** | 5 | No new trust boundaries, no new sudo paths, no path construction changes. |
+| 3 | **Architectural Excellence** | 5 | Leverages existing infrastructure perfectly. No new abstractions that don't earn their keep. Type system enforces transient-not-in-defaults at parse time. |
+| 4 | **Systems Design** | 4 | Correct in steady state. Awareness model interaction (S1) needs attention for operational clarity. |
+| 5 | **Rust Idioms** | 5 | Custom serde visitor is the right approach (better errors than `#[serde(untagged)]`). `as_graduated()` convenience method is clean. |
+| 6 | **Code Quality** | 4 | Clear, readable code. Tests cover the critical paths. One coverage gap for multi-drive (M1). |
+
+---
+
+## Design Tensions
+
+### 1. Reuse existing protection vs. transient-specific logic
+
+**Tension:** The transient path reuses the same unsent-snapshot protection logic as
+graduated retention (lines 348-374 of plan.rs). This means transient behavior is
+coupled to graduated retention's protection semantics — if those semantics change,
+transient changes too.
+
+**Resolution:** Correct call. The unsent-snapshot protection logic is load-bearing
+for data safety in both modes. Having one implementation means one place to get right
+(or wrong). The alternative — duplicating the protection logic for a transient-specific
+path — would be strictly worse: same semantics, two implementations, inevitable
+divergence. The coupling here is *desirable* coupling.
+
+### 2. Awareness model ignorance vs. transient-aware assessment
+
+**Tension:** The implementation explicitly chose not to modify `awareness.rs`. With
+the pinned-snapshot approach, transient subvolumes will usually have exactly 1 local
+snapshot, and existing assessment works. But between the send-delete-create cycle
+(after transient deletes old snapshots and before a new one is created), there may be
+moments with 0 local snapshots, which awareness reports as UNPROTECTED.
+
+**Resolution:** This is the one tension that wasn't resolved correctly. See S1.
+
+---
+
+## Findings
+
+### S1 — Significant: Awareness reports UNPROTECTED for transient subvolumes at rest
+
+`awareness.rs:369` — when `snapshots.len() == 0`, `assess_local()` returns
+`PromiseStatus::Unprotected`. For a transient subvolume after a successful send cycle
+(create → send → pin advances → transient deletes old snapshots), the normal state is
+exactly 1 local snapshot (the pinned one). But there are realistic windows where the
+count is 0:
+
+1. **Between runs when pin is the only snapshot:** If the pinned snapshot is also the
+   only local snapshot, and the next `plan()` call creates a new one and deletes the
+   old pin (after the send advances), there's a window during execution where 0 local
+   snapshots exist (old pin deleted, new one not yet pinned).
+
+2. **First run before any send:** No pins, `send_enabled = true` → unsent protection
+   keeps everything. Count will be > 0. This case is fine.
+
+3. **After send to all drives + transient cleanup, before next create:** The pin points
+   to the latest sent snapshot, which is still local. Count = 1. This case is fine.
+
+On closer inspection, the pinned snapshot is always protected by the transient logic
+and should remain. The real problem is narrower: **`urd status` shows UNPROTECTED for
+the local axis** whenever the pinned snapshot ages past the assessment threshold (which
+it will, since transient subvolumes don't create new snapshots between send intervals).
+A transient subvolume with a 1-day send interval will show its local snapshot aging to
+24h, crossing the UNPROTECTED threshold at ~5× the *snapshot* interval — which may be
+1 hour. The local snapshot is 24h old, the threshold is 5h → local = UNPROTECTED. But
+for transient, this is *expected* — the data is on the external drive.
+
+**Consequence:** Alert fatigue. `urd status` and sentinel health notifications will
+show transient subvolumes as locally UNPROTECTED most of the time, even when external
+copies are recent. The user learns to ignore the local status for these subvolumes,
+which reduces their trust in the overall status display.
+
+**Suggested fix:** Not necessarily now, but flag for the next session. Two options:
+(a) Make awareness aware of transient mode — skip local assessment or report
+`PromiseStatus::Protected` when the mode is transient and external status is good.
+(b) Add an advisory note like "local_retention = transient: local status reflects
+external send recency" to suppress the misleading signal. Either way, the overall
+`SubvolAssessment.status` should weight external assessment more heavily for transient
+subvolumes.
+
+### M1 — Moderate: No test for multi-drive transient interaction
+
+The most subtle correctness property of transient mode is the multi-drive case: with
+2 drives (D1 and D2), the pinned set is the *union* of both drives' pins. If D1's
+pin is at snapshot A and D2's pin is at snapshot B (older), unsent protection keeps
+everything from B onward. Transient then deletes nothing older than B.
+
+This behavior is *correct* (it falls out of the existing unsent-protection logic), but
+there's no test that exercises it. The `transient_config()` test helper has only one
+drive. A multi-drive test would verify the interaction that matters most for real-world
+use (the design doc envisions `drives = ["WD-18TB1"]` but nothing prevents multi-drive
+transient configs).
+
+**Suggested fix:** Add a test with 2 drives where pins are at different snapshots.
+Verify that all snapshots between the older pin and the newer pin are protected (unsent
+to the drive with the older pin).
+
+### M2 — Moderate: `urd plan` output doesn't distinguish transient from graduated deletes visually
+
+The reason string `"transient: not pinned"` is the only signal that a delete is
+transient. In `urd plan` output, transient deletes appear as:
+
+```
+DELETE  /snap/sv1/20260320-1000-one (transient: not pinned)
+```
+
+For a user scanning plan output, the distinction between "retention expired this
+snapshot" and "transient mode is cleaning up" is important — it tells them whether
+this is normal aging or active cleanup. The reason string carries the signal, but it's
+buried in parentheses alongside graduated retention reasons like "(weekly window
+expired)".
+
+**Suggested fix:** This is fine for now — the reason string is there. If transient
+mode becomes commonly used, consider adding a section header in `urd plan` output like
+"Transient cleanup (sv1): 3 snapshots" to make it scannable. Low priority.
+
+### C1 — Commendation: Type system enforcement of transient-not-in-defaults
+
+`DefaultsConfig.local_retention` stays as `GraduatedRetention`, not the new enum.
+This means `local_retention = "transient"` in the `[defaults]` section is a parse
+error at config load time — not a preflight warning, not a runtime check, a type error.
+The user gets an error immediately, not after their first backup run. This is the right
+level of enforcement for a setting that is semantically nonsensical as a default.
+
+### C2 — Commendation: Zero new abstractions
+
+The implementation adds exactly two types (`LocalRetentionConfig` for serde,
+`LocalRetentionPolicy` for resolved config) and touches no module that doesn't need
+touching. No new traits, no new helper modules, no new operation variants. The transient
+delete path in the planner is 7 lines. The existing unsent-snapshot protection, pin
+exclusion, and executor defense-in-depth all apply unchanged. This is a feature that
+was designed to slot into the existing architecture, and it does.
+
+### C3 — Commendation: Custom serde visitor with clear errors
+
+The custom `Deserialize` implementation on `LocalRetentionConfig` produces error
+messages like `unknown local_retention mode "bogus": expected "transient" or a
+retention table`. Compare to `#[serde(untagged)]` which would produce `data did not
+match any variant`. For a config file the user edits by hand, error quality matters —
+a confusing parse error at 04:00 when the backup fails is the difference between a
+5-minute fix and a frustrated hour.
+
+---
+
+## The Simplicity Question
+
+**What could be removed:** Nothing. This is already minimal. Two enums, a serde
+visitor, a match branch in the planner, two preflight checks. Every piece earns its
+keep.
+
+**What's earning its keep:**
+- `as_graduated()` convenience method — eliminates match boilerplate at every consumer
+- Custom serde visitor — better error messages than the alternative
+- Preflight checks for transient+no-send and transient+named-level — catches the two
+  config mistakes a user is most likely to make
+
+---
+
+## For the Dev Team
+
+Priority-ordered action items:
+
+1. **Add multi-drive transient test** (plan.rs). Create a test with 2 drives, pins
+   at different snapshots. Verify unsent protection keeps snapshots between the two
+   pins. This exercises the most important interaction.
+   - File: `src/plan.rs`, tests section
+   - Why: the multi-drive case is the subtle correctness property; existing tests
+     only use 1 drive
+
+2. **Flag awareness interaction for next session.** Transient subvolumes will report
+   local status as UNPROTECTED when the pinned snapshot ages past the assessment
+   threshold. This is expected for transient but confusing for users. Options: (a)
+   teach awareness about transient mode, (b) add an advisory note. Not urgent — the
+   external assessment still shows PROTECTED when sends are recent, and the overall
+   promise status aggregates both. But it will cause noise in `urd status`.
+   - File: `src/awareness.rs` (future work)
+   - Why: prevents alert fatigue and confusion in status output
+
+---
+
+## Open Questions
+
+1. **Should `urd status` show a "transient" indicator in the LOCAL column?** Something
+   like "1 pinned" instead of "1 (12h)" to signal that the low count and old age are
+   expected. This is a voice.rs concern, not an awareness concern.
+
+2. **What happens when a transient subvolume's only drive is unmounted for weeks?**
+   The unsent protection keeps all local snapshots (correct, since nothing has been
+   sent). But local snapshots accumulate without transient cleanup running. The space
+   guard (`min_free_bytes`) prevents exhaustion, but the user may be surprised that
+   "transient" doesn't mean "always 0-1 local snapshots." Worth documenting.
+
+3. **Should transient mode interact with the sentinel's health notifications?** A
+   transient subvolume with `OperationalHealth::Blocked` (no drives mounted) is in a
+   state where local snapshots will accumulate. Should the sentinel flag this
+   specifically for transient subvolumes? Probably not yet — the existing Blocked
+   notification covers it.

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use crate::error::UrdError;
 use crate::notify::NotificationConfig;
 use crate::types::{
-    ByteSize, DriveRole, GraduatedRetention, Interval, ProtectionLevel, ResolvedGraduatedRetention,
-    RunFrequency,
+    ByteSize, DriveRole, GraduatedRetention, Interval, LocalRetentionConfig, LocalRetentionPolicy,
+    ProtectionLevel, ResolvedGraduatedRetention, RunFrequency,
 };
 
 // ── Top-level config ────────────────────────────────────────────────────
@@ -107,7 +107,7 @@ pub struct SubvolumeConfig {
     pub snapshot_interval: Option<Interval>,
     pub send_interval: Option<Interval>,
     pub send_enabled: Option<bool>,
-    pub local_retention: Option<GraduatedRetention>,
+    pub local_retention: Option<LocalRetentionConfig>,
     pub external_retention: Option<GraduatedRetention>,
     #[serde(default)]
     pub protection_level: Option<ProtectionLevel>,
@@ -132,7 +132,7 @@ pub struct ResolvedSubvolume {
     pub snapshot_interval: Interval,
     pub send_interval: Interval,
     pub send_enabled: bool,
-    pub local_retention: ResolvedGraduatedRetention,
+    pub local_retention: LocalRetentionPolicy,
     pub external_retention: ResolvedGraduatedRetention,
     pub protection_level: Option<ProtectionLevel>,
     pub drives: Option<Vec<String>>,
@@ -160,7 +160,11 @@ impl SubvolumeConfig {
             Some(policy) => {
                 // Named level: derived values are the base, explicit overrides replace them.
                 let local_ret = match &self.local_retention {
-                    Some(lr) => {
+                    Some(LocalRetentionConfig::Transient) => {
+                        // Transient overrides derived policy entirely.
+                        LocalRetentionPolicy::Transient
+                    }
+                    Some(LocalRetentionConfig::Graduated(lr)) => {
                         // User's partial retention merges with derived floor as base
                         let derived_as_graduated = GraduatedRetention {
                             hourly: Some(policy.local_retention.hourly),
@@ -168,9 +172,11 @@ impl SubvolumeConfig {
                             weekly: Some(policy.local_retention.weekly),
                             monthly: Some(policy.local_retention.monthly),
                         };
-                        lr.merged_with(&derived_as_graduated).resolved()
+                        LocalRetentionPolicy::Graduated(
+                            lr.merged_with(&derived_as_graduated).resolved(),
+                        )
                     }
-                    None => policy.local_retention,
+                    None => LocalRetentionPolicy::Graduated(policy.local_retention),
                 };
                 let external_ret = match &self.external_retention {
                     Some(er) => {
@@ -202,8 +208,15 @@ impl SubvolumeConfig {
             None => {
                 // Custom / no level: existing defaults-based resolution (migration path).
                 let local_ret = match &self.local_retention {
-                    Some(lr) => lr.merged_with(&defaults.local_retention).resolved(),
-                    None => defaults.local_retention.resolved(),
+                    Some(LocalRetentionConfig::Transient) => LocalRetentionPolicy::Transient,
+                    Some(LocalRetentionConfig::Graduated(lr)) => {
+                        LocalRetentionPolicy::Graduated(
+                            lr.merged_with(&defaults.local_retention).resolved(),
+                        )
+                    }
+                    None => {
+                        LocalRetentionPolicy::Graduated(defaults.local_retention.resolved())
+                    }
                 };
                 let external_ret = match &self.external_retention {
                     Some(er) => er.merged_with(&defaults.external_retention).resolved(),
@@ -601,15 +614,17 @@ send_interval = "2h"
         assert_eq!(resolved.send_interval, Interval::hours(1));
         assert!(resolved.enabled);
         assert!(resolved.send_enabled);
-        assert_eq!(resolved.local_retention.hourly, 24);
-        assert_eq!(resolved.local_retention.daily, 30);
+        let lr = resolved.local_retention.as_graduated().unwrap();
+        assert_eq!(lr.hourly, 24);
+        assert_eq!(lr.daily, 30);
 
         // Second subvolume inherits defaults for retention
         let resolved2 =
             config.subvolumes[1].resolved(&config.defaults, config.general.run_frequency);
         assert_eq!(resolved2.snapshot_interval, Interval::hours(1));
-        assert_eq!(resolved2.local_retention.weekly, 26);
-        assert_eq!(resolved2.local_retention.monthly, 12);
+        let lr2 = resolved2.local_retention.as_graduated().unwrap();
+        assert_eq!(lr2.weekly, 26);
+        assert_eq!(lr2.monthly, 12);
 
         // Check that drop is ignored (suppresses warning about unused binding)
         let _ = toml_str;
@@ -837,15 +852,16 @@ local_retention = { daily = 7, weekly = 4 }
 
         // Explicitly overridden
         assert!(!resolved.send_enabled);
-        assert_eq!(resolved.local_retention.daily, 7);
-        assert_eq!(resolved.local_retention.weekly, 4);
+        let lr = resolved.local_retention.as_graduated().unwrap();
+        assert_eq!(lr.daily, 7);
+        assert_eq!(lr.weekly, 4);
 
         // Inherited from defaults
         assert_eq!(resolved.snapshot_interval, Interval::hours(1));
         assert_eq!(resolved.send_interval, Interval::hours(4));
         assert!(resolved.enabled);
-        assert_eq!(resolved.local_retention.hourly, 24); // from defaults (not overridden)
-        assert_eq!(resolved.local_retention.monthly, 12); // from defaults (not overridden)
+        assert_eq!(lr.hourly, 24); // from defaults (not overridden)
+        assert_eq!(lr.monthly, 12); // from defaults (not overridden)
         assert_eq!(resolved.external_retention.daily, 30);
     }
 
@@ -1034,10 +1050,11 @@ local_retention = { daily = 7, weekly = 4 }
         // Specific check: sv2 with overrides
         let sv2 = config.subvolumes[1].resolved(&config.defaults, freq);
         assert!(!sv2.send_enabled);
-        assert_eq!(sv2.local_retention.daily, 7);
-        assert_eq!(sv2.local_retention.weekly, 4);
-        assert_eq!(sv2.local_retention.hourly, 24); // from defaults
-        assert_eq!(sv2.local_retention.monthly, 12); // from defaults
+        let lr2 = sv2.local_retention.as_graduated().unwrap();
+        assert_eq!(lr2.daily, 7);
+        assert_eq!(lr2.weekly, 4);
+        assert_eq!(lr2.hourly, 24); // from defaults
+        assert_eq!(lr2.monthly, 12); // from defaults
     }
 
     #[test]
@@ -1080,10 +1097,11 @@ protection_level = "protected"
         assert_eq!(resolved.snapshot_interval, Interval::days(1)); // derived from timer
         assert_eq!(resolved.send_interval, Interval::days(1)); // derived from timer
         assert!(resolved.send_enabled);
-        assert_eq!(resolved.local_retention.hourly, 24);
-        assert_eq!(resolved.local_retention.daily, 30);
-        assert_eq!(resolved.local_retention.weekly, 26);
-        assert_eq!(resolved.local_retention.monthly, 12);
+        let lr = resolved.local_retention.as_graduated().unwrap();
+        assert_eq!(lr.hourly, 24);
+        assert_eq!(lr.daily, 30);
+        assert_eq!(lr.weekly, 26);
+        assert_eq!(lr.monthly, 12);
     }
 
     #[test]
@@ -1166,11 +1184,12 @@ local_retention = { daily = 60 }
             config.subvolumes[0].resolved(&config.defaults, config.general.run_frequency);
 
         // User override for daily
-        assert_eq!(resolved.local_retention.daily, 60);
+        let lr = resolved.local_retention.as_graduated().unwrap();
+        assert_eq!(lr.daily, 60);
         // Derived values fill in unspecified fields
-        assert_eq!(resolved.local_retention.hourly, 24);
-        assert_eq!(resolved.local_retention.weekly, 26);
-        assert_eq!(resolved.local_retention.monthly, 12);
+        assert_eq!(lr.hourly, 24);
+        assert_eq!(lr.weekly, 26);
+        assert_eq!(lr.monthly, 12);
     }
 
     #[test]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -9,7 +9,9 @@ use crate::config::{Config, DriveConfig, ResolvedSubvolume};
 use crate::drives::DriveAvailability;
 use crate::error::UrdError;
 use crate::retention;
-use crate::types::{BackupPlan, FullSendReason, PlannedOperation, SnapshotName};
+use crate::types::{
+    BackupPlan, FullSendReason, LocalRetentionPolicy, PlannedOperation, SnapshotName,
+};
 
 // ── FileSystemState trait ───────────────────────────────────────────────
 
@@ -371,25 +373,41 @@ fn plan_local_retention(
         pinned.clone()
     };
 
-    // Check space pressure
-    let min_free = config.root_min_free_bytes(&subvol.name).unwrap_or(0);
-    let free_bytes = fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
-    let space_pressure = min_free > 0 && free_bytes < min_free;
+    match &subvol.local_retention {
+        LocalRetentionPolicy::Transient => {
+            // Transient: delete everything not in the protected set (pins + unsent).
+            for snap in local_snaps {
+                if !protected.contains(snap) {
+                    operations.push(PlannedOperation::DeleteSnapshot {
+                        path: local_dir.join(snap.as_str()),
+                        reason: "transient: not pinned".to_string(),
+                        subvolume_name: subvol.name.clone(),
+                    });
+                }
+            }
+        }
+        LocalRetentionPolicy::Graduated(retention_config) => {
+            // Check space pressure
+            let min_free = config.root_min_free_bytes(&subvol.name).unwrap_or(0);
+            let free_bytes = fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
+            let space_pressure = min_free > 0 && free_bytes < min_free;
 
-    let result = retention::graduated_retention(
-        local_snaps,
-        now,
-        &subvol.local_retention,
-        &protected,
-        space_pressure,
-    );
+            let result = retention::graduated_retention(
+                local_snaps,
+                now,
+                retention_config,
+                &protected,
+                space_pressure,
+            );
 
-    for (snap, reason) in result.delete {
-        operations.push(PlannedOperation::DeleteSnapshot {
-            path: local_dir.join(snap.as_str()),
-            reason,
-            subvolume_name: subvol.name.clone(),
-        });
+            for (snap, reason) in result.delete {
+                operations.push(PlannedOperation::DeleteSnapshot {
+                    path: local_dir.join(snap.as_str()),
+                    reason,
+                    subvolume_name: subvol.name.clone(),
+                });
+            }
+        }
     }
 }
 
@@ -2122,6 +2140,322 @@ drives = ["D1"]
         assert!(
             !d1_sends.is_empty(),
             "D1 should have send operations — it's in the allowed list"
+        );
+    }
+
+    // ── Transient retention tests ──────────────────────────────────
+
+    fn transient_config() -> Config {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+send_enabled = true
+enabled = true
+
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "test"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "one"
+source = "/data/sv1"
+priority = 1
+local_retention = "transient"
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn transient_deletes_all_non_pinned_snapshots() {
+        let config = transient_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260320-1000-one"),
+                snap("20260321-1000-one"),
+                snap("20260322-1000-one"),
+                snap("20260322-1200-one"),
+                snap("20260322-1400-one"),
+            ],
+        );
+        // Pin on the oldest — means it and everything newer-than-it are protected
+        // Only the pin is truly pinned; newer ones are protected as unsent
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap("20260320-1000-one"),
+        );
+        // Drive mounted, recent send — so unsent protection kicks in
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![snap("20260320-1000-one")],
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::DeleteSnapshot { .. }))
+            .collect();
+
+        // All snapshots newer than pin are unsent-protected, so 0 deletes
+        // (the pin at 20260320 is protected, everything newer is unsent)
+        assert_eq!(
+            deletes.len(),
+            0,
+            "all snapshots should be protected (pinned or unsent)"
+        );
+    }
+
+    #[test]
+    fn transient_deletes_old_snapshots_after_send_advances_pin() {
+        // Simulate: pin has advanced to newest, old snapshots are deletable
+        let config = transient_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260320-1000-one"),
+                snap("20260321-1000-one"),
+                snap("20260322-1400-one"),
+            ],
+        );
+        // Pin on the newest — all older snapshots are unprotected
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap("20260322-1400-one"),
+        );
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![
+                snap("20260320-1000-one"),
+                snap("20260321-1000-one"),
+                snap("20260322-1400-one"),
+            ],
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter_map(|op| match op {
+                PlannedOperation::DeleteSnapshot {
+                    subvolume_name,
+                    reason,
+                    ..
+                } if subvolume_name == "sv1" => Some(reason.clone()),
+                _ => None,
+            })
+            .collect();
+
+        // 2 old snapshots should be deleted (pin at newest protects only itself)
+        assert_eq!(deletes.len(), 2, "should delete 2 old snapshots");
+        assert!(
+            deletes[0].contains("transient"),
+            "reason should contain 'transient': {}",
+            deletes[0]
+        );
+    }
+
+    #[test]
+    fn transient_no_pins_keeps_everything() {
+        let config = transient_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260321-1000-one"),
+                snap("20260322-1000-one"),
+            ],
+        );
+        // No pin files — nothing has ever been sent
+        fs.mounted_drives.insert("D1".to_string());
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::DeleteSnapshot {
+                        subvolume_name,
+                        ..
+                    } if subvolume_name == "sv1"
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            deletes.len(),
+            0,
+            "no pins means all snapshots are unsent-protected"
+        );
+    }
+
+    #[test]
+    fn transient_empty_local_snapshots_no_ops() {
+        let config = transient_config();
+        let fs = MockFileSystemState::new();
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::DeleteSnapshot {
+                        subvolume_name,
+                        ..
+                    } if subvolume_name == "sv1"
+                )
+            })
+            .collect();
+
+        assert_eq!(deletes.len(), 0);
+    }
+
+    fn transient_multi_drive_config() -> Config {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+send_enabled = true
+enabled = true
+
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[drives]]
+label = "D2"
+mount_path = "/mnt/d2"
+snapshot_root = ".snapshots"
+role = "offsite"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "one"
+source = "/data/sv1"
+priority = 1
+local_retention = "transient"
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn transient_multi_drive_pins_at_different_snapshots() {
+        // D1 pin advanced to newest, D2 pin still at older snapshot.
+        // Unsent protection must keep everything from D2's pin onward
+        // (those snapshots haven't been sent to D2 yet).
+        let config = transient_multi_drive_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260319-1000-one"), // older than both pins
+                snap("20260320-1000-one"), // D2's pin (older)
+                snap("20260321-1000-one"), // between pins (unsent to D2)
+                snap("20260322-1000-one"), // between pins (unsent to D2)
+                snap("20260322-1400-one"), // D1's pin (newest)
+            ],
+        );
+        // D1 pin at newest, D2 pin at older
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap("20260322-1400-one"),
+        );
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D2".to_string()),
+            snap("20260320-1000-one"),
+        );
+        fs.mounted_drives.insert("D1".to_string());
+        fs.mounted_drives.insert("D2".to_string());
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![
+                snap("20260320-1000-one"),
+                snap("20260322-1400-one"),
+            ],
+        );
+        fs.external_snapshots.insert(
+            ("D2".to_string(), "sv1".to_string()),
+            vec![snap("20260320-1000-one")],
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter_map(|op| match op {
+                PlannedOperation::DeleteSnapshot {
+                    subvolume_name,
+                    path,
+                    ..
+                } if subvolume_name == "sv1" => {
+                    Some(path.file_name().unwrap().to_string_lossy().to_string())
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Only 20260319 should be deleted — it's older than D2's pin (the oldest pin).
+        // D2's pin (20260320) is pinned. Everything newer is unsent-to-D2-protected.
+        assert_eq!(deletes.len(), 1, "only pre-pin snapshot should be deleted: {deletes:?}");
+        assert!(
+            deletes[0].contains("20260319"),
+            "deleted snapshot should be the one older than both pins: {deletes:?}"
         );
     }
 }

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -41,6 +41,7 @@ pub fn preflight_checks(config: &Config) -> Vec<PreflightCheck> {
         }
 
         check_retention_send_compatibility(subvol, &mut checks);
+        check_transient_validity(subvol, &mut checks);
         check_promise_achievability(subvol, config, &mut checks);
     }
 
@@ -69,7 +70,12 @@ fn check_retention_send_compatibility(
         return;
     }
 
-    let retention = &subvol.local_retention;
+    // Transient retention has no retention windows — pins handle chain integrity.
+    let retention = match subvol.local_retention.as_graduated() {
+        Some(r) => r,
+        None => return,
+    };
+
     let guaranteed_survival_hours = i64::from(retention.hourly) + i64::from(retention.daily) * 24;
     let send_interval_hours = subvol.send_interval.as_secs() / 3600;
 
@@ -84,6 +90,44 @@ fn check_retention_send_compatibility(
                  send interval ({}) — incremental chain depends on pin protection \
                  rather than retention to keep parents alive",
                 subvol.name, survival_display, retention.hourly, retention.daily, interval_display,
+            ),
+        });
+    }
+}
+
+/// Check transient retention validity.
+///
+/// Transient retention without send_enabled is nonsensical — snapshots would be created
+/// and immediately deleted with no external copy. Transient with a named protection level
+/// (Guarded/Protected/Resilient) is also invalid since named levels imply graduated retention.
+fn check_transient_validity(
+    subvol: &crate::config::ResolvedSubvolume,
+    checks: &mut Vec<PreflightCheck>,
+) {
+    if !subvol.local_retention.is_transient() {
+        return;
+    }
+
+    if !subvol.send_enabled {
+        checks.push(PreflightCheck {
+            name: "transient-without-send",
+            message: format!(
+                "{}: transient local retention with send_enabled=false — snapshots \
+                 would be created and deleted with no external copy",
+                subvol.name,
+            ),
+        });
+    }
+
+    if let Some(level) = subvol.protection_level
+        && level != ProtectionLevel::Custom
+    {
+        checks.push(PreflightCheck {
+            name: "transient-with-named-level",
+            message: format!(
+                "{}: transient local retention is incompatible with {level} protection \
+                 level — use protection_level = \"custom\" or remove it",
+                subvol.name,
             ),
         });
     }
@@ -202,21 +246,23 @@ fn check_promise_achievability(
         });
     }
 
-    // Retention weakening: check if any bucket is tighter than derived
-    let local = &subvol.local_retention;
-    let derived_local = &derived.local_retention;
-    if local.hourly < derived_local.hourly
-        || local.daily < derived_local.daily
-        || local.weekly < derived_local.weekly
-        || (derived_local.monthly > 0 && local.monthly < derived_local.monthly)
-    {
-        checks.push(PreflightCheck {
-            name: "weakening-override",
-            message: format!(
-                "{}: local_retention is tighter than {} baseline — less history preserved",
-                subvol.name, level,
-            ),
-        });
+    // Retention weakening: check if any bucket is tighter than derived.
+    // Skip for transient — it's a fundamentally different model, not a weakened graduated policy.
+    if let Some(local) = subvol.local_retention.as_graduated() {
+        let derived_local = &derived.local_retention;
+        if local.hourly < derived_local.hourly
+            || local.daily < derived_local.daily
+            || local.weekly < derived_local.weekly
+            || (derived_local.monthly > 0 && local.monthly < derived_local.monthly)
+        {
+            checks.push(PreflightCheck {
+                name: "weakening-override",
+                message: format!(
+                    "{}: local_retention is tighter than {} baseline — less history preserved",
+                    subvol.name, level,
+                ),
+            });
+        }
     }
 }
 
@@ -245,7 +291,9 @@ mod tests {
         Config, DefaultsConfig, DriveConfig, GeneralConfig, LocalSnapshotsConfig, SnapshotRoot,
         SubvolumeConfig,
     };
-    use crate::types::{ByteSize, DriveRole, GraduatedRetention, Interval, RunFrequency};
+    use crate::types::{
+        ByteSize, DriveRole, GraduatedRetention, Interval, LocalRetentionConfig, RunFrequency,
+    };
     use std::path::PathBuf;
 
     /// Build a minimal valid config for testing.
@@ -335,12 +383,12 @@ mod tests {
             snapshot_interval: None,
             send_interval: Some(send_interval.parse().unwrap()),
             send_enabled: None,
-            local_retention: Some(GraduatedRetention {
+            local_retention: Some(LocalRetentionConfig::Graduated(GraduatedRetention {
                 hourly: Some(hourly),
                 daily: Some(daily),
                 weekly: Some(0),
                 monthly: Some(0),
-            }),
+            })),
             external_retention: None,
             protection_level: None,
             drives: None,
@@ -571,12 +619,12 @@ mod tests {
         let mut sv = test_subvolume("documents");
         sv.protection_level = Some(crate::types::ProtectionLevel::Protected);
         // Protected derives hourly=24, daily=30. Set tighter retention.
-        sv.local_retention = Some(GraduatedRetention {
+        sv.local_retention = Some(LocalRetentionConfig::Graduated(GraduatedRetention {
             hourly: Some(6),
             daily: Some(7),
             weekly: Some(4),
             monthly: Some(0),
-        });
+        }));
         let config = test_config(vec![sv], vec![test_drive()]);
         let results: Vec<_> = preflight_checks(&config)
             .into_iter()
@@ -624,5 +672,68 @@ mod tests {
             .collect();
 
         assert!(results.is_empty());
+    }
+
+    // ── Transient validity tests ───────────────────────────────────
+
+    #[test]
+    fn transient_without_send_warns() {
+        let mut sv = test_subvolume("root");
+        sv.local_retention = Some(LocalRetentionConfig::Transient);
+        sv.send_enabled = Some(false);
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "transient-without-send")
+            .collect();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].message.contains("no external copy"));
+    }
+
+    #[test]
+    fn transient_with_named_level_warns() {
+        let mut sv = test_subvolume("root");
+        sv.local_retention = Some(LocalRetentionConfig::Transient);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Guarded);
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "transient-with-named-level")
+            .collect();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].message.contains("incompatible"));
+    }
+
+    #[test]
+    fn transient_with_custom_level_no_warning() {
+        let mut sv = test_subvolume("root");
+        sv.local_retention = Some(LocalRetentionConfig::Transient);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Custom);
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "transient-with-named-level" || c.name == "transient-without-send")
+            .collect();
+
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn transient_skips_retention_send_compatibility() {
+        let mut sv = test_subvolume("root");
+        sv.local_retention = Some(LocalRetentionConfig::Transient);
+        sv.send_interval = Some("1h".parse().unwrap());
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let results: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "retention-send-compatibility")
+            .collect();
+
+        assert!(
+            results.is_empty(),
+            "transient should skip retention-send-compatibility check"
+        );
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -499,6 +499,89 @@ pub struct ResolvedGraduatedRetention {
     pub monthly: u32,
 }
 
+// ── LocalRetentionConfig / LocalRetentionPolicy ───────────────────────
+
+/// Config-level local retention: either `"transient"` (string) or a graduated
+/// retention table. Used in `SubvolumeConfig` (the raw TOML layer).
+///
+/// Transient retention means: delete all local snapshots except those pinned
+/// for incremental chains. Designed for subvolumes on space-constrained volumes
+/// that need external sends but not local history.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LocalRetentionConfig {
+    /// Standard time-windowed retention (hourly/daily/weekly/monthly).
+    Graduated(GraduatedRetention),
+    /// Delete after external send, keep only pinned chain parents.
+    Transient,
+}
+
+impl Serialize for LocalRetentionConfig {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            Self::Transient => serializer.serialize_str("transient"),
+            Self::Graduated(g) => g.serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for LocalRetentionConfig {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct LocalRetentionVisitor;
+
+        impl<'de> Visitor<'de> for LocalRetentionVisitor {
+            type Value = LocalRetentionConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("\"transient\" or a table with hourly/daily/weekly/monthly fields")
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                if value == "transient" {
+                    Ok(LocalRetentionConfig::Transient)
+                } else {
+                    Err(de::Error::custom(format!(
+                        "unknown local_retention mode \"{value}\": expected \"transient\" or a retention table"
+                    )))
+                }
+            }
+
+            fn visit_map<M: de::MapAccess<'de>>(self, map: M) -> Result<Self::Value, M::Error> {
+                let g = GraduatedRetention::deserialize(de::value::MapAccessDeserializer::new(map))?;
+                Ok(LocalRetentionConfig::Graduated(g))
+            }
+        }
+
+        deserializer.deserialize_any(LocalRetentionVisitor)
+    }
+}
+
+/// Fully resolved local retention policy — no optional fields.
+/// Used on `ResolvedSubvolume` after config defaults have been applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LocalRetentionPolicy {
+    /// Standard time-windowed retention.
+    Graduated(ResolvedGraduatedRetention),
+    /// Transient: delete all local snapshots except pinned chain parents.
+    Transient,
+}
+
+impl LocalRetentionPolicy {
+    /// Returns the graduated retention config, if this is not transient.
+    #[must_use]
+    pub fn as_graduated(&self) -> Option<&ResolvedGraduatedRetention> {
+        match self {
+            Self::Graduated(g) => Some(g),
+            Self::Transient => None,
+        }
+    }
+
+    /// Returns `true` if this is the transient retention mode.
+    #[must_use]
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Transient)
+    }
+}
+
 // ── PlannedOperation ────────────────────────────────────────────────────
 
 /// Why a full send was planned instead of an incremental send.
@@ -1165,5 +1248,124 @@ mod tests {
         assert_eq!(p.send_interval, Interval::hours(6));
         // Retention stays the same regardless of timer interval
         assert_eq!(p.local_retention.daily, 30);
+    }
+
+    // ── LocalRetentionConfig serde tests ───────────────────────────
+
+    #[test]
+    fn local_retention_config_deserializes_transient_string() {
+        let toml_str = r#"local_retention = "transient""#;
+
+        #[derive(Deserialize)]
+        struct Wrapper {
+            local_retention: LocalRetentionConfig,
+        }
+
+        let w: Wrapper = toml::from_str(toml_str).unwrap();
+        assert_eq!(w.local_retention, LocalRetentionConfig::Transient);
+    }
+
+    #[test]
+    fn local_retention_config_deserializes_graduated_table() {
+        let toml_str = r#"
+[local_retention]
+daily = 7
+weekly = 4
+"#;
+
+        #[derive(Deserialize)]
+        struct Wrapper {
+            local_retention: LocalRetentionConfig,
+        }
+
+        let w: Wrapper = toml::from_str(toml_str).unwrap();
+        match w.local_retention {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.daily, Some(7));
+                assert_eq!(g.weekly, Some(4));
+                assert_eq!(g.hourly, None);
+                assert_eq!(g.monthly, None);
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+    }
+
+    #[test]
+    fn local_retention_config_deserializes_inline_table() {
+        let toml_str = r#"local_retention = { daily = 30, weekly = 26 }"#;
+
+        #[derive(Deserialize)]
+        struct Wrapper {
+            local_retention: LocalRetentionConfig,
+        }
+
+        let w: Wrapper = toml::from_str(toml_str).unwrap();
+        match w.local_retention {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.daily, Some(30));
+                assert_eq!(g.weekly, Some(26));
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+    }
+
+    #[test]
+    fn local_retention_config_rejects_invalid_string() {
+        let toml_str = r#"local_retention = "bogus""#;
+
+        #[derive(Debug, Deserialize)]
+        struct Wrapper {
+            local_retention: LocalRetentionConfig,
+        }
+
+        let result: Result<Wrapper, _> = toml::from_str(toml_str);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("transient"), "error should mention 'transient': {err}");
+    }
+
+    #[test]
+    fn local_retention_config_serialize_roundtrip() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            local_retention: LocalRetentionConfig,
+        }
+
+        // Transient roundtrip
+        let transient = Wrapper {
+            local_retention: LocalRetentionConfig::Transient,
+        };
+        let toml_str = toml::to_string(&transient).unwrap();
+        let parsed: Wrapper = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed, transient);
+
+        // Graduated roundtrip
+        let graduated = Wrapper {
+            local_retention: LocalRetentionConfig::Graduated(GraduatedRetention {
+                hourly: Some(24),
+                daily: Some(30),
+                weekly: None,
+                monthly: None,
+            }),
+        };
+        let toml_str = toml::to_string(&graduated).unwrap();
+        let parsed: Wrapper = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed, graduated);
+    }
+
+    #[test]
+    fn local_retention_policy_as_graduated() {
+        let graduated = LocalRetentionPolicy::Graduated(ResolvedGraduatedRetention {
+            hourly: 24,
+            daily: 30,
+            weekly: 26,
+            monthly: 12,
+        });
+        assert!(graduated.as_graduated().is_some());
+        assert!(!graduated.is_transient());
+
+        let transient = LocalRetentionPolicy::Transient;
+        assert!(transient.as_graduated().is_none());
+        assert!(transient.is_transient());
     }
 }


### PR DESCRIPTION
## Summary

- Add `local_retention = "transient"` config option: delete local snapshots after external send, keep only pinned chain parents for incremental sends
- Custom serde deserializer accepts both `"transient"` string and graduated retention table with clear error messages
- Planner reuses existing unsent-snapshot protection and three-layer pin defense unchanged
- Preflight catches misconfigurations: transient without send_enabled, transient with named protection levels
- Transient not allowed in `[defaults]` (enforced at parse time by type system)

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 557 tests, all passing (+15 new)
- Multi-drive pin interaction test added per review finding M1
- Integration tests: not applicable (no btrfs calls)

## Review

Arch-adversary review: `docs/99-reports/2026-03-30-transient-snapshots-review.md`
- Scores: 4-5/5 across all 6 dimensions
- M1 (multi-drive test): addressed
- S1 (awareness gap for transient local status): deferred to future session

🤖 Generated with [Claude Code](https://claude.com/claude-code)