### PR TITLE
docs: workflow system overhaul — UPI, registry, /sequence, roadmap rewrite

### DIFF
--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -4,6 +4,17 @@ Decompose an idea or feature into an architecturally sound, implementable design
 
 Read CLAUDE.md (module table, invariants), `docs/96-project-supervisor/status.md` (current state), and any relevant ideas in `docs/95-ideas/`. Understand what exists before proposing what to build.
 
+## UPI Assignment
+
+Every design gets a Unique Project Identifier (UPI). Before writing the design doc:
+
+1. Read `docs/96-project-supervisor/registry.md`
+2. Find the highest existing UPI group number
+3. Assign the next number: `NNN` for standalone items, `NNN-a` for the first sub-item
+   in a group (user specifies if this is a sub-item of an existing group)
+4. After writing the design doc, add a row to registry.md (newest at top) with UPI, title,
+   and design doc link. Fill other columns with `-`.
+
 ## Core job
 
 1. **Decompose to module level.** Which existing modules are affected? What new types/traits/enums? What's the data flow? What's the test strategy? If an operation doesn't fit cleanly into one module per CLAUDE.md's table, that's a design signal.
@@ -23,9 +34,21 @@ Read CLAUDE.md (module table, invariants), `docs/96-project-supervisor/status.md
 
 ## Output
 
-For features affecting >3 files or introducing new modules: write a design proposal per CONTRIBUTING.md template to `docs/95-ideas/YYYY-MM-DD-design-slug.md` (status: proposed). Include a **Ready for Review** section telling the arch-adversary what to focus on.
+For features affecting >3 files or introducing new modules: write a design proposal to
+`docs/95-ideas/YYYY-MM-DD-design-{UPI}-{slug}.md` with YAML frontmatter and status `proposed`.
+Include a **Ready for Review** section telling the arch-adversary what to focus on.
 
-For smaller features: deliver the decomposition conversationally with module mapping, effort estimate, and any gate flags.
+**Frontmatter format:**
+
+```yaml
+---
+upi: "001-a"
+status: proposed
+date: YYYY-MM-DD
+---
+```
+
+For smaller features: deliver the decomposition conversationally with module mapping, effort estimate, and any gate flags. Still assign a UPI and add a registry row.
 
 ## Arguments
 

--- a/.claude/commands/journal.md
+++ b/.claude/commands/journal.md
@@ -8,6 +8,7 @@ Write to `docs/98-journals/YYYY-MM-DD-slug.md`. This is gitignored (private, loc
 - Date: today's date
 - Base commit: `git rev-parse --short HEAD`
 - Slug: derived from $ARGUMENTS or inferred from what was done this session
+- Plan file: the `.claude/plans/` filename if a plan was used this session (from conversation context)
 
 **Template:**
 
@@ -18,6 +19,7 @@ Write to `docs/98-journals/YYYY-MM-DD-slug.md`. This is gitignored (private, loc
 
 **Date:** YYYY-MM-DD
 **Base commit:** `{short hash}`
+**Plan file:** `{.claude/plans/filename.md if used, omit this line if no plan}`
 
 ## What was done
 
@@ -50,7 +52,13 @@ if nothing is open.}
   for HSD-B"), not as tasks. A fresh session checks `git log`, `gh pr list`, and
   `git branch` for actual git state.
 
-## Output 2: Update status.md
+## Output 2: Update registry.md
+
+If this session produced artifacts for a UPI (design review, adversary review, PR merge),
+update the corresponding row in `docs/96-project-supervisor/registry.md` — fill in the
+link for the artifact that was produced. If no UPI-related artifacts were produced, skip.
+
+## Output 3: Update status.md
 
 Overwrite `docs/96-project-supervisor/status.md` with the current state. This is a short
 document (~50 lines) that a fresh session reads first.

--- a/.claude/commands/sequence.md
+++ b/.claude/commands/sequence.md
@@ -1,0 +1,48 @@
+Propose implementation sequencing for reviewed designs.
+
+## Inputs
+
+Read these before sequencing:
+
+1. `docs/96-project-supervisor/registry.md` — find designs with completed design reviews
+2. `docs/96-project-supervisor/roadmap.md` — current active arc and horizon
+3. `docs/96-project-supervisor/status.md` — deployed state and in-progress work
+4. Relevant design docs and their design reviews — for effort estimates, module
+   dependencies, ADR gates, and review findings
+
+## Core job
+
+1. **Identify ready designs.** Scan registry.md for UPIs that have a design review link
+   but are not yet in the roadmap's active arc.
+
+2. **Map decision trees.** If feature X requires ADR change Y, that's a prerequisite gate.
+   If feature A's design review flagged a dependency on feature B, sequence B first. Make
+   the decision tree explicit — draw out the branches and resolve them.
+
+3. **Map dependencies.** Shared modules, prerequisite refactors, features that produce types
+   or traits consumed by later features. Two features touching the same module should be
+   sequenced to avoid rework, not parallelized.
+
+4. **Group by effort clustering.** Small items touching the same modules batch well into
+   a single session. Large items that span multiple modules may need splitting across sessions.
+
+5. **Sequence for risk.** High-uncertainty items first to surface problems early. Features
+   with clear designs and predictable scope can go later. If a design review flagged
+   significant concerns, those should be resolved earlier rather than later.
+
+## Output
+
+Revised `docs/96-project-supervisor/roadmap.md` with updated:
+
+- **Active Arc** — what to build next, in what order, with sequencing rationale. Reference
+  UPIs from registry.md. Include effort estimates from design docs.
+- **Horizon** — what comes after the active arc. 2-3 future arcs with one-line descriptions.
+
+Do not modify registry.md — it is a lookup table, not a sequencing tool.
+
+The user drives prioritization decisions (what matters most). This skill does the analytical
+work of identifying dependencies, decision trees, and optimal ordering within those priorities.
+
+## Arguments
+
+$ARGUMENTS — Optional: specific designs to sequence, or a priority constraint. If empty, sequence all reviewed-but-unscheduled designs from registry.md.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,26 +233,30 @@ cargo run -- get FILE --at DATE      # Restore file from snapshot
 Guideline, not rigid procedure. Skip steps that don't apply to the current work.
 
 ```
-/brainstorm → /design → /grill-me → [build] → /simplify → arch-adversary → /post-review → /check → /journal → /commit-push-pr
+/brainstorm → /design → design-review → /grill-me → /sequence → [plan+build] → /simplify → arch-adversary → /post-review → /check → /journal → /commit-push-pr
 ```
 
 | Tool | Phase | What it does |
 |------|-------|--------------|
 | `/brainstorm` | Ideation | Divergent thinking, no scoring. Output: `docs/95-ideas/` |
-| `/design` | Design | Module decomposition, ADR gate identification |
+| `/design` | Design | Module decomposition, UPI assignment, ADR gate identification |
+| `design-review` | Design review | arch-adversary reviews the design doc (pre-implementation) |
 | `/grill-me` | Stress-test | Socratic interview, resolve decision tree branches |
+| `/sequence` | Sequencing | Order reviewed designs by decision trees and dependencies |
+| `[plan+build]` | Implementation | Planning and execution (intertwined in Claude Code) |
 | `/simplify` | Post-build | Simplification pass: abstractions, types, control flow |
-| `arch-adversary` | Review | Severity-ranked findings with catastrophic failure checklist |
+| `arch-adversary` | Adversary review | Severity-ranked findings on implemented code |
 | `/post-review` | Rework | Systematic fix of review findings, structured disagreement |
 | `test-team` | Testing | Risk-proportional coverage analysis and gap identification |
 | `systematic-debugging` | On-demand | Four-phase root cause investigation (any stage) |
 | `/check` | Quality gate | `cargo clippy` + `cargo test` + `cargo build --release` |
-| `/journal` | Documentation | Session journal + status.md update (two outputs, one command) |
+| `/journal` | Documentation | Session journal + status.md + registry.md updates |
 | `/commit-push-pr` | Integration | PII scan, CHANGELOG, branch, commit, PR |
 | `/release` | Release | SemVer bump, CHANGELOG, tag (user pushes manually) |
 
 ## Project State
 
 See `docs/96-project-supervisor/status.md` for current state and what to build next.
-See `docs/96-project-supervisor/roadmap.md` for the full feature roadmap and priorities.
+See `docs/96-project-supervisor/roadmap.md` for strategy, sequencing, and horizon.
+See `docs/96-project-supervisor/registry.md` for UPI lookup (work items → artifacts).
 See `CONTRIBUTING.md` for documentation structure, conventions, and privacy rules.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,9 +116,10 @@ notes. Ideas that mature get promoted to a plan in `97-plans/`; abandoned ideas 
 with their status updated. Low ceremony — the point is to capture thinking before it's lost.
 
 **96-project-supervisor** — The central tracking hub. Contains `status.md` (short
-current-state document, overwritten each session) and `roadmap.md` (feature priorities,
-completed work, tech debt — the long-lived tracker). Read status.md first for orientation;
-follow links to roadmap.md for the full picture.
+current-state document, overwritten each session), `roadmap.md` (strategy, sequencing,
+and horizon — ~80 lines), and `registry.md` (UPI lookup table linking work items to their
+artifacts). Read status.md first for orientation; follow links to roadmap.md for sequencing
+and registry.md for artifact cross-references.
 
 **97-plans** — Implementation plans. Each plan is a dated snapshot of intent — what we're
 going to build and how. When scope changes significantly, write a new plan.
@@ -143,9 +144,20 @@ All documentation files use **lowercase kebab-case** with `.md` extension. Excep
 | Type | Format | Example |
 |------|--------|---------|
 | Dated documents | `YYYY-MM-DD-slug.md` | `2026-03-22-urd-phase01.md` |
-| Living documents | `slug.md` | `status.md`, `backup-recovery.md` |
+| Living documents | `slug.md` | `status.md`, `registry.md` |
 | ADRs | `YYYY-MM-DD-ADR-NNN-slug.md` | `2026-03-21-ADR-020-daily-external-backups.md` |
-| Ideas | `YYYY-MM-DD-slug.md` | `2026-03-25-sentinel-alternatives.md` |
+| Brainstorms | `YYYY-MM-DD-brainstorm-slug.md` | `2026-03-23-brainstorm-ux-norman-principles.md` |
+| Design docs | `YYYY-MM-DD-design-{UPI}-slug.md` | `2026-04-01-design-001-workflow-system-overhaul.md` |
+| Design reviews | `YYYY-MM-DD-design-review-{UPI}-slug.md` | `2026-04-01-design-review-001-workflow-system-overhaul.md` |
+| Adversary reviews | `YYYY-MM-DD-review-adversary-{UPI}-slug.md` | `2026-04-02-review-adversary-001-workflow-system-overhaul.md` |
+| Process analyses | `YYYY-MM-DD-review-analysis-slug.md` | `2026-04-01-review-analysis-workflow.md` |
+
+**UPI (Unique Project Identifier):** Format `NNN` or `NNN-a` (opaque group number, sequential
+letter suffix for sub-items). Assigned by `/design`, registered in `docs/96-project-supervisor/registry.md`.
+Brainstorms do not get UPIs — the identifier is born when an idea becomes a structured design.
+
+**Pre-2026-04-01 naming:** Review files created before 2026-04-01 use legacy naming patterns
+(various conventions). The archived roadmap's feature table provides traceability for those files.
 
 Use subdirectories within a category when a topic has multiple related files
 (e.g., `decisions/ADR-relating-to-bash-script/`).
@@ -294,15 +306,19 @@ Remove this section if nothing needs handoff.}
 
 Use for features that introduce a new module, change a public interface, or affect more
 than 3 existing files. Not needed for bug fixes, config tweaks, or self-contained additions.
-The adversary review reviews the proposal before implementation begins.
+The design review evaluates the proposal before implementation begins.
 
 ```markdown
+---
+upi: "NNN" or "NNN-a"
+status: proposed
+date: YYYY-MM-DD
+---
+
 # Design: {Feature Name}
 
 > **TL;DR:** {2-3 sentences: what, why, key constraint}
 
-**Date:** YYYY-MM-DD
-**Status:** proposed | reviewed | accepted | abandoned
 **Depends on:** {prior features or ADRs}
 
 ## Problem
@@ -315,8 +331,17 @@ The adversary review reviews the proposal before implementation begins.
 
 ## Rejected Alternatives
 
