### PR TITLE
docs: UX overhaul design — 6 phases with reviews and integrated roadmap

### DIFF
--- a/docs/95-ideas/2026-03-31-design-phase1-vocabulary-landing.md
+++ b/docs/95-ideas/2026-03-31-design-phase1-vocabulary-landing.md
@@ -1,0 +1,281 @@
+# Design: Phase 1 — Vocabulary Landing
+
+> **TL;DR:** Land all resolved vocabulary decisions from the brainstorm/grill-me sessions
+> into presentation-layer code. No data structures change. No new computation. Every
+> user-facing string speaks the final language so all subsequent phases build on stable
+> vocabulary. Purely mechanical — the editorial work is already done.
+
+**Date:** 2026-03-31
+**Status:** proposed
+**Depends on:** 6-E merged (ready now)
+
+---
+
+## Problem
+
+Urd's presentation layer carries inconsistent vocabulary across four dimensions:
+
+1. **Safety labels.** Awareness model says `PROTECTED`/`AT RISK`/`UNPROTECTED`. Voice.rs
+   maps to `OK`/`aging`/`gap`. The brainstorm resolved: **sealed/waning/exposed**.
+
+2. **Chain terminology.** `notify.rs` says "thread." `voice.rs` says "chain." `cli.rs`
+   says "chain." The brainstorm resolved: **thread** everywhere in presentation.
+
+3. **Drive status.** `voice.rs` says "mounted"/"not mounted" regardless of drive role.
+   The brainstorm resolved: **connected/disconnected/away** (role-aware).
+
+4. **Mythic inconsistency.** `notify.rs` uses "loom" and "weave" — the norns spin at
+   a well, they don't weave on a loom. The brainstorm resolved: remove loom/weave/woven,
+   keep thread/fray/well/spindle, add mend.
+
+Every subsequent phase produces user-facing text through `voice.rs`. Building features on
+unstable vocabulary means either shipping text that will change, or deferring vocabulary
+until all features exist (causing a massive rewrite). Landing vocabulary first is cheap
+(presentation-only) and unblocks everything.
+
+---
+
+## Proposed Design
+
+### Change 1: Safety labels → Exposure triad
+
+**File:** `src/voice.rs` — `safety_label()` (line 244)
+
+```rust
+// Before
+fn safety_label(status: &str) -> String {
+    match status {
+        "PROTECTED"   => "OK".to_string(),
+        "AT RISK"     => "aging".to_string(),
+        "UNPROTECTED" => "gap".to_string(),
+        other => other.to_string(),
+    }
+}
+
+// After
+fn exposure_label(status: &str) -> String {
+    match status {
+        "PROTECTED"   => "sealed".to_string(),
+        "AT RISK"     => "waning".to_string(),
+        "UNPROTECTED" => "exposed".to_string(),
+        other => other.to_string(),
+    }
+}
+```
+
+Rename function `safety_label` → `exposure_label` throughout voice.rs.
+
+**Column header:** `"SAFETY"` → `"EXPOSURE"` in `render_subvolume_table()` (line ~165)
+and `render_assessment_table()` (line ~680).
+
+**Summary line:** `render_summary_line()` (lines 70-135):
+- `"All data safe."` → `"All sealed."`
+- `"{N} safe"` → `"{N} sealed"`
+- `"need(s) attention"` → `"exposed"`
+- Pattern: `"{N} of {M} sealed. {names} exposed."`
+
+### Change 2: Chain → Thread
+
+**Column header:** `"CHAIN"` → `"THREAD"` in `render_subvolume_table()`.
+
+**Thread column rendering** (interactive mode only):
+- `"incremental (pin_name)"` → `"unbroken"`
+- `"full (reason)"` → `"broken — full send (~size)"` (include estimated bytes if available)
+- `"none"` → `"—"` (no external sends configured)
+
+Implementation: voice.rs intercepts `ChainHealth` rendering for interactive mode instead
+of calling `.to_string()` (which feeds daemon JSON and must not change).
+
+```rust
+fn render_thread_status(health: &ChainHealth) -> String {
+    match health {
+        ChainHealth::NoDriveData => "—".to_string(),
+        ChainHealth::Incremental(_) => "unbroken".to_string(),
+        ChainHealth::Full(reason) => format!("broken — full send ({})", reason),
+    }
+}
+```
+
+**Error messages:** `src/error.rs` (line 237):
+- `"Incremental parent missing (chain broken)"` → `"Incremental parent missing (thread broken)"`
+- `"Check \`urd verify\` for chain health"` → `"Check \`urd verify\` for thread health"`
+- `UrdError::Chain` error message: `"Chain error: {0}"` → `"Thread error: {0}"`
+  (variant name stays `Chain` — internal, not user-facing)
+
+### Change 3: Drive status → Role-aware vocabulary
+
+**File:** `src/voice.rs` — `render_drive_summary()` (lines 297-327)
+
+- `"mounted"` → `"connected"`
+- `"not mounted"` → role-aware:
+  - `DriveRole::Offsite` → `"away"` + `"last seen N days ago"` if age available
+  - All other roles → `"disconnected"`
+
+**Subvolume table drive cells** (line ~222): Currently shows `"away"` for unmounted drives
+with send history. Make this role-aware: offsite drives show `"away"`, primary/test drives
+show `"—"` (disconnected state is implicit from the column being empty).
+
+**Grouped skip labels:**
+- `"Not mounted:"` → `"Disconnected:"` in `render_drive_not_mounted_group()` (line 932)
+- `"Drives not mounted:"` → `"Drives disconnected:"` in `render_skipped_block()` (line 632)
+
+**Sentinel status** (line ~1538): `"Mounted"` → `"Connected"`
+
+**Init output** (lines ~1370-1392): `"MOUNTED"` → `"CONNECTED"`, `"NOT MOUNTED"` →
+`"DISCONNECTED"` or `"AWAY"` (role-aware)
+
+### Change 4: Skip tag differentiation
+
+**File:** `src/voice.rs` — `render_individual_skips()` (lines 964-977)
+
+Current: `[SPACE]` for SpaceExceeded, `[SKIP]` for Other.
+
+New: per-category tags in grouped renderers too:
+
+| SkipCategory | Tag | Color |
+|---|---|---|
+| `IntervalNotElapsed` | `[WAIT]` | dimmed |
+| `DriveNotMounted` | `[AWAY]` | dimmed |
+| `SpaceExceeded` | `[SPACE]` | yellow |
+| `Disabled` | `[OFF]` | dimmed |
+| `Other` | `[SKIP]` | dimmed |
+
+The grouped renderers (`render_drive_not_mounted_group`, `render_interval_group`,
+`render_disabled_group`) already display their categories in prose. Adding the tag prefix
+makes the vocabulary consistent with the individual skip renderer:
+
+```
+[AWAY]  Disconnected: WD-18TB1 (3 subvolumes), 2TB-backup (1 subvolume)
+[WAIT]  Interval not elapsed: 5 subvolumes (next in ~2h30m)
+[OFF]   Disabled: subvol6-tmp
+```
+
+### Change 5: CLI command descriptions
+
+**File:** `src/cli.rs` (lines 22-39)
+
+| Command | Current | New |
+|---------|---------|-----|
+| Plan | "Show planned backup operations without executing" | "Preview what Urd will do next" |
+| Backup | "Create snapshots, send to external drives, run retention" | "Back up now — snapshot, send, clean up" |
+| Status | "Show snapshot counts, drive status, chain health" | "Check whether your data is safe" |
+| History | "Show backup history" | "Review past backup runs" |
+| Verify | "Verify incremental chain integrity and pin file health" | "Diagnose thread integrity and pin health" |
+| Init | "Initialize state database and validate system readiness" | "Set up Urd and verify the environment" |
+| Calibrate | "Measure snapshot sizes for space estimation (run before first external send)" | "Measure snapshot sizes for send estimates" |
+| Get | "Retrieve a file from a past snapshot" | "Restore a file from a past snapshot" |
+| Sentinel | "Sentinel daemon — monitors backup health and drive connections" | "Sentinel — continuous health monitoring" |
+
+### Change 6: Notification mythology cleanup
+
+**File:** `src/notify.rs`
+
+| Line | Current | New |
+|------|---------|-----|
+| ~202 | "...The well remembers, but the weave grows thin." | "...The well remembers, but the thread grows thin." |
+| ~220 | "The thread of {} is rewoven" | "The thread of {} is mended" |
+| ~274 | "The loom has seized — every weaving failed." | "The spindle has stopped — every thread snapped." |
+| ~277 | "{N} of {total} threads could not be woven." | "{N} of {total} threads could not be spun." |
+
+### Change 7: Column header rename
+
+**File:** `src/voice.rs`
+
+- `"PROMISE"` → `"PROTECTION"` in `render_subvolume_table()` and `render_assessment_table()`
+
+This is a presentation-only change. The `ProtectionLevel` enum and config field name stay
+unchanged until Phase 6.
+
+---
+
+## What does NOT change
+
+- `PromiseStatus::Display` in awareness.rs — stays `"PROTECTED"`/`"AT RISK"`/`"UNPROTECTED"` (ADR-105: heartbeat contract)
+- `ChainHealth` serde serialization in output.rs — daemon JSON consumers may parse these
+- `SkipCategory::from_reason()` string matching in output.rs — matches planner reason strings
+- `ProtectionLevel` enum names and Display — deferred to Phase 6
+- `OperationalHealth` vocabulary — "healthy/degraded/blocked" stays (earned its place)
+- Operation tags — `[CREATE]`/`[SEND]`/`[DELETE]` stay
+- No new types, fields, enums, or modules
+
+---
+
+## Module Mapping
+
+| File | Changes | Lines affected |
+|------|---------|---------------|
+| `src/voice.rs` | safety_label→exposure_label, column headers, summary line, thread rendering, drive vocabulary, skip tags | ~40 string literals, ~10 function calls |
+| `src/cli.rs` | 9 command doc comments | 9 lines |
+| `src/notify.rs` | 4 notification body strings | 4 lines |
+| `src/error.rs` | 3 error message strings | 3 lines |
+
+---
+
+## Test Strategy
+
+**~35 existing tests modified, ~10 new tests added.**
+
+The bulk of the work is updating string assertions in voice.rs tests (67 tests) and
+notify.rs tests (22 tests). Every test checking for `"OK"`, `"aging"`, `"gap"`, `"safe"`,
+`"mounted"`, `"CHAIN"`, `"SAFETY"`, `"PROMISE"` needs updating.
+
+New tests:
+- `exposure_label()` mapping: sealed/waning/exposed for all three inputs
+- Role-aware drive summary: primary → disconnected, offsite → away (new behavior)
+- `render_thread_status()`: unbroken, broken, dash
+- Skip tag variants: [WAIT], [AWAY], [SPACE], [OFF], [SKIP]
+
+---
+
+## Invariants
+
+1. **Daemon JSON unchanged.** `OutputMode::Daemon` paths serialize structured types via
+   serde. `ChainHealth::Display` feeds daemon JSON — must not change.
+2. **Heartbeat strings unchanged.** `promise_status` in heartbeat.json stays
+   `PROTECTED`/`AT RISK`/`UNPROTECTED`.
+3. **Prometheus metrics unchanged.** Metric names and label values are on-disk contracts.
+4. **No data structure changes.** Zero new fields, renamed fields, or new enum variants.
+5. **DriveRole already available.** `DriveInfo` has `role: DriveRole` — no new plumbing
+   needed for role-aware vocabulary.
+
+---
+
+## Integration Points
+
+- **Downstream:** Prometheus metrics unaffected. Sentinel state file unaffected (uses
+  structured types, not voice strings). Heartbeat unaffected.
+- **Upstream:** All subsequent phases (2-6) produce text through voice.rs in the vocabulary
+  landed here. This is the foundation.
+
+---
+
+## Effort Estimate
+
+**1 session (3-4 hours).** Methodical find-and-replace with test updates. The risk is not
+complexity but thoroughness — missing one string creates vocabulary inconsistency. The test
+suite (67 voice.rs tests, 22 notify.rs tests) catches omissions.
+
+Comparable: `SkipCategory` system (output.rs + voice.rs + 17 tests) was one session. This
+phase touches more strings but has simpler logic (no new computation).
+
+---
+
+## Ready for Review
+
+Focus areas for arch-adversary:
+
+1. **Daemon JSON stability.** Verify no serde-derived serialization changes. The
+   `ChainHealth::Display` impl is seductive to change but feeds daemon consumers.
+
+2. **Role-aware "away" reconciliation.** Current `"away"` in the subvolume table (line 222)
+   triggers on unmounted drives with send history, regardless of role. The new vocabulary
+   says `"away"` is offsite-only. The table cell must also become role-aware — offsite
+   drives show `"away"`, primary drives show `"—"` when disconnected.
+
+3. **Skip tag in grouped renderers.** The grouped renderers already display their categories
+   in prose. Adding `[AWAY]`/`[WAIT]`/`[OFF]` prefixes to the grouped output is a
+   presentation choice — verify it doesn't make output too busy.
+
+4. **Thread column data loss.** `"incremental (20260330-0404-htpc-home)"` carries the parent
+   snapshot name. `"unbroken"` discards it. The parent name is useful for debugging. Decision:
+   `"unbroken"` in default, `"unbroken (20260330-0404-htpc-home)"` in `--verbose`.

