### PR TITLE
feat: vocabulary overhaul — Phase 1 landing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Vocabulary overhaul: safety labels are now sealed/waning/exposed, chain→thread, mounted→connected/disconnected/away, SAFETY→EXPOSURE, CHAIN→THREAD, PROMISE→PROTECTION column headers
+- CLI command descriptions rewritten to intent-first language (e.g., "Check whether your data is safe")
+- Summary line now differentiates exposure levels: "htpc-root exposed. docs waning." instead of generic "needs attention"
+- Skip tags differentiated by category: [WAIT], [AWAY], [SPACE], [OFF], [SKIP] replace overloaded [SKIP]
+- Drive status is now role-aware: offsite drives show "away" when disconnected, primary drives show "disconnected"
+- Notification mythology cleaned up: loom/weave→spindle/thread, rewoven→mended, unguarded→exposed
+- `UrdError::Chain` error message changed from "Chain error" to "Thread error" (log grep patterns may need updating)
+
 ### Added
 - Transient immediate cleanup: executor deletes old pin parent immediately after successful send to all drives, reducing local snapshot count from two to one between runs
 - `Config::drive_labels()` helper for collecting configured drive labels

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,24 +8,23 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-589 tests, all passing, clippy clean. Current version: v0.5.0.
+593 tests, all passing, clippy clean. Current version: v0.5.0.
 Transient retention deployed to htpc-root (2026-03-30). Immediate cleanup built, not yet deployed.
 
 ## In Progress
 
-1. **6-B + 6-E merge** — Transient immediate cleanup + promise redundancy encoding.
-   Both implemented, reviewed (arch-adversary + simplify + post-review), all findings
-   addressed. Ready for commit and PR. 17 new tests (6-E).
+1. **Phase 1: Vocabulary landing** — All 7 changes implemented, reviewed (arch-adversary +
+   simplify), all findings addressed including sentinel_runner.rs blind spot. Ready for
+   commit and PR.
 
 ## Next Up
 
-1. **Phase 1: Vocabulary landing** — All presentation-layer string changes (sealed/waning/exposed,
-   thread, connected/disconnected/away, skip tags, CLI descriptions, notification mythology).
-   Blocks all subsequent UX work. 1 session. [Design](../95-ideas/2026-03-31-design-phase1-vocabulary-landing.md) |
-   [Review](../99-reports/2026-03-31-design-phase1-vocabulary-landing-review.md)
-2. **Phase 2a + 2c** — `urd` default one-sentence status (score 10) + shell completions (score 8).
+1. **Phase 2a + 2c** — `urd` default one-sentence status (score 10) + shell completions (score 8).
    1 session. [Design](../95-ideas/2026-03-31-design-phase2-ux-commands.md) |
    [Review](../99-reports/2026-03-31-design-phase2-ux-commands-review.md)
+2. **6-I advisory system** — Structured advisory types replacing string-based advisories.
+   Blocks notification deduplication. ~2 sessions.
+3. **6-N + Phase 2b** — Retention display in status + `urd doctor` command.
 
 ## Build Queue — Priority 6: Voice & UX Overhaul
 
@@ -34,7 +33,7 @@ Setup arc builds the learning/onboarding layer. All designs reviewed by arch-adv
 
 ```
 Voice & UX Arc:                    Progressive & Setup Arc:
-  Phase 1 (vocabulary)               6-O (milestones, 2 sessions)
+  Phase 1 (vocabulary) ✓             6-O (milestones, 2 sessions)
   Phase 2a+2c (urd default, compl.)  ADR-110 enum rename (1 session)
   6-I (advisory system)              Config Serialize (0.5 session)
   6-N + Phase 2b (retention, doctor) 6-H (wizard, 4 sessions)
@@ -42,7 +41,7 @@ Voice & UX Arc:                    Progressive & Setup Arc:
   Phase 4c (transitions)
 ```
 
-Estimated: 15 sessions total, ~150 new/modified tests, test suite → ~740.
+Estimated: 14 sessions remaining, ~150 new/modified tests, test suite → ~740.
 
 ## Key Links
 
@@ -54,6 +53,7 @@ Estimated: 15 sessions total, ~150 new/modified tests, test suite → ~740.
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Phase designs (1-6) | [95-ideas/](../95-ideas/) (2026-03-31-design-phase*.md) |
 | Review reports | [99-reports/](../99-reports/) |
+| Phase 1 implementation review | [99-reports/2026-04-01-phase1-vocabulary-landing-implementation-review.md](../99-reports/2026-04-01-phase1-vocabulary-landing-implementation-review.md) |
 
 ## Known Issues
 
@@ -61,8 +61,7 @@ Estimated: 15 sessions total, ~150 new/modified tests, test suite → ~740.
 - Journal persistence gap: journald may purge user-unit logs; heartbeat partially compensates
 - `FileSystemState` trait (11 methods) outgrowing its name — consider rename to `SystemState`
 - `urd get` doesn't support directory restore (files only in v1)
-- Stringly-typed output boundary: three independent status-ranking implementations across notify.rs and voice.rs (addressed by 6-I migration)
-- `OpResult::Skipped` overloaded: four distinct semantics (addressed by Phase 1 skip tag differentiation)
+- Parallel notification builders in notify.rs and sentinel_runner.rs — same mythology, different data sources (maintenance risk)
 - Sentinel Sessions 3-4 remaining (Session 3 dedup subsumed by 6-I cooldown mechanism)
 
 See [roadmap.md](roadmap.md) for the full tech debt list and dropped features.