+## Ready for Review
+
 ## Open Questions
 ```
+
+**Status vocabulary** (controlled set):
+- `raw` — brainstorm output, not yet structured
+- `proposed` — structured design, ready for review
+- `reviewed` — design review complete
+- `promoted` — sequenced for implementation
+- `abandoned` — explicitly not proceeding
 
 #### Idea
 

--- a/docs/90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md
+++ b/docs/90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md
@@ -1,0 +1,684 @@
+# Urd: BTRFS Time Machine for Linux (Historic Roadmap)
+
+> **Archived:** 2026-04-01. This document is immutable. Superseded by the new
+> `docs/96-project-supervisor/roadmap.md` (strategy and sequencing) and
+> `docs/96-project-supervisor/registry.md` (UPI work item lookup).
+> See [UPI 001 design](../../95-ideas/2026-04-01-design-001-workflow-system-overhaul.md)
+> for rationale behind the restructuring.
+
+> **Original provenance:** This document combines the original project roadmap (2026-03-22)
+> with the living feature tracker. The first half (Context through Critical Files Reference)
+> is the founding architectural vision. The second half (Current Priorities onward) tracks
+> what was built, completed features, and known tech debt as of v0.7.0.
+
+## Context
+
+The homelab's backup system is a 1710-line bash script (`scripts/btrfs-snapshot-backup.sh`) that has been patched through three major incidents. It works but has reached its maintainability limit. The 2026-03-22 journal entry documents a critical audit (15 issues found) and recommends Option C: a purpose-built tool replacing the bash script entirely.
+
+**Name:** Urd — the Norse norn who tends the Well of Urd and knows all that has passed.
+
+**Ambition:** Build a distributable "Time Machine for BTRFS on Linux" that starts as a homelab tool and grows into something others can use.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Language | **Rust** | Distributable binary, type safety, no runtime deps. Bash script covers us while we build. |
+| Drive detection | **udev-first** | True Time Machine behavior. Scheduled fallback (02:00) as nice-to-have for large ops. |
+| Execution model | **Hybrid** | Triggered service for backups + small persistent sentinel for drive monitoring/notifications. |
+| State management | **SQLite + TOML** | TOML config (what to back up), SQLite state (what has been backed up). Clean separation. |
+| CLI name | **`urd`** | `urd status`, `urd backup`, `urd verify`, `urd history` |
+| Project location | **`~/projects/urd`** | Separate git repo, own Cargo workspace. |
+| Notifications | **Deferred** | Build after core is battle-tested. Desktop (notify-send) + Discord for critical. |
+
+## Project Structure
+
+```
+~/projects/urd/
+  Cargo.toml
+  src/
+    main.rs               # CLI entry point (clap), dispatches to commands
+    cli.rs                 # Clap command/argument definitions
+    config.rs              # TOML config loading, validation, defaults
+    types.rs               # Core domain types: Subvolume, Drive, Tier, Schedule, Snapshot
+    plan.rs                # Backup planner: reads state, decides operations (pure logic)
+    executor.rs            # Executes planned operations (snapshot, send, receive, delete)
+    btrfs.rs               # Low-level btrfs command wrappers (trait-based for testing)
+    retention.rs           # Retention engine (graduated + count-based)
+    chain.rs               # Incremental chain tracking (pin files, parent resolution)
+    state.rs               # SQLite state database (history, run records)
+    metrics.rs             # Prometheus .prom file writer (atomic tmp+rename)
+    drives.rs              # External drive detection (mount check, space via statvfs)
+    sentinel.rs            # Drive monitor daemon (Phase 5)
+    error.rs               # Error types (thiserror)
+    commands/
+      mod.rs
+      backup.rs            # `urd backup`
+      status.rs            # `urd status`
+      verify.rs            # `urd verify`
+      history.rs           # `urd history`
+      plan_cmd.rs          # `urd plan` (dry-run planning)
+      init.rs              # `urd init` (state import)
+  config/
+    urd.toml.example       # Reference config
+  systemd/
+    urd-backup.service     # Oneshot backup service
+    urd-backup.timer       # Nightly fallback timer
+    urd-sentinel.service   # Drive monitor (Phase 5)
+  udev/
+    99-urd-backup.rules    # Drive plug events (Phase 5)
+  tests/
+    integration/           # Tests requiring 2TB-backup drive (#[ignore])
+  README.md
+  LICENSE
+```
+
+## Configuration Schema (TOML)
+
+Location: `~/.config/urd/urd.toml`
+
+```toml
+[general]
+state_db = "~/.local/share/urd/urd.db"
+metrics_file = "~/containers/data/backup-metrics/backup.prom"
+log_dir = "~/containers/data/backup-logs"
+
+[local_snapshots]
+roots = [
+  { path = "~/.snapshots", subvolumes = ["htpc-home", "htpc-root"] },
+  { path = "/mnt/btrfs-pool/.snapshots", subvolumes = [
+    "subvol1-docs", "subvol2-pics", "subvol3-opptak",
+    "subvol4-multimedia", "subvol5-music", "subvol6-tmp", "subvol7-containers"
+  ]}
+]
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/run/media/<user>/WD-18TB"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[drives]]
+label = "WD-18TB1"
+mount_path = "/run/media/<user>/WD-18TB1"
+snapshot_root = ".snapshots"
+role = "offsite"
+
+[[drives]]
+label = "2TB-backup"
+mount_path = "/run/media/<user>/2TB-backup"
+snapshot_root = ".snapshots"
+role = "test"
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+send_enabled = true
+enabled = true
+
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0                    # 0 = unlimited
+
+[[subvolumes]]
+name = "htpc-home"
+short_name = "htpc-home"
+source = "/home"
+priority = 1
+snapshot_interval = "15m"
+send_interval = "1h"
+
+[[subvolumes]]
+name = "subvol3-opptak"
+short_name = "opptak"
+source = "/mnt/btrfs-pool/subvol3-opptak"
+priority = 1
+snapshot_interval = "1h"
+send_interval = "2h"
+
+# ... (all 9 subvolumes, see config/urd.toml.example for full reference)
+```
+
+## Architecture: Key Design Principles
+
+### 1. Planner/Executor Separation (most important)
+
+The planner is a **pure function**: `fn plan(config, state, now, filters) -> BackupPlan`. It produces a list of `PlannedOperation` variants:
+
+```rust
+enum PlannedOperation {
+    CreateSnapshot { source, dest, subvolume_name },
+    SendIncremental { parent, snapshot, dest_dir, drive_label, subvolume_name, pin_on_success },
+    SendFull { snapshot, dest_dir, drive_label, subvolume_name, pin_on_success },
+    DeleteSnapshot { path, reason, subvolume_name },
+}
+```
+
+Every variant carries `subvolume_name` so operations are self-describing — no path heuristics needed to determine ownership. Send variants carry `pin_on_success: Option<(PathBuf, SnapshotName)>` — the pin file is written by the executor only on successful send, making the send/pin dependency structural rather than implicit.
+
+`urd plan` prints the plan. `urd backup --dry-run` prints it. `urd backup` executes it. The planner is fully unit-testable without touching any filesystem.
+
+### 2. BtrfsOps Trait (testing seam)
+
+```rust
+pub trait BtrfsOps {
+    fn create_readonly_snapshot(&self, source: &Path, dest: &Path) -> Result<()>;
+    fn send_receive(&self, snapshot: &Path, parent: Option<&Path>, dest: &Path) -> Result<()>;
+    fn delete_subvolume(&self, path: &Path) -> Result<()>;
+    fn subvolume_show(&self, path: &Path) -> Result<SubvolumeInfo>;
+}
+```
+
+`RealBtrfs` calls `sudo btrfs` via `std::process::Command`. `MockBtrfs` records calls for testing. This is the only module that shells out.
+
+### 3. Never Lose Data, Always Continue
+
+Individual subvolume failures do NOT abort the run. Failed sends trigger partial cleanup. Pin files are only updated on success. Exit code 1 if any subvolume failed, 0 if all succeeded/skipped.
+
+### 4. Incremental Chain Integrity
+
+The incremental send/receive chain is the most performance-critical property of the system. A broken chain forces a full send (potentially hundreds of GB) instead of a small incremental diff.
+
+**Invariant:** Retention (local or external) must never delete a snapshot that is the current pin parent for any drive. The system enforces this through:
+- Pin file targets are always in the `pinned` set and are never deleted by retention
+- Unsent snapshot protection: when `send_enabled` is true, snapshots newer than the oldest pin are protected from local retention (they may not have been sent to all drives yet)
+- The planner verifies the parent exists on both local and external before planning an incremental send; if not, it falls back to a full send
+
+**Corollary:** The executor must re-check space between deletions on external drives rather than batch-deleting everything the planner proposed, because the planner cannot know exact snapshot sizes.
+
+### 5. Backward Compatibility
+
+- Snapshot naming:
+  - **Current (write):** `YYYYMMDD-HHMM-shortname` (e.g., `20260322-1430-opptak`)
+  - **Legacy (read-only):** `YYYYMMDD-shortname` (e.g., `20260322-opptak`) — parsed as midnight
+  - Both formats coexist transparently in snapshot directories
+- Directory structure: same locations as bash script
+- Pin files: `.last-external-parent-{DRIVE_LABEL}` format preserved (read+write), with legacy `.last-external-parent` fallback for reading
+- Prometheus metrics: identical names, labels, value semantics (see Prometheus Metrics below)
+
+## Prometheus Metrics
+
+File: `~/containers/data/backup-metrics/backup.prom` (configurable via `metrics_file`).
+Written atomically (temp file + rename) to prevent partial reads by the Prometheus node exporter.
+
+The metrics format must match the bash script's output exactly. Grafana dashboards and alerting depend on these names and labels.
+
+### Per-subvolume metrics
+
+| Metric | Type | Labels | Values |
+|--------|------|--------|--------|
+| `backup_last_success_timestamp` | gauge | `subvolume` | Unix timestamp; only set when `backup_success=1` |
+| `backup_success` | gauge | `subvolume` | `1`=success, `0`=failure, `2`=schedule-skipped |
+| `backup_duration_seconds` | gauge | `subvolume` | Integer seconds for the subvolume's operations |
+| `backup_snapshot_count` | gauge | `subvolume`, `location` | Count of snapshots; `location` is `"local"` or `"external"` (external = first mounted drive by config order, for bash compat) |
+| `backup_send_type` | gauge | `subvolume` | `0`=full, `1`=incremental, `2`=no send this run |
+
+### Global metrics
+
+| Metric | Type | Labels | Values |
+|--------|------|--------|--------|
+| `backup_external_drive_mounted` | gauge | none | `1`=any external drive mounted, `0`=none |
+| `backup_external_free_bytes` | gauge | none | Free bytes on mounted external drive; `0` when unmounted |
+| `backup_script_last_run_timestamp` | gauge | none | Unix timestamp when the backup ran |
+
+**Multi-drive note:** The bash script assumes a single external drive. These three global metrics maintain that assumption for backward compatibility: `backup_external_drive_mounted` is `1` if *any* configured drive is mounted, and `backup_external_free_bytes` reports the free space of the first mounted drive (by config order). Phase 4 may add per-drive metrics with a `drive` label, but the global metrics must remain for Grafana compatibility.
+
+### File format
+
+Each metric group has `# HELP`, `# TYPE gauge`, then one or more value lines. Groups separated by blank lines. `backup_send_type` must emit an entry for every subvolume that has a `backup_success` entry (never omit a series).
+
+Example:
+```
+# HELP backup_success Backup result: 1=success, 0=failure, 2=schedule-skipped
+# TYPE backup_success gauge
+backup_success{subvolume="subvol3-opptak"} 1
+backup_success{subvolume="htpc-home"} 2
+```
+
+## SQLite Schema
+
+The SQLite database records backup history. It is **not** the source of truth for current filesystem state — the filesystem (snapshot directories, pin files) is authoritative. SQLite answers "what happened" (runs, operations); the filesystem answers "what exists now" (snapshots, chain state).
+
+```sql
+CREATE TABLE runs (
+    id INTEGER PRIMARY KEY,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    mode TEXT NOT NULL,        -- "full", "local-only", "external-only", "dry-run"
+    result TEXT NOT NULL       -- "success", "partial", "failure"
+);
+
+CREATE TABLE operations (
+    id INTEGER PRIMARY KEY,
+    run_id INTEGER REFERENCES runs(id),
+    subvolume TEXT NOT NULL,
+    operation TEXT NOT NULL,   -- "snapshot", "send_incremental", "send_full", "delete"
+    drive_label TEXT,
+    duration_secs REAL,
+    result TEXT NOT NULL,      -- "success", "failure", "skipped"
+    error_message TEXT,
+    bytes_transferred INTEGER
+);
+```
+
+The `snapshots` table from the original plan has been removed. Pin files remain the source of truth for chain state, and snapshot directories are the source of truth for what exists. Duplicating this in SQLite creates a sync problem with no clear benefit — `urd status` and `urd history` can query the filesystem directly for current state and SQLite for historical data.
+
+## CLI Commands
+
+```
+urd backup [--dry-run] [--local-only] [--external-only] [--tier N] [--subvolume NAME] [--verbose]
+urd plan   [same filters as backup]     # Print planned operations without executing
+urd status                              # Drives, chain health, snapshot counts, last run
+urd history [--subvolume X] [--last N] [--failures]
+urd verify  [--subvolume X] [--drive LABEL]  # Chain integrity, pin file validation
+urd init                                # First-run: create config, import existing state
+```
+
+`urd status` example output:
+```
+SUBVOLUME          LOCAL  WD-18TB  WD-18TB1  LAST SEND    CHAIN
+htpc-home          15     14       12        2h ago       incremental
+subvol3-opptak     15     1        0         6h ago       full (new)
+subvol7-containers 15     2        1         23h ago      incremental
+
+Drives: WD-18TB1 mounted (4.4TB free / 17TB)
+Next scheduled: subvol2-pics in 5d (Saturday)
+```
+
+## Rust Crates
+
+| Crate | Purpose |
+|-------|---------|
+| `clap` 4.x | CLI with derive macros |
+| `serde` + `toml` | Config parsing |
+| `rusqlite` (bundled) | SQLite state DB |
+| `chrono` | Date/time, ISO week calc |
+| `thiserror` + `anyhow` | Error handling |
+| `nix` | statvfs for disk space |
+| `colored` | Terminal colors |
+| `tabled` | Table formatting for status/history |
+| `dirs` | XDG directory resolution |
+| `log` + `env_logger` | Structured logging |
+| `udev` | Phase 5: drive monitoring |
+
+**Not using:** tokio/async (unnecessary for sequential I/O-bound btrfs ops).
+
+## Implementation Phases
+
+### Phase 1: Skeleton + Config + Plan ✅
+
+**Goal:** `urd plan` reads config, discovers real snapshots, prints correct planned operations.
+
+**Completed:**
+- `config.rs` — TOML parsing, validation, tilde expansion, PathBuf throughout
+- `types.rs` — All domain types (Interval, SnapshotName with dual-format, PlannedOperation, ByteSize)
+- `cli.rs` — clap setup for all commands
+- `plan.rs` — planner logic (schedule, snapshot discovery, parent resolution, unsent protection)
+- `chain.rs` — pin file reading (drive-specific + legacy fallback)
+- `retention.rs` — graduated + count-based + space-governed retention
+- `drives.rs` — drive detection, space checks via statvfs, external snapshot dir construction
+- `error.rs` — thiserror error types
+- `commands/plan_cmd.rs` — `urd plan` with colored grouped output
+- 67 unit tests across all modules
+
+**Hardening (Phase 1.5):**
+- Unsent snapshot protection (prevents retention from deleting snapshots not yet sent externally)
+- `PinParent` removed — pin is now `pin_on_success` field on Send variants
+- `subvolume_name` added to all `PlannedOperation` variants
+- PathBuf migration (no more `to_string_lossy()` roundtrips)
+- Path validation (`validate_path_safe`, `validate_name_safe`)
+- Future-date snapshot warning
+- Monthly retention uses calendar month subtraction (not `days * 30`)
+
+### Phase 2: Execute + State + Metrics (Sessions 3-4)
+
+**Goal:** `urd backup` creates snapshots, sends to 2TB-backup, manages retention, writes metrics.
+
+**New modules:**
+- `btrfs.rs` — BtrfsOps trait + RealBtrfs + MockBtrfs
+- `executor.rs` — sequential operation execution (see Executor Contract below)
+- `state.rs` — SQLite schema, run/operation recording
+- `metrics.rs` — Prometheus .prom writer (exact format match)
+
+**Additions to existing modules:**
+- `chain.rs` — pin file writing (reading already done in Phase 1)
+- `error.rs` — executor error variants (BtrfsError, ExecutorError)
+
+**New commands:**
+- `commands/backup.rs` — `urd backup` (planner + executor), `--dry-run` prints plan
+- `commands/init.rs` — `urd init` (first-run setup: create SQLite DB, verify config paths exist, verify pin files are readable, detect and flag incomplete snapshots on external drives from interrupted bash script runs — offer cleanup with user confirmation, never silently delete, report system state summary)
+
+**Testing:**
+- Unit tests with MockBtrfs for executor logic
+- Integration tests on 2TB-backup drive (`#[ignore]`)
+
+**Deliverable:** Successful backup cycle to test drive. `urd backup --dry-run` on production matches bash.
+
+#### Executor Contract
+
+The executor takes a `BackupPlan` and executes each operation sequentially. Its behavior is governed by these rules:
+
+**Error isolation:** A failure in one subvolume must NOT abort operations for other subvolumes. The executor groups operations by `subvolume_name` and tracks per-subvolume success/failure. The overall result is `success` (all OK), `partial` (some failed), or `failure` (all failed).
+
+**Send execution:** The `btrfs send | btrfs receive` pipeline must:
+- Capture stderr from both the send and receive sides
+- Check exit codes from both processes
+- On failure, clean up any partial snapshot at the destination (`btrfs subvolume delete` on the incomplete receive)
+- Log both stderr streams for diagnostics
+
+**Pin-on-success:** After a successful send, the executor writes the pin file specified in `pin_on_success`. If the pin file write fails, the executor logs a warning and continues — the send itself succeeded and the snapshot is valid on the destination. The pin can be recovered on the next successful send to that drive. Note: repeated pin failures (e.g., due to a read-only mount) degrade performance by forcing full sends. Phase 3's `urd verify` / `urd status` should surface stale pins so the operator can investigate.
+
+**Retention execution on external drives:** The planner proposes deletions based on a point-in-time space check, but it cannot know exact snapshot sizes. The executor must:
+- Execute external deletions oldest-first
+- Re-check free space after each deletion
+- Stop deleting once the `min_free_bytes` threshold is satisfied, logging skipped deletions with reason ("space recovered, N planned deletions skipped") so `urd plan` vs `urd backup` divergence is visible to the operator
+- Never delete a snapshot that is the current pin parent for that drive (defense-in-depth — the planner already excludes these, but the executor double-checks)
+
+**Cascading failure handling:** When an operation fails, the executor must skip dependent operations within the same subvolume rather than letting them fail naturally. Specifically: if a `CreateSnapshot` fails, skip any subsequent `Send` that references the snapshot that was not created. The executor checks that source paths exist before attempting operations. This prevents confusing cascading errors in logs and ensures error messages reflect the root cause.
+
+**Crash recovery:** The executor does not assume clean state from prior runs. Before sending a snapshot to a drive, it checks whether a subvolume with that name already exists at the destination. If it exists but is not the result of a completed send (i.e., the pin file does not point to it), it deletes the partial and proceeds with a fresh send. This handles the case where a prior run was interrupted mid-transfer (power loss, drive disconnect, OOM kill). The pin file is the source of truth for "last successful send" — if the pin doesn't reference a snapshot, that snapshot's presence at the destination is not trusted for incremental chain purposes.
+
+**Operation ordering:** Within a subvolume, operations execute in plan order: create → send → delete. This ensures new snapshots exist before sends reference them, and deletions happen after sends complete. This ordering is load-bearing — the planner emits operations in this order (see comment in `plan()`) and the executor relies on it.
+
+### Phase 3: CLI + Parallel Run (Sessions 5-6) ✅
+
+**Goal:** Full CLI, parallel running with bash script for validation.
+
+**New commands:**
+- `commands/status.rs` — per-subvolume table (local/external counts, chain health), drive summary, last run from SQLite
+- `commands/history.rs` — recent runs, `--subvolume` filter, `--failures`, `--last N`
+- `commands/verify.rs` — pin file validation, pinned snapshot existence (local + external), orphan detection, stale pin detection
+
+**New CLI args:**
+- `HistoryArgs`: `--last N` (default 10), `--subvolume NAME`, `--failures`
+- `VerifyArgs`: `--subvolume NAME`, `--drive LABEL`
+
+**StateDb query methods added:**
+- `last_run()`, `recent_runs(limit)`, `run_operations(run_id)`, `subvolume_history(name, limit)`, `recent_failures(limit)`
+- New types: `RunRecord`, `OperationRow` (query result types separate from write type `OperationRecord`)
+
+**Adversary review fixes applied:**
+- Fixed `to_string_lossy()` in `RealBtrfs` — `create_readonly_snapshot` and `delete_subvolume` now use `.arg(path)` directly on `Command` instead of `run_btrfs(&[&str])`. The `run_btrfs` helper was removed entirely.
+- Extracted `first_mounted_drive_status()` to `drives.rs` for reuse by `status.rs`
+- Consolidated duplicate metrics helpers in `backup.rs` (`append_skipped_metrics`, `write_global_metrics`)
+
+**Systemd units:**
+- `systemd/urd-backup.service` — oneshot service, `ExecStart=%h/.cargo/bin/urd backup`
+- `systemd/urd-backup.timer` — 02:00 daily, `Persistent=true`, `RandomizedDelaySec=300`
+
+**Parallel run strategy:**
+- Pin file contention: no separate namespaces needed. Atomic writes + 1-hour separation sufficient. Last writer wins (correct behavior — pin should reflect most recent successful send).
+- Timing: Urd at 02:00, bash at 03:00. Separate lock files (can technically overlap, but btrfs ops on different subvolumes are safe concurrently).
+- Install: `cp systemd/*.{service,timer} ~/.config/systemd/user/ && systemctl --user daemon-reload && systemctl --user enable --now urd-backup.timer`
+- Change bash timer: `systemctl --user edit btrfs-backup-daily.timer` → set `OnCalendar=*-*-* 03:00:00`
+
+**Deliverable:** Both systems running nightly with equivalent results.
+
+### Phase 4: Cutover + Polish (Session 7) — code ✅, operations pending
+
+**Goal:** Urd is sole backup system.
+
+**Code (complete):** CLI help polish, btrfs_path validation, crash-recovery test, --verbose
+flag, dead code removal, tabled dependency removed. See [Phase 4 journal](../98-journals/2026-03-22-urd-phase4.md).
+
+**Operations (not started):**
+- Install and enable urd-backup.timer, run parallel with bash for 1-2 weeks
+- Disable bash script timer after validation
+- Write ADR-021 for the migration
+- Archive bash script to `scripts/archive/`
+
+See [status.md](status.md) for the detailed cutover checklist.
+
+### Phase 5: Sentinel + udev (Session 8, deferred)
+
+**Goal:** Automatic backup on drive plug-in.
+
+- `sentinel.rs` — udev event listener, debounce (wait for LUKS+mount)
+- `urd-sentinel.service` — persistent user service
+- udev rules for WD-18TB drives
+- Desktop notification hooks (infrastructure only — notification system built separately)
+
+## Migration Strategy
+
+1. **`urd init`** creates SQLite DB, verifies config paths, validates pin files, detects incomplete snapshots on external drives
+2. **Parallel running** (2 weeks): Urd at 02:00, bash at 03:00, compare metrics
+3. **Cutover:** disable bash timer, enable Urd timer, monitor 1 week
+4. Pin file format maintained throughout — both systems can coexist
+
+## Testing Prerequisites
+
+**Sudoers entries needed for 2TB-backup drive** (user must add manually):
+```
+<user> ALL=(root) NOPASSWD: /usr/sbin/btrfs subvolume delete /run/media/<user>/2TB-backup/.snapshots/*
+<user> ALL=(root) NOPASSWD: /usr/sbin/btrfs receive /run/media/<user>/2TB-backup/.snapshots/*
+```
+
+Existing `btrfs send *` and `btrfs subvolume snapshot -r` entries cover the local side.
+
+## Verification Plan
+
+After each phase:
+
+1. **Phase 1:** `urd plan` output matches manual calculation of what bash script would do for the same date/drive state
+2. **Phase 2:** Successful backup to 2TB-backup drive. Restore a file from the backup and verify byte-for-byte match. `backup.prom` output matches format exactly.
+3. **Phase 3:** After 2 weeks parallel run, diff Prometheus metrics between Urd and bash script runs. All subvolumes, all drives, all metrics must match.
+4. **Phase 4:** One week of sole Urd operation with no intervention. Grafana dashboards show continuity.
+5. **Phase 5:** Plug in test drive, verify backup starts within 60 seconds.
+
+## Critical Files Reference
+
+- `~/containers/scripts/btrfs-snapshot-backup.sh` — behavior to match
+- `~/containers/data/backup-metrics/backup.prom` — metrics format to reproduce
+- `~/.config/systemd/user/btrfs-backup-daily.service` — systemd patterns to follow
+- `~/.snapshots/htpc-home/.last-external-parent-WD-18TB1` — pin file format
+- `/etc/sudoers.d/btrfs-backup` — scope constraints for btrfs commands
+
+---
+
+## Current Priorities
+
+> This section is a living tracker. Updated when priorities change.
+
+### Priority 5: Sentinel (paused — resumed after Priority 6)
+
+The Sentinel is three independent systems that compose. Sessions 1-2 complete and deployed.
+Sessions 3-4 deferred below Priority 6 UX work. Session 3's notification dedup is subsumed
+by 6-I's structured advisory cooldown mechanism.
+
+| # | Component | Status | Notes |
+|---|-----------|--------|-------|
+| 5a | **Notification dispatcher** | **Complete** | `notify.rs`: `compute_notifications()` pure function, 4 channel types, urgency filtering. 18 tests. |
+| 5b | **Event reactor (passive)** | **Sessions 1-2 complete, deployed** | Pure state machine + I/O runner + CLI. Running as systemd user service. |
+| 5b-3 | **Sentinel hardening** | Deferred | Scoped after 6-I ships (notification dedup subsumed by advisory cooldown). |
+| 5c | **Active mode** | Designed, not built | Auto-trigger logic: `should_trigger_backup()`, `TriggerPermission`. After Priority 6. |
+
+### Priority 5.5: Safety & Visibility — Complete
+
+All 10 items built and deployed (v0.4.1–v0.5.0):
+- Hardware swap defenses (drive session tokens, chain health as awareness input, full-send gate)
+- Visual feedback model (OperationalHealth enum, two-axis CLI, sentinel visual_state)
+- Transient snapshots (local_retention = "transient", immediate cleanup)
+
+| Item | Design | Review |
+|------|--------|--------|
+| Hardware swap defenses | [design](../95-ideas/2026-03-28-design-hardware-swap-defenses.md) | [review](../99-reports/2026-03-28-hardware-swap-defenses-design-review.md) |
+| Visual feedback model | [design](../95-ideas/2026-03-28-design-visual-feedback-model.md) | [review](../99-reports/2026-03-28-visual-feedback-model-design-review.md) |
+| Spindle tray icon | [brainstorm](../95-ideas/2026-03-28-brainstorm-tray-icon-spindle.md) | Needs design doc (build after Phase 5) |
+
+### Priority 6: Voice, UX & Redundancy Guidance
+
+The next arc: unify Urd's voice, build high-impact UX features, and teach 3-2-1 strategy
+through the promise system and progressive disclosure. Two brainstorm sessions resolved
+the complete vocabulary and scored UX features. Six phase designs reviewed by arch-adversary.
+
+**Two arcs, one dependency chain:**
+
+```
+Voice & UX Arc                        Progressive & Setup Arc
+──────────────                        ───────────────────────
+Merge 6-B + 6-E (ready now)
+  │
+Phase 1: Vocabulary landing
+  │
+Phase 2a+2c: urd default + completions
+  │
+6-I: Advisory system ─────────────────→ 6-O: Progressive disclosure (2 sessions)
+  │                                        │
+6-N + Phase 2b: Retention + doctor        ADR-110 enum rename (1 session)
+  │                                        │
+Phase 4a+4b: Escalation + suggestions    Config Serialize refactor (0.5 session)
+  │                                        │
+Phase 4c: Mythic transitions             6-H: Guided setup wizard (4 sessions)
+```
+
+**Estimated total: 15 sessions, ~150 new/modified tests, test suite 589 → ~740.**
+
+#### Feature table
+
+| # | Feature | Effort | Status | Design | Review |
+|---|---------|--------|--------|--------|--------|
+| 6-B | **Transient immediate cleanup** | 1 session | **Built, reviewed** | [design](../95-ideas/2026-03-31-design-b-transient-immediate-cleanup.md) | [review](../99-reports/2026-03-31-design-b-review.md) |
+| 6-E | **Promise redundancy encoding** | 1 session | **Built, reviewed** | [design](../95-ideas/2026-03-31-design-e-promise-redundancy-encoding.md) | [review](../99-reports/2026-03-31-design-e-review.md) |
+| P1 | **Vocabulary landing** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase1-vocabulary-landing.md) | [review](../99-reports/2026-03-31-design-phase1-vocabulary-landing-review.md) |
+| P2a | **`urd` default status** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase2-ux-commands.md) | [review](../99-reports/2026-03-31-design-phase2-ux-commands-review.md) |
+| P2b | **`urd doctor`** | 1 session | Designed, reviewed | (same as P2a) | (same as P2a) |
+| P2c | **Shell completions** | 0.5 session | Designed, reviewed | (same as P2a) | (same as P2a) |
+| 6-I | **Redundancy recommendations** | 1–2 sessions | Designed, reviewed | [design](../95-ideas/2026-03-31-design-i-redundancy-recommendations.md) | [review](../99-reports/2026-03-31-design-phase3-advisory-retention-review.md) |
+| 6-N | **Retention policy preview** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-n-retention-policy-preview.md) | (same as 6-I) |
+| P4a | **Staleness escalation** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase4-voice-enrichment.md) | [review](../99-reports/2026-03-31-arch-adversary-phase4-voice-enrichment.md) |
+| P4b | **Next-action suggestions** | (with P4a) | Designed, reviewed | (same as P4a) | (same as P4a) |
+| P4c | **Mythic voice on transitions** | 0.5-1 session | Designed, reviewed | (same as P4a) | (same as P4a) |
+| 6-O | **Progressive disclosure** | 2 sessions | Designed, reviewed | [design](../95-ideas/2026-03-31-design-o-progressive-disclosure.md) | [review](../99-reports/2026-03-31-design-phase5-progressive-disclosure-review.md) |
+| P6a | **ADR-110 enum rename** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase6-protection-rename-wizard.md) | [review](../99-reports/2026-03-31-design-phase6-protection-rename-wizard-review.md) |
+| P6b | **Config Serialize refactor** | 0.5 session | Prerequisite for 6-H | (same as P6a) | (same as P6a) |
+| 6-H | **Guided setup wizard** | 4 sessions | Designed, reviewed | [design](../95-ideas/2026-03-31-design-h-guided-setup-wizard.md) | [review](../99-reports/2026-03-31-design-h-review.md) |
+
+#### Key review findings incorporated
+
+| Finding | Source | Resolution |
+|---------|--------|------------|
+| Heartbeat schema bump likely unnecessary | Phase 6 S-1 | Drop — heartbeat serializes promise states, not level names |
+| Config key rename scope too large | Phase 6 M-1 | Defer to ADR-111 config overhaul |
+| Voice thresholds contradict awareness | Phase 4 S-1 | Derive from PromiseStatus, not independent thresholds |
+| Cooldown key must include drive_label | Phase 3 S-1 | Design update before 6-I implementation |
+| Config error conflation in urd default | Phase 2 S-1 | Distinguish NotFound from ParseError |
+| Sentinel notification dedup | Phase 3 | Subsumed by 6-I cooldown mechanism |
+
+#### Brainstorm artifacts
+
+| Document | Content |
+|----------|---------|
+| [Next-level UX brainstorm](../95-ideas/2026-03-31-brainstorm-next-level-ux.md) | 12 candidates scored, 7 accepted (scores 6-10), 4 rejected |
+| [Vocabulary audit](../95-ideas/2026-03-31-brainstorm-vocabulary-audit.md) | Complete vocabulary redesign: exposure triad, protection levels, thread, drives, skip tags |
+
+#### Also in this priority (independent)
+
+| # | Feature | Effort | Notes |
+|---|---------|--------|-------|
+| 6-Sp | **Tray icon (Spindle)** | Low–Medium | Design after Phase 4/5 visual improvements. Build after 6-O. [brainstorm](../95-ideas/2026-03-28-brainstorm-tray-icon-spindle.md). |
+
+#### Deferred from old Priority 6
+
+| # | Feature | Notes |
+|---|---------|-------|
+| 6b | **Smart defaults** | Subsumed by H (wizard infers from filesystem). |
+| 6d | **Drive replacement workflow** | Build after H proves the guided interaction pattern. |
+| 6e | **`urd find` (cross-snapshot search)** | Unsolved perf problem. Deferred until `urd get` proves restore UX. |
+
+### Priority 7: Experience Polish
+
+| # | Feature | Effort | Notes |
+|---|---------|--------|-------|
+| 7a | **Recovery contract** | Low-Medium | Generated from config + awareness model state. Overlaps with H's coverage map. |
+| 7b | **Deep verification** | Medium | `urd verify --deep`: random-sample checksums from external vs. local. |
+| 7c | **Attention budget** | Medium | Priority queue in awareness model. Filter by urgency. |
+| 7d | **Config validation as simulation** | Medium | Subsumed by N (retention preview) and H (setup wizard). |
+
+### Deferred
+
+| Feature | Rationale |
+|---------|-----------|
+| SSH remote targets | Keep the app simple for now. |
+| Cloud backup (S3/B2) | Indefinitely. |
+| Pull mode / mesh | Indefinitely. |
+| Multi-user / library mode | No current need. |
+
+### Open gates (from ADR-110/111)
+
+- [ ] Drive topology constraints — capacity checks require I/O, deferred to Sentinel
+- [ ] Awareness threshold mode — fixed multipliers regardless of run frequency, deferred
+- [ ] Config schema migration (ADR-111) — target architecture defined, legacy schema in use; config key rename (`protection_level` → `protection`) deferred here
+- [ ] Protection level enum rename — resolved vocabulary (recorded/sheltered/fortified), scheduled as P6a after 6-O ships
+- [ ] Heartbeat schema bump — likely unnecessary per Phase 6 review S-1 (heartbeat serializes promise states, not level names); verify before P6a
+
+## Completed Features
+
+### Priority 2: Safety Hardening — Complete
+
+All five items built, adversary-reviewed, and deployed:
+- UUID drive fingerprinting (`DriveAvailability` enum, `findmnt` detection)
+- Local space guard (planner gates on `min_free_bytes`)
+- Surface skipped sends (subsumed by structured summary)
+- Post-backup structured summary (`BackupSummary` output type)
+- Pre-flight config checks (`preflight.rs`, 2 checks)
+- Structured error messages (`translate_btrfs_error()`, 7 patterns)
+
+### Priority 3: Architectural Foundation — Complete
+
+- Awareness model (`awareness.rs`) — pure function, 24 tests
+- Heartbeat file (`heartbeat.rs`) — JSON health signal, schema v1, 7 tests
+- Presentation layer (`output.rs` + `voice.rs`) — 8/8 commands migrated
+- `urd get` (`commands/get.rs`) — file restore, 19 tests
+
+### Priority 4: Protection Promises — Complete
+
+- `ProtectionLevel` enum, `derive_policy()`, config resolution branching
+- Preflight achievability checks (drive-count, voiding, weakening)
+- Planner drive filtering, `--confirm-retention-change` fail-closed gate
+- Promise-anchored status display (conditional PROMISE column)
+- ADR-110 written and revised, ADR-111 (config target architecture) written
+
+## Phase Checklist
+
+- [x] Phase 1 — Skeleton + Config + Plan (67 tests)
+- [x] Phase 1.5 — Hardening (unsent protection, path safety, pin-on-success)
+- [x] Phase 2 — Executor + State DB + Metrics + `urd backup`
+- [x] Phase 3 — CLI commands + systemd units
+- [x] Phase 3.5 — Hardening for cutover
+- [x] Phase 4 code — Cutover polish + space estimation
+- [ ] Phase 4 cutover — Operational transition (monitoring target: 2026-04-01)
+- [x] Post-cutover — Priorities 2-4 complete
+- [x] Phase 5 — Architectural foundation complete
+- [x] Phase 6 — Protection promises complete
+- [x] Phase 7 — Sentinel Sessions 1-2 deployed (Sessions 3-4 deferred after Priority 6)
+- [x] Phase 7.5 — Safety & Visibility (5.5a-d: all 10 items complete, v0.4.1–v0.5.0)
+- [ ] Phase 8 — Voice & UX overhaul (P1→P2→6-I→6-N→P4→6-O→P6a→6-H)
+- [ ] Phase 9 — Sentinel completion (Session 3 hardening, Session 4 active mode)
+- [ ] Phase 10 — Spindle tray icon
+
+## Dropped Features
+
+- **Tier 2 filesystem-level upper bound** — wrong for actual data distribution
+- **Tier 3 Option A opportunistic qgroup query** — quotas confirmed off, speculative
+
+## Tech Debt
+
+- Pipe bytes vs. on-disk size mismatch in space estimation (1.2x margin handles common case)
+- `du -sb` may follow symlinks in snapshots — consider `-P` flag
+- Stale failed send estimates persist indefinitely — consider TTL
+- `SubvolumeResult.send_type` records only last send type for multi-drive sends
+- `heartbeat::read()` returns `Option` — can't distinguish missing from corrupt
+- Per-drive pin protection for external retention: all-drives-union is conservative
+- `urd get` doesn't support directory restore (files only in v1)
+- `warn_missing_uuids` spawns `findmnt` per drive on every run
+- Bootstrap pattern: code touching `external_snapshot_dir()` may assume dirs exist
+- MockBtrfs tests don't exercise filesystem preconditions
+- Journal persistence gap: journald may purge user-unit logs
+- NVMe snapshot accumulation above 10GB threshold not gated

