### PR TITLE
feat: mythic voice on backup transitions (Phase 4c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-01
+
 ### Added
 - Staleness escalation: disconnected drives show graduated urgency text based on awareness promise status (PROTECTED → minimal, AT RISK → "consider connecting", UNPROTECTED → "protection degrading")
 - Next-action suggestions: context-specific dimmed hints after `urd status`, `urd plan`, `urd backup`, `urd verify`, and bare `urd` (silence when healthy)
@@ -160,7 +162,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/vonrobak/urd/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/vonrobak/urd/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/vonrobak/urd/compare/v0.4.3...v0.5.0
 [0.4.3]: https://github.com/vonrobak/urd/compare/v0.4.2...v0.4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `urd retention-preview` command: shows recovery windows, disk estimates, and transient/graduated comparison for retention policies
 - RECOVERY column in `urd status` table showing compact retention summary per subvolume (e.g., "31d / 7mo / ∞")
 - `urd doctor` command: unified health check composing config, infrastructure, awareness, sentinel, and optional thread verification (`--thorough`)
+- Mythic voice on backup transitions: brief event-aware lines when threads are mended, first sends established, promises recovered, or all subvolumes reach sealed
 
 ### Changed
 - Offsite cycling advisory migrated from stringly-typed 7-day threshold to structured `OffsiteDriveStale` with 30-day threshold

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/99-reports/2026-04-01-arch-adversary-phase4c-transitions.md
+++ b/docs/99-reports/2026-04-01-arch-adversary-phase4c-transitions.md
@@ -1,0 +1,255 @@
+# Arch-Adversary Review: Phase 4c -- Mythic Voice on Transitions
+
+**Date:** 2026-04-01
+**Reviewer:** arch-adversary
+**Commit context:** Working tree (unstaged), 3 files modified, not yet committed
+**Base:** `5e353fc` (master, post Phase 4a+4b merge)
+**Type:** Implementation review
+
+**Files reviewed:**
+- `src/output.rs` (diff + full context around `BackupSummary`)
+- `src/commands/backup.rs` (diff + full context, lines 60--260 and 948--1040)
+- `src/voice.rs` (diff + full context, lines 660--718)
+- `src/awareness.rs` (types, `assess()` signature, `PromiseStatus` ordering)
+- `src/plan.rs` (`RealFileSystemState` -- no caching, live reads)
+
+**Tests:** 691 passing, 0 failures, clippy clean.
+
+---
+
+## 1. Executive Summary
+
+Phase 4c is a clean, minimal implementation of transition detection for backup output. The
+`detect_transitions()` function is pure, correctly placed after execution, and entirely
+confined to the presentation layer. The implementation addresses the design review's key
+findings (M3 derives, m1 rendering order, S2 best-effort semantics) and makes one good
+vocabulary choice deviating from the design doc ("first thread to X established" instead
+of "first copy sent to X"). No paths to catastrophic failure exist in this change.
+
+---
+
+## 2. What Kills You
+
+**Catastrophic failure mode: silent data loss from snapshot deletion.**
+
+Distance from catastrophic failure: **4+ bugs away.** This change:
+- Adds no writes to the filesystem
+- Adds no calls to `BtrfsOps`
+- Does not modify the planner, executor, or retention logic
+- Does not influence any control flow that determines what gets backed up or deleted
+- The pre-backup `assess()` call is read-only over `&dyn FileSystemState`
+
+The only theoretical path to harm would be if the pre-backup `assess()` call panicked and
+unwound past the lock acquisition, but `assess()` is a pure function over config and
+filesystem state with no panic paths in normal operation. Even in that case, the advisory
+lock would be released cleanly by the `Drop` impl.
+
+**Verdict: No concern.**
+
+---
+
+## 3. Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4/5 | Logic is sound; one edge case in `FirstSendToDrive` with unmounted drives (see M1) |
+| Security | 5/5 | No filesystem writes, no privilege escalation, pure presentation |
+| Architecture | 5/5 | Stays entirely in presentation layer; `detect_transitions()` is pure; no leakage into execution paths |
+| Systems Design | 4/5 | Pre-backup `assess()` placement is correct but doubles awareness computation cost |
+| Rust Idioms | 5/5 | Proper derives, idiomatic pattern matching, `HashMap` for O(1) lookup, no allocations in hot paths |
+| Code Quality | 4/5 | Good test coverage (8 tests); one missing edge case test; `from`/`to` as `String` instead of typed |
+
+**Overall: 4.5/5** -- Solid implementation of a low-risk, presentation-layer feature.
+
+---
+
+## 4. Design Tensions
+
+### Tension 1: Doubled awareness computation vs. transition accuracy
+
+The pre-backup `assess()` call runs the full awareness model a second time. For 9
+subvolumes this is negligible (microseconds of pure computation), but the pattern sets a
+precedent. The design review (item 3 in "Ready for Review") flagged this and suggested
+lazy computation. The implementation chose the simpler full-assess approach, which is
+the right call at this scale.
+
+### Tension 2: `from`/`to` as `String` vs. typed `PromiseStatus`
+
+`PromiseRecovered` stores `from` and `to` as `String` (via `format!("{}", status)`).
+This works for rendering and JSON serialization, but loses type information. If any
+future consumer needs to branch on the specific status values, it would need to parse
+strings back. The alternative (storing `PromiseStatus` directly) would require adding
+`Serialize` to `PromiseStatus` in `awareness.rs`, which may not be desirable since
+awareness is a pure-function module. The current approach is pragmatic.
+
+### Tension 3: Transition detection granularity
+
+The implementation detects four transition types. The design doc lists exactly these four.
+But there are plausible transitions not covered: drive went from unmounted to mounted
+during backup (very unlikely), retention freed significant space, a full send replaced
+a broken chain. These are all either unlikely during a single backup run or already
+covered by ThreadRestored. The four-variant enum is the right scope.
+
+---
+
+## 5. Findings
+
+### Moderate
+
+**M1: `FirstSendToDrive` treats unmounted drives (`snapshot_count: None`) as empty (`0`).**
+
+In `detect_transitions()`, line 989: `post_ext.snapshot_count.unwrap_or(0)` and line 995:
+`pre_ext.snapshot_count.unwrap_or(0)`. If a drive was unmounted pre-backup (`None`) and
+mounted post-backup with existing snapshots, this would fire `FirstSendToDrive` even
+though the snapshots already existed -- the drive was just away.
+
+**Likelihood:** Very low. Drives don't typically get mounted mid-backup. The executor
+skips sends to unmounted drives, so post-backup assessment would still show the drive
+as having existing snapshots only if it was mounted the whole time.
+
+**Recommendation:** Add a guard: only consider `FirstSendToDrive` when the drive was
+mounted in both pre and post assessments. Or document this as a known best-effort edge
+case. Low priority -- this produces a false-positive voice line, not data loss.
+
+**M2: No test for the unmounted-drive edge case.**
+
+The test suite covers the happy paths well (8 tests), but doesn't exercise the
+`snapshot_count: None` path. A test with `make_drive_assessment("X", None)` in pre
+and `make_drive_assessment("X", Some(5))` in post would document the current behavior.
+
+**Recommendation:** Add one test to pin the behavior, whichever way you want it to go.
+
+### Minor
+
+**m1: Voice line for `PromiseRecovered` is purely mechanical.**
+
+The other three transition types have evocative language ("thread mended", "first thread
+established", "all threads hold"). But `PromiseRecovered` renders as
+`"htpc-home: UNPROTECTED -> PROTECTED."` -- a status change log, not a mythic voice line.
+This is the one transition that doesn't match the "norn speaks" character.
+
+**Recommendation:** Consider something like `"htpc-home: woven back from the exposed."` or
+at minimum `"htpc-home: restored to sealed."` using the vocabulary decisions (sealed,
+waning, exposed). The current form uses the raw `PromiseStatus::Display` output
+(UNPROTECTED, PROTECTED) rather than the user-facing vocabulary (exposed, sealed). This
+is a vocabulary consistency issue.
+
+**m2: `AllSealed` and per-subvolume `PromiseRecovered` can fire together redundantly.**
+
+When the last subvolume recovers to Protected, both `PromiseRecovered` for that subvolume
+and `AllSealed` fire. The multiple_transitions test verifies this intentionally. The output
+would read:
+
+```
+  a: UNPROTECTED -> PROTECTED.
+  b: AT RISK -> PROTECTED.
+  All threads hold.
+```
+
+This is mildly redundant but not wrong. The "All threads hold" line serves as a capstone.
+If this feels noisy, `AllSealed` could suppress individual `PromiseRecovered` events, but
+the current approach is simpler and defensible.
+
+**m3: Design doc says "first copy sent to" but implementation says "first thread to ... established".**
+
+This is a conscious improvement -- "thread" is the correct user-facing vocabulary per the
+vocabulary decisions. The design doc should be updated for consistency, but no code change
+needed.
+
+### Commendation
+
+**C1: Pre-assessment placement is exactly right.**
+
+The `pre_assessments` block (line 169-176) is placed after all early returns (dry-run at
+line 81, nothing-to-do at line 92) and after all plan mutations (promise retention filter,
+drive token verification). This means:
+- No wasted computation on dry runs
+- The pre-assessment reflects the actual state just before execution begins
+- The lock is already held, preventing concurrent modifications
+
+This is careful placement that shows understanding of the backup command's control flow.
+
+**C2: Pure function with clean separation.**
+
+`detect_transitions()` takes two `&[SubvolAssessment]` slices and returns `Vec<TransitionEvent>`.
+No I/O, no side effects, no references to config or filesystem. This is textbook ADR-108
+compliance. The function could be moved to any module without changing its signature.
+
+**C3: Test coverage matches the design doc's test strategy.**
+
+The design doc proposed ~8 tests. The implementation has 8 tests covering: thread restored,
+first send, all sealed, promise recovered, no transitions (routine), multiple transitions,
+all-sealed-not-fired-when-already-sealed, and degradation-is-not-a-transition. Each test
+is focused and readable.
+
+**C4: Design review findings addressed.**
+
+| Finding | Status |
+|---------|--------|
+| S1 (voice/awareness threshold consistency) | Not in scope for 4c (4a concern) |
+| S2 (pre/post assessment error handling) | Addressed: best-effort, empty transitions on failure (assessment can't fail -- it's pure) |
+| M1 (doctor all-clear suggestion) | Addressed in Phase 4b (returns `None`) |
+| M2 (suggestions for nonexistent commands) | Addressed in Phase 4b (`urd doctor` now exists) |
+| M3 (TransitionEvent derives) | Addressed: `#[derive(Debug, Clone, PartialEq, Eq, Serialize)]` |
+| m1 (rendering order) | Addressed: transitions before suggestions (line 679-684 in voice.rs) |
+| m2 (thread vs chain vocabulary) | Addressed: function operates on chain data, user-facing text says "thread" |
+
+---
+
+## 6. The Simplicity Question
+
+**Is this implementation as simple as it could be?**
+
+Yes. The implementation is:
+- 1 enum with 4 variants (output.rs, 18 lines)
+- 1 pure detection function (backup.rs, 60 lines)
+- 1 rendering function (voice.rs, 30 lines)
+- 8 tests (backup.rs, 236 lines)
+- 5 lines of wiring (pre-assessment capture + summary construction)
+
+The detection function uses a straightforward pre/post diff pattern. No framework, no
+trait abstractions, no configuration. The rendering is a simple `match` with `writeln!`.
+
+The one simplification opportunity noted in the design review -- capturing only specific
+data instead of running full `assess()` -- would save negligible computation while adding
+a second, narrower assessment type to maintain. The current approach is simpler to reason
+about and maintain.
+
+---
+
+## 7. For the Dev Team
+
+**Priority order:**
+
+1. **(M1) Decide on unmounted-drive behavior for `FirstSendToDrive`.** Either add a
+   `mounted` guard or document the best-effort semantics. Add a test either way (M2).
+   Effort: 10 minutes.
+
+2. **(m1) Consider using vocabulary-consistent terms in `PromiseRecovered` rendering.**
+   "sealed" instead of "PROTECTED", "exposed" instead of "UNPROTECTED". This aligns
+   with the vocabulary decisions and the other transition voice lines. Effort: 5 minutes.
+
+3. **(m3) Update design doc** to reflect the "first thread established" wording.
+   Effort: 1 minute.
+
+---
+
+## 8. Open Questions
+
+1. **Should transitions appear in daemon/JSON mode?** The `TransitionEvent` has `Serialize`
+   and the `transitions` field has `skip_serializing_if = "Vec::is_empty"`. So in JSON
+   mode, transitions will serialize as structured data. Is any consumer ready to parse
+   these? The Sentinel? The heartbeat? If not, this is forward-compatible and harmless,
+   but worth confirming that no downstream consumer will break on the new field.
+
+2. **Should `PromiseRecovered` use the awareness `PromiseStatus` type instead of `String`?**
+   If awareness ever gains `Serialize` (likely for heartbeat/JSON output), the `from`/`to`
+   fields could be typed. Current approach works but loses round-trip fidelity. Low priority
+   since the strings match `Display` output exactly.
+
+3. **Should transition detection run for the "nothing to do" path?** Currently, when
+   `backup_plan.is_empty()` (line 92), the function returns early without transition
+   detection. This is correct -- no operations means no transitions. But if a time-based
+   promise status change occurred (e.g., a drive's staleness crossed a threshold between
+   the heartbeat timestamp and now), it would be missed. This is by design (transitions
+   are for backup-caused changes), but worth stating explicitly.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use colored::Colorize;
 
-use crate::awareness::{self, SubvolAssessment};
+use crate::awareness::{self, ChainStatus, PromiseStatus, SubvolAssessment};
 use crate::btrfs::RealBtrfs;
 use crate::cli::BackupArgs;
 use crate::config::Config;
@@ -20,7 +20,7 @@ use crate::lock;
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
 use crate::output::{
     BackupSummary, OutputMode, SendSummary, SkipCategory, SkippedSubvolume, StatusAssessment,
-    StructuredError, SubvolumeSummary,
+    StructuredError, SubvolumeSummary, TransitionEvent,
 };
 use crate::notify;
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
@@ -166,6 +166,15 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         }
     }
 