--- a/docs/99-reports/2026-04-01-phase1-vocabulary-landing-implementation-review.md
+++ b/docs/99-reports/2026-04-01-phase1-vocabulary-landing-implementation-review.md
@@ -1,0 +1,359 @@
+# Arch-Adversary Implementation Review: Phase 1 — Vocabulary Landing
+
+**Date:** 2026-04-01
+**Artifact:** Implementation on `master` (commit cc3fd69 and prior merges)
+**Files reviewed:** `src/voice.rs`, `src/error.rs`, `src/cli.rs`, `src/notify.rs`, `src/output.rs`, `src/awareness.rs`, `src/sentinel_runner.rs`
+**Type:** Implementation review (code on master)
+**Reviewer:** arch-adversary
+
+---
+
+## 1. Executive Summary
+
+The Phase 1 vocabulary landing is **well-executed in the four target files** (voice.rs,
+error.rs, cli.rs, notify.rs) with correct boundary discipline. The ChainHealth Display
+impl is untouched, the exposure triad (sealed/waning/exposed) is properly implemented,
+the summary line uses the differentiated approach, and role-aware drive vocabulary works
+correctly.
+
+However, the implementation has one significant gap: **`sentinel_runner.rs` was not
+included in the vocabulary changes** and retains 5 instances of deprecated mythology
+(loom, weave, rewoven, unguarded). This creates a vocabulary inconsistency between
+`notify.rs` (the backup-path notification builder, correctly updated) and
+`sentinel_runner.rs` (the sentinel-path notification builder, not updated). Users
+receiving notifications from the Sentinel will see old vocabulary while backup
+notifications use new vocabulary.
+
+---
+
+## 2. What Kills You
+
+**Catastrophic failure mode for Urd: silent data loss through incorrect snapshot deletion.**
+
+This implementation is **far from the kill zone**. Confirmed:
+
+- **No path to silent data loss.** Every change is a string literal in a rendering or
+  notification function. No computation, retention logic, planner decisions, or executor
+  behavior was modified.
+- **No pin file changes.** Pin file paths, names, and read/write logic are untouched.
+- **No snapshot deletion logic changes.** Retention module untouched.
+- **No btrfs command changes.** `BtrfsOps` trait and implementations untouched.
+
+**Distance from catastrophic failure: 3+ bugs away.** Comfortable.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4/5 | Core vocabulary landed correctly. sentinel_runner.rs omission creates user-facing inconsistency. |
+| **Security** | 5/5 | No security-relevant surface. No I/O changes, no privilege changes, no new inputs. |
+| **Architectural Excellence** | 4/5 | Excellent boundary discipline in the four target files. Stale comments in two locations. Missed a fifth file. |
+| **Systems Design** | 4/5 | Design review findings mostly resolved well. The sentinel_runner.rs parallel notification builder was a blind spot. |
+| **Backward Compatibility** | 5/5 | All on-disk contracts preserved. ChainHealth Display untouched. PromiseStatus Display untouched. Heartbeat strings untouched. Prometheus metrics untouched. SafetyCounts serde fields untouched. |
+| **Test Coverage** | 4/5 | Good test updates: new vocabulary assertions, daemon JSON contract tests, role-aware drive tests. Missing: unit test for `exposure_label()` function directly, missing: unit test for `render_thread_status()` function directly. |
+
+**Overall: 4.3/5** — solid implementation with one meaningful omission.
+
+---
+
+## 4. Design Review Findings Resolution
+
+### S-1: ChainHealth rendering fork (RESOLVED CORRECTLY)
+
+The `Display` impl on `ChainHealth` in `output.rs` lines 70-78 is **untouched** — still
+produces `"none"`, `"full ({reason})"`, `"incremental ({pin})"`. The interactive rendering
+fork is correctly implemented via `render_thread_status()` (voice.rs line 263), called at
+line 241 instead of `.to_string()`. The function has a clear doc comment: "The `Display`
+impl on `ChainHealth` feeds daemon JSON and must not change."
+
+### S-2: Role-aware "away" (RESOLVED CORRECTLY)
+
+The subvolume table drive cell at voice.rs line 228 correctly uses `e.role` from
+`StatusDriveAssessment` (which carries `DriveRole`):
+
+```rust
+Some(e) if e.role == DriveRole::Offsite && e.last_send_age_secs.is_some() => {
+    "away".dimmed().to_string()
+}
+```
+
+The `render_drive_summary()` at line 336 also correctly checks `drive.role == DriveRole::Offsite`
+for the "away" vs "disconnected" distinction. Both sites use the correct struct field.
+
+### M-1: Summary line semantics (RESOLVED — DIFFERENTIATED APPROACH)
+
+The implementation chose the differentiated approach from the design review options:
+
+```rust
+"6 of 9 sealed. htpc-root exposed. docs waning."
+```
+
+Lines 86-105 correctly separate exposed (UNPROTECTED) and waning (AT RISK) subvolumes
+into distinct sentence fragments with appropriate vocabulary. This is the best of the
+three options — accurate and concise.
+
+### M-2: "Chain error" log grep change (PARTIALLY RESOLVED)
+
+The `UrdError::Chain` error message at error.rs line 275 was changed to
+`"Thread error: {0}"`. The `translate_btrfs_error()` messages at lines 237, 241 now use
+"thread broken" and "thread health". However, **no CHANGELOG entry documents this string
+change**. For a pre-1.0 project this is acceptable, but should be noted in the next
+CHANGELOG update.
+
+### M-3: PROTECTION column transitional note (RESOLVED)
+
+Voice.rs line 172 has the transitional note:
+```rust
+// NOTE: Level names (guarded/protected/resilient) stay until Phase 6
+```
+
+This appears in both `render_subvolume_table()` and `render_assessment_table()` (line 696).
+Implementers will not accidentally rename level Display impls.
+
+### N-1: CLI description for status (RESOLVED — DESIGN VERSION)
+
+`cli.rs` line 27: `"Check whether your data is safe"` — the design version was chosen
+over the brainstorm version. Consistent with the intent-first UX philosophy.
+
+### N-2: "unguarded" notification (PARTIALLY RESOLVED)
+
+`notify.rs` line 242: correctly changed to `"your data stands exposed."`
+
+**BUT** `sentinel_runner.rs` line 511: still says `"your data stands unguarded."` — this
+parallel notification builder was missed. See finding S-1 below.
+
+### N-3: "Drives:" prefix (KEPT)
+
+The `render_drive_summary()` function at voice.rs lines 317, 329, 341 retains the
+`"Drives: "` prefix on every line. This was not explicitly resolved in the design but the
+implementation decision to keep it is reasonable — the prefix anchors the section visually.
+
+---
+
+## 5. Findings
+
+### Significant
+
+**S-1: sentinel_runner.rs notification builder was not updated with vocabulary changes.**
+
+The Sentinel has a parallel notification builder (`build_notifications()` at line 441 and
+`build_health_notifications()` at line 565) that constructs the same notification types as
+`notify.rs` but operates on `SubvolAssessment` directly (not `Heartbeat`). This parallel
+builder was **not included** in the Phase 1 vocabulary changes.
+
+Five instances of deprecated vocabulary remain:
+
+| Line | Current (old) | Expected (new) |
+|------|---------------|-----------------|
+| 476 | "the weave grows thin" | "the thread grows thin" |
+| 491 | "is rewoven" | "is mended" |
+| 511 | "stands unguarded" | "stands exposed" |
+| 552 | "The loom sits idle" | "The spindle sits idle" (or similar) |
+| 596, 610 | "The loom for {}" | needs mythology cleanup |
+
+**Impact:** Users receiving notifications from the Sentinel daemon will see "loom" and
+"weave" vocabulary while backup-path notifications use "thread" and "mended." This is a
+user-facing inconsistency that undermines the vocabulary landing's purpose.
+
+**Why significant:** The Phase 1 design explicitly listed notification mythology cleanup
+as Change 6, and `notify.rs` was correctly updated. But `sentinel_runner.rs` was not listed
+in the design's Module Mapping table, creating a blind spot. The design listed only 4 files;
+`sentinel_runner.rs` is a 5th that constructs the same notification types.
+
+**Fix:** Apply the same string substitutions to `sentinel_runner.rs` lines 476, 491, 511,
+552, 596, and 610.
+
+---
+
+### Moderate
+
+**M-1: Two stale comments reference old column names.**
+
+- Voice.rs line 166: Comment says `CHAIN` but the actual header is `THREAD`.
+- Voice.rs line 693: Comment says `[PROMISE]` but the actual header is `PROTECTION`.
+
+These are maintenance hazards — a future developer reading the comment will have a
+different mental model than what the code produces.
+
+**Fix:** Update both comments.
+
+---
+
+**M-2: No dedicated unit tests for `exposure_label()` and `render_thread_status()`.**
+
+These two new helper functions have specific mapping behavior:
+
+- `exposure_label()`: "PROTECTED" -> "sealed", "AT RISK" -> "waning", "UNPROTECTED" -> "exposed", unknown -> passthrough.
+- `render_thread_status()`: NoDriveData -> em dash, Incremental -> "unbroken", Full -> "broken -- full send (reason)".
+
+They are tested *indirectly* through the full `render_status()` integration tests (e.g.,
+`safety_column_uses_new_vocabulary`, `interactive_contains_thread_health`). However,
+dedicated unit tests would catch regressions more precisely and serve as documentation of
+the mapping contract.
+
+**Recommendation:** Add 2 focused unit tests exercising each mapping case directly.
+
+---
+
+**M-3: `[OFF]` skip tag alignment uses trailing space, but `[SPACE]` is still wider.**
+
+```
+[SPACE]  — 7 chars (including brackets)
+[WAIT]   — 6 chars
+[AWAY]   — 6 chars
+[OFF]    — 5 chars + 1 trailing space = 6 chars
+[SKIP]   — 6 chars
+```
+
+`[SPACE]` is one character wider than all others. In practice this creates a 1-character
+misalignment in grouped skip output when space-exceeded skips appear alongside other skip
+types. The visual impact is minimal since space-exceeded skips render individually (not
+grouped), so they rarely appear adjacent to grouped skips. But the inconsistency exists.
+
+**Recommendation:** Either pad all tags to 7 chars or accept the 1-char variance. The
+current state is acceptable.
+
+---
+
+### Minor
+
+**N-1: `SafetyCounts` struct uses old vocabulary field names (ok/aging/gap).**
+
+`output.rs` lines 608-612: The `SafetyCounts` struct has serde-serialized field names
+`ok`, `aging`, `gap` — the old vocabulary. These are consumed by the Spindle/tray icon
+and are an on-disk/API contract. They **must not** change without migration. However, the
+doc comment "Safety axis counts using tray-friendly vocabulary" will become confusing as
+the voice layer vocabulary diverges. Consider adding a comment noting the divergence:
+"These field names are a serde contract; the voice layer uses sealed/waning/exposed."
+
+---
+
+**N-2: `chain_health` daemon JSON field name retained (correct, but undocumented).**
+
+The daemon JSON serializes `chain_health` as the field name. The internal struct names
+(`ChainHealth`, `ChainHealthEntry`, `chain_health`) are unchanged. This is correct
+(ADR-105 backward compatibility), but should be noted as an intentional decision for the
+same reason as M-3 in the design review: implementers might feel the urge to rename the
+field to `thread_health` in a future phase.
+
+---
+
+**N-3: No CHANGELOG entry for vocabulary changes.**
+
+The Phase 1 vocabulary landing is a user-facing change (every `urd status` output now
+uses different words). The `[Unreleased]` section of CHANGELOG.md should note this.
+
+---
+
+### Commendation
+
+**C-1: Excellent boundary discipline on ChainHealth.**
+
+The most dangerous part of this refactor was the `ChainHealth` boundary between interactive
+and daemon output. The implementation handles it perfectly: a new `render_thread_status()`
+function with an explicit doc comment warning against changing the `Display` impl, called
+at precisely the right site. The daemon JSON contract is preserved.
+
+**C-2: Differentiated summary line is well-implemented.**
+
+The three-way split (all sealed / some exposed + some waning / mixed) produces precise,
+accurate output. The implementation correctly collects exposed and waning names separately
+and constructs distinct sentence fragments. This is better than the original design's
+"`{names} exposed`" proposal, which the design review (M-1) correctly flagged as
+semantically imprecise.
+
+**C-3: Role-aware drive vocabulary is clean.**
+
+Both the drive summary and the subvolume table cells correctly dispatch on `DriveRole` from
+the appropriate struct. The offsite -> "away", primary -> "disconnected" distinction is
+implemented consistently across all render sites.
+
+**C-4: Skip tag system is well-designed.**
+
+The `skip_tag()` helper function centralizes the tag-to-color mapping. The five tags
+([WAIT], [AWAY], [SPACE], [OFF], [SKIP]) are used consistently across both individual and
+grouped renderers. The dimmed coloring for informational tags vs. yellow for space warnings
+is a good UX choice.
+
+---
+
+## 6. Backward Compatibility Verification
+
+| Contract | Status | Evidence |
+|----------|--------|----------|
+| `ChainHealth::Display` impl | PRESERVED | output.rs lines 70-78 unchanged; test `chain_health_display` passes |
+| `PromiseStatus::Display` impl | PRESERVED | awareness.rs lines 50-58 unchanged |
+| Heartbeat `promise_status` strings | PRESERVED | Heartbeat writes `PromiseStatus::Display` output |
+| Prometheus metrics | PRESERVED | metrics.rs not in diff |
+| Daemon JSON field names | PRESERVED | serde attributes unchanged; `daemon_produces_valid_json` test passes |
+| `SafetyCounts` serde fields | PRESERVED | output.rs lines 608-612 unchanged |
+| `SentinelStateFile` serde schema | PRESERVED | output.rs sentinel types unchanged |
+| Pin file format | PRESERVED | Not in scope; no changes |
+| Snapshot name format | PRESERVED | Not in scope; no changes |
+
+**All on-disk contracts are intact.**
+
+---
+
+## 7. Test Coverage Assessment
+
+**Current state:** 589 tests, all passing, clippy clean.
+
+| Area | Coverage | Gap |
+|------|----------|-----|
+| Exposure labels (sealed/waning/exposed) | Covered via `safety_column_uses_new_vocabulary` | No direct `exposure_label()` unit test |
+| Thread rendering (unbroken/broken) | Covered via `interactive_contains_thread_health` | No direct `render_thread_status()` unit test |
+| Role-aware "away" | Covered via `unmounted_drive_shows_away` | Only tests Offsite->away; no test for Primary->dash |
+| Differentiated summary line | Covered via `summary_line_all_safe_all_healthy` | No test for mixed exposed+waning summary |
+| Skip tags | Covered indirectly via grouped skip tests | No direct `skip_tag()` unit test |
+| Daemon JSON contract | Covered via `daemon_produces_valid_json`, `daemon_contains_subvolume_data` | Good |
+| CLI descriptions | Not unit-tested | Clap generates these; testing is low value |
+| Notify mythology | Covered via existing `compute_notifications` tests | Assertions check title/urgency, not body text |
+| Sentinel notifications | Not tested for vocabulary | Gap: sentinel_runner.rs vocabulary mismatch |
+
+**Missing test cases (prioritized):**
+
+1. **Primary drive disconnected shows dash, not "away"** — role-aware behavior for non-offsite
+   drives is untested. A test with a Primary drive that is unmounted should verify the cell
+   shows em dash rather than "away".
+
+2. **Mixed exposed+waning summary line** — the differentiated summary output with both
+   exposed and waning subvolumes present is not directly tested.
+
+3. **Direct `exposure_label()` exhaustive test** — all three inputs plus unknown passthrough.
+
+---
+
+## 8. For the Dev Team
+
+Prioritized action items:
+
+1. **[S-1] Update sentinel_runner.rs vocabulary.** Five string replacements in the parallel
+   notification builder. This is the only finding that creates user-visible inconsistency.
+
+2. **[M-1] Fix stale comments.** Two locations: voice.rs line 166 (`CHAIN` -> `THREAD`),
+   voice.rs line 693 (`[PROMISE]` -> `[PROTECTION]`).
+
+3. **[M-2] Add focused unit tests** for `exposure_label()` and `render_thread_status()`.
+
+4. **[N-3] Add CHANGELOG entry** documenting the vocabulary change.
+
+5. **[M-3, N-1, N-2] — informational.** No action required; awareness is sufficient.
+
+---
+
+## 9. The Simplicity Question
+
+**Is this implementation as simple as it could be while achieving its goals?**
+
+Yes. The implementation is a clean mechanical application of the design: string literals
+changed in rendering functions, one new helper function (`render_thread_status()`) for the
+daemon JSON boundary, one extracted helper (`skip_tag()`) for consistent tag rendering. No
+new types, no new abstractions, no structural changes.
+
+The only complexity addition is the differentiated summary line (lines 86-105), which
+correctly replaces the generic "needs attention" with precise exposed/waning vocabulary.
+This is more code than the original single-phrase approach but produces more accurate output.
+The complexity is justified.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,23 +19,23 @@ pub struct Cli {
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {
-    /// Show planned backup operations without executing
+    /// Preview what Urd will do next
     Plan(PlanArgs),
-    /// Create snapshots, send to external drives, run retention
+    /// Back up now — snapshot, send, clean up
     Backup(BackupArgs),
-    /// Show snapshot counts, drive status, chain health
+    /// Check whether your data is safe
     Status,
-    /// Show backup history
+    /// Review past backup runs
     History(HistoryArgs),
-    /// Verify incremental chain integrity and pin file health
+    /// Diagnose thread integrity and pin health
     Verify(VerifyArgs),
-    /// Initialize state database and validate system readiness
+    /// Set up Urd and verify the environment
     Init,
-    /// Measure snapshot sizes for space estimation (run before first external send)
+    /// Measure snapshot sizes for send estimates
     Calibrate(CalibrateArgs),
-    /// Retrieve a file from a past snapshot
+    /// Restore a file from a past snapshot
     Get(GetArgs),
-    /// Sentinel daemon — monitors backup health and drive connections
+    /// Sentinel — continuous health monitoring
     Sentinel(SentinelArgs),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -210,7 +210,7 @@ pub fn translate_btrfs_error(
                 .to_string(),
             remediation: vec![
                 "This is usually harmless \u{2014} the snapshot is already gone".to_string(),
-                "Run `urd verify` to check chain health".to_string(),
+                "Run `urd verify` to check thread health".to_string(),
             ],
         };
     }
@@ -229,16 +229,16 @@ pub fn translate_btrfs_error(
         };
     }
 