--- a/docs/95-ideas/2026-04-01-design-001-workflow-system-overhaul.md
+++ b/docs/95-ideas/2026-04-01-design-001-workflow-system-overhaul.md
@@ -1,0 +1,331 @@
+---
+upi: "001"
+status: proposed
+date: 2026-04-01
+---
+
+# Design: Workflow System Overhaul
+
+> **TL;DR:** Introduce a Unique Project Identifier (UPI) system that threads through all
+> workflow artifacts, standardize review naming, create a project registry, add a `/sequence`
+> skill to the pipeline, and update existing skills to produce consistently named and
+> cross-referenced documentation. This is a documentation and workflow change — no Rust code
+> is modified.
+
+**Depends on:** No ADR gates. This changes documentation conventions and skill prompts only.
+
+## Problem
+
+After 10 days of development (v0.0.0 to v0.7.0), the workflow pipeline (`/brainstorm` →
+`/design` → `arch-adversary` → `/post-review` → `/journal` → `/commit-push-pr`) is
+productive, but the artifact management system has accumulated five structural problems:
+
+1. **77 review files use 7+ naming patterns** — no reliable way to find a review given its
+   design doc
+2. **Phase numbering uses 4+ overlapping schemes** — Phase 1-4, Priority 5/5.5/6, 6-B/E/H,
+   P1/P2a/P6a
+3. **53 Claude Code plan files are orphaned** — auto-generated names, no link to documentation
+4. **arch-adversary produces design and implementation reviews** under inconsistent names
+5. **roadmap.md is 550+ lines** mixing stable architecture reference with living feature tracker
+
+Evidence and full analysis: `docs/99-reports/2026-04-01-workflow-and-project-management-analysis.md`
+and `docs/99-reports/2026-04-01-ccpm-evaluation-and-workflow-comparison.md`.
+
+## Proposed Design
+
+### The UPI System
+
+Every significant unit of work gets a **Unique Project Identifier** assigned at `/design` time.
+
+**Format:** `NNN-a` where:
+- `NNN` — opaque, sequential group number (starting at `001`)
+- `-a` — sequential letter suffix for sub-items within a group
+- Standalone items use `NNN` with no letter suffix
+
+**Properties:**
+- Assigned by `/design` (reads registry.md for next number)
+- Threads through all artifacts: design doc, design review, adversary review, journal, PR
+- The description slug in the filename carries the human-readable meaning — the UPI provides
+  machine-linkable uniqueness
+
+**Registry:** `docs/96-project-supervisor/registry.md` — a minimal lookup table, newest
+entries at top. No status tracking, no grouping, no sequencing.
+
+```markdown
+# Registry
+
+| UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
+|-----|-------|--------|---------------|------------------|----|-----|
+| 001 | Workflow system overhaul | [design](link) | - | - | - | - |
+```
+
+### Artifact Naming Conventions
+
+All artifacts follow `YYYY-MM-DD-{type}-{UPI}-{slug}.md` where the type prefix identifies
+the artifact's role in the pipeline:
+
+| Artifact | Type prefix | Location | Example |
+|----------|------------|----------|---------|
+| Brainstorm | `brainstorm-` | `docs/95-ideas/` | `2026-04-01-brainstorm-progressive-ux.md` |
+| Design doc | `design-{UPI}-` | `docs/95-ideas/` | `2026-04-01-design-001-workflow-system-overhaul.md` |
+| Design review | `design-review-{UPI}-` | `docs/99-reports/` | `2026-04-01-design-review-001-workflow-system-overhaul.md` |
+| Adversary review | `review-adversary-{UPI}-` | `docs/99-reports/` | `2026-04-02-review-adversary-001-workflow-system-overhaul.md` |
+| Process analysis | `review-analysis-` | `docs/99-reports/` | `2026-04-01-review-analysis-workflow.md` |
+
+**Brainstorms do not get UPIs.** They are pre-design artifacts. The UPI is born when
+`/design` structures an idea into an implementable proposal.
+
+**Slug derivation:** Stripped — no duplication of the type prefix. Given a design doc
+`design-001-workflow-system-overhaul`, the design review slug is `001-workflow-system-overhaul`
+(the UPI + description, without repeating `design`).
+
+### Updated Pipeline
+
+```
+/brainstorm → /design → design-review → /grill-me → /sequence → [plan+build] →
+  /simplify → arch-adversary → /post-review → /check → /journal → /commit-push-pr
+```
+
+Changes from current pipeline:
+- `design-review` — explicit slot for arch-adversary reviewing the design doc (was implicit)
+- `/sequence` — new skill: orders reviewed designs for implementation
+- `[plan+build]` — replaces `[build]` to acknowledge planning and execution are intertwined
+
+### Document Responsibility Split
+
+| Document | Tracks | Updated by |
+|----------|--------|-----------|
+| `registry.md` | UPI → artifact links (lookup only) | `/design` (new rows), `/journal` (fill in links) |
+| `roadmap.md` | Strategy and sequencing (~80 lines) | `/sequence` (revised active arc) |
+| `status.md` | Current state (~60 lines) | `/journal` (overwritten each session) |
+
+### YAML Frontmatter
+
+Design docs and reviews adopt YAML frontmatter for machine-parseable metadata:
+
+```yaml
+---
+upi: "001-a"
+status: proposed
+date: 2026-04-01
+---
+```
+
+**Status vocabulary (controlled set):**
+- `raw` — brainstorm output, not yet structured
+- `proposed` — structured design, ready for review
+- `reviewed` — design review complete
+- `promoted` — sequenced for implementation
+- `abandoned` — explicitly not proceeding
+
+The `**Date:**` and `**Status:**` bold-field lines in the body are dropped — that
+information lives in frontmatter. TL;DR remains the first visible content after frontmatter.
+
+**Forward-only adoption.** Existing docs keep their current format.
+
+### New roadmap.md
+
+The current roadmap.md is archived to
+`docs/90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md` (immutable).
+
+New roadmap.md is ~80 lines with three sections:
+
+1. **Active Arc** (~15 lines) — what's being built, why, sequencing rationale
+2. **Horizon** (~20 lines) — 2-3 future arcs with one-line descriptions
+3. **Strategic Context** (~20 lines) — tech debt that gates features, architectural
+   constraints, deferred decisions and why
+
+## Files Affected
+
+### New files
+
+| File | Purpose |
+|------|---------|
+| `docs/96-project-supervisor/registry.md` | UPI lookup table |
+| `.claude/commands/sequence.md` | New `/sequence` skill |
+| `docs/90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md` | Archived old roadmap |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `CONTRIBUTING.md` | File naming table (add UPI patterns, review naming), design proposal template (YAML frontmatter, drop bold-field metadata), status vocabulary, add registry.md to directory details |
+| `CLAUDE.md` | Pipeline description, add registry.md to "Orient Yourself" and project state sections |
+| `.claude/commands/design.md` | UPI assignment logic, new filename format, registry row creation |
+| `.claude/skills/arch-adversary/SKILL.md` | Output filename convention with UPI, registry link update |
+| `.claude/commands/journal.md` | Optional `**Plan file:**` metadata line, registry link updates |
+| `docs/96-project-supervisor/roadmap.md` | Rewritten from scratch (~80 lines) |
+| `docs/96-project-supervisor/status.md` | Updated key links (add registry.md) |
+
+### Not modified
+
+- No Rust source code
+- No ADRs (no architectural contracts changed)
+- No existing design docs or reviews (forward-only adoption)
+- `docs/97-plans/` — stays as-is (operational plans that aren't design docs)
+
+## Skill Change Specifications
+
+### `/design` (`.claude/commands/design.md`)
+
+Add to the skill prompt:
+
+1. **UPI assignment:** Read `docs/96-project-supervisor/registry.md`. Find the highest
+   existing UPI group number. Assign next number (or next letter within a group if the
+   user specifies this is a sub-item of an existing group).
+
+2. **Output filename:** `docs/95-ideas/YYYY-MM-DD-design-{UPI}-{slug}.md`
+
+3. **Registry update:** Append a row to registry.md with UPI, title, and design doc link.
+   Other columns filled with `-`.
+
+4. **Frontmatter:** Add YAML frontmatter block with `upi`, `status: proposed`, `date`.
+
+### `arch-adversary` (`~/.claude/skills/arch-adversary/SKILL.md`)
+
+Add to the "Report output" section:
+
+1. **Design review mode:** Output to
+   `docs/99-reports/YYYY-MM-DD-design-review-{UPI}-{slug}.md`
+
+2. **Implementation review mode:** Output to
+   `docs/99-reports/YYYY-MM-DD-review-adversary-{UPI}-{slug}.md`
+
+3. **Registry update:** After writing the report, update the corresponding UPI row in
+   registry.md — fill in the Design Review or Adversary Review column with a link.
+
+4. **UPI detection:** Read the design doc or identify the feature being reviewed to
+   determine the UPI. If not identifiable, ask the user.
+
+5. **Frontmatter:** Add YAML frontmatter block with `upi`, `date`.
+
+### `/sequence` (`.claude/commands/sequence.md` — new)
+
+```
+Propose implementation sequencing for reviewed designs.
+
+## Inputs
+- docs/96-project-supervisor/registry.md — find designs with completed design reviews
+- docs/96-project-supervisor/roadmap.md — understand current active arc and horizon
+- docs/96-project-supervisor/status.md — understand deployed state and in-progress work
+- Relevant design docs and their design reviews — for effort, dependencies, ADR gates
+
+## Core job
+1. Identify which designs are ready for implementation (have design reviews in registry)
+2. Analyze decision trees: if X requires Y, sequence Y first
+3. Analyze dependencies: shared modules, prerequisite refactors, ADR gates
+4. Group by effort clustering: small items touching the same modules batch well
+5. Sequence for risk: high-uncertainty items first to surface problems early
+
+## Output
+Revised docs/96-project-supervisor/roadmap.md with updated:
+- Active Arc — what to build next, in what order, with rationale
+- Horizon — what comes after, with one-line descriptions
+
+The user drives prioritization decisions. The skill does the analytical work of
+identifying dependencies, decision trees, and optimal ordering.
+```
+
+### `/journal` (`.claude/commands/journal.md`)
+
+Two additions:
+
+1. **Plan file metadata:** Add optional line to journal template:
+   ```
+   **Plan file:** `{.claude/plans/filename.md if used}`
+   ```
+   Filled from conversation context. Omitted if no plan was used.
+
+2. **Registry updates:** When the journal records completion of a design review, adversary
+   review, or PR merge, update the corresponding link in registry.md.
+
+## Invariants
+
+1. **UPI is assigned once, at `/design` time.** It never changes. If a design is abandoned
+   and restarted, it gets a new UPI.
+2. **Registry is a lookup table.** It does not track status, sequencing, or grouping.
+   Those responsibilities belong to status.md and roadmap.md respectively.
+3. **Forward-only adoption.** Existing documents keep their current naming and format.
+   No retroactive renaming, no backfill.
+4. **Brainstorms have no UPI.** The identifier is born when an idea becomes a structured
+   design.
+5. **The slug is stripped.** No redundant prefixes in filenames. The type prefix and
+   slug are complementary, not overlapping.
+
+## Rejected Alternatives
+
+1. **CCPM's full PRD → Epic → Task pipeline.** Too heavyweight for solo development.
+   Adds document types (PRDs, epics, task files) without proportional benefit. The design
+   doc absorbs what a PRD would contain.
+
+2. **GitHub Issues as primary work tracker.** Deferred to Tier 3 as a gradual habit
+   adoption. The registry + roadmap + status.md triad covers tracking needs without
+   external dependencies.
+
+3. **Backfilling historical items with UPIs.** The archived roadmap's feature table
+   provides historical traceability. Retroactive numbering would be busywork producing
+   a table nobody consults.
+
+4. **Task decomposition in `/design` output.** The sequencing and planning phases handle
+   this. Design docs describe what to build and why, not the step-by-step execution order.
+
+5. **Separate architecture.md document.** Most content is already in CLAUDE.md, ADRs, and
+   operating-urd.md. A future documentation effort will address module guides and
+   architecture principles systematically.
+
+6. **Multiple tracking scripts.** Only `validate.sh` solves a problem the new document
+   system doesn't already address. Status and next-up queries are cheap with an 80-line
+   roadmap.
+
+## Tiered Implementation
+
+### Tier 1 — Convention and prompt changes (one session)
+
+Execute in this order (dependency-driven):
+
+1. Create `docs/96-project-supervisor/registry.md` (header row only — unblocks everything)
+2. Update `CONTRIBUTING.md` (naming conventions, frontmatter, status vocabulary)
+3. Update `.claude/commands/design.md` (UPI assignment, filename, registry row)
+4. Update `~/.claude/skills/arch-adversary/SKILL.md` (output naming, registry update)
+5. Create `.claude/commands/sequence.md` (new skill)
+6. Update `.claude/commands/journal.md` (plan file metadata, registry updates)
+7. Update `CLAUDE.md` (pipeline description)
+
+Items 2-6 can be parallelized after item 1.
+
+### Tier 2 — New artifacts (following session)
+
+1. Archive current roadmap.md to `docs/90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md`
+2. Write new roadmap.md from scratch (~80 lines)
+3. Update status.md key links
+4. Write `validate.sh` (checks: registry link consistency, broken links, undated files)
+
+### Tier 3 — Habit adoption (gradual)
+
+- GitHub Issues: one issue per work item, labeled by arc, linked via `Fixes #N` in PRs
+- GH# column in registry fills in as issues are created
+
+## Effort Estimate
+
+| Tier | Work | Estimate |
+|------|------|----------|
+| Tier 1 | 7 file edits/creations, all convention/prompt changes | 1 session |
+| Tier 2 | Roadmap archive + rewrite, validate.sh | 1 session |
+| Tier 3 | Habit adoption | Ongoing, no dedicated session |
+
+No tests — this is documentation and workflow infrastructure, not Rust code.
+
+## Ready for Review
+
+This design should be evaluated for:
+
+1. **Completeness:** Does the UPI system cover all artifact types in the pipeline? Are
+   there artifacts that should carry a UPI but don't?
+2. **Consistency:** Do the naming conventions produce unambiguous, predictable filenames
+   in all cases? Walk through 3-4 hypothetical features.
+3. **Sustainability:** Will the registry stay maintainable as the project grows? At what
+   scale does it need revision?
+4. **Skill prompt feasibility:** Are the skill changes specific enough that Claude Code
+   will follow them consistently across sessions?
+5. **Migration risk:** Does forward-only adoption leave any gaps where old and new
+   conventions interact poorly?

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -1,0 +1,8 @@
+# Registry
+
+> UPI lookup table. Newest entries at top. No status tracking — see roadmap.md
+> for sequencing and status.md for current state.
+
+| UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
+|-----|-------|--------|---------------|------------------|----|-----|
+| 001 | Workflow system overhaul | [design](../95-ideas/2026-04-01-design-001-workflow-system-overhaul.md) | - | - | - | - |

--- a/docs/96-project-supervisor/roadmap.md
+++ b/docs/96-project-supervisor/roadmap.md
@@ -1,679 +1,85 @@
-# Urd: BTRFS Time Machine for Linux
+# Urd Roadmap
 
-> **Provenance:** This document combines the original project roadmap (2026-03-22) with
-> the living feature tracker. The first half (Context through Critical Files Reference) is
-> the founding architectural vision. The second half (Current Priorities onward) tracks
-> what to build next, what's been completed, and known tech debt. For current project
-> state (what's deployed right now), see [status.md](status.md).
+> Strategy, sequencing, and horizon. For current state see [status.md](status.md).
+> For work item → artifact mapping see [registry.md](registry.md).
+> For completed features and historical context see the
+> [archived roadmap](../90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md).
 
-## Context
+## Active Arc: Progressive & Setup
 
-The homelab's backup system is a 1710-line bash script (`scripts/btrfs-snapshot-backup.sh`) that has been patched through three major incidents. It works but has reached its maintainability limit. The 2026-03-22 journal entry documents a critical audit (15 issues found) and recommends Option C: a purpose-built tool replacing the bash script entirely.
+**Goal:** Progressive disclosure for new users, then guided setup wizard. Completes
+the Voice & UX work started in Priority 6.
 
-**Name:** Urd — the Norse norn who tends the Well of Urd and knows all that has passed.
-
-**Ambition:** Build a distributable "Time Machine for BTRFS on Linux" that starts as a homelab tool and grows into something others can use.
-
-## Decisions
-
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| Language | **Rust** | Distributable binary, type safety, no runtime deps. Bash script covers us while we build. |
-| Drive detection | **udev-first** | True Time Machine behavior. Scheduled fallback (02:00) as nice-to-have for large ops. |
-| Execution model | **Hybrid** | Triggered service for backups + small persistent sentinel for drive monitoring/notifications. |
-| State management | **SQLite + TOML** | TOML config (what to back up), SQLite state (what has been backed up). Clean separation. |
-| CLI name | **`urd`** | `urd status`, `urd backup`, `urd verify`, `urd history` |
-| Project location | **`~/projects/urd`** | Separate git repo, own Cargo workspace. |
-| Notifications | **Deferred** | Build after core is battle-tested. Desktop (notify-send) + Discord for critical. |
-
-## Project Structure
+**Sequencing rationale:**
+- 6-O (progressive disclosure) first — builds the framework 6-H needs
+- P6a (ADR-110 enum rename) — vocabulary alignment, small and self-contained
+- P6b (config Serialize refactor) — prerequisite for 6-H's config generation
+- 6-H (guided setup wizard) — largest item, depends on P6a + P6b + 6-O framework
 
 ```
-~/projects/urd/
-  Cargo.toml
-  src/
-    main.rs               # CLI entry point (clap), dispatches to commands
-    cli.rs                 # Clap command/argument definitions
-    config.rs              # TOML config loading, validation, defaults
-    types.rs               # Core domain types: Subvolume, Drive, Tier, Schedule, Snapshot
-    plan.rs                # Backup planner: reads state, decides operations (pure logic)
-    executor.rs            # Executes planned operations (snapshot, send, receive, delete)
-    btrfs.rs               # Low-level btrfs command wrappers (trait-based for testing)
-    retention.rs           # Retention engine (graduated + count-based)
-    chain.rs               # Incremental chain tracking (pin files, parent resolution)
-    state.rs               # SQLite state database (history, run records)
-    metrics.rs             # Prometheus .prom file writer (atomic tmp+rename)
-    drives.rs              # External drive detection (mount check, space via statvfs)
-    sentinel.rs            # Drive monitor daemon (Phase 5)
-    error.rs               # Error types (thiserror)
-    commands/
-      mod.rs
-      backup.rs            # `urd backup`
-      status.rs            # `urd status`
-      verify.rs            # `urd verify`
-      history.rs           # `urd history`
-      plan_cmd.rs          # `urd plan` (dry-run planning)
-      init.rs              # `urd init` (state import)
-  config/
-    urd.toml.example       # Reference config
-  systemd/
-    urd-backup.service     # Oneshot backup service
-    urd-backup.timer       # Nightly fallback timer
-    urd-sentinel.service   # Drive monitor (Phase 5)
-  udev/
-    99-urd-backup.rules    # Drive plug events (Phase 5)
-  tests/
-    integration/           # Tests requiring 2TB-backup drive (#[ignore])
-  README.md
-  LICENSE
-```
-
-## Configuration Schema (TOML)
-
-Location: `~/.config/urd/urd.toml`
-
-```toml
-[general]
-state_db = "~/.local/share/urd/urd.db"
-metrics_file = "~/containers/data/backup-metrics/backup.prom"
-log_dir = "~/containers/data/backup-logs"
-
-[local_snapshots]
-roots = [
-  { path = "~/.snapshots", subvolumes = ["htpc-home", "htpc-root"] },
-  { path = "/mnt/btrfs-pool/.snapshots", subvolumes = [
-    "subvol1-docs", "subvol2-pics", "subvol3-opptak",
-    "subvol4-multimedia", "subvol5-music", "subvol6-tmp", "subvol7-containers"
-  ]}
-]
-
-[[drives]]
-label = "WD-18TB"
-mount_path = "/run/media/<user>/WD-18TB"
-snapshot_root = ".snapshots"
-role = "primary"
-
-[[drives]]
-label = "WD-18TB1"
-mount_path = "/run/media/<user>/WD-18TB1"
-snapshot_root = ".snapshots"
-role = "offsite"
-
-[[drives]]
-label = "2TB-backup"
-mount_path = "/run/media/<user>/2TB-backup"
-snapshot_root = ".snapshots"
-role = "test"
-
-[defaults]
-snapshot_interval = "1h"
-send_interval = "4h"
-send_enabled = true
-enabled = true
-
-[defaults.local_retention]
-hourly = 24
-daily = 30
-weekly = 26
-monthly = 12
-
-[defaults.external_retention]
-daily = 30
-weekly = 26
-monthly = 0                    # 0 = unlimited
-
-[[subvolumes]]
-name = "htpc-home"
-short_name = "htpc-home"
-source = "/home"
-priority = 1
-snapshot_interval = "15m"
-send_interval = "1h"
-
-[[subvolumes]]
-name = "subvol3-opptak"
-short_name = "opptak"
-source = "/mnt/btrfs-pool/subvol3-opptak"
-priority = 1
-snapshot_interval = "1h"
-send_interval = "2h"
-
-# ... (all 9 subvolumes, see config/urd.toml.example for full reference)
-```
-
-## Architecture: Key Design Principles
-
-### 1. Planner/Executor Separation (most important)
-
-The planner is a **pure function**: `fn plan(config, state, now, filters) -> BackupPlan`. It produces a list of `PlannedOperation` variants:
-
-```rust
-enum PlannedOperation {
-    CreateSnapshot { source, dest, subvolume_name },
-    SendIncremental { parent, snapshot, dest_dir, drive_label, subvolume_name, pin_on_success },
-    SendFull { snapshot, dest_dir, drive_label, subvolume_name, pin_on_success },
-    DeleteSnapshot { path, reason, subvolume_name },
-}
-```
-
-Every variant carries `subvolume_name` so operations are self-describing — no path heuristics needed to determine ownership. Send variants carry `pin_on_success: Option<(PathBuf, SnapshotName)>` — the pin file is written by the executor only on successful send, making the send/pin dependency structural rather than implicit.
-
-`urd plan` prints the plan. `urd backup --dry-run` prints it. `urd backup` executes it. The planner is fully unit-testable without touching any filesystem.
-
-### 2. BtrfsOps Trait (testing seam)
-
-```rust
-pub trait BtrfsOps {
-    fn create_readonly_snapshot(&self, source: &Path, dest: &Path) -> Result<()>;
-    fn send_receive(&self, snapshot: &Path, parent: Option<&Path>, dest: &Path) -> Result<()>;
-    fn delete_subvolume(&self, path: &Path) -> Result<()>;
-    fn subvolume_show(&self, path: &Path) -> Result<SubvolumeInfo>;
-}
-```
-
-`RealBtrfs` calls `sudo btrfs` via `std::process::Command`. `MockBtrfs` records calls for testing. This is the only module that shells out.
-
-### 3. Never Lose Data, Always Continue
-
-Individual subvolume failures do NOT abort the run. Failed sends trigger partial cleanup. Pin files are only updated on success. Exit code 1 if any subvolume failed, 0 if all succeeded/skipped.
-
-### 4. Incremental Chain Integrity
-
-The incremental send/receive chain is the most performance-critical property of the system. A broken chain forces a full send (potentially hundreds of GB) instead of a small incremental diff.
-
-**Invariant:** Retention (local or external) must never delete a snapshot that is the current pin parent for any drive. The system enforces this through:
-- Pin file targets are always in the `pinned` set and are never deleted by retention
-- Unsent snapshot protection: when `send_enabled` is true, snapshots newer than the oldest pin are protected from local retention (they may not have been sent to all drives yet)
-- The planner verifies the parent exists on both local and external before planning an incremental send; if not, it falls back to a full send
-
-**Corollary:** The executor must re-check space between deletions on external drives rather than batch-deleting everything the planner proposed, because the planner cannot know exact snapshot sizes.
-
-### 5. Backward Compatibility
-
-- Snapshot naming:
-  - **Current (write):** `YYYYMMDD-HHMM-shortname` (e.g., `20260322-1430-opptak`)
-  - **Legacy (read-only):** `YYYYMMDD-shortname` (e.g., `20260322-opptak`) — parsed as midnight
-  - Both formats coexist transparently in snapshot directories
-- Directory structure: same locations as bash script
-- Pin files: `.last-external-parent-{DRIVE_LABEL}` format preserved (read+write), with legacy `.last-external-parent` fallback for reading
-- Prometheus metrics: identical names, labels, value semantics (see Prometheus Metrics below)
-
-## Prometheus Metrics
-
-File: `~/containers/data/backup-metrics/backup.prom` (configurable via `metrics_file`).
-Written atomically (temp file + rename) to prevent partial reads by the Prometheus node exporter.
-
-The metrics format must match the bash script's output exactly. Grafana dashboards and alerting depend on these names and labels.
-
-### Per-subvolume metrics
-
-| Metric | Type | Labels | Values |
-|--------|------|--------|--------|
-| `backup_last_success_timestamp` | gauge | `subvolume` | Unix timestamp; only set when `backup_success=1` |
-| `backup_success` | gauge | `subvolume` | `1`=success, `0`=failure, `2`=schedule-skipped |
-| `backup_duration_seconds` | gauge | `subvolume` | Integer seconds for the subvolume's operations |
-| `backup_snapshot_count` | gauge | `subvolume`, `location` | Count of snapshots; `location` is `"local"` or `"external"` (external = first mounted drive by config order, for bash compat) |
-| `backup_send_type` | gauge | `subvolume` | `0`=full, `1`=incremental, `2`=no send this run |
-
-### Global metrics
-
-| Metric | Type | Labels | Values |
-|--------|------|--------|--------|
-| `backup_external_drive_mounted` | gauge | none | `1`=any external drive mounted, `0`=none |
-| `backup_external_free_bytes` | gauge | none | Free bytes on mounted external drive; `0` when unmounted |
-| `backup_script_last_run_timestamp` | gauge | none | Unix timestamp when the backup ran |
-
-**Multi-drive note:** The bash script assumes a single external drive. These three global metrics maintain that assumption for backward compatibility: `backup_external_drive_mounted` is `1` if *any* configured drive is mounted, and `backup_external_free_bytes` reports the free space of the first mounted drive (by config order). Phase 4 may add per-drive metrics with a `drive` label, but the global metrics must remain for Grafana compatibility.
-
-### File format
-
-Each metric group has `# HELP`, `# TYPE gauge`, then one or more value lines. Groups separated by blank lines. `backup_send_type` must emit an entry for every subvolume that has a `backup_success` entry (never omit a series).
-
-Example:
-```
-# HELP backup_success Backup result: 1=success, 0=failure, 2=schedule-skipped
-# TYPE backup_success gauge
-backup_success{subvolume="subvol3-opptak"} 1
-backup_success{subvolume="htpc-home"} 2
-```
-
-## SQLite Schema
-
-The SQLite database records backup history. It is **not** the source of truth for current filesystem state — the filesystem (snapshot directories, pin files) is authoritative. SQLite answers "what happened" (runs, operations); the filesystem answers "what exists now" (snapshots, chain state).
-
-```sql
-CREATE TABLE runs (
-    id INTEGER PRIMARY KEY,
-    started_at TEXT NOT NULL,
-    finished_at TEXT,
-    mode TEXT NOT NULL,        -- "full", "local-only", "external-only", "dry-run"
-    result TEXT NOT NULL       -- "success", "partial", "failure"
-);
-
-CREATE TABLE operations (
-    id INTEGER PRIMARY KEY,
-    run_id INTEGER REFERENCES runs(id),
-    subvolume TEXT NOT NULL,
-    operation TEXT NOT NULL,   -- "snapshot", "send_incremental", "send_full", "delete"
-    drive_label TEXT,
-    duration_secs REAL,
-    result TEXT NOT NULL,      -- "success", "failure", "skipped"
-    error_message TEXT,
-    bytes_transferred INTEGER
-);
-```
-
-The `snapshots` table from the original plan has been removed. Pin files remain the source of truth for chain state, and snapshot directories are the source of truth for what exists. Duplicating this in SQLite creates a sync problem with no clear benefit — `urd status` and `urd history` can query the filesystem directly for current state and SQLite for historical data.
-
-## CLI Commands
-
-```
-urd backup [--dry-run] [--local-only] [--external-only] [--tier N] [--subvolume NAME] [--verbose]
-urd plan   [same filters as backup]     # Print planned operations without executing
-urd status                              # Drives, chain health, snapshot counts, last run
-urd history [--subvolume X] [--last N] [--failures]
-urd verify  [--subvolume X] [--drive LABEL]  # Chain integrity, pin file validation
-urd init                                # First-run: create config, import existing state
-```
-
-`urd status` example output:
-```
-SUBVOLUME          LOCAL  WD-18TB  WD-18TB1  LAST SEND    CHAIN
-htpc-home          15     14       12        2h ago       incremental
-subvol3-opptak     15     1        0         6h ago       full (new)
-subvol7-containers 15     2        1         23h ago      incremental
-
-Drives: WD-18TB1 mounted (4.4TB free / 17TB)
-Next scheduled: subvol2-pics in 5d (Saturday)
-```
-
-## Rust Crates
-
-| Crate | Purpose |
-|-------|---------|
-| `clap` 4.x | CLI with derive macros |
-| `serde` + `toml` | Config parsing |
-| `rusqlite` (bundled) | SQLite state DB |
-| `chrono` | Date/time, ISO week calc |
-| `thiserror` + `anyhow` | Error handling |
-| `nix` | statvfs for disk space |
-| `colored` | Terminal colors |
-| `tabled` | Table formatting for status/history |
-| `dirs` | XDG directory resolution |
-| `log` + `env_logger` | Structured logging |
-| `udev` | Phase 5: drive monitoring |
-
-**Not using:** tokio/async (unnecessary for sequential I/O-bound btrfs ops).
-
-## Implementation Phases
-
-### Phase 1: Skeleton + Config + Plan ✅
-
-**Goal:** `urd plan` reads config, discovers real snapshots, prints correct planned operations.
-
-**Completed:**
-- `config.rs` — TOML parsing, validation, tilde expansion, PathBuf throughout
-- `types.rs` — All domain types (Interval, SnapshotName with dual-format, PlannedOperation, ByteSize)
-- `cli.rs` — clap setup for all commands
-- `plan.rs` — planner logic (schedule, snapshot discovery, parent resolution, unsent protection)
-- `chain.rs` — pin file reading (drive-specific + legacy fallback)
-- `retention.rs` — graduated + count-based + space-governed retention
-- `drives.rs` — drive detection, space checks via statvfs, external snapshot dir construction
-- `error.rs` — thiserror error types
-- `commands/plan_cmd.rs` — `urd plan` with colored grouped output
-- 67 unit tests across all modules
-
-**Hardening (Phase 1.5):**
-- Unsent snapshot protection (prevents retention from deleting snapshots not yet sent externally)
-- `PinParent` removed — pin is now `pin_on_success` field on Send variants
-- `subvolume_name` added to all `PlannedOperation` variants
-- PathBuf migration (no more `to_string_lossy()` roundtrips)
-- Path validation (`validate_path_safe`, `validate_name_safe`)
-- Future-date snapshot warning
-- Monthly retention uses calendar month subtraction (not `days * 30`)
-
-### Phase 2: Execute + State + Metrics (Sessions 3-4)
-
-**Goal:** `urd backup` creates snapshots, sends to 2TB-backup, manages retention, writes metrics.
-
-**New modules:**
-- `btrfs.rs` — BtrfsOps trait + RealBtrfs + MockBtrfs
-- `executor.rs` — sequential operation execution (see Executor Contract below)
-- `state.rs` — SQLite schema, run/operation recording
-- `metrics.rs` — Prometheus .prom writer (exact format match)
-
-**Additions to existing modules:**
-- `chain.rs` — pin file writing (reading already done in Phase 1)
-- `error.rs` — executor error variants (BtrfsError, ExecutorError)
-
-**New commands:**
-- `commands/backup.rs` — `urd backup` (planner + executor), `--dry-run` prints plan
-- `commands/init.rs` — `urd init` (first-run setup: create SQLite DB, verify config paths exist, verify pin files are readable, detect and flag incomplete snapshots on external drives from interrupted bash script runs — offer cleanup with user confirmation, never silently delete, report system state summary)
-
-**Testing:**
-- Unit tests with MockBtrfs for executor logic
-- Integration tests on 2TB-backup drive (`#[ignore]`)
-
-**Deliverable:** Successful backup cycle to test drive. `urd backup --dry-run` on production matches bash.
-
-#### Executor Contract
-
-The executor takes a `BackupPlan` and executes each operation sequentially. Its behavior is governed by these rules:
-
-**Error isolation:** A failure in one subvolume must NOT abort operations for other subvolumes. The executor groups operations by `subvolume_name` and tracks per-subvolume success/failure. The overall result is `success` (all OK), `partial` (some failed), or `failure` (all failed).
-
-**Send execution:** The `btrfs send | btrfs receive` pipeline must:
-- Capture stderr from both the send and receive sides
-- Check exit codes from both processes
-- On failure, clean up any partial snapshot at the destination (`btrfs subvolume delete` on the incomplete receive)
-- Log both stderr streams for diagnostics
-
-**Pin-on-success:** After a successful send, the executor writes the pin file specified in `pin_on_success`. If the pin file write fails, the executor logs a warning and continues — the send itself succeeded and the snapshot is valid on the destination. The pin can be recovered on the next successful send to that drive. Note: repeated pin failures (e.g., due to a read-only mount) degrade performance by forcing full sends. Phase 3's `urd verify` / `urd status` should surface stale pins so the operator can investigate.
-
-**Retention execution on external drives:** The planner proposes deletions based on a point-in-time space check, but it cannot know exact snapshot sizes. The executor must:
-- Execute external deletions oldest-first
-- Re-check free space after each deletion
-- Stop deleting once the `min_free_bytes` threshold is satisfied, logging skipped deletions with reason ("space recovered, N planned deletions skipped") so `urd plan` vs `urd backup` divergence is visible to the operator
-- Never delete a snapshot that is the current pin parent for that drive (defense-in-depth — the planner already excludes these, but the executor double-checks)
-
-**Cascading failure handling:** When an operation fails, the executor must skip dependent operations within the same subvolume rather than letting them fail naturally. Specifically: if a `CreateSnapshot` fails, skip any subsequent `Send` that references the snapshot that was not created. The executor checks that source paths exist before attempting operations. This prevents confusing cascading errors in logs and ensures error messages reflect the root cause.
-
-**Crash recovery:** The executor does not assume clean state from prior runs. Before sending a snapshot to a drive, it checks whether a subvolume with that name already exists at the destination. If it exists but is not the result of a completed send (i.e., the pin file does not point to it), it deletes the partial and proceeds with a fresh send. This handles the case where a prior run was interrupted mid-transfer (power loss, drive disconnect, OOM kill). The pin file is the source of truth for "last successful send" — if the pin doesn't reference a snapshot, that snapshot's presence at the destination is not trusted for incremental chain purposes.
-
-**Operation ordering:** Within a subvolume, operations execute in plan order: create → send → delete. This ensures new snapshots exist before sends reference them, and deletions happen after sends complete. This ordering is load-bearing — the planner emits operations in this order (see comment in `plan()`) and the executor relies on it.
-
-### Phase 3: CLI + Parallel Run (Sessions 5-6) ✅
-
-**Goal:** Full CLI, parallel running with bash script for validation.
-
-**New commands:**
-- `commands/status.rs` — per-subvolume table (local/external counts, chain health), drive summary, last run from SQLite
-- `commands/history.rs` — recent runs, `--subvolume` filter, `--failures`, `--last N`
-- `commands/verify.rs` — pin file validation, pinned snapshot existence (local + external), orphan detection, stale pin detection
-
-**New CLI args:**
-- `HistoryArgs`: `--last N` (default 10), `--subvolume NAME`, `--failures`
-- `VerifyArgs`: `--subvolume NAME`, `--drive LABEL`
-
-**StateDb query methods added:**
-- `last_run()`, `recent_runs(limit)`, `run_operations(run_id)`, `subvolume_history(name, limit)`, `recent_failures(limit)`
-- New types: `RunRecord`, `OperationRow` (query result types separate from write type `OperationRecord`)
-
-**Adversary review fixes applied:**
-- Fixed `to_string_lossy()` in `RealBtrfs` — `create_readonly_snapshot` and `delete_subvolume` now use `.arg(path)` directly on `Command` instead of `run_btrfs(&[&str])`. The `run_btrfs` helper was removed entirely.
-- Extracted `first_mounted_drive_status()` to `drives.rs` for reuse by `status.rs`
-- Consolidated duplicate metrics helpers in `backup.rs` (`append_skipped_metrics`, `write_global_metrics`)
-
-**Systemd units:**
-- `systemd/urd-backup.service` — oneshot service, `ExecStart=%h/.cargo/bin/urd backup`
-- `systemd/urd-backup.timer` — 02:00 daily, `Persistent=true`, `RandomizedDelaySec=300`
-
-**Parallel run strategy:**
-- Pin file contention: no separate namespaces needed. Atomic writes + 1-hour separation sufficient. Last writer wins (correct behavior — pin should reflect most recent successful send).
-- Timing: Urd at 02:00, bash at 03:00. Separate lock files (can technically overlap, but btrfs ops on different subvolumes are safe concurrently).
-- Install: `cp systemd/*.{service,timer} ~/.config/systemd/user/ && systemctl --user daemon-reload && systemctl --user enable --now urd-backup.timer`
-- Change bash timer: `systemctl --user edit btrfs-backup-daily.timer` → set `OnCalendar=*-*-* 03:00:00`
-
-**Deliverable:** Both systems running nightly with equivalent results.
-
-### Phase 4: Cutover + Polish (Session 7) — code ✅, operations pending
-
-**Goal:** Urd is sole backup system.
-
-**Code (complete):** CLI help polish, btrfs_path validation, crash-recovery test, --verbose
-flag, dead code removal, tabled dependency removed. See [Phase 4 journal](../98-journals/2026-03-22-urd-phase4.md).
-
-**Operations (not started):**
-- Install and enable urd-backup.timer, run parallel with bash for 1-2 weeks
-- Disable bash script timer after validation
-- Write ADR-021 for the migration
-- Archive bash script to `scripts/archive/`
-
-See [status.md](status.md) for the detailed cutover checklist.
-
-### Phase 5: Sentinel + udev (Session 8, deferred)
-
-**Goal:** Automatic backup on drive plug-in.
-
-- `sentinel.rs` — udev event listener, debounce (wait for LUKS+mount)
-- `urd-sentinel.service` — persistent user service
-- udev rules for WD-18TB drives
-- Desktop notification hooks (infrastructure only — notification system built separately)
-
-## Migration Strategy
-
-1. **`urd init`** creates SQLite DB, verifies config paths, validates pin files, detects incomplete snapshots on external drives
-2. **Parallel running** (2 weeks): Urd at 02:00, bash at 03:00, compare metrics
-3. **Cutover:** disable bash timer, enable Urd timer, monitor 1 week
-4. Pin file format maintained throughout — both systems can coexist
-
-## Testing Prerequisites
-
-**Sudoers entries needed for 2TB-backup drive** (user must add manually):
-```
-<user> ALL=(root) NOPASSWD: /usr/sbin/btrfs subvolume delete /run/media/<user>/2TB-backup/.snapshots/*
-<user> ALL=(root) NOPASSWD: /usr/sbin/btrfs receive /run/media/<user>/2TB-backup/.snapshots/*
-```
-
-Existing `btrfs send *` and `btrfs subvolume snapshot -r` entries cover the local side.
-
-## Verification Plan
-
-After each phase:
-
-1. **Phase 1:** `urd plan` output matches manual calculation of what bash script would do for the same date/drive state
-2. **Phase 2:** Successful backup to 2TB-backup drive. Restore a file from the backup and verify byte-for-byte match. `backup.prom` output matches format exactly.
-3. **Phase 3:** After 2 weeks parallel run, diff Prometheus metrics between Urd and bash script runs. All subvolumes, all drives, all metrics must match.
-4. **Phase 4:** One week of sole Urd operation with no intervention. Grafana dashboards show continuity.
-5. **Phase 5:** Plug in test drive, verify backup starts within 60 seconds.
-
-## Critical Files Reference
-
-- `~/containers/scripts/btrfs-snapshot-backup.sh` — behavior to match
-- `~/containers/data/backup-metrics/backup.prom` — metrics format to reproduce
-- `~/.config/systemd/user/btrfs-backup-daily.service` — systemd patterns to follow
-- `~/.snapshots/htpc-home/.last-external-parent-WD-18TB1` — pin file format
-- `/etc/sudoers.d/btrfs-backup` — scope constraints for btrfs commands
-
----
-
-## Current Priorities
-
-> This section is a living tracker. Updated when priorities change.
-
-### Priority 5: Sentinel (paused — resumed after Priority 6)
-
-The Sentinel is three independent systems that compose. Sessions 1-2 complete and deployed.
-Sessions 3-4 deferred below Priority 6 UX work. Session 3's notification dedup is subsumed
-by 6-I's structured advisory cooldown mechanism.
-
-| # | Component | Status | Notes |
-|---|-----------|--------|-------|
-| 5a | **Notification dispatcher** | **Complete** | `notify.rs`: `compute_notifications()` pure function, 4 channel types, urgency filtering. 18 tests. |
-| 5b | **Event reactor (passive)** | **Sessions 1-2 complete, deployed** | Pure state machine + I/O runner + CLI. Running as systemd user service. |
-| 5b-3 | **Sentinel hardening** | Deferred | Scoped after 6-I ships (notification dedup subsumed by advisory cooldown). |
-| 5c | **Active mode** | Designed, not built | Auto-trigger logic: `should_trigger_backup()`, `TriggerPermission`. After Priority 6. |
-
-### Priority 5.5: Safety & Visibility — Complete
-
-All 10 items built and deployed (v0.4.1–v0.5.0):
-- Hardware swap defenses (drive session tokens, chain health as awareness input, full-send gate)
-- Visual feedback model (OperationalHealth enum, two-axis CLI, sentinel visual_state)
-- Transient snapshots (local_retention = "transient", immediate cleanup)
-
-| Item | Design | Review |
-|------|--------|--------|
-| Hardware swap defenses | [design](../95-ideas/2026-03-28-design-hardware-swap-defenses.md) | [review](../99-reports/2026-03-28-hardware-swap-defenses-design-review.md) |
-| Visual feedback model | [design](../95-ideas/2026-03-28-design-visual-feedback-model.md) | [review](../99-reports/2026-03-28-visual-feedback-model-design-review.md) |
-| Spindle tray icon | [brainstorm](../95-ideas/2026-03-28-brainstorm-tray-icon-spindle.md) | Needs design doc (build after Phase 5) |
-
-### Priority 6: Voice, UX & Redundancy Guidance
-
-The next arc: unify Urd's voice, build high-impact UX features, and teach 3-2-1 strategy
-through the promise system and progressive disclosure. Two brainstorm sessions resolved
-the complete vocabulary and scored UX features. Six phase designs reviewed by arch-adversary.
-
-**Two arcs, one dependency chain:**
-
-```
-Voice & UX Arc                        Progressive & Setup Arc
-──────────────                        ───────────────────────
-Merge 6-B + 6-E (ready now)
+6-O: Progressive disclosure (2 sessions)
   │
-Phase 1: Vocabulary landing
+P6a: ADR-110 enum rename (1 session)
   │
-Phase 2a+2c: urd default + completions
+P6b: Config Serialize refactor (0.5 session)
   │
-6-I: Advisory system ─────────────────→ 6-O: Progressive disclosure (2 sessions)
-  │                                        │
-6-N + Phase 2b: Retention + doctor        ADR-110 enum rename (1 session)
-  │                                        │
-Phase 4a+4b: Escalation + suggestions    Config Serialize refactor (0.5 session)
-  │                                        │
-Phase 4c: Mythic transitions             6-H: Guided setup wizard (4 sessions)
+6-H: Guided setup wizard (4 sessions)
 ```
 
-**Estimated total: 15 sessions, ~150 new/modified tests, test suite 589 → ~740.**
+Estimated: ~7.5 sessions remaining, test suite target ~750.
 
-#### Feature table
+**Legacy identifiers:** These items were designed under the old Priority 6 numbering.
+See the [archived roadmap](../90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md)
+feature table for their design and review links. Future items use UPI numbering
+(see [registry.md](registry.md)).
 
-| # | Feature | Effort | Status | Design | Review |
-|---|---------|--------|--------|--------|--------|
-| 6-B | **Transient immediate cleanup** | 1 session | **Built, reviewed** | [design](../95-ideas/2026-03-31-design-b-transient-immediate-cleanup.md) | [review](../99-reports/2026-03-31-design-b-review.md) |
-| 6-E | **Promise redundancy encoding** | 1 session | **Built, reviewed** | [design](../95-ideas/2026-03-31-design-e-promise-redundancy-encoding.md) | [review](../99-reports/2026-03-31-design-e-review.md) |
-| P1 | **Vocabulary landing** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase1-vocabulary-landing.md) | [review](../99-reports/2026-03-31-design-phase1-vocabulary-landing-review.md) |
-| P2a | **`urd` default status** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase2-ux-commands.md) | [review](../99-reports/2026-03-31-design-phase2-ux-commands-review.md) |
-| P2b | **`urd doctor`** | 1 session | Designed, reviewed | (same as P2a) | (same as P2a) |
-| P2c | **Shell completions** | 0.5 session | Designed, reviewed | (same as P2a) | (same as P2a) |
-| 6-I | **Redundancy recommendations** | 1–2 sessions | Designed, reviewed | [design](../95-ideas/2026-03-31-design-i-redundancy-recommendations.md) | [review](../99-reports/2026-03-31-design-phase3-advisory-retention-review.md) |
-| 6-N | **Retention policy preview** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-n-retention-policy-preview.md) | (same as 6-I) |
-| P4a | **Staleness escalation** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase4-voice-enrichment.md) | [review](../99-reports/2026-03-31-arch-adversary-phase4-voice-enrichment.md) |
-| P4b | **Next-action suggestions** | (with P4a) | Designed, reviewed | (same as P4a) | (same as P4a) |
-| P4c | **Mythic voice on transitions** | 0.5-1 session | Designed, reviewed | (same as P4a) | (same as P4a) |
-| 6-O | **Progressive disclosure** | 2 sessions | Designed, reviewed | [design](../95-ideas/2026-03-31-design-o-progressive-disclosure.md) | [review](../99-reports/2026-03-31-design-phase5-progressive-disclosure-review.md) |
-| P6a | **ADR-110 enum rename** | 1 session | Designed, reviewed | [design](../95-ideas/2026-03-31-design-phase6-protection-rename-wizard.md) | [review](../99-reports/2026-03-31-design-phase6-protection-rename-wizard-review.md) |
-| P6b | **Config Serialize refactor** | 0.5 session | Prerequisite for 6-H | (same as P6a) | (same as P6a) |
-| 6-H | **Guided setup wizard** | 4 sessions | Designed, reviewed | [design](../95-ideas/2026-03-31-design-h-guided-setup-wizard.md) | [review](../99-reports/2026-03-31-design-h-review.md) |
+## Horizon
 