+    // Snapshot awareness state before execution so we can detect transitions
+    // (thread restored, promise recovered, etc.) by diffing with post-backup state.
+    let pre_assessments = {
+        let pre_now = chrono::Local::now().naive_local();
+        let mut pre = awareness::assess(&config, pre_now, &fs_state);
+        awareness::overlay_offsite_freshness(&mut pre, &config);
+        pre
+    };
+
     // Build progress context after token filtering so counters reflect actual work.
     let total_sends = backup_plan.summary().sends as u32;
     let size_estimates = build_size_estimates(&backup_plan, &fs_state);
@@ -228,10 +237,15 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     }
 
     // Build and render structured summary
+    let transitions = detect_transitions(&pre_assessments, &assessments);
+    if !transitions.is_empty() {
+        log::debug!("Detected {} transition(s)", transitions.len());
+    }
     let summary = build_backup_summary(
         &backup_plan,
         &result,
         &assessments,
+        transitions,
         exec_duration,
         &preflight_warnings,
     );
@@ -255,6 +269,7 @@ fn build_backup_summary(
     plan: &BackupPlan,
     result: &ExecutionResult,
     assessments: &[SubvolAssessment],
+    transitions: Vec<TransitionEvent>,
     duration: Duration,
     preflight_warnings: &[preflight::PreflightCheck],
 ) -> BackupSummary {
@@ -410,6 +425,7 @@ fn build_backup_summary(
             .iter()
             .map(StatusAssessment::from_assessment)
             .collect(),
+        transitions,
         warnings,
     }
 }