-    // Pattern 7: Parent not found (chain broken)
+    // Pattern 7: Parent not found (thread broken)
     if stderr_lower.contains("parent not found")
         || stderr_lower.contains("cannot find parent subvolume")
     {
         return BtrfsErrorDetail {
-            summary: "Incremental parent missing (chain broken)".to_string(),
+            summary: "Incremental parent missing (thread broken)".to_string(),
             cause: "The parent snapshot for incremental send no longer exists".to_string(),
             remediation: vec![
                 "This is recoverable \u{2014} next send will be a full send".to_string(),
-                "Check `urd verify` for chain health".to_string(),
+                "Check `urd verify` for thread health".to_string(),
                 "If recurring, check retention/send interval alignment".to_string(),
             ],
         };
@@ -272,7 +272,7 @@ pub enum UrdError {
     #[error("Parse error: {0}")]
     Parse(String),
 
-    #[error("Chain error: {0}")]
+    #[error("Thread error: {0}")]
     Chain(String),
 
     #[error("Retention error: {0}")]

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -200,7 +200,7 @@ pub fn compute_notifications(
                         ),
                         body: format!(
                             "The thread of {} has frayed — it was {}, now {}. \
-                             The well remembers, but the weave grows thin.",
+                             The well remembers, but the thread grows thin.",
                             current_sv.name, prev_sv.promise_status, current_sv.promise_status
                         ),
                     });