-#### Key review findings incorporated
+**Sentinel completion** — Sessions 3-4: notification dedup (subsumed by 6-I cooldown),
+active mode (auto-trigger backup on drive connect). Designed, not built.
 
-| Finding | Source | Resolution |
-|---------|--------|------------|
-| Heartbeat schema bump likely unnecessary | Phase 6 S-1 | Drop — heartbeat serializes promise states, not level names |
-| Config key rename scope too large | Phase 6 M-1 | Defer to ADR-111 config overhaul |
-| Voice thresholds contradict awareness | Phase 4 S-1 | Derive from PromiseStatus, not independent thresholds |
-| Cooldown key must include drive_label | Phase 3 S-1 | Design update before 6-I implementation |
-| Config error conflation in urd default | Phase 2 S-1 | Distinguish NotFound from ParseError |
-| Sentinel notification dedup | Phase 3 | Subsumed by 6-I cooldown mechanism |
+**Experience polish** — Recovery contract generation, deep verification (`urd verify --deep`),
+attention budget (priority queue in awareness model). Requires the UX foundation from the
+active arc.
 
-#### Brainstorm artifacts
+**Spindle** — Tray icon for desktop integration. Urd's desktop face. Depends on Sentinel
+active mode and the visual state work from Priority 5.5.
 
