### PR TITLE
fix: awareness model adaptation for transient retention mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Transient local retention mode (`local_retention = "transient"`): delete local snapshots after external send, keep only pinned chain parents for incremental sends
 - Preflight checks for transient misconfiguration (transient without send, transient with named protection level)
 
+### Fixed
+- Awareness model now understands transient retention: local status defers to external send freshness instead of falsely reporting UNPROTECTED
+
 ## [0.4.3] - 2026-03-30
 
 ### Added

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,33 +8,35 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-556 tests, all passing, clippy clean. Current version: v0.4.3.
+563 tests, all passing, clippy clean. Current version: v0.4.3.
 
-## In Progress
+## Recently Completed
 
+- **Transient awareness fix** (2026-03-30). Awareness model now understands transient
+  retention: local status = Protected (defers to external send freshness). Includes
+  `clamp_age()` extraction, clock-skew advisory for transient, guard for transient+no-sends
+  edge case. 6 new tests. Reviewed and post-review fixes applied.
 - **Transient snapshots** (2026-03-30). `local_retention = "transient"` — delete local
   snapshots after external send, keep only pinned chain parents. For space-constrained
-  NVMe volumes (htpc-root). New types, config integration, planner branch, preflight
-  checks. 5 files changed, 14 new tests.
+  NVMe volumes (htpc-root). Merged. Ready to deploy to production config.
 
-## Build Queue
+## Next Up
 
-Seven-step sequence resolved 2026-03-29. See [roadmap.md Priority 5.5](roadmap.md) for
-full details, design decisions, and review findings.
+1. **Deploy transient to htpc-root** — update production `urd.toml`, monitor after next
+   backup cycle. The awareness gap is resolved; this is now a config change only.
+2. **Tray icon (Spindle)** — reads sentinel-state.json visual_state, 4 static icons.
+   Brainstorm exists, needs design doc. `docs/95-ideas/2026-03-28-brainstorm-tray-icon-spindle.md`
+3. **Shell completions (6a)** — `clap_complete` for static completions. Low effort, no design needed.
 
-1. ~~**HSD-A**~~ — drive session tokens + chain health as awareness input. **Done.**
-2. ~~**VFM-A**~~ — `OperationalHealth` enum, two-axis CLI rendering. **Done.**
-3. ~~**Sentinel Session 3**~~ — hardening + notification deduplication. **Done.**
-4. ~~**UX-1**~~ — plan output: structural headings + collapsed skips. **Done.**
-5. ~~**UX-2**~~ — plan output: estimated send sizes, cross-drive fallback. **Done.**
-6. ~~**UX-3**~~ — plan output: rich progress display + ETA. **Done.**
-7. ~~**HSD-B**~~ — sentinel chain-break detection + full-send gate. **Done (v0.4.2).**
-8. ~~**VFM-B**~~ — sentinel visual state + health notifications. **Done (v0.4.3).**
-9. **Transient snapshots** — `local_retention = "transient"` for NVMe space pressure. **In progress.**
-10. **Tray icon (Spindle)** — reads sentinel-state.json, 4 static icons.
+## Build Queue (Priority 5.5) — Complete
 
-Designs: `docs/95-ideas/2026-03-29-design-*.md`.
-Reviews: `docs/99-reports/2026-03-30-vfm-b-visual-state-review.md`.
+All 10 items in the 5.5 build sequence are done. Designs: `docs/95-ideas/2026-03-2*-design-*.md`.
+
+| # | Feature | Status |
+|---|---------|--------|
+| 1–8 | HSD-A, VFM-A, Session 3, UX-1/2/3, HSD-B, VFM-B | Done (v0.4.1–v0.4.3) |
+| 9 | Transient snapshots | Done (merged, awareness fix applied) |
+| 10 | Tray icon (Spindle) | Brainstormed, not designed |
 
 **Later:** Config system migration (ADR-111), shell completions (6a).
 