@@ -217,7 +217,7 @@ pub fn compute_notifications(
                             current_sv.name, current_sv.promise_status
                         ),
                         body: format!(
-                            "The thread of {} is rewoven — restored from {} to {}.",
+                            "The thread of {} is mended — restored from {} to {}.",
                             current_sv.name, prev_sv.promise_status, current_sv.promise_status
                         ),
                     });
@@ -239,7 +239,7 @@ pub fn compute_notifications(
             urgency: Urgency::Critical,
             title: "Urd: all promises broken".to_string(),
             body: "Every thread in the well has snapped. No subvolume is protected. \
-                   Attend to this — your data stands unguarded."
+                   Attend to this — your data stands exposed."
                 .to_string(),
         });
     }
@@ -271,10 +271,10 @@ pub fn compute_notifications(
             urgency,
             title: format!("Urd: {failed_count}/{total_count} backups failed"),
             body: if failed_count == total_count {
-                "The loom has seized — every weaving failed. Check the logs.".to_string()
+                "The spindle has stopped — every thread snapped. Check the logs.".to_string()
             } else {
                 format!(
-                    "{failed_count} of {total_count} threads could not be woven. \
+                    "{failed_count} of {total_count} threads could not be spun. \
                      The others hold, but the pattern is incomplete."
                 )
             },

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -473,7 +473,7 @@ pub fn build_notifications(
                     title: format!("Urd: {} is now {}", assess.name, to),
                     body: format!(
                         "The thread of {} has frayed — it was {}, now {}. \
-                         The well remembers, but the weave grows thin.",
+                         The well remembers, but the thread grows thin.",
                         assess.name, from, to
                     ),
                 });