@@ -932,12 +948,94 @@ fn filter_promise_retention(config: &Config, plan: &mut BackupPlan) {
     }
 }
 
+// ── Transition detection ────────────────────────────────────────────────
+
+/// Detect meaningful state changes by comparing pre-backup and post-backup
+/// awareness assessments. Pure function: two assessment snapshots in,
+/// transition events out.
+fn detect_transitions(
+    pre: &[SubvolAssessment],
+    post: &[SubvolAssessment],
+) -> Vec<TransitionEvent> {
+    let pre_by_name: HashMap<&str, &SubvolAssessment> =
+        pre.iter().map(|a| (a.name.as_str(), a)).collect();
+
+    let mut transitions = Vec::new();
+
+    for post_a in post {
+        let Some(pre_a) = pre_by_name.get(post_a.name.as_str()) else {
+            continue;
+        };
+
+        // Thread restored: chain was Broken, now Intact
+        for post_ch in &post_a.chain_health {
+            if !matches!(post_ch.status, ChainStatus::Intact { .. }) {
+                continue;
+            }
+            let was_broken = pre_a.chain_health.iter().any(|pre_ch| {
+                pre_ch.drive_label == post_ch.drive_label
+                    && matches!(pre_ch.status, ChainStatus::Broken { .. })
+            });
+            if was_broken {
+                transitions.push(TransitionEvent::ThreadRestored {
+                    subvolume: post_a.name.clone(),
+                    drive: post_ch.drive_label.clone(),
+                });
+            }
+        }
+
+        // First send to drive: mounted with zero snapshots before, has some now.
+        // Only fires for drives that were mounted pre-backup (Some(0)), not
+        // drives that were unmounted (None) — a drive appearing mid-backup
+        // with existing snapshots is not a "first send".
+        for post_ext in &post_a.external {
+            let post_count = post_ext.snapshot_count.unwrap_or(0);
+            if post_count == 0 {
+                continue;
+            }
+            let was_mounted_empty = pre_a.external.iter().any(|pre_ext| {
+                pre_ext.drive_label == post_ext.drive_label
+                    && pre_ext.snapshot_count == Some(0)
+            });
+            if was_mounted_empty {
+                transitions.push(TransitionEvent::FirstSendToDrive {
+                    subvolume: post_a.name.clone(),
+                    drive: post_ext.drive_label.clone(),
+                });
+            }
+        }
+
+        // Promise recovered: status improved
+        if post_a.status > pre_a.status {
+            transitions.push(TransitionEvent::PromiseRecovered {
+                subvolume: post_a.name.clone(),
+                from: format!("{}", pre_a.status),
+                to: format!("{}", post_a.status),
+            });
+        }
+    }
+
+    // AllSealed: all post are Protected, but not all pre were
+    let all_post_protected = !post.is_empty()
+        && post.iter().all(|a| a.status == PromiseStatus::Protected);
+    let any_pre_not_protected = pre.iter().any(|a| a.status != PromiseStatus::Protected);
+    if all_post_protected && any_pre_not_protected {
+        transitions.push(TransitionEvent::AllSealed);
+    }
+
+    transitions
+}
+
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::awareness::{LocalAssessment, OperationalHealth, PromiseStatus, SubvolAssessment};
+    use crate::awareness::{
+        ChainBreakReason, ChainStatus, DriveAssessment, DriveChainHealth, LocalAssessment,
+        OperationalHealth, PromiseStatus, SubvolAssessment,
+    };
+    use crate::types::DriveRole;
     use crate::executor::{
         ExecutionResult, OpResult, OperationOutcome, RunResult, SendType, SubvolumeResult,
         TransientCleanupOutcome,
@@ -1049,6 +1147,7 @@ mod tests {
             &empty_plan(),
             &result,
             &empty_assessments(),
+            vec![],
             Duration::from_secs(5),
             &[],
         );
@@ -1102,6 +1201,7 @@ mod tests {
             &empty_plan(),
             &result,
             &empty_assessments(),
+            vec![],
             Duration::from_secs(120),
             &[],
         );
@@ -1129,6 +1229,7 @@ mod tests {
             &empty_plan(),
             &result,
             &empty_assessments(),
+            vec![],
             Duration::from_secs(1),
             &[],
         );
@@ -1150,6 +1251,7 @@ mod tests {
             &empty_plan(),
             &result,
             &empty_assessments(),
+            vec![],
             Duration::from_secs(1),
             &[],
         );
@@ -1201,6 +1303,7 @@ mod tests {
             &plan,
             &result,
             &empty_assessments(),
+            vec![],
             Duration::from_secs(1),
             &[],
         );
@@ -1233,6 +1336,7 @@ mod tests {
             &plan,
             &result,
             &empty_assessments(),
+            vec![],
             Duration::from_secs(0),
             &[],
         );
@@ -1256,6 +1360,7 @@ mod tests {
             &empty_plan(),
             &result,
             &sample_assessments(),
+            vec![],
             Duration::from_secs(1),
             &[],
         );
@@ -1277,6 +1382,7 @@ mod tests {
             &empty_plan(),
             &result,
             &empty_assessments(),
+            vec![],
             Duration::from_millis(12300),
             &[],
         );
@@ -1312,6 +1418,7 @@ mod tests {
             &empty_plan(),
             &result,
             &empty_assessments(),
+            vec![],
             Duration::from_secs(1),
             &[],
         );
@@ -1706,5 +1813,265 @@ mod tests {
             subvolumes: vec![],
             notifications: NotificationConfig::default(),
         }
+    }
+
+    // ── Transition detection tests ──────────────────────────────────
+
+    fn make_assessment(
+        name: &str,
+        status: PromiseStatus,
+        chain_health: Vec<DriveChainHealth>,
+        external: Vec<DriveAssessment>,
+    ) -> SubvolAssessment {
+        SubvolAssessment {
+            name: name.to_string(),
+            status,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
+            local: LocalAssessment {
+                status: PromiseStatus::Protected,
+                snapshot_count: 10,
+                newest_age: None,
+                configured_interval: Interval::hours(1),
+            },
+            external,
+            chain_health,
+            advisories: vec![],
+            redundancy_advisories: vec![],
+            errors: vec![],
+        }
+    }
+
+    fn make_drive_assessment(label: &str, count: Option<usize>) -> DriveAssessment {
+        DriveAssessment {
+            drive_label: label.to_string(),
+            status: PromiseStatus::Protected,
+            mounted: true,
+            snapshot_count: count,
+            last_send_age: None,
+            configured_interval: Interval::hours(4),
+            role: DriveRole::Primary,
+        }
+    }
+
+    #[test]
+    fn detect_thread_restored() {
+        let pre = vec![make_assessment(
+            "htpc-home",
+            PromiseStatus::Protected,
+            vec![DriveChainHealth {
+                drive_label: "WD-18TB".to_string(),
+                status: ChainStatus::Broken {
+                    reason: ChainBreakReason::PinMissingOnDrive,
+                    pin_parent: Some("20260401-0400-htpc-home".to_string()),
+                },
+            }],
+            vec![make_drive_assessment("WD-18TB", Some(5))],
+        )];
+        let post = vec![make_assessment(
+            "htpc-home",
+            PromiseStatus::Protected,
+            vec![DriveChainHealth {
+                drive_label: "WD-18TB".to_string(),
+                status: ChainStatus::Intact {
+                    pin_parent: "20260401-1200-htpc-home".to_string(),
+                },
+            }],
+            vec![make_drive_assessment("WD-18TB", Some(6))],
+        )];
+
+        let transitions = detect_transitions(&pre, &post);
+        assert_eq!(
+            transitions,
+            vec![TransitionEvent::ThreadRestored {
+                subvolume: "htpc-home".to_string(),
+                drive: "WD-18TB".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn detect_first_send_to_drive() {
+        let pre = vec![make_assessment(
+            "docs",
+            PromiseStatus::AtRisk,
+            vec![],
+            vec![make_drive_assessment("WD-18TB", Some(0))],
+        )];
+        let post = vec![make_assessment(
+            "docs",
+            PromiseStatus::Protected,
+            vec![],
+            vec![make_drive_assessment("WD-18TB", Some(1))],
+        )];
+
+        let transitions = detect_transitions(&pre, &post);
+        assert!(transitions.contains(&TransitionEvent::FirstSendToDrive {
+            subvolume: "docs".to_string(),
+            drive: "WD-18TB".to_string(),
+        }));
+    }
+
+    #[test]
+    fn detect_all_sealed() {
+        let pre = vec![
+            make_assessment("a", PromiseStatus::Protected, vec![], vec![]),
+            make_assessment("b", PromiseStatus::AtRisk, vec![], vec![]),
+        ];
+        let post = vec![
+            make_assessment("a", PromiseStatus::Protected, vec![], vec![]),
+            make_assessment("b", PromiseStatus::Protected, vec![], vec![]),
+        ];
+
+        let transitions = detect_transitions(&pre, &post);
+        assert!(transitions.contains(&TransitionEvent::AllSealed));
+    }
+
+    #[test]
+    fn detect_promise_recovered() {
+        let pre = vec![make_assessment(
+            "htpc-home",
+            PromiseStatus::Unprotected,
+            vec![],
+            vec![],
+        )];
+        let post = vec![make_assessment(
+            "htpc-home",
+            PromiseStatus::Protected,
+            vec![],
+            vec![],
+        )];
+
+        let transitions = detect_transitions(&pre, &post);
+        assert!(transitions.contains(&TransitionEvent::PromiseRecovered {
+            subvolume: "htpc-home".to_string(),
+            from: "UNPROTECTED".to_string(),
+            to: "PROTECTED".to_string(),
+        }));
+    }
+
+    #[test]
+    fn no_transitions_routine_backup() {
+        let pre = vec![
+            make_assessment("a", PromiseStatus::Protected, vec![], vec![]),
+            make_assessment("b", PromiseStatus::Protected, vec![], vec![]),
+        ];
+        let post = vec![
+            make_assessment("a", PromiseStatus::Protected, vec![], vec![]),
+            make_assessment("b", PromiseStatus::Protected, vec![], vec![]),
+        ];
+
+        let transitions = detect_transitions(&pre, &post);
+        assert!(transitions.is_empty(), "routine backup should have no transitions");
+    }
+
+    #[test]
+    fn multiple_transitions() {
+        let pre = vec![
+            make_assessment(
+                "a",
+                PromiseStatus::Unprotected,
+                vec![DriveChainHealth {
+                    drive_label: "WD-18TB".to_string(),
+                    status: ChainStatus::Broken {
+                        reason: ChainBreakReason::NoPinFile,
+                        pin_parent: None,
+                    },
+                }],
+                vec![make_drive_assessment("WD-18TB", Some(0))],
+            ),
+            make_assessment("b", PromiseStatus::AtRisk, vec![], vec![]),
+        ];
+        let post = vec![
+            make_assessment(
+                "a",
+                PromiseStatus::Protected,
+                vec![DriveChainHealth {
+                    drive_label: "WD-18TB".to_string(),
+                    status: ChainStatus::Intact {
+                        pin_parent: "20260401-1200-a".to_string(),
+                    },
+                }],
+                vec![make_drive_assessment("WD-18TB", Some(1))],
+            ),
+            make_assessment("b", PromiseStatus::Protected, vec![], vec![]),
+        ];
+
+        let transitions = detect_transitions(&pre, &post);
+        // Should detect: ThreadRestored, FirstSendToDrive, PromiseRecovered (for a and b), AllSealed
+        assert!(transitions.len() >= 4, "expected multiple transitions, got {transitions:?}");
+        assert!(transitions.contains(&TransitionEvent::AllSealed));
+        assert!(transitions.contains(&TransitionEvent::ThreadRestored {
+            subvolume: "a".to_string(),
+            drive: "WD-18TB".to_string(),
+        }));
+    }
+
+    #[test]
+    fn all_sealed_not_fired_when_already_sealed() {
+        let pre = vec![
+            make_assessment("a", PromiseStatus::Protected, vec![], vec![]),
+            make_assessment("b", PromiseStatus::Protected, vec![], vec![]),
+        ];
+        let post = vec![
+            make_assessment("a", PromiseStatus::Protected, vec![], vec![]),
+            make_assessment("b", PromiseStatus::Protected, vec![], vec![]),
+        ];
+
+        let transitions = detect_transitions(&pre, &post);
+        assert!(
+            !transitions.contains(&TransitionEvent::AllSealed),
+            "AllSealed should not fire when already all sealed"
+        );
+    }
+
+    #[test]
+    fn promise_degraded_not_a_transition() {
+        let pre = vec![make_assessment(
+            "htpc-home",
+            PromiseStatus::Protected,
+            vec![],
+            vec![],
+        )];
+        let post = vec![make_assessment(
+            "htpc-home",
+            PromiseStatus::AtRisk,
+            vec![],
+            vec![],
+        )];
+
+        let transitions = detect_transitions(&pre, &post);
+        assert!(
+            transitions.is_empty(),
+            "degradation should not produce transitions"
+        );
+    }
+
+    #[test]
+    fn first_send_not_fired_for_unmounted_drive() {
+        // Drive was unmounted (snapshot_count: None) pre-backup, mounted with
+        // existing snapshots post-backup. This is not a "first send" — the
+        // snapshots already existed, the drive was just away.
+        let pre = vec![make_assessment(
+            "docs",
+            PromiseStatus::Protected,
+            vec![],
+            vec![make_drive_assessment("WD-18TB", None)],
+        )];
+        let post = vec![make_assessment(
+            "docs",
+            PromiseStatus::Protected,
+            vec![],
+            vec![make_drive_assessment("WD-18TB", Some(5))],
+        )];
+
+        let transitions = detect_transitions(&pre, &post);
+        assert!(
+            !transitions.contains(&TransitionEvent::FirstSendToDrive {
+                subvolume: "docs".to_string(),
+                drive: "WD-18TB".to_string(),
+            }),
+            "should not fire FirstSendToDrive for previously unmounted drive"
+        );
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -475,8 +475,32 @@ pub struct BackupSummary {
     /// Per-subvolume promise status AFTER the run (from awareness model).
     pub assessments: Vec<StatusAssessment>,
 
+    /// State transitions detected during this run (pre/post awareness diff).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transitions: Vec<TransitionEvent>,
+
     /// Summary warnings (pin failures, skipped deletions, etc.)
     pub warnings: Vec<String>,
+}
+
+/// A meaningful state change detected by comparing pre-backup and post-backup
+/// awareness assessments. Rendered as brief voice lines in interactive mode;
+/// serialized as structured JSON in daemon mode.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TransitionEvent {
+    /// Incremental chain was broken before backup, now intact.
+    ThreadRestored { subvolume: String, drive: String },
+    /// Drive had no snapshots for this subvolume before, now has at least one.
+    FirstSendToDrive { subvolume: String, drive: String },
+    /// All subvolumes reached Protected status (and weren't all Protected before).
+    AllSealed,
+    /// A subvolume's promise status improved (e.g., Unprotected → Protected).
+    PromiseRecovered {
+        subvolume: String,
+        from: String,
+        to: String,
+    },
 }
 
 /// Per-subvolume execution summary.

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -676,11 +676,52 @@ fn render_backup_interactive(data: &BackupSummary) -> String {
         }
     }
 
+    // ── Transitions (mythic voice on events) ─────────────────────────
+    render_transitions(&data.transitions, &mut out);
+
     // ── Next-action suggestion ──────────────────────────────────────
     let has_failures = data.subvolumes.iter().any(|sv| !sv.success);
     append_suggestion(&SuggestionContext::Backup { has_failures }, &mut out);
 
     out
+}
+
+/// Render transition events as brief mythic voice lines.
+/// Each transition gets one line. Empty transitions produce no output.
+fn render_transitions(transitions: &[crate::output::TransitionEvent], out: &mut String) {
+    use crate::output::TransitionEvent;
+
+    if transitions.is_empty() {
+        return;
+    }
+    writeln!(out).ok();
+    for t in transitions {
+        match t {
+            TransitionEvent::ThreadRestored { subvolume, drive } => {
+                writeln!(out, "  {}: thread to {} mended.", subvolume, drive).ok();
+            }
+            TransitionEvent::FirstSendToDrive { subvolume, drive } => {
+                writeln!(out, "  {}: first thread to {} established.", subvolume, drive).ok();
+            }
+            TransitionEvent::AllSealed => {
+                writeln!(out, "  All threads hold.").ok();
+            }
+            TransitionEvent::PromiseRecovered {
+                subvolume,
+                from,
+                to,
+            } => {
+                writeln!(
+                    out,
+                    "  {}: {} \u{2192} {}.",
+                    subvolume,
+                    exposure_label(from),
+                    exposure_label(to),
+                )
+                .ok();
+            }
+        }
+    }
 }
 
 fn format_send_info(sends: &[crate::output::SendSummary]) -> String {
@@ -2261,8 +2302,8 @@ mod tests {
         ChainHealthEntry, DriveInfo, HistoryOutput, HistoryRun, InitCheck, InitDriveStatus,
         InitOutput, InitPinFile, InitSnapshotCount, InitStatus, LastRunInfo, PlanOperationEntry,
         PlanOutput, PlanSummaryOutput, SendSummary, SkipCategory, SkippedSubvolume,
-        StatusAssessment, StatusDriveAssessment, SubvolumeSummary, VerifyCheck, VerifyDrive,
-        VerifyOutput, VerifySubvolume,
+        StatusAssessment, StatusDriveAssessment, SubvolumeSummary, TransitionEvent, VerifyCheck,
+        VerifyDrive, VerifyOutput, VerifySubvolume,
     };
 
     fn test_status_output() -> StatusOutput {
@@ -2647,6 +2688,7 @@ mod tests {
                 retention_summary: None,
                 errors: vec![],
             }],
+            transitions: vec![],
             warnings: vec![],
         }
     }
@@ -2841,6 +2883,7 @@ mod tests {
                 },
             ],
             assessments: vec![],