-| Document | Content |
-|----------|---------|
-| [Next-level UX brainstorm](../95-ideas/2026-03-31-brainstorm-next-level-ux.md) | 12 candidates scored, 7 accepted (scores 6-10), 4 rejected |
-| [Vocabulary audit](../95-ideas/2026-03-31-brainstorm-vocabulary-audit.md) | Complete vocabulary redesign: exposure triad, protection levels, thread, drives, skip tags |
+## Strategic Context
 
-#### Also in this priority (independent)
+**ADR-111 config migration is the largest deferred gate.** The target config architecture
+(explicit drive routing, no inheritance, named levels are opaque) is defined but not
+implemented. Legacy schema (`[defaults]`, `[local_snapshots]`) is in use. The guided setup
+wizard (6-H) will generate new-schema configs, but existing configs won't auto-migrate
+until ADR-111 is implemented. This is intentional — the wizard proves the schema before
+migration code is written.
 
-| # | Feature | Effort | Notes |
-|---|---------|--------|-------|
-| 6-Sp | **Tray icon (Spindle)** | Low–Medium | Design after Phase 4/5 visual improvements. Build after 6-O. [brainstorm](../95-ideas/2026-03-28-brainstorm-tray-icon-spindle.md). |
+**Sentinel active mode requires trust.** Auto-triggering backups on drive connect is
+powerful but risky. It must prove its circuit breaker, cooldown, and permission model
+before deployment. Passive mode (current) is the safety net.
 
-#### Deferred from old Priority 6
-
-| # | Feature | Notes |
-|---|---------|-------|
-| 6b | **Smart defaults** | Subsumed by H (wizard infers from filesystem). |
-| 6d | **Drive replacement workflow** | Build after H proves the guided interaction pattern. |
-| 6e | **`urd find` (cross-snapshot search)** | Unsolved perf problem. Deferred until `urd get` proves restore UX. |
-
-### Priority 7: Experience Polish
-
-| # | Feature | Effort | Notes |
-|---|---------|--------|-------|
-| 7a | **Recovery contract** | Low-Medium | Generated from config + awareness model state. Overlaps with H's coverage map. |
-| 7b | **Deep verification** | Medium | `urd verify --deep`: random-sample checksums from external vs. local. |
-| 7c | **Attention budget** | Medium | Priority queue in awareness model. Filter by urgency. |
-| 7d | **Config validation as simulation** | Medium | Subsumed by N (retention preview) and H (setup wizard). |
-
-### Deferred
-
-| Feature | Rationale |
-|---------|-----------|
-| SSH remote targets | Keep the app simple for now. |
-| Cloud backup (S3/B2) | Indefinitely. |
-| Pull mode / mesh | Indefinitely. |
-| Multi-user / library mode | No current need. |
-
-### Open gates (from ADR-110/111)
-
-- [ ] Drive topology constraints — capacity checks require I/O, deferred to Sentinel
-- [ ] Awareness threshold mode — fixed multipliers regardless of run frequency, deferred
-- [ ] Config schema migration (ADR-111) — target architecture defined, legacy schema in use; config key rename (`protection_level` → `protection`) deferred here
-- [ ] Protection level enum rename — resolved vocabulary (recorded/sheltered/fortified), scheduled as P6a after 6-O ships
-- [ ] Heartbeat schema bump — likely unnecessary per Phase 6 review S-1 (heartbeat serializes promise states, not level names); verify before P6a
-
-## Completed Features
-
-### Priority 2: Safety Hardening — Complete
-
-All five items built, adversary-reviewed, and deployed:
-- UUID drive fingerprinting (`DriveAvailability` enum, `findmnt` detection)
-- Local space guard (planner gates on `min_free_bytes`)
-- Surface skipped sends (subsumed by structured summary)
-- Post-backup structured summary (`BackupSummary` output type)
-- Pre-flight config checks (`preflight.rs`, 2 checks)
-- Structured error messages (`translate_btrfs_error()`, 7 patterns)
-
-### Priority 3: Architectural Foundation — Complete
-
-- Awareness model (`awareness.rs`) — pure function, 24 tests
-- Heartbeat file (`heartbeat.rs`) — JSON health signal, schema v1, 7 tests
-- Presentation layer (`output.rs` + `voice.rs`) — 8/8 commands migrated
-- `urd get` (`commands/get.rs`) — file restore, 19 tests
-
-### Priority 4: Protection Promises — Complete
-
-- `ProtectionLevel` enum, `derive_policy()`, config resolution branching
-- Preflight achievability checks (drive-count, voiding, weakening)
-- Planner drive filtering, `--confirm-retention-change` fail-closed gate
-- Promise-anchored status display (conditional PROMISE column)
-- ADR-110 written and revised, ADR-111 (config target architecture) written
-
-## Phase Checklist
-
-- [x] Phase 1 — Skeleton + Config + Plan (67 tests)
-- [x] Phase 1.5 — Hardening (unsent protection, path safety, pin-on-success)
-- [x] Phase 2 — Executor + State DB + Metrics + `urd backup`
-- [x] Phase 3 — CLI commands + systemd units
-- [x] Phase 3.5 — Hardening for cutover
-- [x] Phase 4 code — Cutover polish + space estimation
-- [ ] Phase 4 cutover — Operational transition (monitoring target: 2026-04-01)
-- [x] Post-cutover — Priorities 2-4 complete
-- [x] Phase 5 — Architectural foundation complete
-- [x] Phase 6 — Protection promises complete
-- [x] Phase 7 — Sentinel Sessions 1-2 deployed (Sessions 3-4 deferred after Priority 6)
-- [x] Phase 7.5 — Safety & Visibility (5.5a-d: all 10 items complete, v0.4.1–v0.5.0)
-- [ ] Phase 8 — Voice & UX overhaul (P1→P2→6-I→6-N→P4→6-O→P6a→6-H)
-- [ ] Phase 9 — Sentinel completion (Session 3 hardening, Session 4 active mode)
-- [ ] Phase 10 — Spindle tray icon
-
-## Dropped Features
-
-- **Tier 2 filesystem-level upper bound** — wrong for actual data distribution
-- **Tier 3 Option A opportunistic qgroup query** — quotas confirmed off, speculative
+**Documentation effort planned.** Module design guides, architecture principles document,
+API reference. Not in scope until the codebase stabilizes after the setup wizard. The
+current CLAUDE.md + ADRs + operating guide covers development needs.
 
 ## Tech Debt
 
+Maintained here as context for sequencing decisions. Items that gate features are noted.
+
+- NVMe snapshot accumulation above 10GB threshold not gated (6-B partially addresses)
+- `FileSystemState` trait (11 methods) outgrowing its name — consider rename to `SystemState`
+- Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" as raw strings (constants needed)
+- Parallel notification builders in notify.rs and sentinel_runner.rs (maintenance risk)
+- `assess()` does not respect per-subvolume `drives` scoping
 - Pipe bytes vs. on-disk size mismatch in space estimation (1.2x margin handles common case)
-- `du -sb` may follow symlinks in snapshots — consider `-P` flag
-- Stale failed send estimates persist indefinitely — consider TTL
-- `SubvolumeResult.send_type` records only last send type for multi-drive sends
-- `heartbeat::read()` returns `Option` — can't distinguish missing from corrupt
-- Per-drive pin protection for external retention: all-drives-union is conservative
 - `urd get` doesn't support directory restore (files only in v1)
-- `warn_missing_uuids` spawns `findmnt` per drive on every run
-- Bootstrap pattern: code touching `external_snapshot_dir()` may assume dirs exist
-- MockBtrfs tests don't exercise filesystem preconditions
 - Journal persistence gap: journald may purge user-unit logs