--- a/docs/95-ideas/2026-03-31-design-phase2-ux-commands.md
+++ b/docs/95-ideas/2026-03-31-design-phase2-ux-commands.md
@@ -1,0 +1,380 @@
+# Design: Phase 2 — Independent UX Commands
+
+> **TL;DR:** Three independent capabilities built in parallel: (2a) `urd` with no subcommand
+> shows a live one-sentence status, (2b) `urd doctor` composes existing diagnostics into a
+> unified health check, (2c) `urd completions` generates shell tab-completion scripts. All
+> three are high-scored UX features that require Phase 1 vocabulary to be landed.
+
+**Date:** 2026-03-31
+**Status:** proposed
+**Depends on:** Phase 1 (vocabulary landing)
+
+---
+
+## 2a: `urd` Default One-Sentence Status
+
+### Problem
+
+When a user types `urd` with no arguments, clap prints help text. The most common question
+is "is my data safe?" and the most natural invocation is the bare command. This should
+answer that question with a single, fresh sentence — not cached sentinel state.
+
+### Proposed Design
+
+**CLI change:** Make subcommand optional.
+
+```rust
+// src/cli.rs
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,  // was: Commands (required)
+    // ...
+}
+```
+
+**Main dispatch:** `src/main.rs` — add `None` arm.
+
+```rust
+match cli.command {
+    None => {
+        // First-time path: detect missing config
+        let config = match config::Config::load(config_path) {
+            Ok(c) => c,
+            Err(_) => {
+                println!("{}", voice::render_first_time(mode));
+                return Ok(());
+            }
+        };
+        commands::default::run(config, mode)?;
+    }
+    Some(cmd) => { /* existing dispatch */ }
+}
+```
+
+**New file:** `src/commands/default.rs`
+
+```rust
+pub fn run(config: Config, mode: OutputMode) -> anyhow::Result<()> {
+    let state = StateDb::open(&config.state_db_path).ok();
+    let fs_state = RealFileSystemState::new(/* ... */);
+    let assessments = awareness::assess(&config, now, &fs_state);
+    // Apply offsite overlay if applicable
+    let last_run = state.as_ref().and_then(|s| s.last_run().ok().flatten());
+    let output = DefaultStatusOutput::from(assessments, last_run);
+    print!("{}", voice::render_default_status(&output, mode));
+    Ok(())
+}
+```
+
+**New type:** `src/output.rs`
+
+```rust
+pub struct DefaultStatusOutput {
+    pub total: usize,
+    pub sealed_count: usize,
+    pub waning_names: Vec<String>,
+    pub exposed_names: Vec<String>,
+    pub last_backup: Option<LastBackupInfo>,
+    pub health_issues: Vec<String>,
+}
+
+pub struct LastBackupInfo {
+    pub age_secs: i64,
+    pub result: String,
+}
+```
+
+**Voice rendering:** `src/voice.rs`
+
+Interactive mode:
+```
+All sealed. Last backup 7 hours ago.
+Run `urd status` for details, `urd --help` for commands.
+```
+
+```
+3 of 9 sealed. htpc-root, subvol1-docs exposed.
+Run `urd status` for details.
+```
+
+First-time (no config):
+```
+Urd is not configured yet.
+Run `urd init` to get started, or see `urd --help`.
+```
+
+Daemon mode: JSON serialization of `DefaultStatusOutput`.
+
+### Module Mapping
+
+| File | Change |
+|------|--------|
+| `src/cli.rs` | `command: Commands` → `command: Option<Commands>` |
+| `src/main.rs` | Add `None` dispatch arm with first-time detection |
+| `src/output.rs` | Add `DefaultStatusOutput`, `LastBackupInfo` |
+| `src/voice.rs` | Add `render_default_status()`, `render_first_time()` |
+| `src/commands/default.rs` | New file — wire awareness to voice |
+| `src/commands/mod.rs` | Add `pub mod default;` |
+
+### Test Strategy (~10 new tests)
+
+- `default_all_sealed()` — all PROTECTED → `"All sealed."`
+- `default_some_exposed()` — mixed states → `"{N} of {M} sealed. {names} exposed."`
+- `default_with_last_backup()` — includes `"Last backup N hours ago."`
+- `default_no_last_backup()` — omits last backup line
+- `default_health_issues()` — appends health summary
+- `default_daemon_json()` — valid JSON
+- `first_time_no_config()` — includes `urd init` guidance
+- CLI parsing: bare `urd` parses to `None` subcommand
+
+### Invariants
+
+- Config loading for subcommands must not regress (the `Option<Commands>` change is structural)
+- First-time path must not attempt awareness assessment (no config = nothing to assess)
+- Default output must be fast — no extra I/O beyond what `awareness::assess()` already does
+
+### Effort: 1 session
+
+---
+
+## 2b: `urd doctor`
+
+### Problem
+
+Diagnosing Urd's health requires running multiple commands: `urd init` (infrastructure),
+`urd verify` (threads), `urd status` (promises). No single command says "check everything
+and tell me what's wrong." `doctor` composes existing checks into a unified diagnostic.
+
+### Proposed Design
+
+**New command:** `urd doctor [--thorough]`
+
+Fast by default (config + preflight + awareness). `--thorough` adds the verify pass
+(filesystem scanning for pin files, orphan detection).
+
+**New file:** `src/commands/doctor.rs`
+
+```rust
+pub fn run(config: Config, args: DoctorArgs, mode: OutputMode) -> anyhow::Result<()> {
+    // 1. Config + preflight (pure, instant)
+    let preflight = preflight::preflight_checks(&config);
+
+    // 2. Infrastructure checks (I/O: path existence, drive mounts)
+    let infra = init::collect_infrastructure_checks(&config, &btrfs);
+
+    // 3. Awareness (pure + fs reads for snapshot discovery)
+    let assessments = awareness::assess(&config, now, &fs_state);
+
+    // 4. Verify (optional, --thorough only)
+    let verify = if args.thorough {
+        Some(verify::collect_verify_data(&config, &btrfs, &fs_state)?)
+    } else {
+        None
+    };
+
+    // 5. Assemble and render
+    let output = DoctorOutput { preflight, infra, assessments, verify };
+    print!("{}", voice::render_doctor(&output, mode));
+    Ok(())
+}
+```
+
+**Prerequisite refactor:** `init::collect_infrastructure_checks()` must be extracted from
+`init::run()` as a `pub(crate)` function. Similarly, verify's data collection logic should
+be extractable from `verify::run()`.
+
+**New types:** `src/output.rs`
+
+```rust
+pub struct DoctorOutput {
+    pub config_checks: Vec<DoctorCheck>,
+    pub infra_checks: Vec<DoctorCheck>,
+    pub assessments: Vec<StatusAssessment>,
+    pub verify: Option<VerifyOutput>,
+    pub verdict: DoctorVerdict,
+}
+
+pub struct DoctorCheck {
+    pub name: String,
+    pub status: CheckStatus,  // Ok, Warn, Error
+    pub detail: Option<String>,
+    pub suggestion: Option<String>,
+}
+
+pub enum DoctorVerdict {
+    Healthy,
+    Warnings(usize),
+    Issues(usize),
+}
+```
+
+**Voice rendering:** `src/voice.rs`
+
+```
+Checking Urd health...
+
+  Config
+    ✓ 9 subvolumes, 3 drives
+    ✓ All protection levels achievable
+    ⚠ retention window shorter than send interval for htpc-root
+
+  Infrastructure
+    ✓ State DB accessible
+    ✓ Sentinel running (PID 366735)
+    ✓ sudo btrfs available
+    ✓ All snapshot roots writable
+
+  Data safety
+    ✓ 8 of 9 sealed
+    ✗ htpc-root exposed — last backup 3 days ago
+      → Connect a drive and run `urd backup`
+
+  [Threads — run with --thorough]
+
+1 warning, 1 issue. Run suggested commands to resolve.
+```
+
+With `--thorough`, the `[Threads]` section shows verify results inline.
+
+### Module Mapping
+
+| File | Change |
+|------|--------|
+| `src/cli.rs` | Add `Doctor(DoctorArgs)` variant, `DoctorArgs { thorough: bool }` |
+| `src/main.rs` | Add dispatch arm |
+| `src/output.rs` | Add `DoctorOutput`, `DoctorCheck`, `DoctorVerdict` |
+| `src/voice.rs` | Add `render_doctor()` |
+| `src/commands/doctor.rs` | New file |
+| `src/commands/mod.rs` | Add `pub mod doctor;` |
+| `src/commands/init.rs` | Extract `collect_infrastructure_checks()` as `pub(crate)` |
+| `src/commands/verify.rs` | Extract data collection as `pub(crate)` if needed |
+
+### Test Strategy (~12 new tests)
+
+- `doctor_all_healthy()` — clean config, all sealed, no warnings
+- `doctor_config_warnings()` — preflight issues surface
+- `doctor_promise_issues()` — waning/exposed appear
+- `doctor_with_thorough()` — verify section present
+- `doctor_without_thorough()` — verify section absent, placeholder shown
+- `doctor_verdict_healthy/warnings/issues()` — verdict logic
+- `doctor_daemon_json()` — valid JSON
+- Integration: init's infrastructure checks callable from doctor
+
+### Invariants
+
+- Doctor never modifies anything (diagnostic-only, ADR-100 spirit)
+- `--thorough` verify logic must not duplicate `commands/verify.rs` — share extraction
+- `init::collect_infrastructure_checks()` remains pure-ish (I/O for checks, structured output)
+
+### Effort: 1-2 sessions
+
+---
+
+## 2c: Shell Completions
+
+### Problem
+
+Tab completion for `urd` subcommands and flags requires shell integration scripts.
+`clap_complete` generates these from the CLI definition.
+
+### Proposed Design
+
+**New command:** `urd completions <shell>`
+
+```rust
+// src/cli.rs
+/// Generate shell completion scripts
+Completions(CompletionsArgs),
+
+// CompletionsArgs
+pub struct CompletionsArgs {
+    /// Shell to generate completions for
+    pub shell: clap_complete::Shell,  // bash, zsh, fish, elvish, powershell
+}
+```
+
+**New file:** `src/commands/completions.rs`
+
+```rust
+pub fn run(args: CompletionsArgs) {
+    let mut cmd = Cli::command();
+    clap_complete::generate(args.shell, &mut cmd, "urd", &mut std::io::stdout());
+}
+```
+
+**Usage:**
+```bash
+# Bash
+urd completions bash > ~/.local/share/bash-completion/completions/urd
+
+# Zsh
+urd completions zsh > ~/.zfunc/_urd
+
+# Fish
+urd completions fish > ~/.config/fish/completions/urd.fish
+```
+
+**Dynamic completions (stretch goal, deferred):** For `--subvolume` and `--drive` arguments,
+`clap_complete` 4.x supports custom value hints. This would read config at completion time
+to suggest subvolume names and drive labels. Deferred because:
+- Config loading at tab-time adds latency
+- Missing/invalid config must degrade gracefully
+- Static completions cover the high-value case (subcommands + flags)
+
+### Module Mapping
+
+| File | Change |
+|------|--------|
+| `Cargo.toml` | Add `clap_complete = "4"` dependency |
+| `src/cli.rs` | Add `Completions(CompletionsArgs)` variant |
+| `src/main.rs` | Add dispatch arm (runs before config load) |
+| `src/commands/completions.rs` | New file |
+| `src/commands/mod.rs` | Add `pub mod completions;` |
+
+### Test Strategy (~4 new tests)
+
+- Static completions generate non-empty output for bash/zsh/fish
+- Generated script contains expected subcommand names
+- No config required (completions command works without urd.toml)
+
+### Invariants
+
+- Completions must work without a valid config file
+- `clap_complete` version must match `clap` version (both 4.x)
+- Completions command runs before config loading in main.rs dispatch
+
+### Effort: 0.5 session
+
+---
+
+## Phase 2 Overall
+
+**Total effort: 2-3 sessions.** All three features are independent and can be built in any
+order. 2a and 2c both modify `cli.rs`'s `Commands` enum — if built in parallel, merge
+carefully.
+
+---
+
+## Ready for Review
+
+Focus areas for arch-adversary:
+
+1. **2a: `Option<Commands>` in clap.** Verify that `--help` still works correctly when
+   subcommand is optional. Clap may show a different help layout. Test: `urd --help` should
+   still list all subcommands.
+
+2. **2a: First-time detection.** The config load error is used to detect first-time users.
+   This conflates "no config" with "broken config." The first-time path should only trigger
+   on file-not-found, not on parse errors. Parse errors should still surface as errors.
+
+3. **2b: Doctor I/O characteristics.** `collect_infrastructure_checks()` may spawn btrfs
+   subprocess calls. Document what I/O doctor performs so users know it's not just reading
+   state files.
+
+4. **2b: Verify extraction.** If verify's data collection is tightly coupled to its
+   rendering, extracting it cleanly may require a larger refactor. Assess the coupling
+   before committing to the extraction approach.
+
+5. **2c: Completions dispatch order.** Completions must run before config loading
+   (`urd completions bash` shouldn't fail because no config exists). This means the
+   main.rs dispatch needs to handle completions before the config load block.

--- a/docs/95-ideas/2026-03-31-design-phase3-advisory-retention.md
+++ b/docs/95-ideas/2026-03-31-design-phase3-advisory-retention.md
@@ -1,0 +1,155 @@
+# Design: Phase 3 — Advisory System + Retention Preview (6-I + 6-N Orchestration)
+
+> **TL;DR:** This phase builds two already-designed features in parallel: 6-I (redundancy
+> recommendations with structured advisories) and 6-N (retention policy preview). Both have
+> full design docs and reviews. This orchestration document specifies vocabulary adjustments
+> needed after Phase 1 and integration sequencing.
+
+**Date:** 2026-03-31
+**Status:** proposed
+**Depends on:** Phase 1 (vocabulary landing), 6-E merged
+
+---
+
+## Problem
+
+Urd detects problems but doesn't guide users toward solutions. String-based advisories in
+`StatusAssessment` are fragile and unstructured. Users have no visibility into what retention
+will do before it runs. These two features — structured advisories and retention preview —
+are the infrastructure that Phase 4 (voice enrichment) and Phase 5 (progressive disclosure)
+build upon.
+
+---
+
+## Existing Designs
+
+Both features have been through brainstorm → design → arch-adversary review:
+
+| Feature | Design doc | Review | Score |
+|---------|-----------|--------|-------|
+| 6-I Redundancy recommendations | [design-i](2026-03-31-design-i-redundancy-recommendations.md) | [review](../99-reports/2026-03-31-design-i-review.md) | 8/10 |
+| 6-N Retention policy preview | [design-n](2026-03-31-design-n-retention-policy-preview.md) | [review](../99-reports/2026-03-31-design-n-review.md) | reviewed |
+
+**This document does not duplicate those designs.** It specifies:
+1. Vocabulary adjustments required after Phase 1
+2. Integration points between the two features
+3. Build sequencing
+4. Test coverage requirements
+
+---
+
+## Vocabulary Adjustments
+
+After Phase 1, all user-facing text must use the resolved vocabulary. The following
+adjustments apply to the existing design docs:
+
+### 6-I Adjustments
+
+1. **Advisory text uses Phase 1 vocabulary:**
+   - `"chain"` → `"thread"` in any advisory about incremental health
+   - `"mounted"` → `"connected"`, `"not mounted"` → `"disconnected"`/`"away"` (role-aware)
+   - `"safe"` → `"sealed"` in any safety references
+   - `"promise"` → `"protection"` in user-facing advisory text
+
+2. **The `"consider cycling"` advisory migration** (from stringly-typed to
+   `RedundancyAdvisory`) must use `"away"` for offsite drives, `"disconnected"` for
+   primary drives.
+
+3. **Advisory rendering** through voice.rs inherits Phase 1's `exposure_label()`,
+   `render_thread_status()`, and drive vocabulary automatically — no special handling
+   needed if advisories reference structured output types rather than hardcoded strings.
+
+### 6-N Adjustments
+
+1. **CLI description:** `urd retention-preview` (or whatever the command is named) must
+   use intent-first style per Phase 1: `"Preview what retention will keep and remove"`.
+
+2. **Output vocabulary:** Use `"cleanup"` for retention in casual output, `"retention"`
+   in technical detail — per vocabulary audit decisions.
+
+3. **Column headers:** Use `"PROTECTION"` not `"PROMISE"` for any protection-level
+   references in preview output.
+
+---
+
+## Integration Points Between 6-I and 6-N
+
+The two features are parallel and share no data structures, but they have conceptual overlap:
+
+1. **Both surface in `urd status`.** 6-I adds structured advisories below the status table.
+   6-N adds a retention one-liner. They should render in a consistent visual hierarchy:
+   advisories first (actionable), retention summary second (informational).
+
+2. **Both feed into Phase 5 (progressive disclosure).** 6-I's advisory types are milestones
+   triggers. 6-N's retention visibility is a progressive disclosure surface.
+
+3. **Both feed into Phase 6 (setup wizard).** 6-H presents retention preview during setup
+   and uses advisory types to validate the generated config.
+
+---
+
+## Build Sequencing
+
+```
+6-I and 6-N are independent. Build in either order or parallel.
+
+6-I touches:
+  - output.rs (RedundancyAdvisory type, replaces advisories: Vec<String>)
+  - awareness.rs (advisory computation)
+  - voice.rs (advisory rendering)
+  - notify.rs (advisory-to-notification mapping)
+
+6-N touches:
+  - cli.rs (new command)
+  - output.rs (RetentionPreview type)
+  - retention.rs (preview computation — pure function)
+  - voice.rs (preview rendering)
+  - commands/retention_preview.rs (new file)
+```
+
+No module overlap except output.rs and voice.rs, which are additive (new types, new render
+functions). Safe to build in parallel.
+
+### Atomicity constraint for 6-I
+
+6-I replaces `advisories: Vec<String>` on `StatusAssessment` with structured
+`RedundancyAdvisory` types. This migration must be atomic — a half-migration (some
+advisories structured, some strings) is worse than either end state. All advisory
+producers and consumers must move together.
+
+---
+
+## Test Coverage Requirements
+
+Beyond the test counts in the individual design docs, verify:
+
+- Advisory text uses Phase 1 vocabulary (no `"chain"`, `"mounted"`, `"safe"`, `"promise"`)
+- 6-I advisories render correctly through `render_advisories()` in voice.rs
+- 6-N retention preview uses `"cleanup"` in casual output
+- Both features produce valid daemon JSON
+
+---
+
+## Effort Estimate
+
+**1-2 sessions total, parallelizable.** Per the individual design docs. 6-I is more
+integrated (touches awareness, output, voice, notify). 6-N is more self-contained (new
+command, new type, new renderer).
+
+---
+
+## Ready for Review
+
+Focus areas for arch-adversary:
+
+1. **6-I advisory migration atomicity.** The `Vec<String>` → `Vec<RedundancyAdvisory>`
+   change on `StatusAssessment` breaks every test that constructs a `StatusAssessment`.
+   Plan the migration to minimize churn.
+
+2. **6-N estimation accuracy.** Retention preview without calibration data is necessarily
+   imprecise. The `EstimateMethod::Unknown` tier must be clearly distinguished from
+   calibrated estimates in the output — users should not mistake a guess for a measurement.
+
+3. **Vocabulary consistency.** After Phase 1, the vocabulary is the ground truth. Both
+   6-I and 6-N designs were written before the vocabulary audit resolved. Review all
+   user-facing text in both designs against the resolved vocabulary.

--- a/docs/95-ideas/2026-03-31-design-phase4-voice-enrichment.md
+++ b/docs/95-ideas/2026-03-31-design-phase4-voice-enrichment.md
@@ -1,0 +1,314 @@
+# Design: Phase 4 — Voice Enrichment
+
+> **TL;DR:** Three voice.rs features that make Urd's output contextual and alive: (4a)
+> staleness escalation — graduated natural language as conditions age, (4b) next-action
+> suggestions — context-specific one-liners after each command, (4c) mythic voice on
+> transitions — the norn speaks on events, is silent on queries. All are pure presentation
+> over existing data. No new computation beyond pattern-matching on structured output.
+
+**Date:** 2026-03-31
+**Status:** proposed
+**Depends on:** Phase 1 (vocabulary), Phase 3 (6-I advisory types — for 4a integration)
+
+---
+
+## 4a: Staleness Escalation
+
+### Problem
+
+Urd reports staleness as bare numbers: `"WD-18TB1 away — last seen 8 days ago"`. The
+urgency of 8 days vs 80 days is identical in tone. Gentle nudging at low stakes prevents
+crisis decision-making at high stakes. The voice should graduate naturally with time.
+
+### Proposed Design
+
+New pure function in `src/voice.rs`:
+
+```rust
+/// Graduated staleness text for disconnected drives.
+/// Returns None when age is below the observation threshold (silence = fine).
+fn escalated_drive_text(age_days: i64, role: DriveRole, label: &str) -> Option<String> {
+    let (observe, suggest, warn) = match role {
+        DriveRole::Offsite => (7, 21, 45),
+        _ => (3, 7, 14),
+    };
+    if age_days < observe {
+        None  // Silence — everything is fine
+    } else if age_days < suggest {
+        Some(format!("{label} away for {age_days} days"))
+    } else if age_days < warn {
+        Some(format!("{label} away for {age_days} days — consider connecting"))
+    } else {
+        Some(format!("{label} absent {age_days} days — protection degrading"))
+    }
+}
+```
+
+Thresholds are presentation-layer constants in voice.rs. These are distinct from
+awareness.rs thresholds (`DRIVE_AWAY_DEGRADED_DAYS = 7`) which govern state transitions.
+Voice thresholds govern graduated *text* — they can be more granular because text has
+more resolution than enum states.
+
+**Integration points:**
+- Called from `render_drive_summary()` for disconnected drives
+- Called from `render_advisories()` when Phase 3 advisory types include drive staleness
+- Similar pattern for space pressure: `escalated_space_text(free_pct, label)`
+- Similar pattern for thread health: `escalated_thread_text(age_since_broken, subvol)`
+
+### Module Mapping
+
+| File | Change |
+|------|--------|
+| `src/voice.rs` | Add `escalated_drive_text()`, `escalated_space_text()`, `escalated_thread_text()` |
+
+No other files change. All inputs (age, role, label, free space) are already available
+in the render functions' parameters.
+
+### Test Strategy (~15 new tests)
+
+- Each escalation tier for each drive role (8 tests minimum)
+- Boundary values (exactly at threshold)
+- `None` return for sub-threshold ages
+- Space pressure escalation tiers (3-4 tests)
+- Thread health escalation (2-3 tests)
+- Verify escalation text uses Phase 1 vocabulary
+
+### Invariants
+
+- Escalation is purely in voice.rs — must not change awareness.rs thresholds
+- Daemon JSON must not include escalated text (presentation concern only)
+- Escalation must be monotonic: longer absence = more urgent text, never less
+
+### Effort: 1 session
+
+---
+
+## 4b: Next-Action Suggestions
+
+### Problem
+
+After running any command, Urd is silent about what to do next. A user who sees degraded
+health in `urd status` has to know to run `urd doctor`. A user who sees space issues in
+`urd plan` has to know about `urd calibrate`. The system should anticipate the next step.
+
+**Design principle:** Parsimonious. One or two lines max, dimmed, only when there's a clear
+next step. Healthy state produces silence. The norn anticipates — she doesn't nag.
+
+### Proposed Design
+
+New function in `src/voice.rs`:
+
+```rust
+/// Generate a context-specific suggestion based on command output.
+/// Returns None when there is nothing useful to suggest (silence is correct).
+fn suggest_next_action(context: &SuggestionContext) -> Option<String> {
+    match context {
+        // Status shows exposed subvolumes
+        SuggestionContext::Status { has_exposed: true, .. } =>
+            Some("Run `urd doctor` to diagnose.".into()),
+
+        // Plan shows space exceeded
+        SuggestionContext::Plan { has_space_skip: true, .. } =>
+            Some("Run `urd calibrate` to measure actual snapshot sizes.".into()),
+
+        // Plan is ready to execute
+        SuggestionContext::Plan { has_operations: true, .. } =>
+            Some("Run `urd backup` to execute this plan.".into()),
+
+        // Backup completed with thread restored
+        SuggestionContext::Backup { threads_restored: true, .. } =>
+            Some("Run `urd status` to confirm.".into()),
+
+        // Backup completed with failures
+        SuggestionContext::Backup { has_failures: true, .. } =>
+            Some("Run `urd doctor` for a full diagnostic.".into()),
+
+        // Verify shows broken threads
+        SuggestionContext::Verify { has_broken: true, .. } =>
+            Some("Connect the drive and run `urd backup` to restore the thread.".into()),
+
+        // Default status (2a) shows issues
+        SuggestionContext::Default { has_issues: true } =>
+            Some("Run `urd status` for details.".into()),
+
+        // Doctor all clear
+        SuggestionContext::Doctor { all_clear: true } =>
+            Some("All clear. No action needed.".into()),
+
+        // Everything healthy — silence
+        _ => None,
+    }
+}
+```
+
+**`SuggestionContext`** is a lightweight enum derived from the structured output types
+at the call site. It extracts only the boolean flags needed for matching — not the full
+output type.
+
+```rust
+enum SuggestionContext {
+    Default { has_issues: bool },
+    Status { has_exposed: bool, has_degraded: bool },
+    Plan { has_operations: bool, has_space_skip: bool },
+    Backup { has_failures: bool, threads_restored: bool },
+    Verify { has_broken: bool },
+    Doctor { all_clear: bool },
+}
+```
+
+**Rendering:** Each `render_*` function appends the suggestion at the end, dimmed:
+
+```rust
+if let Some(suggestion) = suggest_next_action(&context) {
+    output.push_str(&format!("\n  {}\n", suggestion.dimmed()));
+}
+```
+
+### Module Mapping
+
+| File | Change |
+|------|--------|
+| `src/voice.rs` | Add `SuggestionContext` enum, `suggest_next_action()`, call from each `render_*_interactive()` |
+
+No output.rs changes — `SuggestionContext` is internal to voice.rs, constructed from
+the output types that are already passed to render functions.
+
+### Test Strategy (~12 new tests)
+
+- One test per suggestion rule (8-10 rules)
+- Test that healthy state produces no suggestion (silence)
+- Test that suggestions use Phase 1 vocabulary
+- Test that suggestions are absent in daemon mode
+
+### Invariants
+
+- Suggestions are interactive-mode only (no JSON output)
+- Suggestions must be dimmed (secondary visual weight)
+- Healthy states produce `None` — no "everything is fine!" noise
+- Each render function has at most one suggestion line
+
+### Effort: 1 session
+
+---
+
+## 4c: Mythic Voice on Transitions
+
+### Problem
+
+Urd speaks technically on queries and mythically on notifications. The voice should be
+refined: **voice on events, data on queries.** When a backup completes and a thread is
+restored, the summary carries weight. When the user queries status, the output is crisp.
+
+**Principle from the brainstorm:** Mythic quality = precision + authority + economy, not
+Norse vocabulary. Technical descriptions are the default and fallback. The voice earns
+character through correctness.
+
+### Proposed Design
+
+Voice on transitions means detecting when something *changed* during the command's
+execution, and adding a brief line that carries weight.
+
+**New field on `BackupSummary`:** `src/output.rs`
+
+```rust
+pub struct BackupSummary {
+    // ... existing fields ...
+    pub transitions: Vec<TransitionEvent>,
+}
+
+pub enum TransitionEvent {
+    ThreadRestored { subvolume: String, drive: String },
+    FirstSendToDrive { subvolume: String, drive: String },
+    AllSealed,
+    PromiseRecovered { subvolume: String, from: String, to: String },
+}
+```
+
+The executor populates `transitions` by comparing pre-backup and post-backup awareness
+assessments. This is a small addition to `commands/backup.rs` — run `awareness::assess()`
+before and after, diff the results.
+
+**Voice rendering:** `src/voice.rs` — in `render_backup_interactive()`
+
+```rust
+// After the summary section, before the suggestion
+for transition in &summary.transitions {
+    match transition {
+        TransitionEvent::AllSealed =>
+            output.push_str("  All threads hold.\n"),
+        TransitionEvent::ThreadRestored { subvolume, drive } =>
+            output.push_str(&format!("  {subvolume}: thread to {drive} mended.\n")),
+        TransitionEvent::FirstSendToDrive { subvolume, drive } =>
+            output.push_str(&format!("  {subvolume}: first copy sent to {drive}.\n")),
+        TransitionEvent::PromiseRecovered { subvolume, from, to } =>
+            output.push_str(&format!("  {subvolume}: {from} → {to}.\n")),
+    }
+}
+```
+
+**Status remains data-only.** No mythic additions to `render_status()` — the status
+command is a query, not an event. This is the boundary.
+
+### Module Mapping
+
+| File | Change |
+|------|--------|
+| `src/output.rs` | Add `TransitionEvent` enum, add `transitions` field to `BackupSummary` |
+| `src/commands/backup.rs` | Compute transitions by diffing pre/post awareness assessments |
+| `src/voice.rs` | Render transitions in `render_backup_interactive()` |
+
+### Test Strategy (~8 new tests)
+
+- `backup_thread_restored_voice()` — mythic line appears
+- `backup_first_send_voice()` — "first copy" line
+- `backup_all_sealed_voice()` — "All threads hold."
+- `backup_no_transitions()` — no mythic lines (routine backup)
+- `status_no_mythic_voice()` — verify status output has no transition voice
+- Daemon mode: transitions serialize as structured JSON, not rendered text
+
+### Invariants
+
+- Status and other query commands never have mythic voice lines
+- Transitions are computed from awareness diff, not from operation results
+  (a send that succeeded but didn't change promise state is not a transition)
+- The mythic lines are brief (one line per transition, no elaboration)
+
+### Effort: 1 session
+
+---
+
+## Phase 4 Overall
+
+**Total effort: 2-3 sessions.** All three features are independent within voice.rs and can
+be built in any order. 4a and 4b are highest-value (scored 9 each). 4c is the most
+editorial (choosing good mythic lines is the bottleneck, not engineering).
+
+---
+
+## Ready for Review
+
+Focus areas for arch-adversary:
+
+1. **4a: Voice thresholds vs awareness thresholds.** Voice.rs escalation thresholds are for
+   graduated text. Awareness.rs thresholds are for state transitions. They must be
+   consistent but are not the same thing. The voice should never claim urgency that the
+   awareness model doesn't support — e.g., voice saying "protection degrading" while
+   awareness still shows PROTECTED would be contradictory.
+
+2. **4b: Over-suggestion risk.** If every command emits a suggestion, the UX becomes noisy.
+   Verify that healthy states produce silence. The test for this is critical — `None` is the
+   most important return value of `suggest_next_action()`.
+
+3. **4c: Pre/post awareness diff cost.** Running `awareness::assess()` twice per backup
+   (before and after) doubles the awareness computation. Assess whether this is acceptable
+   for the typical 9-subvolume case. If costly, the diff could be computed lazily only when
+   the backup had interesting results.
+
+4. **4c: Transition detection accuracy.** A thread is "restored" when the pin file is
+   updated after a full send. But the awareness model doesn't know about pin updates mid-run.
+   The pre/post diff approach handles this correctly (post-backup awareness reads the new
+   pin files), but verify the timing.
+
+5. **4b + 4c interaction.** Both features append to the end of backup output. Define the
+   rendering order: transitions first (what happened), suggestion second (what to do next).
+   They should not conflict or repeat.

--- a/docs/95-ideas/2026-03-31-design-phase5-progressive-disclosure.md
+++ b/docs/95-ideas/2026-03-31-design-phase5-progressive-disclosure.md
@@ -1,0 +1,182 @@
+# Design: Phase 5 — Progressive Disclosure (6-O Orchestration)
+
+> **TL;DR:** This phase implements the already-designed progressive disclosure system (6-O).
+> This orchestration document specifies vocabulary adjustments after Phase 1, integration
+> with Phase 3 advisory types and Phase 4 voice enrichment, and sequencing considerations.
+
+**Date:** 2026-03-31
+**Status:** proposed
+**Depends on:** Phase 1 (vocabulary), Phase 3 (6-I advisory types), Phase 4 (voice enrichment)
+
+---
+
+## Problem
+
+Urd shows the same information density to a first-day user and a six-month user. Progressive
+disclosure surfaces insights at the right time — once-ever milestones that acknowledge
+achievement, teach concepts, and nudge toward stronger protection. The system must earn its
+voice: no insight fires until the user has enough context to appreciate it.
+
+---
+
+## Existing Design
+
+Fully designed and reviewed (scored 10/10):
+
+| Document | Link |
+|----------|------|
+| Design doc | [design-o](2026-03-31-design-o-progressive-disclosure.md) |
+| Review | [review](../99-reports/2026-03-31-design-o-review.md) |
+
+**This document does not duplicate that design.** It specifies adjustments and integration
+points with the four prior phases.
+
+---
+
+## Vocabulary Adjustments
+
+All milestone messages must use Phase 1 vocabulary:
+
+| Old term | New term | Context |
+|----------|----------|---------|
+| "safe" / "OK" | "sealed" | Milestone about achieving safety |
+| "chain" | "thread" | Milestone about incremental health |
+| "mounted" | "connected" | Milestone about drive availability |
+| "promise" | "protection" | Milestone about protection levels |
+| "guarded/protected/resilient" | Display as-is until Phase 6 | Protection level names stay current until ADR-110 rework |
+
+**Important:** Phase 5 ships before Phase 6. Milestone text that mentions protection levels
+should use the current names (guarded/protected/resilient), not the Phase 6 names
+(recorded/sheltered/fortified). Phase 6 will update these strings as part of the rename.
+
+---
+
+## Integration with Prior Phases
+
+### Phase 3 (6-I Advisory Types)
+
+6-I introduces `RedundancyAdvisory` as structured types. Progressive disclosure milestones
+can reference advisory state:
+
+- **"First offsite backup" milestone** can be triggered by the absence of a
+  `RedundancyAdvisory::OffsiteStaleness` advisory (meaning offsite is now current).
+- **"All drives seen" milestone** can be triggered when no
+  `RedundancyAdvisory::DriveUnseen` advisories exist.
+
+The milestone detection function receives the advisory state as input, keeping milestones.rs
+(or the milestone logic within awareness.rs) pure.
+
+### Phase 4a (Staleness Escalation)
+
+Staleness escalation and milestones are conceptually similar — both are time/state-dependent
+text. They must not conflict:
+
+- **Escalation** is repeated, graduated, per-render. Appears every time you check status.
+- **Milestones** are once-ever. Appear once, then are recorded in SQLite and never shown again.
+
+The implementation is distinct: escalation lives in voice.rs render functions, milestones
+live in a milestone tracker with SQLite persistence. No interaction needed.
+
+### Phase 4b (Next-Action Suggestions)
+
+After a milestone fires, the next-action suggestion should not repeat the milestone's
+content. The suggestion function should be aware of whether a milestone was just shown
+and suppress redundant advice.
+
+Implementation: the render function calls milestone rendering first, then suggestion
+rendering, and the suggestion context includes a `milestone_shown: bool` flag.
+
+### Phase 4c (Mythic Voice on Transitions)
+
+Milestones have a different voice register than transitions. Transitions are brief ("thread
+mended"). Milestones are observational insights ("Your first offsite backup is complete —
+your data now survives a house fire."). They should not appear in the same output section.
+
+Rendering order in status output:
+1. Status table (data)
+2. Advisories (from 6-I)
+3. Milestones (if any fire this render)
+4. Suggestion (from 4b)
+
+---
+
+## Key Implementation Notes
+
+### Milestone Storage
+
+New SQLite table in `state.rs`:
+
+```sql
+CREATE TABLE IF NOT EXISTS milestones (
+    id TEXT PRIMARY KEY,
+    fired_at TEXT NOT NULL
+);
+```
+
+`CREATE TABLE IF NOT EXISTS` ensures forward compatibility — existing databases gain the
+table on first access. SQLite failures must not prevent backups (ADR-102), so milestone
+queries use `.ok()` fallback.
+
+### Milestone Detection
+
+Pure function (ADR-108):
+
+```rust
+fn detect_milestones(
+    assessments: &[SubvolAssessment],
+    advisories: &[RedundancyAdvisory],  // From Phase 3
+    fired: &HashSet<String>,            // Already-fired milestone IDs from SQLite
+) -> Vec<Milestone>
+```
+
+Returns milestones that should fire (not yet in `fired` set and condition is met).
+
+### Milestone Rendering
+
+In voice.rs, milestones render as a distinct block:
+
+```
+  ── Milestone ──
+  Your first external backup is complete. Local failures can no longer
+  destroy this data.
+```
+
+Dimmed header, normal text body. One milestone per render (if multiple fire, show the
+highest-priority one and queue the rest for next invocation).
+
+### Surface Through Status + Spindle
+
+Per the design doc, milestones surface through `urd status` and sentinel state file
+(for Spindle consumption). They do NOT surface through the notification pipeline — milestones
+are observations, not alerts.
+
+---
+
+## Effort Estimate
+
+**2 sessions** as the design doc specifies. The milestone catalog is intentionally small
+(8 milestones) to prioritize quality over quantity.
+
+---
+
+## Ready for Review
+
+Focus areas for arch-adversary:
+
+1. **Milestone storage and ADR-102.** Adding a SQLite table is a schema change. Verify that
+   `CREATE TABLE IF NOT EXISTS` is sufficient migration strategy and that milestone failures
+   degrade gracefully (milestones re-fire on next run if insert failed — acceptable).
+
+2. **Once-ever guarantee under concurrency.** Sentinel and CLI may invoke awareness
+   concurrently. If both detect a milestone simultaneously, both may try to insert. Use
+   `INSERT OR IGNORE` to handle this — the first writer wins, the second is silently
+   deduplicated.
+
+3. **Milestone priority when multiple fire.** If a user connects a drive for the first
+   time and several milestones trigger simultaneously (first external, first offsite,
+   all drives seen), showing all of them would be noisy. The design should define priority
+   ordering and show only the most significant one per invocation.
+
+4. **Protection level names.** Phase 5 ships before Phase 6. Verify that milestone text
+   does not hardcode protection level display names — use the `ProtectionLevel::Display`
+   impl so Phase 6's rename automatically propagates.

--- a/docs/95-ideas/2026-03-31-design-phase6-protection-rename-wizard.md
+++ b/docs/95-ideas/2026-03-31-design-phase6-protection-rename-wizard.md
@@ -1,0 +1,309 @@
+# Design: Phase 6 — ADR-110 Protection Level Rework + Guided Setup Wizard (6-H)
+
+> **TL;DR:** The capstone phase. Renames the `ProtectionLevel` enum from
+> guarded/protected/resilient to recorded/sheltered/fortified (an ADR-110 addendum), adds
+> `urd migrate` for config transition, and delivers the guided setup wizard (6-H) that
+> integrates all vocabulary, advisory, and progressive disclosure infrastructure from
+> phases 1-5. This is the only phase that changes data structures and on-disk contracts.
+
+**Date:** 2026-03-31
+**Status:** proposed
+**Depends on:** All prior phases (1-5)
+
+---
+
+## Problem
+
+### The rename
+
+The current protection level names (guarded/protected/resilient) have known issues
+documented in ADR-110:
+
+- **"Guarded" and "protected" are near-synonyms** — users can't infer hierarchy from names
+- **"Guarded" implies stronger protection than it provides** — it's actually local-only
+- The brainstorm resolved: **recorded/sheltered/fortified** — each word describes what
+  the user *did* (record → shelter → fortify), creating a natural progression
+
+By Phase 6, the voice layer (Phase 1) has been showing the resolved vocabulary in the
+PROTECTION column header for months. This phase brings the data layer into alignment.
+
+### The wizard
+
+Urd's setup is currently manual TOML editing. The guided setup wizard (6-H) is the
+capstone that integrates everything: it discovers subvolumes, asks about user intent,
+derives protection levels and retention policies, and generates a validated config.
+
+---
+
+## Part A: ADR-110 Protection Level Rework
+
+### Existing Design
+
+ADR-110 documents the provisional taxonomy and graduation criteria:
+
+| Document | Link |
+|----------|------|
+| ADR-110 | [decisions/2026-03-26-ADR-110-protection-promises.md](../00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md) |
+
+### Proposed Changes
+
+**Gate: ADR-110 addendum required** before implementation. The addendum documents:
+- Operational evidence justifying the rename (phases 1-5 prove the vocabulary in production)
+- New names and their rationale
+- Migration path
+- Backward compatibility impact
+
+#### 1. Enum rename in `src/types.rs`
+
+```rust
+pub enum ProtectionLevel {
+    /// Local snapshots only. Urd noted your data.
+    #[serde(alias = "guarded")]
+    Recorded,
+    /// Local + at least one external drive current. Data moved to safety.
+    #[serde(alias = "protected")]
+    Sheltered,
+    /// Local + multiple external drives + offsite. The 3-2-1.
+    #[serde(alias = "resilient")]
+    Fortified,
+    /// User manages all parameters manually.
+    Custom,
+}
+
+impl Display for ProtectionLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Recorded => write!(f, "recorded"),
+            Self::Sheltered => write!(f, "sheltered"),
+            Self::Fortified => write!(f, "fortified"),
+            Self::Custom => write!(f, "custom"),
+        }
+    }
+}
+```
+
+The `#[serde(alias = "guarded")]` attributes ensure backward compatibility — existing
+configs with `protection_level = "guarded"` still parse correctly.
+
+#### 2. Config field rename
+
+```toml
+# Old (still accepted via alias)
+protection_level = "guarded"
+
+# New (canonical)
+protection = "recorded"
+```
+
+In `src/config.rs`, the subvolume config struct gets a serde alias:
+
+```rust
+#[serde(alias = "protection_level")]
+pub protection: Option<ProtectionLevel>,
+```
+
+This is a one-way migration: old configs parse, new configs use the new field name.
+`urd migrate` handles the explicit conversion.
+
+#### 3. Heartbeat schema change
+
+Heartbeat JSON includes protection level strings. These change from `"guarded"` to
+`"recorded"`, etc. This is a **backward compatibility break** (ADR-105).
+
+Mitigation:
+- Bump `schema_version` from 1 to 2
+- Document the change in the heartbeat schema
+- Sentinel's heartbeat reader must handle both versions gracefully
+- Downstream homelab monitoring must update (per CLAUDE.md downstream consumer contract)
+
+#### 4. `urd migrate` command
+
+**New file:** `src/commands/migrate.rs`
+
+```rust
+pub fn run(config_path: &Path) -> anyhow::Result<()> {
+    // 1. Read raw TOML
+    let raw = fs::read_to_string(config_path)?;
+
+    // 2. Apply migrations
+    let migrated = migrate_protection_fields(&raw);
+
+    // 3. Write backup
+    let backup_path = config_path.with_extension("toml.backup");
+    fs::copy(config_path, &backup_path)?;
+
+    // 4. Write migrated config
+    fs::write(config_path, &migrated)?;
+
+    // 5. Validate by loading
+    config::Config::load(config_path)?;
+
+    println!("Config migrated. Backup at {}", backup_path.display());
+    Ok(())
+}
+```
+
+The migration operates on raw TOML strings (not parsed+serialized) to preserve comments
+and formatting. Specific replacements:
+- `protection_level = "guarded"` → `protection = "recorded"`
+- `protection_level = "protected"` → `protection = "sheltered"`
+- `protection_level = "resilient"` → `protection = "fortified"`
+- `protection_level = "custom"` → `protection = "custom"`
+
+#### Module mapping
+
+| File | Change |
+|------|--------|
+| `src/types.rs` | Rename enum variants, add serde aliases, update Display |
+| `src/config.rs` | Field rename with serde alias |
+| `src/awareness.rs` | Update all `ProtectionLevel::Guarded/Protected/Resilient` references |
+| `src/preflight.rs` | Update protection level references |
+| `src/heartbeat.rs` | Bump schema_version, update serialized strings |
+| `src/voice.rs` | Update any remaining hardcoded level names |
+| `src/cli.rs` | Add `Migrate` command |
+| `src/main.rs` | Add dispatch arm |
+| `src/commands/migrate.rs` | New file |
+| `src/commands/mod.rs` | Add `pub mod migrate;` |
+
+#### Test strategy (~20 tests modified, ~10 new)
+
+- All tests referencing `Guarded`/`Protected`/`Resilient` update to new names
+- Backward compatibility: old config values (`guarded`, `protected`, `resilient`) parse
+- Serde alias composition: `#[serde(alias)]` + `#[serde(rename_all)]` work together
+- Migration: raw TOML transformation is correct, preserves comments
+- Migration idempotency: running twice produces same result
+- Heartbeat v1 → v2 schema transition
+- Sentinel reads both heartbeat versions gracefully
+
+#### Effort: 2 sessions
+
+---
+
+## Part B: Guided Setup Wizard (6-H)
+
+### Existing Design
+
+Fully designed and reviewed:
+
+| Document | Link |
+|----------|------|
+| Design doc | [design-h](2026-03-31-design-h-guided-setup-wizard.md) |
+| Review | [review](../99-reports/2026-03-31-design-h-review.md) |
+
+### Vocabulary Adjustments
+
+The wizard must use Phase 6 protection level names:
+- `"recorded"` not `"guarded"` when presenting local-only protection
+- `"sheltered"` not `"protected"` when presenting single-external protection
+- `"fortified"` not `"resilient"` when presenting multi-external + offsite protection
+
+### Prerequisite: Config Serialize Refactor
+
+The wizard generates a `Config` struct and writes it as TOML. This requires `Serialize`
+derives on all config types, which currently only have `Deserialize`.
+
+**Affected types in `src/config.rs`:**
+- `Config` and all nested structs
+- `SubvolumeConfig`, `DriveConfig`, `RetentionConfig`, etc.
+
+This is mechanical but touches many structs. Verify round-trip: `deserialize(serialize(config)) == config` for all existing configs.
+
+**Risk:** TOML serialization may reorder fields or change formatting compared to
+hand-written configs. The wizard writes new configs (not re-serializing existing ones),
+so this is acceptable — but document that `urd migrate` uses string replacement (Part A)
+specifically to preserve formatting.
+
+### Integration with Prior Phases
+
+| Phase | Integration point |
+|-------|-------------------|
+| Phase 1 | Wizard output uses all resolved vocabulary |
+| Phase 3 (6-I) | Wizard validates generated config against redundancy advisories |
+| Phase 3 (6-N) | Wizard shows retention preview for the generated config |
+| Phase 4b | Wizard's "what's next" suggestions use the suggestion infrastructure |
+| Phase 5 (6-O) | Wizard completion fires the "first setup" milestone |
+
+### Module mapping (from existing design doc)
+
+| File | Change |
+|------|--------|
+| `src/cli.rs` | Add `Setup(SetupArgs)` command |
+| `src/main.rs` | Add dispatch arm |
+| `src/commands/setup.rs` | New file — interactive wizard |
+| `src/config.rs` | Add `Serialize` derives |
+| `src/output.rs` | Add `SetupOutput` / `SetupPreview` types |
+| `src/voice.rs` | Add `render_setup_preview()`, `render_setup_complete()` |
+
+### Test strategy (~20 new tests)
+
+- Config derivation: answers → config is a pure function, extensively testable
+- Intent mapping: survival scenarios → protection levels
+- Edge cases: no drives, single subvolume, many subvolumes
+- Round-trip: generated config passes `Config::load()` validation
+- Evaluate mode: existing config → assessment summary
+
+### Effort: 3-4 sessions
+
+---
+
+## Phase 6 Overall
+
+**Total effort: 5-6 sessions.**
+
+Build sequence within Phase 6:
+```
+1. ADR-110 addendum (document the decision)
+2. Config Serialize refactor (mechanical prerequisite)
+3. ProtectionLevel enum rename + serde aliases
+4. urd migrate command
+5. Heartbeat schema bump
+6. Setup wizard implementation
+7. Integration testing
+```
+
+The enum rename (steps 3-5) should be a single PR to avoid a half-migrated state.
+The wizard (steps 6-7) is a separate PR that depends on the rename.
+
+---
+
+## Invariants
+
+1. **ADR-105: Backward compatibility.** Serde aliases ensure old configs parse. The
+   heartbeat schema version bump is the documented exception mechanism.
+2. **ADR-110: Named levels are opaque.** The rename does not change this contract — no
+   per-field overrides on named levels.
+3. **Config migration is safe.** `urd migrate` writes a backup before modifying. The
+   migration is idempotent. Parse errors during migration abort without writing.
+4. **Wizard never bypasses validation.** Generated configs must pass `Config::load()`
+   before being written to disk.
+5. **Downstream consumer notification.** Heartbeat schema change requires updating homelab
+   ADR-021 at `~/containers/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md`.
+
+---
+
+## Ready for Review
+
+Focus areas for arch-adversary:
+
+1. **Heartbeat schema break.** Highest-risk change in the entire overhaul. Verify:
+   - Old sentinel reading new heartbeat (schema_version 2) — must degrade gracefully
+   - New sentinel reading old heartbeat (schema_version 1) — must still work
+   - Both directions must log the version mismatch but not fail
+
+2. **Serde alias stacking.** `#[serde(alias = "guarded")]` on `Recorded` with
+   `#[serde(rename_all = "lowercase")]` on the enum — verify these compose correctly.
+   The alias should allow `"guarded"` to deserialize as `Recorded`, while `"recorded"`
+   is the canonical serialization.
+
+3. **Raw TOML migration vs parsed+serialized.** `urd migrate` uses string replacement
+   to preserve comments and formatting. This is fragile if the field appears in comments
+   or unusual positions. The migration should match on `protection_level\s*=\s*"guarded"`
+   patterns, not bare string replacement.
+
+4. **Config Serialize round-trip.** Adding `Serialize` enables `toml::to_string()`. Verify
+   that `deserialize(serialize(config)) == config` for existing production configs. TOML
+   serialization may produce different formatting but must preserve semantic equivalence.
+
+5. **Wizard BtrfsOps dependency.** The wizard discovers subvolumes via btrfs commands,
+   requiring sudo. Verify the fallback when sudo is unavailable (the design doc specifies
+   tiered privilege escalation).

--- a/docs/96-project-supervisor/roadmap.md
+++ b/docs/96-project-supervisor/roadmap.md
@@ -481,118 +481,105 @@ After each phase:
 
 > This section is a living tracker. Updated when priorities change.
 
-### Priority 5: Sentinel (in progress)
+### Priority 5: Sentinel (paused — resumed after Priority 6)
 
-The Sentinel is three independent systems that compose. Build and test them separately.
+The Sentinel is three independent systems that compose. Sessions 1-2 complete and deployed.
+Sessions 3-4 deferred below Priority 6 UX work. Session 3's notification dedup is subsumed
+by 6-I's structured advisory cooldown mechanism.
 
 | # | Component | Status | Notes |
 |---|-----------|--------|-------|
 | 5a | **Notification dispatcher** | **Complete** | `notify.rs`: `compute_notifications()` pure function, 4 channel types, urgency filtering. 18 tests. |
-| 5b | **Event reactor (passive)** | **Session 2 complete** | Pure state machine (Session 1) + I/O runner + CLI (Session 2). Session 3 next: hardening + notification dedup. |
-| 5c | **Active mode** | Designed, not built | Auto-trigger logic in Session 1: `should_trigger_backup()`, `TriggerPermission`. Session 4. |
+| 5b | **Event reactor (passive)** | **Sessions 1-2 complete, deployed** | Pure state machine + I/O runner + CLI. Running as systemd user service. |
+| 5b-3 | **Sentinel hardening** | Deferred | Scoped after 6-I ships (notification dedup subsumed by advisory cooldown). |
+| 5c | **Active mode** | Designed, not built | Auto-trigger logic: `should_trigger_backup()`, `TriggerPermission`. After Priority 6. |
 
-### Priority 5.5: Safety & Visibility (designed, not built)
+### Priority 5.5: Safety & Visibility — Complete
 
-Three design trajectories that extend Urd's safety model and user-facing feedback.
-Each has been through brainstorm → design → arch-adversary review. Build order
-matters — later items depend on earlier ones.
+All 10 items built and deployed (v0.4.1–v0.5.0):
+- Hardware swap defenses (drive session tokens, chain health as awareness input, full-send gate)
+- Visual feedback model (OperationalHealth enum, two-axis CLI, sentinel visual_state)
+- Transient snapshots (local_retention = "transient", immediate cleanup)
 
-**Build sequence** (resolved 2026-03-29):
+| Item | Design | Review |
+|------|--------|--------|
+| Hardware swap defenses | [design](../95-ideas/2026-03-28-design-hardware-swap-defenses.md) | [review](../99-reports/2026-03-28-hardware-swap-defenses-design-review.md) |
+| Visual feedback model | [design](../95-ideas/2026-03-28-design-visual-feedback-model.md) | [review](../99-reports/2026-03-28-visual-feedback-model-design-review.md) |
+| Spindle tray icon | [brainstorm](../95-ideas/2026-03-28-brainstorm-tray-icon-spindle.md) | Needs design doc (build after Phase 5) |
 
-```
-1. HSD-A     Drive tokens + chain health as awareness input
-2. VFM-A     OperationalHealth enum, two-axis CLI rendering
-3. Session 3 Sentinel hardening + notification dedup
-4. HSD-B     Sentinel chain-break detection + full-send gate (Norman escalation)
-5. VFM-B     Sentinel visual state + health notifications
-6. Transient  After foundations are solid
-7. Spindle    After VFM-B
-```
+### Priority 6: Voice, UX & Redundancy Guidance
 
-HSD-A before Session 3: no module overlap (drives/awareness vs. sentinel/notify),
-and HSD-A unblocks VFM-A which is the higher-value user-facing deliverable.
-Session 3 is needed by HSD-B and VFM-B (sentinel infrastructure), not earlier.
+The next arc: unify Urd's voice, build high-impact UX features, and teach 3-2-1 strategy
+through the promise system and progressive disclosure. Two brainstorm sessions resolved
+the complete vocabulary and scored UX features. Six phase designs reviewed by arch-adversary.
 
-| # | Feature | Effort | Status | Design doc | Review |
-|---|---------|--------|--------|------------|--------|
-| 5.5a | **Hardware swap defenses** | 2–3 sessions | Designed, reviewed | [design](../95-ideas/2026-03-28-design-hardware-swap-defenses.md) | [review](../99-reports/2026-03-28-hardware-swap-defenses-design-review.md) |
-| | Session A: drive session tokens (`.urd-drive-token`), chain health as pre-computed awareness input | ~1 session | | | |
-| | Session B: sentinel chain-break detection, full-send confirmation gate | ~1 session | | | |
-| 5.5b | **Visual feedback model** | 2 sessions | Designed, reviewed | [design](../95-ideas/2026-03-28-design-visual-feedback-model.md) | [review](../99-reports/2026-03-28-visual-feedback-model-design-review.md) |
-| | Session A: `OperationalHealth` enum in awareness, two-axis CLI rendering | ~1 session | | | |
-| | Session B: sentinel `visual_state` in state file, `HealthDegraded` notifications | ~1 session | | | |
-| 5.5c | **Tray icon (Spindle)** | Low–Medium | Brainstormed | [brainstorm](../95-ideas/2026-03-28-brainstorm-tray-icon-spindle.md) | — |
-| | Reads `sentinel-state.json` visual_state. Start with 4 static icons (ok/warning/critical/active). | | | | |
-| 5.5d | **Transient snapshots** | Medium | Designed | [design](../95-ideas/2026-03-27-design-transient-snapshots.md) | — |
-| | `local_retention = "transient"`: create → send → delete (keep one pinned). For space-constrained NVMe. | | | | |
-
-**Design decisions (resolved 2026-03-29):**
-
-1. **Chain health as awareness input (facade pattern).** Callers pre-compute chain state
-   and pass it into awareness as a simple struct. Awareness stays pure, stays ignorant of
-   pin files and paths, but is the single facade for "subvolume health." This avoids the
-   protocol obligation problem (every consumer assembling the picture themselves).
-
-2. **Full-send gate: never auto-proceed (Norman escalation).** Gated sends escalate through
-   notification urgency, never through automation. Day 1 informational → Day 3 warning →
-   Day 7 critical (channel escalation: desktop → desktop+discord). The gate never lifts
-   without explicit `--force-full`. Awareness transitions affected subvolumes through
-   AT RISK → UNPROTECTED as time passes — truthful natural pressure, not automated override.
-   UX principles: visibility (prominent in status), mapping (notification names the exact
-   command to run), feedback (each status check shows how long gated and what's at risk).
-
-**Other review findings to address:**
-- HSD: Token verification should use `VerifiedDrive` wrapper or collapse into `drive_availability()`
-- VFM: `Blocked` for unmounted drives too aggressive — only block when send is due AND no drives mounted
-- VFM: Start with 4 icon states (ok/warning/critical/active), not 7
-- VFM: Keep structured data only in state file — no pre-computed text
-
-**Supporting brainstorms:**
-- [Hardware swap solutions brainstorm](../95-ideas/2026-03-28-brainstorm-hardware-swap-solutions.md) — drive identity, chain-break detection, space deltas, full-send gates, new-drive onboarding
-
-### Priority 6: Redundancy Guidance & User Experience
-
-The next arc: teach users 3-2-1 backup strategy through Urd's promise system, advisories,
-and progressive disclosure — not through documentation. The setup wizard is the capstone.
-Build sequence resolved 2026-03-31; dependency arrows flow downward.
-
-**Build sequence:**
+**Two arcs, one dependency chain:**
 
 ```
-1. B   Transient immediate cleanup (executor-only, independent)
-2. E   Promise levels encode redundancy (foundational — I, O, H reference it)
-3. I+N In parallel: redundancy recommendations + retention preview
-4. O   Progressive disclosure (needs E + I infrastructure)
-5. H   Guided setup wizard (capstone — integrates E, N, G; voice is the work)
+Voice & UX Arc                        Progressive & Setup Arc
+──────────────                        ───────────────────────
+Merge 6-B + 6-E (ready now)
+  │
+Phase 1: Vocabulary landing
+  │
+Phase 2a+2c: urd default + completions
+  │
+6-I: Advisory system ─────────────────→ 6-O: Progressive disclosure (2 sessions)
+  │                                        │
+6-N + Phase 2b: Retention + doctor        ADR-110 enum rename (1 session)
+  │                                        │
+Phase 4a+4b: Escalation + suggestions    Config Serialize refactor (0.5 session)
+  │                                        │
+Phase 4c: Mythic transitions             6-H: Guided setup wizard (4 sessions)
 ```
 
-B is independent. E is the foundation. I and N are parallel (I builds advisory
-infrastructure, N builds retention preview — both feed H). O needs E's promise
-semantics and I's advisory types. H pulls everything together.
+**Estimated total: 15 sessions, ~150 new/modified tests, test suite 589 → ~740.**
 
-| # | Feature | Effort | Status | Design doc | Review |
-|---|---------|--------|--------|------------|--------|
-| 6-B | **Transient immediate cleanup** | 1 session | Reviewed | [design](../95-ideas/2026-03-31-design-b-transient-immediate-cleanup.md) | [review](../99-reports/2026-03-31-design-b-review.md) |
-| | Executor deletes old pin parent after send to all drives. No new types. | | | | |
-| 6-E | **Promise redundancy encoding** | 1 session | Reviewed | [design](../95-ideas/2026-03-31-design-e-promise-redundancy-encoding.md) | [review](../99-reports/2026-03-31-design-e-review.md) |
-| | Resilient requires offsite-role drive. Offsite staleness as post-processing overlay. Gate: ADR-110 addendum. | | | | |
-| 6-I | **Redundancy recommendations** | 1–2 sessions | Reviewed | [design](../95-ideas/2026-03-31-design-i-redundancy-recommendations.md) | [review](../99-reports/2026-03-31-design-i-review.md) |
-| | Structured advisory system with notification cooldown. Migrates stringly-typed advisories. | | | | |
-| 6-N | **Retention policy preview** | 1 session | Reviewed | [design](../95-ideas/2026-03-31-design-n-retention-policy-preview.md) | [review](../99-reports/2026-03-31-design-n-review.md) |
-| | Cascading retention windows + status one-liner. Two-tier estimation (Calibrated/Unknown). | | | | |
-| 6-O | **Progressive disclosure** | 2 sessions | Reviewed | [design](../95-ideas/2026-03-31-design-o-progressive-disclosure.md) | [review](../99-reports/2026-03-31-design-o-review.md) |
-| | Delivers through status + Spindle (not notifications). 8 milestones, parameterized identity. | | | | |
-| 6-H | **Guided setup wizard** | 4–5 sessions | Reviewed | [design](../95-ideas/2026-03-31-design-h-guided-setup-wizard.md) | [review](../99-reports/2026-03-31-design-h-review.md) |
-| | Prerequisite: Config Serialize refactor. Migration safety. Tiered discovery. | | | | |
+#### Feature table
 
-**Also in this priority (independent, low effort):**
+| # | Feature | Effort | Status | Design | Review |
+|---|---------|--------|--------|--------|--------|
+| 6-B | **Transient immediate cleanup** | 1 session | **Built, reviewed** | [design](../95-ideas/2026-03-31-design-b-transient-immediate-cleanup.md) | [review](../99-reports/2026-03-31-design-b-review.md) |
+| 6-E | **Promise redundancy encoding** | 1 session | **Built, reviewed** | [design](../95-ideas/2026-03-31-design-e-promise-redundancy-encoding.md) | [review](../99-reports/2026-03-31-design-e-review.md) |
+| P1 | **Vocabulary landing** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase1-vocabulary-landing.md) | [review](../99-reports/2026-03-31-design-phase1-vocabulary-landing-review.md) |
+| P2a | **`urd` default status** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase2-ux-commands.md) | [review](../99-reports/2026-03-31-design-phase2-ux-commands-review.md) |
+| P2b | **`urd doctor`** | 1 session | Designed, reviewed | (same as P2a) | (same as P2a) |
+| P2c | **Shell completions** | 0.5 session | Designed, reviewed | (same as P2a) | (same as P2a) |
+| 6-I | **Redundancy recommendations** | 1–2 sessions | Designed, reviewed | [design](../95-ideas/2026-03-31-design-i-redundancy-recommendations.md) | [review](../99-reports/2026-03-31-design-phase3-advisory-retention-review.md) |
+| 6-N | **Retention policy preview** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-n-retention-policy-preview.md) | (same as 6-I) |
+| P4a | **Staleness escalation** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase4-voice-enrichment.md) | [review](../99-reports/2026-03-31-arch-adversary-phase4-voice-enrichment.md) |
+| P4b | **Next-action suggestions** | (with P4a) | Designed, reviewed | (same as P4a) | (same as P4a) |
+| P4c | **Mythic voice on transitions** | 0.5-1 session | Designed, reviewed | (same as P4a) | (same as P4a) |
+| 6-O | **Progressive disclosure** | 2 sessions | Designed, reviewed | [design](../95-ideas/2026-03-31-design-o-progressive-disclosure.md) | [review](../99-reports/2026-03-31-design-phase5-progressive-disclosure-review.md) |
+| P6a | **ADR-110 enum rename** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase6-protection-rename-wizard.md) | [review](../99-reports/2026-03-31-design-phase6-protection-rename-wizard-review.md) |
+| P6b | **Config Serialize refactor** | 0.5 session | Prerequisite for 6-H | (same as P6a) | (same as P6a) |
+| 6-H | **Guided setup wizard** | 4 sessions | Designed, reviewed | [design](../95-ideas/2026-03-31-design-h-guided-setup-wizard.md) | [review](../99-reports/2026-03-31-design-h-review.md) |
+
+#### Key review findings incorporated
+
+| Finding | Source | Resolution |
+|---------|--------|------------|
+| Heartbeat schema bump likely unnecessary | Phase 6 S-1 | Drop — heartbeat serializes promise states, not level names |
+| Config key rename scope too large | Phase 6 M-1 | Defer to ADR-111 config overhaul |
+| Voice thresholds contradict awareness | Phase 4 S-1 | Derive from PromiseStatus, not independent thresholds |
+| Cooldown key must include drive_label | Phase 3 S-1 | Design update before 6-I implementation |
+| Config error conflation in urd default | Phase 2 S-1 | Distinguish NotFound from ParseError |
+| Sentinel notification dedup | Phase 3 | Subsumed by 6-I cooldown mechanism |
+
+#### Brainstorm artifacts
+
+| Document | Content |
+|----------|---------|
+| [Next-level UX brainstorm](../95-ideas/2026-03-31-brainstorm-next-level-ux.md) | 12 candidates scored, 7 accepted (scores 6-10), 4 rejected |
+| [Vocabulary audit](../95-ideas/2026-03-31-brainstorm-vocabulary-audit.md) | Complete vocabulary redesign: exposure triad, protection levels, thread, drives, skip tags |
+
+#### Also in this priority (independent)
 
 | # | Feature | Effort | Notes |
 |---|---------|--------|-------|