+            transitions: vec![],
             warnings: vec![],
         };
         let output = render_backup_summary(&data, OutputMode::Interactive);
@@ -4801,5 +4844,63 @@ mod tests {
         assert!(output.contains("All clear."), "missing verdict: {output}");
         // The suggestion system returns None for doctor, so no "urd" command in suggestion
         // (verdict line already contains guidance for non-healthy cases)
+    }
+
+    // ── Transition rendering tests ──────────────────────────────────
+
+    #[test]
+    fn render_transitions_interactive() {
+        colored::control::set_override(false);
+        let mut summary = test_backup_summary();
+        summary.transitions = vec![
+            TransitionEvent::ThreadRestored {
+                subvolume: "htpc-home".to_string(),
+                drive: "WD-18TB".to_string(),
+            },
+            TransitionEvent::FirstSendToDrive {
+                subvolume: "docs".to_string(),
+                drive: "WD-18TB1".to_string(),
+            },
+            TransitionEvent::PromiseRecovered {
+                subvolume: "htpc-home".to_string(),
+                from: "UNPROTECTED".to_string(),
+                to: "PROTECTED".to_string(),
+            },
+            TransitionEvent::AllSealed,
+        ];
+
+        let output = render_backup_summary(&summary, OutputMode::Interactive);
+        assert!(
+            output.contains("thread to WD-18TB mended"),
+            "missing thread restored: {output}"
+        );
+        assert!(
+            output.contains("first thread to WD-18TB1 established"),
+            "missing first send: {output}"
+        );
+        assert!(
+            output.contains("exposed \u{2192} sealed"),
+            "missing promise recovered: {output}"
+        );
+        assert!(
+            output.contains("All threads hold."),
+            "missing all sealed: {output}"
+        );
+    }
+
+    #[test]
+    fn no_transitions_no_output() {
+        colored::control::set_override(false);
+        let summary = test_backup_summary();
+        assert!(summary.transitions.is_empty());
+        let output = render_backup_summary(&summary, OutputMode::Interactive);
+        assert!(
+            !output.contains("thread"),
+            "should have no transition text: {output}"
+        );
+        assert!(
+            !output.contains("All threads hold"),
+            "should have no all-sealed text: {output}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Transition detection**: pure `detect_transitions()` function diffs pre-backup and post-backup awareness assessments to identify meaningful state changes
- **Four transition types**: thread restored, first send to drive, promise recovered, all sealed — each rendered as a brief mythic voice line
- **Vocabulary-consistent**: uses exposure labels (sealed/waning/exposed) not raw status names; unmounted-drive guard prevents false positives on FirstSendToDrive
- **Completes the Voice & UX arc** (Priority 6, Phase 4 complete)

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 692 tests, all passing
- Integration tests: not applicable (presentation layer only)
- Arch-adversary review: 4.5/5, 0 critical, findings addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)