### PR TITLE
refactor: overhaul development workflow — tiered pipelines, /prepare skill

### DIFF
--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -30,13 +30,13 @@ Every design gets a Unique Project Identifier (UPI). Before writing the design d
 
 5. **Sequence for risk.** High-risk, assumption-heavy pieces first so bugs surface early. The pre-cutover hardening found 3 bugs sharing one root cause — sequencing should expose those patterns.
 
-6. **Leave room for review.** State alternatives you rejected and assumptions you're making. The arch-adversary will push against these — make it productive by being explicit.
+6. **Leave room for stress-testing.** State alternatives you rejected, assumptions you're making, and decision branches that need resolving. `/grill-me` will push on these — make it productive by being explicit.
 
 ## Output
 
 For features affecting >3 files or introducing new modules: write a design proposal to
 `docs/95-ideas/YYYY-MM-DD-design-{UPI}-{slug}.md` with YAML frontmatter and status `proposed`.
-Include a **Ready for Review** section telling the arch-adversary what to focus on.
+Include an **Open Questions** section listing assumptions and decision branches for `/grill-me` to stress-test.
 
 **Frontmatter format:**
 

--- a/.claude/commands/grill-me.md
+++ b/.claude/commands/grill-me.md
@@ -25,7 +25,15 @@ Walk down each branch of the decision tree, resolving dependencies between decis
 
 ## Output
 