@@ -47,7 +49,7 @@ Reviews: `docs/99-reports/2026-03-30-vfm-b-visual-state-review.md`.
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Latest journals | `docs/98-journals/` (local only, gitignored) |
-| Latest reviews | [VFM-B review](../99-reports/2026-03-30-vfm-b-visual-state-review.md), [HSD-B review](../99-reports/2026-03-30-hsd-b-chain-break-detection-review.md) |
+| Latest reviews | [Transient awareness review](../99-reports/2026-03-30-transient-awareness-fix-review.md), [Transient snapshots review](../99-reports/2026-03-30-transient-snapshots-review.md) |
 
 ## Known Issues
 
@@ -56,12 +58,8 @@ Reviews: `docs/99-reports/2026-03-30-vfm-b-visual-state-review.md`.
 - `FileSystemState` trait (11 methods) outgrowing its name — consider rename to `SystemState`
 - `urd get` doesn't support directory restore (files only in v1)
 - Calibrated sizes use `du -sb` but btrfs send streams are ~10% larger — affects size estimates
-- Per-drive pin protection for external retention: all-drives-union is conservative but suboptimal for space
 - Stringly-typed output boundary: three independent status-ranking implementations across notify.rs and voice.rs
-- `drive_connections` table has no retention policy (negligible for years at ~1000 rows/year)
-- `render_skipped_block` (backup summary) uses ad-hoc string grouping; could adopt `SkipCategory`
-- Progress completion line byte count lags true total by up to one poll interval (~45 MB at USB3 speeds)
-- `OpResult::Skipped` is overloaded: four distinct semantics (prior failure, optimization, safety guard, safety gate)
+- `OpResult::Skipped` is overloaded: four distinct semantics
 - `urd sentinel status` interactive mode doesn't render health/visual_state fields yet
 
 See [roadmap.md](roadmap.md) for the full tech debt list and dropped features.