-| 6a | **Shell completions** | Low | `clap_complete` for static; custom completer for subvolume/drive names. |
-| 6-Sp | **Tray icon (Spindle)** | Low–Medium | Reads sentinel-state.json. 4 static icons. [brainstorm](../95-ideas/2026-03-28-brainstorm-tray-icon-spindle.md). Needs design doc. |
+| 6-Sp | **Tray icon (Spindle)** | Low–Medium | Design after Phase 4/5 visual improvements. Build after 6-O. [brainstorm](../95-ideas/2026-03-28-brainstorm-tray-icon-spindle.md). |
 
-**Deferred from old Priority 6:**
+#### Deferred from old Priority 6
 
 | # | Feature | Notes |
 |---|---------|-------|
@@ -622,8 +609,9 @@ semantics and I's advisory types. H pulls everything together.
 
 - [ ] Drive topology constraints — capacity checks require I/O, deferred to Sentinel
 - [ ] Awareness threshold mode — fixed multipliers regardless of run frequency, deferred
-- [ ] Config schema migration (ADR-111) — target architecture defined, legacy schema in use
-- [ ] Protection level taxonomy rework — provisional names, needs operational data first
+- [ ] Config schema migration (ADR-111) — target architecture defined, legacy schema in use; config key rename (`protection_level` → `protection`) deferred here
+- [ ] Protection level enum rename — resolved vocabulary (recorded/sheltered/fortified), scheduled as P6a after 6-O ships
+- [ ] Heartbeat schema bump — likely unnecessary per Phase 6 review S-1 (heartbeat serializes promise states, not level names); verify before P6a
 
 ## Completed Features
 
