### PR TITLE
feat: bare urd default status and shell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- Vocabulary overhaul: safety labels are now sealed/waning/exposed, chain→thread, mounted→connected/disconnected/away, SAFETY→EXPOSURE, CHAIN→THREAD, PROMISE→PROTECTION column headers
-- CLI command descriptions rewritten to intent-first language (e.g., "Check whether your data is safe")
-- Summary line now differentiates exposure levels: "htpc-root exposed. docs waning." instead of generic "needs attention"
-- Skip tags differentiated by category: [WAIT], [AWAY], [SPACE], [OFF], [SKIP] replace overloaded [SKIP]
-- Drive status is now role-aware: offsite drives show "away" when disconnected, primary drives show "disconnected"
-- Notification mythology cleaned up: loom/weave→spindle/thread, rewoven→mended, unguarded→exposed
-- `UrdError::Chain` error message changed from "Chain error" to "Thread error" (log grep patterns may need updating)
+## [0.6.0] - 2026-04-01
 
 ### Added
 - Bare `urd` (no subcommand) shows a one-sentence status: "All sealed. Last backup 7h ago." or "3 of 9 sealed. htpc-root exposed." First-time users see setup guidance instead of help text
@@ -26,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Preflight check `resilient-without-offsite` warns when resilient subvolume lacks an offsite drive
 - Offsite drive role shown as "(offsite)" annotation in `urd status` table column headers
 - `DriveRole` plumbed through `DriveAssessment`, `StatusDriveAssessment`, `DriveInfo`, and `InitDriveStatus`
+
+### Changed
+- Vocabulary overhaul: safety labels are now sealed/waning/exposed, chain→thread, mounted→connected/disconnected/away, SAFETY→EXPOSURE, CHAIN→THREAD, PROMISE→PROTECTION column headers
+- CLI command descriptions rewritten to intent-first language (e.g., "Check whether your data is safe")
+- Summary line now differentiates exposure levels: "htpc-root exposed. docs waning." instead of generic "needs attention"
+- Skip tags differentiated by category: [WAIT], [AWAY], [SPACE], [OFF], [SKIP] replace overloaded [SKIP]
+- Drive status is now role-aware: offsite drives show "away" when disconnected, primary drives show "disconnected"
+- Notification mythology cleaned up: loom/weave→spindle/thread, rewoven→mended, unguarded→exposed
+- `UrdError::Chain` error message changed from "Chain error" to "Thread error" (log grep patterns may need updating)
 
 ### Fixed
 - 7-day "consider cycling" advisory now scoped to offsite-role drives only (previously fired for all unmounted drives)
@@ -144,7 +146,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.4.1...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/vonrobak/urd/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/vonrobak/urd/compare/v0.4.3...v0.5.0
+[0.4.3]: https://github.com/vonrobak/urd/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/vonrobak/urd/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/vonrobak/urd/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/vonrobak/urd/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/vonrobak/urd/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `UrdError::Chain` error message changed from "Chain error" to "Thread error" (log grep patterns may need updating)
 
 ### Added
+- Bare `urd` (no subcommand) shows a one-sentence status: "All sealed. Last backup 7h ago." or "3 of 9 sealed. htpc-root exposed." First-time users see setup guidance instead of help text
+- `urd completions <shell>` generates tab-completion scripts for bash, zsh, fish, elvish, and powershell
+- `StateDb::last_run_info()` shared helper for building presentation-ready last-run summaries
 - Transient immediate cleanup: executor deletes old pin parent immediately after successful send to all drives, reducing local snapshot count from two to one between runs
 - `Config::drive_labels()` helper for collecting configured drive labels
 - Promise redundancy encoding: resilient protection level now requires at least one offsite-role drive and degrades promise status when the offsite copy goes stale (30/90-day thresholds)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +940,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "clap_complete",
  "colored",
  "ctrlc",
  "dirs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/vonrobak/urd"
 [dependencies]
 # CLI
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 
 # Serialization & config
 serde = { version = "1", features = ["derive"] }

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -8,23 +8,23 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-593 tests, all passing, clippy clean. Current version: v0.5.0.
+610 tests, all passing, clippy clean. Current version: v0.5.0.
 Transient retention deployed to htpc-root (2026-03-30). Immediate cleanup built, not yet deployed.
 
 ## In Progress
 
-1. **Phase 1: Vocabulary landing** — All 7 changes implemented, reviewed (arch-adversary +
-   simplify), all findings addressed including sentinel_runner.rs blind spot. Ready for
+1. **Phase 2a + 2c** — Bare `urd` default one-sentence status + shell completions.
+   Implemented, reviewed (arch-adversary + simplify), all findings addressed. Ready for
    commit and PR.
 
 ## Next Up
 
-1. **Phase 2a + 2c** — `urd` default one-sentence status (score 10) + shell completions (score 8).
-   1 session. [Design](../95-ideas/2026-03-31-design-phase2-ux-commands.md) |
-   [Review](../99-reports/2026-03-31-design-phase2-ux-commands-review.md)
-2. **6-I advisory system** — Structured advisory types replacing string-based advisories.
+1. **6-I advisory system** — Structured advisory types replacing string-based advisories.
    Blocks notification deduplication. ~2 sessions.
