### PR TITLE
docs: split /journal + /session-close, improve /design skill

### DIFF
--- a/.claude/commands/design.md
+++ b/.claude/commands/design.md
@@ -1,8 +1,31 @@
 Decompose an idea or feature into an architecturally sound, implementable design.
 
+The design doc is a durable artifact — it will be read by `/grill-me`, `/prepare`, and
+`arch-adversary` across separate sessions with no shared conversation context. Every
+design must be self-contained: a reader with access to CLAUDE.md and the codebase, but
+no memory of how this design was discussed, should understand what's being built and why.
+
 ## Before designing
 
-Read CLAUDE.md (module table, invariants), `docs/96-project-supervisor/status.md` (current state), and any relevant ideas in `docs/95-ideas/`. Understand what exists before proposing what to build.
+Read CLAUDE.md (module table, invariants), `docs/96-project-supervisor/status.md` (current
+state), and any relevant ideas in `docs/95-ideas/`. Understand what exists before proposing
+what to build.
+
+**Verify the problem exists.** Before designing a solution, read the relevant source modules
+to confirm the problem isn't already solved or partially addressed. Brainstorm ideas
+especially can be stale — the codebase may have evolved since the idea was written. If the
+problem is already handled, say so and skip the design. A "this is already solved" finding
+is more valuable than a design for something that doesn't need building.
+
+**When the input is a brainstorm with multiple ideas:** Triage first, then design. Read
+each idea and evaluate it against the current codebase:
+- Which ideas are already solved? (Skip with a note explaining what exists)
+- Which are mature enough for design? (Design these)
+- Which should be deferred? (Note why — dependency, prerequisite, scope)
+- Can related ideas be grouped into one design? (If so, explain the grouping and provide
+  a clean partial-delivery boundary so each piece can stand alone)
+
+Produce one design doc per coherent scope. Don't force unrelated ideas into a single design.
 
 ## UPI Assignment
 
@@ -17,26 +40,34 @@ Every design gets a Unique Project Identifier (UPI). Before writing the design d
 
 ## Core job
 
-1. **Decompose to module level.** Which existing modules are affected? What new types/traits/enums? What's the data flow? What's the test strategy? If an operation doesn't fit cleanly into one module per CLAUDE.md's table, that's a design signal.
+1. **Decompose to module level.** Which existing modules are affected? What new
+   types/traits/enums? What's the data flow? What's the test strategy? If an operation
+   doesn't fit cleanly into one module per CLAUDE.md's table, that's a design signal.
 
-2. **Identify architectural gates.** Features that introduce new public contracts, change existing contract meanings, or cross module boundaries need an ADR before code. Flag explicitly: "Gate: ADR needed for X."
+2. **Identify architectural gates.** Features that introduce new public contracts, change
+   existing contract meanings, or cross module boundaries need an ADR before code. Flag
+   explicitly: "Gate: ADR needed for X."
 
 3. **Calibrate effort to completed work.** Use status.md as reference:
    - UUID fingerprinting: 1 module extended, 10 tests, one session
    - Awareness model: 1 new module, 24 tests, one session
    - `urd get`: 1 new command, 19 tests, one session
 
-4. **The 9 founding ADRs (ADR-100 through ADR-109) are hard constraints.** If the design benefits from relaxing one, that's an ADR-gate finding, not a design assumption.
+4. **The 9 founding ADRs (ADR-100 through ADR-109) are hard constraints.** If the design
+   benefits from relaxing one, that's an ADR-gate finding, not a design assumption.
 
-5. **Sequence for risk.** High-risk, assumption-heavy pieces first so bugs surface early. The pre-cutover hardening found 3 bugs sharing one root cause — sequencing should expose those patterns.
+5. **Sequence for risk.** High-risk, assumption-heavy pieces first so bugs surface early.
+   The pre-cutover hardening found 3 bugs sharing one root cause — sequencing should expose
+   those patterns.
 
-6. **Leave room for stress-testing.** State alternatives you rejected, assumptions you're making, and decision branches that need resolving. `/grill-me` will push on these — make it productive by being explicit.
+6. **Leave room for stress-testing.** State alternatives you rejected, assumptions you're
+   making, and decision branches that need resolving. `/grill-me` will push on these — make
+   it productive by being explicit.
 
 ## Output
 
 For features affecting >3 files or introducing new modules: write a design proposal to
 `docs/95-ideas/YYYY-MM-DD-design-{UPI}-{slug}.md` with YAML frontmatter and status `proposed`.