--- a/docs/99-reports/2026-03-30-transient-awareness-fix-review.md
+++ b/docs/99-reports/2026-03-30-transient-awareness-fix-review.md
@@ -1,0 +1,257 @@
+# Implementation Review: Transient Awareness Fix
+
+**Project:** Urd
+**Date:** 2026-03-30
+**Scope:** Implementation review of awareness model adaptation for transient retention
+**Base commit:** `4d139ac` (master, post-merge of transient snapshots)
+**Files reviewed:** `src/awareness.rs` (diff + full context), `src/types.rs`, `src/output.rs`, `src/voice.rs`, `src/notify.rs`, `src/sentinel.rs`, `src/heartbeat.rs`, `src/preflight.rs`
+**Mode:** Implementation review (6 dimensions, arch-adversary methodology)
+**Prior review:** `docs/99-reports/2026-03-30-transient-snapshots-review.md` (S1 finding — this change resolves it)
+
+---
+
+## Executive Summary
+
+Correct fix for a real problem. The prior review identified that awareness reports
+UNPROTECTED for transient subvolumes in their normal resting state (0 local snapshots
+between send cycles). This change resolves it cleanly: transient local status is always
+Protected, so overall status reduces to external assessment via `min(Protected, external)
+= external`. The `clamp_age()` extraction is a good deduplication. One finding matters:
+the rule "transient local = always Protected" is unconditionally correct only when
+`send_enabled = true`, which preflight warns about but does not enforce.
+
+---
+
+## What Kills You
+
+The catastrophic failure mode for this change is **masking real data loss behind a false
+Protected status**. If the awareness model says Protected when data is actually at risk,
+the user receives no signal that action is needed. Silent data loss follows.
+
+Distance from catastrophe: **well-distanced for the intended use case.** Transient mode
+requires `send_enabled = true` (preflight warns if not), and with sends enabled, "local =
+Protected, overall = external status" is semantically correct. The dangerous configuration
+(transient + no sends) is caught by preflight. The only gap is that preflight is advisory,
+not enforcing.
+
+---
+
+## Premise Challenge: Is "transient local = always Protected" the right rule?
+
+**Yes, with a qualification.**
+
+The reasoning: for transient subvolumes, local snapshots are ephemeral staging areas for
+external sends. Data safety comes exclusively from external copies. Reporting local status
+based on snapshot freshness would produce false alarms (the normal state is 0 or 1 old
+snapshots). The correct signal is: "local is not a data safety axis for this subvolume —
+defer entirely to external assessment."
+
+`PromiseStatus::Protected` is the mechanism for expressing "this axis is not the
+bottleneck." Since `compute_overall_status` uses `min(local, best_external)`, setting local
+to Protected makes overall status track external status exactly. This is the right
+semantic.
+
+The qualification: this rule is unconditionally applied regardless of whether external sends
+are actually configured and working. See S1.
+
+---
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | **Correctness** | 4 | Core logic is right. One edge case (S1) where Protected is misleading. |
+| 2 | **Security** | 5 | No new trust boundaries, no path changes, no privilege changes. |
+| 3 | **Architectural Excellence** | 5 | Pure function stays pure. No new types. `clamp_age()` extraction improves consistency. |
+| 4 | **Systems Design** | 4 | Correct for steady state. Downstream consumers (heartbeat, sentinel, voice) consume `LocalAssessment` unchanged — no adaptation needed, which validates the design. |
+| 5 | **Rust Idioms** | 5 | Clean pattern match on `is_transient()`, early return, no unnecessary allocation. |
+| 6 | **Code Quality** | 5 | Five well-chosen tests covering the key states. `clamp_age()` dedup is good housekeeping. |
+
+---
+
+## Design Tensions
+
+### 1. Unconditional Protected vs. conditional on external send health
+
+**Tension:** The transient branch returns `PromiseStatus::Protected` for local status
+regardless of whether external sends exist, are configured, or have ever succeeded. The
+overall status formula `min(Protected, external)` only produces the right answer when
+there *is* an external axis to evaluate. When `drives` is empty (or all unmounted with
+no send history), `compute_overall_status` returns `local.status` directly — which is
+Protected.
+
+**Resolution:** Preflight catches the dangerous configuration (`transient-without-send`)
+and warns. The preflight is advisory, not enforcing, but this is consistent with Urd's
+design: ADR-109 says structural config errors refuse to start, while semantic warnings
+are advisory. A transient+no-send config is semantically nonsensical but structurally
+valid. The user has been warned. Acceptable.
+
+### 2. Enriching LocalAssessment vs. keeping it mode-agnostic
+
+**Tension:** `LocalAssessment` carries `snapshot_count` and `newest_age` — fields that
+remain meaningful for transient (they show the pinned snapshot count and age). But it
+does *not* carry any indicator that the assessment was produced under transient rules.
+Downstream consumers (voice.rs, output.rs) render the LOCAL column identically for
+transient and graduated subvolumes.
+
+**Resolution:** Correct call for now. Adding a mode flag to `LocalAssessment` would
+push transient awareness into the presentation layer, which would then need to decide
+how to render "this is transient, the low count is expected." That is future work (see
+Open Question 1 from the prior review). The current approach is simpler: status is
+Protected, count and age are factual, consumers render without special cases.
+
+---
+
+## Findings
+
+### S1 — Significant: Transient + send_enabled=false + no drives = false Protected
+
+When a transient subvolume has `send_enabled = false` (preflight warns but does not
+block), the assessment path is:
+
+1. `assess_local()` returns Protected (transient branch, unconditional)
+2. `compute_overall_status()` receives empty `drives` vec, returns `local.status` = Protected
+3. Overall status: Protected
+
+This is incorrect. With no external sends, a transient subvolume has no data safety
+mechanism — local snapshots are being deleted, and nothing is being sent anywhere. The
+correct status is Unprotected.
+
+**Proximity to catastrophe:** Low. Preflight emits a clear warning. The user would have
+to ignore the warning, deploy this config, and then trust the Protected status. This is
+a two-mistake scenario. But the principle is important: awareness should never report
+Protected when data is demonstrably not safe, even if the config is nonsensical.
+
+**Suggested fix:** Add a guard in `assess_local()` for the transient branch:
+
+```rust
+if retention.is_transient() {
+    // Transient without external sends has no data safety mechanism.
+    // This config is warned by preflight but not blocked.
+    if !has_external_drives {
+        return (LocalAssessment {
+            status: PromiseStatus::Unprotected,
+            ...
+        }, Some("transient retention with no external sends — data is not protected".into()));
+    }
+    // ... existing transient Protected logic
+}
+```
+
+This requires passing `send_enabled` (or the drive count) to `assess_local()`. The
+alternative is a post-hoc check in the `assess()` function body, after `compute_overall_status`,
+which avoids changing `assess_local()`'s signature further. Either approach is acceptable.
+
+**Priority:** Low-medium. The preflight warning is the primary defense. But if you touch
+this function again, fix it.
+
+### M1 — Moderate: No test for transient with send_enabled=false
+
+The test suite covers transient with fresh/stale/very-stale/never-sent external, and
+transient with a pinned snapshot. It does not cover the S1 scenario: transient with
+`send_enabled = false`. This is the configuration that produces the misleading Protected
+status.
+
+**Suggested fix:** Add a test with `send_enabled = false` on the transient subvolume.
+Assert that overall status is Unprotected (this test will fail today, confirming S1).
+
+### M2 — Moderate: Transient with all drives unmounted and no send history reports Protected
+
+Similar to S1 but for a runtime state rather than a config error. A transient subvolume
+with `send_enabled = true` and one configured drive, but that drive has never been
+mounted and no sends have ever occurred:
+
+1. Local: Protected (transient branch)
+2. External: drive is unmounted, `last_send_time` is None, `assess_external_status(None, _)` returns Unprotected
+3. Overall: `min(Protected, Unprotected)` = Unprotected
+
+This case is **correct**. Noting it here because it was the boundary I stress-tested
+and it passes. No action needed.
+
+### L1 — Low: Clock skew advisory duplicated across transient and graduated branches
+
+The clock skew advisory message is identical between the transient early-return branch
+(line 373-376) and the graduated branch (line 412-415). The `clamp_age()` extraction
+deduplicated the clamping logic but not the advisory string. If the message wording
+changes, two sites need updating.
+
+**Suggested fix:** Extract a `clock_skew_advisory(snapshot: &SnapshotName) -> String`
+helper. Not urgent — the duplication is small and the message is unlikely to change
+frequently.
+
+### C1 — Commendation: clamp_age() extraction
+
+Three call sites (two in `assess_local`, one in the external assessment loop) used
+identical `if age < Duration::zero() { Duration::zero() } else { age }` logic. Extracting
+`clamp_age()` removes the duplication and names the concept. The function is pure, small,
+and well-documented. Good housekeeping.
+
+### C2 — Commendation: Test coverage targets the right states
+
+The five transient tests exercise the state matrix that matters:
+
+| Local snapshots | External send age | Expected overall |
+|----------------|-------------------|------------------|
+| 0 | Fresh (6h, < 1.5x 1d) | Protected |
+| 0 | Stale (40h, > 1.5x 1d) | AtRisk |
+| 0 | Very stale (4d, > 3x 1d) | Unprotected |
+| 1 (old pinned) | Fresh | Protected |
+| 0 | Never sent, drive mounted | Unprotected |
+
+This covers the critical boundary: overall status is driven entirely by external
+freshness, and local status is always Protected regardless of count or age. The
+"one old pinned snapshot" test specifically validates that an aged local snapshot
+does not drag down the overall status — which was the exact bug the prior review
+identified.
+
+### C3 — Commendation: No changes to downstream consumers
+
+The change is entirely contained in `assess_local()` and the `clamp_age()` extraction.
+No changes to `output.rs`, `voice.rs`, `heartbeat.rs`, `sentinel.rs`, or `notify.rs`.
+These modules consume `LocalAssessment` and `SubvolAssessment` structs, which have not
+changed shape. The fact that downstream consumers required zero adaptation validates
+that the fix is at the right level of abstraction.
+
+---
+
+## The Simplicity Question
+
+**What could be removed:** Nothing. The change adds one early-return branch (transient),
+one helper function (`clamp_age`), and five tests. Every piece earns its keep.
+
+**What's earning its keep:**
+- The transient early return prevents the graduated logic from evaluating a mode it
+  doesn't understand
+- `clamp_age()` names a concept that was previously anonymous at three call sites
+- The five tests form a complete state matrix for the transient awareness path
+
+---
+
+## For the Dev Team
+
+Priority-ordered action items:
+
+1. **Consider guarding transient + no external sends** (S1). Either in `assess_local()`
+   with a `send_enabled` parameter, or as a post-hoc correction in `assess()`. Low
+   priority given preflight catches it, but fixes a semantic incorrectness.
+
+2. **Add a test for transient + send_enabled=false** (M1). This documents the S1 edge
+   case and will fail until S1 is fixed, serving as a reminder.
+
+3. **Optional: extract clock skew advisory string** (L1). Small dedup, not urgent.
+
+---
+
+## Open Questions
+
+1. **Should the LOCAL column in `urd status` render differently for transient?** Currently
+   it shows "0" or "1 (12h)" like any other subvolume. A label like "transient" or
+   "1 pinned" would signal to the user that the low count is expected. This is a voice.rs
+   concern, deferred from the prior review. Still worth doing eventually.
+
+2. **Should `compute_overall_status` know about retention mode?** Currently it is mode-agnostic:
+   `min(local, best_external)`. The transient fix works by manipulating `local` before
+   it reaches `compute_overall_status`. An alternative design would be to pass the retention
+   mode into `compute_overall_status` and have it ignore local for transient. The current
+   approach (manipulate inputs, keep the combiner generic) is simpler and correct. No change
+   recommended.

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -13,7 +13,7 @@ use chrono::{Duration, NaiveDateTime};
 
 use crate::config::{Config, DriveConfig};
 use crate::plan::FileSystemState;