-3. **6-N + Phase 2b** — Retention display in status + `urd doctor` command.
+2. **6-N + Phase 2b** — Retention display in status + `urd doctor` command.
+   [Design](../95-ideas/2026-03-31-design-phase2-ux-commands.md) |
+   [Review](../99-reports/2026-03-31-design-phase2-ux-commands-review.md)
+3. **6-O milestones** — Progressive learning/onboarding layer. ~2 sessions.
 
 ## Build Queue — Priority 6: Voice & UX Overhaul
 
@@ -34,14 +34,14 @@ Setup arc builds the learning/onboarding layer. All designs reviewed by arch-adv
 ```
 Voice & UX Arc:                    Progressive & Setup Arc:
   Phase 1 (vocabulary) ✓             6-O (milestones, 2 sessions)
-  Phase 2a+2c (urd default, compl.)  ADR-110 enum rename (1 session)
+  Phase 2a+2c (urd default, compl.)✓ ADR-110 enum rename (1 session)
   6-I (advisory system)              Config Serialize (0.5 session)
   6-N + Phase 2b (retention, doctor) 6-H (wizard, 4 sessions)
   Phase 4a+4b (escalation, suggest.)
   Phase 4c (transitions)
 ```
 
-Estimated: 14 sessions remaining, ~150 new/modified tests, test suite → ~740.
+Estimated: 13 sessions remaining, ~140 new/modified tests, test suite → ~750.
 
 ## Key Links
 
@@ -53,7 +53,7 @@ Estimated: 14 sessions remaining, ~150 new/modified tests, test suite → ~740.
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Phase designs (1-6) | [95-ideas/](../95-ideas/) (2026-03-31-design-phase*.md) |
 | Review reports | [99-reports/](../99-reports/) |
-| Phase 1 implementation review | [99-reports/2026-04-01-phase1-vocabulary-landing-implementation-review.md](../99-reports/2026-04-01-phase1-vocabulary-landing-implementation-review.md) |
+| Phase 2a+2c implementation review | [99-reports/2026-04-01-phase2a-2c-implementation-review.md](../99-reports/2026-04-01-phase2a-2c-implementation-review.md) |
 
 ## Known Issues
 