@@ -664,9 +652,11 @@ All five items built, adversary-reviewed, and deployed:
 - [x] Post-cutover — Priorities 2-4 complete
 - [x] Phase 5 — Architectural foundation complete
 - [x] Phase 6 — Protection promises complete
-- [ ] Phase 7 — Sentinel (5a done, 5b Sessions 1-2 done, Sessions 3-4 remaining)
+- [x] Phase 7 — Sentinel Sessions 1-2 deployed (Sessions 3-4 deferred after Priority 6)
 - [x] Phase 7.5 — Safety & Visibility (5.5a-d: all 10 items complete, v0.4.1–v0.5.0)
-- [ ] Phase 8 — Redundancy guidance & UX (6-B, 6-E, 6-I+N, 6-O, 6-H)
+- [ ] Phase 8 — Voice & UX overhaul (P1→P2→6-I→6-N→P4→6-O→P6a→6-H)
+- [ ] Phase 9 — Sentinel completion (Session 3 hardening, Session 4 active mode)
+- [ ] Phase 10 — Spindle tray icon
 
 ## Dropped Features
 

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -13,30 +13,36 @@ Transient retention deployed to htpc-root (2026-03-30). Immediate cleanup built,
 
 ## In Progress
 
-1. **6-E: Promise redundancy encoding** — implemented, reviewed (arch-adversary + simplify +
-   post-review), all findings addressed. Ready for commit and PR. 17 new tests.
+1. **6-B + 6-E merge** — Transient immediate cleanup + promise redundancy encoding.
+   Both implemented, reviewed (arch-adversary + simplify + post-review), all findings
+   addressed. Ready for commit and PR. 17 new tests (6-E).
 
 ## Next Up
 
-1. **6-I + 6-N in parallel** — redundancy recommendations + retention policy preview.
-   Both designed and reviewed. 1-2 sessions each.
-2. **Spindle design post-review update** — incorporate 3 high findings before building.
+1. **Phase 1: Vocabulary landing** — All presentation-layer string changes (sealed/waning/exposed,
+   thread, connected/disconnected/away, skip tags, CLI descriptions, notification mythology).
+   Blocks all subsequent UX work. 1 session. [Design](../95-ideas/2026-03-31-design-phase1-vocabulary-landing.md) |
+   [Review](../99-reports/2026-03-31-design-phase1-vocabulary-landing-review.md)
+2. **Phase 2a + 2c** — `urd` default one-sentence status (score 10) + shell completions (score 8).
+   1 session. [Design](../95-ideas/2026-03-31-design-phase2-ux-commands.md) |
+   [Review](../99-reports/2026-03-31-design-phase2-ux-commands-review.md)
 
-## Build Queue (Priority 6) — Redundancy Guidance & UX
+## Build Queue — Priority 6: Voice & UX Overhaul
+
+Two arcs. The Voice & UX arc lands vocabulary and high-impact commands. The Progressive &
+Setup arc builds the learning/onboarding layer. All designs reviewed by arch-adversary.
 
 ```
-B (merged) → E (ready to merge) → I+N (parallel) → O → H (capstone)
+Voice & UX Arc:                    Progressive & Setup Arc:
+  Phase 1 (vocabulary)               6-O (milestones, 2 sessions)
+  Phase 2a+2c (urd default, compl.)  ADR-110 enum rename (1 session)
+  6-I (advisory system)              Config Serialize (0.5 session)
+  6-N + Phase 2b (retention, doctor) 6-H (wizard, 4 sessions)
+  Phase 4a+4b (escalation, suggest.)
+  Phase 4c (transitions)
 ```
 