-- NVMe snapshot accumulation above 10GB threshold not gated
+
+## Deferred (no current timeline)
+
+- SSH remote targets
+- Cloud backup (S3/B2)
+- Pull mode / mesh topology
+- Multi-user / library mode
+- `urd find` (cross-snapshot search) — unsolved perf problem
+- Drive replacement workflow — build after 6-H proves guided interaction

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -1,7 +1,8 @@
 # Urd Project Status
 
 > This is a short current-state document (~50 lines). Overwritten each session, not appended.
-> For the full feature roadmap, see [roadmap.md](roadmap.md).
+> For strategy and sequencing, see [roadmap.md](roadmap.md).
+> For work item → artifact mapping, see [registry.md](registry.md).
 > For architecture and code conventions, see [CLAUDE.md](../../CLAUDE.md).
 
 ## Current State
@@ -9,59 +10,47 @@
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
 692 tests, all passing, clippy clean. Current version: v0.7.0.
-Transient retention deployed to htpc-root (2026-03-30). Immediate cleanup built, not yet deployed.
 
-**Voice & UX arc complete.** All six phases merged: vocabulary (Phase 1), urd default +
-completions (Phase 2a+2c), redundancy advisories (6-I), retention preview + doctor
-(6-N + Phase 2b), staleness escalation + suggestions (Phase 4a+4b), mythic transitions
-(Phase 4c).
+**Voice & UX arc complete.** All six phases merged: vocabulary (P1), urd default +
+completions (P2a+2c), redundancy advisories (6-I), retention preview + doctor (6-N + P2b),
+staleness escalation + suggestions (P4a+4b), mythic transitions (P4c).
+
+**Workflow system overhaul complete (UPI 001).** UPI system, registry.md, /sequence skill,
+updated pipeline, archived 550-line roadmap and replaced with 85-line version, validate.sh.
 
 ## In Progress
 
-Nothing active. Last completed: Phase 4c (mythic voice on transitions) + v0.7.0 release.
+Nothing active. Last completed: UPI 001 workflow system overhaul.
 
 ## Next Up
 
 1. **6-O** — Progressive disclosure (milestones, onboarding layer). ~2 sessions.
-   [Design](../95-ideas/2026-03-31-design-o-progressive-disclosure.md) |
-   [Review](../99-reports/2026-03-31-design-phase5-progressive-disclosure-review.md)
-2. **P6a: ADR-110 enum rename** — Vocabulary alignment for protection level enums. ~1 session.
-   [Design](../95-ideas/2026-03-31-design-phase6-protection-rename-wizard.md) |
-   [Review](../99-reports/2026-03-31-design-phase6-protection-rename-wizard-review.md)
-3. **P6b: Config Serialize refactor** — Prerequisite for 6-H wizard. ~0.5 session.
+   Design: [95-ideas/2026-03-31-design-o-progressive-disclosure.md](../95-ideas/2026-03-31-design-o-progressive-disclosure.md)
+2. **P6a** — ADR-110 enum rename. ~1 session.
+3. **P6b** — Config Serialize refactor. ~0.5 session.
+4. **6-H** — Guided setup wizard. ~4 sessions.
 
-## Build Queue — Priority 6: Progressive & Setup Arc
-
-```
-Progressive & Setup Arc:
-  6-O: Progressive disclosure (2 sessions)
-  P6a: ADR-110 enum rename (1 session)
-  P6b: Config Serialize refactor (0.5 session)
-  6-H: Guided setup wizard (4 sessions)
-```
-
-Estimated: ~7.5 sessions remaining, test suite target ~750.
+These use legacy identifiers from the old Priority 6 system. See
+[roadmap.md](roadmap.md) for sequencing rationale.
 
 ## Key Links
 
 | Purpose | Document |
 |---------|----------|
-| Feature roadmap and priorities | [roadmap.md](roadmap.md) |
+| Strategy and sequencing | [roadmap.md](roadmap.md) |
+| UPI work item registry | [registry.md](registry.md) |
 | Architecture and code conventions | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
-| Phase designs (1-6) | [95-ideas/](../95-ideas/) (2026-03-31-design-*.md) |
+| Design docs | [95-ideas/](../95-ideas/) |
 | Review reports | [99-reports/](../99-reports/) |
-| Phase 4c implementation review | [99-reports/2026-04-01-arch-adversary-phase4c-transitions.md](../99-reports/2026-04-01-arch-adversary-phase4c-transitions.md) |
+| Historic roadmap (pre-UPI) | [archived](../90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md) |
 
 ## Known Issues
 
-- NVMe snapshot accumulation: space guard prevents catastrophic exhaustion but gradual accumulation above 10GB threshold not gated (6-B partially addresses for transient subvolumes)
-- Journal persistence gap: journald may purge user-unit logs; heartbeat partially compensates
+- NVMe snapshot accumulation: space guard prevents catastrophic exhaustion but gradual accumulation above 10GB threshold not gated
 - `FileSystemState` trait (11 methods) outgrowing its name — consider rename to `SystemState`
-- `urd get` doesn't support directory restore (files only in v1)
-- Parallel notification builders in notify.rs and sentinel_runner.rs — same mythology, different data sources (maintenance risk)
-- Sentinel Sessions 3-4 remaining (Session 3 dedup subsumed by 6-I cooldown mechanism)
-- `assess()` does not respect per-subvolume `drives` scoping — downstream consumers must filter independently (pre-existing, documented in 6-I review)
-- Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" matched as raw strings across voice.rs — consider constants in output.rs (flagged in Phase 4a+4b and 4c reviews)
-- PromiseRecovered voice line uses raw status strings instead of vocabulary terms (sealed/waning/exposed) — cosmetic, could fold into P6a
+- Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" matched as raw strings — consider constants
+- Parallel notification builders in notify.rs and sentinel_runner.rs (maintenance risk)
+- `assess()` does not respect per-subvolume `drives` scoping
+- Legacy active arc items (6-O, P6a, P6b, 6-H) use old naming — may get UPIs when redesigned