--- a/docs/99-reports/2026-04-01-phase2a-2c-implementation-review.md
+++ b/docs/99-reports/2026-04-01-phase2a-2c-implementation-review.md
@@ -1,0 +1,271 @@
+# Arch-Adversary Review: Phase 2a + 2c — Implementation
+
+**Date:** 2026-04-01
+**Reviewer:** arch-adversary
+**Scope:** Implementation diff — bare `urd` default status (2a), shell completions (2c),
+main.rs restructure, simplify pass (last_run_info extraction, sealed_count derivation)
+**Type:** Implementation review (post-simplify)
+
+---
+
+## 1. Executive Summary
+
+A clean, well-structured implementation of two low-risk UX features. The main.rs restructure
+is the most architecturally significant change and is handled well — three explicit dispatch
+strategies with clear control flow. Two findings worth fixing: a purity violation in voice.rs
+(architectural invariant 7) and a boundary violation in output.rs. Neither is near the
+catastrophic failure mode.
+
+---
+
+## 2. What Kills You
+
+**Catastrophic failure mode: silent data loss via deleted snapshots.**
+
+None of this code is within striking distance. All new paths are read-only: awareness
+assessment, status rendering, and shell completion generation. No code touches retention,
+deletion, the executor, or btrfs commands. The `Option<Commands>` change in cli.rs could
+theoretically regress command dispatch, but only in the "command doesn't run" direction
+(fail-closed), never the "wrong thing gets deleted" direction.
+
+**Proximity to catastrophe: NONE.** No finding in this review is within two bugs of silent
+data loss.
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 5/5 | Config error discrimination is correct for all realistic paths. Derived sealed_count is mathematically sound. Edge case (no $HOME) degrades gracefully. |
+| **Security** | 5/5 | No new privilege escalation, no new I/O paths beyond existing modules. Completions write to stdout only. |
+| **Architectural Excellence** | 4/5 | Three-strategy main.rs is well-designed. Two boundary violations: `last_run_info()` in output.rs and `Local::now()` in voice.rs. |
+| **Systems Design** | 5/5 | Correct dispatch ordering, config-free completions, fallible first-time detection. OutputMode deferred past completions branch. |
+| **Rust Idioms** | 5/5 | Single-pass fold, derived method over redundant field, clean error discrimination with guard clause, `#[must_use]` on return values. |
+| **Code Quality** | 4/5 | Good test coverage (16 new tests). Simplify pass caught a real consistency bug (sealed_count=6 was wrong). Blank lines left from removed `sealed_count:` fields are cosmetic noise. |
+
+---
+
+## 4. Design Tensions
+
+### 4.1 Config-path ownership: main.rs vs. default.rs
+
+The default command receives the raw config path (`Option<&Path>`) rather than a pre-loaded
+config. This breaks the pattern of every other command (which receives `Config`). The reason
+is sound: default needs fallible config loading with error discrimination, and that logic
+belongs in the command, not in main.rs. The cost is that `default::run` has a different
+signature than every sibling. This is the right trade-off — the alternative (error
+discrimination in main.rs) would couple main.rs to first-time UX logic.
+
+### 4.2 Derived vs. stored sealed_count
+
+The simplify pass removed `sealed_count` from `DefaultStatusOutput` and replaced it with a
+derived `sealed_count()` method. This eliminates a class of synchronization bugs (the test
+data actually had an inconsistent value). The trade-off: the JSON daemon output no longer
+includes `sealed_count` — external consumers must derive it. For a new, unreleased output
+type with no consumers yet, this is the right call. If Spindle later needs `sealed_count`
+in JSON, add `#[serde(serialize_with)]` or a flattened computed field.
+
+### 4.3 last_run_info extraction: reuse vs. purity
+
+The simplify pass correctly identified duplicate last-run logic across status.rs and
+default.rs. Extraction is the right instinct. But the function landed in `output.rs`,
+which was a pure types module. See finding S1.
+
+---
+
+## 5. Findings
+
+### Significant
+
+**S1: `last_run_info()` in output.rs violates module purity (ADR-108)**
+
+`output.rs` header (line 1-4) describes it as a types module: "structured data produced by
+commands for the presentation layer." Before this change, it imported only type definitions.
+The new `last_run_info()` function performs SQLite I/O (`db.last_run()`), calls business
+logic (`format_run_duration()`), and logs warnings. This makes `output.rs` impure.
+
+**Impact:** The output module is no longer a clean types boundary. Future developers may add
+more query logic here, eroding the separation between "what data looks like" and "how data
+is fetched."
+
+**Recommendation:** Move `last_run_info()` to `src/state.rs` (where `StateDb` and `last_run()`
+live). It wraps a state query and constructs an output type — that's a bridge function that
+belongs at the state boundary, not the output boundary. Import `LastRunInfo` in state.rs and
+export the helper from there.
+
+```rust
+// src/state.rs
+use crate::output::LastRunInfo;
+
+impl StateDb {
+    pub fn last_run_info(&self) -> Option<LastRunInfo> { ... }
+}
+```
+
+Then call sites become `state_db.as_ref().and_then(|db| db.last_run_info())`.
+
+---
+
+**S2: `parse_timestamp_age_secs()` in voice.rs breaks purity invariant**
+
+CLAUDE.md architectural invariant 7: "Core logic modules are pure functions. Planner,
+awareness, retention, **voice** — inputs in, outputs out, no I/O."
+
+The new `parse_timestamp_age_secs()` at voice.rs:1679 calls `chrono::Local::now()`, which is
+a syscall (`clock_gettime`). This makes voice.rs impure. Before this change, voice.rs had
+zero I/O — every function took structured data and returned a string.
+
+**Impact:** The function is also untestable in isolation — you can't control "now" from a
+test, so any test involving "Last backup N ago" is non-deterministic. The existing test
+(`default_with_last_backup`) works only because the test fixture has a timestamp far enough
+in the past that "ago" always appears, but it can't assert the specific duration.
+
+**Recommendation:** Compute `last_run_age_secs` in the command handler (where `now` is
+already available) and pass it through the output type. Voice stays pure.
+
+```rust
+// output.rs
+pub struct DefaultStatusOutput {
+    // ...
+    pub last_run: Option<LastRunInfo>,
+    pub last_run_age_secs: Option<i64>,  // computed by command handler
+}
+
+// voice.rs — no chrono::Local::now() needed
+if let Some(age_secs) = data.last_run_age_secs {
+    write!(out, " Last backup {} ago.", humanize_duration(age_secs)).ok();
+}
+```
+
+Delete `parse_timestamp_age_secs()` entirely. The command handler already has `now` from
+the `awareness::assess()` call.
+
+---
+
+### Moderate
+
+**M1: `default_config_path()` returns `UrdError::Config`, not `UrdError::Io`**
+
+When `dirs::config_dir()` returns `None` (no `$HOME` set), `Config::load(None)` returns
+`UrdError::Config("could not determine XDG config directory")`. The error discrimination
+in `default.rs` only catches `UrdError::Io` with `NotFound`, so this path shows an error
+rather than the first-time welcome message.
+
+**Impact:** On systems without `$HOME` (containers, minimal environments), bare `urd`
+shows "Configuration error: could not determine XDG config directory" instead of "Urd is
+not configured yet." This is a degraded experience but not wrong — the user genuinely
+can't configure Urd without a config directory.
+
+**Recommendation:** Acceptable as-is. The error message is actionable (user needs to set
+`$HOME` or use `--config`). Treating "can't find config dir" as "first-time user" would be
+misleading — the user may have a config that can't be located. If you want to improve this,
+add a hint to the error: "Set $HOME or use --config to specify a path."
+
+---
+
+### Minor
+
+**m1: Blank lines from removed `sealed_count:` field in test data**
+
+The simplify pass removed `sealed_count:` lines from test constructor calls but left blank
+lines where they were:
+
+```rust
+DefaultStatusOutput {
+    total: 4,
+                    // ← blank line where sealed_count: 4 was
+    waning_names: vec![],
+```
+
+**Impact:** Cosmetic. Makes the test code look like it has a formatting error.
+
+**Recommendation:** Remove the blank lines in a cleanup pass.
+
+---
+
+### Commendation
+
+**C1: Three-strategy main.rs restructure**
+
+The dispatch restructure is the right design. Strategy A (config-free) → Strategy B
+(fallible config) → Strategy C (mandatory config) is explicit, grep-friendly, and easy
+to extend. The completions branch runs before `OutputMode::detect()`, avoiding an
+unnecessary ioctl. The safety comment on `.unwrap()` is appropriate. This is better than
+the design doc's original snippet, which showed only the `None` arm in isolation.
+
+**C2: sealed_count derivation caught a real bug**
+
+The simplify pass removed `sealed_count` as a stored field and replaced it with a derived
+method. This immediately exposed that the test fixture `default_some_exposed` had
+`sealed_count: 6` with `total: 9` and `exposed_names.len(): 2` — the correct sealed count
+is 7. This is exactly the class of bug that derived state eliminates: silent inconsistency
+between redundant fields that only surfaces when someone reads carefully.
+
+**C3: Config error discrimination (S1 from design review)**
+
+The design review's top finding was "don't conflate missing config with broken config." The
+implementation handles this correctly: `UrdError::Io` with `source.kind() == NotFound`
+triggers the first-time path; all other errors (parse, validation, permission) surface as
+real errors. The test `config_parse_error_surfaces_error` writes invalid TOML and verifies
+it returns Err. This is the right test — it guards the exact regression the design review
+warned about.
+
+**C4: Completions implementation is minimal**
+
+`completions.rs` is 10 lines of production code wrapping `clap_complete::generate()`. The
+test suite uses `generate_to_string()` to capture output without stdout interference.
+Dynamic completions are correctly deferred. This is proportional engineering.
+
+---
+
+## 6. The Simplicity Question
+
+**Is there anything that could be removed or simplified?**
+
+No. The implementation is already minimal:
+- `completions.rs`: 10 lines of production code
+- `default.rs`: 50 lines of production code (config load + assess + build output)
+- `DefaultStatusOutput`: 5 fields (now 4 after simplify)
+- `render_default_status_interactive`: 25 lines
+- `render_first_time`: 7 lines
+
+The simplify pass already removed `sealed_count` and extracted `last_run_info`. The
+remaining code is load-bearing. The only further simplification is fixing S2 (removing
+`parse_timestamp_age_secs` by pre-computing age), which actually reduces code.
+
+---
+
+## 7. For the Dev Team
+
+Prioritized action items:
+
+1. **Fix S2: Move timestamp age computation out of voice.rs** — compute `last_run_age_secs`
+   in `default.rs` (where `now` already exists from `awareness::assess`), add it to
+   `DefaultStatusOutput`, delete `parse_timestamp_age_secs()` from voice.rs. This restores
+   voice.rs purity and makes the "Last backup N ago" test deterministic.
+
+   Files: `src/commands/default.rs`, `src/output.rs`, `src/voice.rs`
+
+2. **Fix S1: Move `last_run_info()` out of output.rs** — relocate to `StateDb` as a method.
+   Update call sites in `default.rs` and `status.rs`. This restores output.rs as a pure
+   types module.
+
+   Files: `src/output.rs`, `src/state.rs`, `src/commands/default.rs`, `src/commands/status.rs`
+
+3. **Fix m1: Remove blank lines** in voice.rs test data constructors (cosmetic).
+
+   File: `src/voice.rs`
+
+---
+
+## 8. Open Questions
+
+1. **Should `sealed_count` appear in daemon JSON?** The current daemon output omits it (not
+   a serialized field). If Spindle or other consumers expect it, add a
+   `#[serde(serialize_with)]` or restructure. Since this output type is new and unreleased,
+   now is the time to decide.
+
+2. **Should bare `urd` show exit code 1 when subvolumes are exposed?** Currently it always
+   returns `Ok(())`. A non-zero exit code when data is at risk would enable shell scripting
+   (`urd && echo safe || echo check`). This is a UX decision, not a code quality issue.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,7 +6,7 @@ use clap::{Parser, Subcommand};
 #[command(name = "urd", about = "BTRFS Time Machine for Linux", version)]
 pub struct Cli {
     #[command(subcommand)]
-    pub command: Commands,
+    pub command: Option<Commands>,
 
     /// Path to config file (default: ~/.config/urd/urd.toml)
     #[arg(long, short)]
@@ -37,6 +37,14 @@ pub enum Commands {
     Get(GetArgs),
     /// Sentinel — continuous health monitoring
     Sentinel(SentinelArgs),
+    /// Generate shell completion scripts
+    Completions(CompletionsArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct CompletionsArgs {
+    /// Shell to generate completions for (bash, zsh, fish, elvish, powershell)
+    pub shell: clap_complete::Shell,
 }
 
 #[derive(clap::Args, Debug)]
@@ -154,4 +162,35 @@ pub struct VerifyArgs {
     /// Only verify against this drive
     #[arg(long)]
     pub drive: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn bare_urd_parses_to_none() {
+        let cli = Cli::try_parse_from(["urd"]).expect("bare urd should parse");
+        assert!(cli.command.is_none(), "bare urd should yield None command");
+    }
+
+    #[test]
+    fn completions_bash_parses() {
+        let cli =
+            Cli::try_parse_from(["urd", "completions", "bash"]).expect("completions should parse");
+        assert!(
+            matches!(cli.command, Some(Commands::Completions(_))),
+            "should parse as Completions"
+        );
+    }
+
+    #[test]
+    fn existing_commands_still_parse() {
+        let cli = Cli::try_parse_from(["urd", "status"]).expect("status should parse");
+        assert!(
+            matches!(cli.command, Some(Commands::Status)),
+            "status should parse as Some(Status)"
+        );
+    }
 }

--- a/src/commands/completions.rs
+++ b/src/commands/completions.rs
@@ -1,0 +1,53 @@
+use clap::CommandFactory;
+
+use crate::cli::{Cli, CompletionsArgs};
+
+pub fn run(args: &CompletionsArgs) -> anyhow::Result<()> {
+    let mut cmd = Cli::command();
+    clap_complete::generate(args.shell, &mut cmd, "urd", &mut std::io::stdout());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap_complete::Shell;
+
+    fn generate_to_string(shell: Shell) -> String {
+        let mut cmd = Cli::command();
+        let mut buf = Vec::new();
+        clap_complete::generate(shell, &mut cmd, "urd", &mut buf);
+        String::from_utf8(buf).expect("completions should be valid UTF-8")
+    }
+
+    #[test]
+    fn completions_bash_nonempty() {
+        let output = generate_to_string(Shell::Bash);
+        assert!(!output.is_empty(), "bash completions should not be empty");
+    }
+
+    #[test]
+    fn completions_zsh_nonempty() {
+        let output = generate_to_string(Shell::Zsh);
+        assert!(!output.is_empty(), "zsh completions should not be empty");
+    }
+
+    #[test]
+    fn completions_contains_subcommands() {
+        let output = generate_to_string(Shell::Bash);
+        assert!(output.contains("status"), "completions should contain 'status'");
+        assert!(output.contains("backup"), "completions should contain 'backup'");
+        assert!(output.contains("plan"), "completions should contain 'plan'");
+    }
+
+    #[test]
+    fn completions_works_without_config() {
+        // Completions must work without any config file — they only need the CLI definition.
+        // This test verifies the function succeeds without touching Config::load().
+        let args = CompletionsArgs { shell: Shell::Bash };
+        // run() writes to stdout which we can't easily capture in a unit test,
+        // but we can verify it doesn't error. The generate_to_string tests above
+        // verify the actual output content.
+        assert!(run(&args).is_ok(), "completions should work without config");
+    }
+}

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -1,0 +1,96 @@
+use std::path::Path;
+
+use crate::awareness;
+use crate::config;
+use crate::error::UrdError;
+use crate::output::{DefaultStatusOutput, OutputMode};
+use crate::plan::RealFileSystemState;
+use crate::state::StateDb;
+use crate::voice;
+
+pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<()> {
+    // Fallible config load with error discrimination (S1):
+    // file-not-found → first-time user; all other errors → surface.
+    let config = match config::Config::load(config_path) {
+        Ok(c) => c,
+        Err(UrdError::Io { ref source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
+            print!("{}", voice::render_first_time(output_mode));
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let state_db = if config.general.state_db.exists() {
+        StateDb::open(&config.general.state_db).ok()
+    } else {
+        None
+    };
+    let fs_state = RealFileSystemState {
+        state: state_db.as_ref(),
+    };
+
+    // Awareness assessment — lighter than status (no chain health, no drive info, no pins)
+    let now = chrono::Local::now().naive_local();
+    let mut assessments = awareness::assess(&config, now, &fs_state);
+    awareness::overlay_offsite_freshness(&mut assessments, &config);
+
+    let last_run = state_db.as_ref().and_then(|db| db.last_run_info());
+
+    // Pre-compute age for voice rendering (voice.rs must stay pure — no I/O)
+    let last_run_age_secs = last_run.as_ref().and_then(|run| {
+        let dt = chrono::NaiveDateTime::parse_from_str(&run.started_at, "%Y-%m-%dT%H:%M:%S")
+            .ok()?;
+        let age = now.signed_duration_since(dt).num_seconds();
+        if age >= 0 { Some(age) } else { None }
+    });
+
+    // Build output — single pass over assessments
+    let total = assessments.len();
+    let mut waning_names = Vec::new();
+    let mut exposed_names = Vec::new();
+    for a in &assessments {
+        match a.status {
+            awareness::PromiseStatus::AtRisk => waning_names.push(a.name.clone()),
+            awareness::PromiseStatus::Unprotected => exposed_names.push(a.name.clone()),
+            awareness::PromiseStatus::Protected => {}
+        }
+    }
+
+    let output = DefaultStatusOutput {
+        total,
+        waning_names,
+        exposed_names,
+        last_run,
+        last_run_age_secs,
+    };
+
+    print!("{}", voice::render_default_status(&output, output_mode));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn config_not_found_returns_ok() {
+        // A nonexistent config path should return Ok (first-time path), not an error.
+        let bogus = PathBuf::from("/tmp/urd-test-nonexistent-config-12345.toml");
+        let result = run(Some(&bogus), OutputMode::Daemon);
+        assert!(result.is_ok(), "config-not-found should return Ok: {result:?}");
+    }
+
+    #[test]
+    fn config_parse_error_surfaces_error() {
+        // A config file with invalid TOML should return an error, not the first-time message.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let bad_config = dir.path().join("bad.toml");
+        std::fs::write(&bad_config, "this is not valid toml [[[").expect("write bad config");
+        let result = run(Some(&bad_config), OutputMode::Daemon);
+        assert!(
+            result.is_err(),
+            "parse error should surface as Err, not first-time message: {result:?}"
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,7 @@
 pub mod backup;
 pub mod calibrate;
+pub mod completions;
+pub mod default;
 pub mod get;
 pub mod history;
 pub mod init;

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -3,7 +3,7 @@ use crate::chain;
 use crate::config::Config;
 use crate::drives;
 use crate::output::{
-    ChainHealth, ChainHealthEntry, DriveInfo, LastRunInfo, OutputMode, StatusAssessment,
+    ChainHealth, ChainHealthEntry, DriveInfo, OutputMode, StatusAssessment,
     StatusOutput,
 };
 use crate::plan::RealFileSystemState;
@@ -71,25 +71,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         .collect();
 
     // ── Last run ────────────────────────────────────────────────────
-    let last_run = state_db.as_ref().and_then(|db| match db.last_run() {
-        Ok(Some(run)) => {
-            let duration = run
-                .finished_at
-                .as_ref()
-                .and_then(|f| crate::types::format_run_duration(&run.started_at, f));
-            Some(LastRunInfo {
-                id: run.id,
-                started_at: run.started_at.clone(),
-                result: run.result.clone(),
-                duration,
-            })
-        }
-        Ok(None) => None,
-        Err(e) => {
-            log::warn!("Failed to query last run: {e}");
-            None
-        }
-    });
+    let last_run = state_db.as_ref().and_then(|db| db.last_run_info());
 
     // ── Pin count ───────────────────────────────────────────────────
     let total_pins: usize = config

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,11 +44,24 @@ fn main() -> anyhow::Result<()> {
         })
         .parse_default_env() // RUST_LOG still overrides if set
         .init();
-    let config = config::Config::load(cli.config.as_deref())?;
+
+    // Strategy A: config-free commands — dispatch before config load
+    if let Some(Commands::Completions(ref args)) = cli.command {
+        return commands::completions::run(args);
+    }
 
     let output_mode = output::OutputMode::detect();
 
-    match cli.command {
+    // Strategy B: bare urd — fallible config load (handled inside default::run)
+    if cli.command.is_none() {
+        return commands::default::run(cli.config.as_deref(), output_mode);
+    }
+
+    // Strategy C: mandatory config load (all existing commands)
+    let config = config::Config::load(cli.config.as_deref())?;
+
+    // Safe to unwrap: None case returned above
+    match cli.command.unwrap() {
         Commands::Plan(args) => commands::plan_cmd::run(config, args, output_mode),
         Commands::Backup(args) => commands::backup::run(config, args),
         Commands::Init => commands::init::run(config),
@@ -61,5 +74,6 @@ fn main() -> anyhow::Result<()> {
             cli::SentinelCommands::Run => commands::sentinel::run_daemon(config),
             cli::SentinelCommands::Status => commands::sentinel::status(config, output_mode),
         },
+        Commands::Completions(_) => unreachable!("handled above"),
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -192,6 +192,31 @@ pub struct LastRunInfo {
     pub duration: Option<String>,
 }
 
+// ── DefaultStatusOutput ────────────────────────────────────────────────
+
+/// Structured output for bare `urd` — one-sentence status.
+#[derive(Debug, Serialize)]
+pub struct DefaultStatusOutput {
+    /// Total number of configured subvolumes.
+    pub total: usize,
+    /// Names of subvolumes with AT RISK status.
+    pub waning_names: Vec<String>,
+    /// Names of subvolumes with UNPROTECTED status.
+    pub exposed_names: Vec<String>,
+    /// Last backup run info.
+    pub last_run: Option<LastRunInfo>,
+    /// Seconds since last backup started, pre-computed by the command handler.
+    pub last_run_age_secs: Option<i64>,
+}
+
+impl DefaultStatusOutput {
+    /// Number of sealed (PROTECTED) subvolumes, derived from total minus non-sealed.
+    #[must_use]
+    pub fn sealed_count(&self) -> usize {
+        self.total - self.waning_names.len() - self.exposed_names.len()
+    }
+}
+
 // ── GetOutput ──────────────────────────────────────────────────────────
 
 /// Structured output for the `urd get` command (metadata, not file content).

--- a/src/state.rs
+++ b/src/state.rs
@@ -248,6 +248,30 @@ impl StateDb {
         }
     }
 
+    /// Query last run and build a presentation-ready `LastRunInfo`.
+    #[must_use]
+    pub fn last_run_info(&self) -> Option<crate::output::LastRunInfo> {
+        match self.last_run() {
+            Ok(Some(run)) => {
+                let duration = run
+                    .finished_at
+                    .as_ref()
+                    .and_then(|f| crate::types::format_run_duration(&run.started_at, f));
+                Some(crate::output::LastRunInfo {
+                    id: run.id,
+                    started_at: run.started_at.clone(),
+                    result: run.result.clone(),
+                    duration,
+                })
+            }
+            Ok(None) => None,
+            Err(e) => {
+                log::warn!("Failed to query last run: {e}");
+                None
+            }
+        }
+    }
+
     /// Get the N most recent runs.
     pub fn recent_runs(&self, limit: usize) -> crate::error::Result<Vec<RunRecord>> {
         let mut stmt = self

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -12,10 +12,10 @@ use std::fmt::Write;
 use colored::Colorize;
 
 use crate::output::{
-    BackupSummary, CalibrateOutput, CalibrateResult, ChainHealth, FailuresOutput, GetOutput,
-    HistoryOutput, InitOutput, InitStatus, OutputMode, PlanOutput, SentinelStatusOutput,
-    SkipCategory, SkippedSubvolume, StatusOutput, SubvolumeHistoryOutput, VerifyOutput,
-    parse_duration_to_minutes,
+    BackupSummary, CalibrateOutput, CalibrateResult, ChainHealth, DefaultStatusOutput,
+    FailuresOutput, GetOutput, HistoryOutput, InitOutput, InitStatus, OutputMode, PlanOutput,
+    SentinelStatusOutput, SkipCategory, SkippedSubvolume, StatusOutput, SubvolumeHistoryOutput,
+    VerifyOutput, parse_duration_to_minutes,
 };
 use crate::plan::format_duration_short;
 use crate::types::{ByteSize, DriveRole};
@@ -1625,6 +1625,66 @@ fn format_tick_description(tick_secs: u64, promise_states: &[crate::output::Sent
     format!("{tick_str} — {state_desc}")
 }
 
+// ── Default status (bare `urd`) ────────────────────────────────────────
+
+/// Render bare `urd` one-sentence status.
+#[must_use]
+pub fn render_default_status(data: &DefaultStatusOutput, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => render_default_status_interactive(data),
+        OutputMode::Daemon => render_default_status_daemon(data),
+    }
+}
+
+fn render_default_status_daemon(data: &DefaultStatusOutput) -> String {
+    serde_json::to_string_pretty(data).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
+}
+
+fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
+    let mut out = String::new();
+
+    // Safety line
+    if data.sealed_count() == data.total {
+        write!(out, "{}", "All sealed.".green()).ok();
+    } else {
+        write!(out, "{} of {} sealed.", data.sealed_count(), data.total).ok();
+        if !data.exposed_names.is_empty() {
+            write!(out, " {} {}.", data.exposed_names.join(", "), "exposed".red()).ok();
+        }
+        if !data.waning_names.is_empty() {
+            write!(out, " {} waning.", data.waning_names.join(", ")).ok();
+        }
+    }
+
+    // Last backup age (pre-computed by command handler to keep voice pure)
+    if let Some(age_secs) = data.last_run_age_secs {
+        write!(out, " Last backup {} ago.", humanize_duration(age_secs)).ok();
+    }
+
+    writeln!(out).ok();
+
+    // Hint line
+    if data.sealed_count() == data.total {
+        writeln!(out, "Run `urd status` for details, `urd --help` for commands.").ok();
+    } else {
+        writeln!(out, "Run `urd status` for details.").ok();
+    }
+
+    out
+}
+
+/// Render first-time message (no config found).
+#[must_use]
+pub fn render_first_time(mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => {
+            "Urd is not configured yet.\nRun `urd init` to get started, or see `urd --help`.\n"
+                .to_string()
+        }
+        OutputMode::Daemon => r#"{"status":"not_configured"}"#.to_string(),
+    }
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -3226,5 +3286,155 @@ mod tests {
             output.contains("offsite copy stale"),
             "offsite degradation advisory should be rendered: {output}"
         );
+    }
+
+    // ── Default status tests ───────────────────────────────────────────
+
+    fn test_default_all_sealed() -> DefaultStatusOutput {
+        DefaultStatusOutput {
+            total: 4,
+            waning_names: vec![],
+            exposed_names: vec![],
+            last_run: Some(LastRunInfo {
+                id: 42,
+                started_at: "2026-03-31T21:00:00".to_string(),
+                result: "success".to_string(),
+                duration: Some("1m 30s".to_string()),
+            }),
+            last_run_age_secs: Some(25200), // 7 hours
+        }
+    }
+
+    #[test]
+    fn default_all_sealed() {
+        colored::control::set_override(false);
+        let output = render_default_status(&test_default_all_sealed(), OutputMode::Interactive);
+        assert!(output.contains("All sealed."), "missing 'All sealed.' in: {output}");
+        assert!(
+            output.contains("urd status"),
+            "missing hint to run urd status: {output}"
+        );
+        assert!(
+            output.contains("urd --help"),
+            "all-sealed should mention --help: {output}"
+        );
+    }
+
+    #[test]
+    fn default_some_exposed() {
+        colored::control::set_override(false);
+        let data = DefaultStatusOutput {
+            total: 9,
+            waning_names: vec![],
+            exposed_names: vec!["htpc-root".to_string(), "docs".to_string()],
+            last_run: None,
+            last_run_age_secs: None,
+        };
+        let output = render_default_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("7 of 9 sealed."),
+            "missing count in: {output}"
+        );
+        assert!(
+            output.contains("htpc-root, docs"),
+            "missing exposed names in: {output}"
+        );
+        assert!(
+            output.contains("exposed"),
+            "missing 'exposed' label in: {output}"
+        );
+        assert!(
+            !output.contains("urd --help"),
+            "non-sealed should not mention --help: {output}"
+        );
+    }
+
+    #[test]
+    fn default_some_waning() {
+        colored::control::set_override(false);
+        let data = DefaultStatusOutput {
+            total: 5,
+            waning_names: vec!["htpc-config".to_string()],
+            exposed_names: vec!["htpc-root".to_string()],
+            last_run: None,
+            last_run_age_secs: None,
+        };
+        let output = render_default_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("3 of 5 sealed."),
+            "missing count in: {output}"
+        );
+        assert!(
+            output.contains("htpc-root"),
+            "missing exposed name in: {output}"
+        );
+        assert!(
+            output.contains("htpc-config waning"),
+            "missing waning name in: {output}"
+        );
+    }
+
+    #[test]
+    fn default_with_last_backup() {
+        colored::control::set_override(false);
+        let output = render_default_status(&test_default_all_sealed(), OutputMode::Interactive);
+        assert!(
+            output.contains("Last backup 7h ago."),
+            "missing deterministic 'Last backup 7h ago.' in: {output}"
+        );
+    }
+
+    #[test]
+    fn default_no_last_backup() {
+        colored::control::set_override(false);
+        let data = DefaultStatusOutput {
+            total: 2,
+            waning_names: vec![],
+            exposed_names: vec![],
+            last_run: None,
+            last_run_age_secs: None,
+        };
+        let output = render_default_status(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("Last backup"),
+            "should not contain last backup when None: {output}"
+        );
+    }
+
+    #[test]
+    fn default_daemon_json() {
+        let data = DefaultStatusOutput {
+            total: 3,
+            waning_names: vec!["sv1".to_string()],
+            exposed_names: vec![],
+            last_run: None,
+            last_run_age_secs: None,
+        };
+        let output = render_default_status(&data, OutputMode::Daemon);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&output).expect("daemon output should be valid JSON");
+        assert_eq!(parsed["total"], 3);
+        assert_eq!(parsed["waning_names"][0], "sv1");
+    }
+
+    #[test]
+    fn first_time_interactive() {
+        let output = render_first_time(OutputMode::Interactive);
+        assert!(
+            output.contains("not configured yet"),
+            "missing 'not configured yet' in: {output}"
+        );
+        assert!(
+            output.contains("urd init"),
+            "missing 'urd init' guidance in: {output}"
+        );
+    }
+
+    #[test]
+    fn first_time_daemon_json() {
+        let output = render_first_time(OutputMode::Daemon);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&output).expect("daemon first-time should be valid JSON");
+        assert_eq!(parsed["status"], "not_configured");
     }
 }


### PR DESCRIPTION
## Summary

- **Bare `urd`** (no subcommand) shows a one-sentence status: "All sealed. Last backup 7h ago." or "3 of 9 sealed. htpc-root exposed." First-time users see `urd init` guidance.
- **`urd completions <shell>`** generates tab-completion scripts for bash/zsh/fish/elvish/powershell via clap_complete.
- **main.rs restructured** with three config-loading strategies: config-free (completions), fallible (bare urd), mandatory (everything else).
- Config error discrimination: file-not-found → first-time message; parse errors → surfaced to user.
- Arch-adversary review findings addressed: voice.rs purity restored, output.rs types-only boundary preserved, last_run_info() extracted to StateDb.

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 610 tests, all passing
- cargo build --release: clean
- Manual: `urd` (bare), `urd completions bash`, `urd --help`, `urd status` all verified
- Integration tests: not applicable (read-only diagnostic paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)