@@ -488,7 +488,7 @@ pub fn build_notifications(
                     urgency: Urgency::Info,
                     title: format!("Urd: {} restored to {}", assess.name, to),
                     body: format!(
-                        "The thread of {} is rewoven — restored from {} to {}.",
+                        "The thread of {} is mended — restored from {} to {}.",
                         assess.name, from, to
                     ),
                 });
@@ -508,7 +508,7 @@ pub fn build_notifications(
             urgency: Urgency::Critical,
             title: "Urd: all promises broken".to_string(),
             body: "Every thread in the well has snapped. No subvolume is protected. \
-                   Attend to this — your data stands unguarded."
+                   Attend to this — your data stands exposed."
                 .to_string(),
         });
     }
@@ -548,8 +548,8 @@ pub fn check_backup_overdue(
         urgency: Urgency::Warning,
         title: format!("Urd: no backup in {age_hours}h"),
         body: format!(
-            "The last weaving was {age_hours}h ago — expected within {stale_hours}h. \
-             The loom sits idle. Check that the timer is running."
+            "The last run was {age_hours}h ago — expected within {stale_hours}h. \
+             The spindle sits idle. Check that the timer is running."
         ),
     })
 }
@@ -593,7 +593,7 @@ pub fn build_health_notifications(
                     urgency: Urgency::Info,
                     title: format!("Urd: {} health now {}", assess.name, to),
                     body: format!(
-                        "The loom for {} reports {} — was {}.{}",
+                        "The spindle for {} reports {} — was {}.{}",
                         assess.name, to, from, reasons
                     ),
                 });
@@ -607,7 +607,7 @@ pub fn build_health_notifications(
                     urgency: Urgency::Info,
                     title: format!("Urd: {} health restored to {}", assess.name, to),
                     body: format!(
-                        "The loom for {} is running smoothly again — restored from {} to {}.",
+                        "The spindle for {} is running smoothly again — restored from {} to {}.",
                         assess.name, from, to
                     ),
                 });

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -12,9 +12,9 @@ use std::fmt::Write;
 use colored::Colorize;
 
 use crate::output::{
-    BackupSummary, CalibrateOutput, CalibrateResult, FailuresOutput, GetOutput, HistoryOutput,
-    InitOutput, InitStatus, OutputMode, PlanOutput, SentinelStatusOutput, SkipCategory,
-    SkippedSubvolume, StatusOutput, SubvolumeHistoryOutput, VerifyOutput,
+    BackupSummary, CalibrateOutput, CalibrateResult, ChainHealth, FailuresOutput, GetOutput,
+    HistoryOutput, InitOutput, InitStatus, OutputMode, PlanOutput, SentinelStatusOutput,
+    SkipCategory, SkippedSubvolume, StatusOutput, SubvolumeHistoryOutput, VerifyOutput,
     parse_duration_to_minutes,
 };
 use crate::plan::format_duration_short;
@@ -81,23 +81,28 @@ fn render_summary_line(data: &StatusOutput, out: &mut String) {
     let has_health_issues = data.assessments.iter().any(|a| a.health != "healthy");
 
     let safety_part = if safe_count == total {
-        "All data safe.".green().to_string()
+        "All sealed.".green().to_string()
     } else {
-        let unsafe_names: Vec<&str> = data
+        let exposed_names: Vec<&str> = data
             .assessments
             .iter()
-            .filter(|a| a.status != "PROTECTED")
+            .filter(|a| a.status == "UNPROTECTED")
             .map(|a| a.name.as_str())
             .collect();
-        format!(
-            "{} of {} safe. {} {} attention.",
-            safe_count,
-            total,
-            unsafe_names.join(", "),
-            if unsafe_names.len() == 1 { "needs" } else { "need" },
-        )
-        .yellow()
-        .to_string()
+        let waning_names: Vec<&str> = data
+            .assessments
+            .iter()
+            .filter(|a| a.status == "AT RISK")
+            .map(|a| a.name.as_str())
+            .collect();
+        let mut parts = vec![format!("{} of {} sealed.", safe_count, total)];
+        if !exposed_names.is_empty() {
+            parts.push(format!("{} exposed.", exposed_names.join(", ")));
+        }
+        if !waning_names.is_empty() {
+            parts.push(format!("{} waning.", waning_names.join(", ")));
+        }
+        parts.join(" ").yellow().to_string()
     };
 
     let health_part = if has_health_issues {
@@ -158,20 +163,21 @@ fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
     // Only show HEALTH column when at least one subvolume is non-healthy
     let show_health = data.assessments.iter().any(|a| a.health != "healthy");
 
-    // Build headers: SAFETY  [HEALTH]  [PROMISE]  SUBVOLUME  LOCAL  [DRIVES...]  CHAIN
-    let mut headers: Vec<String> = vec!["SAFETY".to_string()];
+    // Build headers: EXPOSURE  [HEALTH]  [PROTECTION]  SUBVOLUME  LOCAL  [DRIVES...]  THREAD
+    let mut headers: Vec<String> = vec!["EXPOSURE".to_string()];
     if show_health {
         headers.push("HEALTH".to_string());
     }
     if has_promises {
-        headers.push("PROMISE".to_string());
+        // NOTE: Level names (guarded/protected/resilient) stay until Phase 6
+        headers.push("PROTECTION".to_string());
     }
     headers.push("SUBVOLUME".to_string());
     headers.push("LOCAL".to_string());
     for label in &drive_labels {
         headers.push(label.to_string());
     }
-    headers.push("CHAIN".to_string());
+    headers.push("THREAD".to_string());
 
     // Track which columns need coloring
     let safety_col = Some(0usize);
@@ -181,7 +187,7 @@ fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
     let mut rows: Vec<Vec<String>> = Vec::new();
     for assessment in &data.assessments {
         // Safety column — new vocabulary
-        let safety = safety_label(&assessment.status);
+        let safety = exposure_label(&assessment.status);
         let mut row = vec![safety];
 
         if show_health {
@@ -219,20 +225,22 @@ fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
                         "\u{2014}".to_string()
                     }
                 }
-                Some(e) if e.last_send_age_secs.is_some() => "away".dimmed().to_string(),
+                Some(e) if e.role == DriveRole::Offsite && e.last_send_age_secs.is_some() => {
+                    "away".dimmed().to_string()
+                }
                 _ => "\u{2014}".to_string(),
             };
             row.push(cell);
         }
 