-| # | Feature | Effort | Status |
-|---|---------|--------|--------|
-| 6-B | Transient immediate cleanup | 1 session | **Merged** |
-| 6-E | Promise redundancy encoding | 1 session | **Built, reviewed, ready to merge** |
-| 6-I | Redundancy recommendations | 1-2 sessions | Designed, reviewed |
-| 6-N | Retention policy preview | 1 session | Designed, reviewed |
-| 6-O | Progressive disclosure | 2 sessions | Designed, reviewed |
-| 6-H | Guided setup wizard | 4-5 sessions | Designed, reviewed |
-| 6-Sp | Spindle tray icon | 2 sessions | Designed, reviewed |
+Estimated: 15 sessions total, ~150 new/modified tests, test suite → ~740.
 
 ## Key Links
 
@@ -46,7 +52,8 @@ B (merged) → E (ready to merge) → I+N (parallel) → O → H (capstone)
 | Architecture and code conventions | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
-| Latest review | [6-E implementation review](../99-reports/2026-03-31-design-e-implementation-review.md) |
+| Phase designs (1-6) | [95-ideas/](../95-ideas/) (2026-03-31-design-phase*.md) |
+| Review reports | [99-reports/](../99-reports/) |
 
 ## Known Issues
 
@@ -55,6 +62,7 @@ B (merged) → E (ready to merge) → I+N (parallel) → O → H (capstone)
 - `FileSystemState` trait (11 methods) outgrowing its name — consider rename to `SystemState`
 - `urd get` doesn't support directory restore (files only in v1)
 - Stringly-typed output boundary: three independent status-ranking implementations across notify.rs and voice.rs (addressed by 6-I migration)
-- `OpResult::Skipped` is overloaded: four distinct semantics
+- `OpResult::Skipped` overloaded: four distinct semantics (addressed by Phase 1 skip tag differentiation)
+- Sentinel Sessions 3-4 remaining (Session 3 dedup subsumed by 6-I cooldown mechanism)
 
 See [roadmap.md](roadmap.md) for the full tech debt list and dropped features.

--- a/docs/99-reports/2026-03-31-arch-adversary-phase4-voice-enrichment.md
+++ b/docs/99-reports/2026-03-31-arch-adversary-phase4-voice-enrichment.md
@@ -1,0 +1,244 @@
+# Arch-Adversary Review: Phase 4 — Voice Enrichment
+
+**Date:** 2026-03-31
+**Reviewer:** arch-adversary
+**Artifact:** `docs/95-ideas/2026-03-31-design-phase4-voice-enrichment.md`
+**Type:** Design review (no code)
+
+---
+
+## 1. Executive Summary
+
+This is a well-scoped, low-risk design that adds graduated urgency, next-action
+suggestions, and transition-aware voice to Urd's output. All three features are
+presentation-layer only (or nearly so), which limits blast radius. The one
+architectural concern is 4c's `TransitionEvent` addition to `output.rs` / `BackupSummary`,
+which introduces a computation step in `commands/backup.rs` that blurs the clean
+"awareness is pure" boundary and creates a subtle coupling between backup execution
+and awareness assessment ordering.
+
+---
+
+## 2. What Kills You
+
+**Catastrophic failure mode: silent data loss from snapshot deletion.**
+
+None of these features interact with retention, deletion, or the btrfs layer. They
+are all read-only over existing structured output. Distance from catastrophic failure:
+**3+ bugs away.** This is safe territory.
+
+The only path to danger would be if transition detection (4c) somehow influenced
+planner or executor decisions, but the design explicitly keeps it in the output layer.
+No concern here.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4/5 | Voice/awareness threshold consistency is flagged but not fully resolved |
+| Security | 5/5 | No filesystem writes, no privilege escalation, pure presentation |
+| Architectural Excellence | 4/5 | 4a and 4b are pristine voice.rs additions; 4c introduces justified but non-trivial output.rs coupling |
+| Systems Design | 4/5 | Solid integration points, but the pre/post awareness diff in 4c needs error handling design |
+
+**Overall: 4.25/5** — Clean design with minor tensions to resolve before building.
+
+---
+
+## 4. Design Tensions
+
+### Tension 1: Voice thresholds vs awareness thresholds (4a)
+
+The design acknowledges this but doesn't fully resolve it. Voice has finer-grained
+escalation tiers (observe/suggest/warn) than awareness (binary: `DRIVE_AWAY_DEGRADED_DAYS = 7`).
+The risk: voice says "protection degrading" at day 14 (warn tier for primary) while
+awareness still shows PROTECTED for an offsite drive with a 7-day interval (since
+`EXTERNAL_AT_RISK_MULTIPLIER = 1.5` means AT_RISK only at 10.5 days for a weekly
+interval). The design's invariant ("voice should never claim urgency the awareness
+model doesn't support") is correct but needs a concrete enforcement mechanism, not
+just a stated principle.
+
+### Tension 2: SuggestionContext as a parallel type hierarchy (4b)
+
+`SuggestionContext` extracts boolean flags from the structured output types. This is
+pragmatic but creates a second representation of the same data. If `StatusOutput` or
+`BackupSummary` gain new fields that should trigger suggestions, the developer must
+remember to update `SuggestionContext` too. The coupling is loose but invisible.
+
+### Tension 3: 4c crosses the "voice.rs is pure presentation" line (4c)
+
+Adding `TransitionEvent` to `output.rs` and computing it in `commands/backup.rs` means
+the backup command now has awareness-diffing logic. This is justified (transitions are
+meaningful output data, not decoration), but it's the first time a voice feature has
+required changes outside voice.rs. Worth being explicit that this is a conscious
+boundary expansion, not a precedent for putting arbitrary computation in backup.rs.
+
+---
+
+## 5. Findings
+
+### Significant
+
+**S1: Voice escalation can contradict awareness state.**
+The design proposes voice.rs thresholds independent of awareness.rs thresholds. For
+an offsite drive with 14-day send interval, awareness considers it PROTECTED until
+`14 * 1.5 = 21` days. But voice's warn tier for offsite kicks in at 45 days, and
+the suggest tier at 21 days. These happen to align for offsite, but for primary drives,
+voice warns at 14 days ("protection degrading") while awareness thresholds depend on
+send_interval. A primary drive with a 30-day send interval would be PROTECTED at
+day 14, while voice says "protection degrading." The contradiction erodes user trust.
+
+**Recommendation:** Voice escalation thresholds should be derived from awareness
+thresholds or from send interval, not hardcoded per role. Either:
+(a) `escalated_drive_text` takes the send_interval and computes tiers as fractions
+of the awareness thresholds, or
+(b) voice reads the awareness PromiseStatus and only escalates text *within* the
+current awareness state (e.g., "consider connecting" only when AT_RISK, "protection
+degrading" only when UNPROTECTED).
+
+**S2: Pre/post awareness diff has no error handling design.**
+If the post-backup `assess()` call fails (e.g., filesystem state read error), what
+happens? The design doesn't specify. Options: (a) skip transitions silently (loses
+information), (b) emit a warning (noisy), (c) treat missing post-state as "no
+transitions" (correct default). The design should pick (c) explicitly.
+
+**Recommendation:** Specify that transition detection is best-effort. If post-backup
+assessment fails, `transitions` is empty and no voice lines appear. Log at debug level.
+
+### Moderate
+
+**M1: `SuggestionContext::Doctor { all_clear: true }` emits text, violating the
+"silence when healthy" principle.**
+The design shows `Doctor { all_clear: true }` returning `Some("All clear. No action needed.")`.
+But the stated invariant is "healthy states produce `None` -- no 'everything is fine!' noise."
+This is a direct contradiction within the design.
+
+**Recommendation:** `Doctor { all_clear: true }` should return `None`. The doctor
+command's own output already communicates the all-clear state. The suggestion line
+should only appear when there's an actual *next* action to suggest.
+
+**M2: `SuggestionContext` references `urd doctor` and `urd calibrate` which don't exist yet.**
+The design proposes suggestions like "Run `urd doctor` to diagnose" and "Run `urd calibrate`
+to measure actual snapshot sizes." Neither command exists in the current codebase.
+Building 4b before those commands creates dead suggestions.
+
+**Recommendation:** Either (a) build 4b after `urd doctor` exists, or (b) gate those
+specific suggestions behind a feature check / omit them until the commands land.
+Suggesting a command that doesn't exist is worse than silence.
+
+**M3: 4c `TransitionEvent` is not `Clone` or `PartialEq` in the design.**
+The design shows the enum but doesn't specify derives. For testing (asserting on
+specific transitions) and for potential daemon serialization, `TransitionEvent` needs
+at minimum `Clone`, `PartialEq`, `Eq`, and `Serialize`. The project convention requires
+`Debug` on all types plus `Clone`, `PartialEq`, `Eq` where sensible -- all are sensible
+here.
+
+**Recommendation:** Specify `#[derive(Debug, Clone, PartialEq, Eq, Serialize)]` on
+`TransitionEvent`.
+
+### Minor
+
+**m1: Rendering order of 4b + 4c not specified in the design doc.**
+The "Ready for Review" section mentions it as a concern but doesn't resolve it. When
+both transitions and suggestions appear, the order matters for visual coherence.
+
+**Recommendation:** Transitions first (what happened), then suggestion (what to do next).
+Add this to the design doc as an invariant.
+
+**m2: `escalated_thread_text` references "thread health" but the current codebase
+uses `ChainHealth` in data structures.**
+The vocabulary decision ("thread" replaces "chain" in user-facing text) is documented,
+but `escalated_thread_text()` operates on chain health data. The function name uses
+the new vocabulary while its inputs use the old. This is consistent with the naming
+decision but worth a comment in the code for clarity.
+
+**Recommendation:** Add a brief doc comment: `/// Escalated text for chain health
+(user-facing: "thread").`
+
+### Commendation
+
+**C1: Strong adherence to the "voice.rs is pure" principle.**
+Features 4a and 4b are entirely within voice.rs with no state changes, no I/O, and
+clear `None`-means-silence semantics. This is exactly how presentation-layer features
+should be designed. The project has internalized the pure-function module pattern
+(ADR-108) deeply enough that it shapes new feature design by default.
+
+**C2: Honest self-assessment in "Ready for Review" section.**
+The design identifies its own weakest points (threshold consistency, over-suggestion,
+diff cost, transition accuracy, rendering order) and asks the reviewer to focus there.
+This is a sign of mature design practice.
+
+**C3: Minimal blast radius for maximum UX value.**
+Three features, approximately 35 new tests, changes to 2-3 files. The ratio of user
+value to code surface area is excellent. The brainstorm scoring (9, 9, 8) reflects
+genuine user desire, not engineering enthusiasm.
+
+---
+
+## 6. The Simplicity Question
+
+**Is this design as simple as it could be?**
+
+4a and 4b: Yes. Pure functions with clear inputs and outputs. No simpler design exists
+that achieves the same goal.
+
+4c: Almost. The `TransitionEvent` enum and pre/post diff are the minimal mechanism for
+detecting state changes. An alternative would be to infer transitions from operation
+results (e.g., "a full send to a new drive = first send"), but this would be fragile
+and couple voice to executor internals. The awareness diff approach is more robust.
+The one simplification opportunity: instead of a full `assess()` before backup, capture
+only the specific data needed for transition detection (promise statuses per subvolume
+per drive). This avoids redundant computation without losing accuracy.
+
+---
+
+## 7. For the Dev Team
+
+**Priority order (do these before or during build):**
+
+1. **Resolve voice/awareness threshold consistency (S1).** This is the design's one
+   real flaw. Pick option (b): voice reads the awareness PromiseStatus and calibrates
+   its text to the current state, not to independent thresholds. This makes the
+   escalation *complement* the awareness model rather than *compete* with it.
+
+2. **Remove the Doctor all-clear suggestion (M1).** Simple fix, but it's a contradiction
+   that would ship if not caught.
+
+3. **Gate suggestions on command existence (M2).** Don't suggest `urd doctor` until
+   it exists.
+
+4. **Specify error handling for post-backup assessment failure (S2).** One sentence
+   in the design doc: "If post-backup assessment fails, transitions is empty."
+
+5. **Add derives to TransitionEvent (M3).** Mechanical but easy to forget.
+
+6. **Document rendering order as an invariant (m1).** Transitions, then suggestions.
+
+---
+
+## 8. Open Questions
+
+1. **Should voice escalation tiers be configurable?** The design hardcodes them. For
+   an offsite drive that rotates monthly, the 45-day warn threshold may be too tight.
+   For a primary drive that syncs daily, 14-day warn may be too loose. If thresholds
+   are always derived from awareness/interval, this question dissolves. If hardcoded,
+   it will surface as a user request eventually.
+
+2. **Should `TransitionEvent::AllSealed` include which subvolumes transitioned?** The
+   current design makes it a global event ("all threads hold"), but if only one of
+   nine subvolumes actually changed state, the user might want to know which one. On
+   the other hand, the brevity is valuable. Worth a conscious decision.
+
+3. **Does the pre-backup `assess()` call need filesystem access that might not be
+   available?** If the backup is running via systemd timer (nightly, no terminal),
+   the assessment reads filesystem state and SQLite. This should work, but if any
+   assessment path requires an interactive resource (e.g., terminal width for rendering),
+   the pre-backup call would need to be assessment-only, not render-ready. The design
+   implies this (it calls `assess()` not `render()`), but confirm that `assess()` is
+   truly I/O-minimal.
+
+4. **4c says "status and other query commands never have mythic voice lines" -- does
+   `urd plan` count as a query or an event?** Plan is a dry-run preview. If a future
+   plan output shows "this would restore a thread," is that a transition voice line or
+   a factual preview? The boundary should be defined now, not discovered later.