-Include an **Open Questions** section listing assumptions and decision branches for `/grill-me` to stress-test.
 
 **Frontmatter format:**
 
@@ -48,8 +79,70 @@ date: YYYY-MM-DD
 ---
 ```
 
-For smaller features: deliver the decomposition conversationally with module mapping, effort estimate, and any gate flags. Still assign a UPI and add a registry row.
+For smaller features: deliver the decomposition conversationally with module mapping, effort
+estimate, and any gate flags. Still assign a UPI and add a registry row.
+
+### Design document structure
+
+Use this skeleton. Include every section — thin sections are fine, but missing sections
+leave gaps that `/grill-me` and `/prepare` will struggle with.
+
+```markdown
+# Design: {Title} (UPI {NNN})
+
+> **TL;DR:** {2-3 sentences: what's being built and why it matters}
+
+## Problem
+Why this feature exists. What's broken, missing, or suboptimal today.
+Ground it in concrete user experience, not abstract architecture.
+
+## Proposed Design
+The solution at module level. For each affected module:
+- What changes (types, functions, data flow)
+- Why this module and not another (reference CLAUDE.md's table)
+- Test strategy for this module's changes
+
+## Module Map
+Table or list: module → changes → test strategy. Makes scope visible at a glance.
+
+## Effort Estimate
+Session count, calibrated against completed work from status.md.
+
+## Sequencing
+What order to implement, and why. Dependencies, risk-first ordering.
+
+## Architectural Gates
+ADRs needed, contracts affected, or "None" if clean.
+
+## Rejected Alternatives
+What you considered and why you chose differently. Be specific — "considered X but
+rejected because Y" gives /grill-me something to push on. If the rejection reasoning
+is weak, /grill-me will find it.
+
+## Assumptions
+What you're taking for granted. Each assumption is a risk — if it's wrong, the design
+may need revision. Call them out so /grill-me can verify or challenge them.
+
+## Open Questions
+Decision branches that need resolving before implementation. Frame each as a choice
+with alternatives, not just an uncertainty:
+
+Good: "Should pin files be updated before or after send? Option A (before): guarantees
+protection but creates orphan pins on failure. Option B (after): cleaner but leaves a
+window where retention could delete the parent."
+
+Weak: "Need to figure out pin file timing."
+
+These are the primary input to `/grill-me` — the clearer the decision branches, the
+more productive the stress-test session. This format matters even for small features:
+`/grill-me` needs alternatives to push on regardless of scope.
+```
+
+The exact sections can flex for the feature — add sections where the design needs them,
+but don't drop the core ones (Problem, Proposed Design, Module Map, Rejected Alternatives,
+Assumptions, Open Questions). The downstream consumers depend on them.
 
 ## Arguments
 
-$ARGUMENTS — The idea or feature to design. Can be a reference to an idea doc, a feature name from status.md, or a free-form description.
+$ARGUMENTS — The idea or feature to design. Can be a reference to an idea doc, a feature
+name from status.md, or a free-form description.

--- a/.claude/commands/journal.md
+++ b/.claude/commands/journal.md
@@ -1,85 +1,78 @@
-Write a session journal and update the project status document. Two outputs from one invocation.
+Capture a focused journal entry about a specific topic, observation, or lesson learned.
 
-## Output 1: Journal entry
+This is the lightweight, mid-session journal — use it whenever something worth recording
+happens during work. It writes a single focused entry and nothing else. For end-of-session
+wrap-up (journal + status.md + registry.md updates), use `/session-close` instead.
 
-Write to `docs/98-journals/YYYY-MM-DD-slug.md`. This is gitignored (private, local only).
+## When to use
+
+- You hit a surprising behavior or non-obvious finding during implementation
+- You need to retrace a step in the workflow and want to document why
+- You're about to leave and need a quick record so you can pick up later
+- You discovered something about the codebase, a tool, or a pattern worth preserving
+- A debugging session revealed root causes worth recording
+- You encountered a workflow gap or process improvement worth noting
+
+The common thread: something happened that future-you would benefit from knowing, but
+the session isn't over and you don't need the full session-close ritual.
+
+## Output
+
+Write to `docs/98-journals/YYYY-MM-DD-{slug}.md`. This is gitignored (private, local only).
 
 **Auto-fill metadata:**
 - Date: today's date
 - Base commit: `git rev-parse --short HEAD`
-- Slug: derived from $ARGUMENTS or inferred from what was done this session
-- Plan file: the `.claude/plans/` filename if a plan was used this session (from conversation context)
+- Slug: derived from $ARGUMENTS or the topic being documented
 
 **Template:**
 
 ```markdown
-# Session Journal: {Title}
+# Journal: {Specific Topic Title}
 
-> **TL;DR:** {2-3 sentences: what was done and what was learned}
+> **TL;DR:** {1-2 sentences: the key insight or observation}
 
 **Date:** YYYY-MM-DD
 **Base commit:** `{short hash}`
-**Plan file:** `{.claude/plans/filename.md if used, omit this line if no plan}`
+**Context:** {what you were doing when this came up — 1 line}
 
-## What was done
+## What happened
 
-{Concrete deliverables. What was built, fixed, or changed. Reference files, modules,
-test counts. Keep it factual — the diff tells implementation details.}
+{The specific event, behavior, or discovery. Be concrete — name modules, error messages,
+test results, file paths. This section answers "what did I observe?"}
 
-## What was learned
+## Lessons learned
 
-{Insights, surprises, non-obvious findings. This is the most valuable section for future
-sessions — what would you tell yourself before starting this work?}
+{The insight extracted from the observation. This is the most valuable section — what
+would you tell someone about to encounter the same situation? What was non-obvious?
+What assumption was wrong?}
 
-## Open questions
+## Impact on current work
 
-{Unresolved issues, deferred decisions, things to investigate next. Remove this section
-if nothing is open.}
+{How this affects what you're building right now. Does it change the plan? Does it
+require a detour? Is it just context for later? Remove this section if purely
+informational with no impact on active work.}
 ```
 
 **Content guidelines:**
-- Gather context from the current conversation — what was built, reviewed, discussed
-- The TL;DR is the most important line. A future session may read only that.
-- Be specific: name modules, test counts, ADRs. "Improved error handling" is useless.
-  "Added `translate_btrfs_error()` covering 7 btrfs stderr patterns" is useful.
+- Focus tightly on the specific topic — this is not a session summary
+- The TL;DR is the most important line. A future session scanning journal filenames
+  and TL;DRs should be able to decide whether to read further.
+- Be specific: "retention logic silently keeps snapshots when pin file has a trailing
+  newline" is useful. "Found a bug in retention" is not.
 - Journals are private — real paths, real output, real mistakes are fine
-- Don't duplicate the commit message. The journal captures context the commit doesn't.
-- **Forward-looking handoff is encouraged** — "When you return" sections with verification
-  steps, things to watch for, and context the next session needs are high-value. This is a
-  core function of the journal.
-- **Exception: git workflow state.** Don't write "PR #45 is open" or "merge branch X" as
-  pending actions — these decay within minutes. Record PRs as deliverables ("Opened PR #45
-  for HSD-B"), not as tasks. A fresh session checks `git log`, `gh pr list`, and
-  `git branch` for actual git state.
+- Multiple journal entries in one day are fine — use different slugs
 
-## Output 2: Update registry.md
+## What NOT to do
 
-If this session produced artifacts for a UPI (design review, adversary review, PR merge),
-update the corresponding row in `docs/96-project-supervisor/registry.md` — fill in the
-link for the artifact that was produced. If no UPI-related artifacts were produced, skip.
-
-## Output 3: Update status.md
-
-Overwrite `docs/96-project-supervisor/status.md` with the current state. This is a short
-document (~50 lines) that a fresh session reads first.
-
-**Structure:**
-1. **Current State** — what's deployed, test count, current version
-2. **In Progress** — 0-2 items actively being worked on
-3. **Next Up** — 1-3 items from roadmap.md that are next
-4. **Key Links** — pointers to roadmap, CLAUDE.md, CONTRIBUTING.md, latest review
-5. **Known Issues** — only active issues that affect current work (not the full debt list)
-
-**Rules:**
-- Overwrite entirely — don't append to the existing content
-- Keep under 60 lines. Ruthlessly cut anything that belongs in roadmap.md or journals.
-- Update test count, version, and "In Progress" to reflect this session's outcomes
-- "Next Up" should reflect what the user would likely work on in the next session
-- Use PII placeholders for any tracked paths (status.md is tracked, not gitignored)
-- **Git state is checked, not recorded.** Write "HSD-B complete" not "PR #45 open."
-  Status.md tells the next session *what was built and what to build next*. The session
-  checks `git log`, `gh pr list`, `git branch` for actual branch/PR state.
+- Do not update `status.md` — that's `/session-close`'s job
+- Do not update `registry.md` — that's `/session-close`'s job
+- Do not write a comprehensive session summary — keep it focused on the specific topic
+- Do not defer writing because "I'll capture it in the session close" — the detail
+  and immediacy of mid-session capture is the whole point
 
 ## Arguments
 
-$ARGUMENTS — Optional: slug or topic for the journal entry. If empty, infer from conversation context.
+$ARGUMENTS — The topic to document. Can be a short description ("btrfs send failure
+on readonly subvolumes"), a focus area ("lessons from debugging the chain module"),
+or a reference to what just happened ("what we just discovered about retention edge cases").

--- a/.claude/commands/session-close.md
+++ b/.claude/commands/session-close.md
@@ -1,0 +1,92 @@
+Wrap up a development session. Write a comprehensive journal entry, update status.md,
+and update registry.md. This is the final step in every workflow tier.
+
+For mid-session journal entries about specific topics or lessons learned, use `/journal`
+instead — it's lighter and doesn't touch status.md or registry.md.
+
+## Output 1: Journal entry
+
+Write to `docs/98-journals/YYYY-MM-DD-slug.md`. This is gitignored (private, local only).
+
+**Auto-fill metadata:**
+- Date: today's date
+- Base commit: `git rev-parse --short HEAD`
+- Slug: derived from $ARGUMENTS or inferred from what was done this session
+- Plan file: the `.claude/plans/` filename if a plan was used this session (from conversation context)
+
+**Template:**
+
+```markdown
+# Session Journal: {Title}
+
+> **TL;DR:** {2-3 sentences: what was done and what was learned}
+
+**Date:** YYYY-MM-DD
+**Base commit:** `{short hash}`
+**Plan file:** `{.claude/plans/filename.md if used, omit this line if no plan}`
+
+## What was done
+
+{Concrete deliverables. What was built, fixed, or changed. Reference files, modules,
+test counts. Keep it factual — the diff tells implementation details.}
+
+## What was learned
+
+{Insights, surprises, non-obvious findings. This is the most valuable section for future
+sessions — what would you tell yourself before starting this work?}
+
+## Open questions
+
+{Unresolved issues, deferred decisions, things to investigate next. Remove this section
+if nothing is open.}
+```
+
+**Content guidelines:**
+- Gather context from the current conversation — what was built, reviewed, discussed
+- The TL;DR is the most important line. A future session may read only that.
+- Be specific: name modules, test counts, ADRs. "Improved error handling" is useless.
+  "Added `translate_btrfs_error()` covering 7 btrfs stderr patterns" is useful.
+- Journals are private — real paths, real output, real mistakes are fine
+- Don't duplicate the commit message. The journal captures context the commit doesn't.
+- **Forward-looking handoff is encouraged** — "When you return" sections with verification
+  steps, things to watch for, and context the next session needs are high-value. This is a
+  core function of the journal.
+- **Exception: git workflow state.** Don't write "PR #45 is open" or "merge branch X" as
+  pending actions — these decay within minutes. Record PRs as deliverables ("Opened PR #45
+  for HSD-B"), not as tasks. A fresh session checks `git log`, `gh pr list`, and
+  `git branch` for actual git state.
+- **Reference mid-session journals.** If `/journal` entries were written during this session,
+  reference them rather than duplicating their content. "See journal entry
+  `2026-04-02-retention-edge-case.md` for the detailed finding."
+
+## Output 2: Update registry.md
+
+If this session produced artifacts for a UPI (design review, adversary review, PR merge),
+update the corresponding row in `docs/96-project-supervisor/registry.md` — fill in the
+link for the artifact that was produced. If no UPI-related artifacts were produced, skip.
+
+## Output 3: Update status.md
+
+Overwrite `docs/96-project-supervisor/status.md` with the current state. This is a short
+document (~50 lines) that a fresh session reads first.
+
+**Structure:**
+1. **Current State** — what's deployed, test count, current version
+2. **In Progress** — 0-2 items actively being worked on
+3. **Next Up** — 1-3 items from roadmap.md that are next
+4. **Key Links** — pointers to roadmap, CLAUDE.md, CONTRIBUTING.md, latest review
+5. **Known Issues** — only active issues that affect current work (not the full debt list)
+
+**Rules:**
+- Overwrite entirely — don't append to the existing content
+- Keep under 60 lines. Ruthlessly cut anything that belongs in roadmap.md or journals.
+- Update test count, version, and "In Progress" to reflect this session's outcomes
+- "Next Up" should reflect what the user would likely work on in the next session
+- Use PII placeholders for any tracked paths (status.md is tracked, not gitignored)
+- **Git state is checked, not recorded.** Write "HSD-B complete" not "PR #45 open."
+  Status.md tells the next session *what was built and what to build next*. The session
+  checks `git log`, `gh pr list`, `git branch` for actual branch/PR state.
+
+## Arguments
+
+$ARGUMENTS — Optional: slug or topic for the journal entry. If empty, infer from conversation context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,19 +237,19 @@ valuable discoveries. Skipping them should be the exception, not the default.
 ### Patch — bug fixes, small changes, <3 files
 
 ```
-systematic-debugging → build → /check → /commit-push-pr → /journal
+systematic-debugging → build → /check → /commit-push-pr → /session-close
 ```
 
 ### Standard — medium features, clear scope, no new modules
 
 ```
-/design → /grill-me → /prepare → arch-adversary → /post-review → build → /simplify → /check → /commit-push-pr → /journal
+/design → /grill-me → /prepare → arch-adversary → /post-review → build → /simplify → /check → /commit-push-pr → /session-close
 ```
 
 ### Full — new modules, architectural changes, ADR gates
 
 ```
-/brainstorm → /design → /grill-me → [/sequence] → /prepare → arch-adversary → /post-review → build → /simplify → /check → /commit-push-pr → /journal
+/brainstorm → /design → /grill-me → [/sequence] → /prepare → arch-adversary → /post-review → build → /simplify → /check → /commit-push-pr → /session-close
 ```
 
 ### Tool reference
@@ -269,7 +269,8 @@ systematic-debugging → build → /check → /commit-push-pr → /journal
 | `systematic-debugging` | Diagnosis | Four-phase root cause investigation (any tier, especially patch) |
 | `/check` | Quality gate | `cargo clippy` + `cargo test` + `cargo build --release` |
 | `/commit-push-pr` | Integration | PII scan, CHANGELOG, branch, commit, PR |
-| `/journal` | Session close | Session journal + status.md + registry.md updates (always last) |
+| `/journal` | Any time | Focused journal entry about a specific topic or lesson learned |
+| `/session-close` | Session close | Comprehensive journal + status.md + registry.md updates (always last) |
 | `/release` | Release | SemVer bump, CHANGELOG, tag (user pushes manually) |
 
 ## Project State


### PR DESCRIPTION
## Summary

- Split `/journal` into two skills: `/journal` (lightweight, mid-session topic capture) and `/session-close` (full end-of-session ritual with status.md + registry.md updates)
- Improved `/design` skill with document template, brainstorm triage guidance, problem verification step, and self-containment emphasis
- Both skills validated via skill-creator eval framework with quantitative benchmarks

## Testing

- `/journal` + `/session-close`: 6 eval runs (3 with-skill, 3 baseline). With-skill: 100% pass rate on scope boundary assertions. Baseline: 60%.
- `/design`: 8 eval runs (4 with new skill, 4 with old skill). New skill: 97% structural assertion pass rate. Old skill: 51%.
- Documentation-only changes — no Rust code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)