### PR TITLE
fix: honest communication for safety gates and diagnostics (Phase B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-04-03
+
 ### Fixed
 - Safety gate (chain-break full send blocked) now reports `DEFERRED` instead of `FAILED` — the tool made a correct decision, not an error
 - Deferred-only backup runs report "success" instead of "failure" in summary, heartbeat, and metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Safety gate (chain-break full send blocked) now reports `DEFERRED` instead of `FAILED` — the tool made a correct decision, not an error
+- Deferred-only backup runs report "success" instead of "failure" in summary, heartbeat, and metrics
+- `urd doctor --thorough` stale-pin message changed from accusatory "sends may be failing" to neutral "last successful send was N day(s) ago"
+- `urd doctor` no longer suggests adding a UUID that's already configured on another drive (cloned drive scenario)
+
 ## [0.8.1] - 2026-04-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,7 +545,10 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
+ "bitflags",
  "libc",
+ "plain",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -639,6 +653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,6 +706,15 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_users"
@@ -945,6 +974,7 @@ dependencies = [
  "ctrlc",
  "dirs",
  "env_logger",
+ "filetime",
  "log",
  "nix 0.29.0",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ log = "0.4"
 env_logger = "0.11"
 
 [dev-dependencies]
+filetime = "0.2.27"
 tempfile = "3"
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -6,11 +6,11 @@
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
 | 009 | `urd drives` subcommand | [design](../95-ideas/2026-04-02-design-009-urd-drives-subcommand.md) | - | - | - | - |
-| 008 | Doctor pin-age correlation | [design](../95-ideas/2026-04-02-design-008-doctor-pin-age-correlation.md) | - | - | - | - |
-| 007 | Safety gate communication | [design](../95-ideas/2026-04-02-design-007-safety-gate-communication.md) | - | - | - | - |
+| 008 | Doctor pin-age correlation | [design](../95-ideas/2026-04-02-design-008-doctor-pin-age-correlation.md) | - | [adversary](../99-reports/2026-04-03-design-review-007-008-phase-b-communication.md) | - | - |
+| 007 | Safety gate communication | [design](../95-ideas/2026-04-02-design-007-safety-gate-communication.md) | - | [adversary](../99-reports/2026-04-03-design-review-007-008-phase-b-communication.md) | - | - |
 | 006 | Drive reconnection notifications | [design](../95-ideas/2026-04-02-design-006-drive-reconnection-notifications.md) | - | - | - | - |
-| 005 | Status truth (assess scoping + local label) | [design](../95-ideas/2026-04-02-design-005-status-truth.md) | - | [adversary](../99-reports/2026-04-03-review-adversary-004-005-phase-a.md) | - | - |
-| 004 | TokenMissing safety gate | [design](../95-ideas/2026-04-02-design-004-token-missing-gate.md) | - | [adversary](../99-reports/2026-04-03-review-adversary-004-005-phase-a.md) | - | - |
+| 005 | Status truth (assess scoping + local label) | [design](../95-ideas/2026-04-02-design-005-status-truth.md) | - | [adversary](../99-reports/2026-04-03-review-adversary-004-005-phase-a.md) | merged | [#68](https://github.com/vonrobak/urd/pull/68) |
+| 004 | TokenMissing safety gate | [design](../95-ideas/2026-04-02-design-004-token-missing-gate.md) | - | [adversary](../99-reports/2026-04-03-review-adversary-004-005-phase-a.md) | merged | [#68](https://github.com/vonrobak/urd/pull/68) |
 | 003 | Backup-now imperative | [design](../95-ideas/2026-04-02-design-003-backup-now-imperative.md) | [review](../99-reports/2026-04-02-design-review-003-backup-now-imperative.md) | [adversary](../99-reports/2026-04-02-design-review-003-backup-now-imperative.md) | merged | [#67](https://github.com/vonrobak/urd/pull/67) |
 | 002 | Output polish | [design](../95-ideas/2026-04-01-design-002-output-polish.md) | [review](../99-reports/2026-04-01-design-review-002-output-polish.md) | - | - | - |
 | 001 | Workflow system overhaul | [design](../95-ideas/2026-04-01-design-001-workflow-system-overhaul.md) | - | - | - | - |

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -9,14 +9,17 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-713 tests, all passing, clippy clean. Current version: v0.8.0.
+725 tests, all passing, clippy clean. Current version: v0.8.1.
 
-**Backup-now imperative complete (UPI 003).** `urd backup` by a human now takes fresh
-snapshots and sends immediately, ignoring interval gating. `--auto` flag preserves timer
-behavior. Pre-action briefing shown before manual TTY runs. Mode-aware empty-plan messages
-with reasons and suggestions. PR #67 merged, v0.8.0 tagged and released.
+**Phase A complete (UPI 004 + 005).** Token safety gate blocks sends to drives with
+missing identity tokens when SQLite has a stored record (cloned/swapped drive detection).
+assess() now respects per-subvolume `drives` scoping — fixes false degradation.
+Local-only subvolumes display as `[LOCAL]` instead of `[OFF] Disabled`.
+PR #68 shipped, v0.8.1 tagged.
 
-**Deployment note:** Systemd timer unit needs `--auto` added to `ExecStart` line.
+**Deployment notes:**
+- Systemd timer needs `--auto` added to `ExecStart` line (pending since v0.8.0)
+- After merging PR #68: `cargo install --path .` to deploy v0.8.1
 
 ## In Progress
 
@@ -24,11 +27,15 @@ Nothing active.
 
 ## Next Up
 
-1. **assess() scoping fix** — correctness bug: promise model ignores per-subvolume drive
-   scoping, causes false degradation for htpc-root. Patch tier. ~0.5 session.
-2. **6-O: Progressive disclosure** — milestones, onboarding layer. ~2 sessions.
-   Design: [95-ideas/2026-03-31-design-o-progressive-disclosure.md](../95-ideas/2026-03-31-design-o-progressive-disclosure.md)
-3. **6-H: The Encounter** — guided setup wizard as a conversation. ~4-6 sessions.
+1. **Phase B: Make communication honest (v0.8.2)** — ~0.75 session total
+   - UPI 007: Safety gate communication (`[DEFERRED]` replaces `[FAILED]`)
+   - UPI 008: Doctor pin-age correlation (fix contradictory UUID advice)
+   - Designs: grill-me complete, ready for /prepare
+2. **Phase C: Give drives a face (v0.9.0)** — ~1-2 sessions total
+   - UPI 009: `urd drives` subcommand
+   - UPI 006: Drive reconnection notifications
+3. **Untracked docs commit** — 6 design docs, brainstorm, Steve reviews, test report
+   from the 2026-04-02 design session remain untracked. Commit as docs PR.
 
 ## Key Links
 
@@ -49,6 +56,5 @@ Nothing active.
 - `FileSystemState` trait (11 methods) outgrowing its name — consider rename to `SystemState`
 - Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" matched as raw strings — consider constants
 - Parallel notification builders in notify.rs and sentinel_runner.rs (maintenance risk)
-- **assess() does not respect per-subvolume `drives` scoping** — correctness bug, next fix (causes false degradation for htpc-root)
 - RECOVERY column hidden — needs real snapshot depth calculation before it can return
 - Planner helper functions approaching parameter limit (10 args) — pass `&PlanFilters` instead of destructured bools in next planner change

--- a/docs/99-reports/2026-04-03-design-review-007-008-phase-b-communication.md
+++ b/docs/99-reports/2026-04-03-design-review-007-008-phase-b-communication.md
@@ -1,0 +1,243 @@
+---
+upi: "007+008"
+date: 2026-04-03
+---
+
+# Architectural Adversary Review: Phase B Implementation Plan (UPI 007 + 008)
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-03
+**Scope:** Implementation plan `docs/97-plans/2026-04-03-plan-007-008-phase-b-communication.md`
+**Mode:** Design review (pre-implementation plan)
+**Designs:** UPI 007 (Safety Gate Communication), UPI 008 (Doctor Pin-Age Correlation)
+
+---
+
+## Executive Summary
+
+UPI 007 is well-traced and will work as planned. The plan correctly identifies the single
+change site in the executor and lets the compiler enforce exhaustive handling. UPI 008
+has a premise error: the plan adds a `drive_mounted: bool` parameter to
+`collect_stale_pin_check()`, but the verify loop already short-circuits at line 87-98
+when a drive is unmounted — the function is never called for absent drives. The real
+problem (stale pin on a recently *reconnected* drive) requires a different fix.
+
+---
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — deleting snapshots that shouldn't be
+deleted.
+
+**Distance:** This plan is far from the catastrophic failure. Both UPI 007 and 008 are
+communication-layer changes. The `Deferred` variant doesn't touch retention, pin
+protection, or deletion logic. The closest proximity is through the transient cleanup
+path (a deferred send changes `sends_succeeded` vs `planned_send_drives`), but this
+correctly results in `SkippedPartialSends` — which is the safe default.
+
+---
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | **Correctness** | 3 | 007 is correct. 008 has a premise error — the drive-unmounted path never reaches the function being modified. |
+| 2 | **Security** | 5 | No sudo paths, no filesystem mutations, no new trust boundaries. |
+| 3 | **Architectural Excellence** | 4 | 007 follows the data cleanly through the pipeline. 008 Step 9 (UUID suppression) is well-placed. |
+| 4 | **Systems Design** | 3 | 008 misidentifies the runtime scenario. The plan also doesn't address what metrics/heartbeat consumers see for deferred runs. |
+
+**Overall: 3.75/5** — Strong plan with one significant premise error in 008 that needs
+correction before building.
+
+---
+
+## Design Tensions
+
+### 1. `success: bool` vs. a tri-state on SubvolumeSummary
+
+The plan adds `deferred: Vec<DeferredInfo>` alongside the existing `success: bool`. This
+creates a compound check: voice.rs must check `sv.success && !sv.deferred.is_empty()` to
+distinguish OK from DEFERRED. The alternative — replacing `success: bool` with a
+`SubvolStatus` enum (as the design doc proposed) — would make the state unambiguous.
+
+The plan's choice is the right trade-off *for now*. Changing `success: bool` to an enum
+would touch every consumer (metrics, heartbeat, notifications, test helpers), expanding
+the blast radius significantly for a patch-tier change. The compound check in voice.rs
+is localized. If a third state ever appears, refactor then.
+
+### 2. Deferred info via `error` field vs. dedicated field
+
+The plan reuses `OperationOutcome.error: Option<String>` to carry the deferred suggestion
+text, noting it's already used for informational messages on `Skipped` ops. This is a
+pragmatic choice — changing the field name or adding a separate `deferred_info` field to
+`OperationOutcome` would cascade to SQLite recording, metrics, and every test that
+constructs outcomes. But it means "error" doesn't mean "error" — it means "additional
+context for non-success results." Document this in a code comment at the field level.
+
+### 3. Accuracy vs. simplicity in pin-age diagnostics (008)
+
+The design doc's scenario — drive absent for 8 days, pin stale — suggests a simple mount
+check. But the actual code path reveals a harder problem: the drive is mounted when doctor
+runs. The staleness is historical, not current. A proper fix would need to correlate pin
+age with drive reconnection time (e.g., from sentinel events or mount timestamps). That's
+over-engineered for a 0.25-session patch. The simpler fix (acknowledged in "Rejected
+Alternatives") is to just change the message to be less accusatory.
+
+---
+
+## Findings
+
+### F1: UPI 008 premise error — `collect_stale_pin_check()` never runs for unmounted drives [Significant]
+
+**What:** The plan's Step 7 adds `drive_mounted: bool` to `collect_stale_pin_check()` and
+changes the message when `!drive_mounted`. But `verify.rs:87-98` does an early `continue`
+for unmounted drives — `collect_stale_pin_check()` at line 190 is unreachable when the
+drive is not mounted.
+
+**Why it matters:** The parameter would compile and pass tests, but the `drive_mounted: false`
+branch would be dead code. The actual problem scenario — drive mounted NOW but pin stale from
+prior absence — would remain unfixed.
+
+**Suggested fix:** Two options:
+
+**(A) Remove the early continue for unmounted drives (broader fix).** Let the verify loop
+  proceed into the pin-age check even for unmounted drives. This enables the
+  `drive_mounted: false` message path. Pros: all existing verify checks that are purely
+  local (pin file existence, staleness) can still run without the drive. Cons: checks 3
+  (pin exists on external) and 4 (orphan detection) need the drive mounted. Those would
+  need individual guards rather than the blanket `continue`.
+
+**(B) Change the message without a mount-state parameter (simpler).** When the pin is stale,
+  check whether the *pin age exceeds a "recently reconnected" grace period* or simply
+  soften the message unconditionally from "sends may be failing" to "last successful send
+  was N days ago." The current message's problem is the accusation ("may be failing"), not
+  the data. A neutral message is always correct: whether the drive was absent or sends are
+  actually failing, "last successful send was N days ago" is true either way.
+
+  Recommended: Option B. It's a one-line message change, no signature change, no dead code.
+  The per-subvolume `drives` scoping (shipped in v0.8.1) means `urd status` already shows
+  whether sends are failing. Doctor doesn't need to speculate.
+
+### F2: Deferred subvolume with mixed operations renders ambiguously [Moderate]
+
+**What:** The plan says voice.rs will check `!sv.deferred.is_empty() && sv.success` to
+render DEFERRED. But a subvolume can have BOTH successful ops (snapshot create, incremental
+send to drive A) AND deferred ops (chain-break full send to drive B). In that case:
+`sv.success = true`, `sv.deferred` is non-empty, AND `sv.sends` is non-empty.
+
+**Why it matters:** The rendering would show "DEFERRED" as the status label, which hides
+the successful sends. The user needs to see that *some* drives got new data and one was
+deferred.
+
+**Suggested fix:** Render the mixed case explicitly. If a subvolume has both sends and
+deferred items, show "OK" status with the send info, then add the deferred items below
+it (same indentation as errors). The deferred info is *additional context*, not a
+replacement for the success line. E.g.:
+
+```
+  OK     htpc-root  [30.7s]  (incremental → WD-18TB, 1.6GB)
+    DEFERRED  full send to 2TB-backup gated — requires opt-in
+    → Run `urd backup --force-full --subvolume htpc-root` when ready
+```
+
+### F3: `test_backup_summary()` helper needs deferred field — 30+ test callsites [Moderate]
+
+**What:** The plan says "Update `test_backup_summary()` helper to optionally include
+deferred data." But `SubvolumeSummary` gains a new required field `deferred: Vec<DeferredInfo>`.
+Every construction of `SubvolumeSummary` — including the `test_backup_summary()` helper and
+every test that constructs one directly — needs `deferred: vec![]` added.
+
+**Why it matters:** Not a correctness issue, but the plan undercounts the mechanical work.
+There are 10+ direct `SubvolumeSummary` constructions in voice.rs tests and several in
+backup.rs tests. Missing this leads to "why am I still fixing compile errors" frustration
+during the build phase.
+
+**Suggested fix:** Acknowledge in the plan as mechanical churn. Alternatively, consider
+`#[serde(default)]` on the field and providing a `Default` impl (but `SubvolumeSummary`
+doesn't derive Default, and adding it for one field is overkill — just note the work).
+
+### F4: Transient cleanup correctly handles deferred — but plan should document why [Minor]
+
+**What:** A deferred `SendFull` adds the drive to `planned_send_drives` (line 305) but
+not to `sends_succeeded`. The `attempt_transient_cleanup` check at line 858
+(`sends_succeeded != planned_send_drives`) will return `SkippedPartialSends`. This is
+correct (don't clean up old parents if not all drives have the new snapshot).
+
+**Why it matters:** The plan doesn't mention transient cleanup at all. A future reader
+verifying the plan would have to trace this themselves. Explicitly noting "deferred sends
+correctly trigger SkippedPartialSends in transient cleanup — no change needed" prevents
+a future developer from "fixing" this.
+
+**Suggested fix:** Add a note to Step 2.
+
+### C1: Compiler-enforced exhaustive match is the right strategy [Commendation]
+
+The plan correctly identifies that adding a variant to `OpResult` will cause exhaustive
+match failures at compile time, letting the compiler find every site that needs updating.
+This is the right approach — it turns a category of runtime bugs into compile-time errors.
+The plan's risk flag #2 correctly predicts there's only one `match` site (line 967)
+because other sites use equality comparisons. Good code archaeology.
+
+### C2: "Do NOT change the `result` string logic" insight [Commendation]
+
+Step 4 correctly identifies that `build_backup_summary` already uses `result.overall.as_str()`
+and that the overall result is now naturally "success" for deferred-only runs. This avoids
+a tempting but unnecessary change — a less careful plan would have added explicit deferred
+logic to the summary result computation.
+
+---
+
+## The Simplicity Question
+
+**What could be removed?** The `deferred_count` field on `BackupSummary` (Step 3). It's
+derivable from `subvolumes.iter().map(|sv| sv.deferred.len()).sum()` and adds a field that
+must be kept in sync. Voice.rs can compute it inline. One fewer field to maintain.
+
+**What's earning its keep?** `DeferredInfo` as a struct (not just a String) is justified.
+It separates the reason from the suggestion, which the rendering needs to format differently.
+The `OpResult::Deferred` variant earns its keep by giving the compiler exhaustive match
+enforcement.
+
+---
+
+## For the Dev Team
+
+Priority-ordered action items:
+
+1. **[Significant] Fix 008 premise — use Option B.** In `collect_stale_pin_check()`,
+   change the stale-pin message from `"sends may be failing"` to `"last successful send
+   was {N} day(s) ago"`. No parameter change needed. Remove Steps 7 and 8 from the plan.
+   The neutral message is correct whether the drive was absent, sends are failing, or the
+   config was recently changed. Still add a test that verifies the new message wording.
+
+2. **[Moderate] Handle mixed success+deferred rendering in Step 5.** Add a rendering case
+   for subvolumes with both successful sends and deferred ops. Show "OK" with send info,
+   then list deferred items below. Only use "DEFERRED" as the status when the subvolume
+   has *no* successful sends — i.e., the only send operations were deferred.
+
+3. **[Moderate] Account for test construction churn in Step 3.** Note that adding
+   `deferred: Vec<DeferredInfo>` to `SubvolumeSummary` will require `deferred: vec![]`
+   in ~15 test callsites across voice.rs and backup.rs. This is mechanical but takes time.
+
+4. **[Minor] Document transient cleanup non-interaction in Step 2.** Add: "Deferred sends
+   add to `planned_send_drives` but not `sends_succeeded`, which correctly triggers
+   `SkippedPartialSends` in transient cleanup. No change needed."
+
+5. **[Minor] Consider dropping `deferred_count` from `BackupSummary`.** Derive it in
+   voice.rs from `data.subvolumes` instead. One fewer field to keep in sync.
+
+---
+
+## Open Questions
+
+1. **What did the v0.8.0 test session actually observe for T1.4?** The design doc says
+   2TB-backup was absent for 8 days and the stale-pin warning fired. Given the current
+   code's early `continue` for unmounted drives, either: (a) the drive was re-mounted
+   before running doctor, or (b) the code was different at v0.8.0. If (a), the "drive not
+   connected" message path would never fire. Confirming the actual scenario determines
+   whether Option A or B is the right fix.
+
+2. **Should `urd failures` show deferred operations?** The `recent_failures()` SQL query
+   uses `WHERE result = 'failure'`. Deferred operations will be invisible in `urd failures`.
+   Is this correct? A user might want to see "what was deferred" alongside "what failed."
+   Not blocking — just a UX decision to make explicitly.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -19,8 +19,8 @@ use crate::heartbeat;
 use crate::lock;
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
 use crate::output::{
-    BackupSummary, EmptyPlanExplanation, OutputMode, SendSummary, SkipCategory, SkippedSubvolume,
-    StatusAssessment, StructuredError, SubvolumeSummary, TransitionEvent,
+    BackupSummary, DeferredInfo, EmptyPlanExplanation, OutputMode, SendSummary, SkipCategory,
+    SkippedSubvolume, StatusAssessment, StructuredError, SubvolumeSummary, TransitionEvent,
 };
 use crate::notify;
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
@@ -314,58 +314,58 @@ fn build_backup_summary(
         .subvolume_results
         .iter()
         .map(|sv| {
-            let sends: Vec<SendSummary> = sv
-                .operations
-                .iter()
-                .filter(|op| {
-                    (op.operation == "send_incremental" || op.operation == "send_full")
-                        && op.result == OpResult::Success
-                })
-                .map(|op| SendSummary {
-                    drive: op.drive_label.clone().unwrap_or_default(),
-                    send_type: if op.operation == "send_full" {
-                        "full".to_string()
-                    } else {
-                        "incremental".to_string()
-                    },
-                    bytes_transferred: op.bytes_transferred,
-                })
-                .collect();
+            let mut sends = Vec::new();
+            let mut errors = Vec::new();
+            let mut structured_errors = Vec::new();
+            let mut deferred = Vec::new();
 
-            let errors: Vec<String> = sv
-                .operations
-                .iter()
-                .filter(|op| op.result == OpResult::Failure)
-                .filter_map(|op| {
-                    op.error
-                        .as_ref()
-                        .map(|e| format!("{}: {}", op.operation, e))
-                })
-                .collect();
-
-            let structured_errors: Vec<StructuredError> = sv
-                .operations
-                .iter()
-                .filter(|op| op.result == OpResult::Failure)
-                .filter_map(|op| {
-                    let btrfs_op = op.btrfs_operation?;
-                    let stderr = op.btrfs_stderr.as_deref().unwrap_or("");
-                    let detail = crate::error::translate_btrfs_error(
-                        btrfs_op,
-                        stderr,
-                        op.drive_label.as_deref(),
-                        Some(&sv.name),
-                    );
-                    Some(StructuredError {
-                        operation: op.operation.clone(),
-                        summary: detail.summary,
-                        cause: detail.cause,
-                        remediation: detail.remediation,
-                        drive: op.drive_label.clone(),
-                        bytes_transferred: op.bytes_transferred,
-                    })
-                })
-                .collect();
+            for op in &sv.operations {
+                match op.result {
+                    OpResult::Success => {
+                        if op.operation == "send_incremental" || op.operation == "send_full" {
+                            sends.push(SendSummary {
+                                drive: op.drive_label.clone().unwrap_or_default(),
+                                send_type: if op.operation == "send_full" {
+                                    "full".to_string()
+                                } else {
+                                    "incremental".to_string()
+                                },
+                                bytes_transferred: op.bytes_transferred,
+                            });
+                        }
+                    }
+                    OpResult::Failure => {
+                        if let Some(e) = &op.error {
+                            errors.push(format!("{}: {}", op.operation, e));
+                        }
+                        if let Some(btrfs_op) = op.btrfs_operation {
+                            let stderr = op.btrfs_stderr.as_deref().unwrap_or("");
+                            let detail = crate::error::translate_btrfs_error(
+                                btrfs_op,
+                                stderr,
+                                op.drive_label.as_deref(),
+                                Some(&sv.name),
+                            );
+                            structured_errors.push(StructuredError {
+                                operation: op.operation.clone(),
+                                summary: detail.summary,
+                                cause: detail.cause,
+                                remediation: detail.remediation,
+                                drive: op.drive_label.clone(),
+                                bytes_transferred: op.bytes_transferred,
+                            });
+                        }
+                    }
+                    OpResult::Deferred => {
+                        let drive = op.drive_label.as_deref().unwrap_or("unknown");
+                        deferred.push(DeferredInfo {
+                            reason: format!("full send to {drive} gated — requires opt-in"),
+                            suggestion: op.error.clone().unwrap_or_default(),
+                        });
+                    }
+                    OpResult::Skipped => {}
+                }
+            }
 
             SubvolumeSummary {
                 name: sv.name.clone(),
@@ -374,6 +374,7 @@ fn build_backup_summary(
                 sends,
                 errors,
                 structured_errors,
+                deferred,
             }
         })
         .collect();

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -324,7 +324,7 @@ fn collect_stale_pin_check(
             name: "stale-pin".to_string(),
             status: "warn".to_string(),
             detail: Some(format!(
-                "Pin file is {days} day(s) old (threshold: {threshold_str}) \u{2014} sends may be failing"
+                "Pin file is {days} day(s) old (threshold: {threshold_str}) \u{2014} last successful send was {days} day(s) ago"
             )),
         });
         *total_warn += 1;
@@ -406,5 +406,47 @@ mod tests {
         assert_eq!(warn, 0);
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].status, "ok");
+    }
+
+    #[test]
+    fn stale_pin_warns_with_neutral_message() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let name = SnapshotName::parse("20260322-1430-opptak").unwrap();
+        crate::chain::write_pin_file(dir.path(), "WD-18TB", &name).unwrap();
+
+        // Backdate the pin file to 3 days ago
+        let pin_path = dir.path().join(".last-external-parent-WD-18TB");
+        let three_days_ago = std::time::SystemTime::now()
+            - std::time::Duration::from_secs(3 * 86400);
+        filetime::set_file_mtime(
+            &pin_path,
+            filetime::FileTime::from_system_time(three_days_ago),
+        )
+        .unwrap();
+
+        let mut checks = Vec::new();
+        let mut ok = 0;
+        let mut warn = 0;
+        let interval = Interval::hours(4); // threshold = max(2*4h, 1d) = 1d, pin is 3d old
+        collect_stale_pin_check(
+            dir.path(),
+            "WD-18TB",
+            &interval,
+            &mut checks,
+            &mut ok,
+            &mut warn,
+        );
+        assert_eq!(warn, 1);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, "warn");
+        let detail = checks[0].detail.as_ref().unwrap();
+        assert!(
+            detail.contains("last successful send was"),
+            "should use neutral message, got: {detail}"
+        );
+        assert!(
+            !detail.contains("sends may be failing"),
+            "should not use accusatory message, got: {detail}"
+        );
     }
 }

--- a/src/drives.rs
+++ b/src/drives.rs
@@ -109,19 +109,44 @@ pub fn get_filesystem_uuid(mount_path: &Path) -> crate::error::Result<Option<Str
 /// Check mounted drives for missing UUID configuration.
 /// Returns a list of (drive_label, detected_uuid, config_snippet) for each
 /// mounted drive without a UUID configured.
+///
+/// Suppresses suggestions when the detected UUID is already configured on
+/// another drive (cloned drive scenario — suggesting it would be contradictory).
 #[must_use]
 pub fn check_missing_uuids(drives: &[DriveConfig]) -> Vec<(String, String, String)> {
-    let mut results = Vec::new();
-    for drive in drives {
-        if drive.uuid.is_some() || !is_path_mounted(&drive.mount_path) {
-            continue;
-        }
-        if let Ok(Some(uuid)) = get_filesystem_uuid(&drive.mount_path) {
+    let detected: Vec<(String, String)> = drives
+        .iter()
+        .filter(|d| d.uuid.is_none() && is_path_mounted(&d.mount_path))
+        .filter_map(|d| {
+            get_filesystem_uuid(&d.mount_path)
+                .ok()
+                .flatten()
+                .map(|uuid| (d.label.clone(), uuid))
+        })
+        .collect();
+    filter_uuid_suggestions(drives, detected)
+}
+
+/// Pure filtering logic for UUID suggestion suppression. Filters out detected
+/// UUIDs that are already configured on another drive (cloned drive scenario).
+#[must_use]
+pub(crate) fn filter_uuid_suggestions(
+    drives: &[DriveConfig],
+    detected: Vec<(String, String)>,
+) -> Vec<(String, String, String)> {
+    let configured_uuids: std::collections::HashSet<&str> = drives
+        .iter()
+        .filter_map(|d| d.uuid.as_deref())
+        .collect();
+
+    detected
+        .into_iter()
+        .filter(|(_label, uuid)| !configured_uuids.contains(uuid.as_str()))
+        .map(|(label, uuid)| {
             let snippet = format!("uuid = \"{}\"", uuid);
-            results.push((drive.label.clone(), uuid.to_string(), snippet));
-        }
-    }
-    results
+            (label, uuid, snippet)
+        })
+        .collect()
 }
 
 // ── Existing functions ─────────────────────────────────────────────────
@@ -629,5 +654,70 @@ mod tests {
             verify_drive_token(&drive, &db),
             DriveAvailability::TokenMissing
         );
+    }
+
+    #[test]
+    fn filter_uuid_suggestions_suppresses_duplicate() {
+        let drives = vec![
+            DriveConfig {
+                label: "WD-18TB".to_string(),
+                uuid: Some("aaaa-bbbb".to_string()),
+                mount_path: PathBuf::from("/mnt/wd"),
+                snapshot_root: ".snapshots".to_string(),
+                role: DriveRole::Primary,
+                max_usage_percent: None,
+                min_free_bytes: None,
+            },
+            DriveConfig {
+                label: "WD-18TB1".to_string(),
+                uuid: None, // cloned, no UUID configured
+                mount_path: PathBuf::from("/mnt/wd1"),
+                snapshot_root: ".snapshots".to_string(),
+                role: DriveRole::Primary,
+                max_usage_percent: None,
+                min_free_bytes: None,
+            },
+        ];
+
+        // Detected: WD-18TB1 has the same UUID as WD-18TB
+        let detected = vec![
+            ("WD-18TB1".to_string(), "aaaa-bbbb".to_string()),
+        ];
+
+        let results = filter_uuid_suggestions(&drives, detected);
+        assert!(results.is_empty(), "should suppress UUID already configured on WD-18TB");
+    }
+
+    #[test]
+    fn filter_uuid_suggestions_allows_unique_uuid() {
+        let drives = vec![
+            DriveConfig {
+                label: "WD-18TB".to_string(),
+                uuid: Some("aaaa-bbbb".to_string()),
+                mount_path: PathBuf::from("/mnt/wd"),
+                snapshot_root: ".snapshots".to_string(),
+                role: DriveRole::Primary,
+                max_usage_percent: None,
+                min_free_bytes: None,
+            },
+            DriveConfig {
+                label: "2TB-backup".to_string(),
+                uuid: None,
+                mount_path: PathBuf::from("/mnt/2tb"),
+                snapshot_root: ".snapshots".to_string(),
+                role: DriveRole::Primary,
+                max_usage_percent: None,
+                min_free_bytes: None,
+            },
+        ];
+
+        // Detected: 2TB-backup has a different UUID
+        let detected = vec![
+            ("2TB-backup".to_string(), "cccc-dddd".to_string()),
+        ];
+
+        let results = filter_uuid_suggestions(&drives, detected);
+        assert_eq!(results.len(), 1, "should allow unique UUID suggestion");
+        assert_eq!(results[0].0, "2TB-backup");
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -57,6 +57,9 @@ impl SendType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OpResult {
     Success,
+    /// A safety gate deliberately blocked this operation. Not a failure —
+    /// the tool made a correct decision to defer unsafe work.
+    Deferred,
     Failure,
     Skipped,
 }
@@ -76,6 +79,8 @@ pub struct OperationOutcome {
     pub drive_label: Option<String>,
     pub result: OpResult,
     pub duration: std::time::Duration,
+    /// Contextual message for non-Success results: error details for Failure,
+    /// reason/suggestion for Deferred, skip reason for Skipped.
     pub error: Option<String>,
     pub bytes_transferred: Option<u64>,
     /// Typed btrfs operation for structured error translation.
@@ -315,7 +320,7 @@ impl<'a> Executor<'a> {
                         OperationOutcome {
                             operation: "send_full".to_string(),
                             drive_label: Some(drive_label.clone()),
-                            result: OpResult::Failure,
+                            result: OpResult::Deferred,
                             duration: std::time::Duration::ZERO,
                             error: Some(format!(
                                 "chain-break full send gated — run \
@@ -966,6 +971,7 @@ impl<'a> Executor<'a> {
         if let Some(state) = self.state {
             let result_str = match outcome.result {
                 OpResult::Success => "success",
+                OpResult::Deferred => "deferred",
                 OpResult::Failure => "failure",
                 OpResult::Skipped => "skipped",
             };
@@ -2007,9 +2013,9 @@ source = "/data/sv1"
 
         let result = executor.execute(&chain_broken_plan(), "full");
 
-        assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Failure);
-        assert!(!result.subvolume_results[0].success, "subvolume should report failure");
-        assert_eq!(result.overall, RunResult::Failure);
+        assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Deferred);
+        assert!(result.subvolume_results[0].success, "deferred is not a failure");
+        assert_eq!(result.overall, RunResult::Success, "deferred-only run is success");
         assert!(mock.calls().is_empty(), "btrfs should not be called");
         assert!(
             result.subvolume_results[0].operations[0]
@@ -2017,7 +2023,7 @@ source = "/data/sv1"
                 .as_ref()
                 .unwrap()
                 .contains("chain-break full send gated"),
-            "error message should indicate gating"
+            "message should indicate gating"
         );
     }
 
@@ -2060,6 +2066,53 @@ source = "/data/sv1"
         let result = executor.execute(&chain_broken_plan(), "full");
 
         assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Success);
+    }
+
+    #[test]
+    fn deferred_with_failure_reports_partial() {
+        let mock = MockBtrfs::new();
+        // Fail snapshot creation for sv-b so it genuinely fails
+        mock.fail_creates
+            .borrow_mut()
+            .insert(PathBuf::from("/snap/sv-b/20260322-1430-b"));
+
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_full_send_policy(FullSendPolicy::SkipAndNotify);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                // sv-a: chain-break full send → will be deferred
+                PlannedOperation::SendFull {
+                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
+                    drive_label: "TEST-DRIVE".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    pin_on_success: None,
+                    reason: FullSendReason::ChainBroken,
+                },
+                // sv-b: snapshot create that will fail
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/b"),
+                    dest: PathBuf::from("/snap/sv-b/20260322-1430-b"),
+                    subvolume_name: "sv-b".to_string(),
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        // sv-a deferred → success, sv-b failed → overall is partial
+        assert!(result.subvolume_results[0].success, "deferred subvol is success");
+        assert!(!result.subvolume_results[1].success, "failed subvol is failure");
+        assert_eq!(result.overall, RunResult::Partial);
     }
 
     // ── Transient immediate cleanup tests ──────────────────────────────

--- a/src/output.rs
+++ b/src/output.rs
@@ -519,6 +519,16 @@ pub struct SubvolumeSummary {
     /// Structured error details (when btrfs errors have been translated).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub structured_errors: Vec<StructuredError>,
+    /// Operations deferred by safety gates (not failures).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub deferred: Vec<DeferredInfo>,
+}
+
+/// A safety gate that deliberately blocked an operation.
+#[derive(Debug, Serialize)]
+pub struct DeferredInfo {
+    pub reason: String,
+    pub suggestion: String,
 }
 
 /// A translated btrfs error with layered detail.

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -570,11 +570,20 @@ fn render_backup_interactive(data: &BackupSummary) -> String {
         Some(id) => format!("run #{id}, "),
         None => String::new(),
     };
+    let (failed_count, deferred_count) = data.subvolumes.iter().fold((0usize, 0usize), |(f, d), sv| {
+        (f + (!sv.success as usize), d + sv.deferred.len())
+    });
+    let count_suffix = match (failed_count, deferred_count) {
+        (0, 0) => String::new(),
+        (0, d) => format!(" ── ({d} deferred)"),
+        (f, 0) => format!(" ── ({f} failed)"),
+        (f, d) => format!(" ── ({f} failed, {d} deferred)"),
+    };
     writeln!(
         out,
         "{}",
         format!(
-            "── Urd backup: {result_colored} ── [{run_info}{:.1}s] ──",
+            "── Urd backup: {result_colored} ── [{run_info}{:.1}s] ──{count_suffix}",
             data.duration_secs,
         )
         .bold()
@@ -585,10 +594,16 @@ fn render_backup_interactive(data: &BackupSummary) -> String {
     if !data.subvolumes.is_empty() {
         writeln!(out).ok();
         for sv in &data.subvolumes {
-            let status = if sv.success {
-                "OK".green().to_string()
-            } else {
+            let has_deferred = !sv.deferred.is_empty();
+            let has_sends = !sv.sends.is_empty();
+
+            // Status label: OK (with or without deferred), DEFERRED (only), or FAILED
+            let status = if !sv.success {
                 "FAILED".red().to_string()
+            } else if has_deferred && !has_sends {
+                "DEFERRED".yellow().to_string()
+            } else {
+                "OK".green().to_string()
             };
 
             let send_info = format_send_info(&sv.sends);
@@ -601,6 +616,11 @@ fn render_backup_interactive(data: &BackupSummary) -> String {
                 send_info,
             )
             .ok();
+
+            for d in &sv.deferred {
+                writeln!(out, "    {} {}", "DEFERRED".yellow(), d.reason).ok();
+                writeln!(out, "    \u{2192} {}", d.suggestion).ok();
+            }
 
             if !sv.structured_errors.is_empty() {
                 // Render structured errors with layered detail
@@ -2424,9 +2444,9 @@ mod tests {
     use super::*;
     use crate::output::{
         BackupSummary, CalibrateEntry, CalibrateOutput, CalibrateResult, ChainHealth,
-        ChainHealthEntry, DisconnectedDrive, DriveInfo, HistoryOutput, HistoryRun, InitCheck,
-        InitDriveStatus, InitOutput, InitPinFile, InitSnapshotCount, InitStatus, LastRunInfo,
-        PlanOperationEntry, PlanOutput, PlanSummaryOutput, SendSummary, SkipCategory,
+        ChainHealthEntry, DeferredInfo, DisconnectedDrive, DriveInfo, HistoryOutput, HistoryRun,
+        InitCheck, InitDriveStatus, InitOutput, InitPinFile, InitSnapshotCount, InitStatus,
+        LastRunInfo, PlanOperationEntry, PlanOutput, PlanSummaryOutput, SendSummary, SkipCategory,
         SkippedSubvolume, StatusAssessment, StatusDriveAssessment, SubvolumeSummary,
         TransitionEvent, VerifyCheck, VerifyDrive, VerifyOutput, VerifySubvolume,
     };
@@ -2783,6 +2803,7 @@ mod tests {
                     sends: vec![],
                     errors: vec![],
                     structured_errors: vec![],
+                    deferred: vec![],
                 },
                 SubvolumeSummary {
                     name: "htpc-docs".to_string(),
@@ -2795,6 +2816,7 @@ mod tests {
                     }],
                     errors: vec![],
                     structured_errors: vec![],
+                    deferred: vec![],
                 },
             ],
             skipped: vec![
@@ -2948,6 +2970,64 @@ mod tests {
         let output = render_backup_summary(&data, OutputMode::Interactive);
         assert!(output.contains("FAILED"), "missing FAILED status");
         assert!(output.contains("btrfs send failed"), "missing error detail");
+    }
+
+    #[test]
+    fn backup_deferred_only_renders_deferred_status() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        // htpc-home: deferred-only (no sends)
+        data.subvolumes[0].deferred = vec![DeferredInfo {
+            reason: "full send to 2TB-backup gated — requires opt-in".to_string(),
+            suggestion: "chain-break full send gated — run `urd backup --force-full --subvolume htpc-home` to proceed".to_string(),
+        }];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(output.contains("DEFERRED"), "should show DEFERRED label");
+        assert!(output.contains("requires opt-in"), "should show deferred reason");
+        assert!(output.contains("--force-full"), "should show suggestion");
+    }
+
+    #[test]
+    fn backup_mixed_success_and_deferred_renders_ok() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        // htpc-docs: has a successful send AND a deferred op
+        data.subvolumes[1].deferred = vec![DeferredInfo {
+            reason: "full send to 2TB-backup gated — requires opt-in".to_string(),
+            suggestion: "chain-break full send gated — run `urd backup --force-full --subvolume htpc-docs` to proceed".to_string(),
+        }];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(output.contains("OK"), "mixed success+deferred should show OK");
+        assert!(output.contains("DEFERRED"), "should also show deferred info below");
+        assert!(output.contains("WD-18TB"), "should show successful send");
+    }
+
+    #[test]
+    fn backup_header_shows_deferred_count() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.subvolumes[0].deferred = vec![DeferredInfo {
+            reason: "full send gated".to_string(),
+            suggestion: "run --force-full".to_string(),
+        }];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(output.contains("1 deferred"), "header should show deferred count");
+    }
+
+    #[test]
+    fn backup_header_shows_failed_and_deferred_counts() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.result = "partial".to_string();
+        data.subvolumes[0].success = false;
+        data.subvolumes[0].errors = vec!["snapshot create failed".to_string()];
+        data.subvolumes[1].deferred = vec![DeferredInfo {
+            reason: "full send gated".to_string(),
+            suggestion: "run --force-full".to_string(),
+        }];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(output.contains("1 failed"), "header should show failed count");
+        assert!(output.contains("1 deferred"), "header should show deferred count");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **UPI 007:** Chain-break full send gate now reports `DEFERRED` (yellow) instead of `FAILED` (red). Deferred-only runs are "success" in summary, heartbeat, and metrics. Mixed success+deferred subvolumes render OK with deferred items below.
- **UPI 008:** Stale-pin diagnostic changed from "sends may be failing" to neutral "last successful send was N day(s) ago". UUID suggestions suppressed for cloned drives.
- Arch-adversary review caught and fixed a premise error in the original 008 design (verify loop short-circuits for unmounted drives, so the planned `drive_mounted` parameter would have been dead code).
- Simplify pass merged 4 iterator passes into 1 in `build_backup_summary()` and deduplicated UUID filtering logic in `drives.rs`.

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 733 tests, all passing (8 new)
- Integration tests: not applicable (no btrfs/filesystem changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)