-use crate::types::{Interval, SnapshotName};
+use crate::types::{Interval, LocalRetentionPolicy, SnapshotName};
 
 // ── Thresholds ─────────────────────────────────────────────────────────
 
@@ -229,7 +229,7 @@ pub fn assess(
 
         let local = {
             let (assessment, advisory) =
-                assess_local(&local_snaps, now, subvol.snapshot_interval);
+                assess_local(&local_snaps, now, subvol.snapshot_interval, subvol.local_retention);
             if let Some(adv) = advisory {
                 advisories.push(adv);
             }
@@ -276,15 +276,7 @@ pub fn assess(
                 }
 
                 let last_send_time = fs.last_successful_send_time(&subvol.name, &drive.label);
-                // Clamp negative ages to zero (clock skew protection, same as local)
-                let last_send_age = last_send_time.map(|t| {
-                    let age = now - t;
-                    if age < Duration::zero() {
-                        Duration::zero()
-                    } else {
-                        age
-                    }
-                });
+                let last_send_age = last_send_time.map(|t| clamp_age(now - t));
 
                 let status = assess_external_status(last_send_age, subvol.send_interval);
 
@@ -311,7 +303,14 @@ pub fn assess(
         }
 
         // ── Overall status ──────────────────────────────────────────
-        let overall = compute_overall_status(&local, &drive_assessments);
+        let mut overall = compute_overall_status(&local, &drive_assessments);
+
+        // Transient without external sends has no data safety mechanism —
+        // local snapshots get deleted and nothing is sent anywhere.
+        // Preflight warns about this config, but awareness must not lie.
+        if subvol.local_retention.is_transient() && !subvol.send_enabled {
+            overall = PromiseStatus::Unprotected;
+        }
 
         // ── Operational health ─────────────────────────────────────
         // Pre-compute local space pressure (needs config access not available in compute_health)
@@ -359,12 +358,39 @@ pub fn assess(
 // ── Helpers ────────────────────────────────────────────────────────────
 
 /// Returns (LocalAssessment, Option<advisory>) — advisory is set when clock skew is detected.
+///
+/// For transient retention, local snapshots don't determine data safety — external
+/// sends do. Local status is always Protected so `compute_overall_status` reduces to
+/// the external assessment: `min(Protected, external) = external`.
 fn assess_local(
     snapshots: &[crate::types::SnapshotName],
     now: NaiveDateTime,
     interval: Interval,
+    retention: LocalRetentionPolicy,
 ) -> (LocalAssessment, Option<String>) {
     let count = snapshots.len();
+
+    // Transient: local snapshots are ephemeral by design. Data safety comes
+    // from external sends, so local status is always Protected.
+    if retention.is_transient() {
+        let mut advisory = None;
+        let newest_age = snapshots.iter().max().map(|s| {
+            let raw_age = now - s.datetime();
+            if raw_age < Duration::zero() {
+                advisory = Some(clock_skew_advisory(s));
+            }
+            clamp_age(raw_age)
+        });
+        return (
+            LocalAssessment {
+                status: PromiseStatus::Protected,
+                snapshot_count: count,
+                newest_age,
+                configured_interval: interval,
+            },
+            advisory,
+        );
+    }
 
     if count == 0 {
         return (
@@ -384,17 +410,11 @@ fn assess_local(
     // Clock skew: newest snapshot is in the future. Clamp to zero so we don't
     // falsely report PROTECTED (negative age < any threshold). The planner already
     // suppresses new snapshot creation in this case, so the user needs to know.
-    let (age, advisory) = if raw_age < Duration::zero() {
-        (
-            Duration::zero(),
-            Some(format!(
-                "clock skew detected: newest snapshot {} is dated in the future — \
-                 snapshot creation may be suppressed until clock catches up",
-                newest,
-            )),
-        )
+    let age = clamp_age(raw_age);
+    let advisory = if raw_age < Duration::zero() {
+        Some(clock_skew_advisory(newest))
     } else {
-        (raw_age, None)
+        None
     };
 
     let status = freshness_status(
@@ -427,6 +447,14 @@ fn assess_external_status(last_send_age: Option<Duration>, interval: Interval) -
     }
 }
 
+fn clock_skew_advisory(snapshot: &crate::types::SnapshotName) -> String {
+    format!(
+        "clock skew detected: newest snapshot {} is dated in the future — \
+         snapshot creation may be suppressed until clock catches up",
+        snapshot,
+    )
+}
+
 fn freshness_status(
     age: Duration,
     interval: Interval,
@@ -442,6 +470,15 @@ fn freshness_status(
         PromiseStatus::AtRisk
     } else {
         PromiseStatus::Unprotected
+    }
+}
+
+/// Clamp a duration to zero if negative (clock skew protection).
+fn clamp_age(age: Duration) -> Duration {
+    if age < Duration::zero() {
+        Duration::zero()
+    } else {
+        age
     }
 }
 
@@ -2263,5 +2300,206 @@ send_enabled = false
             results[0].health_reasons.iter().any(|r| r.contains("full send size unknown")),
             "expected uncertainty reason, got: {:?}", results[0].health_reasons
         );
+    }
+
+    // ── Transient awareness tests ─────────────────────────────────────
+
+    /// Config with one transient subvolume and one drive.
+    fn transient_config() -> Config {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv-transient"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/mnt/wd"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "sv-transient"
+short_name = "svt"
+source = "/data/svt"
+local_retention = "transient"
+"#;
+        toml::from_str(toml_str).expect("transient test config should parse")
+    }
+
+    #[test]
+    fn transient_zero_local_snapshots_with_fresh_external_is_protected() {
+        let config = transient_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // No local snapshots — normal transient state after cleanup
+        // Fresh external send (6h ago, within 1.5× of 1d)
+        fs.send_times.insert(
+            ("sv-transient".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 8, 0),
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].name, "sv-transient");
+        assert_eq!(results[0].local.status, PromiseStatus::Protected);
+        assert_eq!(results[0].local.snapshot_count, 0);
+        assert_eq!(results[0].status, PromiseStatus::Protected);
+    }
+
+    #[test]
+    fn transient_zero_local_snapshots_with_stale_external_is_at_risk() {
+        let config = transient_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // No local snapshots, stale external (40h ago > 1.5× of 1d = 36h)
+        fs.send_times.insert(
+            ("sv-transient".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 21, 22, 0),
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].local.status, PromiseStatus::Protected);
+        // Overall dragged down by external, not local
+        assert_eq!(results[0].status, PromiseStatus::AtRisk);
+    }
+
+    #[test]
+    fn transient_zero_local_snapshots_with_very_stale_external_is_unprotected() {
+        let config = transient_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // No local snapshots, very stale external (4 days ago > 3× of 1d)
+        fs.send_times.insert(
+            ("sv-transient".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 19, 14, 0),
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].local.status, PromiseStatus::Protected);
+        assert_eq!(results[0].status, PromiseStatus::Unprotected);
+    }
+
+    #[test]
+    fn transient_one_pinned_snapshot_is_locally_protected() {
+        let config = transient_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // One old pinned snapshot (12h old — would be UNPROTECTED for graduated
+        // with 1h interval, but transient doesn't care about local age)
+        fs.local_snapshots.insert(
+            "sv-transient".to_string(),
+            vec![snap(dt(2026, 3, 23, 2, 0), "svt")],
+        );
+
+        fs.send_times.insert(
+            ("sv-transient".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 8, 0),
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].local.status, PromiseStatus::Protected);
+        assert_eq!(results[0].local.snapshot_count, 1);
+        assert!(results[0].local.newest_age.is_some());
+        assert_eq!(results[0].status, PromiseStatus::Protected);
+    }
+
+    #[test]
+    fn transient_no_external_sends_ever_is_unprotected() {
+        let config = transient_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // No local snapshots, no external sends, drive mounted
+        fs.mounted_drives.insert("WD-18TB".to_string());
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].local.status, PromiseStatus::Protected);
+        // External: never sent → UNPROTECTED
+        assert_eq!(results[0].external[0].status, PromiseStatus::Unprotected);
+        // Overall: min(Protected, Unprotected) = Unprotected
+        assert_eq!(results[0].status, PromiseStatus::Unprotected);
+    }
+
+    #[test]
+    fn transient_without_send_enabled_is_unprotected() {
+        // Transient + send_enabled=false = no data safety mechanism.
+        // Preflight warns but does not block; awareness must not report Protected.
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv-nosend"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/mnt/wd"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "sv-nosend"
+short_name = "svns"
+source = "/data/svns"
+local_retention = "transient"
+send_enabled = false
+"#;
+        let config: Config = toml::from_str(toml_str).expect("test config should parse");
+        let now = dt(2026, 3, 23, 14, 0);
+        let fs = MockFileSystemState::new();
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(results[0].name, "sv-nosend");
+        // Local returns Protected (transient branch), but overall must be Unprotected
+        // because there is no external safety mechanism.
+        assert_eq!(results[0].local.status, PromiseStatus::Protected);
+        assert_eq!(results[0].status, PromiseStatus::Unprotected);
     }
 }


### PR DESCRIPTION
## Summary

- Awareness model now understands transient retention: local status = Protected (defers to external send freshness) instead of falsely reporting UNPROTECTED for the normal 0-snapshot resting state
- Extracted `clamp_age()` and `clock_skew_advisory()` helpers to deduplicate 3 age-clamping sites and 2 advisory message sites
- Guard for transient + `send_enabled=false` edge case: forces Unprotected (preflight warns but awareness must not lie)
- 6 new tests covering the transient awareness state matrix; arch-adversary review with all findings addressed

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 563 tests, all passing
- Integration tests: not applicable (pure function change, no I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)