--- a/docs/99-reports/2026-03-31-design-phase1-vocabulary-landing-review.md
+++ b/docs/99-reports/2026-03-31-design-phase1-vocabulary-landing-review.md
@@ -1,0 +1,295 @@
+# Arch-Adversary Review: Phase 1 — Vocabulary Landing
+
+**Date:** 2026-03-31
+**Artifact:** `docs/95-ideas/2026-03-31-design-phase1-vocabulary-landing.md`
+**Type:** Design review (no code yet)
+**Reviewer:** arch-adversary
+
+---
+
+## 1. Executive Summary
+
+This is a well-scoped presentation-layer refactor that lands resolved vocabulary decisions
+from a thorough brainstorm/grill-me process. The design correctly identifies the blast
+radius (string literals in four files, no data structures), correctly preserves all
+backward-compatibility contracts, and sequences itself as a foundation for subsequent
+phases. The main risks are not in what the design does but in what it under-specifies at
+the boundary between interactive and daemon output modes.
+
+---
+
+## 2. What Kills You
+
+**Catastrophic failure mode for Urd: silent data loss through incorrect snapshot deletion.**
+
+This design is **far from the kill zone**. It changes no computation, no retention logic,
+no planner decisions, no executor behavior. Every change is a string literal in a rendering
+function. There is no path from this work to silent data loss.
+
+**Distance from catastrophic failure: 3+ bugs away.** Comfortable.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4/5 | Sound design with one under-specified boundary (daemon vs. interactive ChainHealth rendering). |
+| **Security** | 5/5 | No security-relevant surface. No I/O changes, no privilege changes, no new inputs. |
+| **Architectural Excellence** | 5/5 | Respects every invariant. Presentation-only changes. No new types. Clean module boundaries. |
+| **Systems Design** | 4/5 | Good integration analysis but two edge cases need explicit handling before implementation. |
+
+---
+
+## 4. Design Tensions
+
+**Tension 1: Information density vs. scannability.**
+The thread column change from `"incremental (20260330-0404-htpc-home)"` to `"unbroken"` trades
+debugging information for scannability. The design acknowledges this and proposes verbose-mode
+fallback, which is the right resolution. But the design should specify what `--verbose` thread
+rendering looks like, not leave it as a note in the "Ready for Review" section.
+
+**Tension 2: Skip tag proliferation vs. visual noise.**
+Adding `[AWAY]`, `[WAIT]`, `[OFF]` prefixes to grouped renderers that already describe their
+category in prose creates redundancy. `[AWAY]  Disconnected: WD-18TB1 (3 subvolumes)` says
+"away" and "disconnected" -- the tag and the prose carry the same information. The tension is
+between consistency with the individual renderer (which needs the tag) and the grouped renderer
+(which doesn't). The design should explicitly decide whether grouped renderers need tags or
+whether the prose heading is sufficient.
+
+**Tension 3: "waning" as a term.**
+"Sealed" and "exposed" are strong: clear, precise, low ambiguity. "Waning" is the weakest
+link in the triad. It is an unusual word in a technical context. A user encountering "waning"
+for the first time may not immediately understand it means "protection is degrading over time."
+The brainstorm scored it well, and the narrative arc (sealed -> waning -> exposed) works, so
+this is a tension to be aware of rather than a finding to act on.
+
+---
+
+## 5. Findings
+
+### Significant
+
+**S-1: ChainHealth Display impl is a shared boundary — design must specify how to fork it.**
+
+The design says `ChainHealth::Display` "feeds daemon JSON and must not change" and proposes
+a separate `render_thread_status()` function for interactive mode. This is the correct
+approach. However, the design does not specify *where* the fork happens. Currently, line 233
+of voice.rs calls `c.health.to_string()` to render the chain column. The implementation must
+replace this call site with a conditional: `render_thread_status()` for interactive mode,
+`.to_string()` for daemon mode.
+
+The risk: if the implementer changes `ChainHealth::Display` instead of adding a parallel
+rendering path, daemon JSON consumers break silently. The design should make the fork point
+explicit: "In `render_subvolume_table()`, replace `c.health.to_string()` with
+`render_thread_status(&c.health)`. Do NOT modify the `Display` impl on `ChainHealth`."
+
+**Why significant:** Daemon JSON is a downstream contract. Breaking it silently would affect
+monitoring and the Sentinel state machine. Not catastrophic (no data loss), but operationally
+damaging.
+
+---
+
+**S-2: The "away" cell in the subvolume table needs role information from a different struct than it currently uses.**
+
+The current code at voice.rs line 222:
+```rust
+Some(e) if e.last_send_age_secs.is_some() => "away".dimmed().to_string(),
+```
+
+This matches on `ExternalAssessment` (the per-subvolume-per-drive data), not `DriveInfo`.
+The design says to make this role-aware: offsite drives show "away", primary drives show
+"--". The `drive.role` is available in the outer loop (`for drive in &data.drives`), so
+this is mechanically feasible. But the design should state explicitly that the conditional
+becomes `if drive.role == DriveRole::Offsite { "away" } else { "\u{2014}" }` inside the
+existing match arm. Without this, an implementer might try to look up the role from the
+`ExternalAssessment`, which doesn't carry it.
+
+**Why significant:** Getting this wrong means offsite drives show "--" (losing the "away"
+signal) or primary drives show "away" (giving false reassurance that absence is expected).
+Neither is catastrophic but both are misleading.
+
+---
+
+### Moderate
+
+**M-1: The design silently changes the summary line semantics.**
+
+Current: `"{N} of {M} safe. {names} needs attention."`
+Proposed: `"{N} of {M} sealed. {names} exposed."`
+
+The word "exposed" in the proposed summary only applies to UNPROTECTED subvolumes. But the
+current `needs attention` covers both AT RISK and UNPROTECTED subvolumes (any non-PROTECTED
+subvolume gets listed). If the new summary says "{names} exposed", it implies all listed
+subvolumes are exposed (UNPROTECTED), when some may be merely waning (AT RISK).
+
+The design should decide: does the summary line list *all* non-sealed subvolumes (in which
+case "{names} exposed" is inaccurate for waning ones), or only exposed subvolumes (losing
+visibility of waning ones)? Options:
+- `"6 of 9 sealed. htpc-root exposed, docs waning."`  (differentiated)
+- `"6 of 9 sealed. 3 need attention."` (keep the generic phrasing)
+- `"6 of 9 sealed. htpc-root, docs, photos not sealed."` (accurate but verbose)
+
+**Why moderate:** Incorrect labeling in the summary line erodes trust in Urd's reporting,
+but doesn't cause data loss.
+
+---
+
+**M-2: The `UrdError::Chain` error message change has broader grep implications.**
+
+The design proposes changing the `#[error("Chain error: {0}")]` message to
+`#[error("Thread error: {0}")]`. This error string appears in log files, journal output,
+and potentially in monitoring grep patterns. Users who have built alerting on "Chain error"
+will silently stop matching.
+
+This is a minor backward-compatibility concern. The design's "What does NOT change" section
+covers heartbeat, Prometheus, and daemon JSON, but doesn't address error message strings in
+logs. For a pre-1.0 project this is acceptable, but it should be documented as a known
+string change in the CHANGELOG.
+
+**Why moderate:** Log grep patterns are fragile by nature, but the homelab integration
+specifically consumes Urd's external interface. Worth a one-line callout.
+
+---
+
+**M-3: Protection level vocabulary (recorded/sheltered/fortified) is mentioned in the brainstorm resolution but explicitly deferred in the design. The PROMISE -> PROTECTION column rename IS in scope. This mismatch needs one sentence of clarification.**
+
+The design's Change 7 renames the column header from PROMISE to PROTECTION. The brainstorm
+resolved that protection *level names* change too (guarded -> recorded, protected -> sheltered,
+resilient -> fortified). The design correctly defers level names to Phase 6. But the PROTECTION
+column will display the *old* level names (guarded, protected, resilient) under a *new* header.
+This is fine as a transitional state, but the design should explicitly state: "The PROTECTION
+column will temporarily show legacy level names until Phase 6 renames them."
+
+**Why moderate:** Without this note, an implementer might also rename the level Display impls,
+breaking config parsing and on-disk contracts.
+
+---
+
+### Minor
+
+**N-1: CLI description for `status` diverges between brainstorm and design.**
+
+Brainstorm resolution: `"Check data safety — exposure, drives, threads"`
+Design Change 5: `"Check whether your data is safe"`
+
+The brainstorm version is more specific (lists what it checks). The design version is more
+intent-first but loses the specificity. Pick one and be consistent between documents.
+
+---
+
+**N-2: The notification body for "all unprotected" (line 241-243) uses "unguarded" which collides with the vocabulary change.**
+
+Current: `"Attend to this — your data stands unguarded."`
+
+The design's Change 6 table doesn't list this string. If "guarded" is being phased out as a
+protection level name (brainstorm resolved: guarded -> recorded), then "unguarded" in this
+notification becomes orphaned vocabulary. This notification body should be included in Change 6
+and rewritten to use the new vocabulary.
+
+---
+
+**N-3: `render_drive_summary` currently repeats "Drives:" prefix on every line.**
+
+The brainstorm resolved to drop the "Drives:" prefix. The design's Change 3 describes
+"connected" / "disconnected" / "away" replacements but doesn't explicitly state whether the
+"Drives:" prefix is dropped. The current code (line 299, 311, 319) shows `"Drives: {label}
+{status}"` on every drive line. The design should confirm: drop the prefix or keep it.
+
+---
+
+### Commendation
+
+**C-1: Excellent boundary discipline.**
+
+The design draws a sharp line between what changes (presentation strings) and what doesn't
+(data structures, serde serialization, heartbeat contracts, Prometheus metrics). This is
+exactly the right instinct for a project with downstream consumers. The "What does NOT
+change" section is the most important part of the document.
+
+**C-2: The skip tag differentiation is a genuine UX improvement.**
+
+The current `[SKIP]` tag is overloaded (noted in status.md known issues). Breaking it into
+`[WAIT]`, `[AWAY]`, `[SPACE]`, `[OFF]`, `[SKIP]` directly addresses the `OpResult::Skipped`
+overloading problem at the presentation layer. The user can now distinguish "this will happen
+later" from "this needs attention" at a glance.
+
+**C-3: The vocabulary brainstorm and grill-me process was thorough.**
+
+Twenty domains evaluated individually, each term tested against four criteria, with a clear
+resolution for every decision. The design document is an honest mechanical translation of
+resolved decisions. This is how vocabulary changes should be done: editorial work first,
+implementation second.
+
+---
+
+## 6. The Simplicity Question
+
+**Is this design as simple as it could be while achieving its goals?**
+
+Yes. The design is deliberately mechanical: it changes string literals in rendering functions
+and nothing else. It avoids the temptation to restructure types, add new abstractions, or
+introduce rendering modes. The one complexity addition (a separate `render_thread_status()`
+function) is justified by the daemon JSON contract.
+
+The skip tag differentiation adds five tag variants where two existed before. This is added
+complexity, but it resolves a known overloading issue. The complexity is proportional to the
+problem.
+
+**Could anything be cut?** Change 7 (PROMISE -> PROTECTION header) could be deferred to
+Phase 6 alongside the level name changes. Shipping the header rename now, with old level
+names under it, creates a transitional state that lasts until Phase 6. If Phase 6 is soon,
+this is fine. If Phase 6 is months away, consider deferring.
+
+---
+
+## 7. For the Dev Team
+
+Prioritized action items before implementation:
+
+1. **[S-1] Specify the ChainHealth rendering fork point.** Add one sentence to Change 2:
+   "Replace `c.health.to_string()` on line 233 with `render_thread_status(&c.health)`.
+   The `Display` impl on `ChainHealth` must not change."
+
+2. **[S-2] Specify the role-aware cell conditional.** Add the exact conditional to Change 3:
+   inside the drive column loop, match on `drive.role` from the outer iterator, not from
+   `ExternalAssessment`.
+
+3. **[M-1] Resolve the summary line semantics.** Decide whether "{names} exposed" lists
+   all non-sealed subvolumes or only UNPROTECTED ones. If all, use a word that covers both
+   waning and exposed (e.g., "not sealed"). If only UNPROTECTED, consider whether waning
+   subvolumes should also appear.
+
+4. **[M-3] Add a transitional note for PROTECTION column.** One sentence: "The PROTECTION
+   column shows legacy level names (guarded/protected/resilient) until Phase 6."
+
+5. **[N-2] Add the "unguarded" notification to Change 6.** Rewrite the "all unprotected"
+   body to use the new vocabulary.
+
+6. **[N-3] Confirm "Drives:" prefix decision.** State explicitly whether it stays or goes.
+
+---
+
+## 8. Open Questions
+
+1. **Verbose thread rendering.** The design mentions `"unbroken (20260330-0404-htpc-home)"`
+   for `--verbose` but doesn't specify where this flag is threaded through voice.rs. Does
+   `render_thread_status()` take an `OutputMode` parameter, or a `verbose: bool`? This
+   affects the function signature.
+
+2. **Color semantics for new exposure labels.** The current `safety_label` return value gets
+   colored by the table renderer based on column position. The design doesn't specify colors
+   for sealed/waning/exposed. Presumably: sealed = green, waning = yellow, exposed = red
+   (matching the current OK/aging/gap colors). Worth confirming.
+
+3. **"Last seen N days ago" data source.** Change 3 proposes adding "last seen N days ago"
+   for absent drives. Where does this data come from? `DriveInfo` has `free_bytes` and
+   `mounted` but no `last_seen` timestamp. The subvolume-level `ExternalAssessment` has
+   `last_send_age_secs`, but that's per-subvolume, not per-drive. The design may need a
+   `last_seen_age_secs` field on `DriveInfo` -- which would violate the "no data structure
+   changes" invariant. Alternatively, derive it from the oldest `last_send_age_secs` across
+   subvolumes for that drive, but this is new computation. Clarify.
+
+4. **Phase 6 timeline.** If Change 7 (PROMISE -> PROTECTION) lands now, how long will
+   the transitional state last? If Phase 6 is more than 2-3 sessions away, consider
+   deferring Change 7.

--- a/docs/99-reports/2026-03-31-design-phase2-ux-commands-review.md
+++ b/docs/99-reports/2026-03-31-design-phase2-ux-commands-review.md
@@ -1,0 +1,280 @@
+# Arch-Adversary Review: Phase 2 — Independent UX Commands
+
+**Date:** 2026-03-31
+**Reviewer:** arch-adversary
+**Artifact:** `docs/95-ideas/2026-03-31-design-phase2-ux-commands.md`
+**Type:** Design review (no code yet)
+
+---
+
+## 1. Executive Summary
+
+A well-scoped design for three independent, low-risk UX features. The most architecturally
+interesting piece (2a: bare `urd` default status) introduces a structural CLI change that needs
+careful handling in `main.rs` to avoid a config-loading regression. The doctor composition (2b)
+is sound in concept but the extraction boundary from init/verify needs more precision before
+building. Shell completions (2c) is trivially correct.
+
+---
+
+## 2. What Kills You
+
+**Catastrophic failure mode: silent data loss via deleted snapshots.**
+
+None of these three features are within striking distance. All are read-only diagnostic or
+rendering paths. No feature touches retention, deletion, or the executor. The `Option<Commands>`
+refactor in 2a could theoretically regress existing command dispatch, but only in the "command
+doesn't run at all" direction (fail-closed), not the "wrong thing gets deleted" direction.
+
+**Proximity to catastrophe: LOW.** No finding in this review is within one bug of silent
+data loss.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4/5 | First-time detection conflates missing config with broken config (self-identified). Otherwise logic is straightforward. |
+| **Security** | 5/5 | No new privilege escalation, no new I/O paths beyond existing modules, completions write to stdout only. |
+| **Architectural Excellence** | 4/5 | Clean module boundaries, respects pure-function invariants, but doctor's extraction contract is under-specified. |
+| **Systems Design** | 4/5 | Good progressive disclosure (doctor --thorough), correct dispatch ordering for completions. Minor gap in error UX for bare `urd`. |
+
+---
+
+## 4. Design Tensions
+
+### 4.1 Config-required vs. config-free commands
+
+The current `main.rs` loads config unconditionally before dispatch. 2a needs config loading to
+be fallible (first-time detection), and 2c needs to bypass it entirely. This creates a tension:
+config loading moves from "always happens first" to "sometimes happens, sometimes doesn't, and
+failure semantics differ by command." The design acknowledges this but doesn't show the full
+`main.rs` restructure — it will be messier than the snippets suggest.
+
+### 4.2 Doctor as compositor vs. doctor as new diagnostic
+
+The design positions doctor as pure composition of existing checks. But the "checking Sentinel
+is running" diagnostic shown in the voice example doesn't come from init, verify, or awareness.
+Either doctor quietly introduces new checks (scope creep) or the Sentinel check needs to be
+added to init first. This tension should be resolved before building.
+
+### 4.3 Extraction granularity from init.rs
+
+`collect_infrastructure_checks()` is currently `fn` (private). Making it `pub(crate)` is
+trivial. But the design's pseudocode shows doctor calling `init::collect_infrastructure_checks(&config, &btrfs)` with a `&btrfs` parameter that the actual function doesn't take — it calls
+`StateDb::open()` directly. The extraction will need to either inject I/O dependencies or
+accept that these checks aren't pure.
+
+### 4.4 Bare `urd` latency expectations
+
+Bare `urd` calls `awareness::assess()` which scans snapshot directories on the filesystem.
+For users with many snapshots or slow storage, this might not feel "instant." The design says
+"no extra I/O beyond what `awareness::assess()` already does" but doesn't set a latency budget.
+If this is the most-typed command, its performance ceiling matters.
+
+---
+
+## 5. Findings
+
+### Significant
+
+**S1: Config error conflation in bare `urd` (self-identified, confirming)**
+
+The design catches `Err(_)` on config load and assumes first-time user. A TOML parse error,
+a permission denied on the config file, or a path expansion failure would all trigger the
+"Urd is not configured yet" message. The user would think they need `urd init` when they
+actually have a syntax error in their config.
+
+**Impact:** Misleading UX, user chases wrong problem.
+**Recommendation:** Match on error kind. Config-not-found -> first-time message. All other
+errors -> report the actual error. The `Config::load()` return type may need to distinguish
+these cases (e.g., a `ConfigError::NotFound` variant vs. `ConfigError::Parse`).
+
+---
+
+**S2: `main.rs` restructure is under-designed**
+
+The design shows the `None` arm in isolation but doesn't show the full new structure of
+`main.rs`. Currently, config loads unconditionally on line 47, before dispatch. The new
+design needs:
+
+1. Completions dispatched before config load
+2. Bare `urd` with fallible config load (first-time path)
+3. All other commands with mandatory config load (current behavior)
+
+This is three different config-loading strategies in one function. The design should show
+the complete `main.rs` flow, not just the new arms, to ensure the restructure doesn't
+accidentally change behavior for existing commands.
+
+**Impact:** Implementation ambiguity leads to ad-hoc restructuring.
+**Recommendation:** Write the full `main()` function skeleton in the design, showing where
+config loads for each path. Consider: parse CLI first, then branch on whether config is
+needed, then dispatch.
+
+---
+
+### Moderate
+
+**M1: Doctor's Sentinel check is unaccounted for**
+
+The voice rendering example shows "Sentinel running (PID 366735)" but none of the composed
+modules (preflight, init infrastructure, awareness, verify) currently check Sentinel status.
+This is a new diagnostic that the design doesn't mention building.
+
+**Impact:** Either doctor's example output is aspirational (misleading the design review)
+or there's hidden work.
+**Recommendation:** Either (a) explicitly add a Sentinel status check to doctor's scope and
+estimate, or (b) remove it from the example output and defer to a later phase.
+
+---
+
+**M2: `DoctorOutput` type doesn't match the pseudocode**
+
+The `DoctorOutput` struct in the design has fields `config_checks`, `infra_checks`,
+`assessments`, `verify`, `verdict`. But the pseudocode in `doctor.rs` assigns different
+names: `preflight`, `infra`, `assessments`, `verify`. The struct also doesn't include a
+`preflight` field — only `config_checks`. These need to align.
+
+**Impact:** Cosmetic, but signals the design isn't fully thought through at the type level.
+**Recommendation:** Reconcile the struct fields with the pseudocode. Decide whether preflight
+checks and config checks are the same concept.
+
+---
+
+**M3: Doctor `--thorough` flag naming**
+
+`--thorough` is clear enough, but it creates a precedent for "how deep should a command dig"
+flags. If other commands later want similar progressive depth (e.g., `urd status --detailed`),
+the naming convention should be established now.
+
+**Impact:** Minor inconsistency risk across future commands.
+**Recommendation:** Acceptable as-is. Note that `--thorough` is doctor-specific vocabulary
+and doesn't set a project-wide convention.
+
+---
+
+### Minor
+
+**m1: `DefaultStatusOutput.health_issues` is vague**
+
+The `health_issues: Vec<String>` field has no defined source. What counts as a health issue?
+Is it preflight warnings? Heartbeat staleness? The design doesn't specify where these come
+from or what populates them.
+
+**Impact:** Implementation will need to make this decision without design guidance.
+**Recommendation:** Either specify the source (e.g., "populated from preflight warnings and
+heartbeat age") or remove the field and add it when a concrete need arises.
+
+---
+
+**m2: `LastBackupInfo.result` is `String`**
+
+The `result: String` field in `LastBackupInfo` should be a typed enum, consistent with the
+project's "strong types over primitives" convention. The status.rs code already has
+structured `LastRunInfo` — the default status should reuse or alias it.
+
+**Impact:** Stringly-typed output — the same problem noted in status.md's known issues.
+**Recommendation:** Reuse `LastRunInfo` from the existing output types, or at minimum use
+an enum for result.
+
+---
+
+**m3: Completions test coverage is minimal**
+
+Four tests for completions is fine for the feature's risk level, but the design should
+mention testing that `urd completions bash` works without a config file — this is the key
+invariant and the most likely regression if `main.rs` restructuring is done carelessly.
+
+**Impact:** The important test case is implied but not stated.
+**Recommendation:** Explicitly list "completions works without config" as a test case
+(it's mentioned as an invariant but not in the test strategy).
+
+---
+
+### Commendation
+
+**C1: Self-aware review focus areas**
+
+The design's "Ready for Review" section correctly identifies the highest-risk areas and even
+self-identifies the config error conflation issue. This kind of self-aware design writing
+saves review cycles and signals engineering maturity.
+
+**C2: Independence and parallelism**
+
+All three features are genuinely independent with no shared state mutations. The merge
+conflict risk (2a and 2c both modify `Commands` enum) is noted. This is well-structured
+for parallel execution.
+
+**C3: Deferred dynamic completions**
+
+Correctly deferring dynamic completions (config-dependent tab completion) avoids the latency
+and error-handling complexity. Static completions cover the high-value case.
+
+---
+
+## 6. The Simplicity Question
+
+**Is there a simpler way to achieve the same goals?**
+
+For 2a: Yes, slightly. Instead of `Option<Commands>`, you could add a `Default` variant to
+the `Commands` enum and set it as `#[command(default)]`. This avoids the `Option` unwrapping
+throughout main.rs. However, clap's default subcommand behavior can be surprising (it may
+consume arguments meant for the default subcommand). The `Option<Commands>` approach is more
+explicit and probably correct here.
+
+For 2b: The design is already the simplest reasonable approach — compose existing modules.
+The only risk is that the extraction boundaries don't line up cleanly with the existing code,
+which would force either duplication or a larger refactor.
+
+For 2c: This is already minimal. `clap_complete` does all the work.
+
+**Overall: The design is appropriately simple for what it delivers.** No over-engineering
+detected. The main complexity is in the `main.rs` restructuring, which is inherent to the
+problem.
+
+---
+
+## 7. For the Dev Team
+
+Prioritized action items before building:
+
+1. **Design the full `main.rs` flow** (S2). Write out the complete `main()` skeleton showing
+   config-free dispatch (completions), fallible-config dispatch (bare urd), and mandatory-config
+   dispatch (everything else). This is the load-bearing change.
+
+2. **Distinguish config-not-found from config-broken** (S1). Add error discrimination to
+   `Config::load()` or match on `std::io::ErrorKind::NotFound` in the bare `urd` path.
+   Don't show "not configured yet" for a parse error.
+
+3. **Resolve the Sentinel check scope** (M1). Decide if doctor checks Sentinel status or not.
+   If yes, add it to scope. If no, fix the example output.
+
+4. **Reconcile `DoctorOutput` fields** (M2). Align struct definition with pseudocode before
+   building.
+
+5. **Spike the init extraction** before committing to doctor's timeline. Read
+   `collect_infrastructure_checks()` end-to-end and confirm it can be made `pub(crate)`
+   without dragging in unwanted dependencies. Same for verify.
+
+---
+
+## 8. Open Questions
+
+1. **Should bare `urd` show help text as well as status?** The design replaces help with
+   status. Some users expect `command` with no args to print help. Should it be
+   `status + "Run urd --help for commands"` (as designed) or should `urd --help` behavior
+   be mentioned as still working? The design's test strategy doesn't include "urd --help
+   still works after Option<Commands> change."
+
+2. **Does `awareness::assess()` performance matter for bare `urd`?** If someone runs `urd`
+   frequently (habit, alias, prompt integration), the snapshot directory scan latency matters.
+   Has this been profiled? Is caching worth considering?
+
+3. **Should doctor be `urd check` instead?** `doctor` is common (brew doctor, flutter doctor)
+   but `check` is shorter and more Urd-like. The vocabulary audit may have an opinion.
+
+4. **What happens when bare `urd` is run as root?** Config path resolution, state DB path,
+   and awareness all assume the user's home directory. If someone runs `sudo urd` (which they
+   might, since btrfs needs sudo), the paths will resolve to root's home. Is this worth a
+   warning?

--- a/docs/99-reports/2026-03-31-design-phase3-advisory-retention-review.md
+++ b/docs/99-reports/2026-03-31-design-phase3-advisory-retention-review.md
@@ -1,0 +1,189 @@
+# Architectural Review: Phase 3 — Advisory System + Retention Preview
+
+**Reviewer:** arch-adversary
+**Date:** 2026-03-31
+**Scope:** Design review (no code yet)
+**Documents reviewed:**
+- `docs/95-ideas/2026-03-31-design-phase3-advisory-retention.md` (orchestration)
+- `docs/95-ideas/2026-03-31-design-i-redundancy-recommendations.md` (6-I)
+- `docs/95-ideas/2026-03-31-design-n-retention-policy-preview.md` (6-N)
+- Current code: `awareness.rs`, `output.rs`, `voice.rs`, `retention.rs`
+
+---
+
+## 1. Executive Summary
+
+The Phase 3 design is well-structured, correctly separates advisory from enforcement, and keeps both features as pure functions consistent with Urd's architecture. The main risk is the `Vec<String>` to `Vec<RedundancyAdvisory>` migration on `StatusAssessment`, which the orchestration doc correctly identifies but whose blast radius is underestimated. The notification cooldown logic in 6-I introduces hidden state that needs careful design to avoid masking genuine new problems.
+
+---
+
+## 2. What Kills You (Catastrophic Failure Proximity)
+
+**Verdict: No catastrophic proximity.** Neither feature modifies snapshots, drives retention decisions, or interacts with the deletion pipeline. Both are read-only advisory/preview functions. The design explicitly states advisories do not block backups or degrade promise states (enforcement belongs to 6-E, which is separate).
+
+One indirect path to watch: the orchestration doc mentions that 6-E "could use I's detection logic to decide when to degrade a promise." If a future integration wires advisory detection into promise degradation, and a bug in advisory detection causes false "all clear," it could prevent degradation that should happen. This is not in the current design, but the relationship table plants the seed. Flagged as a design tension, not a finding.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4/5 | Cascading retention formula verified against code. Notification cooldown has an edge case (see S1). |
+| Security | 5/5 | No attack surface. Read-only pure functions. No new privilege escalation paths. |
+| Architectural Excellence | 4/5 | Clean module boundaries, proper pure-function pattern. Migration atomicity is the weak point. |
+| Systems Design | 4/5 | Sentinel integration and Spindle contract are thoughtful. Cooldown state persistence is underspecified. |
+
+**Overall: 17/20 — Approve with findings.**
+
+---
+
+## 4. Design Tensions
+
+### T1: Advisory Migration Atomicity vs. Test Churn
+
+The `Vec<String>` to `Vec<RedundancyAdvisory>` change on `StatusAssessment` breaks every test that constructs a `StatusAssessment` (the orchestration doc acknowledges this). The tension: doing it atomically is architecturally correct but creates a large diff that touches many test files. The alternative -- keeping both fields temporarily -- creates the parallel-systems problem the design explicitly wants to avoid. The atomic approach is right; the cost is accepted.
+
+### T2: Notification Cooldown Complexity vs. User Experience
+
+The cooldown/suppression logic (48h resolution suppression, 7-day re-detection suppression) adds hidden temporal state to the notification system. This is justified by a real UX problem (monthly drive cycling noise), but it introduces a class of bug where genuine new problems are silently suppressed. The tension is between notification hygiene and notification reliability.
+
+### T3: Calibrated vs. Uncalibrated Estimation Honesty
+
+The retention preview correctly refuses to show byte estimates when uncalibrated. But even calibrated estimates use `du -sb` which measures apparent size, not BTRFS exclusive usage. The design acknowledges this with a disclaimer, but the 5-10x gap between the displayed number and reality is large enough that users may still make poor decisions based on the "calibrated" upper bound. The tension is between showing something useful and showing something misleading.
+
+---
+
+## 5. Findings
+
+### Significant
+
+#### S1: Cooldown suppression can mask genuinely new offsite problems
+
+**Location:** 6-I design, notify.rs section, cooldown for cyclic advisories.
+
+The 7-day re-detection suppression after resolution works for the normal cycle: drive departs, ages past 30 days, returns, departs again. But consider: drive returns (resolving `OffsiteDriveStale`), user swaps the wrong drive back in (different drive, not the offsite one), and the original offsite drive is still away. The `(kind, subvolume)` key would suppress the re-detection because the same kind just resolved, even though the underlying condition is different (a different drive is now stale).
+
+**Recommendation:** Key the suppression on `(kind, subvolume, drive_label)`, not `(kind, subvolume)`. This preserves the cycling-noise benefit while allowing detection of a different drive's staleness. The `RedundancyAdvisory` already carries `drive: Option<String>`, so the data is available.
+
+**Severity:** Significant. Not catastrophic (advisories don't affect backups), but a user could miss a real gap for 7 days due to a suppression keyed too broadly.
+
+#### S2: Cooldown state persistence across sentinel restarts
+
+**Location:** 6-I design, notify.rs section.
+
+The cooldown logic requires tracking when advisories were first detected and when they last resolved. The design does not specify where this state lives. If it is in-memory only, a sentinel restart (systemd restart, reboot) resets all cooldowns, causing a burst of notifications for all existing conditions. If it is persisted, where? The sentinel state file? A separate file? SQLite?
+
+This is not a correctness issue -- the worst case is extra notifications after a restart -- but it should be specified at design time to avoid an implementation-time decision that might pick the wrong storage.
+
+**Recommendation:** Persist cooldown state in the sentinel state file alongside `advisory_summary`. Add a `cooldowns: HashMap<(kind, subvolume, drive_label), CooldownEntry>` with detection/resolution timestamps. This is small, JSON-serializable, and lives where sentinel state already lives.
+
+**Severity:** Significant. Unspecified state persistence is a design gap that will cause either notification spam (in-memory) or an ad-hoc storage decision (implementation time).
+
+### Moderate
+
+#### M1: The stringly-typed advisory migration boundary is unclear
+
+**Location:** 6-I design, advisory type 2 migration note.
+
+The design says: "Non-redundancy advisories (clock skew, send_enabled without drives) remain stringly-typed since they are operational, not redundancy-related." But `SubvolAssessment.advisories` is `Vec<String>`, and the migration replaces this field on `StatusAssessment` with `Vec<RedundancyAdvisory>`. What happens to the non-redundancy advisories?
+
+Options: (a) `StatusAssessment` gets two fields (`redundancy_advisories: Vec<RedundancyAdvisory>` and `advisories: Vec<String>`), (b) the non-redundancy advisories are migrated to a separate typed enum at the same time, or (c) they are dropped. The design does not specify.
+
+**Recommendation:** Keep both fields on `StatusAssessment` during this phase. The `advisories: Vec<String>` field continues to carry operational advisories. The new `redundancy_advisories: Vec<RedundancyAdvisory>` field carries the structured ones. This avoids scope creep (migrating all advisory types at once) while maintaining the clean separation. `voice.rs` renders both sections. The `SubvolAssessment` struct gets the same treatment: keep `advisories: Vec<String>` for operational, add `redundancy_advisories: Vec<RedundancyAdvisory>` for structured.
+
+**Severity:** Moderate. If not resolved before implementation, the developer will face an ambiguous choice mid-build.
+
+#### M2: `du -sb` in the command handler breaks pure-function chain
+
+**Location:** 6-N design, module changes.
+
+The design says `commands/retention_preview.rs` will "optionally measure snapshot sizes" via `du -sb`. This is I/O in the command handler, which is fine architecturally (command handlers are the I/O boundary). But the design should note that this measurement can be slow (seconds for large snapshot directories) and should have a timeout or skip mechanism. A user running `urd retention-preview --all` with 5 subvolumes and large snapshots could wait 30+ seconds for size measurement.
+
+**Recommendation:** Add a `--no-size` flag (or make size measurement opt-in with `--estimate-size`) so users can get instant recovery-window output without waiting for `du -sb`. Default behavior: attempt measurement with a per-subvolume timeout (e.g., 5 seconds), fall back to `Unknown` if it takes too long.
+
+**Severity:** Moderate. Not a correctness issue, but a UX gap that could make the command feel sluggish.
+
+#### M3: Vocabulary mapping incomplete for existing advisories
+
+**Location:** Orchestration doc, vocabulary adjustments section.
+
+The orchestration doc lists vocabulary mappings (`"chain"` to `"thread"`, `"mounted"` to `"connected"`, etc.) but the existing `awareness.rs` code (line 295) uses `"consider cycling"` and `"offsite drive"` in its stringly-typed advisories. The migration from stringly-typed to `RedundancyAdvisory` will rewrite these messages, but the orchestration doc should explicitly list the old strings being retired and their structured replacements. Without this, the implementer must audit awareness.rs manually to find all the strings that need migration.
+
+**Recommendation:** Add a migration table to the orchestration doc: old string pattern, new `RedundancyAdvisoryKind`, and new voice rendering. There are at least three: (1) `"offsite drive {} last sent {} days ago -- consider cycling"` becomes `OffsiteDriveStale`, (2) `"offsite copy stale -- resilient promise degraded"` (from `overlay_offsite_freshness`) stays as-is (it is an enforcement message from 6-E, not an advisory), (3) `"send_enabled but no drives configured"` stays stringly-typed (operational, not redundancy).
+
+**Severity:** Moderate. Missing this mapping risks leaving orphaned string advisories or migrating the wrong ones.
+
+### Minor
+
+#### N1: `AdvisorySummary.worst` is `Option<String>` instead of typed
+
+**Location:** 6-I design, sentinel state file section.
+
+`worst: Option<String>` serializes the advisory kind as a string for Spindle consumption. This means Spindle (or any consumer) must parse the string back to understand severity ordering. If a new advisory kind is added later, old Spindle versions will see an unknown string. Using `Option<RedundancyAdvisoryKind>` with serde `rename_all = "snake_case"` would be type-safe internally while producing the same JSON output. The JSON contract is identical; the Rust side is stronger.
+
+**Recommendation:** Use `Option<RedundancyAdvisoryKind>` instead of `Option<String>`. The serde output is the same (`"no_offsite_protection"`, etc.), but Rust code that reads the state file back gets type safety.
+
+#### N2: Schema version bump to v3 lacks migration story
+
+**Location:** 6-I design, sentinel state file section.
+
+The design bumps schema to v3 and notes backward compatibility (v2 readers ignore the field). But what about v3 readers encountering a v2 file? The `skip_serializing_if` + `default` pattern handles deserialization, but the design should explicitly state: "v3 code reading a v2 state file sees `advisory_summary: None`, which means 'unknown, not zero' as specified." This is implied but worth stating explicitly for the implementer.
+
+#### N3: Retention preview `--compare` default direction unstated
+
+**Location:** 6-N design, CLI design section.
+
+`--compare` shows transient vs. graduated comparison. For a graduated subvolume, it shows what switching to transient would save/lose. For a transient subvolume, it shows what switching to graduated would cost/gain. But the default graduated policy for comparison is not specified. Which graduated settings does it use? The subvolume's configured graduated policy (which does not exist for a transient subvolume)? A system default? The design should state: for transient subvolumes, `--compare` uses the default graduated retention values from `[defaults]` in config.
+
+### Commendation
+
+#### C1: Advisory/enforcement separation is exactly right
+
+The design's relationship between 6-I (advise) and 6-E (enforce) is the correct architecture. The explicit documentation of intentional overlap at different layers (config-time vs. runtime) prevents future consolidation that would lose either the early-catch or persistent-surfacing property. This is mature architectural thinking.
+
+#### C2: "Absent means unknown, not zero" for schema evolution
+
+The sentinel state file design's explicit statement that `advisory_summary: None` means "not computed" rather than "no advisories" is the correct null-semantics decision. This prevents a v2 Urd from falsely appearing advisory-free to a v3 Spindle. More designs should include this kind of explicit null-semantics specification.
+
+---
+
+## 6. The Simplicity Question
+
+**Is this design as simple as it could be?**
+
+Mostly yes. The core of both features is pure functions with clean inputs and outputs. The complexity is concentrated in two areas:
+
+1. **Notification cooldown** (6-I): The 48h/7d suppression logic adds temporal state and edge cases. Consider whether the simpler alternative -- deduplicate by only notifying on state transitions, with no cooldown -- is sufficient. The monthly cycling pattern would produce exactly two notifications per cycle (gap detected, gap resolved), which may be acceptable. The cooldown saves one notification per cycle at the cost of hidden state and suppression bugs.
+
+2. **Transient comparison** (6-N): Computing both policies and diffing adds code but provides clear user value. The `--compare` flag keeps it opt-in. This complexity is justified.
+
+**Verdict:** The cooldown logic is the one area where simplification should be seriously considered. Everything else is proportional to the problem.
+
+---
+
+## 7. For the Dev Team (Prioritized Action Items)
+
+1. **Resolve M1 before building.** Decide whether `StatusAssessment` gets two advisory fields or one. The two-field approach (keep `advisories: Vec<String>` for operational, add `redundancy_advisories: Vec<RedundancyAdvisory>`) is recommended. This decision affects the migration blast radius.
+
+2. **Key cooldown suppression on `(kind, subvolume, drive_label)`** (S1). Prevents masking genuinely new problems after a different drive's advisory resolves.
+
+3. **Specify cooldown state persistence** (S2). Recommend sentinel state file. Decide before building.
+
+4. **Add migration table for existing string advisories** (M3). List every stringly-typed advisory in `awareness.rs` and its fate: migrate to structured, keep as string, or remove.
+
+5. **Consider dropping cooldown entirely** (simplicity question). Evaluate whether bare state-transition notifications (no suppression) are acceptable for the drive cycling use case. If two notifications per monthly cycle is tolerable, the cooldown can be deferred to "add if needed" rather than "build preemptively."
+
+6. **Address `du -sb` performance for `--all`** (M2). Add timeout or opt-out flag.
+
+7. **Use typed `Option<RedundancyAdvisoryKind>` for `worst`** (N1). Free type safety.
+
+---
+
+## 8. Open Questions
+
+1. **Should the cooldown logic ship in Phase 3, or be deferred until notification fatigue is observed?** Building it preemptively adds ~20 lines of code and ~5 tests, plus persistent state. Deferring it means accepting 2 notifications per monthly drive cycle until the next release. The YAGNI argument is strong here.
+
+2. **What graduated policy does `--compare` use for a transient subvolume?** The design needs to specify the source of the comparison policy. Options: `[defaults]` graduated values, a hardcoded "typical" policy, or require the user to specify via flags.
+
+3. **Should `overlay_offsite_freshness()` advisory messages (line 739 of awareness.rs) be migrated into the structured system?** These are enforcement messages ("resilient promise degraded"), not advisory guidance. The design implies they stay stringly-typed, but this should be an explicit decision since they share vocabulary with the new `OffsiteDriveStale` advisory.

--- a/docs/99-reports/2026-03-31-design-phase5-progressive-disclosure-review.md
+++ b/docs/99-reports/2026-03-31-design-phase5-progressive-disclosure-review.md
@@ -1,0 +1,317 @@
+# Arch-Adversary Review: Phase 5 — Progressive Disclosure (6-O)
+
+**Date:** 2026-03-31
+**Reviewer:** arch-adversary
+**Scope:** Design review (no code yet)
+**Documents reviewed:**
+- `docs/95-ideas/2026-03-31-design-phase5-progressive-disclosure.md` (orchestration)
+- `docs/95-ideas/2026-03-31-design-o-progressive-disclosure.md` (underlying design)
+- `src/state.rs`, `src/awareness.rs` (current infrastructure)
+
+---
+
+## 1. Executive Summary
+
+This is a well-constrained design for a feature that has no proximity to data loss. The
+pure-function decomposition, INSERT OR IGNORE concurrency handling, and explicit delivery
+channel separation show mature architectural thinking. The primary risks are schema design
+decisions that could cause incorrect milestone behavior under edge cases, and a `RunContext`
+type that does not yet exist in the codebase.
+
+---
+
+## 2. What Kills You
+
+**Catastrophic failure mode for Urd:** silent data loss from deleting snapshots that
+shouldn't be deleted.
+
+**Proximity assessment: None.** This design is read-only with respect to snapshots. It
+adds a SQLite table, reads assessments, and renders text. No milestone logic touches
+retention, planning, or execution. No code path in this design can cause snapshot deletion,
+modification, or interference with pin files. The milestone system is purely observational
+output bolted onto existing state.
+
+The only tangential concern: if milestone detection code were accidentally placed inside
+the planner or executor (violating module boundaries), it could theoretically delay or
+interfere with backup execution. But the design explicitly places it after the heartbeat
+write in the backup command and in a separate pure module. This is clean.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4/5 | Sound logic, but `RunContext` is undefined and streak semantics have an unaddressed gap (see F-2, F-3) |
+| **Security** | 5/5 | No new attack surface. SQLite writes use parameterized queries. No privilege escalation paths. |
+| **Architectural Excellence** | 5/5 | Clean module boundaries, pure functions, single-writer discipline, ADR-102 compliance. Textbook adherence to Urd's invariants. |
+| **Systems Design** | 4/5 | Delivery pipeline is well-separated, but streak counter as a column on the milestone row creates awkward update semantics (see F-4) |
+
+---
+
+## 4. Design Tensions
+
+### Tension 1: Schema simplicity vs. streak correctness
+
+Putting `streak_days` as a column on the `HealthyStreak` milestone row avoids a second
+table, but creates a row that must be inserted before it is meaningful (with `delivered=0,
+streak_days=0`) and then mutated in place. Every other milestone row is write-once. This
+asymmetry will require special-case code in every function that operates on milestones.
+
+### Tension 2: Once-ever milestones vs. config changes
+
+Milestones are once-ever by design. But config changes can make old milestones misleading.
+If a user removes a subvolume and re-adds it, `RecoveryFromUnprotected:htpc-home` will
+never re-fire because the key already exists. This is explicitly called out for drives
+(intentional) but not for subvolumes. For recovery milestones specifically, suppressing
+re-fire after config changes may confuse the user who expects acknowledgment of their fix.
+
+### Tension 3: Backup-writes vs. sentinel-reads timing
+
+The backup command writes milestones after heartbeat. The sentinel reads milestones during
+Assess ticks. If the sentinel assesses before the backup command finishes writing, the
+sentinel's state file will be stale for that tick. This is fine (eventual consistency),
+but the design should acknowledge the window explicitly.
+
+---
+
+## 5. Findings
+
+### Significant
+
+**F-1: `RunContext` does not exist in the codebase.**
+
+The `compute_insights()` signature requires `run_history: &RunContext`, but no `RunContext`
+type exists anywhere in `src/`. The design references "run count == 1" for FirstBackup
+detection and says RunContext "comes from the heartbeat, not the DB." But the heartbeat
+struct has no run count field either. This is a gap between design and implementation
+reality.
+
+**Impact:** The FirstBackup milestone has no obvious data source for its trigger condition.
+Detecting "first ever backup" requires either counting rows in the `runs` table (an I/O
+operation, which conflicts with the pure-function contract) or receiving the count as an
+input parameter from the caller.
+
+**Recommendation:** Define `RunContext` explicitly. The simplest correct approach: the
+caller queries `StateDb::get_run_count()` before calling the pure function and passes it
+as a field. Document that this is a DB read that happens in the command layer, not in the
+pure module.
+
+---
+
+**F-2: DB-unavailable edge case causes milestone storm.**
+
+The design acknowledges: "State DB unavailable: `compute_insights()` receives empty
+milestone history, which could cause all milestones to re-fire." The proposed guard is
+checking `RunContext` to avoid firing FirstBackup. But:
+
+1. `RunContext` doesn't exist yet (F-1).
+2. Even if it did, only FirstBackup is guarded. AllProtected, FirstOffsite, NewDrive,
+   and RecoveryFromUnprotected would all re-fire if milestone history is empty but the
+   system has been running for months.
+
+The heartbeat can provide evidence of prior runs, but the design doesn't specify how the
+pure function uses it to suppress re-fires for milestones other than FirstBackup.
+
+**Impact:** On a corrupt or recreated DB, the user gets a cascade of milestones they
+already saw. Not harmful (no data loss), but annoying and undermines the "earned voice"
+principle.
+
+**Recommendation:** Accept this as a known limitation and document it. A user who loses
+their SQLite DB will see milestones re-fire. This is the correct trade-off: ADR-102 says
+SQLite is history, not truth. Re-firing milestones is harmless noise. Do not add complex
+cross-checking logic to prevent it. Add a brief note in the design: "DB loss causes
+milestone re-fire. This is acceptable — milestones are observational, not operational."
+
+---
+
+### Moderate
+
+**F-3: Streak counter has no writer for the initial row.**
+
+The design says: "The HealthyStreak row is inserted early (when streak tracking begins)
+with `delivered = 0` and `streak_days = 0`, then updated in place." But it never specifies
+*who* inserts this initial row or *when*. The sentinel manages streak increments and resets.
+The backup command writes milestones at end-of-run. Neither is clearly designated as the
+creator of the initial HealthyStreak row.
+
+**Recommendation:** The sentinel should create the HealthyStreak row on first healthy
+assessment if it doesn't exist (`INSERT OR IGNORE` with `streak_days=0, delivered=0`).
+This is consistent with the sentinel being the sole streak writer.
+
+---
+
+**F-4: `update_streak_days` and `reset_streak` are mutation methods on an otherwise
+write-once table.**
+
+Every other milestone row follows: INSERT OR IGNORE (write once), then `mark_delivered`
+(flip a boolean once). The HealthyStreak row gets repeatedly mutated via
+`update_streak_days`. This asymmetry means:
+
+- `get_milestones()` returns a mix of final and in-progress records.
+- `get_undelivered_milestones()` could return the HealthyStreak row with `delivered=0`
+  long before `streak_days >= 30`, which would be incorrect to display.
+
+**Recommendation:** Filter HealthyStreak from `get_undelivered_milestones()` until
+`streak_days >= 30`. The simplest SQL: `WHERE delivered = 0 AND (insight_type !=
+'HealthyStreak' OR streak_days >= 30)`. Alternatively, don't set `delivered=0` on the
+HealthyStreak row until the streak actually reaches 30.
+
+---
+
+**F-5: `compute_insights()` cannot detect RecoveryFromUnprotected without previous state.**
+
+RecoveryFromUnprotected fires on "UNPROTECTED -> PROTECTED transition." But the pure
+function receives `current_assessments` (current state) and `milestone_history` (past
+milestones). It does not receive *previous assessments*. Without knowing the subvolume was
+previously UNPROTECTED, the function cannot detect the transition — it only sees that the
+subvolume is currently PROTECTED.
+
+**Recommendation:** Either (a) add a `previous_assessments` parameter or a
+`recently_recovered: Vec<String>` parameter to the function, or (b) have the caller
+(backup command) detect the transition by comparing before/after assessments and pass it
+as part of `RunContext`. Option (b) is cleaner — the pure function receives facts, not
+raw state it must diff.
+
+---
+
+**F-6: Orchestration document and underlying design disagree on table name.**
+
+The orchestration document specifies:
+```sql
+CREATE TABLE IF NOT EXISTS milestones (id TEXT PRIMARY KEY, fired_at TEXT NOT NULL);
+```
+
+The underlying design specifies:
+```sql
+CREATE TABLE IF NOT EXISTS insight_milestones (insight_key TEXT PRIMARY KEY, ...);
+```
+
+These are different table names, different column names, and different schemas. The
+underlying design is clearly more complete and correct, but the orchestration document
+should not contradict it.
+
+**Recommendation:** Update the orchestration document to reference the underlying design's
+schema rather than providing its own simplified version. One source of truth.
+
+---
+
+### Minor
+
+**F-7: ChainBreakRecovered milestone trigger is vague.**
+
+"First successful incremental send after a full send was required (chain break detected
+and resolved in the same or subsequent run)." The backup command does not currently track
+whether a send was full-because-of-chain-break vs. full-because-first-ever-send-to-drive.
+Both result in a full send. The milestone needs the backup command to distinguish these
+cases, which may require planner/executor changes not scoped in this design.
+
+**Recommendation:** Either defer ChainBreakRecovered to a later milestone catalog expansion,
+or explicitly scope the executor change needed (e.g., tagging operation results with
+`send_reason: Initial | ChainBreak | Manual`).
+
+---
+
+**F-8: One-milestone-per-render priority ordering is undefined.**
+
+The design says "show the highest-priority one" when multiple milestones fire. But no
+priority ordering is specified for the 8 milestone types. The test strategy references it
+("only highest-priority returned") but the catalog doesn't assign priorities.
+
+**Recommendation:** Define an explicit priority ordering. Suggested: Recovery milestones >
+journey milestones > operational milestones. Within each group, order by significance
+(FirstBackup > FirstOffsite > AllProtected > HealthyStreak).
+
+---
+
+### Commendation
+
+**C-1: Notification pipeline exclusion is the right call.**
+
+The decision to remove insights from the notification pipeline entirely (finding #4 from
+the prior review) is architecturally excellent. Insights and alerts are different categories
+with different urgency semantics. Routing insights through alert infrastructure would have
+caused silent filtering (default `min_urgency: Warning`) or forced urgency model changes.
+The three-channel delivery (status, state file, log) is clean and each channel has a single
+writer.
+
+**C-2: INSERT OR IGNORE for concurrency is exactly right.**
+
+No locks, no distributed coordination, no "check then insert" race conditions. The
+database enforces the invariant. This is the correct level of complexity for the problem.
+
+**C-3: Anti-patterns section is unusually valuable.**
+
+Explicitly listing what *not* to do (tutorial voice, generic tips, repetition, urgency
+escalation, blocking behavior, volume, premature voice) provides clearer guidance than
+most design docs. This will prevent scope drift during implementation.
+
+---
+
+## 6. The Simplicity Question
+
+**Is this design as simple as it could be while still solving the problem?**
+
+Nearly. The core concept (pure function detects milestones, SQLite records them, voice
+renders them) is minimal. Two areas have unnecessary complexity:
+
+1. **Streak tracking via a mutating column** on an otherwise write-once table. A separate
+   single-row `streak_state` table (just `current_days INTEGER, last_reset TEXT`) would be
+   simpler to reason about, even though the design explicitly rejected it. The rejected
+   approach is actually cleaner — it avoids the HealthyStreak row existing in an ambiguous
+   state for up to 30 days.
+
+2. **`RunContext` as a parameter** adds a type that doesn't exist for a single use case
+   (FirstBackup detection). A simpler approach: pass `is_first_run: bool` directly. The
+   caller can determine this from the `runs` table count. No new type needed.
+
+---
+
+## 7. For the Dev Team
+
+Prioritized action items before implementation:
+
+1. **Resolve F-1:** Define how FirstBackup gets its trigger data. Simplest: pass
+   `is_first_run: bool` instead of inventing `RunContext`.
+
+2. **Resolve F-5:** Determine how RecoveryFromUnprotected detects the state transition.
+   Add `recovered_subvolumes: Vec<String>` to the function inputs, computed by the caller.
+
+3. **Resolve F-3 + F-4:** Decide streak row lifecycle. Either use a separate
+   `streak_state` table (simpler) or specify the initial row creator (sentinel) and add the
+   `streak_days >= 30` filter to `get_undelivered_milestones()`.
+
+4. **Fix F-6:** Remove the schema snippet from the orchestration doc or align it with the
+   underlying design.
+
+5. **Address F-8:** Add explicit priority ordering to the milestone catalog.
+
+6. **Consider F-7:** Decide whether ChainBreakRecovered ships in the initial catalog or is
+   deferred.
+
+---
+
+## 8. Open Questions
+
+1. **What happens to milestones when config changes?** If a user removes a subvolume and
+   its `RecoveryFromUnprotected:subvol-name` milestone row persists, is that a problem? If
+   the subvolume is re-added later, the recovery milestone is permanently suppressed. Is
+   this the intended behavior?
+
+2. **Should `delivered` be marked by status command only, or also by sentinel?** The design
+   says status marks delivered. But if the user only uses Spindle (reads sentinel state
+   file) and never runs `urd status`, milestones accumulate as undelivered forever. Should
+   the sentinel mark delivery when it writes to the state file?
+
+3. **Voice rendering location (from the design's own open questions):** The architecture is
+   clear: voice.rs renders, pure modules compute. The design already answers its own
+   question correctly. `insight.rs` returns `InsightType` + context; `voice.rs` renders.
+   This is consistent with how `plan.rs` produces structured data and `voice.rs` renders
+   it. No ambiguity here.
+
+4. **Streak duration (from the design's own open questions):** 30 days is reasonable. The
+   insight's purpose is to briefly surface the "silence means safety" principle. 30 days is
+   long enough to be meaningful, short enough that most regular users will see it. If
+   concerned, make it a const (`HEALTHY_STREAK_THRESHOLD_DAYS`) so it's trivially tunable
+   later. Do not make it configurable — that violates the "opaque or doesn't exist"
+   principle.

--- a/docs/99-reports/2026-03-31-design-phase6-protection-rename-wizard-review.md
+++ b/docs/99-reports/2026-03-31-design-phase6-protection-rename-wizard-review.md
@@ -1,0 +1,306 @@
+# Arch-Adversary Review: Phase 6 — Protection Level Rework + Guided Setup Wizard
+
+**Reviewer:** arch-adversary
+**Date:** 2026-03-31
+**Document reviewed:** `docs/95-ideas/2026-03-31-design-phase6-protection-rename-wizard.md`
+**Review type:** Design review (no code yet)
+
+---
+
+## 1. Executive Summary
+
+A well-structured capstone design that bundles a vocabulary rename with a setup wizard.
+The rename is lower-risk than the document suggests because the heartbeat does not
+actually serialize protection level names (it uses promise states). The wizard design
+delegates appropriately to existing modules, though the raw TOML migration strategy has
+a fragility that could silently produce invalid configs. Overall, the design respects
+existing invariants and identifies its own highest-risk areas accurately.
+
+---
+
+## 2. What Kills You
+
+**Catastrophic failure mode for Urd: silent data loss from deleting snapshots that
+should be kept.**
+
+This design is **not near the catastrophic boundary.** The rename touches presentation
+and config parsing, not the retention/deletion pipeline. The `derive_policy()` function
+maps level names to the same operational parameters regardless of whether the variant
+is called `Guarded` or `Recorded`. Serde aliases mean old configs parse to the same
+runtime values.
+
+The only path toward catastrophe would be if the rename somehow broke `derive_policy()`
+such that a named level returned different retention parameters, causing the retention
+module to delete more aggressively. This requires a code bug during implementation, not
+a design flaw. The test strategy (modifying ~20 existing tests) provides adequate
+coverage against this.
+
+**Proximity: 2 bugs away.** (1) `derive_policy()` returns wrong values for renamed
+variant, AND (2) tests fail to catch it. Acceptable distance given the test density.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4/5 | Solid rename mechanics; heartbeat schema concern is overstated (see Finding 1); migration has a fragility edge case |
+| **Security** | 4/5 | Config backup before migration is good; wizard privilege escalation is appropriately tiered; no new attack surface |
+| **Architectural Excellence** | 4/5 | Clean separation of concerns; serde aliases are the right tool; wizard delegates to existing modules rather than reimplementing |
+| **Systems Design** | 3/5 | Raw TOML string replacement is the weakest element; multi-step migration with no atomicity guarantees; schema version bump may be unnecessary |
+
+---
+
+## 4. Design Tensions
+
+### Tension 1: Raw TOML manipulation vs. parse-then-serialize
+
+The design correctly identifies that parsed+serialized TOML destroys comments and
+formatting. But raw string replacement is fragile against edge cases (values in comments,
+multi-line strings, quoted keys). The tension is real and the design chose the right side,
+but the implementation must be more rigorous than the design suggests.
+
+### Tension 2: Schema version bump necessity
+
+The heartbeat's `promise_status` field contains awareness states (PROTECTED / AT RISK /
+UNPROTECTED), not protection level names. If no field actually changes values, bumping
+`schema_version` creates unnecessary downstream work for zero benefit. But if any future
+consumer reads protection level names from some other field, not bumping would be a
+contract violation. The tension is between preemptive versioning and unnecessary churn.
+
+### Tension 3: Big-bang rename PR vs. incremental migration
+
+The design calls for a single PR for the enum rename (steps 3-5). This is pragmatically
+correct (avoiding a half-migrated state), but it means a large diff touching 8+ files
+with 97 total occurrences of the old names. Review quality may suffer under volume.
+
+---
+
+## 5. Findings
+
+### Significant
+
+**S1. Heartbeat schema version bump may be unnecessary.**
+
+The design states: "Heartbeat JSON includes protection level strings. These change from
+`guarded` to `recorded`, etc. This is a backward compatibility break."
+
+Examining the actual code, `SubvolumeHeartbeat.promise_status` is set to
+`a.status.to_string()` where `a` is a `SubvolAssessment`. The awareness model's
+`PromiseStatus` enum has variants `Protected`, `AtRisk`, `Unprotected` — these are
+promise *states*, not protection *levels*. They do not change with this rename.
+
+No field in the heartbeat currently serializes `ProtectionLevel` values. Unless the
+design intends to ADD a protection level field to the heartbeat (which it does not
+specify), no heartbeat schema change occurs and no version bump is needed.
+
+**Impact:** Bumping schema_version when nothing changed forces downstream consumers
+(homelab monitoring) to update for no reason. Worse, it establishes a precedent that
+schema versions track application changes rather than actual schema changes.
+
+**Recommendation:** Verify this analysis against the full heartbeat builder. If correct,
+remove the schema version bump entirely. If a protection_level field is planned for the
+heartbeat, add it explicitly to the design and THEN bump.
+
+---
+
+**S2. Raw TOML migration is under-specified for edge cases.**
+
+The design says specific replacements like `protection_level = "guarded"` to
+`protection = "recorded"`. The "Ready for Review" section suggests regex patterns
+(`protection_level\s*=\s*"guarded"`). But neither addresses:
+
+- **Commented-out lines:** `# protection_level = "guarded"` should arguably be migrated
+  too (users often toggle by commenting). Or should it be left alone? The design is silent.
+- **Inline comments:** `protection_level = "guarded" # keep this local` — the replacement
+  must preserve the trailing comment.
+- **Multiple subvolumes with different levels:** The migration must handle per-subvolume
+  `protection_level` fields, not just a single global one.
+- **Whitespace variants:** Tabs vs spaces, no spaces around `=`.
+
+**Impact:** A migration that silently produces a config that still parses (via serde
+alias fallback) but was only partially migrated. The user thinks they migrated but some
+subvolumes still use old field names. Not catastrophic, but confusing.
+
+**Recommendation:** Define the regex precisely in the design. Require a post-migration
+verification step that loads the config and checks all subvolumes use canonical names.
+Consider a `--check` mode that reports what would change without modifying.
+
+---
+
+### Moderate
+
+**M1. Config field rename (`protection_level` to `protection`) is a larger break than presented.**
+
+The design treats the field rename as equivalent to the enum rename — both handled by
+serde aliases. But this is a different kind of change:
+
+- The enum rename changes *values*: `"guarded"` -> `"recorded"`. Serde aliases on enum
+  variants handle this cleanly.
+- The field rename changes *keys*: `protection_level` -> `protection`. Serde alias on the
+  struct field handles this for deserialization, but `ResolvedSubvolume.protection_level`
+  (a non-serde struct field) and all code references to `.protection_level` also need
+  renaming throughout the codebase. The design's module mapping lists 10 files but doesn't
+  call out the `ResolvedSubvolume` field rename.
+
+The 97 occurrences across 8 files include references to the *struct field* name, not just
+the enum variants. This is a larger mechanical change than the design suggests.
+
+**Recommendation:** Decide whether to rename the struct field (`protection_level` to
+`protection`) or only the config TOML key and enum variants. If renaming the struct field,
+acknowledge the scope explicitly. If not, document why the internal field name diverges
+from the config key name.
+
+---
+
+**M2. Serde alias composition needs a spike, not just a test.**
+
+The design identifies the risk: `#[serde(alias = "guarded")]` on `Recorded` with
+`#[serde(rename_all = "lowercase")]` on the enum. The question is whether the alias
+takes the raw input string or the already-lowercased string. Serde documentation is not
+entirely clear on alias interaction with rename_all.
+
+If `rename_all = "lowercase"` transforms the variant name `Recorded` to `"recorded"` for
+deserialization, and the alias `"guarded"` is checked separately against the raw input,
+this works. But if rename_all is applied to the alias too (turning `"guarded"` into...
+`"guarded"`, since it's already lowercase), this also works. The concern is real but
+likely resolves cleanly.
+
+**Recommendation:** Write a standalone Rust test (5 lines) before implementation begins
+to confirm the exact serde behavior. This is a 10-minute spike that eliminates a class
+of surprises.
+
+---
+
+**M3. Wizard's Config Serialize refactor is under-scoped.**
+
+The design says adding `Serialize` derives is "mechanical but touches many structs." The
+actual risk is that some config types may not be serializable:
+
+- `PathBuf` serializes fine, but expanded paths (e.g., `~/.local/share/urd/`) may
+  serialize differently than the original input. A round-trip through
+  `deserialize(serialize(config))` may fail if path expansion happens during `load()`.
+- Types with custom `Deserialize` impls (like `RunFrequency`, `Interval`, `ByteSize`)
+  need matching `Serialize` impls for round-trip fidelity. `RunFrequency` already has
+  one, but verify the others.
+
+**Recommendation:** Audit all config types for custom deserialize impls and verify each
+has a matching serialize impl before claiming the refactor is mechanical.
+
+---
+
+### Minor
+
+**N1. The ADR-110 addendum gate is good process but creates a blocking dependency.**
+
+The design requires an ADR-110 addendum "before implementation" documenting operational
+evidence from phases 1-5. This is methodologically sound, but phases 1-5 haven't all
+shipped yet (6-E is ready to merge, 6-I and 6-N are designed but not built). The gate
+may block Phase 6 longer than expected if the "operational evidence" bar is high.
+
+**Recommendation:** Clarify what constitutes sufficient operational evidence. Is it "the
+voice layer has been showing the new vocabulary for N weeks without user confusion"? Or
+is it "all prerequisite phases are merged"? Be explicit.
+
+---
+
+**N2. Wizard `--evaluate` mode reuse constraint is good but needs enforcement.**
+
+The design (from the wizard review) mandates that evaluate mode reuses `awareness.rs
+assess()` rather than reimplementing. This is the right call, but in the Phase 6 design
+doc there's no mention of how this constraint is enforced during implementation.
+
+**Recommendation:** Add a comment in the module mapping: "evaluate mode MUST call
+`awareness::assess()` — no independent status computation."
+
+---
+
+### Commendation
+
+**C1. Serde aliases as the backward compatibility mechanism.**
+
+This is exactly the right tool. No custom deserialization logic, no version-checking
+if/else trees, no migration that must run before the new binary works. Old configs just
+parse. Clean and idiomatic.
+
+**C2. Migration writes backup before modifying.**
+
+Simple, effective. The design also validates by loading the migrated config after
+writing, catching structural errors before the user discovers them. The "abort without
+writing on parse error" safeguard is well-placed.
+
+**C3. Correct identification of the single-PR constraint.**
+
+Recognizing that the rename must be atomic (one PR, not spread across multiple) prevents
+the half-migrated state that would be genuinely confusing. Good systems thinking.
+
+---
+
+## 6. The Simplicity Question
+
+**Is this design as simple as it can be while achieving its goals?**
+
+Almost. Two simplifications are available:
+
+1. **Drop the heartbeat schema version bump** if the analysis in S1 is correct. This
+   removes downstream consumer coordination, the need for Sentinel to handle two schema
+   versions, and the associated tests. Significant complexity reduction for zero
+   functional loss.
+
+2. **Consider deferring the config key rename** (`protection_level` to `protection`).
+   The enum variant rename (guarded to recorded) is the user-visible change. The TOML
+   key rename is a cosmetic improvement that doubles the migration surface area. You
+   could ship the enum rename now and rename the key when ADR-111's config overhaul
+   lands (which plans its own migration anyway).
+
+If both simplifications are adopted, the design shrinks from "touches 10 files including
+heartbeat schema" to "touches 6-7 files, all serde alias additions, no schema breaks."
+
+---
+
+## 7. For the Dev Team
+
+Prioritized action items:
+
+1. **Verify heartbeat schema claim (S1).** Read `heartbeat.rs` builder code and confirm
+   no field serializes `ProtectionLevel` values. If confirmed, remove schema version
+   bump, remove Sentinel dual-version handling, remove downstream consumer update
+   requirement. [5 minutes, high impact]
+
+2. **Spike serde alias + rename_all composition (M2).** Write a 10-line test with a
+   dummy enum using both attributes. Confirm aliases work as expected. [10 minutes,
+   eliminates uncertainty]
+
+3. **Specify migration regex precisely (S2).** Define the exact patterns, decide on
+   comment handling, add a `--dry-run` mode that shows what would change. [Design
+   update, 15 minutes]
+
+4. **Decide on config key rename scope (M1).** Either rename `protection_level` to
+   `protection` everywhere (struct fields included, 97 occurrences) or keep the
+   internal field name and only alias the TOML key. Document the decision.
+
+5. **Audit Serialize readiness (M3).** List all config types, check for custom
+   Deserialize impls, verify Serialize round-trip for each.
+
+---
+
+## 8. Open Questions
+
+1. **Does any consumer (Sentinel, Spindle, external scripts) read protection level
+   names from the heartbeat?** The heartbeat schema does not contain them today, but
+   if any consumer derives level information from the config file directly, the alias
+   mechanism handles it. Verify there are no shadow dependencies.
+
+2. **What happens to existing pin files?** Pin files are named
+   `.last-external-parent-{DRIVE_LABEL}` and are not affected by this rename. But
+   confirm: does any pin file content reference protection levels?
+
+3. **Will the wizard ship to users who have never run Urd before?** If so, the serde
+   aliases for old names are unnecessary for wizard-generated configs. But they're still
+   needed for documentation examples and tutorials that reference the old names. No
+   action needed, just awareness.
+
+4. **The design says "5-6 sessions" for Phase 6.** Given that this depends on all prior
+   phases (1-5) being complete, and 6-I and 6-N are not yet built, what's the realistic
+   calendar timeline? Is Phase 6 blocked or can Part A (rename) proceed independently
+   once 6-E merges?


### PR DESCRIPTION
## Summary

- **6 phase design documents** for Urd's voice and UX overhaul (vocabulary landing, UX commands, advisory orchestration, voice enrichment, progressive disclosure, protection rename + wizard)
- **6 arch-adversary reviews** — all scored 15-18/20, zero critical findings, 12 significant findings with resolutions
- **Roadmap restructured** with two-arc dependency diagram (Voice & UX + Progressive & Setup), 16-row feature table, and review findings table
- **5 cross-cutting decisions** that simplify the build path: heartbeat schema bump likely unnecessary, config key rename deferred to ADR-111, Sentinel Session 3 dedup subsumed by 6-I, vocabulary-first sequencing, voice thresholds derive from awareness state

## Testing

- Documentation-only change — no Rust code modified
- All file paths and cross-references verified
- status.md: 68 lines (under 70-line target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)