### PR TITLE
fix: token safety gate and status truth (Phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-04-03
+
 ### Fixed
 - `urd status` no longer shows false degradation for subvolumes scoped to specific drives (assess ignored per-subvolume `drives` field)
 - Cloned or swapped drives with missing identity tokens are now blocked from receiving sends (TokenExpectedButMissing safety gate)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `urd status` no longer shows false degradation for subvolumes scoped to specific drives (assess ignored per-subvolume `drives` field)
+- Cloned or swapped drives with missing identity tokens are now blocked from receiving sends (TokenExpectedButMissing safety gate)
+
+### Changed
+- Local-only subvolumes (`send_enabled = false`) display as `[LOCAL]` instead of `[OFF] Disabled` in plan output
+- Local-only subvolumes suppressed from backup summary skip section (they're complete, not skipped)
+- `urd plan` and `urd backup --dry-run` show `[WARNING]` for drives with token identity issues
+
 ## [0.8.0] - 2026-04-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,6 +5,12 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
+| 009 | `urd drives` subcommand | [design](../95-ideas/2026-04-02-design-009-urd-drives-subcommand.md) | - | - | - | - |
+| 008 | Doctor pin-age correlation | [design](../95-ideas/2026-04-02-design-008-doctor-pin-age-correlation.md) | - | - | - | - |
+| 007 | Safety gate communication | [design](../95-ideas/2026-04-02-design-007-safety-gate-communication.md) | - | - | - | - |
+| 006 | Drive reconnection notifications | [design](../95-ideas/2026-04-02-design-006-drive-reconnection-notifications.md) | - | - | - | - |
+| 005 | Status truth (assess scoping + local label) | [design](../95-ideas/2026-04-02-design-005-status-truth.md) | - | [adversary](../99-reports/2026-04-03-review-adversary-004-005-phase-a.md) | - | - |
+| 004 | TokenMissing safety gate | [design](../95-ideas/2026-04-02-design-004-token-missing-gate.md) | - | [adversary](../99-reports/2026-04-03-review-adversary-004-005-phase-a.md) | - | - |
 | 003 | Backup-now imperative | [design](../95-ideas/2026-04-02-design-003-backup-now-imperative.md) | [review](../99-reports/2026-04-02-design-review-003-backup-now-imperative.md) | [adversary](../99-reports/2026-04-02-design-review-003-backup-now-imperative.md) | merged | [#67](https://github.com/vonrobak/urd/pull/67) |
 | 002 | Output polish | [design](../95-ideas/2026-04-01-design-002-output-polish.md) | [review](../99-reports/2026-04-01-design-review-002-output-polish.md) | - | - | - |
 | 001 | Workflow system overhaul | [design](../95-ideas/2026-04-01-design-001-workflow-system-overhaul.md) | - | - | - | - |

--- a/docs/96-project-supervisor/roadmap.md
+++ b/docs/96-project-supervisor/roadmap.md
@@ -5,49 +5,120 @@
 > For completed features and historical context see the
 > [archived roadmap](../90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md).
 
-## Active Arc: Core Correctness & The Encounter
+## Active Arc: Foundation Integrity → The Encounter
 
-**Goal:** Fix correctness gaps in the promise model, deliver backup-now, then build the
-first-encounter experience (setup wizard as a conversation, not a config form).
+**Goal:** Fix correctness and communication issues surfaced by v0.8.0 testing before
+building the first-encounter experience. Every phase answers a question:
+- Phase A: "Is Urd telling the truth?"
+- Phase B: "Is Urd speaking clearly?"
+- Phase C: "Does Urd know its drives?"
+- Phase D: "Can Urd welcome a new user?"
 
-**Sequencing rationale:**
-- assess() scoping fix first — the promise model must not lie (correctness)
-- Backup-now imperative — highest-impact functional gap, already sketched
-- 6-O (progressive disclosure) — builds the framework the encounter needs
-- 6-H (guided setup wizard) — the encounter: Fate Conversation, auto-detection,
-  config generation as pure function, generates ADR-111-schema configs from day one
+**Sequencing rationale:** The v0.8.0 comprehensive test session (30 tests, 3 drive
+configs) proved the foundation has gaps. Cloned drives pass through identity checks
+(F2.3). Status displays false degradation (T3.3). Safety gates announce themselves
+as failures (T1.6). These must be fixed before the encounter (6-H), which is Urd's
+first impression — you don't launch the store with broken display cases.
 
-P6a (enum rename) and P6b (config Serialize) are demoted to patch-tier chores — do them
-as quick PRs when convenient, not as roadmap milestones.
+### Phase A: Make promises true (v0.8.1)
+
+Fix the two correctness issues that make Urd's core outputs unreliable.
 
 ```
-assess() scoping fix (patch, ~0.5 session)
-  │
-Backup-now imperative ✓ (v0.8.0)
-  │
-6-O: Progressive disclosure (2 sessions)
-  │
-6-H: The Encounter (4-6 sessions)
-     ├── Auto-trigger onboarding (any urd command, no config → offer setup)
-     ├── Auto-detection (drives, subvolumes, filesystem content analysis)
-     ├── Fate Conversation (disaster scenario walk → protection level mapping)
-     └── Config generation (EncounterResult → Config, pure function, ADR-111 schema)
+UPI 004 — TokenMissing safety gate     (~0.5 session, patch)
+    Modules: drives.rs, commands/backup.rs, plan_cmd.rs, output.rs
+    
+UPI 005 — Status truth                 (~0.5 session, patch)
+    Modules: awareness.rs, output.rs, voice.rs
+    Subsumes existing "assess() scoping fix" roadmap item
 ```
 
-Estimated: ~9-11 sessions remaining.
+**Dependencies:** None between them — can build in parallel or sequence either way.
+Share `output.rs` but changes are additive (new enum variant, new skip category).
+
+**Gate:** After Phase A, `urd status` tells the truth and cloned drives are blocked.
+
+### Phase B: Make communication honest (v0.8.2)
+
+Fix how Urd communicates about safety decisions and drive state.
+
+```
+UPI 007 — Safety gate communication    (~0.5 session, patch)
+    Modules: executor.rs, output.rs, voice.rs, commands/backup.rs
+
+UPI 008 — Doctor pin-age + UUID fix    (~0.25 session, patch)
+    Modules: commands/verify.rs, commands/doctor.rs, drives.rs
+```
+
+**Dependencies:** None between them. 007 touches `output.rs`/`voice.rs` (shared with
+Phase A) but changes are additive — new `OpResult::Deferred` variant, rendering updates.
+
+**Gate:** After Phase B, "DEFERRED" replaces "FAILED" for safety gates, doctor stops
+giving contradictory UUID advice and false "sends may be failing" warnings.
+
+### Phase C: Give drives a face (v0.9.0)
+
+Drives become first-class citizens with a management surface and lifecycle events.
+
+```
+UPI 009 — `urd drives` subcommand     (~0.5-1 session, standard)
+    Modules: NEW commands/drives.rs, output.rs, voice.rs, main.rs
+
+UPI 006 — Drive reconnection notifications (~0.5-1 session, standard)
+    Modules: notify.rs, sentinel.rs, sentinel_runner.rs
+```
+
+**Dependencies:** 009 and 006 are independent. After 009 lands, update UPI 004's
+interim error message from "Run `urd doctor`" to "Run `urd drives adopt {label}`".
+
+**Gate:** After Phase C, drives have a user-facing identity layer and reconnection
+closes the anxiety loop. MINOR version bump (new command = new feature).
+
+### Phase D: Progressive disclosure + The Encounter
+
+```
+6-O — Progressive disclosure          (~2 sessions)
+    Design: docs/95-ideas/2026-03-31-design-o-progressive-disclosure.md
+
+6-H — The Encounter                   (~4-6 sessions)
+    Auto-trigger onboarding, auto-detection, Fate Conversation, config generation
+```
+
+**Dependencies:** 6-O builds the framework 6-H needs. Both benefit from Phases A-C:
+truthful status (A), honest communication (B), drive identity layer (C).
 
 **Design constraints from Steve reviews (2026-04-02):**
 - The encounter is a conversation about what you're afraid of losing, not a config form
 - "Set and forget" vs "delve deeper" — two exits, same quality config
 - Strategy names (3-2-1, GFS, etc.) stay internal — never user-facing
-- Drop: loom metaphor, scenario simulator, witness mode, summary box-drawing
-- Summary is plain text: survival matrix, gaps, next steps
 - Config generation is a pure function — enables CLI, future TUI, future Spindle
-  to share the same engine
 
-**Legacy identifiers:** 6-O, 6-H, P6a, P6b were designed under the old Priority 6
-numbering. See the [archived roadmap](../90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md)
-for their design and review links.
+```
+Phase A: v0.8.1 (~1 session)
+  004 (token gate) ─┐
+  005 (assess + local) ─┘─→ tag v0.8.1
+                            │
+Phase B: v0.8.2 (~0.75 session)
+  007 (deferred) ─┐
+  008 (doctor) ───┘─→ tag v0.8.2
+                       │
+Phase C: v0.9.0 (~1-2 sessions)
+  009 (urd drives) ─────┐
+  006 (notifications) ──┘─→ tag v0.9.0
+                             │
+                      Update 004 message
+                      (doctor → drives adopt)
+                             │
+Phase D: (~6-8 sessions)
+  6-O (progressive disclosure)
+    │
+  6-H (the encounter) ─→ v1.0 horizon
+```
+
+Estimated: ~10-12 sessions remaining to v1.0 readiness.
+
+P6a (enum rename) and P6b (config Serialize) remain deferred patch-tier chores — do
+as quick PRs when convenient. P6b is a prerequisite for 6-H config generation.
 
 ## Horizon
 
@@ -113,6 +184,7 @@ Maintained here as context for sequencing decisions.
 - Journal persistence gap: journald may purge user-unit logs
 - P6a: ADR-110 enum rename (recorded/sheltered/fortified) — do as patch when convenient
 - P6b: Config Serialize refactor — do as patch, prerequisite for 6-H config generation
+- Planner helper functions approaching parameter limit (10 args) — pass `&PlanFilters` instead of destructured bools in next planner change
 
 ## Deferred (no current timeline)
 

--- a/docs/99-reports/2026-04-03-review-adversary-004-005-phase-a.md
+++ b/docs/99-reports/2026-04-03-review-adversary-004-005-phase-a.md
@@ -1,0 +1,212 @@
+---
+upi: "004, 005"
+date: 2026-04-03
+---
+
+# Architectural Adversary Review: Phase A Implementation Plan (UPI 004 + 005)
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-03
+**Scope:** Implementation plan at `docs/97-plans/2026-04-03-plan-004-005-phase-a.md`
+**Mode:** Design review (plan, no code yet)
+**Design docs:** UPI 004 (TokenMissing safety gate), UPI 005 (Status truth)
+
+---
+
+## Executive Summary
+
+The plan is sound and well-sequenced. Both UPIs address real correctness issues surfaced by
+testing. The main risk is a contradictory approach in Step 7 (assess scoping) where the plan
+proposes two different strategies and self-corrects partway through without cleaning up — a
+builder following the document linearly will hit confusion. One significant finding: the plan
+misses that `build_plan_output()` is called from `backup.rs` too, not just `plan_cmd.rs`.
+
+## What Kills You
+
+**Catastrophic failure mode: sending backups to an impostor drive.** UPI 004 is precisely about
+closing this gap. The plan's approach — returning `TokenExpectedButMissing` when SQLite has a
+stored token but the drive has no token file — is the right fix at the right layer. Distance
+from catastrophe: one missing `if` check. The plan closes this correctly.
+
+**Secondary: false promise states.** UPI 005 fixes `assess()` reporting false degradation. This
+is a trust problem, not a data safety problem — false "protected" would be dangerous, but false
+"degraded" is merely annoying. No proximity to data loss.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | **Correctness** | 4 | Both fixes target real bugs with correct logic. Step 7 has an unresolved approach conflict. |
+| 2 | **Security** | 4 | Token gate correctly fails-closed for identity uncertainty; fail-open for SQLite errors (ADR-107). |
+| 3 | **Architectural Excellence** | 4 | Respects pure/impure boundaries, adds variant to existing enum, uses established patterns. |
+| 4 | **Systems Design** | 3 | Missing a call site for `build_plan_output`, and Step 7's dual approach needs resolution. |
+
+## Design Tensions
+
+**1. Planner purity vs. token verification completeness.**
+
+The planner calls `drive_availability()` which checks mount + UUID only — it never returns
+token variants. The `TokenMismatch` and `TokenMissing` match arms in `plan.rs:186-226` are
+only exercisable via `MockFileSystemState`. Real token enforcement happens in `backup.rs` as
+a post-plan filter.
+
+The plan adds `TokenExpectedButMissing` to the planner match (Step 2). This is architecturally
+correct — the planner must be exhaustive on the enum, and mocks exercise the path. But the plan
+should make explicit that **production safety comes from Step 3 (backup.rs), not Step 2
+(plan.rs)**. A builder reading Step 2 in isolation might believe the planner handles it in
+production.
+
+**Trade-off resolved correctly.** The alternative — making the planner call `verify_drive_token()`
+directly — would violate the pure-function contract (ADR-100/108). The two-layer approach
+(planner handles it for testability, command handles it for production) is the right architecture.
+
+**2. Display completeness vs. scoping correctness (Step 7).**
+
+The grill-me decision (005-Q1) says: iterate all drives, build full vectors for display, filter
+before passing to health computation. The plan proposes: iterate only effective drives, making
+all vectors scoped. These are different designs with different display behavior.
+
+Under the plan's approach, a subvolume scoped to `["WD-18TB"]` won't show any 2TB-backup column
+in the status table — even if historical snapshots exist on 2TB-backup from before scoping was
+configured. The plan self-corrects to accept this, calling it "correct behavior."
+
+This is the right call for a patch. Historical data on unscoped drives is an edge case that
+affects display, not safety. The simpler approach (iterate only scoped drives) eliminates an
+entire category of filtering bugs. But the grill-me decision should be formally updated to
+match — contradictory resolved decisions create confusion in future sessions.
+
+## Findings
+
+### Significant
+
+**S1: `build_plan_output()` is called from `backup.rs`, not just `plan_cmd.rs`.**
+
+`backup.rs:77` and `backup.rs:132` both call `build_plan_output()`. Adding `warnings: Vec<String>`
+to `PlanOutput` means the function (or struct construction) must be updated. The plan only
+mentions changes in `plan_cmd.rs`.
+
+**Consequence:** Compile error during build, or — if the builder adds a default — backup dry-run
+output silently omits token warnings that were shown in `urd plan`.
+
+**Fix:** Step 4 should note that `build_plan_output()` is shared. Simplest approach: set
+`warnings` on the output struct after construction rather than adding a parameter. Backup command
+already handles token issues via its own filter, so `backup.rs` callers pass empty warnings.
+
+### Moderate
+
+**M1: Step 7 contains two contradictory approaches that aren't cleaned up.**
+
+Lines of the plan describe building `scoped_drive_assessments` and `scoped_chain_health` as
+filtered subsets passed to `compute_overall_status()` and `compute_health()`. Then the plan
+self-corrects: "Wait — after re-reading: the iteration now only covers `effective_drives`..."
+Both approaches remain in the document.
+
+**Consequence:** A builder reading linearly will implement the filter-after-build approach
+(unnecessary complexity). Or worse, implement both — filtering an already-scoped vector.
+
+**Fix:** Remove the clone-and-filter discussion. The final approach is: replace
+`for drive in &config.drives` with `for drive in &effective_drives`. The vectors built in the
+loop are already scoped. Pass them directly to `compute_overall_status()` and `compute_health()`.
+No signature changes, no separate scoped vectors, no cloning.
+
+**M2: Retention deletes still execute on a token-suspicious drive.**
+
+The `backup.rs` post-plan filter (Step 3) only removes `SendFull` and `SendIncremental`
+operations. `DeleteSnapshot` operations planned for the suspicious drive remain. The planner
+plans retention deletes in `plan_external_retention()` which runs in the same iteration as
+sends — but only the planner's match arm (Step 2) can skip both. In production, the planner
+doesn't see the token issue, so it plans both sends AND deletes. The backup filter removes
+sends but leaves deletes.
+
+**Consequence:** Retention deletes execute on an unverified (possibly cloned) drive. This is
+likely harmless — deleting redundant copies from a clone doesn't affect the real drive. But
+it's architecturally inconsistent: "this drive is suspicious, block writes but allow deletes."
+
+**Fix:** Accept this as a conscious trade-off and document it. Blocking deletes on a suspicious
+drive has no safety benefit (the snapshots are copies) and could cause space exhaustion on a
+drive that might be legitimately reformatted. Add a brief comment in `backup.rs` near the
+filter explaining why only sends are blocked.
+
+### Minor
+
+**m1: Existing `all_known_skip_reasons_classify_correctly` test (output.rs:1286) also uses
+`"send disabled"` → `Disabled`.** The plan mentions updating it but only in the Risk Flags
+section, not in Step 5's test list. Include it explicitly in Step 5 to prevent a missed test
+update.
+
+**m2: `skip_tag()` in voice.rs is an exhaustive match (no wildcard).** Adding `LocalOnly`
+without adding a match arm causes a compile error. The plan covers this in Step 6, but the
+exhaustive nature isn't called out — worth noting for the builder since this is a common source
+of "why won't it compile" confusion when adding enum variants.
+
+### Commendation
+
+**C1: The two-layer token verification respects architectural boundaries perfectly.** Planner
+stays pure (ADR-100/108), command layer handles I/O-dependent verification, tests exercise
+both paths via mocks. This is exactly how the planner/executor separation should work.
+
+**C2: Risk Flag 1 (existing test will break) is an excellent catch.** The test
+`verify_drive_token_no_file_on_drive` sets up the exact scenario the fix targets — SQLite has
+a token, drive doesn't. Identifying that this test must change from asserting `TokenMissing`
+to asserting `TokenExpectedButMissing` shows the planner read the code, not just the design.
+
+**C3: Step sequencing (dependencies flow forward) is clean.** Each step only touches what was
+established in prior steps. No circular dependencies, no "go back and update Step 2 after
+Step 5." The two UPIs are cleanly independent despite sharing `output.rs`.
+
+## The Simplicity Question
+
+The plan is appropriately scoped. Nothing here is speculative — every change addresses a
+concrete bug or display issue surfaced by testing. No new modules, no new abstractions, no
+new traits. The `TokenExpectedButMissing` variant is an enum extension; the `LocalOnly` variant
+is an enum extension; the assess scoping is a filter addition. This is how patch-tier work
+should look.
+
+**One thing to consider deleting:** The `PlanOutput.warnings` field (Step 4) adds a new
+communication channel. Is it necessary? The planner already generates skip reasons for token
+issues (Step 2), which appear in the plan's skip section. Adding a separate warning block
+means token issues appear in *two* places: skip section ("drive D1 token expected but missing")
+AND warning block ("Drive D1 is mounted but missing its identity token...").
+
+Counter-argument: the skip reason is per-subvolume, buried in a list. The warning is drive-level,
+prominent, and actionable. A user with 8 subvolumes sending to a suspicious drive would see 8
+skip lines but only 1 warning. The warning is the right UX. Keep it.
+
+But — in production, the planner won't generate skip reasons for token issues (it doesn't see
+them). Only `plan_cmd.rs` post-plan check generates warnings. So there's no duplication in
+production, only in tests. The warning field earns its keep.
+
+## For the Dev Team
+
+Priority order for fixes before building:
+
+1. **Step 4: Note shared call site.** Add to Step 4: "`build_plan_output()` is also called
+   from `backup.rs:77` and `backup.rs:132`. Set `warnings` on the struct after construction
+   (field default: empty vec) so backup callers don't need changes. `backup.rs` handles token
+   issues via its own filter, so it passes no warnings."
+
+2. **Step 7: Remove contradictory text.** Delete the clone-and-filter discussion. The approach
+   is: compute `effective_drives` from `subvol.drives`, iterate `effective_drives` instead of
+   `config.drives`. Vectors are automatically scoped. No signature changes. No `scoped_*`
+   intermediaries. Pass `drive_assessments` and `chain_health_entries` directly — they already
+   contain only scoped entries.
+
+3. **Step 3: Document retention-delete trade-off.** Add a comment in `backup.rs` near the
+   send filter explaining: "Only sends are blocked for token-suspicious drives. Retention
+   deletes proceed — deleting redundant copies from a clone is harmless and prevents space
+   exhaustion."
+
+4. **Step 5: Include `all_known_skip_reasons_classify_correctly` in test list.** Move from
+   Risk Flags to Step 5's test section. This test will fail when `"send disabled"` changes
+   from `Disabled` to `LocalOnly`.
+
+## Open Questions
+
+1. **Should the grill-me resolution 005-Q1 be formally updated?** The plan departs from it
+   (iterate scoped drives vs. iterate all + filter). If Q1 is referenced in future sessions,
+   the stale decision could cause confusion.
+
+2. **Does `urd backup --dry-run` need token warnings?** Currently `backup.rs:77` calls
+   `build_plan_output()` for dry-run. If warnings are populated in `plan_cmd.rs` but not in
+   `backup.rs`, a dry-run won't show them. Should dry-run also run the post-plan token check?
+   Or is the dry-run's purpose purely "what would the planner do" without command-layer enrichment?

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -250,7 +250,18 @@ pub fn assess(
                 advisories.push("send_enabled but no drives configured".to_string());
             }
 
-            for drive in &config.drives {
+            // Filter drives to the subvolume's effective set (respects `drives = [...]`
+            // scoping in config). Same pattern as compute_redundancy_advisories().
+            let effective_drives: Vec<&DriveConfig> = match &subvol.drives {
+                Some(allowed) => config
+                    .drives
+                    .iter()
+                    .filter(|d| allowed.iter().any(|a| a == &d.label))
+                    .collect(),
+                None => config.drives.iter().collect(),
+            };
+
+            for drive in &effective_drives {
                 let mounted = fs.is_drive_mounted(drive);
 
                 let ext_snaps = if mounted {
@@ -3395,6 +3406,183 @@ local_retention = "transient"
             !advisories.iter().any(|a| a.kind
                 == crate::output::RedundancyAdvisoryKind::TransientNoLocalRecovery),
             "mounted drive should prevent transient advisory: {advisories:?}"
+        );
+    }
+
+    // ── assess() drive scoping tests (UPI 005) ───────────────────────
+
+    /// Config with two drives but sv1 scoped to only D1.
+    fn test_config_scoped_drives() -> Config {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[drives]]
+label = "D2"
+mount_path = "/mnt/d2"
+snapshot_root = ".snapshots"
+role = "offsite"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "sv1"
+source = "/data/sv1"
+drives = ["D1"]
+"#;
+        toml::from_str(toml_str).expect("scoped drives config should parse")
+    }
+
+    #[test]
+    fn assess_respects_subvol_drive_scoping() {
+        let config = test_config_scoped_drives();
+        let now = dt(2026, 4, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // Fresh local snapshot
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
+
+        // D1 is mounted with a recent send
+        fs.mounted_drives.insert("D1".to_string());
+        fs.send_times.insert(
+            ("sv1".to_string(), "D1".to_string()),
+            dt(2026, 4, 1, 10, 0),
+        );
+
+        // D2 is NOT mounted — but sv1 is scoped to D1 only,
+        // so D2 absence should NOT affect sv1's status.
+
+        let assessments = assess(&config, now, &fs);
+        let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
+
+        assert_eq!(
+            sv1.status,
+            PromiseStatus::Protected,
+            "sv1 should be Protected — D2 is out of scope. Got: {:?}",
+            sv1.status
+        );
+    }
+
+    #[test]
+    fn assess_no_drives_field_uses_all_drives() {
+        // Use test_config_two_drives — sv1 has no `drives` field, so all drives affect it
+        let config = test_config_two_drives();
+        let now = dt(2026, 4, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
+
+        // D1 is mounted with a recent send
+        fs.mounted_drives.insert("D1".to_string());
+        fs.send_times.insert(
+            ("sv1".to_string(), "D1".to_string()),
+            dt(2026, 4, 1, 10, 0),
+        );
+
+        // D2 is NOT mounted and has no send history
+
+        let assessments = assess(&config, now, &fs);
+        let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
+
+        // Without per-subvolume drives scoping, all configured drives appear in assessments
+        assert_eq!(
+            sv1.external.len(),
+            2,
+            "without drives scoping, all 2 drives should appear in external assessments"
+        );
+    }
+
+    #[test]
+    fn assess_scoped_subvol_external_only_has_scoped_drives() {
+        let config = test_config_scoped_drives();
+        let now = dt(2026, 4, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
+        fs.mounted_drives.insert("D1".to_string());
+        fs.mounted_drives.insert("D2".to_string());
+        fs.send_times.insert(
+            ("sv1".to_string(), "D1".to_string()),
+            dt(2026, 4, 1, 10, 0),
+        );
+
+        let assessments = assess(&config, now, &fs);
+        let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
+
+        assert_eq!(
+            sv1.external.len(),
+            1,
+            "scoped to D1, should only have 1 external assessment, got: {:?}",
+            sv1.external.iter().map(|d| &d.drive_label).collect::<Vec<_>>()
+        );
+        assert_eq!(sv1.external[0].drive_label, "D1");
+    }
+
+    #[test]
+    fn assess_scoped_health_ignores_out_of_scope_chains() {
+        let config = test_config_scoped_drives();
+        let now = dt(2026, 4, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
+
+        // D1 mounted with healthy chain
+        fs.mounted_drives.insert("D1".to_string());
+        fs.send_times.insert(
+            ("sv1".to_string(), "D1".to_string()),
+            dt(2026, 4, 1, 10, 0),
+        );
+        fs.external_snapshots.insert(
+            ("/mnt/d1/.snapshots".to_string(), "sv1".to_string()),
+            vec![snap(dt(2026, 4, 1, 10, 0), "sv1")],
+        );
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap(dt(2026, 4, 1, 10, 0), "sv1"),
+        );
+
+        // D2 would have a broken chain if assessed, but it's out of scope
+        // (sv1 is scoped to D1 only). Verify health is not degraded.
+
+        let assessments = assess(&config, now, &fs);
+        let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
+
+        assert_eq!(
+            sv1.health,
+            OperationalHealth::Healthy,
+            "health should be Healthy — D2 is out of scope. Got: {:?} reasons: {:?}",
+            sv1.health, sv1.health_reasons
         );
     }
 }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -74,7 +74,13 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 
     // Dry run: print plan and exit (no lock needed)
     if args.dry_run {
-        let plan_output = crate::commands::plan_cmd::build_plan_output(&backup_plan, &fs_state);
+        let mut plan_output =
+            crate::commands::plan_cmd::build_plan_output(&backup_plan, &fs_state);
+        crate::commands::plan_cmd::populate_token_warnings(
+            &mut plan_output,
+            state_db.as_ref(),
+            &config,
+        );
         let mode = crate::output::OutputMode::detect();
         print!("{}", crate::voice::render_plan(&plan_output, mode));
         return Ok(());
@@ -151,35 +157,47 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         executor.set_full_send_policy(FullSendPolicy::SkipAndNotify);
     }
 
-    // Verify drive tokens: collect mismatched drives, then filter in one pass.
+    // Verify drive tokens: collect suspicious drives, then filter sends in one pass.
     if let Some(ref db) = state_db {
-        let mismatched: std::collections::BTreeSet<String> = config
+        let blocked: std::collections::BTreeSet<String> = config
             .drives
             .iter()
             .filter(|d| drives::is_drive_mounted(d))
-            .filter_map(|drive| {
-                if let drives::DriveAvailability::TokenMismatch { expected, found } =
-                    drives::verify_drive_token(drive, db)
-                {
+            .filter_map(|drive| match drives::verify_drive_token(drive, db) {
+                drives::DriveAvailability::TokenMismatch { expected, found } => {
                     log::warn!(
                         "Drive {} has a token mismatch (expected {}, found {}) — \
                          skipping sends to this drive",
                         drive.label, expected, found,
                     );
                     Some(drive.label.clone())
-                } else {
-                    None
                 }
+                drives::DriveAvailability::TokenExpectedButMissing => {
+                    // PLACEHOLDER: directs to `urd doctor` until UPI 009 ships
+                    // `urd drives adopt {label}`.
+                    log::warn!(
+                        "Drive {} is mounted but missing its identity token. Urd has \
+                         previously sent to a drive with this label — this may be a \
+                         different physical drive. Sends to {} are blocked. \
+                         Run `urd doctor` for guidance.",
+                        drive.label, drive.label,
+                    );
+                    Some(drive.label.clone())
+                }
+                _ => None,
             })
             .collect();
 
-        if !mismatched.is_empty() {
+        if !blocked.is_empty() {
+            // Only sends are blocked for token-suspicious drives. Retention deletes
+            // proceed — a clone's snapshots are redundant copies, and blocking deletes
+            // would cause space exhaustion without safety benefit.
             backup_plan.operations.retain(|op| {
                 !matches!(
                     op,
                     PlannedOperation::SendFull { drive_label, .. }
                     | PlannedOperation::SendIncremental { drive_label, .. }
-                    if mismatched.contains(drive_label)
+                    if blocked.contains(drive_label)
                 )
             });
         }
@@ -539,7 +557,7 @@ fn build_empty_plan_explanation(
 
     for (_, reason) in &plan.skipped {
         match SkipCategory::from_reason(reason) {
-            SkipCategory::Disabled => has_disabled = true,
+            SkipCategory::Disabled | SkipCategory::LocalOnly => has_disabled = true,
             SkipCategory::SpaceExceeded => has_space = true,
             SkipCategory::DriveNotMounted => has_not_mounted = true,
             SkipCategory::IntervalNotElapsed => has_interval = true,

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -1,5 +1,6 @@
 use crate::cli::PlanArgs;
 use crate::config::Config;
+use crate::drives;
 use crate::output::{
     OutputMode, PlanOperationEntry, PlanOutput, PlanSummaryOutput, SkipCategory,
     SkippedSubvolume,
@@ -25,7 +26,8 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
     };
     let backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
 
-    let output = build_plan_output(&backup_plan, &fs_state);
+    let mut output = build_plan_output(&backup_plan, &fs_state);
+    populate_token_warnings(&mut output, state_db.as_ref(), &config);
     print!("{}", voice::render_plan(&output, mode));
 
     Ok(())
@@ -77,6 +79,36 @@ pub fn build_plan_output(
             skipped: summary.skipped,
             estimated_total_bytes,
         },
+        warnings: Vec::new(),
+    }
+}
+
+/// Post-plan token verification — planner is pure (ADR-100/108) and has no
+/// StateDb access. Token checks happen here in the command layer.
+/// See design-004 resolved decision 004-Q2.
+pub fn populate_token_warnings(
+    output: &mut PlanOutput,
+    state_db: Option<&StateDb>,
+    config: &crate::config::Config,
+) {
+    let Some(db) = state_db else { return };
+    for drive in config.drives.iter().filter(|d| drives::is_drive_mounted(d)) {
+        match drives::verify_drive_token(drive, db) {
+            drives::DriveAvailability::TokenExpectedButMissing => {
+                output.warnings.push(format!(
+                    "Drive {} is mounted but missing its identity token \u{2014} \
+                     possible drive swap. Sends blocked. Run `urd doctor` for guidance.",
+                    drive.label,
+                ));
+            }
+            drives::DriveAvailability::TokenMismatch { .. } => {
+                output.warnings.push(format!(
+                    "Drive {} token mismatch \u{2014} possible drive swap. Sends blocked.",
+                    drive.label,
+                ));
+            }
+            _ => {}
+        }
     }
 }
 

--- a/src/drives.rs
+++ b/src/drives.rs
@@ -30,7 +30,12 @@ pub enum DriveAvailability {
     TokenMismatch { expected: String, found: String },
     /// Drive is mounted and UUID matches, but no token file exists on the drive.
     /// Normal for drives that have not completed their first Urd send.
+    /// Only returned when SQLite has no stored token for this label (genuine first use).
     TokenMissing,
+    /// Drive is mounted and UUID matches, but no token file exists while SQLite
+    /// has a stored token for this label. The drive may have been swapped or cloned.
+    /// Sends should be blocked until the user explicitly adopts the drive.
+    TokenExpectedButMissing,
 }
 
 /// Check whether a drive is available: mounted and UUID-verified.
@@ -283,8 +288,19 @@ pub fn verify_drive_token(drive: &DriveConfig, state: &StateDb) -> DriveAvailabi
     let drive_token = match read_drive_token(drive) {
         Ok(Some(t)) => t,
         Ok(None) => {
-            // No token file on drive. Normal for pre-token drives.
-            return DriveAvailability::TokenMissing;
+            // No token file on drive. Check if SQLite already knows this label.
+            return match state.get_drive_token(&drive.label) {
+                Ok(Some(_)) => {
+                    // SQLite has a record but drive has no file — suspicious.
+                    // Possible swap or clone. Block sends.
+                    DriveAvailability::TokenExpectedButMissing
+                }
+                _ => {
+                    // No SQLite record either (genuine first use), or SQLite
+                    // unavailable (fail-open per ADR-107).
+                    DriveAvailability::TokenMissing
+                }
+            };
         }
         Err(e) => {
             // Fail-open (ADR-107): can't read token, proceed with caution.
@@ -569,18 +585,18 @@ mod tests {
     }
 
     #[test]
-    fn verify_drive_token_no_file_on_drive() {
+    fn verify_drive_token_no_file_sqlite_has_record() {
         let tmp = tempfile::TempDir::new().unwrap();
         let drive = tempdir_drive(tmp.path());
         let db = StateDb::open_memory().unwrap();
 
-        // SQLite has a token but drive has no file
+        // SQLite has a token but drive has no file — suspicious
         db.store_drive_token(&drive.label, "stored-token", "2026-03-29T10:00:00")
             .unwrap();
 
         assert_eq!(
             verify_drive_token(&drive, &db),
-            DriveAvailability::TokenMissing
+            DriveAvailability::TokenExpectedButMissing
         );
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -553,6 +553,9 @@ pub enum SkipCategory {
     DriveNotMounted,
     IntervalNotElapsed,
     Disabled,
+    /// Subvolume has `send_enabled = false` — local snapshots only, by design.
+    /// Distinct from `Disabled` (which means `enabled = false` — does nothing).
+    LocalOnly,
     SpaceExceeded,
     Other,
 }
@@ -565,8 +568,10 @@ impl SkipCategory {
     /// known patterns classify correctly.
     #[must_use]
     pub fn from_reason(reason: &str) -> Self {
-        if reason == "disabled" || reason == "send disabled" {
+        if reason == "disabled" {
             Self::Disabled
+        } else if reason == "send disabled" {
+            Self::LocalOnly
         } else if reason.starts_with("drive ")
             && reason.ends_with(" not mounted")
         {
@@ -638,6 +643,11 @@ pub struct PlanOutput {
     pub operations: Vec<PlanOperationEntry>,
     pub skipped: Vec<SkippedSubvolume>,
     pub summary: PlanSummaryOutput,
+
+    /// Drive-level warnings (token issues, identity concerns).
+    /// Populated by command layer after plan generation — planner is pure (ADR-100/108).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<String>,
 }
 
 /// A single planned operation for display.
@@ -1192,9 +1202,13 @@ mod tests {
     #[test]
     fn classify_disabled() {
         assert_eq!(SkipCategory::from_reason("disabled"), SkipCategory::Disabled);
+    }
+
+    #[test]
+    fn classify_local_only() {
         assert_eq!(
             SkipCategory::from_reason("send disabled"),
-            SkipCategory::Disabled
+            SkipCategory::LocalOnly
         );
     }
 
@@ -1284,13 +1298,13 @@ mod tests {
         );
     }
 
-    /// Completeness test: all 14 known plan.rs skip patterns classify to their
+    /// Completeness test: all 15 known plan.rs skip patterns classify to their
     /// expected category. Prevents silent regressions when new patterns are added.
     #[test]
-    fn classify_all_14_patterns() {
+    fn classify_all_15_patterns() {
         let patterns = vec![
             ("disabled", SkipCategory::Disabled),
-            ("send disabled", SkipCategory::Disabled),
+            ("send disabled", SkipCategory::LocalOnly),
             ("drive WD-18TB not mounted", SkipCategory::DriveNotMounted),
             (
                 "drive WD-18TB UUID mismatch (expected abc, found def)",
@@ -1301,7 +1315,11 @@ mod tests {
                 SkipCategory::Other,
             ),
             (
-                "drive WD-18TB token mismatch (expected abc, found def) — possible drive swap",
+                "drive WD-18TB token mismatch (expected abc, found def) \u{2014} possible drive swap",
+                SkipCategory::Other,
+            ),
+            (
+                "drive WD-18TB token expected but missing \u{2014} possible drive swap",
                 SkipCategory::Other,
             ),
             (
@@ -1436,6 +1454,7 @@ mod tests {
                 skipped: 2,
                 estimated_total_bytes: Some(10_000_500_000),
             },
+            warnings: vec![],
         };
 
         let config: crate::config::Config = toml::from_str(

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -219,6 +219,22 @@ pub fn plan(
                         ));
                         continue;
                     }
+                    DriveAvailability::TokenExpectedButMissing => {
+                        // SQLite has a stored token but drive has no token file.
+                        // Possible swap or clone — block sends.
+                        // NOTE: In production, RealFileSystemState::drive_availability()
+                        // never returns token variants (it only checks mount + UUID).
+                        // Production safety comes from commands/backup.rs post-plan filter.
+                        // This arm exists for enum exhaustiveness and mock-based testing.
+                        skipped.push((
+                            subvol.name.clone(),
+                            format!(
+                                "drive {} token expected but missing \u{2014} possible drive swap",
+                                drive.label
+                            ),
+                        ));
+                        continue;
+                    }
                     DriveAvailability::TokenMissing => {
                         // Benign: first use or pre-token drive. Proceed with send.
                         // Token will be written by executor on successful send.
@@ -1939,6 +1955,60 @@ send_enabled = false
         assert!(
             !sends.is_empty(),
             "Sends should proceed when token is missing (backward compat)"
+        );
+    }
+
+    #[test]
+    fn token_expected_but_missing_skips_sends() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
+        fs.drive_availability_overrides
+            .insert("D1".to_string(), DriveAvailability::TokenExpectedButMissing);
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        assert!(
+            result
+                .skipped
+                .iter()
+                .any(|(_, reason)| reason.contains("token expected but missing")),
+            "TokenExpectedButMissing should produce a skip reason: {:?}",
+            result.skipped
+        );
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::SendFull { .. } | PlannedOperation::SendIncremental { .. }
+                )
+            })
+            .collect();
+        assert!(
+            sends.is_empty(),
+            "No sends should be planned on TokenExpectedButMissing"
+        );
+    }
+
+    #[test]
+    fn token_expected_but_missing_still_creates_local_snapshots() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        // No existing snapshots — planner should create one
+        fs.drive_availability_overrides
+            .insert("D1".to_string(), DriveAvailability::TokenExpectedButMissing);
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { .. }))
+            .collect();
+        assert!(
+            !creates.is_empty(),
+            "Local snapshots should still be created when external sends are blocked"
         );
     }
 

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -749,6 +749,7 @@ fn render_skipped_block(skipped: &[crate::output::SkippedSubvolume], out: &mut S
             not_mounted_count += 1;
         } else if skip.category != SkipCategory::IntervalNotElapsed
             && skip.category != SkipCategory::Disabled
+            && skip.category != SkipCategory::LocalOnly
         {
             actionable_skips.push(skip);
         }
@@ -1021,6 +1022,14 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
     .ok();
     writeln!(out).ok();
 
+    // === Warnings ===
+    if !data.warnings.is_empty() {
+        for warning in &data.warnings {
+            writeln!(out, "  {}  {}", "[WARNING]".yellow().bold(), warning).ok();
+        }
+        writeln!(out).ok();
+    }
+
     if data.operations.is_empty() && data.skipped.is_empty() {
         writeln!(out, "{}", "Nothing to do.".dimmed()).ok();
         return out;
@@ -1132,6 +1141,7 @@ fn render_plan_skipped_grouped(skipped: &[SkippedSubvolume], out: &mut String) {
         SkipCategory::DriveNotMounted,
         SkipCategory::IntervalNotElapsed,
         SkipCategory::Disabled,
+        SkipCategory::LocalOnly,
         SkipCategory::SpaceExceeded,
         SkipCategory::Other,
     ];
@@ -1146,6 +1156,7 @@ fn render_plan_skipped_grouped(skipped: &[SkippedSubvolume], out: &mut String) {
             SkipCategory::DriveNotMounted => render_drive_not_mounted_group(&items, out),
             SkipCategory::IntervalNotElapsed => render_interval_group(&items, out),
             SkipCategory::Disabled => render_disabled_group(&items, out),
+            SkipCategory::LocalOnly => render_local_only_group(&items, out),
             SkipCategory::SpaceExceeded | SkipCategory::Other => {
                 render_individual_skips(&items, cat, out);
             }
@@ -1224,14 +1235,27 @@ fn render_disabled_group(items: &[&SkippedSubvolume], out: &mut String) {
     .ok();
 }
 
+fn render_local_only_group(items: &[&SkippedSubvolume], out: &mut String) {
+    let names: Vec<&str> = items.iter().map(|s| s.name.as_str()).collect();
+    writeln!(
+        out,
+        "  {}  {} {}",
+        skip_tag(&SkipCategory::LocalOnly),
+        "Local only:".dimmed(),
+        names.join(", "),
+    )
+    .ok();
+}
+
 /// Map skip category to a colored tag for display.
 fn skip_tag(category: &SkipCategory) -> String {
     match category {
         SkipCategory::SpaceExceeded => "[SPACE]".yellow().to_string(),
         SkipCategory::IntervalNotElapsed => "[WAIT]".dimmed().to_string(),
         SkipCategory::DriveNotMounted => "[AWAY]".dimmed().to_string(),
-        SkipCategory::Disabled => "[OFF] ".dimmed().to_string(),
-        SkipCategory::Other => "[SKIP]".dimmed().to_string(),
+        SkipCategory::Disabled => "[OFF]  ".dimmed().to_string(),
+        SkipCategory::LocalOnly => "[LOCAL]".dimmed().to_string(),
+        SkipCategory::Other => "[SKIP] ".dimmed().to_string(),
     }
 }
 
@@ -3048,6 +3072,7 @@ mod tests {
                 skipped: 0,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(output.contains("htpc-home"), "missing subvolume name");
@@ -3068,6 +3093,7 @@ mod tests {
                 skipped: 0,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Daemon);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
@@ -3102,6 +3128,7 @@ mod tests {
                 skipped: 1,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
@@ -3129,6 +3156,7 @@ mod tests {
                 skipped: 1,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
@@ -3171,6 +3199,7 @@ mod tests {
                 skipped: 3,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
@@ -3224,6 +3253,7 @@ mod tests {
                 skipped: 3,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
@@ -3266,6 +3296,7 @@ mod tests {
                 skipped: 2,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         // 2h30m (150 min) < 9d (12960 min) — must show 2h30m as shortest, not 9d
@@ -3295,7 +3326,7 @@ mod tests {
                 SkippedSubvolume {
                     name: "subvol6-tmp".to_string(),
                     reason: "send disabled".to_string(),
-                    category: SkipCategory::Disabled,
+                    category: SkipCategory::LocalOnly,
                 },
             ],
             summary: PlanSummaryOutput {
@@ -3305,15 +3336,28 @@ mod tests {
                 skipped: 3,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
             output.contains("Disabled:"),
-            "missing disabled group"
+            "missing disabled group: {output}"
         );
         assert!(
-            output.contains("htpc-root, subvol4-multimedia, subvol6-tmp"),
-            "names should be comma-separated: {output}"
+            output.contains("htpc-root, subvol4-multimedia"),
+            "disabled names should be comma-separated: {output}"
+        );
+        assert!(
+            output.contains("[LOCAL]"),
+            "local-only should render with [LOCAL] tag: {output}"
+        );
+        assert!(
+            output.contains("Local only:"),
+            "missing local-only group: {output}"
+        );
+        assert!(
+            output.contains("subvol6-tmp"),
+            "local-only subvolume should appear: {output}"
         );
     }
 
@@ -3336,6 +3380,7 @@ mod tests {
                 skipped: 1,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
@@ -3378,6 +3423,7 @@ mod tests {
                 skipped: 3,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         let not_mounted_pos = output.find("Disconnected:").expect("missing Disconnected");
@@ -3410,6 +3456,7 @@ mod tests {
                 skipped: 1,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Daemon);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
@@ -3454,6 +3501,7 @@ mod tests {
                 skipped: 0,
                 estimated_total_bytes: Some(54_200_000_000),
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
@@ -3489,6 +3537,7 @@ mod tests {
                 skipped: 0,
                 estimated_total_bytes: Some(5_500_000),
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
@@ -3530,6 +3579,7 @@ mod tests {
                 skipped: 0,
                 estimated_total_bytes: Some(53_000_000_000),
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
@@ -3560,6 +3610,7 @@ mod tests {
                 skipped: 0,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
@@ -3593,6 +3644,7 @@ mod tests {
                 skipped: 0,
                 estimated_total_bytes: Some(53_000_000_000),
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Daemon);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
@@ -3627,6 +3679,7 @@ mod tests {
                 skipped: 0,
                 estimated_total_bytes: None,
             },
+            warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Daemon);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
@@ -3641,6 +3694,153 @@ mod tests {
         assert!(
             parsed["operations"][0].get("is_full_send").is_none(),
             "null is_full_send should be omitted from JSON"
+        );
+    }
+
+    // ── Plan warnings tests ─────────────────────────────────────────────
+
+    #[test]
+    fn plan_warnings_render_prominently() {
+        let data = PlanOutput {
+            timestamp: "2026-04-03 12:00".to_string(),
+            operations: vec![],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 0,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: None,
+            },
+            warnings: vec![
+                "Drive WD-18TB token mismatch \u{2014} possible drive swap. Sends blocked."
+                    .to_string(),
+            ],
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("[WARNING]"),
+            "warnings should render with [WARNING] tag: {output}"
+        );
+        assert!(
+            output.contains("token mismatch"),
+            "warning content should appear: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_warnings_omitted_from_json_when_empty() {
+        let data = PlanOutput {
+            timestamp: "2026-04-03 12:00".to_string(),
+            operations: vec![],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 0,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: None,
+            },
+            warnings: vec![],
+        };
+        let output = render_plan(&data, OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        assert!(
+            parsed.get("warnings").is_none(),
+            "empty warnings should be omitted from JSON: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_warnings_included_in_json_when_present() {
+        let data = PlanOutput {
+            timestamp: "2026-04-03 12:00".to_string(),
+            operations: vec![],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 0,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: None,
+            },
+            warnings: vec!["Drive X identity suspect".to_string()],
+        };
+        let output = render_plan(&data, OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        assert_eq!(
+            parsed["warnings"][0].as_str(),
+            Some("Drive X identity suspect"),
+            "warnings should appear in JSON: {output}"
+        );
+    }
+
+    // ── History tests ───────────────────────────────────────────────────
+
+    // ── LocalOnly skip category tests ───────────────────────────────────
+
+    #[test]
+    fn local_only_suppressed_in_backup_summary() {
+        colored::control::set_override(false);
+        let data = BackupSummary {
+            result: "success".to_string(),
+            run_id: Some(1),
+            duration_secs: 10.0,
+            subvolumes: vec![],
+            skipped: vec![
+                SkippedSubvolume {
+                    name: "subvol4-multimedia".to_string(),
+                    reason: "send disabled".to_string(),
+                    category: SkipCategory::LocalOnly,
+                },
+                SkippedSubvolume {
+                    name: "htpc-home".to_string(),
+                    reason: "drive WD-18TB not mounted".to_string(),
+                    category: SkipCategory::DriveNotMounted,
+                },
+            ],
+            assessments: vec![],
+            transitions: vec![],
+            warnings: vec![],
+        };
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        // Local-only should NOT appear in the skip section
+        assert!(
+            !output.contains("subvol4-multimedia"),
+            "local-only should be suppressed from backup summary: {output}"
+        );
+        // But drive-not-mounted should still appear
+        assert!(
+            output.contains("WD-18TB"),
+            "drive-not-mounted should still appear: {output}"
+        );
+    }
+
+    #[test]
+    fn local_only_preserved_in_daemon_json() {
+        let data = PlanOutput {
+            timestamp: "2026-04-03 12:00".to_string(),
+            operations: vec![],
+            skipped: vec![SkippedSubvolume {
+                name: "subvol4-multimedia".to_string(),
+                reason: "send disabled".to_string(),
+                category: SkipCategory::LocalOnly,
+            }],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 0,
+                deletions: 0,
+                skipped: 1,
+                estimated_total_bytes: None,
+            },
+            warnings: vec![],
+        };
+        let output = render_plan(&data, OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        assert_eq!(
+            parsed["skipped"][0]["category"].as_str(),
+            Some("local_only"),
+            "LocalOnly should serialize as 'local_only' in JSON: {output}"
         );
     }
 


### PR DESCRIPTION
## Summary

- **UPI 004 — TokenExpectedButMissing safety gate:** Blocks sends to drives where the identity token file is missing but SQLite has a stored token for that label. Prevents cloned/swapped drives from silently receiving backups. Resolution path: `urd drives adopt` (UPI 009).
- **UPI 005 — assess() drive scoping:** Filters drive iteration through per-subvolume `drives` field, fixing false degradation for scoped subvolumes.
- **UPI 005 — LocalOnly skip category:** `send_enabled = false` subvolumes display as `[LOCAL]` instead of `[OFF] Disabled`, suppressed from backup summary.
- **Plan warnings:** `PlanOutput.warnings` field with `[WARNING]` rendering for token identity issues in `urd plan` and `urd backup --dry-run`.

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 725 tests, all passing
- Arch-adversary review: completed, all findings addressed in post-review revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)