-        // Chain health
-        let chain = data
+        // Thread health (interactive rendering — Display impl feeds daemon JSON, do not change it)
+        let thread = data
             .chain_health
             .iter()
             .find(|c| c.subvolume == assessment.name)
-            .map(|c| c.health.to_string())
+            .map(|c| render_thread_status(&c.health))
             .unwrap_or_else(|| "\u{2014}".to_string());
-        row.push(chain);
+        row.push(thread);
 
         rows.push(row);
     }
@@ -240,13 +248,23 @@ fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
     format_status_table(&headers, &rows, safety_col, health_col, out);
 }
 
-/// Map legacy status strings to new vocabulary.
-fn safety_label(status: &str) -> String {
+/// Map promise status to exposure vocabulary.
+fn exposure_label(status: &str) -> String {
     match status {
-        "PROTECTED" => "OK".to_string(),
-        "AT RISK" => "aging".to_string(),
-        "UNPROTECTED" => "gap".to_string(),
+        "PROTECTED" => "sealed".to_string(),
+        "AT RISK" => "waning".to_string(),
+        "UNPROTECTED" => "exposed".to_string(),
         other => other.to_string(),
+    }
+}
+
+/// Render chain health for interactive display.
+/// The `Display` impl on `ChainHealth` feeds daemon JSON and must not change.
+fn render_thread_status(health: &ChainHealth) -> String {
+    match health {
+        ChainHealth::NoDriveData => "\u{2014}".to_string(),
+        ChainHealth::Incremental(_) => "unbroken".to_string(),
+        ChainHealth::Full(reason) => format!("broken \u{2014} full send ({reason})"),
     }
 }
 
@@ -310,18 +328,17 @@ fn render_drive_summary(data: &StatusOutput, out: &mut String) {
                 out,
                 "Drives: {} {}{}",
                 drive.label.bold(),
-                "mounted".green(),
+                "connected".green(),
                 free_str,
             )
             .ok();
         } else {
-            writeln!(
-                out,
-                "Drives: {} {}",
-                drive.label.bold(),
-                "not mounted".dimmed(),
-            )
-            .ok();
+            let status = if drive.role == DriveRole::Offsite {
+                "away".dimmed()
+            } else {
+                "disconnected".dimmed()
+            };
+            writeln!(out, "Drives: {} {}", drive.label.bold(), status,).ok();
         }
     }
 }