-The interview itself is the output. The resolved decision tree becomes input to whatever comes next in the pipeline — typically `/design` (if the idea is still forming) or direct implementation (if the design is already written and we're stress-testing it).
+The interview itself is the primary output. When the interview is complete:
+
+1. **Update the design doc.** Write resolved decisions back into the design document in
+   `docs/95-ideas/`. Add a **Resolved Decisions** section (or update the existing one) with
+   each resolved branch and its rationale. This is critical — `/prepare` reads the design
+   doc in a later session and needs the full picture, not just the original proposal.
+
+2. **Summary.** Present the full resolved decision tree so the user can verify completeness
+   before moving to `/prepare`.
 
 ## Arguments
 

--- a/.claude/commands/post-review.md
+++ b/.claude/commands/post-review.md
@@ -1,30 +1,25 @@
-Address arch-adversary review findings systematically.
+Revise an implementation plan to address arch-adversary findings before building.
 
 ## Workflow
 
-1. **Find the review report.** Look in `docs/99-reports/` for the most recent review matching the current work, or use the report path provided as argument. Read the **For the Dev Team** section first — it lists exactly what to fix in priority order.
+1. **Find the review report.** Look in `docs/99-reports/` for the most recent review matching the current work, or use the report path provided as argument. Read the **For the Dev Team** section first — it lists exactly what to address in priority order.
 
 2. **Address findings by severity, then by impact.** Critical first, then Significant, then Moderate. Within each severity level, order by blast radius — findings that affect more code paths or more users come first. Minor findings can be batched or deferred if purely stylistic.
 
 3. **For each finding:**
    - Understand the *consequence* (why it matters), not just the fix
-   - Implement the fix
-   - Add or update tests to cover the fixed case
-   - Run `/check` after each critical or significant fix to catch regressions early
+   - Revise the plan to address it: change module boundaries, adjust sequencing, add missing error handling steps, update test strategy
+   - If the finding requires an ADR gate, flag it explicitly
 
 4. **When you disagree with a finding**, provide a structured rebuttal:
    - State what the reviewer's concern is (prove you understood it)
    - Explain why you believe it doesn't apply in this context
    - Cite evidence: code paths, invariants, tests, or ADRs that support your position
-   - Document the rebuttal in the commit message — not "I disagree" but a factual argument
+   - Record the rebuttal in the revised plan — not "I disagree" but a factual argument
 
-5. **Factual acknowledgment, not performative agreement.** Commit messages and comments should state what changed and why. "Moved bounds check before the btrfs call to prevent path traversal" is useful. "Great catch!" is not — it adds nothing to git history.
+5. **Factual acknowledgment, not performative agreement.** Plan revisions should state what changed and why. "Added bounds check step before btrfs call to prevent path traversal" is useful. "Great catch!" adds nothing.
 
-6. **Run quality gates** after all fixes: `cargo clippy -- -D warnings`, `cargo test`, `cargo build`.
-
-7. **Commit message format:** "fix: Address arch-adversary findings — [list of addressed items]"
-
-8. **PII check** before committing — scan diffs for real usernames, home paths, hostnames per CONTRIBUTING.md.
+6. **Output:** The revised plan, ready for implementation. Summarize what changed from the original plan and which findings were addressed vs. rebutted.
 
 ## Arguments
 

--- a/.claude/commands/prepare.md
+++ b/.claude/commands/prepare.md
@@ -1,0 +1,65 @@
+Produce a concrete implementation plan from a reviewed design. Do NOT write any production code.
+
+## Before planning
+
+1. Read the design doc provided as argument (or the most recent `proposed` design in `docs/95-ideas/`)
+2. Read CLAUDE.md — module table, invariants, coding conventions
+3. Read `docs/96-project-supervisor/status.md` — current state, what exists
+4. If a `/grill-me` session preceded this, review the resolved decision tree
+
+## Core job
+
+Translate the design into an executable plan. The design says *what* to build; the plan says
+*how*, in what order, touching which files, with what tests.
+
+1. **Identify every file that will be touched.** Read each one. Do not plan changes to code
+   you haven't read. For new files, identify where they fit in the module structure.
+
+2. **Map changes to modules.** Each change must respect CLAUDE.md's module responsibility
+   table. If a planned change crosses module boundaries, that's a plan signal — flag it and
+   resolve it now, not during build.
+
+3. **Sequence the implementation.** Order steps so that:
+   - Dependencies are built before dependents
+   - High-risk, assumption-heavy pieces come first (surface bugs early)
+   - Tests accompany each step (vertical slicing, not "all tests at the end")
+
+4. **Define the test strategy.** For each step: what tests, what mocks, what edge cases.
+   Reference existing test patterns in the codebase where applicable.
+
+5. **Flag ADR gates.** If any step requires a new ADR or modifies an existing contract,
+   make this explicit. ADRs must be written before the code that depends on them.
+
+6. **Estimate scope.** Use status.md calibration points:
+   - UUID fingerprinting: 1 module, 10 tests, one session
+   - Awareness model: 1 new module, 24 tests, one session
+   - `urd get`: 1 new command, 19 tests, one session
+
+## What NOT to do
+
+- **Do not write code.** Not even "rough sketches" or "example implementations." The plan
+  describes what to change; the build phase writes it.
+- **Do not skip reading files.** Every file in the plan must be read first. Planning changes
+  to unread code produces plans that don't survive contact with reality.
+- **Do not merge plan and build.** If you feel the urge to "just quickly implement this part,"
+  stop. That impulse is the plan telling you it's not concrete enough — add more detail instead.
+
+## Output
+
+Write the plan to `docs/97-plans/YYYY-MM-DD-plan-{UPI}-{slug}.md` (gitignored — local only).
+Then enter plan mode so the user can review and refine interactively.
+
+The plan document should contain:
+
+- **Steps** — numbered, ordered, each with: files touched, what changes, tests to write
+- **Risk flags** — assumptions, ADR gates, areas of uncertainty
+- **Scope estimate** — session count based on calibration points above
+- **Ready signal** — explicit statement: "This plan is ready for arch-adversary review"
+
+The plan stays in plan mode until the user promotes it. Next step: `arch-adversary` reviews
+the plan document. After review and `/post-review` revision, the user triggers the build.
+
+## Arguments
+
+$ARGUMENTS — The design doc to plan from. Can be a path to a design in `docs/95-ideas/`,
+a UPI from registry.md, or a free-form description for smaller work that skipped formal design.

--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -4,7 +4,7 @@ This is a focused simplification pass. The question is not "is this correct?" (t
 
 ## When to run
 
-After building a feature, before running arch-adversary. Simplifying first means arch-adversary reviews cleaner code, which produces more useful findings.
+After building a feature, before `/check`. The build executes a plan already reviewed by arch-adversary — this pass catches implementation-level complexity that crept in during coding.
 
 ## What to examine
 

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ Thumbs.db
 /tmp-test-*/
 
 # Private documentation (contains system-specific details)
+docs/97-plans/
+!docs/97-plans/README.md
 docs/98-journals/
 !docs/98-journals/README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,28 +230,46 @@ cargo run -- get FILE --at DATE      # Restore file from snapshot
 
 ## Development Workflow
 
-Guideline, not rigid procedure. Skip steps that don't apply to the current work.
+Three tiers based on scope. Use the lightest tier that fits — but when in doubt, tier up.
+The review and stress-test phases (`/grill-me`, `arch-adversary`) consistently surface
+valuable discoveries. Skipping them should be the exception, not the default.
+
+### Patch — bug fixes, small changes, <3 files
 
 ```
-/brainstorm → /design → design-review → /grill-me → /sequence → [plan+build] → /simplify → arch-adversary → /post-review → /check → /journal → /commit-push-pr
+systematic-debugging → build → /check → /commit-push-pr → /journal
 ```
+
+### Standard — medium features, clear scope, no new modules
+
+```
+/design → /grill-me → /prepare → arch-adversary → /post-review → build → /simplify → /check → /commit-push-pr → /journal
+```
+
+### Full — new modules, architectural changes, ADR gates
+
+```
+/brainstorm → /design → /grill-me → [/sequence] → /prepare → arch-adversary → /post-review → build → /simplify → /check → /commit-push-pr → /journal
+```
+
+### Tool reference
 
 | Tool | Phase | What it does |
 |------|-------|--------------|
 | `/brainstorm` | Ideation | Divergent thinking, no scoring. Output: `docs/95-ideas/` |
 | `/design` | Design | Module decomposition, UPI assignment, ADR gate identification |
-| `design-review` | Design review | arch-adversary reviews the design doc (pre-implementation) |
-| `/grill-me` | Stress-test | Socratic interview, resolve decision tree branches |
-| `/sequence` | Sequencing | Order reviewed designs by decision trees and dependencies |
-| `[plan+build]` | Implementation | Planning and execution (intertwined in Claude Code) |
+| `/grill-me` | Stress-test | Socratic interview, resolve decisions, update design doc |
+| `/sequence` | Sequencing | (Optional) Order reviewed designs by dependencies when multiple are queued |
+| `/prepare` | Planning | Read design + codebase, produce implementation plan in `docs/97-plans/`. No code. |
+| `arch-adversary` | Plan review | Severity-ranked findings on the implementation plan |
+| `/post-review` | Plan revision | Revise the plan to address adversary findings |
+| `build` | Implementation | Execute the reviewed plan |
 | `/simplify` | Post-build | Simplification pass: abstractions, types, control flow |
-| `arch-adversary` | Adversary review | Severity-ranked findings on implemented code |
-| `/post-review` | Rework | Systematic fix of review findings, structured disagreement |
 | `test-team` | Testing | Risk-proportional coverage analysis and gap identification |
-| `systematic-debugging` | On-demand | Four-phase root cause investigation (any stage) |
+| `systematic-debugging` | Diagnosis | Four-phase root cause investigation (any tier, especially patch) |
 | `/check` | Quality gate | `cargo clippy` + `cargo test` + `cargo build --release` |
-| `/journal` | Documentation | Session journal + status.md + registry.md updates |
 | `/commit-push-pr` | Integration | PII scan, CHANGELOG, branch, commit, PR |
+| `/journal` | Session close | Session journal + status.md + registry.md updates (always last) |
 | `/release` | Release | SemVer bump, CHANGELOG, tag (user pushes manually) |
 
 ## Project State

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ docs/
   90-archive/               Superseded documents (mirrors original directory structure)
   95-ideas/                 Brainstorming, rough proposals, pre-plan thinking
   96-project-supervisor/    Progress tracker and project roadmap — living documents
-  97-plans/                 Implementation plans — dated, mostly immutable
+  97-plans/                 Implementation plans — GITIGNORED, transient working documents
   98-journals/              Session logs — GITIGNORED, private, authentic
   99-reports/               Reviews, analysis, generated output — dated, mostly immutable
 ```
@@ -112,8 +112,9 @@ directory structure inside (e.g., a superseded plan moves to `90-archive/97-plan
 Preserves historical record while keeping active directories uncluttered.
 
 **95-ideas** — Pre-plan thinking. Rough proposals, "what if" explorations, brainstorming
-notes. Ideas that mature get promoted to a plan in `97-plans/`; abandoned ideas stay here
-with their status updated. Low ceremony — the point is to capture thinking before it's lost.
+notes. Ideas that mature get promoted to a design (status updated, `/design` run); abandoned
+ideas stay here with their status updated. Low ceremony — the point is to capture thinking
+before it's lost.
 
 **96-project-supervisor** — The central tracking hub. Contains `status.md` (short
 current-state document, overwritten each session), `roadmap.md` (strategy, sequencing,
@@ -121,8 +122,11 @@ and horizon — ~80 lines), and `registry.md` (UPI lookup table linking work ite
 artifacts). Read status.md first for orientation; follow links to roadmap.md for sequencing
 and registry.md for artifact cross-references.
 
-**97-plans** — Implementation plans. Each plan is a dated snapshot of intent — what we're
-going to build and how. When scope changes significantly, write a new plan.
+**97-plans** — Implementation plans (gitignored — local only). Transient working documents
+produced by `/prepare`, reviewed by arch-adversary, revised by `/post-review`, consumed
+during the build phase. Plans become stale once the code is written — the design docs in
+`95-ideas/` are the durable design artifacts. Write freely: specific file paths, detailed
+steps, raw implementation notes.
 
 **98-journals** — Session logs and handoff documents (gitignored — local only). Each
 journal serves two functions: (1) historical record of what was done and learned, and
@@ -351,7 +355,7 @@ date: YYYY-MM-DD
 > **TL;DR:** {1-2 sentence summary}
 
 **Date:** YYYY-MM-DD
-**Status:** raw | developing | promoted to [plan](link) | abandoned
+**Status:** raw | developing | promoted to [design](link) | abandoned
 
 {free-form exploration}
 ```
@@ -374,8 +378,8 @@ date: YYYY-MM-DD
 ### When you have a rough idea
 
 Write it in `95-ideas/` with status `raw`. No ceremony needed — capture the thinking.
-When the idea matures into something actionable, write a plan in `97-plans/` and update
-the idea's status to `promoted to [plan](link)`.
+When the idea matures into something actionable, run `/design` and update the idea's
+status to `promoted to [design](link)`.
 
 ### When a decision needs to be recorded
 


### PR DESCRIPTION
## Summary

- Reorder workflow sequence: grill-me refines design before adversary reviews the plan (not code), separating plan from build to catch issues at their cheapest revision point
- Three explicit workflow tiers (patch/standard/full) replace ambiguous "skip steps that don't apply" with scope-based guidance
- New `/prepare` skill produces structured implementation plans in `docs/97-plans/` (gitignored) and explicitly prevents premature building
- `/grill-me` now writes resolved decisions back to the design doc, closing the cross-session context gap
- `/post-review` reframed from fixing code to revising plans before building
- `/journal` moved to always-last position across all tiers

## Testing

- Documentation and skill definitions only — no Rust code changes
- Verified all skill files parse correctly and cross-references are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)