--- a/docs/99-reports/2026-04-01-ccpm-evaluation-and-workflow-comparison.md
+++ b/docs/99-reports/2026-04-01-ccpm-evaluation-and-workflow-comparison.md
@@ -1,0 +1,488 @@
+# CCPM Evaluation and Workflow Comparison
+
+> **TL;DR:** CCPM (Claude Code Project Manager) is a spec-driven workflow skill that
+> solves several gaps in Urd's current workflow — particularly planning/execution separation,
+> task decomposition, and progress tracking. However, it's designed for multi-developer
+> product teams building web features, not a solo developer building a systems tool with
+> a deep documentation culture. The right approach is selective adoption: take CCPM's
+> strongest ideas (structured planning artifacts, task decomposition with dependencies,
+> script-based tracking, GitHub issue integration) and adapt them to Urd's existing
+> strengths (ADR system, review pipeline, mythic voice philosophy, document-as-context
+> design). This document maps CCPM's five phases against Urd's nine-command pipeline,
+> identifies what each system does better, and proposes a synthesis.
+
+**Date:** 2026-04-01
+**Type:** Comparative analysis
+**Sources:** [CCPM repository](https://github.com/automazeio/ccpm), Urd workflow analysis
+(`docs/99-reports/2026-04-01-workflow-and-project-management-analysis.md`)
+
+---
+
+## 1. What CCPM Is
+
+CCPM is a Claude Code Agent Skill implementing a five-phase workflow:
+
+```
+Plan (PRD) → Structure (Epic + Tasks) → Sync (GitHub Issues) → Execute (Parallel Agents) → Track (Bash Scripts)
+```
+
+Key properties:
+- **Spec-driven:** Everything starts as a PRD (Product Requirements Document), becomes
+  a technical epic, decomposes into numbered tasks with dependency metadata
+- **GitHub-centric:** Tasks sync to GitHub Issues with labels, sub-issues, and worktrees
+- **Parallelism-first:** Tasks are analyzed for file conflicts and launched as parallel
+  agents in isolated worktrees
+- **Script-based tracking:** 14 bash scripts handle status/standup/search/validation
+  without LLM overhead
+- **Local files as source of truth:** `.claude/prds/` and `.claude/epics/` persist across
+  sessions; GitHub is a synchronized mirror
+
+---
+
+## 2. Side-by-Side Comparison
+
+### 2.1 Workflow Phase Mapping
+
+| Concern | CCPM | Urd | Assessment |
+|---------|------|-----|------------|
+| **Ideation** | PRD brainstorming (guided questions) | `/brainstorm` (divergent, no scoring) | Both good. Urd's is more creative; CCPM's is more structured |
+| **Requirements** | PRD document with acceptance criteria | No explicit step | **Gap in Urd.** Design docs assume requirements are understood |
+| **Design** | Epic (technical decomposition from PRD) | `/design` (module decomposition, ADR gates) | Urd's is deeper — it reasons about architectural invariants |
+| **Stress-testing** | None | `/grill-me` (Socratic interview) | **Urd advantage.** CCPM has no equivalent |
+| **Task breakdown** | Structure phase (numbered tasks, dependencies, parallelization) | Implicit in design doc | **Gap in Urd.** No formal task decomposition |
+| **GitHub sync** | Sync phase (issues, labels, worktrees) | `/commit-push-pr` (branch, commit, PR) | **Gap in Urd.** No issue tracking, no task-level visibility |
+| **Execution** | Parallel agents with stream analysis | Manual implementation | **Gap in Urd.** But solo developer rarely needs parallelism |
+| **Code review** | None built-in | `arch-adversary` + `/post-review` + `/simplify` | **Urd advantage.** CCPM has no review pipeline |
+| **Quality gate** | None built-in | `/check` (clippy + tests + build) | **Urd advantage.** CCPM assumes CI handles this |
+| **Tracking** | 14 bash scripts (standup, blocked, next, search) | `status.md` + `roadmap.md` (manual) | **CCPM advantage.** Automated, zero LLM cost |
+| **Documentation** | Minimal (PRD + epic + task files) | Rich (ADRs, journals, design docs, reviews, CONTRIBUTING.md) | **Urd advantage.** CCPM treats docs as tickets, not knowledge |
+| **Release** | None | `/release` (SemVer, CHANGELOG, tags) | **Urd advantage.** CCPM doesn't cover release workflow |
+| **Session continuity** | `.claude/` files persist context | `status.md` → journals → design docs | Both good. Different mechanisms, same goal |
+
+### 2.2 Artifact Comparison
+
+| Artifact | CCPM | Urd |
+|----------|------|-----|
+| Requirements | `.claude/prds/<name>.md` with frontmatter | Absorbed into design docs or conversation |
+| Technical plan | `.claude/epics/<name>/epic.md` | `docs/95-ideas/YYYY-MM-DD-design-slug.md` |
+| Tasks | `.claude/epics/<name>/<N>.md` with status, dependencies | None (implicit in design docs) |
+| Progress | `.claude/epics/<name>/updates/<N>/progress.md` | `docs/96-project-supervisor/status.md` (manual) |
+| Reviews | None | `docs/99-reports/YYYY-MM-DD-{review}.md` |
+| Decisions | None | `docs/00-foundation/decisions/ADR-NNN.md` |
+| Session logs | None | `docs/98-journals/YYYY-MM-DD-slug.md` |
+| Cross-reference | `github-mapping.md` + frontmatter links | Feature table in `roadmap.md` |
+
+### 2.3 Philosophy Comparison
+
+| Dimension | CCPM | Urd |
+|-----------|------|-----|
+| **Who is it for?** | Teams shipping product features | Solo developer building a systems tool |
+| **What's the unit of work?** | GitHub Issue | Design doc + implementation session |
+| **What's the source of truth?** | Local `.claude/` files mirrored to GitHub | `docs/` directory tracked in git |
+| **How is quality ensured?** | Spec completeness + parallel execution | Review pipeline (design → impl → post-review) |
+| **How is knowledge preserved?** | Ticket lifecycle (open → closed → archived) | Documentation lifecycle (idea → design → ADR → journal) |
+| **What's the failure mode?** | Ticket debt (stale issues, zombie epics) | Documentation drift (naming inconsistency, growing roadmap) |
+| **Context model** | Structured frontmatter with status fields | TL;DR convention + information hierarchy |
+
+---
+
+## 3. What CCPM Does Better
+
+### 3.1 Planning/Execution Separation (Critical Gap in Urd)
+
+CCPM enforces a hard boundary: you cannot start executing until you have a PRD, an epic,
+and decomposed tasks. Urd's workflow allows jumping from `/design` directly to implementation
+without an explicit "what are the discrete tasks?" step.
+
+**Evidence from Urd:** The `.claude/plans/` directory contains 53 session plans that are
+essentially ad-hoc task lists Claude Code created during sessions. These are the task
+decomposition step happening implicitly and ephemerally rather than as a durable artifact.
+
+**What to adopt:** A lightweight task decomposition step between design and implementation.
+Not CCPM's full PRD → Epic → Task pipeline (too heavyweight for solo development), but a
+structured "implementation plan" section in the design doc that lists discrete tasks with
+ordering.
+
+### 3.2 Task Decomposition with Dependencies
+
+CCPM's task files carry structured metadata:
+
+```yaml
+depends_on: [1234, 1235]     # can't start until these close
+parallel: true                # safe to run concurrently
+conflicts_with: [1237]        # touches same files
+```
+
+Urd has nothing equivalent. The design doc describes what modules are affected, but doesn't
+decompose into ordered steps with explicit dependencies.
+
+**What to adopt:** When `/design` produces a multi-session feature, include a task table:
+
+```markdown
+## Implementation Tasks
+
+| # | Task | Depends on | Modules | Est. |
+|---|------|-----------|---------|------|
+| 1 | Add new types to types.rs | - | types | 0.5h |
+| 2 | Implement pure logic in awareness.rs | 1 | awareness | 1h |
+| 3 | Wire into executor | 1, 2 | executor, commands | 1h |
+| 4 | Add voice rendering | 2 | voice, output | 0.5h |
+| 5 | Tests for all new paths | 1-4 | tests | 1h |
+```
+
+This is lighter than CCPM's per-file task system but captures the same information.
+
+### 3.3 Script-Based Tracking (Zero LLM Cost)
+
+CCPM's 14 bash scripts are brilliant. Status queries, standups, blocked items, and
+validation run as deterministic shell scripts. No tokens consumed. Instant results.
+
+Urd's equivalent — reading status.md and roadmap.md — consumes tokens every session and
+requires LLM interpretation. The `/journal` command manually overwrites status.md.
+
+**What to adopt:** A small set of tracking scripts that answer common session-start questions
+without LLM overhead:
+
+| Script | Purpose | Urd equivalent today |
+|--------|---------|---------------------|
+| `status.sh` | What's deployed, test count, version | Read status.md (tokens) |
+| `next.sh` | What to work on next | Read status.md + roadmap.md (tokens) |
+| `validate.sh` | Check for naming inconsistencies, orphaned docs | None |
+| `review-map.sh` | Find the review for a given design doc | Manual grep |
+
+These don't replace status.md (which serves as a handoff document for context), but they
+reduce the token cost of routine queries.
+
+### 3.4 GitHub Issue Integration
+
+CCPM uses GitHub Issues as a task tracking layer. Each task gets an issue number, labels
+link issues to epics, and progress is posted as comments.
+
+Urd currently uses PRs for code integration but doesn't use Issues for task tracking. Work
+items are tracked in roadmap.md's feature table and status.md's "Next Up" section.
+
+**What to adopt (carefully):** GitHub Issues could track the "Next Up" queue from
+status.md. Each priority item (6-O, P6a, P6b, 6-H) could be an issue with a label. This
+provides:
+- A public-facing view of what's planned
+- A place for implementation notes that's not a full design doc
+- Automatic linkage to PRs via `Fixes #N` in commit messages
+
+**What NOT to adopt:** CCPM's full epic/sub-issue hierarchy. For a solo developer, the
+overhead of managing issue relationships exceeds the benefit. A flat list of issues
+labeled by priority arc is sufficient.
+
+### 3.5 Frontmatter as Structured Metadata
+
+CCPM puts machine-readable frontmatter on every artifact:
+
+```yaml
+---
+name: feature-name
+status: backlog | in-progress | completed
+created: 2026-04-01T12:00:00Z
+github: https://github.com/.../issues/42
+depends_on: [41, 43]
+---
+```
+
+Urd's documents have TL;DR blocks and metadata fields, but they're not consistently
+structured for machine parsing. The `Status:` field in `docs/95-ideas/` files is good,
+but it's free-text, not a controlled vocabulary.
+
+**What to adopt:** Standardize the status field vocabulary across all Urd document types.
+Use YAML frontmatter where documents might be programmatically queried (especially in
+`docs/95-ideas/` and `docs/99-reports/`). This enables future tracking scripts.
+
+---
+
+## 4. What Urd Does Better
+
+### 4.1 Review Pipeline (CCPM Has None)
+
+CCPM goes from "tasks decomposed" to "agents executing" with no review step. There is no
+design review, no implementation review, no adversarial challenge. Quality is assumed to
+come from spec completeness and test coverage.
+
+Urd's `arch-adversary` → `/post-review` → `/simplify` pipeline is one of its most valuable
+assets. The 6-dimension scorecard (premises, flow, gates, error paths, simplicity, naming)
+with severity ratings has caught significant bugs before they shipped.
+
+**Verdict:** Keep everything. CCPM has nothing to offer here.
+
+### 4.2 Architectural Decision Records
+
+CCPM has no concept of ADRs. Decisions are embedded in PRDs and epics. There's no mechanism
+for recording why architectural choices were made, making them immutable, or superseding them.
+
+Urd's ADR system (14 records, strict numbering, immutability, supersession workflow) is
+among the most disciplined aspects of the project. For a systems tool where backward
+compatibility matters, this is essential.
+
+**Verdict:** Keep everything. This is infrastructure CCPM doesn't need (web features)
+but Urd absolutely does (on-disk data formats, config contracts).
+
+### 4.3 Documentation as Knowledge (Not Just Tickets)
+
+CCPM treats documents as workflow artifacts: they're created, tracked, and archived. Once
+an epic is merged, its docs move to `.claude/epics/archived/`. Knowledge lives in the code
+and commit history.
+
+Urd treats documents as accumulated knowledge: design docs capture reasoning, ADRs record
+decisions, journals preserve context, reviews identify patterns. The documentation system
+is designed for a project that will be maintained for years, not a feature that ships and
+is forgotten.
+
+**Verdict:** Urd's approach is correct for its domain. A backup tool's documentation needs
+to explain *why* decisions were made years after the fact. CCPM's archive-and-forget model
+would lose this context.
+
+### 4.4 The Grill-Me Step
+
+`/grill-me` is a Socratic interview that stress-tests a design before committing to
+implementation. CCPM has no equivalent — the gap between PRD and execution is filled by
+structural decomposition, not intellectual challenge.
+
+For a solo developer where Claude is both the implementer and the reviewer, having a
+dedicated adversarial step before implementation is uniquely valuable. It catches
+assumption errors that would otherwise survive until the implementation review.
+
+**Verdict:** Keep. This is a workflow innovation that CCPM hasn't discovered yet.
+
+### 4.5 Quality Gate Integration
+
+`/check` runs `cargo clippy -- -D warnings`, the full test suite, and a release build
+before any commit is allowed. This is integrated into the workflow, not delegated to CI.
+
+CCPM assumes CI/CD handles quality gating. For a solo developer without CI, the local
+quality gate is essential.
+
+**Verdict:** Keep. CCPM's assumption that CI exists doesn't apply here.
+
+### 4.6 Release Workflow
+
+`/release` handles SemVer bumps, CHANGELOG.md updates, git tags, and version consistency.
+CCPM has no release concept — it ends at "epic merged."
+
+**Verdict:** Keep. Urd's release workflow is mature and well-integrated.
+
+---
+
+## 5. What's Genuinely Missing from Both
+
+### 5.1 Structured Progress Tracking (Neither Does This Well)
+
+CCPM has progress files but they're designed for parallel agent coordination, not human
+status tracking. Urd has status.md but it's manually maintained and only captures
+current state, not progress over time.
+
+Neither system answers: "How much of Priority 6 is done? How fast are we moving? When
+might we reach v1.0?"
+
+**Proposed:** A lightweight progress section in roadmap.md's feature table:
+
+```markdown
+| # | Feature | Status | Sessions Est. | Sessions Actual |
+| P1 | Vocabulary landing | Complete | 1 | 1 |
+| P2a | urd default | Complete | 1 | 0.5 |
+| 6-O | Progressive disclosure | Next | 2 | - |
+```
+
+The "Sessions Actual" column provides velocity data. No external tools needed.
+
+### 5.2 Validation Scripts (Neither Has Them for Docs)
+
+CCPM's `validate.sh` checks frontmatter and broken references, but only for its own
+`.claude/` files. Urd has no validation for its `docs/` structure.
+
+**Proposed:** A `docs-validate.sh` script that checks:
+- All files in `99-reports/` match the naming convention
+- All design docs in `95-ideas/` have a Status field
+- All files referenced in roadmap.md's feature table actually exist
+- No undated files in dated directories
+
+---
+
+## 6. Synthesis: Proposed Workflow Evolution
+
+### 6.1 What to Adopt from CCPM
+
+| CCPM Concept | Adaptation for Urd | Effort |
+|-------------|-------------------|--------|
+| **Task decomposition in design docs** | Add "Implementation Tasks" table to `/design` output | Low — update skill prompt |
+| **Script-based status queries** | 3-4 bash scripts for common queries | Medium — write scripts |
+| **GitHub Issues for work items** | Issue per priority item, labeled by arc | Low — new habit |
+| **Structured frontmatter** | Standardize Status vocabulary, add YAML frontmatter | Low — convention change |
+| **Worktree per feature** | Already using feature branches; worktrees for parallel work if needed | None — available but rarely needed |
+
+### 6.2 What to Keep from Urd
+
+| Urd Strength | Why It Stays |
+|-------------|-------------|
+| ADR system | On-disk contracts need immutable decision records |
+| `/grill-me` | Unique adversarial step CCPM lacks |
+| `arch-adversary` + `/post-review` | Full review pipeline CCPM doesn't have |
+| `/check` quality gate | No CI to delegate to |
+| `/release` workflow | SemVer + CHANGELOG integrated into pipeline |
+| Journal system | Knowledge preservation, not just task tracking |
+| CONTRIBUTING.md conventions | Document-as-context design serves Claude efficiency |
+| TL;DR convention | Token-efficient scanning across 200+ files |
+
+### 6.3 What to Reject from CCPM
+
+| CCPM Feature | Why It Doesn't Fit |
+|-------------|-------------------|
+| **PRD as separate artifact** | Urd's `/brainstorm` → `/design` pipeline already captures requirements within design docs. A separate PRD adds a document without adding information. |
+| **Epic/sub-issue hierarchy** | Overhead exceeds benefit for a solo developer. Flat issue list with labels is sufficient. |
+| **Parallel agent execution** | Solo developer rarely works on multiple streams simultaneously. The complexity of agent coordination (progress files, stream analysis, conflict detection) is unwarranted. |
+| **`.claude/` as artifact home** | Urd's `docs/` directory is tracked in git, follows naming conventions, and serves as project knowledge. Moving artifacts to `.claude/` (which is less visible, less structured) would be a regression. |
+| **Archive-and-forget lifecycle** | Urd's documentation is accumulated knowledge, not disposable tickets. Completed design docs remain reference material. |
+| **14 bash scripts** | Most are for parallel agent coordination that doesn't apply. Adopt 3-4 that solve real Urd needs. |
+
+### 6.4 Proposed Evolved Pipeline
+
+```
+/brainstorm → /design (with task table) → /grill-me → [build per task] →
+  /simplify → arch-adversary → /post-review → /check → /journal → /commit-push-pr
+```
+
+Changes from current pipeline:
+1. `/design` output gains an "Implementation Tasks" section with ordering and dependencies
+2. GitHub Issues created for each priority item (one issue per 6-O, P6a, etc.)
+3. PRs reference issues via `Fixes #N` for automatic closure
+4. 3-4 bash scripts added for status queries
+5. Session start reads status.md (context) then runs `status.sh` (facts)
+
+The pipeline structure doesn't change. The artifacts get richer. The tracking gets cheaper.
+
+---
+
+## 7. GitHub Issues: New Habit Proposal
+
+The single highest-value CCPM concept for Urd is using GitHub Issues as a lightweight
+work tracker. Here's what this looks like in practice:
+
+### Current State (Urd)
+
+Work items live in:
+- `roadmap.md` feature table (design + review links)
+- `status.md` "Next Up" section (1-3 items)
+- Session conversation ("let's work on 6-O")
+
+### Proposed State
+
+Work items also exist as GitHub Issues:
+
+```
+#61  6-O: Progressive disclosure               [priority-6] [feature]
+#62  P6a: ADR-110 enum rename                   [priority-6] [refactor]
+#63  P6b: Config Serialize refactor             [priority-6] [refactor]
+#64  6-H: Guided setup wizard                   [priority-6] [feature]
+```
+
+**Benefits:**
+- PRs link to issues (`Fixes #61`) — automatic traceability
+- Issues persist as a searchable record of what was planned vs. what was built
+- `gh issue list --label priority-6` replaces reading roadmap.md for "what's in this arc"
+- Issues can hold implementation notes, blockers, and session handoff context
+- Public visibility for anyone following the project
+
+**Rules to keep it lightweight:**
+- One issue per work item (not per task within a work item)
+- Created when work enters the "Next Up" queue, not when brainstormed
+- Closed by PR merge, not manually
+- Labels: `priority-N` (arc), `feature`/`fix`/`refactor`/`docs` (type)
+- No milestones, no projects, no sub-issues — just flat issues with labels
+- The design doc link goes in the issue body; the review link is added when available
+
+**What changes in the workflow:**
+- `/commit-push-pr` already creates PRs — add `Fixes #N` to PR body when an issue exists
+- `/journal` notes which issues were worked on (already notes what was done)
+- Status.md's "Next Up" section links to issues instead of just naming them
+
+---
+
+## 8. Recommendations by Priority
+
+| # | Action | Source | Effort | Impact |
+|---|--------|--------|--------|--------|
+| 1 | Add "Implementation Tasks" table to `/design` output | CCPM's Structure phase | Low | High — closes planning gap |
+| 2 | Start using GitHub Issues for work items | CCPM's Sync concept | Low | High — adds traceability |
+| 3 | Write 3-4 status/validation bash scripts | CCPM's Track phase | Medium | Medium — saves tokens |
+| 4 | Standardize frontmatter vocabulary | CCPM's conventions | Low | Medium — enables scripts |
+| 5 | Add `Fixes #N` to `/commit-push-pr` | CCPM's issue lifecycle | Trivial | Medium — automatic closure |
+| 6 | Adopt review naming convention | Workflow analysis | Low | High — solves naming chaos |
+| 7 | Split roadmap.md | Workflow analysis | Medium | Medium — reduces token waste |
+
+Items 1-2 and 5-6 can be implemented in a single session (convention and skill prompt
+changes only). Items 3-4 and 7 are a second session.
+
+---
+
+## 9. What the User Should Learn
+
+The CCPM evaluation reveals a broader lesson about Claude-first development workflows:
+
+### 9.1 Documents serve two masters
+
+Every document in the system serves both the user (learning, remembering, deciding) and
+Claude (context, constraints, continuity). CCPM optimizes for Claude (structured frontmatter,
+machine-parseable status). Urd optimizes for the user (TL;DR, narrative design docs, mythic
+voice). The best system does both — structured metadata for machines, readable prose for
+humans. YAML frontmatter + TL;DR is the synthesis.
+
+### 9.2 Planning and execution are different cognitive modes
+
+CCPM's biggest insight is that planning (divergent, creative, considering alternatives) and
+execution (convergent, precise, following a plan) should be structurally separated. Urd's
+`/design` step is planning; the build step is execution. But without an explicit task
+decomposition between them, the transition is abrupt. Adding a task table to design docs
+is a small change with outsized impact on execution clarity.
+
+### 9.3 Tracking should be free
+
+Every status query that requires reading a document consumes tokens and LLM time. CCPM's
+script-first principle is correct: if a question can be answered by parsing files, it
+should be answered by a script. Reserve the LLM for reasoning, not reporting.
+
+### 9.4 GitHub Issues are underused
+
+For a public project with a git-centric workflow, GitHub Issues are a natural work tracker.
+They're free, they integrate with PRs, they're searchable, and they persist as a record
+of intent. The overhead of creating an issue is trivial compared to the traceability it
+provides. The key is keeping it flat — issues, not epics, not projects, not milestones.
+
+### 9.5 Don't adopt what doesn't fit
+
+CCPM's parallel agent execution, epic hierarchies, and archive-and-forget lifecycle are
+designed for a different context (product teams, web features, multiple developers). Adopting
+them would add complexity without proportional benefit. The skill of workflow design is
+knowing what to leave out.
+
+---
+
+## Appendix: CCPM Reference Architecture
+
+For reference, CCPM's complete file structure:
+
+```
+.claude/
+├── prds/<feature-name>.md              # Product requirements
+├── epics/<feature-name>/
+│   ├── epic.md                          # Technical decomposition
+│   ├── <N>.md                           # Task files (by issue number)
+│   ├── <N>-analysis.md                  # Parallel stream analysis
+│   ├── github-mapping.md               # Issue → URL mapping
+│   ├── execution-status.md             # Active agent tracker
+│   └── updates/<N>/                     # Per-issue progress
+│       ├── stream-{A,B,C}.md           # Per-agent progress
+│       ├── progress.md                  # Overall completion
+│       └── execution.md                # Execution state
+└── context/                             # Project context docs
+```
+
+CCPM bash scripts: `status.sh`, `standup.sh`, `epic-list.sh`, `epic-show.sh`,
+`epic-status.sh`, `prd-list.sh`, `prd-status.sh`, `search.sh`, `in-progress.sh`,
+`next.sh`, `blocked.sh`, `validate.sh`, `help.sh`, `init.sh`.
+
+Urd should not replicate this structure. It should learn from the principles behind it.

--- a/docs/99-reports/2026-04-01-workflow-and-project-management-analysis.md
+++ b/docs/99-reports/2026-04-01-workflow-and-project-management-analysis.md
@@ -1,0 +1,633 @@
+# Workflow and Project Management Analysis
+
+> **TL;DR:** After 10 days of AI-assisted development (v0.0.0 to v0.7.0, 692 tests,
+> 14 ADRs, 60 PRs), the Urd project's development pipeline is well-designed and
+> productive. The artifact management system around that pipeline has not kept pace,
+> accumulating five structural problems: inconsistent review naming (7 patterns across
+> 77 reports), incoherent phase numbering (4+ overlapping schemes), orphaned Claude Code
+> plans (53 unmappable files), undistinguished review types (design vs. implementation),
+> and a roadmap document serving dual duty as architecture reference and living tracker.
+> All proposed solutions are convention-based — no external tools, no databases, no
+> retroactive renaming.
+
+**Date:** 2026-04-01
+**Type:** Process analysis
+**Scope:** Development workflow, documentation artifacts, project management conventions
+
+---
+
+## 1. Executive Summary
+
+The Urd project has built a remarkably productive development workflow in 10 days.
+Nine slash commands form a coherent pipeline from ideation to release. The ADR system
+is exemplary. The information hierarchy (status.md -> roadmap.md -> specific docs) works.
+The CONTRIBUTING.md conventions (TL;DR, privacy, immutability rules) are thoughtful and
+consistently applied.
+
+The problem is not the pipeline — it's the artifact trail the pipeline leaves behind.
+Design docs don't systematically connect to their reviews. Phase identifiers have fractured
+into four overlapping numbering schemes. Claude Code's working plans are invisible to the
+documentation system. The arch-adversary skill produces two fundamentally different artifact
+types under one naming convention. And the roadmap has grown into a 550+ line document that
+mixes stable architecture reference with rapidly-changing feature tracking.
+
+These are problems of success — a fast-moving project outgrowing its initial conventions.
+The solutions below are proportional to a solo developer workflow: naming conventions,
+file placement rules, and Markdown indexes that Claude Code can maintain as part of existing
+slash commands.
+
+---
+
+## 2. What Works Well
+
+These strengths should be preserved in any changes.
+
+### 2.1 ADR System
+
+Zero naming inconsistencies across 14 ADRs. Strict sequential numbering (ADR-100 through
+ADR-112), immutability enforced by convention, supersession workflow documented. The split
+between bash-era (001-099) and Urd-era (100+) is clean. Every ADR has a date, explicit
+dependencies, and a TL;DR. This is the project's gold standard for documentation.
+
+### 2.2 Slash Command Pipeline
+
+Nine commands forming a complete lifecycle:
+
+```
+/brainstorm -> /design -> /grill-me -> [build] -> /simplify -> arch-adversary -> /post-review -> /check -> /journal -> /commit-push-pr
+```
+
+Each command has a clear scope, defined inputs and outputs, and a known artifact location.
+The pipeline emerged from deliberate skill evaluation (2026-03-30 mattpocock-skills-evaluation
+journal) and subsequent refinement.
+
+### 2.3 Information Hierarchy
+
+The three-tier routing system works:
+
+1. `status.md` (~60 lines, overwritten each session) — "what's happening now"
+2. `roadmap.md` (feature tables with design + review links) — "what's planned"
+3. Specific docs (ADRs, designs, reviews) — "the details"
+
+A new session reads status.md first and follows links. This is explicitly codified in
+CONTRIBUTING.md and consistently applied.
+
+### 2.4 Document Conventions
+
+- **TL;DR on every document >30 lines** — token-efficient scanning across 200+ files
+- **Privacy model** — journals gitignored, tracked docs use `<user>` placeholders
+- **Immutability tiers** — strict for ADRs, guideline for reports, mutable for ideas
+- **Document templates** in CONTRIBUTING.md for each type
+
+### 2.5 Feature Table Traceability
+
+The Priority 6 feature table in roadmap.md is excellent:
+
+```
+| # | Feature | Status | Design | Review |
+| 6-B | Transient immediate cleanup | Built | [design](link) | [review](link) |
+```
+
+This provides bidirectional traceability from roadmap to artifacts. The pattern should
+be the universal standard, not an exception.
+
+### 2.6 Commit and Branch Conventions
+
+Consistent patterns across 159 commits and 60 PRs:
+- Branches: `{type}/{slug}` (feat/, fix/, docs/, chore/, refactor/)
+- Commits: `{type}: {description}` with module lists and co-author attribution
+- PRs: feature bundles with CHANGELOG entries and status.md updates
+
+---
+
+## 3. Five Structural Problems
+
+### 3.1 Review Naming: Seven Competing Patterns
+
+The 77 files in `docs/99-reports/` use at least seven distinct naming patterns:
+
+| Pattern | Example | Count |
+|---------|---------|-------|
+| `arch-adversary-{topic}` | `arch-adversary-phase35.md`, `arch-adversary-space-estimation.md` | 8 |
+| `{topic}-design-review` | `heartbeat-design-review.md`, `sentinel-design-review.md` | 14 |
+| `{topic}-implementation-review` | `awareness-model-implementation-review.md`, `urd-get-implementation-review.md` | 11 |
+| `design-{letter}-review` | `design-b-review.md`, `design-h-review.md` | 8 |
+| `design-{letter}-implementation-review` | `design-b-implementation-review.md`, `design-e-implementation-review.md` | 2 |
+| `phase{N}-{type}-review` | `phase1-arch-review.md`, `phase2-adversary-review.md` | 7 |
+| `{topic}-review` | `sentinel-session1-review.md`, `transient-snapshots-review.md` | 16 |
+| Miscellaneous | `brainstorm-synthesis.md`, `design-evolution-analysis.md` | 5 |
+| **Undated** | `adversary-review-phase-4-comprehensive.md` | 1 |
+
+**Consequence:** Given a design doc like `2026-03-31-design-i-redundancy-recommendations.md`,
+its review is `2026-03-31-design-i-review.md` — but only if you know the `design-{letter}-review`
+pattern. For `2026-03-28-design-hardware-swap-defenses.md`, the review is
+`2026-03-28-hardware-swap-defenses-design-review.md` — a different pattern entirely.
+Neither Claude Code nor the user can reliably predict the review filename from the design
+filename without consulting roadmap.md.
+
+**How it happened:** The naming evolved across three periods:
+1. **Phase 1-4 (March 22):** `phase{N}-{type}-review` and `arch-adversary-{topic}`
+2. **Feature designs (March 23-29):** `{topic}-design-review` and `{topic}-implementation-review`
+3. **Priority 6 batch (March 31):** `design-{letter}-review` (shortest form, for the 7 batch reviews)
+
+Each pattern was internally consistent within its period, but the periods weren't coordinated.
+
+### 3.2 Phase Numbering: Four Overlapping Schemes
+
+The project uses at least four numbering schemes simultaneously:
+
+| Scheme | Examples | Context |
+|--------|----------|---------|
+| Phase N | Phase 1, 2, 3, 3.5, 4 | Infrastructure (roadmap sections) |
+| Priority N | Priority 5, 5.5, 6 | Feature arcs (roadmap sections) |
+| N-{Letter} | 6-B, 6-E, 6-H, 6-I, 6-N, 6-O | Sub-features within Priority 6 |
+| P{N}{letter} | P1, P2a, P2b, P2c, P4a, P4b, P4c, P6a, P6b | Phases within Priority 6 |
+
+**Consequence:** "Phase 1" in the roadmap's infrastructure section and "P1" (Phase 1 of
+Priority 6's Voice & UX arc) are different things that look similar. "6-I" and "P2b" are
+peers in the same build queue but use completely different notation. A reader encountering
+"P4c" in a commit message cannot decode it without roadmap.md context.
+
+**How it happened:** Organic growth. Phases 1-4 were implementation stages. "Priority" was
+introduced to distinguish planned feature arcs from completed infrastructure phases. The
+letter designators (6-B, 6-I) came from brainstorm scoring. The P-prefixes came from
+internal sequencing of the Voice & UX arc. Each made local sense at the time of introduction.
+
+### 3.3 Claude Code Plans: Orphaned from the Documentation System
+
+The `.claude/plans/` directory contains 53 files with auto-generated names:
+
+```
+eager-plotting-wigderson.md
+elegant-soaring-meerkat.md
+imperative-spinning-finch.md
+```
+
+These are Claude Code session artifacts. They carry no dates in their names (file timestamps
+exist but aren't surfaced). They carry no topic slugs. They cannot be mapped to design docs,
+journal entries, or PRs.
+
+Meanwhile, `docs/97-plans/` — the project's designated plan directory — contains only 2 files:
+- `2026-03-23-git-history-pii-scrub.md`
+- `2026-03-29-hsd-a-drive-tokens-chain-health.md`
+
+**Consequence:** The "real" implementation plans that guided 90%+ of sessions exist only
+in `.claude/plans/` under opaque names. A future session cannot find the plan that preceded
+a given implementation without reading all 53 files. The plans are not linked from journals,
+designs, or reviews.
+
+**How it happened:** `.claude/plans/` is Claude Code infrastructure with auto-naming. The
+project's `/design` command writes to `docs/95-ideas/`, not to `docs/97-plans/`. The two
+systems never connected.
+
+### 3.4 arch-adversary: Two Roles, One Name
+
+The arch-adversary skill reviews two fundamentally different artifacts:
+
+1. **Design reviews** (pre-implementation): Evaluate a design proposal from `docs/95-ideas/`.
+   Gate implementation decisions. Findings must be addressed before building.
+
+2. **Implementation reviews** (post-implementation): Evaluate completed code on a feature
+   branch. Validate that the design was realized correctly. Findings feed into `/post-review`.
+
+Both are valuable. Both produce reports in `docs/99-reports/`. But they serve different
+audiences at different points in the pipeline:
+
+| Aspect | Design Review | Implementation Review |
+|--------|--------------|----------------------|
+| Input | Design document | Source code + tests |
+| Timing | Before implementation | After implementation |
+| Consumer | `/design` refinement, implementation planning | `/post-review` fixes |
+| Shelf life | Superseded by implementation decisions | Superseded by next implementation |
+| Failure mode | Design flaw passes through to code | Code quality issue ships |
+
+**Consequence:** When `/post-review` looks for "the most recent arch-adversary review," it
+cannot distinguish the design review (already addressed during implementation) from the
+implementation review (the one with actionable findings). The naming doesn't help — both
+might be `{topic}-review.md` or `arch-adversary-{topic}.md`.
+
+**How it happened:** The arch-adversary skill was originally designed for design review
+(the `/design` -> `arch-adversary` -> `/grill-me` pipeline). Implementation review was added
+as the same skill applied to a different input, without updating the naming convention.
+
+### 3.5 roadmap.md: Dual Duty
+
+The roadmap file is currently 550+ lines serving two distinct purposes:
+
+1. **Lines 1-477: Founding architecture reference** — context, decisions table, project
+   structure, config schema, architecture principles, Prometheus metrics format, SQLite
+   schema, CLI commands, Rust crates, implementation phases 1-5, migration strategy,
+   testing prerequisites, verification plan, critical files reference.
+
+2. **Lines 480+: Living feature tracker** — Priority 5-6 status, feature tables with
+   design/review links, deferred items, completed work, tech debt.
+
+The first half changes rarely. The second half changes every session.
+
+**Consequence:** A session reading roadmap.md for "what to build next" consumes tokens on
+architectural reference that CLAUDE.md already covers more authoritatively. The provenance
+note at the top acknowledges this tension ("This document combines the original project
+roadmap with the living feature tracker") but doesn't resolve it.
+
+**How it happened:** The roadmap was written on day 1 (2026-03-22) as a comprehensive
+project plan. It was the right document at the time. Ten days later, the stable architecture
+content has migrated to CLAUDE.md and ADRs, but the original text remains in roadmap.md as
+well, creating redundancy.
+
+---
+
+## 4. Proposed Solutions
+
+### 4.1 Standardize Review Naming
+
+**Convention:**
+```
+YYYY-MM-DD-review-{type}-{slug}.md
+```
+
+Where:
+- `{type}` is one of: `design`, `impl`, `analysis`
+- `{slug}` matches the source document's slug exactly
+
+**Examples:**
+
+| Source Document | Review |
+|----------------|--------|
+| `2026-03-31-design-b-transient-immediate-cleanup.md` | `2026-03-31-review-design-b-transient-immediate-cleanup.md` |
+| Same feature after implementation | `2026-04-01-review-impl-b-transient-immediate-cleanup.md` |
+| This document (process analysis) | `2026-04-01-review-analysis-workflow.md` (if reviewed) |
+
+**Properties:**
+- `review-` prefix makes all reviews greppable: `ls docs/99-reports/review-*`
+- `design`/`impl`/`analysis` type tag is immediately visible
+- Slug matching enables programmatic cross-referencing
+- Date may differ between design review and impl review (correct — they happen on different days)
+
+**Migration:** Forward-only. Existing 77 files keep their names. A note in CONTRIBUTING.md
+states that pre-2026-04-01 reviews use legacy naming. The roadmap.md feature table already
+provides traceability for historical reviews.
+
+**Implementation:** Update CONTRIBUTING.md's file naming table and the arch-adversary skill
+prompt to emit the new naming convention.
+
+### 4.2 Adopt a Simple Work-Item Scheme Going Forward
+
+The existing Phase/Priority/letter/P-prefix system is too entangled to rename retroactively.
+The pragmatic approach has two parts:
+
+**Part A: Document what exists.** Add a "Numbering Legend" section to roadmap.md that
+explicitly maps every identifier:
+
+```markdown
+## Numbering Legend
+
+| ID | Full Name | Status |
+|----|-----------|--------|
+| Phase 1-4 | Infrastructure phases | Complete |
+| Phase 3.5 | Post-cutover hardening | Complete |
+| P5 / Priority 5 | Sentinel daemon | Sessions 1-2 complete, 3-4 deferred |
+| P5.5 / Priority 5.5 | Safety & Visibility | Complete |
+| P6 / Priority 6 | Voice, UX & Redundancy | In progress |
+| 6-B | Transient immediate cleanup | Complete |
+| 6-E | Promise redundancy encoding | Complete |
+| P1 | Vocabulary landing (within P6 arc) | Complete |
+| P2a | `urd` default status (within P6 arc) | Complete |
+| P2b | `urd doctor` (within P6 arc) | Complete |
+| P2c | Shell completions (within P6 arc) | Complete |
+| 6-I | Redundancy recommendations | Complete |
+| 6-N | Retention policy preview | Complete |
+| P4a+4b | Staleness escalation + suggestions | Complete |
+| P4c | Mythic transitions | Complete |
+| 6-O | Progressive disclosure | Next |
+| P6a | ADR-110 enum rename | Next |
+| P6b | Config Serialize refactor | Next |
+| 6-H | Guided setup wizard | Next |
+```
+
+**Part B: Clean scheme for Priority 7+.** Use a simpler flat numbering within each
+priority arc:
+
+```
+P7.1, P7.2, P7.3 ...
+```
+
+No letter designators. No nested phase numbers. Sub-items use `.N` notation. The priority
+number provides the arc context; the decimal provides sequence.
+
+**Trade-off:** This doesn't fix the existing inconsistency — it documents it and prevents
+it from recurring. Retroactive renaming would require updating commit messages, journal
+entries, design docs, review filenames, roadmap references, and status.md links. The cost
+far exceeds the benefit.
+
+### 4.3 Bridge Claude Code Plans into Documentation
+
+The gap between `.claude/plans/` (53 ephemeral files) and `docs/97-plans/` (2 promoted
+files) is structural. Not all plans warrant promotion — many are exploratory scaffolding
+that becomes irrelevant after the session. The solution is selective promotion at a natural
+workflow moment.
+
+**Convention:** When `/design` produces a design document ready for implementation, the
+plan's key decisions and approach should be captured in the design doc itself (in
+`docs/95-ideas/`). The design doc IS the promoted plan.
+
+This means `docs/97-plans/` becomes the home for plans that are NOT design docs — operational
+plans like the PII scrub, incident response plans, or multi-session coordination plans. These
+are rare (2 in 10 days), and the current ad-hoc promotion works fine for rare events.
+
+**What changes:**
+- `/journal` should note which `.claude/plans/` file was used during the session (the
+  auto-generated name, for forensic traceability if needed later)
+- Design docs should include a "Plan" or "Approach" section that captures the implementation
+  strategy (most already do)
+- No changes to `.claude/plans/` naming — it's Claude Code infrastructure, not project
+  documentation
+
+**Trade-off:** This accepts that `.claude/plans/` files are ephemeral and not worth
+integrating. The design doc absorbs the plan's content. The plan file name is recorded
+in the journal for forensic purposes only.
+
+### 4.4 Distinguish Design Reviews from Implementation Reviews
+
+Split the arch-adversary's dual role into clearly distinguished outputs. Two approaches:
+
+**Option A: One skill, two modes.** The arch-adversary skill detects its context:
+- If reviewing a document from `docs/95-ideas/`: design review mode, output named
+  `review-design-{slug}.md`
+- If reviewing code on a feature branch: implementation review mode, output named
+  `review-impl-{slug}.md`
+- If ambiguous: ask the user
+
+**Option B: Two skills.** Split into `design-adversary` and `impl-adversary` with distinct
+prompts optimized for their respective review types.
+
+**Recommendation: Option A.** The review methodology is fundamentally the same (6-dimension
+scorecard, severity ratings, catastrophic failure checklist). The difference is input and
+output naming, not review philosophy. Two skills would duplicate 90% of the prompt content
+and create a maintenance burden.
+
+**Implementation:** Update the arch-adversary skill prompt to:
+1. Detect whether the review target is a design doc or source code
+2. Include the review type in the output filename
+3. Adjust the review framing (design reviews assess feasibility and completeness;
+   implementation reviews assess correctness and quality)
+
+### 4.5 Split roadmap.md
+
+Separate the stable architecture reference from the living feature tracker:
+
+**New file:** `docs/00-foundation/architecture.md`
+Contains: Context, Decisions table, Project Structure, Configuration Schema, Architecture
+Key Design Principles, Prometheus Metrics, SQLite Schema, CLI Commands, Rust Crates,
+Implementation Phases 1-5 (historical record), Migration Strategy, Testing Prerequisites,
+Verification Plan, Critical Files Reference.
+
+**Trimmed file:** `docs/96-project-supervisor/roadmap.md`
+Contains: A provenance header linking to architecture.md, then the living content: Current
+Priorities, feature tables, deferred items, completed work log, tech debt, numbering legend.
+
+**Link updates needed:**
+- `status.md` — add architecture.md to Key Links
+- `CLAUDE.md` — the "Orient Yourself" section already points to status.md, which will
+  link to both documents
+
+**Trade-off:** This is a one-time structural change. The architecture content in
+roadmap.md is largely duplicated by CLAUDE.md at this point — CLAUDE.md has the module
+table, architectural invariants, config system notes, and error handling conventions.
+The split clarifies what roadmap.md is: a tracker, not a reference.
+
+**Token impact:** Positive. Sessions that need "what to build next" read a shorter
+roadmap.md. Sessions that need architecture reference read CLAUDE.md (already loaded)
+or architecture.md (stable, rarely needed beyond CLAUDE.md).
+
+---
+
+## 5. Artifact Registry
+
+The Priority 6 feature table in roadmap.md already serves as a proto-registry:
+
+```
+| # | Feature | Status | Design | Review |
+| 6-B | Transient immediate cleanup | Built | [design](link) | [review](link) |
+```
+
+The question is whether to formalize this into a separate registry document or keep it
+embedded in roadmap.md.
+
+**Recommendation: Keep it in roadmap.md.** The feature table works well where it is. A
+separate registry would duplicate information and add another document to maintain. The
+feature table already provides the cross-referencing the system needs — the problem was
+never the registry's absence, but the naming inconsistency that makes the registry necessary.
+
+If the review naming convention (Solution 4.1) is adopted, the need for a registry
+diminishes: given a design doc slug, the review filename becomes predictable. The
+feature table remains valuable for tracking status and effort estimates, but it no longer
+needs to be the sole traceability mechanism.
+
+**If the project grows beyond Priority 8-9**, a dedicated registry may become worthwhile.
+The trigger would be: "the roadmap feature table exceeds 50 rows and spans multiple
+priority arcs." At that point, extract it to `docs/96-project-supervisor/registry.md`.
+
+---
+
+## 6. Document Type Classification
+
+This document is a **process analysis** — an analytical report examining project practices
+and proposing improvements. It fits naturally in `docs/99-reports/` as a report subtype.
+
+Under the proposed naming convention (Solution 4.1), future process analyses would be:
+```
+YYYY-MM-DD-review-analysis-{topic}.md
+```
+
+No new document type, directory, or template is needed. The existing report template in
+CONTRIBUTING.md covers this use case. The `analysis` type tag in the naming convention
+distinguishes process analyses from design and implementation reviews.
+
+---
+
+## 7. Implementation Priority
+
+Ordered by impact-to-effort ratio:
+
+| Priority | Solution | Effort | Impact | Dependencies |
+|----------|----------|--------|--------|-------------|
+| 1 | Review naming convention (4.1) | Low — update 2 files | High — all future reviews predictable | None |
+| 2 | Review type distinction (4.4) | Low — update 1 skill | High — resolves arch-adversary ambiguity | Depends on 4.1 for naming |
+| 3 | Numbering legend (4.2 Part A) | Low — add section to roadmap.md | Medium — documents existing system | None |
+| 4 | Roadmap split (4.5) | Medium — one-time file surgery | Medium — reduces token waste | None |
+| 5 | Clean numbering for P7+ (4.2 Part B) | Low — convention decision | Medium — prevents future inconsistency | Depends on 4.2A |
+| 6 | Plan bridging (4.3) | Low — convention adjustment | Low — ephemeral plans are acceptable | None |
+
+**Recommended first session:** Items 1-3 (review naming, type distinction, numbering legend).
+These are all convention changes — updating CONTRIBUTING.md, the arch-adversary skill, and
+adding a roadmap section. No code changes, no file renaming.
+
+**Recommended second session:** Item 4 (roadmap split). This requires careful file surgery
+to separate content without losing cross-references.
+
+---
+
+## 8. Risks and Constraints
+
+### Over-engineering risk
+
+This is a solo developer project with Claude Code as the primary development partner. Every
+convention must be simple enough that Claude Code can follow it from a skill prompt, and
+simple enough that the user can remember it without consulting documentation. The solutions
+above are all naming conventions and Markdown structure — no external tools, no databases,
+no CI integrations, no issue trackers.
+
+### Migration burden
+
+Retroactive renaming of 77 review files would require updating every reference in roadmap.md,
+status.md, design docs, journal entries, and CONTRIBUTING.md examples. The benefit does not
+justify the cost. Forward-only adoption is the right strategy — the existing roadmap feature
+table provides traceability for historical artifacts.
+
+### Token budget
+
+Every new document competes for Claude Code's context window. The proposed changes should
+be net-positive for token consumption:
+- Splitting roadmap.md means sessions read a shorter tracker document
+- Predictable review naming means fewer exploratory file reads to find the right review
+- The numbering legend adds ~30 lines to roadmap.md but saves explanation time in every
+  session that encounters an unfamiliar identifier
+
+### Convention drift
+
+The highest risk is that new conventions are defined but not followed. Mitigation: encode
+the conventions in the skill prompts that produce the artifacts. If `/design` and
+`arch-adversary` emit files with the correct naming, the convention is self-enforcing.
+CONTRIBUTING.md is the reference; skill prompts are the enforcement mechanism.
+
+---
+
+## Appendix A: Complete Review Naming Audit
+
+All 77 files in `docs/99-reports/` grouped by naming pattern:
+
+**Pattern 1: `arch-adversary-{topic}`** (8 files)
+```
+2026-03-22-arch-adversary-phase35.md
+2026-03-22-arch-adversary-phase4.md
+2026-03-23-arch-adversary-proposal-review.md
+2026-03-23-arch-adversary-space-estimation.md
+2026-03-31-arch-adversary-phase4-voice-enrichment.md
+2026-04-01-arch-adversary-6i-implementation-review.md
+2026-04-01-arch-adversary-6n-2b-implementation-review.md
+2026-04-01-arch-adversary-phase4ab-implementation-review.md
+2026-04-01-arch-adversary-phase4c-transitions.md
+```
+
+**Pattern 2: `{topic}-design-review`** (14 files)
+```
+2026-03-23-awareness-model-design-review.md
+2026-03-24-heartbeat-design-review.md
+2026-03-24-presentation-layer-design-review.md
+2026-03-24-urd-get-design-review.md
+2026-03-24-uuid-fingerprinting-design-review.md
+2026-03-26-backup-summary-design-review.md
+2026-03-26-next-sessions-design-review.md
+2026-03-26-protection-promises-design-review.md
+2026-03-26-sentinel-design-review.md
+2026-03-26-structured-errors-design-review.md
+2026-03-27-sentinel-implementation-design-review.md
+2026-03-27-sentinel-session2-design-review.md
+2026-03-28-hardware-swap-defenses-design-review.md
+2026-03-28-visual-feedback-model-design-review.md
+```
+
+**Pattern 3: `{topic}-implementation-review`** (11 files)
+```
+2026-03-22-phase2-implementation-review.md
+2026-03-23-awareness-model-implementation-review.md
+2026-03-24-heartbeat-implementation-review.md
+2026-03-24-presentation-layer-implementation-review.md
+2026-03-24-urd-get-implementation-review.md
+2026-03-24-uuid-fingerprinting-implementation-review.md
+2026-03-27-sentinel-session2-implementation-review.md
+2026-03-29-hsd-a-implementation-review.md
+2026-03-29-vfm-a-implementation-review.md
+2026-03-31-design-b-implementation-review.md
+2026-03-31-design-e-implementation-review.md
+2026-04-01-phase1-vocabulary-landing-implementation-review.md
+2026-04-01-phase2a-2c-implementation-review.md
+```
+
+**Pattern 4: `design-{letter}-review`** (8 files)
+```
+2026-03-31-design-b-review.md
+2026-03-31-design-e-review.md
+2026-03-31-design-h-review.md
+2026-03-31-design-i-review.md
+2026-03-31-design-n-review.md
+2026-03-31-design-o-review.md
+2026-03-31-design-spindle-review.md
+2026-03-31-design-phase1-vocabulary-landing-review.md
+2026-03-31-design-phase2-ux-commands-review.md
+2026-03-31-design-phase3-advisory-retention-review.md
+2026-03-31-design-phase5-progressive-disclosure-review.md
+2026-03-31-design-phase6-protection-rename-wizard-review.md
+```
+
+**Pattern 5: `phase{N}-{type}-review`** (7 files)
+```
+2026-03-22-phase1-arch-review.md
+2026-03-22-phase1-arch-review-v3.md
+2026-03-22-phase1-hardening-review.md
+2026-03-22-phase2-adversary-review.md
+2026-03-22-phase2-plan-review.md
+2026-03-22-phase3-adversary-review.md
+2026-03-22-phase3-final-adversary-review.md
+```
+
+**Pattern 6: `{topic}-review`** (miscellaneous)
+```
+2026-03-23-brainstorm-synthesis-review.md
+2026-03-23-post-cutover-features-review.md
+2026-03-24-pre-cutover-testing-review.md
+2026-03-26-test-strategy-review.md
+2026-03-27-adr-suite-consistency-review.md
+2026-03-27-sentinel-session1-review.md
+2026-03-29-post-review-cross-drive-fallback-review.md
+2026-03-29-progress-display-design-review.md
+2026-03-29-sentinel-session3-implementation-review.md
+2026-03-30-hsd-b-chain-break-detection-review.md
+2026-03-30-transient-awareness-fix-review.md
+2026-03-30-transient-snapshots-review.md
+2026-03-30-ux1-plan-output-review.md
+2026-03-30-ux2-estimated-sizes-review.md
+2026-03-30-ux3-progress-display-review.md
+2026-03-30-vfm-b-visual-state-review.md
+2026-03-26-preflight-implementation-review.md
+```
+
+**Pattern 7: Non-review reports**
+```
+2026-03-23-brainstorm-synthesis.md
+2026-03-23-proposal-progress-and-size-estimation.md
+2026-03-23-vision-architecture-review.md
+2026-03-24-design-evolution-analysis.md
+```
+
+**Undated:**
+```
+adversary-review-phase-4-comprehensive.md
+```
+
+---
+
+## Appendix B: Design-to-Review Mapping Examples
+
+Illustrating the naming inconsistency across periods:
+
+| Design Document | Actual Review Name | Predicted Name (if consistent) |
+|----------------|-------------------|-------------------------------|
+| `design-hardware-swap-defenses.md` | `hardware-swap-defenses-design-review.md` | `review-design-hardware-swap-defenses.md` |
+| `design-b-transient-immediate-cleanup.md` | `design-b-review.md` | `review-design-b-transient-immediate-cleanup.md` |
+| `design-i-redundancy-recommendations.md` | `design-i-review.md` | `review-design-i-redundancy-recommendations.md` |
+| `design-phase1-vocabulary-landing.md` | `design-phase1-vocabulary-landing-review.md` | `review-design-phase1-vocabulary-landing.md` |
+| `design-sentinel.md` | `sentinel-design-review.md` | `review-design-sentinel.md` |
+
+The "Predicted Name" column shows what the proposed convention (Solution 4.1) would produce —
+consistent, greppable, and mechanically derivable from the source document name.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# validate.sh — Check documentation consistency
+# Checks: registry link integrity, broken links in key docs, undated files in dated dirs.
+# Run from project root: bash scripts/validate.sh
+
+set -euo pipefail
+
+DOCS="docs"
+REGISTRY="$DOCS/96-project-supervisor/registry.md"
+STATUS="$DOCS/96-project-supervisor/status.md"
+ROADMAP="$DOCS/96-project-supervisor/roadmap.md"
+
+errors=0
+warnings=0
+
+echo "=== Urd Documentation Validator ==="
+echo ""
+
+# --- Check 1: Registry link consistency ---
+echo "--- Registry link consistency ---"
+
+if [[ ! -f "$REGISTRY" ]]; then
+    echo "ERROR: Registry file not found: $REGISTRY"
+    errors=$((errors + 1))
+else
+    # Extract markdown links from registry using grep
+    while IFS= read -r link_path; do
+        # Skip external URLs
+        [[ "$link_path" =~ ^https?:// ]] && continue
+        [[ -z "$link_path" ]] && continue
+
+        # Resolve relative path from registry location
+        resolved="$DOCS/96-project-supervisor/$link_path"
+        if [[ ! -f "$resolved" ]]; then
+            echo "ERROR: Registry link broken: $link_path"
+            echo "       Expected file: $resolved"
+            errors=$((errors + 1))
+        fi
+    done < <(grep -oP '\]\(\K[^)]+' "$REGISTRY" | grep -v '^#')
+fi
+echo ""
+
+# --- Check 2: Broken links in status.md and roadmap.md ---
+echo "--- Key document link integrity ---"
+
+for doc in "$STATUS" "$ROADMAP"; do
+    [[ ! -f "$doc" ]] && continue
+    doc_dir=$(dirname "$doc")
+
+    while IFS= read -r match; do
+        link_path=$(echo "$match" | grep -oP '\]\(\K[^)]+')
+
+        # Skip external URLs, anchors, and placeholder dashes
+        [[ "$link_path" =~ ^https?:// ]] && continue
+        [[ "$link_path" =~ ^# ]] && continue
+        [[ -z "$link_path" ]] && continue
+
+        resolved="$doc_dir/$link_path"
+        if [[ ! -f "$resolved" ]] && [[ ! -d "$resolved" ]]; then
+            echo "ERROR: Broken link in $(basename "$doc"): $link_path"
+            echo "       Expected: $resolved"
+            errors=$((errors + 1))
+        fi
+    done < <(grep -oP '\[[^\]]*\]\([^)]+\)' "$doc")
+done
+echo ""
+
+# --- Check 3: Undated files in dated directories ---
+echo "--- Undated files in dated directories ---"
+
+for dir in "$DOCS/95-ideas" "$DOCS/99-reports" "$DOCS/97-plans"; do
+    [[ ! -d "$dir" ]] && continue
+
+    for file in "$dir"/*.md; do
+        [[ ! -f "$file" ]] && continue
+        basename=$(basename "$file")
+
+        # Skip README.md and other conventional files
+        [[ "$basename" == "README.md" ]] && continue
+
+        # Check for YYYY-MM-DD prefix
+        if ! [[ "$basename" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}- ]]; then
+            echo "WARNING: Undated file in $(basename "$dir")/: $basename"
+            warnings=$((warnings + 1))
+        fi
+    done
+done
+echo ""
+
+# --- Summary ---
+echo "=== Summary ==="
+echo "Errors:   $errors"
+echo "Warnings: $warnings"
+
+if [[ $errors -gt 0 ]]; then
+    echo ""
+    echo "FAIL: $errors error(s) found."
+    exit 1
+else
+    echo ""
+    echo "PASS: All checks passed."
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- **UPI system:** Unique Project Identifiers (`NNN-a` format) thread through all workflow artifacts — design docs, reviews, registry, PRs. Assigned by `/design`, tracked in `registry.md`.
- **Registry:** New `docs/96-project-supervisor/registry.md` — minimal lookup table mapping UPIs to their design docs, reviews, and PRs.
- **Pipeline update:** Added `design-review`, `/sequence`, and `[plan+build]` slots. New `/sequence` skill orders reviewed designs by decision trees and dependencies.
- **Roadmap rewrite:** Archived 550+ line roadmap, replaced with 85-line version (Active Arc, Horizon, Strategic Context, Tech Debt, Deferred).
- **Naming conventions:** Standardized review naming (`design-review-{UPI}-slug` and `review-adversary-{UPI}-slug`), YAML frontmatter on design docs, controlled status vocabulary.
- **Skill updates:** `/design` (UPI assignment), `arch-adversary` (output naming, registry updates), `/journal` (plan file metadata, registry updates).
- **Validation:** `scripts/validate.sh` checks registry link integrity, broken links, and undated files.

Based on two analysis documents: workflow audit (7 naming patterns across 77 reviews, 4 overlapping phase schemes) and CCPM comparative evaluation (adopted 4 ideas, rejected 6).

## Testing

- No Rust code changed — documentation and workflow infrastructure only
- `bash scripts/validate.sh`: PASS (0 errors, 1 warning for known legacy undated file)
- All skill prompt changes are forward-only — existing docs unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)