### PR TITLE
feat: backup-now imperative — manual runs skip intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `/steve` skill: Steve Jobs product vision and UX quality gatekeeper — reviews brainstorms, designs, and finished features from the user's perspective
+- `urd backup` now acts immediately — fresh snapshots and sends without waiting for intervals. Automated runs use `--auto` to respect interval gating.
+- Pre-action briefing shown before manual backups: "Backing up everything to WD-18TB. 7 snapshots, 7 sends, ~53.0GB"
+- Mode-aware empty-plan messages explain why nothing was backed up and suggest fixes
+
+### Changed
+- `urd plan` shows the manual (no-interval) view by default; `urd plan --auto` shows the timer view
+- Lock trigger string changed from "timer" to "auto"/"manual" for clearer diagnostics
 
 ## [0.7.1] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-02
+
 ### Added
 - `/steve` skill: Steve Jobs product vision and UX quality gatekeeper — reviews brainstorms, designs, and finished features from the user's perspective
 - `urd backup` now acts immediately — fresh snapshots and sends without waiting for intervals. Automated runs use `--auto` to respect interval gating.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/95-ideas/2026-04-02-design-003-backup-now-imperative.md
+++ b/docs/95-ideas/2026-04-02-design-003-backup-now-imperative.md
@@ -1,0 +1,415 @@
+---
+upi: "003"
+status: proposed
+date: 2026-04-02
+---
+
+# Design: Backup-Now Imperative (UPI 003)
+
+> **TL;DR:** `urd backup` typed by a human takes immediate action — fresh snapshots for
+> all enabled subvolumes, sends to all connected drives, regardless of interval timers.
+> Automated runs (systemd timer, cron) pass `--auto` to preserve current interval-gated
+> behavior. The planner becomes mode-aware through `skip_intervals` in `PlanFilters`.
+
+## Problem
+
+When a user types `urd backup` in a terminal, the planner checks snapshot and send
+intervals and often responds "nothing to do" because the nightly timer already ran.
+This violates the Time Machine mental model: the user asked for a backup and got refused.
+
+The interval logic exists to throttle *automated* runs, not to refuse *manual* ones.
+Urd's two modes of existence (invisible worker / invoked norn) should have different
+invocation semantics, but currently both share the same interval-gated path.
+
+The current empty-plan response — `"Nothing to do."` in dim text — is dismissive when
+a human explicitly asked for action. The invoked norn doesn't shrug.
+
+## Proposed Design
+
+### 1. CLI layer — `--auto` flag
+
+Add an `--auto` flag to `BackupArgs` and `PlanArgs`. When present, the planner applies
+interval checks (current behavior). When absent, intervals are skipped.
+
+**Why `--auto`:** The flag appears in every systemd unit file, every cron job, every
+automation script — it's Urd's most-read CLI argument. `--auto` reads naturally
+(`ExecStart=urd backup --auto`) and describes the behavior it enables: "I'm an automated
+run, apply the automated-run rules." Rejected alternatives:
+- `--scheduled` — implementation concept, describes *when* not *what*
+- `--unattended` — accurate but too long for the most common flag
+
+**Why not TTY detection:** TTY detection (`stdout.is_terminal()`) is already used for
+output mode selection (`OutputMode::detect()`). Reusing it to control *behavior* (not
+just *presentation*) creates a coupling where piping output (`urd backup | tee log`)
+silently changes what gets backed up. `--auto` is explicit, auditable in the systemd
+unit, and visible in `ps` output. TTY detection stays in the presentation layer.
+
+**Edge case — bare `urd backup` from a cron job:** Gets manual-mode semantics. This is
+correct: a custom cron job is an intentional invocation. If interval gating is wanted,
+add `--auto`.
+
+**Module:** `src/cli.rs` — add `auto: bool` to `BackupArgs` and `PlanArgs`.
+
+**Tests:** None needed — clap struct fields.
+
+### 2. Planner — `skip_intervals` in `PlanFilters`
+
+Add `skip_intervals: bool` to the existing `PlanFilters` struct. When true,
+`plan_local_snapshot()` and `plan_external_send()` bypass their interval checks,
+behaving as if the interval has always elapsed.
+
+**Why in `PlanFilters`:** The `plan()` function signature stays unchanged. `PlanFilters`
+already carries all "how should this plan be shaped" knobs (`priority`, `subvolume`,
+`local_only`, `external_only`). `skip_intervals` is the same kind of shaping parameter.
+
+**Why a bool, not `PlanMode` enum:** The behavioral difference is exactly one boolean
+condition in two places. An enum adds a type without clarity. If a third mode emerges,
+the refactor from bool to enum is trivial. YAGNI.
+
+**Composition with `force`:** Both `plan_local_snapshot()` and `plan_external_send()`
+already have a `force: bool` parameter (from `PlanFilters.subvolume` — forces a specific
+subvolume regardless of interval). `skip_intervals` is semantically different: `force`
+targets one subvolume, `skip_intervals` affects all. They compose naturally:
+`if force || skip_intervals { true }`. When `--subvolume` is set, `force` already skips
+the interval for the targeted subvolume, so `skip_intervals` is redundant but harmless.
+
+**Safety invariant:** `skip_intervals` must NOT override the local space guard. The space
+check happens before the interval check in both functions (plan.rs:262-278 for snapshots),
+so `skip_intervals` slots in after the space guard — same as `force`.
+
+**Module:** `src/plan.rs` — add field to `PlanFilters`, thread to `plan_local_snapshot()`
+and `plan_external_send()`.
+
+**Tests:**
+- Existing tests continue to pass with `skip_intervals: false` (no behavior change)
+- New: `skip_intervals_creates_snapshot_despite_recent_one` — snapshot 5min ago, interval
+  1h, `skip_intervals: true` → snapshot planned
+- New: `skip_intervals_sends_despite_recent_send` — send 1h ago, interval 4h,
+  `skip_intervals: true` → send planned
+- New: `skip_intervals_still_respects_space_guard` — even with skip_intervals, space
+  guard must NOT be bypassed (load-bearing)
+- New: `skip_intervals_still_runs_retention` — manual mode doesn't skip cleanup
+- New: `skip_intervals_composes_with_filters` — skip_intervals + local_only still
+  filters out external sends
+
+### 3. Backup command — wire flag to planner
+
+`src/commands/backup.rs` maps `args.auto` to `skip_intervals`:
+
+```rust
+let skip_intervals = !args.auto;
+```
+
+The `PlanFilters` construction adds `skip_intervals`. No other changes to backup command
+logic — retention, locking, metrics, heartbeat, notifications all work unchanged.
+
+**Lock trigger source:** Currently hardcoded to `"timer"` (line 84). Change to:
+
+```rust
+let trigger = if args.auto { "auto" } else { "manual" };
+let _lock = lock::acquire_lock(&lock_path, trigger)?;
+```
+
+This makes lock metadata honest. Lock contention messages (lock.rs:63) already print the
+trigger, so conflicts will now show `trigger: auto` or `trigger: manual`.
+
+**Module:** `src/commands/backup.rs`
+
+**Tests:** None needed at this layer — planner tests cover the logic, lock tests already
+verify trigger strings.
+
+### 4. Plan command — wire `--auto` flag
+
+`src/commands/plan_cmd.rs` maps `args.auto` to `skip_intervals` in `PlanFilters`,
+matching backup command semantics:
+
+- `urd plan` (bare) → shows what a manual backup would do (skip intervals)
+- `urd plan --auto` → shows what the timer would do (apply intervals)
+
+This is a behavior change from today's `urd plan` (which currently shows the scheduled
+view). The consistency argument is decisive: if `urd plan` says "nothing to do" but
+`urd backup` takes action, that's confusing. `urd plan` in scripts is unlikely — it's a
+preview command.
+
+**Module:** `src/commands/plan_cmd.rs`
+
+**Tests:** None needed — planner tests cover the logic.
+
+### 5. Pre-action feedback (manual+TTY only)
+
+When `!args.auto && !args.dry_run` and stdout is a terminal, print a brief summary of
+what's about to happen *before* execution begins. This is the first beat of the narrative
+arc: "Here's what I'm about to do → Here's what I'm doing → Here's what I did."
+
+**Output structure (new types in `output.rs`):**
+
+```rust
+pub struct PreActionSummary {
+    pub snapshot_count: usize,
+    pub send_plan: Vec<PreActionDriveSummary>,
+    pub disconnected_drives: Vec<DisconnectedDrive>,
+    pub filters: PreActionFilters,
+}
+
+pub struct PreActionDriveSummary {
+    pub drive_label: String,
+    pub subvolume_count: usize,
+    pub estimated_bytes: Option<u64>,
+}
+
+pub struct DisconnectedDrive {
+    pub label: String,
+    pub role: DriveRole,
+}
+
+pub struct PreActionFilters {
+    pub local_only: bool,
+    pub external_only: bool,
+    pub subvolume: Option<String>,
+}
+```
+
+**Rendering (in `voice.rs`):** Compact, natural language. Lead with the action and
+destination, not the counts. Adapt the opening line to the operation shape:
+
+**Full backup, one drive connected:**
+```
+Backing up everything to WD-18TB.
+  7 snapshots, ~9.2GB to send
+
+  WD-18TB1 is away — copies will update when it returns.
+  2TB-backup not connected.
+```
+
+**Full backup, multiple drives connected:**
+```
+Backing up everything to WD-18TB and 2TB-backup.
+  7 snapshots, ~18.4GB to send
+```
+
+**Local-only:**
+```
+Snapshotting 7 subvolumes.
+```
+
+**Single subvolume filter:**
+```
+Backing up htpc-home to WD-18TB.
+  1 snapshot, ~1.2GB to send
+```
+
+**External-only:**
+```
+Sending to WD-18TB.
+  7 subvolumes, ~9.2GB to send
+```
+
+**Drive role distinction:** Disconnected offsite drives show as "away — copies will
+update when it returns" (expected lifecycle state). Disconnected primary drives show as
+"not connected" (might warrant plugging in). The `DriveRole` enum provides this data.
+In `--local-only` mode, disconnected drives are not shown (sends aren't part of the plan).
+
+**Construction:** Built from the `BackupPlan` after planning, before execution. Count
+`CreateSnapshot` operations, group `Send*` operations by drive, sum estimates.
+Disconnected drives from the plan's skipped list (category = DriveNotMounted), enriched
+with `DriveRole` from config.
+
+**Module:** `src/output.rs` (types), `src/voice.rs` (rendering), `src/commands/backup.rs`
+(construction and printing).
+
+**Tests:**
+- `voice.rs`: render tests for each operation shape (full/local/external/filtered/
+  multi-drive), disconnected drive role variants, no-estimates case
+- `output.rs`: `PreActionSummary` construction test from a mock `BackupPlan`
+
+### 6. Mode-aware empty-plan messaging
+
+When `!args.auto` and the plan is empty, explain why instead of printing "Nothing to do."
+The explanation is derived from the skipped reasons already in the plan.
+
+**Possible empty-plan causes in manual mode** (intervals can't cause it):
+- All subvolumes disabled
+- `--external-only` with no drives connected
+- `--subvolume foo` where `foo` doesn't exist or is disabled
+- All subvolumes hit the space guard (filesystem full)
+
+**Output structure (new type in `output.rs`):**
+
+```rust
+pub struct EmptyPlanExplanation {
+    pub reasons: Vec<String>,
+    pub suggestion: Option<String>,
+}
+```
+
+**Rendering example:**
+```
+Nothing to back up — all subvolumes are disabled in config.
+  Enable subvolumes in ~/.config/urd/urd.toml
+```
+
+**Module:** `src/output.rs` (type), `src/voice.rs` (rendering), `src/commands/backup.rs`
+(construction — replaces current `"Nothing to do."` path for manual mode).
+
+**Tests:**
+- `voice.rs`: render test for each cause
+- Planner tests verify skip reasons are present for each case
+
+### 7. Dry-run behavior
+
+`--dry-run` inherits mode from `--auto`. `urd backup --dry-run` shows the manual plan
+(skip intervals). `urd backup --auto --dry-run` shows the scheduled plan. No special
+handling — `skip_intervals = !args.auto` is computed before the dry-run check, and the
+plan rendering path uses whatever plan was computed.
+
+### 8. Systemd timer migration
+
+The systemd timer unit is not shipped in the repo — deployed by the user. Migration:
+
+1. **CHANGELOG entry:** Note that `urd backup` now runs unconditionally; systemd timer
+   units should add `--auto`.
+2. **`urd init` guidance:** Updated output mentions `--auto` for timer units.
+
+No `urd doctor` check for systemd unit files — scanning unit file paths is fragile
+(non-standard paths, multiple units). The CHANGELOG + init guidance is sufficient.
+
+### 9. Backward compatibility (ADR-105)
+
+**No on-disk format changes.** Snapshots, pin files, metrics, heartbeat — all unchanged.
+The `--auto` flag is additive CLI surface. Existing `urd backup` invocations get new
+behavior (manual mode), which is the *intended* semantic change — the old behavior
+(interval-gated manual runs) was a bug, not a feature.
+
+**Existing scripts that call `urd backup`:** Will now produce more snapshots. This is
+safe — retention cleans them up. If a script needs the old behavior, add `--auto`.
+
+### 10. Architectural question: `INVOCATION_ID` check
+
+**For arch-adversary review.** The existing `INVOCATION_ID` check at backup.rs:125 gates
+chain-break full sends (`FullSendPolicy::SkipAndNotify`) in systemd contexts. This serves
+a related but distinct purpose to `--auto` — gating expensive operations in unattended
+contexts.
+
+**Question:** Should `args.auto` replace the `INVOCATION_ID` check for consistency? The
+two signals overlap but aren't identical:
+- `--auto` means "apply automated-run rules" (user-declared intent)
+- `INVOCATION_ID` means "running inside systemd" (environmental fact)
+
+A manual `urd backup` inside a systemd oneshot would see different behavior depending on
+which signal is used. Replacing `INVOCATION_ID` with `args.auto` is cleaner (one signal
+for "automated") but loses the environmental safety net. Keeping both means two detection
+mechanisms for overlapping concepts.
+
+**Current recommendation:** Do not change in this PR. Flag for arch-adversary review.
+
+## Module Map
+
+| Module | Changes | Test strategy |
+|--------|---------|---------------|
+| `src/cli.rs` | Add `auto: bool` to `BackupArgs` and `PlanArgs` | Covered by integration |
+| `src/plan.rs` | Add `skip_intervals: bool` to `PlanFilters`, thread to `plan_local_snapshot()` and `plan_external_send()` | 5 new unit tests |
+| `src/commands/backup.rs` | Map `!args.auto` → `skip_intervals`, fix lock trigger, build + print `PreActionSummary`, mode-aware empty plan | Existing tests + manual verification |
+| `src/commands/plan_cmd.rs` | Map `!args.auto` → `skip_intervals` in `PlanFilters` | Existing tests |
+| `src/output.rs` | Add `PreActionSummary`, `PreActionDriveSummary`, `DisconnectedDrive`, `PreActionFilters`, `EmptyPlanExplanation` types | Construction tests |
+| `src/voice.rs` | Add `render_pre_action()` and `render_empty_plan()` functions | 6-8 render tests |
+
+## Effort Estimate
+
+**~1 session.** Calibration:
+- UUID fingerprinting (1 module, 10 tests): 1 session
+- `urd get` (1 new command, 19 tests): 1 session
+
+Comparable scope — core planner change is mechanical, pre-action summary follows
+established output.rs/voice.rs patterns, empty-plan messaging is small. The plan command
+wiring is a few lines.
+
+## Sequencing
+
+1. **Planner `skip_intervals` in `PlanFilters`** — core behavior change, all planner
+   tests. Risk: none, pure function with existing test patterns.
+2. **CLI `--auto` flag + backup/plan command wiring + lock trigger fix** — connects
+   planner to user. Risk: low, verify existing tests still pass.
+3. **Pre-action summary** — output.rs types, voice.rs rendering, backup.rs construction.
+   Risk: low, follows established patterns. Build last because it depends on the plan.
+4. **Empty-plan messaging** — small addition, depends on the mode being wired.
+
+## Architectural Gates
+
+**None for this PR.** The `INVOCATION_ID` question (section 10) is flagged for
+arch-adversary review but does not block implementation.
+
+## Rejected Alternatives
+
+### TTY detection for mode selection
+
+Rejected: couples *behavior* to *presentation*. Piping `urd backup | tee backup.log`
+would silently switch to interval-gated mode. TTY detection stays in the presentation
+layer (`OutputMode::detect()`).
+
+### `PlanMode` enum instead of `skip_intervals: bool`
+
+Rejected: one boolean checked in two places doesn't warrant an enum. YAGNI. Refactor is
+trivial if a third mode emerges.
+
+### Confirmation prompt before manual backup
+
+Rejected: user already typed `urd backup`. Pre-action summary provides visibility without
+blocking. `--dry-run` exists for preview-before-commit.
+
+### `--force` flag instead of `--auto`
+
+Rejected: inverts the mental model. The human at the terminal is the default case, the
+timer is the special case. The special case gets the qualifier.
+
+### `--scheduled` flag name
+
+Rejected: implementation concept, describes *when* not *what*. `--auto` reads like
+English in unit files and describes the behavior it enables.
+
+### Doctor check for systemd unit files
+
+Rejected: scanning unit file paths is fragile (non-standard paths, multiple units).
+CHANGELOG + init guidance is sufficient.
+
+## Assumptions
+
+1. **The systemd timer is the primary automated caller.** Custom cron jobs calling
+   `urd backup` without `--auto` get manual semantics — intentional invocation.
+
+2. **`force` and `skip_intervals` compose without conflict.** `force` is a subset of
+   `skip_intervals`. When both are true, behavior equals `skip_intervals` alone.
+
+3. **Pre-action summary can be built from `BackupPlan` alone.** Plan contains all
+   operations and skipped reasons. Drive roles come from config (already available in
+   backup command scope). No additional filesystem queries needed.
+
+4. **Retention behavior is identical in both modes.** Manual runs that create extra
+   snapshots see those snapshots subject to normal retention on the next run.
+
+5. **Space guard is never bypassed.** Space check precedes interval check in the planner.
+   `skip_intervals` slots in after the space guard, same as `force`.
+
+## Open Questions
+
+**All resolved.** See Resolved Decisions below.
+
+## Resolved Decisions
+
+Decisions resolved during `/grill-me` session (2026-04-02), incorporating Steve Jobs
+review findings from `docs/99-reports/2026-04-02-steve-jobs-003-backup-now-almost-right.md`.
+
+| # | Decision | Resolution | Rationale |
+|---|----------|------------|-----------|
+| 1 | Flag name | `--auto` | Reads naturally in unit files, describes behavior not scheduling |
+| 2 | Lock trigger source | Include: `"auto"` vs `"manual"` | One-line fix, directly adjacent, makes metadata honest |
+| 3 | `urd plan` gains `--auto` | Yes, same PR | Consistency — plan should preview what backup would do |
+| 4 | Pre-action summary tone | Lead with action+destination, adapt to operation shape | Narrative arc: briefing from authority, not spreadsheet |
+| 5 | Empty-plan messaging | Include mode-aware explanation | Core pain point; dismissive response undermines the feature |
+| 6 | Parameter location | `skip_intervals: bool` in `PlanFilters` | Keeps `plan()` signature stable, groups with plan-shaping knobs |
+| 7 | Pre-action in auto mode | Manual+TTY only | Daemon path has backup summary; pre-action serves watching humans |
+| 8 | `INVOCATION_ID` replacement | Flag for arch-adversary, don't change | Overlapping but distinct signals; needs architectural scrutiny |
+| 9 | Dry-run behavior | Inherits mode from `--auto` | Falls out naturally, no special handling |
+| 10 | `--subvolume` composition | No action, composes via `force` | Existing mechanism handles it |
+| 11 | Vocabulary: "away" | Use "away" for offsite drives | Load-bearing vocabulary for off-site lifecycle state |
+| 12 | Drive role in pre-action | Distinguish by `DriveRole` | Offsite="away", primary="not connected"; data exists |
+| 13 | Scope boundary | Confirmed | See Architectural Gates and section 10 |

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,5 +5,6 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
+| 003 | Backup-now imperative | [design](../95-ideas/2026-04-02-design-003-backup-now-imperative.md) | [review](../99-reports/2026-04-02-design-review-003-backup-now-imperative.md) | - | - | - |
 | 002 | Output polish | [design](../95-ideas/2026-04-01-design-002-output-polish.md) | [review](../99-reports/2026-04-01-design-review-002-output-polish.md) | - | - | - |
 | 001 | Workflow system overhaul | [design](../95-ideas/2026-04-01-design-001-workflow-system-overhaul.md) | - | - | - | - |

--- a/docs/99-reports/2026-04-02-design-review-003-backup-now-imperative.md
+++ b/docs/99-reports/2026-04-02-design-review-003-backup-now-imperative.md
@@ -1,0 +1,232 @@
+---
+upi: "003"
+date: 2026-04-02
+---
+
+# Architectural Adversary Review: Backup-Now Imperative (UPI 003)
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-02
+**Scope:** Design review of implementation plan `docs/97-plans/2026-04-02-plan-003-backup-now-imperative.md` and design doc `docs/95-ideas/2026-04-02-design-003-backup-now-imperative.md`
+**Mode:** Design review (plan, not yet implemented)
+
+---
+
+## Executive Summary
+
+A well-motivated feature with a sound core design. The `skip_intervals` bool in
+`PlanFilters` is the right abstraction — it changes the planner's behavior without
+changing its interface, and the space guard safety contract is explicitly preserved.
+One significant finding: the empty-plan branch guard change in Step 4 silently
+reroutes plans-with-skips-but-no-operations from the execution path to the early-return
+path, which uses a different heartbeat builder. The remaining findings are about
+underspecified construction details that should be resolved before build, not during it.
+
+## What Kills You
+
+**Catastrophic failure mode:** silent data loss from deleting snapshots that shouldn't
+be deleted, or space exhaustion from uncontrolled snapshot creation.
+
+**Distance from this plan:** Far. `skip_intervals` only affects the interval gate — it
+does not touch retention, pin protection, or the space guard. The space guard precedes
+the interval check in both `plan_local_snapshot()` (line 262) and `plan_external_send()`
+(line 492), so `skip_intervals` cannot cause space exhaustion. Retention runs identically
+in both modes. No finding in this review is within two bugs of data loss.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | Core planner change is correct; empty-plan branch needs one guard fix |
+| 2 | Security | 5 | No new trust boundaries; sudo paths untouched; space guard preserved |
+| 3 | Architectural Excellence | 4 | Clean extension of existing patterns; one underspecified data flow |
+| 4 | Systems Design | 4 | Mode semantics well-reasoned; systemd migration path clear |
+
+## Design Tensions
+
+### 1. `skip_intervals` bool vs. richer mode concept
+
+The plan uses a single bool where an enum (`PlanMode::Manual` / `PlanMode::Auto`) might
+better communicate intent. The design doc explicitly considered and rejected this — one
+boolean checked in two places doesn't warrant a type. This is the right call today. The
+tension point is that `--auto` also implies "lock trigger = auto" and "no pre-action
+summary" and "different empty-plan messaging" — the bool is growing semantic weight outside
+the planner. If a third mode-dependent behavior appears, the refactor to an enum should
+happen then. For now, YAGNI applies correctly.
+
+### 2. Pre-action summary construction: BackupPlan vs. PlanOutput
+
+The design says to build `PreActionSummary` from `BackupPlan`, but estimated send bytes
+aren't stored in `PlannedOperation` — they're computed in `plan_cmd::build_operation_entry()`
+via `FileSystemState` queries. The plan says "reuse the size estimation logic from
+plan_cmd.rs" but doesn't specify the mechanism. Two clean options exist; the plan should
+pick one before build. See Finding 3.
+
+### 3. Hardcoded "Nothing to do" vs. voice module
+
+The current backup empty-plan message (`println!("{}", "Nothing to do.".dimmed())` at
+backup.rs:87) is hardcoded outside the voice module. The plan correctly moves this to
+voice.rs for the manual-mode case. The design's instinct to route all user-facing text
+through voice is sound and consistent with the module responsibility table.
+
+## Findings
+
+### Finding 1 — Significant: Empty-plan branch guard change reroutes heartbeat builder
+
+**What:** Step 4 proposes changing backup.rs:86 from
+`if backup_plan.is_empty() && backup_plan.skipped.is_empty()` to `if backup_plan.is_empty()`.
+This is needed so that empty-plan-with-skips gets mode-aware messaging. But it also changes
+which heartbeat builder runs for this case.
+
+**Consequence:** Today, when operations are empty but skips exist (e.g., all drives
+unmounted), execution falls through to the main path: the executor runs zero operations,
+then `heartbeat::build_from_run()` writes the heartbeat with `run_result` based on
+`ExecutionResult`. After the change, these cases hit the early-return path using
+`heartbeat::build_empty()` with `run_result: "empty"`. This changes the heartbeat's
+`run_result` field from execution-derived to hardcoded "empty" for a case that previously
+produced a different value.
+
+In practice, executing zero operations produces a success result, so the behavioral
+difference is likely `run_result: "success"` → `run_result: "empty"`. This affects
+downstream consumers (Sentinel, monitoring stack). The change might actually be *more
+correct* ("empty" describes what happened better than "success"), but it should be a
+conscious decision, not a side effect.
+
+**Fix:** Acknowledge this behavior change explicitly. Verify that `heartbeat::build_empty()`
+produces appropriate output when `backup_plan.skipped` is non-empty. Consider whether the
+metrics path also differs: `write_metrics_for_skipped()` vs `write_metrics_after_execution()`
+— confirm both produce correct metrics for zero-operation plans. Add a test that verifies
+heartbeat output for the empty-plan-with-skips case.
+
+### Finding 2 — Significant: Pre-action summary needs size estimates that live in a different module
+
+**What:** `PreActionSummary.send_plan[].estimated_bytes` requires the same 3-tier size
+estimation (same-drive history → cross-drive → calibrated) that `plan_cmd::build_operation_entry()`
+performs. But the plan puts pre-action construction in `backup.rs` without specifying how
+it gets the estimates.
+
+**Consequence:** Without a clear mechanism, the build phase will either (a) duplicate the
+estimation logic, (b) import and call `build_plan_output()` for its side effects, or
+(c) skip estimates for pre-action. Option (a) violates DRY for load-bearing estimation
+logic. Option (b) computes a full `PlanOutput` just to extract byte counts.
+
+**Fix:** Use option (b) — call `plan_cmd::build_plan_output(&backup_plan, &fs_state)` and
+extract from it. This is what `--dry-run` already does (backup.rs:76). The `PlanOutput`
+is cheap to construct (no I/O, just lookups into `FileSystemState`). Build the
+`PreActionSummary` from `PlanOutput` rather than directly from `BackupPlan`. This reuses
+existing logic and keeps size estimation in one place.
+
+### Finding 3 — Moderate: Disconnected drive extraction from skip reasons is fragile
+
+**What:** The plan builds `DisconnectedDrive` by parsing skip reason strings
+("drive {label} not mounted") from `backup_plan.skipped`. This is the same string-parsing
+pattern used in `voice::render_drive_not_mounted_group()` (voice.rs:1050-1064).
+
+**Consequence:** The pattern is established but inherently fragile — a wording change in
+plan.rs breaks extraction in two places. This is acceptable for one consumer (voice.rs
+already does it) but adding a second consumer (backup.rs) doubles the maintenance surface.
+
+**Fix:** Extract a shared helper: `fn extract_unmounted_drive_label(reason: &str) -> Option<&str>`
+in `output.rs` next to `SkipCategory::from_reason()`. Both voice.rs and backup.rs call it.
+This is a small refactor that pays for itself immediately. Alternatively, since the plan
+already proposes building `PreActionSummary` after planning, and `build_plan_output()`
+already classifies skips into `SkippedSubvolume` with `SkipCategory`, the pre-action
+construction can filter on `SkipCategory::DriveNotMounted` and extract labels from
+the classified output — cleaner than re-parsing raw strings.
+
+### Finding 4 — Moderate: Function signature growth in planner
+
+**What:** `plan_local_snapshot()` already has 9 parameters with
+`#[allow(clippy::too_many_arguments)]`. Adding `skip_intervals` makes 10.
+`plan_external_send()` same situation.
+
+**Consequence:** Not a correctness issue, but the parameter count signals that these
+functions are doing too much arg-threading. The alternative — passing `&PlanFilters`
+directly to both functions instead of destructured bools — would be cleaner and wouldn't
+require a new parameter each time a filter is added.
+
+**Fix:** Not in this PR scope. But note that passing `&PlanFilters` to both helpers
+(instead of `force: bool` + `skip_intervals: bool`) would simplify all call sites and
+prevent future parameter growth. Flag for a follow-up simplification.
+
+### Finding 5 — Minor: `urd plan` behavior change could affect `urd plan --dry-run` style usage
+
+**What:** `urd plan` (bare) changes from scheduled view to manual view. The design doc
+acknowledges this and argues it's correct (consistency with `urd backup`).
+
+**Consequence:** Low risk — `urd plan` is a preview command unlikely to be in scripts.
+But any monitoring or cron job that runs `urd plan` and parses the output to check
+"are there pending operations?" will now see a different (larger) set of operations.
+
+**Fix:** The CHANGELOG entry (mentioned in design doc section 8) should note this behavior
+change explicitly. No code change needed.
+
+### Commendation: Space guard preservation is explicitly designed
+
+The design doc's safety invariant section (design doc lines 76-78) explicitly states that
+`skip_intervals` must NOT override the space guard, and explains *why* by position: the
+space check precedes the interval check in both planner functions. This is the right way
+to reason about safety — by structural position, not by hoping nobody reorders the checks.
+The plan preserves this by slotting `skip_intervals` into the existing `force` position,
+which already sits after the space guard.
+
+### Commendation: `--auto` as the qualifier for the special case
+
+The flag design inverts the typical pattern (most tools require a flag to *force* action).
+Here, the human at the terminal is the default; automation gets the qualifier. This is
+the right call for a tool whose primary interaction model is "I asked for a backup."
+The design doc's rejected-alternatives section shows this was a conscious, well-reasoned
+decision.
+
+## The Simplicity Question
+
+**What could be removed?** Nothing in the core design. The `skip_intervals` bool is the
+minimum viable change to the planner. The pre-action summary and empty-plan messaging are
+the UX payoff that justifies the feature — without them, the user just gets more snapshots
+but no acknowledgment. The lock trigger fix is one line and makes existing metadata honest.
+
+**What's earning its keep?** Every output type (`PreActionSummary`, `EmptyPlanExplanation`)
+carries information the user needs. The operation-shape adaptive rendering (full/local/
+external/filtered) in voice.rs follows the established pattern of speaking to what the
+user actually asked for.
+
+**What could be simpler?** The pre-action summary construction. Rather than building
+from `BackupPlan` directly (which requires reimplementing size estimation), build from
+`PlanOutput` (which `--dry-run` already constructs). This eliminates Finding 2 entirely.
+
+## For the Dev Team
+
+Priority-ordered actions:
+
+1. **Resolve empty-plan branch guard (Step 4).** Before changing the guard from
+   `is_empty() && skipped.is_empty()` to `is_empty()`, verify:
+   - What `heartbeat::build_empty()` produces when skipped is non-empty
+   - Whether `write_metrics_for_skipped()` and `write_metrics_after_execution()` produce
+     equivalent output for zero operations
+   - Add a test covering the "operations empty, skips non-empty" case in both old and new paths
+   - If the heartbeat difference is acceptable, document it as intentional in a code comment
+
+2. **Specify pre-action summary data source (Step 3).** Build `PreActionSummary` from
+   `PlanOutput` (via `plan_cmd::build_plan_output()`) rather than directly from `BackupPlan`.
+   This gives you `SkippedSubvolume` with `SkipCategory` for disconnected drive extraction,
+   and `PlanOperationEntry.estimated_bytes` for size estimates — no logic duplication.
+
+3. **Extract drive label parser (Step 3).** Create a shared helper for extracting drive
+   labels from "drive {label} not mounted" skip reasons, or use the `SkipCategory`-based
+   approach from item 2 to avoid string parsing entirely.
+
+4. **(Future) Pass `&PlanFilters` to plan helpers.** Not this PR, but threading individual
+   bools is approaching its limit. Note for next planner change.
+
+## Open Questions
+
+1. **Heartbeat `run_result` values:** What distinct values does `heartbeat::build_from_run()`
+   produce for zero-operation execution results? If it produces "success", is the monitoring
+   stack sensitive to "success" vs "empty"? If so, the guard change in Step 4 needs a
+   homelab ADR-021 update.
+
+2. **Pre-action summary in `--auto` mode:** The design says manual+TTY only. But what about
+   `urd backup --dry-run` (no `--auto`)? The dry-run path (backup.rs:74-79) exits before
+   the pre-action summary point. This means `--dry-run` shows the plan view (operations list)
+   but NOT the pre-action summary (natural language briefing). Is that intentional? The plan
+   view is more detailed, so this is probably fine — just confirm the intent.

--- a/docs/99-reports/2026-04-02-steve-jobs-003-backup-now-almost-right.md
+++ b/docs/99-reports/2026-04-02-steve-jobs-003-backup-now-almost-right.md
@@ -1,0 +1,194 @@
+---
+upi: "003"
+date: 2026-04-02
+mode: design-critique
+---
+
+# Steve Jobs Review: Backup-Now Imperative
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-02
+**Scope:** Design spec UPI 003 — backup-now imperative (`docs/95-ideas/2026-04-02-design-003-backup-now-imperative.md`)
+**Mode:** Design Critique
+
+## The Verdict
+
+The core insight is exactly right — and it's one of those things that seems obvious in
+hindsight, which is how you know it's a real design insight. But the design gets the flag
+name wrong, and the pre-action feedback doesn't go far enough to make the manual experience
+feel like consulting an authority.
+
+## What's Insanely Great
+
+**The inversion of defaults.** This is the single best decision in the design. When you
+type a command, the command should do what you asked. `--scheduled` on the timer instead of
+`--force` on the human — that's exactly the right mental model. The rejected alternatives
+section explains this beautifully: "the systemd timer is the special case, not the human at
+the terminal." That's product thinking, not engineering thinking. Protect this decision at
+all costs.
+
+**The TTY rejection.** Refusing to use TTY detection for behavior selection is correct, and
+the reasoning is sharp: piping output shouldn't change what gets backed up. When I built the
+original Mac, we had a similar principle — how you observe the system should never change
+what the system does. The design correctly confines TTY detection to the presentation layer.
+
+**The space guard preservation.** Manual mode skips intervals but never skips the space
+guard. This is the kind of safety discipline that separates a tool you trust from a tool
+you use carefully. The user says "back up now" and Urd says "yes" — except when saying yes
+would destroy the very data it's protecting. That's not a refusal, that's a guardian.
+
+## What's Not Good Enough
+
+### The flag name is wrong
+
+`--scheduled` is an implementation concept. It describes *when* the backup runs, not *what
+it means*. A systemd timer doesn't think of itself as "scheduled" — it just fires. The
+flag should describe the behavior it enables, from the perspective of someone reading the
+unit file six months from now.
+
+`--auto` is better. It says: "I'm running automatically, apply the automatic-run rules."
+Short, clear, scannable in `ps` output. `ExecStart=urd backup --auto` reads like English.
+`ExecStart=urd backup --scheduled` reads like a developer wrote it.
+
+Even better: consider `--unattended`. It says exactly what's true — nobody is watching,
+apply throttling. But it's long. `--auto` wins on brevity.
+
+This matters because this flag will appear in every systemd unit file, every cron job, every
+automation script. It's Urd's most-read CLI argument. Get the word right.
+
+### The pre-action summary is too timid
+
+The design proposes:
+```
+Snapshotting 7 subvolumes
+Sending to WD-18TB: 7 subvolumes (~9.2GB estimated)
+Drives away: WD-18TB1, 2TB-backup
+```
+
+This is a status report. It's accurate. It's also forgettable. When the user types
+`urd backup`, they're in a moment of *agency* — they chose to act. The pre-action feedback
+should meet that moment.
+
+What great looks like:
+```
+Backing up everything to WD-18TB.
+  7 snapshots, ~9.2GB to send
+
+  WD-18TB1, 2TB-backup not connected — their copies will wait.
+```
+
+Three differences:
+1. **Lead with the action and the destination**, not the count. The user wants to know
+   "where is my data going?" before "how many subvolumes?"
+2. **One line for the core action.** Don't make me parse three lines to understand that
+   a backup is happening.
+3. **"Their copies will wait"** instead of "Drives away." The user isn't monitoring drive
+   attachment state — they want to know that Urd noticed, and that it's not a problem.
+   "Away" is a status word. "Will wait" is a promise.
+
+When multiple drives are connected, the first line expands naturally: "Backing up
+everything to WD-18TB and 2TB-backup."
+
+### The "Nothing to do" path survives
+
+The design correctly makes manual mode skip intervals, so the "nothing to do" path (line
+86-87 of backup.rs) should be nearly impossible to hit in manual mode — you'd need all
+subvolumes disabled or all drives disconnected with external-only mode.
+
+But the design doesn't address what happens when it *does* hit. Today it prints
+`"Nothing to do."` in dim text. For a manual invocation, that's dismissive. The invoked
+norn doesn't shrug.
+
+If a user types `urd backup` and nothing can happen (all disabled, or no drives for
+external-only), the response should explain *why* nothing can happen and what the user
+can do about it:
+```
+Nothing to back up — all subvolumes are disabled in config.
+  Enable subvolumes in ~/.config/urd/urd.toml
+```
+
+This is a small thing. But it's the difference between a tool that respects the user's
+intent and a tool that silently declines to help.
+
+### The lock trigger source is hardcoded
+
+Line 84 of backup.rs: `lock::acquire_lock(&lock_path, "timer")`. When the user runs
+`urd backup` manually, the lock metadata says the trigger source is "timer." That's a lie.
+
+This isn't in the design scope, but it's directly adjacent — if you're building the
+concept of manual vs. scheduled invocation, the lock should know which one it is. When
+the user hits a lock conflict (`urd backup` while the timer is running), the error
+message should say "a scheduled backup is already running" or "a manual backup is already
+running" — not just "locked."
+
+## The Vision
+
+Here's what this feature is really about: it's the first time Urd distinguishes between
+being a daemon and being a tool. Every feature you build after this — the encounter,
+restore verification, directory restore — will inherit this distinction. Get it right here
+and everything downstream benefits.
+
+The manual backup experience should feel like pressing a physical button. One action,
+immediate response, clear feedback. Not a form submission. Not a pipeline trigger. A
+button.
+
+When I think about what "Back Up Now" meant in Time Machine, it wasn't the backing up that
+made it great — it was the *certainty*. You pressed the button, and you knew. The spinning
+gear, the progress bar, the timestamp update. You never wondered "did it work?" You never
+had to check.
+
+The pre-action summary, the progress display (which already exists), and the backup summary
+should form a continuous narrative: "Here's what I'm about to do → Here's what I'm doing →
+Here's what I did." That narrative arc is what makes a manual backup feel *handled*.
+
+The design gets the architecture right for this. The pre-action summary is the missing
+first beat of that narrative. Make it count.
+
+## The Details
+
+1. **"Drives away"** — this phrase appears in the pre-action summary example. "Away" is
+   the vocabulary term for disconnected drives, which is correct per the frozen vocabulary.
+   But in the pre-action summary context, the phrase reads oddly. "Not connected" or
+   "offline" would be clearer in this specific rendering. The vocabulary freeze covers
+   status labels and promise states; rendering text can use natural language that maps to
+   the underlying status.
+
+2. **The `skip_intervals` parameter name** — threading a negation (`skip_intervals: true`
+   means "don't check intervals") is mildly confusing. The design chose it over an enum for
+   simplicity, which is fair. But consider `force_all: bool` — it extends the existing
+   `force` concept (which already means "skip interval for one subvolume") to all. The code
+   reads: `if force || force_all { true }`. Though I acknowledge `skip_intervals` is more
+   precise about what it does.
+
+3. **Open Question Q1 is not really open.** The design recommends that `urd plan` should
+   also respect the flag, and the reasoning is airtight: "the plan command exists to answer
+   'what will happen if I run backup?'" — it should match backup semantics. This isn't
+   a question, it's a decision. Make it. Ship it in the same PR.
+
+4. **The design says "~1 session" but includes `urd plan` consistency.** If Q1 is resolved
+   as recommended (it should be), that adds `PlanArgs` changes and plan command wiring.
+   Still one session, but call it out in the module map — it's currently missing.
+
+5. **The example pre-action text says "Drives away: WD-18TB1, 2TB-backup"** but the
+   design also says disconnected drives come from the skipped list. If a drive is
+   disconnected and the user is running in `--local-only` mode, does it still show the
+   disconnected drives? It shouldn't — the user explicitly said local-only. The pre-action
+   summary should respect the same filters the planner does.
+
+## The Ask
+
+1. **Rename `--scheduled` to `--auto`.** This is the highest-impact change because the
+   flag name becomes part of every deployment. Get it right before it ships.
+
+2. **Rewrite the pre-action summary** to lead with the action and destination, not the
+   counts. Use natural language. Make it feel like a briefing from an authority, not a
+   spreadsheet preview.
+
+3. **Update the lock trigger source** to reflect manual vs. auto invocation. Small change,
+   adjacent to the work, improves error messages for lock conflicts.
+
+4. **Resolve Q1 as decided** — `urd plan` matches `urd backup` semantics. Add it to the
+   module map and ship it together.
+
+5. **Address the "nothing to do" path** for manual invocations. Even if rare, the response
+   should explain why and guide the user, not shrug.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -103,6 +103,10 @@ pub struct PlanArgs {
     /// Only show external operations
     #[arg(long)]
     pub external_only: bool,
+
+    /// Show automated-run plan (apply interval gating)
+    #[arg(long)]
+    pub auto: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -136,6 +140,10 @@ pub struct BackupArgs {
     /// Without this flag, chain-break full sends are skipped in autonomous mode (systemd).
     #[arg(long)]
     pub force_full: bool,
+
+    /// Automated run — apply interval gating. Without this flag, Urd backs up immediately.
+    #[arg(long)]
+    pub auto: bool,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -19,8 +19,8 @@ use crate::heartbeat;
 use crate::lock;
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
 use crate::output::{
-    BackupSummary, OutputMode, SendSummary, SkipCategory, SkippedSubvolume, StatusAssessment,
-    StructuredError, SubvolumeSummary, TransitionEvent,
+    BackupSummary, EmptyPlanExplanation, OutputMode, SendSummary, SkipCategory, SkippedSubvolume,
+    StatusAssessment, StructuredError, SubvolumeSummary, TransitionEvent,
 };
 use crate::notify;
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
@@ -36,6 +36,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         subvolume: args.subvolume,
         local_only: args.local_only,
         external_only: args.external_only,
+        skip_intervals: !args.auto,
     };
 
     let mode = if args.dry_run {
@@ -81,11 +82,21 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 
     // Acquire advisory lock to prevent concurrent backup runs
     let lock_path = config.general.state_db.with_extension("lock");
-    let _lock = lock::acquire_lock(&lock_path, "timer")?;
+    let trigger = if args.auto { "auto" } else { "manual" };
+    let _lock = lock::acquire_lock(&lock_path, trigger)?;
 
-    if backup_plan.is_empty() && backup_plan.skipped.is_empty() {
-        println!("{}", "Nothing to do.".dimmed());
-        write_metrics_for_skipped(&config, &backup_plan, now)?;
+    if backup_plan.is_empty() {
+        // Empty plan: no operations to execute. This includes plans where all subvolumes
+        // were skipped (drives disconnected, space guard, etc.). Previously this case fell
+        // through to the executor which ran zero operations and reported run_result "success".
+        // Now it uses build_empty() with run_result "empty" — more accurate for monitoring.
+        if !args.auto && !backup_plan.skipped.is_empty() {
+            let explanation = build_empty_plan_explanation(&backup_plan, &filters);
+            print!("{}", crate::voice::render_empty_plan(&explanation));
+        } else {
+            println!("{}", "Nothing to do.".dimmed());
+        }
+        write_metrics_for_skipped(&config, &backup_plan, now, &fs_state)?;
         let heartbeat_now = chrono::Local::now().naive_local();
         let previous_hb = heartbeat::read(&config.general.heartbeat_file);
         let mut assessments = awareness::assess(&config, heartbeat_now, &fs_state);
@@ -113,6 +124,20 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         eprintln!("\nSignal received, finishing current operation...");
     }) {
         log::warn!("Failed to set signal handler: {e}");
+    }
+
+    // Pre-action briefing for manual TTY runs
+    if !args.auto && std::io::stdout().is_terminal() {
+        let plan_output =
+            crate::commands::plan_cmd::build_plan_output(&backup_plan, &fs_state);
+        let pre_filters = crate::output::PreActionFilters {
+            local_only: filters.local_only,
+            external_only: filters.external_only,
+            subvolume: filters.subvolume.clone(),
+        };
+        let summary =
+            crate::output::build_pre_action_summary(&plan_output, &config, pre_filters);
+        print!("{}", crate::voice::render_pre_action(&summary));
     }
 
     // Set up executor with live byte counter for progress display
@@ -482,15 +507,15 @@ fn write_metrics_for_skipped(
     config: &Config,
     plan: &crate::types::BackupPlan,
     now: chrono::NaiveDateTime,
+    fs_state: &dyn FileSystemState,
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
-    let fs_state = RealFileSystemState { state: None };
     let mut subvolume_metrics = Vec::new();
 
     append_skipped_metrics(
         config,
         plan,
-        &fs_state,
+        fs_state,
         &mut subvolume_metrics,
         &HashSet::new(),
     );
@@ -500,6 +525,76 @@ fn write_metrics_for_skipped(
     metrics::apply_carried_forward_timestamps(&mut subvolume_metrics, &carried);
 
     write_global_metrics(config, now_ts, subvolume_metrics)
+}
+
+fn build_empty_plan_explanation(
+    plan: &crate::types::BackupPlan,
+    filters: &PlanFilters,
+) -> EmptyPlanExplanation {
+    // Single pass to classify all skip reasons
+    let mut has_disabled = false;
+    let mut has_space = false;
+    let mut has_not_mounted = false;
+    let mut has_interval = false;
+
+    for (_, reason) in &plan.skipped {
+        match SkipCategory::from_reason(reason) {
+            SkipCategory::Disabled => has_disabled = true,
+            SkipCategory::SpaceExceeded => has_space = true,
+            SkipCategory::DriveNotMounted => has_not_mounted = true,
+            SkipCategory::IntervalNotElapsed => has_interval = true,
+            SkipCategory::Other => {}
+        }
+    }
+
+    let all_disabled = has_disabled && !has_space && !has_not_mounted && !has_interval;
+    let all_space = has_space && !has_disabled && !has_not_mounted && !has_interval;
+    let all_not_mounted = has_not_mounted && !has_disabled && !has_space && !has_interval;
+
+    if all_disabled {
+        EmptyPlanExplanation {
+            reasons: vec!["all subvolumes are disabled in config".to_string()],
+            suggestion: Some("Enable subvolumes in ~/.config/urd/urd.toml".to_string()),
+        }
+    } else if filters.external_only && all_not_mounted {
+        EmptyPlanExplanation {
+            reasons: vec!["no drives are connected".to_string()],
+            suggestion: Some("Connect a drive or run without --external-only".to_string()),
+        }
+    } else if let Some(ref name) = filters.subvolume {
+        EmptyPlanExplanation {
+            reasons: vec![format!("{name} not found or disabled")],
+            suggestion: Some("Check subvolume names with `urd status`".to_string()),
+        }
+    } else if all_space {
+        EmptyPlanExplanation {
+            reasons: vec!["local filesystem full".to_string()],
+            suggestion: Some(
+                "Free space or increase min_free_bytes threshold".to_string(),
+            ),
+        }
+    } else {
+        let mut reasons = Vec::new();
+        if has_not_mounted {
+            reasons.push("drives not connected".to_string());
+        }
+        if has_disabled {
+            reasons.push("some subvolumes disabled".to_string());
+        }
+        if has_space {
+            reasons.push("space exceeded".to_string());
+        }
+        if has_interval {
+            reasons.push("intervals not elapsed".to_string());
+        }
+        if reasons.is_empty() {
+            reasons.push("all operations were skipped".to_string());
+        }
+        EmptyPlanExplanation {
+            reasons,
+            suggestion: Some("Run `urd plan` for details".to_string()),
+        }
+    }
 }
 
 fn append_skipped_metrics(

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -16,6 +16,7 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
         subvolume: args.subvolume,
         local_only: args.local_only,
         external_only: args.external_only,
+        skip_intervals: !args.auto,
     };
 
     let state_db = StateDb::open(&config.general.state_db).ok();
@@ -293,6 +294,7 @@ fn build_operation_entry(
             subvolume: subvolume_name.clone(),
             operation: "create".to_string(),
             detail: format!("{} -> {}", source.display(), dest.display()),
+            drive_label: None,
             estimated_bytes: None,
             is_full_send: None,
             full_send_reason: None,
@@ -327,6 +329,7 @@ fn build_operation_entry(
                 detail: format!(
                     "{snap_name} -> {drive_label} (incremental, parent: {parent_name}){pin_suffix}"
                 ),
+                drive_label: Some(drive_label.clone()),
                 estimated_bytes,
                 is_full_send: Some(false),
                 full_send_reason: None,
@@ -359,6 +362,7 @@ fn build_operation_entry(
                 detail: format!(
                     "{snap_name} -> {drive_label} (full \u{2014} {reason}){pin_suffix}"
                 ),
+                drive_label: Some(drive_label.clone()),
                 estimated_bytes,
                 is_full_send: Some(true),
                 full_send_reason: Some(reason.to_string()),
@@ -374,6 +378,7 @@ fn build_operation_entry(
                 subvolume: subvolume_name.clone(),
                 operation: "delete".to_string(),
                 detail: format!("{snap_name} ({reason})"),
+                drive_label: None,
                 estimated_bytes: None,
                 is_full_send: None,
                 full_send_reason: None,

--- a/src/output.rs
+++ b/src/output.rs
@@ -646,6 +646,9 @@ pub struct PlanOperationEntry {
     pub subvolume: String,
     pub operation: String,
     pub detail: String,
+    /// Target drive label for send operations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drive_label: Option<String>,
     /// Estimated bytes for send operations (from history or calibration).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub estimated_bytes: Option<u64>,
@@ -669,6 +672,114 @@ pub struct PlanSummaryOutput {
     /// Aggregated estimated bytes across all sends with estimates.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub estimated_total_bytes: Option<u64>,
+}
+
+// ── EmptyPlanExplanation ───────────────────────────────────────────────
+
+/// Explanation shown when a manual backup produces an empty plan.
+#[derive(Debug)]
+pub struct EmptyPlanExplanation {
+    pub reasons: Vec<String>,
+    pub suggestion: Option<String>,
+}
+
+// ── PreActionSummary ───────────────────────────────────────────────────
+
+/// Pre-action briefing shown to manual+TTY users before execution begins.
+#[derive(Debug)]
+pub struct PreActionSummary {
+    pub snapshot_count: usize,
+    pub send_plan: Vec<PreActionDriveSummary>,
+    pub disconnected_drives: Vec<DisconnectedDrive>,
+    pub filters: PreActionFilters,
+}
+
+/// Per-drive send summary for the pre-action briefing.
+#[derive(Debug)]
+pub struct PreActionDriveSummary {
+    pub drive_label: String,
+    pub subvolume_count: usize,
+    pub estimated_bytes: Option<u64>,
+}
+
+/// A drive that was skipped because it's not mounted.
+#[derive(Debug)]
+pub struct DisconnectedDrive {
+    pub label: String,
+    pub role: DriveRole,
+}
+
+/// Active filters for the pre-action briefing context.
+#[derive(Debug)]
+pub struct PreActionFilters {
+    pub local_only: bool,
+    pub external_only: bool,
+    pub subvolume: Option<String>,
+}
+
+/// Build a pre-action summary from a `PlanOutput` and config.
+/// Pure function — extracts counts, groups sends by drive, classifies disconnected drives.
+#[must_use]
+pub fn build_pre_action_summary(
+    plan_output: &PlanOutput,
+    config: &crate::config::Config,
+    filters: PreActionFilters,
+) -> PreActionSummary {
+    let snapshot_count = plan_output.summary.snapshots;
+
+    let mut drive_map: std::collections::BTreeMap<String, (usize, Option<u64>)> =
+        std::collections::BTreeMap::new();
+    for op in &plan_output.operations {
+        if op.operation == "send"
+            && let Some(ref label) = op.drive_label
+        {
+            let entry = drive_map.entry(label.clone()).or_insert((0, None));
+            entry.0 += 1;
+            if let Some(bytes) = op.estimated_bytes {
+                *entry.1.get_or_insert(0) += bytes;
+            }
+        }
+    }
+    let send_plan: Vec<PreActionDriveSummary> = drive_map
+        .into_iter()
+        .map(|(label, (count, bytes))| PreActionDriveSummary {
+            drive_label: label,
+            subvolume_count: count,
+            estimated_bytes: bytes,
+        })
+        .collect();
+
+    // Disconnected drives: deduplicate by label from skipped entries
+    let mut seen_labels = std::collections::HashSet::new();
+    let disconnected_drives: Vec<DisconnectedDrive> = plan_output
+        .skipped
+        .iter()
+        .filter(|s| s.category == SkipCategory::DriveNotMounted)
+        .filter_map(|s| {
+            // Extract drive label from reason: "drive {label} not mounted"
+            let label = s
+                .reason
+                .strip_prefix("drive ")?
+                .strip_suffix(" not mounted")?
+                .to_string();
+            if !seen_labels.insert(label.clone()) {
+                return None;
+            }
+            let role = config
+                .drives
+                .iter()
+                .find(|d| d.label == label)
+                .map(|d| d.role)?;
+            Some(DisconnectedDrive { label, role })
+        })
+        .collect();
+
+    PreActionSummary {
+        snapshot_count,
+        send_plan,
+        disconnected_drives,
+        filters,
+    }
 }
 
 // ── HistoryOutput ──────────────────────────────────────────────────────
@@ -1271,5 +1382,132 @@ mod tests {
         let days = parse_duration_to_minutes("~9d").unwrap();
         let hours = parse_duration_to_minutes("~2h30m").unwrap();
         assert!(days > hours, "9d ({days}m) should be > 2h30m ({hours}m)");
+    }
+
+    #[test]
+    fn build_pre_action_from_plan_output() {
+        let plan_output = PlanOutput {
+            timestamp: "2026-04-02 15:00".to_string(),
+            operations: vec![
+                PlanOperationEntry {
+                    subvolume: "sv1".to_string(),
+                    operation: "create".to_string(),
+                    detail: "/data/sv1 -> /snap/sv1/...".to_string(),
+                    drive_label: None,
+                    estimated_bytes: None,
+                    is_full_send: None,
+                    full_send_reason: None,
+                },
+                PlanOperationEntry {
+                    subvolume: "sv1".to_string(),
+                    operation: "send".to_string(),
+                    detail: "snap -> D1 (full)".to_string(),
+                    drive_label: Some("D1".to_string()),
+                    estimated_bytes: Some(10_000_000_000),
+                    is_full_send: Some(true),
+                    full_send_reason: None,
+                },
+                PlanOperationEntry {
+                    subvolume: "sv2".to_string(),
+                    operation: "send".to_string(),
+                    detail: "snap -> D1 (incremental)".to_string(),
+                    drive_label: Some("D1".to_string()),
+                    estimated_bytes: Some(500_000),
+                    is_full_send: Some(false),
+                    full_send_reason: None,
+                },
+            ],
+            skipped: vec![
+                SkippedSubvolume {
+                    name: "sv1".to_string(),
+                    reason: "drive D2 not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
+                },
+                SkippedSubvolume {
+                    name: "sv2".to_string(),
+                    reason: "drive D2 not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
+                },
+            ],
+            summary: PlanSummaryOutput {
+                snapshots: 1,
+                sends: 2,
+                deletions: 0,
+                skipped: 2,
+                estimated_total_bytes: Some(10_000_500_000),
+            },
+        };
+
+        let config: crate::config::Config = toml::from_str(
+            r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [{ path = "/snap", subvolumes = ["sv1", "sv2"] }]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+send_enabled = true
+enabled = true
+
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[drives]]
+label = "D2"
+mount_path = "/mnt/d2"
+snapshot_root = ".snapshots"
+role = "offsite"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "one"
+source = "/data/sv1"
+
+[[subvolumes]]
+name = "sv2"
+short_name = "two"
+source = "/data/sv2"
+"#,
+        )
+        .unwrap();
+
+        let filters = PreActionFilters {
+            local_only: false,
+            external_only: false,
+            subvolume: None,
+        };
+
+        let summary = build_pre_action_summary(&plan_output, &config, filters);
+
+        assert_eq!(summary.snapshot_count, 1);
+        assert_eq!(summary.send_plan.len(), 1);
+        assert_eq!(summary.send_plan[0].drive_label, "D1");
+        assert_eq!(summary.send_plan[0].subvolume_count, 2);
+        assert_eq!(summary.send_plan[0].estimated_bytes, Some(10_000_500_000));
+        assert_eq!(summary.disconnected_drives.len(), 1);
+        assert_eq!(summary.disconnected_drives[0].label, "D2");
+        assert_eq!(
+            summary.disconnected_drives[0].role,
+            crate::types::DriveRole::Offsite
+        );
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -81,6 +81,9 @@ pub struct PlanFilters {
     pub subvolume: Option<String>,
     pub local_only: bool,
     pub external_only: bool,
+    /// When true, bypass interval gating for snapshots and sends.
+    /// Used by manual `urd backup` (default) — automated runs set this to false.
+    pub skip_intervals: bool,
 }
 
 // ── Planner ─────────────────────────────────────────────────────────────
@@ -152,6 +155,7 @@ pub fn plan(
                 &local_snaps,
                 now,
                 force,
+                filters.skip_intervals,
                 min_free,
                 fs,
                 &mut operations,
@@ -228,6 +232,7 @@ pub fn plan(
                     &local_snaps,
                     now,
                     force,
+                    filters.skip_intervals,
                     fs,
                     &mut operations,
                     &mut skipped,
@@ -254,6 +259,7 @@ fn plan_local_snapshot(
     local_snaps: &[SnapshotName],
     now: NaiveDateTime,
     force: bool,
+    skip_intervals: bool,
     min_free: u64,
     fs: &dyn FileSystemState,
     operations: &mut Vec<PlannedOperation>,
@@ -295,7 +301,7 @@ fn plan_local_snapshot(
         );
     }
 
-    let should_create = if force {
+    let should_create = if force || skip_intervals {
         true
     } else if let Some(newest) = newest {
         let elapsed = now.signed_duration_since(newest.datetime());
@@ -419,6 +425,7 @@ fn plan_external_send(
     local_snaps: &[SnapshotName],
     now: NaiveDateTime,
     force: bool,
+    skip_intervals: bool,
     fs: &dyn FileSystemState,
     operations: &mut Vec<PlannedOperation>,
     skipped: &mut Vec<(String, String)>,
@@ -430,7 +437,7 @@ fn plan_external_send(
 
     // Check send interval
     let newest_ext = ext_snaps.iter().max();
-    let should_send = if force {
+    let should_send = if force || skip_intervals {
         true
     } else if let Some(newest) = newest_ext {
         let elapsed = now.signed_duration_since(newest.datetime());
@@ -2457,5 +2464,174 @@ local_retention = "transient"
             deletes[0].contains("20260319"),
             "deleted snapshot should be the one older than both pins: {deletes:?}"
         );
+    }
+
+    // ── skip_intervals tests ────────────────────────────────────────────
+
+    #[test]
+    fn skip_intervals_creates_snapshot_despite_recent_one() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        // sv1 last snapshot was 5 minutes ago (interval is 15m) — normally skipped
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1455-one")]);
+
+        let filters = PlanFilters {
+            skip_intervals: true,
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "skip_intervals should bypass interval gating");
+    }
+
+    #[test]
+    fn skip_intervals_sends_despite_recent_send() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        // sv1 has a local snapshot and a recent external snapshot (30 min ago, interval is 1h)
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1500-one")]);
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![snap("20260322-1430-one")],
+        );
+        fs.drive_availability_overrides
+            .insert("D1".to_string(), DriveAvailability::Available);
+
+        let filters = PlanFilters {
+            skip_intervals: true,
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::SendFull { subvolume_name, .. }
+                        | PlannedOperation::SendIncremental { subvolume_name, .. }
+                    if subvolume_name == "sv1"
+                )
+            })
+            .collect();
+        assert!(
+            !sends.is_empty(),
+            "skip_intervals should bypass send interval gating"
+        );
+    }
+
+    #[test]
+    fn skip_intervals_still_respects_space_guard() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        // sv1 needs snapshot but local filesystem is below min_free_bytes (10GB)
+        fs.free_bytes
+            .insert(PathBuf::from("/snap/sv1"), 1_000_000_000); // 1GB < 10GB threshold
+
+        let filters = PlanFilters {
+            skip_intervals: true,
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(
+            creates.len(),
+            0,
+            "skip_intervals must NOT bypass space guard"
+        );
+        assert!(
+            result
+                .skipped
+                .iter()
+                .any(|(name, reason)| name == "sv1" && reason.contains("low on space")),
+            "should report space guard skip"
+        );
+    }
+
+    #[test]
+    fn skip_intervals_still_runs_retention() {
+        // Verify retention runs alongside skip_intervals by creating enough old
+        // snapshots that graduated retention must prune some.
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+
+        // Build 30 daily snapshots for sv1 plus one very old one.
+        // Pin the newest so unsent-protection doesn't blanket-protect.
+        let mut snaps = Vec::new();
+        for day in 1..=28 {
+            let d = format!("202603{day:02}-1200-one");
+            snaps.push(snap(&d));
+        }
+        // Add a very old snapshot well outside all retention buckets
+        snaps.push(snap("20240101-1200-one"));
+        let newest = snaps.iter().max().unwrap().clone();
+        fs.local_snapshots.insert("sv1".to_string(), snaps);
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            newest,
+        );
+        fs.drive_availability_overrides
+            .insert("D1".to_string(), DriveAvailability::Available);
+
+        let filters = PlanFilters {
+            skip_intervals: true,
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::DeleteSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert!(
+            !deletes.is_empty(),
+            "skip_intervals should not prevent retention from running: ops={:?}",
+            result.operations.iter().map(|o| format!("{o:?}")).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn skip_intervals_composes_with_local_only() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        // sv1 recent snapshot (interval not elapsed)
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1455-one")]);
+        fs.drive_availability_overrides
+            .insert("D1".to_string(), DriveAvailability::Available);
+
+        let filters = PlanFilters {
+            skip_intervals: true,
+            local_only: true,
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::SendFull { .. } | PlannedOperation::SendIncremental { .. }
+                )
+            })
+            .collect();
+        assert_eq!(creates.len(), 1, "skip_intervals + local_only should create snapshot");
+        assert!(sends.is_empty(), "local_only should suppress sends even with skip_intervals");
     }
 }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -14,10 +14,10 @@ use colored::Colorize;
 use crate::output::{
     BackupSummary, CalibrateOutput, CalibrateResult, ChainHealth, DefaultStatusOutput,
     DoctorCheck, DoctorCheckStatus, DoctorOutput, DoctorVerdictStatus, FailuresOutput, GetOutput,
-    HistoryOutput,
-    InitOutput, InitStatus, OutputMode, PlanOutput, RecoveryWindow, RedundancyAdvisoryKind,
-    RetentionPreviewOutput, SentinelStatusOutput, SkipCategory, SkippedSubvolume,
-    StatusAssessment, StatusOutput, SubvolumeHistoryOutput, VerifyOutput, parse_duration_to_minutes,
+    HistoryOutput, InitOutput, InitStatus, OutputMode, PlanOutput, PreActionSummary,
+    RecoveryWindow, RedundancyAdvisoryKind, RetentionPreviewOutput, SentinelStatusOutput,
+    SkipCategory, SkippedSubvolume, StatusAssessment, StatusOutput, SubvolumeHistoryOutput,
+    VerifyOutput, parse_duration_to_minutes,
 };
 use crate::plan::format_duration_short;
 use crate::types::{ByteSize, DriveRole};
@@ -890,6 +890,114 @@ fn render_get_interactive(data: &GetOutput) -> String {
 }
 
 // ── Plan ────────────────────────────────────────────────────────────────
+
+// ── Empty Plan ─────────────────────────────────────────────────────────
+
+/// Render an explanation for why a manual backup produced an empty plan.
+#[must_use]
+pub fn render_empty_plan(explanation: &crate::output::EmptyPlanExplanation) -> String {
+    let mut out = String::new();
+    let reasons = explanation.reasons.join("; ");
+    let _ = write!(out, "Nothing to back up — {reasons}.");
+    if let Some(ref suggestion) = explanation.suggestion {
+        let _ = write!(out, "\n  {suggestion}");
+    }
+    let _ = writeln!(out);
+    out
+}
+
+// ── Pre-Action Summary ─────────────────────────────────────────────────
+
+/// Render a pre-action briefing for manual backup runs.
+#[must_use]
+pub fn render_pre_action(summary: &PreActionSummary) -> String {
+    let mut out = String::new();
+
+    // Build drive list string
+    let drive_labels: Vec<&str> = summary
+        .send_plan
+        .iter()
+        .map(|d| d.drive_label.as_str())
+        .collect();
+    let drive_list = format_list(&drive_labels);
+
+    // Total estimated bytes across all drives
+    let total_bytes: Option<u64> = {
+        let sum: u64 = summary
+            .send_plan
+            .iter()
+            .filter_map(|d| d.estimated_bytes)
+            .sum();
+        if sum > 0 { Some(sum) } else { None }
+    };
+
+    // Size annotation
+    let size_str = total_bytes
+        .map(|b| format!(", ~{}", ByteSize(b)))
+        .unwrap_or_default();
+
+    // Main line depends on filters
+    if summary.filters.local_only {
+        let _ = writeln!(
+            out,
+            "Snapshotting {} subvolume{}.",
+            summary.snapshot_count,
+            if summary.snapshot_count == 1 { "" } else { "s" }
+        );
+    } else if summary.filters.external_only {
+        let total_sends: usize = summary.send_plan.iter().map(|d| d.subvolume_count).sum();
+        let _ = writeln!(
+            out,
+            "Sending to {drive_list}.\n  {total_sends} subvolume{}{size_str}",
+            if total_sends == 1 { "" } else { "s" },
+        );
+    } else if let Some(ref name) = summary.filters.subvolume {
+        let _ = writeln!(
+            out,
+            "Backing up {name} to {drive_list}.\n  1 snapshot{size_str}",
+        );
+    } else {
+        let total_sends: usize = summary.send_plan.iter().map(|d| d.subvolume_count).sum();
+        let _ = writeln!(
+            out,
+            "Backing up everything to {drive_list}.\n  {} snapshot{}, {total_sends} send{}{size_str}",
+            summary.snapshot_count,
+            if summary.snapshot_count == 1 { "" } else { "s" },
+            if total_sends == 1 { "" } else { "s" },
+        );
+    }
+
+    // Disconnected drives
+    for d in &summary.disconnected_drives {
+        match d.role {
+            DriveRole::Offsite => {
+                let _ = writeln!(
+                    out,
+                    "  {} is away — copies will update when it returns.",
+                    d.label
+                );
+            }
+            _ => {
+                let _ = writeln!(out, "  {} not connected.", d.label);
+            }
+        }
+    }
+
+    out
+}
+
+/// Format a list of items as "A", "A and B", or "A, B, and C".
+fn format_list(items: &[&str]) -> String {
+    match items.len() {
+        0 => String::new(),
+        1 => items[0].to_string(),
+        2 => format!("{} and {}", items[0], items[1]),
+        _ => {
+            let (last, rest) = items.split_last().unwrap();
+            format!("{}, and {last}", rest.join(", "))
+        }
+    }
+}
 
 /// Render plan output according to the given mode.
 #[must_use]
@@ -2292,11 +2400,11 @@ mod tests {
     use super::*;
     use crate::output::{
         BackupSummary, CalibrateEntry, CalibrateOutput, CalibrateResult, ChainHealth,
-        ChainHealthEntry, DriveInfo, HistoryOutput, HistoryRun, InitCheck, InitDriveStatus,
-        InitOutput, InitPinFile, InitSnapshotCount, InitStatus, LastRunInfo, PlanOperationEntry,
-        PlanOutput, PlanSummaryOutput, SendSummary, SkipCategory, SkippedSubvolume,
-        StatusAssessment, StatusDriveAssessment, SubvolumeSummary, TransitionEvent, VerifyCheck,
-        VerifyDrive, VerifyOutput, VerifySubvolume,
+        ChainHealthEntry, DisconnectedDrive, DriveInfo, HistoryOutput, HistoryRun, InitCheck,
+        InitDriveStatus, InitOutput, InitPinFile, InitSnapshotCount, InitStatus, LastRunInfo,
+        PlanOperationEntry, PlanOutput, PlanSummaryOutput, SendSummary, SkipCategory,
+        SkippedSubvolume, StatusAssessment, StatusDriveAssessment, SubvolumeSummary,
+        TransitionEvent, VerifyCheck, VerifyDrive, VerifyOutput, VerifySubvolume,
     };
 
     fn test_status_output() -> StatusOutput {
@@ -2917,6 +3025,7 @@ mod tests {
                     subvolume: "htpc-home".to_string(),
                     operation: "create".to_string(),
                     detail: "/home -> /snapshots/htpc-home/20260326-0400-home".to_string(),
+                    drive_label: None,
                     estimated_bytes: None,
                     is_full_send: None,
                     full_send_reason: None,
@@ -2925,6 +3034,7 @@ mod tests {
                     subvolume: "htpc-home".to_string(),
                     operation: "send".to_string(),
                     detail: "20260326-0400-home -> WD-18TB (incremental, parent: 20260325-0400-home) + pin".to_string(),
+                    drive_label: Some("WD-18TB".to_string()),
                     estimated_bytes: None,
                     is_full_send: None,
                     full_send_reason: None,
@@ -2975,6 +3085,7 @@ mod tests {
                 subvolume: "htpc-home".to_string(),
                 operation: "send".to_string(),
                 detail: "20260329-0404-htpc-home -> WD-18TB (full) + pin".to_string(),
+                drive_label: Some("WD-18TB".to_string()),
                 estimated_bytes: None,
                 is_full_send: None,
                 full_send_reason: None,
@@ -3320,6 +3431,7 @@ mod tests {
                     subvolume: "htpc-home".to_string(),
                     operation: "send".to_string(),
                     detail: "snap -> WD-18TB (full)".to_string(),
+                    drive_label: Some("WD-18TB".to_string()),
                     estimated_bytes: Some(53_000_000_000),
                     is_full_send: Some(true),
                     full_send_reason: None,
@@ -3328,6 +3440,7 @@ mod tests {
                     subvolume: "htpc-docs".to_string(),
                     operation: "send".to_string(),
                     detail: "snap -> WD-18TB (full)".to_string(),
+                    drive_label: Some("WD-18TB".to_string()),
                     estimated_bytes: Some(1_200_000_000),
                     is_full_send: Some(true),
                     full_send_reason: None,
@@ -3363,6 +3476,7 @@ mod tests {
                 subvolume: "htpc-home".to_string(),
                 operation: "send".to_string(),
                 detail: "snap -> WD-18TB (incremental, parent: prev)".to_string(),
+                drive_label: Some("WD-18TB".to_string()),
                 estimated_bytes: Some(5_500_000),
                 is_full_send: Some(false),
                 full_send_reason: None,
@@ -3393,6 +3507,7 @@ mod tests {
                     subvolume: "htpc-home".to_string(),
                     operation: "send".to_string(),
                     detail: "snap -> WD-18TB (full)".to_string(),
+                    drive_label: Some("WD-18TB".to_string()),
                     estimated_bytes: Some(53_000_000_000),
                     is_full_send: Some(true),
                     full_send_reason: None,
@@ -3401,6 +3516,7 @@ mod tests {
                     subvolume: "htpc-docs".to_string(),
                     operation: "send".to_string(),
                     detail: "snap -> WD-18TB (full)".to_string(),
+                    drive_label: Some("WD-18TB".to_string()),
                     estimated_bytes: None,
                     is_full_send: Some(true),
                     full_send_reason: None,
@@ -3431,6 +3547,7 @@ mod tests {
                 subvolume: "htpc-home".to_string(),
                 operation: "send".to_string(),
                 detail: "snap -> WD-18TB (full)".to_string(),
+                drive_label: Some("WD-18TB".to_string()),
                 estimated_bytes: None,
                 is_full_send: None,
                 full_send_reason: None,
@@ -3463,6 +3580,7 @@ mod tests {
                 subvolume: "htpc-home".to_string(),
                 operation: "send".to_string(),
                 detail: "snap -> WD-18TB (full)".to_string(),
+                drive_label: Some("WD-18TB".to_string()),
                 estimated_bytes: Some(53_000_000_000),
                 is_full_send: Some(true),
                 full_send_reason: None,
@@ -3496,6 +3614,7 @@ mod tests {
                 subvolume: "htpc-home".to_string(),
                 operation: "send".to_string(),
                 detail: "snap -> WD-18TB (full)".to_string(),
+                drive_label: Some("WD-18TB".to_string()),
                 estimated_bytes: None,
                 is_full_send: None,
                 full_send_reason: None,
@@ -4946,6 +5065,266 @@ mod tests {
         assert!(
             !output.contains("All threads hold"),
             "should have no all-sealed text: {output}"
+        );
+    }
+
+    // ── Pre-action summary rendering tests ────────────────────────────
+
+    #[test]
+    fn pre_action_full_backup_one_drive() {
+        let summary = PreActionSummary {
+            snapshot_count: 7,
+            send_plan: vec![crate::output::PreActionDriveSummary {
+                drive_label: "WD-18TB".to_string(),
+                subvolume_count: 7,
+                estimated_bytes: Some(53_000_000_000),
+            }],
+            disconnected_drives: vec![],
+            filters: crate::output::PreActionFilters {
+                local_only: false,
+                external_only: false,
+                subvolume: None,
+            },
+        };
+        let output = render_pre_action(&summary);
+        assert!(
+            output.contains("Backing up everything to WD-18TB"),
+            "should mention full backup: {output}"
+        );
+        assert!(output.contains("7 snapshots"), "should count snapshots: {output}");
+        assert!(output.contains("~53.0GB"), "should show size estimate: {output}");
+    }
+
+    #[test]
+    fn pre_action_full_backup_multi_drive() {
+        let summary = PreActionSummary {
+            snapshot_count: 7,
+            send_plan: vec![
+                crate::output::PreActionDriveSummary {
+                    drive_label: "WD-18TB".to_string(),
+                    subvolume_count: 7,
+                    estimated_bytes: None,
+                },
+                crate::output::PreActionDriveSummary {
+                    drive_label: "WD-18TB1".to_string(),
+                    subvolume_count: 7,
+                    estimated_bytes: None,
+                },
+            ],
+            disconnected_drives: vec![],
+            filters: crate::output::PreActionFilters {
+                local_only: false,
+                external_only: false,
+                subvolume: None,
+            },
+        };
+        let output = render_pre_action(&summary);
+        assert!(
+            output.contains("WD-18TB and WD-18TB1"),
+            "should list both drives: {output}"
+        );
+    }
+
+    #[test]
+    fn pre_action_local_only() {
+        let summary = PreActionSummary {
+            snapshot_count: 5,
+            send_plan: vec![],
+            disconnected_drives: vec![],
+            filters: crate::output::PreActionFilters {
+                local_only: true,
+                external_only: false,
+                subvolume: None,
+            },
+        };
+        let output = render_pre_action(&summary);
+        assert!(
+            output.contains("Snapshotting 5 subvolumes"),
+            "should show local-only message: {output}"
+        );
+    }
+
+    #[test]
+    fn pre_action_external_only() {
+        let summary = PreActionSummary {
+            snapshot_count: 0,
+            send_plan: vec![crate::output::PreActionDriveSummary {
+                drive_label: "WD-18TB".to_string(),
+                subvolume_count: 3,
+                estimated_bytes: Some(10_000_000_000),
+            }],
+            disconnected_drives: vec![],
+            filters: crate::output::PreActionFilters {
+                local_only: false,
+                external_only: true,
+                subvolume: None,
+            },
+        };
+        let output = render_pre_action(&summary);
+        assert!(
+            output.contains("Sending to WD-18TB"),
+            "should show external-only message: {output}"
+        );
+        assert!(output.contains("3 subvolumes"), "should count subvolumes: {output}");
+    }
+
+    #[test]
+    fn pre_action_single_subvolume() {
+        let summary = PreActionSummary {
+            snapshot_count: 1,
+            send_plan: vec![crate::output::PreActionDriveSummary {
+                drive_label: "WD-18TB".to_string(),
+                subvolume_count: 1,
+                estimated_bytes: Some(500_000_000),
+            }],
+            disconnected_drives: vec![],
+            filters: crate::output::PreActionFilters {
+                local_only: false,
+                external_only: false,
+                subvolume: Some("htpc-home".to_string()),
+            },
+        };
+        let output = render_pre_action(&summary);
+        assert!(
+            output.contains("Backing up htpc-home to WD-18TB"),
+            "should name the subvolume: {output}"
+        );
+    }
+
+    #[test]
+    fn pre_action_disconnected_offsite() {
+        let summary = PreActionSummary {
+            snapshot_count: 7,
+            send_plan: vec![crate::output::PreActionDriveSummary {
+                drive_label: "WD-18TB".to_string(),
+                subvolume_count: 7,
+                estimated_bytes: None,
+            }],
+            disconnected_drives: vec![DisconnectedDrive {
+                label: "WD-offsite".to_string(),
+                role: DriveRole::Offsite,
+            }],
+            filters: crate::output::PreActionFilters {
+                local_only: false,
+                external_only: false,
+                subvolume: None,
+            },
+        };
+        let output = render_pre_action(&summary);
+        assert!(
+            output.contains("WD-offsite is away"),
+            "offsite drive should use 'away' language: {output}"
+        );
+    }
+
+    #[test]
+    fn pre_action_disconnected_primary() {
+        let summary = PreActionSummary {
+            snapshot_count: 7,
+            send_plan: vec![],
+            disconnected_drives: vec![DisconnectedDrive {
+                label: "WD-primary".to_string(),
+                role: DriveRole::Primary,
+            }],
+            filters: crate::output::PreActionFilters {
+                local_only: false,
+                external_only: false,
+                subvolume: None,
+            },
+        };
+        let output = render_pre_action(&summary);
+        assert!(
+            output.contains("WD-primary not connected"),
+            "primary drive should use 'not connected' language: {output}"
+        );
+    }
+
+    // ── Empty plan rendering tests ──────────────────────────────────────
+
+    #[test]
+    fn empty_plan_all_disabled() {
+        let explanation = crate::output::EmptyPlanExplanation {
+            reasons: vec!["all subvolumes are disabled in config".to_string()],
+            suggestion: Some("Enable subvolumes in ~/.config/urd/urd.toml".to_string()),
+        };
+        let output = render_empty_plan(&explanation);
+        assert!(
+            output.contains("Nothing to back up"),
+            "should start with nothing message: {output}"
+        );
+        assert!(
+            output.contains("disabled"),
+            "should mention disabled: {output}"
+        );
+        assert!(
+            output.contains("Enable subvolumes"),
+            "should include suggestion: {output}"
+        );
+    }
+
+    #[test]
+    fn empty_plan_no_drives() {
+        let explanation = crate::output::EmptyPlanExplanation {
+            reasons: vec!["no drives are connected".to_string()],
+            suggestion: Some("Connect a drive or run without --external-only".to_string()),
+        };
+        let output = render_empty_plan(&explanation);
+        assert!(
+            output.contains("no drives are connected"),
+            "should explain no drives: {output}"
+        );
+    }
+
+    #[test]
+    fn empty_plan_subvolume_not_found() {
+        let explanation = crate::output::EmptyPlanExplanation {
+            reasons: vec!["my-vol not found or disabled".to_string()],
+            suggestion: Some("Check subvolume names with `urd status`".to_string()),
+        };
+        let output = render_empty_plan(&explanation);
+        assert!(
+            output.contains("my-vol not found"),
+            "should name the subvolume: {output}"
+        );
+        assert!(
+            output.contains("urd status"),
+            "should suggest urd status: {output}"
+        );
+    }
+
+    #[test]
+    fn empty_plan_space_guard() {
+        let explanation = crate::output::EmptyPlanExplanation {
+            reasons: vec!["local filesystem full".to_string()],
+            suggestion: Some("Free space or increase min_free_bytes threshold".to_string()),
+        };
+        let output = render_empty_plan(&explanation);
+        assert!(
+            output.contains("filesystem full"),
+            "should mention space: {output}"
+        );
+    }
+
+    #[test]
+    fn pre_action_no_estimates() {
+        let summary = PreActionSummary {
+            snapshot_count: 3,
+            send_plan: vec![crate::output::PreActionDriveSummary {
+                drive_label: "WD-18TB".to_string(),
+                subvolume_count: 3,
+                estimated_bytes: None,
+            }],
+            disconnected_drives: vec![],
+            filters: crate::output::PreActionFilters {
+                local_only: false,
+                external_only: false,
+                subvolume: None,
+            },
+        };
+        let output = render_pre_action(&summary);
+        assert!(
+            !output.contains("~"),
+            "no estimates should mean no size annotation: {output}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **Manual `urd backup` now acts immediately** — fresh snapshots and sends to all connected drives without interval gating. `--auto` flag preserves timer behavior for systemd.
- **Pre-action briefing** shown before manual TTY backups: "Backing up everything to WD-18TB. 7 snapshots, 7 sends, ~53.0GB"
- **Mode-aware empty-plan messages** explain why nothing was backed up (disabled, no drives, space full) with actionable suggestions
- **`urd plan`** shows manual view by default; `urd plan --auto` shows the timer view

## Testing

- cargo clippy: pass (clean)
- cargo test: 713 tests, all passing (18 new)
- cargo build --release: pass
- Integration tests: not applicable (no btrfs operations changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)