@@ -385,7 +402,7 @@ fn format_status_table(
                 let w = widths.get(i).copied().unwrap_or(cell.len());
                 let visible_len = strip_ansi_len(cell);
                 if safety_col == Some(i) {
-                    color_and_pad(&color_safety_str(cell), cell.len(), w)
+                    color_and_pad(&color_exposure_str(cell), cell.len(), w)
                 } else if health_col == Some(i) {
                     color_and_pad(&color_health_str(cell), cell.len(), w)
                 } else if visible_len != cell.len() {
@@ -401,10 +418,6 @@ fn format_status_table(
     }
 }
 
-/// Generic table formatter (no column coloring). Used by backup summary.
-fn format_table(headers: &[String], rows: &[Vec<String>], out: &mut String) {
-    format_status_table(headers, rows, None, None, out);
-}
 
 /// Get visible (non-ANSI) length of a string.
 fn strip_ansi_len(s: &str) -> usize {
@@ -433,11 +446,11 @@ fn color_and_pad(colored: &str, visible_len: usize, width: usize) -> String {
 
 // ── Color helpers ───────────────────────────────────────────────────────
 
-fn color_safety_str(safety: &str) -> String {
-    match safety {
-        "OK" => "OK".green().to_string(),
-        "aging" => "aging".yellow().to_string(),
-        "gap" => "gap".red().to_string(),
+fn color_exposure_str(exposure: &str) -> String {
+    match exposure {
+        "sealed" => "sealed".green().to_string(),
+        "waning" => "waning".yellow().to_string(),
+        "exposed" => "exposed".red().to_string(),
         other => other.to_string(),
     }
 }
@@ -562,7 +575,7 @@ fn render_backup_interactive(data: &BackupSummary) -> String {
         render_assessment_advisories(data, &mut out);
     } else if !data.assessments.is_empty() {
         writeln!(out).ok();
-        writeln!(out, "All subvolumes {}.", "PROTECTED".green()).ok();
+        writeln!(out, "All subvolumes {}.", "sealed".green()).ok();
     }
 
     // ── Warnings ─────────────────────────────────────────────────────
@@ -628,8 +641,9 @@ fn render_skipped_block(skipped: &[crate::output::SkippedSubvolume], out: &mut S
     if !not_mounted_drives.is_empty() {
         writeln!(
             out,
-            "  {} {}",
-            "Drives not mounted:".dimmed(),
+            "  {}  {} {}",
+            skip_tag(&SkipCategory::DriveNotMounted),
+            "Drives disconnected:".dimmed(),
             not_mounted_drives.join(", "),
         )
         .ok();
@@ -648,7 +662,7 @@ fn render_skipped_block(skipped: &[crate::output::SkippedSubvolume], out: &mut S
         writeln!(
             out,
             "  {} {}  {}",
-            "SKIP".yellow(),
+            skip_tag(&skip.category),
             skip.name.bold(),
             skip.reason,
         )
@@ -676,10 +690,11 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
 
     let has_promises = data.assessments.iter().any(|a| a.promise_level.is_some());
 
-    // Build headers: STATUS  [PROMISE]  SUBVOLUME  LOCAL  [DRIVE1]  [DRIVE2]
-    let mut headers: Vec<String> = vec!["STATUS".to_string()];
+    // Build headers: EXPOSURE  [PROTECTION]  SUBVOLUME  LOCAL  [DRIVE1]  [DRIVE2]
+    let mut headers: Vec<String> = vec!["EXPOSURE".to_string()];
     if has_promises {
-        headers.push("PROMISE".to_string());
+        // NOTE: Level names (guarded/protected/resilient) stay until Phase 6
+        headers.push("PROTECTION".to_string());
     }
     headers.push("SUBVOLUME".to_string());
     headers.push("LOCAL".to_string());
@@ -690,7 +705,7 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
     // Build rows
     let mut rows: Vec<Vec<String>> = Vec::new();
     for assessment in &data.assessments {
-        let mut row = vec![assessment.status.clone()];
+        let mut row = vec![exposure_label(&assessment.status)];
         if has_promises {
             row.push(
                 assessment
@@ -717,7 +732,7 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
         rows.push(row);
     }
 
-    format_table(&headers, &rows, out);
+    format_status_table(&headers, &rows, Some(0), None, out);
 }
 
 /// Render advisories and errors from awareness assessments.
@@ -929,7 +944,14 @@ fn render_drive_not_mounted_group(items: &[&SkippedSubvolume], out: &mut String)
             format!("{label} ({count} {noun})")
         })
         .collect();
-    writeln!(out, "  {} {}", "Not mounted:".dimmed(), parts.join(", ")).ok();
+    writeln!(
+        out,
+        "  {}  {} {}",
+        skip_tag(&SkipCategory::DriveNotMounted),
+        "Disconnected:".dimmed(),
+        parts.join(", "),
+    )
+    .ok();
 }
 
 /// Render IntervalNotElapsed skips as a single line with count and shortest duration.
@@ -947,7 +969,8 @@ fn render_interval_group(items: &[&SkippedSubvolume], out: &mut String) {
 
     writeln!(
         out,
-        "  {} {} subvolumes{}",
+        "  {}  {} {} subvolumes{}",
+        skip_tag(&SkipCategory::IntervalNotElapsed),
         "Interval not elapsed:".dimmed(),
         items.len(),
         suffix,
@@ -958,7 +981,25 @@ fn render_interval_group(items: &[&SkippedSubvolume], out: &mut String) {
 /// Render Disabled skips as an inline comma-separated name list.
 fn render_disabled_group(items: &[&SkippedSubvolume], out: &mut String) {
     let names: Vec<&str> = items.iter().map(|s| s.name.as_str()).collect();
-    writeln!(out, "  {} {}", "Disabled:".dimmed(), names.join(", ")).ok();
+    writeln!(
+        out,
+        "  {}  {} {}",
+        skip_tag(&SkipCategory::Disabled),
+        "Disabled:".dimmed(),
+        names.join(", "),
+    )
+    .ok();
+}
+
+/// Map skip category to a colored tag for display.
+fn skip_tag(category: &SkipCategory) -> String {
+    match category {
+        SkipCategory::SpaceExceeded => "[SPACE]".yellow().to_string(),
+        SkipCategory::IntervalNotElapsed => "[WAIT]".dimmed().to_string(),
+        SkipCategory::DriveNotMounted => "[AWAY]".dimmed().to_string(),
+        SkipCategory::Disabled => "[OFF] ".dimmed().to_string(),
+        SkipCategory::Other => "[SKIP]".dimmed().to_string(),
+    }
 }
 
 /// Render SpaceExceeded or Other skips as individual lines (detail matters).
@@ -967,10 +1008,7 @@ fn render_individual_skips(
     category: &SkipCategory,
     out: &mut String,
 ) {
-    let tag = match category {
-        SkipCategory::SpaceExceeded => "[SPACE]".yellow().to_string(),
-        _ => "[SKIP]".dimmed().to_string(),
-    };
+    let tag = skip_tag(category);
     for item in items {
         writeln!(out, "  {} {}: {}", tag, item.name, item.reason.dimmed()).ok();
     }
@@ -1373,9 +1411,11 @@ fn render_init_interactive(data: &InitOutput) -> String {
     writeln!(out, "{}", "Drive status:".bold()).ok();
     for drive in &data.drives {
         let status = if drive.mounted {
-            "MOUNTED".green().to_string()
+            "CONNECTED".green().to_string()
+        } else if drive.role == DriveRole::Offsite {
+            "AWAY".yellow().to_string()
         } else {
-            "NOT MOUNTED".yellow().to_string()
+            "DISCONNECTED".yellow().to_string()
         };
         let free_info = drive
             .free_bytes
@@ -1533,9 +1573,9 @@ fn render_sentinel_status_interactive(data: &SentinelStatusOutput) -> String {
 
             // Mounted drives
             if state.mounted_drives.is_empty() {
-                writeln!(out, "  {:<14}{}", "Mounted", "none".dimmed()).ok();
+                writeln!(out, "  {:<14}{}", "Connected", "none".dimmed()).ok();
             } else {
-                writeln!(out, "  {:<14}{}", "Mounted", state.mounted_drives.join(", ")).ok();
+                writeln!(out, "  {:<14}{}", "Connected", state.mounted_drives.join(", ")).ok();
             }
         }
         SentinelStatusOutput::NotRunning { last_seen } => {
@@ -1691,8 +1731,8 @@ mod tests {
     fn interactive_contains_safety_vocabulary() {
         colored::control::set_override(false);
         let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("OK"), "missing OK safety label");
-        assert!(output.contains("aging"), "missing aging safety label");
+        assert!(output.contains("sealed"), "missing sealed exposure label");
+        assert!(output.contains("waning"), "missing waning exposure label");
     }
 
     #[test]
@@ -1702,7 +1742,7 @@ mod tests {
         // Set a promise level on one assessment
         data.assessments[0].promise_level = Some("protected".to_string());
         let output = render_status(&data, OutputMode::Interactive);
-        assert!(output.contains("PROMISE"), "missing PROMISE header");
+        assert!(output.contains("PROTECTION"), "missing PROTECTION header");
         assert!(output.contains("protected"), "missing promise level value");
         // The second assessment should show an em dash
         assert!(
@@ -1717,8 +1757,8 @@ mod tests {
         let data = test_status_output(); // all promise_level are None
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
-            !output.contains("PROMISE"),
-            "PROMISE column should be hidden when no promises set"
+            !output.contains("PROTECTION"),
+            "PROTECTION column should be hidden when no protection levels set"
         );
     }
 
@@ -1727,9 +1767,9 @@ mod tests {
         colored::control::set_override(false);
         let output = render_status(&test_status_output(), OutputMode::Interactive);
         assert!(output.contains("WD-18TB"), "missing drive label");
-        assert!(output.contains("mounted"), "missing mounted status");
+        assert!(output.contains("connected"), "missing connected status");
         assert!(output.contains("Offsite-4TB"), "missing unmounted drive");
-        assert!(output.contains("not mounted"), "missing not mounted status");
+        assert!(output.contains("away"), "missing away status for offsite drive");
     }
 
     #[test]
@@ -1742,11 +1782,14 @@ mod tests {
     }
 
     #[test]
-    fn interactive_contains_chain_health() {
+    fn interactive_contains_thread_health() {
         colored::control::set_override(false);
         let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("incremental"), "missing incremental chain");
-        assert!(output.contains("full (no pin)"), "missing full chain");
+        assert!(output.contains("unbroken"), "missing unbroken thread");
+        assert!(
+            output.contains("broken"),
+            "missing broken thread"
+        );
     }
 
     #[test]
@@ -1913,7 +1956,7 @@ mod tests {
         let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
         assert!(output.contains("htpc-home"), "missing subvolume name");
         assert!(output.contains("htpc-docs"), "missing subvolume name");
-        assert!(output.contains("OK"), "missing OK status");
+        assert!(output.contains("sealed"), "missing sealed status");
     }
 
     #[test]
@@ -1931,7 +1974,7 @@ mod tests {
         colored::control::set_override(false);
         let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
         assert!(
-            output.contains("Drives not mounted"),
+            output.contains("Drives disconnected"),
             "missing grouped skip header"
         );
         assert!(
@@ -1973,8 +2016,8 @@ mod tests {
         colored::control::set_override(false);
         let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
         assert!(
-            output.contains("All subvolumes PROTECTED"),
-            "missing all-protected summary"
+            output.contains("All subvolumes sealed"),
+            "missing all-sealed summary"
         );
         // Should NOT contain a table header
         assert!(
@@ -1993,7 +2036,7 @@ mod tests {
             output.contains("SUBVOLUME"),
             "should show table when not all protected"
         );
-        assert!(output.contains("AT RISK"), "missing AT RISK status");
+        assert!(output.contains("waning"), "missing waning exposure label");
     }
 
     #[test]
@@ -2092,7 +2135,7 @@ mod tests {
         };
         let output = render_backup_summary(&data, OutputMode::Interactive);
         assert!(
-            output.contains("Drives not mounted"),
+            output.contains("Drives disconnected"),
             "missing grouped header for all-skips run"
         );
         assert!(
@@ -2263,7 +2306,7 @@ mod tests {
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
-            output.contains("Not mounted:"),
+            output.contains("Disconnected:"),
             "missing grouped not-mounted line"
         );
         assert!(
@@ -2469,7 +2512,7 @@ mod tests {
             },
         };
         let output = render_plan(&data, OutputMode::Interactive);
-        let not_mounted_pos = output.find("Not mounted:").expect("missing Not mounted");
+        let not_mounted_pos = output.find("Disconnected:").expect("missing Disconnected");
         let interval_pos = output.find("Interval not elapsed:").expect("missing Interval");
         let disabled_pos = output.find("Disabled:").expect("missing Disabled");
         assert!(
@@ -3009,7 +3052,7 @@ mod tests {
             a.health_reasons = vec![];
         }
         let output = render_status(&data, OutputMode::Interactive);
-        assert!(output.contains("All data safe"), "missing summary line, got: {output}");
+        assert!(output.contains("All sealed"), "missing summary line, got: {output}");
     }
 
     #[test]
@@ -3028,10 +3071,74 @@ mod tests {
         colored::control::set_override(false);
         let data = test_status_output();
         let output = render_status(&data, OutputMode::Interactive);
-        assert!(output.contains("OK"), "missing OK label");
-        assert!(output.contains("aging"), "missing aging label");
+        assert!(output.contains("sealed"), "missing sealed label");
+        assert!(output.contains("waning"), "missing waning label");
         assert!(!output.contains("PROTECTED"), "should not contain legacy PROTECTED");
         assert!(!output.contains("AT RISK"), "should not contain legacy AT RISK");
+    }
+
+    #[test]
+    fn exposure_label_maps_all_statuses() {
+        assert_eq!(exposure_label("PROTECTED"), "sealed");
+        assert_eq!(exposure_label("AT RISK"), "waning");
+        assert_eq!(exposure_label("UNPROTECTED"), "exposed");
+        assert_eq!(exposure_label("UNKNOWN"), "UNKNOWN");
+    }
+
+    #[test]
+    fn render_thread_status_maps_all_variants() {
+        assert_eq!(render_thread_status(&ChainHealth::NoDriveData), "\u{2014}");
+        assert_eq!(
+            render_thread_status(&ChainHealth::Incremental("pin".to_string())),
+            "unbroken"
+        );
+        assert_eq!(
+            render_thread_status(&ChainHealth::Full("no pin".to_string())),
+            "broken \u{2014} full send (no pin)"
+        );
+    }
+
+    #[test]
+    fn summary_line_differentiates_exposed_and_waning() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        data.assessments[0].status = "UNPROTECTED".to_string();
+        data.assessments[1].status = "AT RISK".to_string();
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(output.contains("exposed"), "missing exposed in summary");
+        assert!(output.contains("waning"), "missing waning in summary");
+        assert!(output.contains("0 of 2 sealed"), "missing sealed count");
+    }
+
+    #[test]
+    fn primary_drive_unmounted_shows_dash_not_away() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        // Add an unmounted Primary drive with send history
+        data.assessments[0].external.push(StatusDriveAssessment {
+            drive_label: "Test-Drive".to_string(),
+            status: "PROTECTED".to_string(),
+            mounted: false,
+            snapshot_count: None,
+            last_send_age_secs: Some(86400),
+            role: DriveRole::Primary,
+        });
+        data.drives.push(DriveInfo {
+            label: "Test-Drive".to_string(),
+            mounted: false,
+            free_bytes: None,
+            role: DriveRole::Primary,
+        });
+        let output = render_status(&data, OutputMode::Interactive);
+        // Primary drives should NOT show "away" — only offsite drives do
+        let lines: Vec<&str> = output.lines().collect();
+        let test_drive_line = lines.iter().find(|l| l.contains("Test-Drive"));
+        assert!(test_drive_line.is_some(), "missing Test-Drive in output");
+        // The drive summary should show "disconnected" not "away"
+        assert!(
+            output.contains("disconnected"),
+            "primary drive should show disconnected, not away: {output}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Exposure triad**: OK/aging/gap → sealed/waning/exposed across all presentation surfaces. Summary line now differentiates: "htpc-root exposed. docs waning."
- **Chain → thread**: New `render_thread_status()` for interactive display (unbroken/broken). `ChainHealth::Display` untouched (daemon JSON contract preserved).
- **Role-aware drives**: mounted → connected, not mounted → disconnected (primary) or away (offsite). Applied to status table, drive summary, init output, sentinel, and skip labels.
- **Skip tag differentiation**: [WAIT]/[AWAY]/[SPACE]/[OFF]/[SKIP] replace overloaded [SKIP]. Extracted `skip_tag()` helper.
- **CLI descriptions**: 9 intent-first rewrites (e.g., "Check whether your data is safe").
- **Notification mythology**: loom/weave → spindle/thread in both notify.rs and sentinel_runner.rs. Arch-adversary review caught the sentinel_runner.rs blind spot.
- **PROMISE → PROTECTION** column header with Phase 6 transitional note.

All backward-compatibility contracts preserved: ChainHealth Display, heartbeat strings, Prometheus metrics, daemon JSON, SafetyCounts serde fields.

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 593 tests, all passing (+4 new: exposure_label mapping, render_thread_status variants, differentiated summary, primary-drive-disconnected)
- Integration tests: not applicable (presentation-layer only)

## Review artifacts

- Design: `docs/95-ideas/2026-03-31-design-phase1-vocabulary-landing.md`
- Design review: `docs/99-reports/2026-03-31-design-phase1-vocabulary-landing-review.md`
- Implementation review: `docs/99-reports/2026-04-01-phase1-vocabulary-landing-implementation-review.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)