### PR TITLE
docs: UPI 010 config schema v1 design + roadmap restructuring

### DIFF
--- a/docs/95-ideas/2026-04-03-design-010-config-schema-v1.md
+++ b/docs/95-ideas/2026-04-03-design-010-config-schema-v1.md
@@ -1,0 +1,888 @@
+---
+upi: "010"
+status: proposed
+date: 2026-04-03
+---
+
+# Design: Config Schema v1 — ADR-111 Revision (UPI 010)
+
+> **TL;DR:** Revise ADR-111 to reflect everything that shipped since its March 27 inception.
+> The principles are sound; the specification is stale. This revision brings the config schema
+> definition into alignment with current vocabulary, current features (transient retention,
+> drive tokens, drive roles, notifications), and the forward-looking needs of config generation.
+> The result is the authoritative spec for `config_version = 1` — the schema that new configs
+> will be born into.
+
+## Problem
+
+ADR-111 was written on 2026-03-27. Since then, the codebase has shipped:
+
+| Feature | Date | Impact on config schema |
+|---------|------|------------------------|
+| Transient retention (`local_retention = "transient"`) | 2026-03-30 | New retention variant not in ADR-111's field tables |
+| Drive tokens (`.urd-drive-token`) | 2026-03-29 | Identity layer ADR-111 doesn't mention |
+| Drive roles (primary/offsite/test) | 2026-03-31 | `role` field exists in code but missing from ADR-111's drive example |
+| Promise redundancy encoding (offsite freshness) | 2026-03-31 | Resilient requires offsite role — not in ADR-111 |
+| Notification config | 2026-03-27 | `[notifications]` section not covered in ADR-111 |
+| Vocabulary overhaul (sealed/waning/exposed, thread) | 2026-04-01 | Presentation terms diverged from ADR-111's language |
+| Protection level rename decision (recorded/sheltered/fortified) | 2026-03-31 | Decided, not shipped. ADR-111 uses old names. |
+| Skip tag differentiation (WAIT/AWAY/SPACE/OFF/SKIP) | 2026-04-01 | Presentation change, no config impact but terminology context |
+| Drive status vocabulary (connected/disconnected/away) | 2026-04-01 | Presentation change, no config impact but terminology context |
+| Backup-now imperative (manual vs auto mode) | 2026-04-02 | `run_frequency` semantics evolved |
+
+The result: ADR-111's principles hold but its specification — field tables, examples,
+implementation gates, config version semantics — describes a schema that doesn't match
+the system it's supposed to govern.
+
+This matters now because:
+
+1. **Config generation is imminent.** The encounter (6-H) generates configs. It needs an
+   authoritative schema to target. Building against a stale spec means either generating
+   wrong configs or improvising around the spec.
+
+2. **`urd migrate` needs a clear delta.** Migration from legacy to v1 requires knowing
+   exactly what changed. The current ADR-111 is ambiguous about what "version 0" vs
+   "version 1" means in concrete terms.
+
+3. **The protection level rename (P6a) needs a home.** The recorded/sheltered/fortified
+   decision is floating — decided but not anchored in any ADR. The config schema revision
+   is where it lands, because `protection_level = "fortified"` is a config field.
+
+## Proposed Design
+
+This is not a rewrite of ADR-111. It's a revision that preserves the principles (all 10
+hold) and updates the specification to match reality. The structure follows the existing
+ADR format.
+
+### What changes in the revised ADR-111
+
+#### 1. Schema version semantics
+
+**Current gap:** ADR-111 says `config_version = 1` but doesn't define what the unversioned
+(legacy) schema is, or what the concrete differences between legacy and v1 are.
+
+**Revision:**
+
+- **Legacy (unversioned):** The current schema. `[defaults]`, `[local_snapshots]`,
+  `short_name` required, operational overrides on named levels permitted. No
+  `config_version` field. Urd accepts this schema today.
+
+- **v1:** The ADR-111 target. `config_version = 1` required in `[general]`. Self-describing
+  subvolume blocks, no `[defaults]`, no `[local_snapshots]`, named levels fully opaque.
+
+- **Parser behavior:** When `config_version` is absent, Urd reads the legacy schema (the
+  current code path). When `config_version = 1`, Urd reads the v1 schema. The parser does
+  NOT accept both simultaneously — it branches on the version field. This keeps the parser
+  clean (ADR-111 principle 9: one schema version at a time).
+
+- **`urd migrate`:** Transforms legacy → v1. The migration is mechanical:
+  - Inject `config_version = 1` into `[general]`
+  - Inline `snapshot_root` from `[local_snapshots]` into each `[[subvolumes]]` block
+  - Inline `min_free_bytes` from `[local_snapshots]` root entries onto each subvolume
+    that belonged to that root
+  - Remove `[local_snapshots]` section
+  - Remove `[defaults]` section — for custom subvolumes that relied on defaults,
+    bake the resolved values into the subvolume block. Add a comment on baked
+    retention fields: `# inherited from [defaults] — removing changes retention`
+  - Make `short_name` optional (default to `name`) — keep explicit `short_name` where
+    it differs from `name`, remove where redundant
+  - If named levels have operational overrides, convert to custom (keep the overrides
+    as explicit policy) with a `⚠` warning in the summary
+  - Preserve all comments where possible (TOML editing, not regeneration)
+
+#### 2. Protection level names
+
+**Current:** `guarded` / `protected` / `resilient` / `custom`
+
+**v1:** `recorded` / `sheltered` / `fortified` / `custom`
+
+This rename is anchored in the vocabulary decisions (2026-03-31). The names communicate
+the operational axis:
+
+| Level | What it means | Old name |
+|-------|--------------|----------|
+| `recorded` | Data is recorded locally. Snapshots exist on this machine. | `guarded` |
+| `sheltered` | Data is sheltered on an external drive. Survives drive failure. | `protected` |
+| `fortified` | Data is fortified across geography. Survives site loss. | `resilient` |
+| `custom` | Operator specifies all parameters. First-class, not fallback. | `custom` |
+
+The config field becomes `protection = "fortified"` (dropping `_level` suffix — the field
+name is the concept, the value is the level).
+
+**Migration:** `urd migrate` renames the values. `guarded` → `recorded`, etc. The enum
+in `types.rs` changes; the old names become parse errors in v1 schema.
+
+**Backward compatibility:** Legacy configs keep old names and continue to work without
+migration. The v1 parser rejects old names. This is intentional — one schema version at
+a time.
+
+#### 3. Complete field tables
+
+**Subvolume block (v1 schema):**
+
+```toml
+[[subvolumes]]
+name = "subvol3-opptak"                          # Required. On-disk contract (ADR-105).
+source = "/mnt/btrfs-pool/subvol3-opptak"        # Required. Path to live subvolume.
+snapshot_root = "/mnt/btrfs-pool/.snapshots"      # Required. Where local snapshots live.
+short_name = "opptak"                             # Optional. Defaults to name.
+priority = 1                                      # Optional. Default: 2.
+protection = "fortified"                          # Optional. Omit for custom.
+drives = ["WD-18TB", "WD-18TB1"]                  # Required when protection needs external.
+```
+
+For custom subvolumes (no `protection` field), specify only what differs from defaults:
+
+```toml
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+local_retention = "transient"
+drives = ["WD-18TB1"]
+```
+
+A verbose custom block (all fields explicit, for documentation purposes):
+
+```toml
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+snapshot_interval = "1d"
+send_interval = "1d"
+send_enabled = true
+local_retention = "transient"
+external_retention = { daily = 30, weekly = 26 }
+drives = ["WD-18TB1"]
+```
+
+Generated configs use the minimal form. The verbose form is for users who want
+self-documenting configs. Both are valid; the result is identical.
+
+**Complete field reference for custom subvolumes:**
+
+| Field | Required? | Default | Notes |
+|-------|-----------|---------|-------|
+| `name` | Yes | — | On-disk contract (ADR-105). Directory name. |
+| `source` | Yes | — | Path to live subvolume. |
+| `snapshot_root` | Yes | — | Where local snapshots are stored. |
+| `short_name` | No | `name` | Snapshot name suffix. Only when different from `name`. |
+| `priority` | No | `2` | Execution order (lower = first). |
+| `protection` | No | — | Named level. Omit for custom. |
+| `snapshot_interval` | No | `1d` | How often to snapshot. |
+| `send_interval` | No | `1d` | How often to send externally. |
+| `send_enabled` | No | `true` if `drives` non-empty | Pause button for sends. |
+| `enabled` | No | `true` | Set `false` to exclude from backups without removing. |
+| `local_retention` | No | `{ hourly = 24, daily = 30, weekly = 26, monthly = 12 }` | Graduated retention or `"transient"`. |
+| `external_retention` | No | `{ daily = 30, weekly = 26 }` | Graduated retention for drives. |
+| `min_free_bytes` | No | — | Skip snapshots when free space on `snapshot_root` drops below this. |
+| `drives` | No | `[]` | Which drives to send to. Omit = no sends. |
+
+**Validation rule:** When `protection` is set to a named level, operational fields
+(`snapshot_interval`, `send_interval`, `send_enabled`, `local_retention`,
+`external_retention`) are rejected as structural errors. Only identity fields (`name`,
+`source`, `snapshot_root`, `short_name`, `priority`) and `drives` are permitted.
+
+**Exception: transient retention with named levels.** `local_retention = "transient"` is
+permitted alongside named levels because transient is a storage constraint (the NVMe is
+too small for local history), not a policy override. The named level still derives all
+other parameters. The subvolume's protection promise is unchanged — transient just means
+local copies are ephemeral.
+
+**This exception is unique.** No other operational field may accompany named protection
+levels. The transient exception exists because it addresses a physical constraint
+(storage capacity), not a policy preference. Extending this precedent to other fields
+would erode the opacity principle and requires an ADR amendment.
+
+**Drive block (v1 schema):**
+
+```toml
+[[drives]]
+label = "WD-18TB"                                 # Required. Unique label.
+mount_path = "/run/media/user/WD-18TB"            # Required. Where it mounts.
+snapshot_root = ".snapshots"                       # Required. Relative to mount_path.
+role = "primary"                                   # Required. primary / offsite / test.
+uuid = "647693ed-490e-4c09-8816-189ba2baf03f"     # Recommended. Identity verification.
+max_usage_percent = 90                             # Optional. Space threshold.
+min_free_bytes = "500GB"                           # Optional. Space threshold.
+```
+
+| Field | Required? | Default | Notes |
+|-------|-----------|---------|-------|
+| `label` | Yes | — | Unique identifier. Used in subvolume `drives` lists. |
+| `mount_path` | Yes | — | Where the drive mounts. |
+| `snapshot_root` | Yes | — | Relative path under `mount_path` for snapshots. |
+| `role` | Yes | — | `primary`, `offsite`, or `test`. |
+| `uuid` | No | — | BTRFS filesystem UUID. Strongly recommended. Verified before sends. |
+| `max_usage_percent` | No | — | Skip sends when usage exceeds this. |
+| `min_free_bytes` | No | — | Skip sends when free space drops below this. |
+
+**Note on drive tokens:** Drive tokens (`.urd-drive-token`) are a runtime identity
+mechanism managed by Urd automatically. They are not config fields. When a drive's token
+doesn't match expectations, Urd blocks sends and guides the user to `urd drives adopt`.
+The config declares the drive; the token system verifies it at runtime.
+
+**Space constraints (v1 schema):**
+
+Space constraints move from `[local_snapshots]` roots to a `min_free_bytes` field on each
+subvolume block. This keeps each block fully self-describing — no cross-referencing
+between sections, no path-matching between `[[space_constraints]]` and `snapshot_root`.
+
+```toml
+[[subvolumes]]
+name = "htpc-home"
+source = "/home"
+snapshot_root = "~/.snapshots"
+min_free_bytes = "10GB"                            # Skip snapshots when space is low
+protection = "fortified"
+drives = ["WD-18TB", "WD-18TB1"]
+```
+
+When multiple subvolumes share a `snapshot_root`, each declares its own threshold (or
+omits it). At runtime, the space check is per-subvolume: "does the filesystem containing
+this subvolume's `snapshot_root` have at least `min_free_bytes` free?" Subvolumes sharing
+a root naturally share the filesystem check — no deduplication needed.
+
+**Migration:** `urd migrate` copies the `min_free_bytes` value from the legacy
+`[local_snapshots]` root entry onto each subvolume that was in that root's list.
+
+**Design rationale (adversary finding #3):** The original ADR-111 proposed a separate
+`[[space_constraints]]` section with path-based matching. This introduced cross-referencing
+by path — the very problem ADR-111 was designed to solve. The subvolume-level field is
+simpler, eliminates path-matching fragility (tilde expansion, trailing slashes,
+canonicalization), and keeps each block fully self-describing.
+
+**General section (v1 schema):**
+
+The v1 `[general]` section is minimal by default. Infrastructure paths use XDG-compliant
+defaults and only appear when the user overrides them. A generated config looks like:
+
+```toml
+[general]
+config_version = 1
+run_frequency = "daily"
+```
+
+A power user who overrides paths:
+
+```toml
+[general]
+config_version = 1
+run_frequency = "daily"
+state_db = "/custom/path/urd.db"
+metrics_file = "/custom/path/backup.prom"
+```
+
+| Field | Required? | Default | Notes |
+|-------|-----------|---------|-------|
+| `config_version` | Yes (v1) | — | Must be `1`. Absent = legacy schema. |
+| `run_frequency` | No | `daily` | How often Urd runs. Determines derived intervals. |
+| `state_db` | No | `~/.local/share/urd/urd.db` | SQLite database path. |
+| `metrics_file` | No | `~/.local/share/urd/backup.prom` | Prometheus textfile path. |
+| `log_dir` | No | `~/.local/share/urd/logs` | Log directory. |
+| `btrfs_path` | No | `/usr/sbin/btrfs` | Path to btrfs binary. |
+| `heartbeat_file` | No | `~/.local/share/urd/heartbeat.json` | Health signal path. |
+
+**Migration note:** `urd migrate` preserves existing path overrides but omits fields
+that match the defaults. The migrated config is as short as possible while preserving
+the user's customizations.
+
+**Design rationale:** The encounter generates the shortest possible config that fully
+describes the user's protection intent. Every line the user doesn't need to read is a
+line that doesn't confuse them. Infrastructure paths are not protection intent.
+
+**Notifications (v1 schema):**
+
+```toml
+[notifications]
+enabled = true
+min_urgency = "warning"                            # info / warning / critical
+
+[[notifications.channels]]
+type = "desktop"
+
+[[notifications.channels]]
+type = "webhook"
+url = "https://ntfy.sh/my-backups"
+
+[[notifications.channels]]
+type = "command"
+path = "/usr/local/bin/notify-script"
+args = ["--json"]
+
+[[notifications.channels]]
+type = "log"
+```
+
+The notification config structure is unchanged from the current implementation. Including
+it here makes ADR-111 the complete schema reference it's supposed to be.
+
+#### 4. `ResolvedSubvolume` gains `snapshot_root` — the critical migration path
+
+**Adversary finding #2:** The legacy codebase uses `Config::snapshot_root_for(&name)`,
+`Config::local_snapshot_dir(&name)`, and `Config::root_min_free_bytes(&name)` — methods
+that iterate `[local_snapshots]` to find the root for a subvolume by name. In v1,
+`[local_snapshots]` doesn't exist. If these methods return `None`, backups silently stop.
+
+**Resolution:** `ResolvedSubvolume` gains a `snapshot_root: PathBuf` field:
+
+- **v1 path:** populated directly from the `snapshot_root` field on the subvolume block.
+- **Legacy path:** populated by looking up `config.snapshot_root_for(&name)` during
+  resolution (the existing cross-reference, preserved for backward compatibility).
+
+All 12+ callers of `snapshot_root_for()`, `local_snapshot_dir()`, and
+`root_min_free_bytes()` migrate to reading from `ResolvedSubvolume` instead of querying
+`Config`. This is the highest-risk mechanical change — a missed caller means broken
+backups. The migration must be exhaustive:
+
+| Module | Callers | Migration |
+|--------|---------|-----------|
+| `plan.rs` | `snapshot_root_for` (1), `root_min_free_bytes` (2) | Read from `ResolvedSubvolume` |
+| `executor.rs` | `local_snapshot_dir` (2), `root_min_free_bytes` (1), `snapshot_root_for` (2) | Read from `ResolvedSubvolume` |
+| `awareness.rs` | `snapshot_root_for` (1), `root_min_free_bytes` (1) | Read from `ResolvedSubvolume` |
+| `config.rs` | `snapshot_root_for` internal (3) | Becomes legacy-only helper |
+
+After migration, `snapshot_root_for()` is a legacy-only method used only during
+resolution of legacy configs. V1 configs never call it.
+
+Similarly, `ResolvedSubvolume` gains `min_free_bytes: Option<u64>` — populated from the
+subvolume's `min_free_bytes` field in v1, or from `root_min_free_bytes()` in legacy.
+
+#### 5. Updated implementation gates
+
+Replace the old checklist with one that reflects current state and remaining work:
+
+**Already implemented (remove from gates):**
+- [x] `ProtectionLevel` enum and `derive_policy()` exist in `types.rs`
+- [x] `protection_level`, `drives`, `run_frequency` config fields parsed and validated
+- [x] `resolve_subvolume()` branches on protection level with custom fallthrough
+- [x] Achievability preflight checks active
+- [x] `urd status` shows protection level
+- [x] Pin-protection safety tests pass with derived retention
+- [x] Transient retention as `local_retention` variant
+- [x] Drive `role` field (primary/offsite/test)
+- [x] Drive UUID verification
+- [x] Notification config parsing
+- [x] `Serialize` on `Interval`, `RunFrequency`, `DriveRole`, `GraduatedRetention`
+
+**Remaining gates for v1:**
+- [ ] `config_version` field in `[general]`; parser branches on version
+- [ ] v1 parser: `[general]` fields defaultable (state_db, metrics_file, log_dir, heartbeat_file)
+- [ ] v1 parser: `snapshot_root` and `min_free_bytes` on subvolume blocks; `[local_snapshots]` eliminated
+- [ ] v1 parser: `[defaults]` section eliminated; custom subvolumes use hardcoded fallbacks
+- [ ] v1 parser: `short_name` optional, defaults to `name`
+- [ ] v1 parser: `protection` field (renamed from `protection_level`)
+- [ ] v1 parser: `enabled` field with default `true`
+- [ ] v1 validation: reject operational fields alongside named `protection` (transient exception only)
+- [ ] v1 validation: error messages guide the user (see §11 for exact messages)
+- [ ] `ResolvedSubvolume` gains `snapshot_root: PathBuf` and `min_free_bytes: Option<u64>`
+- [ ] All callers of `snapshot_root_for()` / `local_snapshot_dir()` / `root_min_free_bytes()` migrated to `ResolvedSubvolume`
+- [ ] Protection level rename: `recorded` / `sheltered` / `fortified` in enum and parsing
+- [ ] `urd migrate` command: legacy → v1 transformation with backup file
+- [ ] `Config` and all nested types derive `Serialize` (P6b prerequisite)
+- [ ] `--confirm-retention-change` flag gates retention tightening on level changes
+- [ ] Hardcoded fallback values documented in help text (generous: hourly=24, daily=30, weekly=26, monthly=12)
+
+#### 6. Terminology alignment
+
+The revised ADR-111 uses current vocabulary throughout:
+
+| Context | ADR-111 currently says | Revision says |
+|---------|----------------------|---------------|
+| Protection levels | guarded/protected/resilient | recorded/sheltered/fortified |
+| Config field name | `protection_level` | `protection` |
+| Incremental mechanism | chain | thread |
+| Drive absence | not mounted | disconnected / away (role-dependent) |
+| Promise states (presentation) | — | sealed/waning/exposed |
+| Safety column | — | EXPOSURE |
+
+These are presentation-layer terms referenced for consistency. The ADR governs config
+structure, not voice rendering — but examples and explanations should use the vocabulary
+the user actually sees.
+
+#### 7. Example configs
+
+The revised ADR includes two complete example configs: one legacy (what exists today)
+and one v1 (what `urd migrate` or `urd setup` produces). This makes the delta concrete
+and serves as the reference for both migration and generation.
+
+**Legacy example (abbreviated):**
+
+```toml
+# No config_version — legacy schema
+
+[general]
+state_db = "~/.local/share/urd/urd.db"
+# ...
+run_frequency = "daily"
+
+[local_snapshots]
+roots = [
+  { path = "~/.snapshots", subvolumes = ["htpc-home", "htpc-root"], min_free_bytes = "10GB" },
+  { path = "/mnt/btrfs-pool/.snapshots", subvolumes = ["docs", "pics"], min_free_bytes = "50GB" }
+]
+
+[defaults]
+snapshot_interval = "1d"
+send_interval = "1d"
+[defaults.local_retention]
+hourly = 24
+daily = 30
+[defaults.external_retention]
+daily = 30
+
+[[subvolumes]]
+name = "htpc-home"
+short_name = "htpc-home"
+source = "/home"
+protection_level = "resilient"
+drives = ["WD-18TB", "WD-18TB1"]
+```
+
+**v1 example (abbreviated):**
+
+```toml
+[general]
+config_version = 1
+run_frequency = "daily"
+
+# ── Drives ───────────────────────────────────────
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/run/media/user/WD-18TB"
+snapshot_root = ".snapshots"
+role = "primary"
+uuid = "647693ed-490e-4c09-8816-189ba2baf03f"
+max_usage_percent = 90
+min_free_bytes = "500GB"
+
+# ── NVMe volumes (snapshot root: ~/.snapshots) ───
+
+[[subvolumes]]
+name = "htpc-home"
+source = "/home"
+snapshot_root = "~/.snapshots"
+min_free_bytes = "10GB"
+protection = "fortified"           # irreplaceable — survive site loss
+drives = ["WD-18TB", "WD-18TB1"]
+
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+min_free_bytes = "10GB"
+local_retention = "transient"      # NVMe too small for local history
+drives = ["WD-18TB1"]
+
+# ── Storage pool (snapshot root: /mnt/btrfs-pool/.snapshots) ──
+
+[[subvolumes]]
+name = "subvol2-pics"
+source = "/mnt/btrfs-pool/subvol2-pics"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+min_free_bytes = "50GB"
+protection = "fortified"           # irreplaceable — survive site loss
+drives = ["WD-18TB", "WD-18TB1"]
+```
+
+Note what's different:
+- `config_version = 1` present
+- `[general]` only has `config_version` and `run_frequency` — infrastructure paths use defaults
+- No `[defaults]` section
+- No `[local_snapshots]` section — `snapshot_root` and `min_free_bytes` inline on each subvolume
+- `protection` replaces `protection_level`, values are `fortified` not `resilient`
+- `short_name` omitted where it equals `name`
+- No operational overrides on named levels
+
+#### 8. `snapshot_root` repetition — acknowledged tension
+
+The v1 schema inlines `snapshot_root` on every subvolume block. For a config with 9
+subvolumes on two filesystems, that's 9 `snapshot_root` lines — 7 of them identical.
+This is the correct trade-off: self-describing blocks are worth the repetition, and
+cross-referencing (which `[local_snapshots]` was) is the problem ADR-111 solves.
+
+But the repetition matters for readability. Config generators (the encounter, `urd migrate`)
+should mitigate this through **grouping and visual structure**:
+
+```toml
+# ── NVMe volumes (snapshot root: ~/.snapshots) ──
+
+[[subvolumes]]
+name = "htpc-home"
+source = "/home"
+snapshot_root = "~/.snapshots"
+protection = "fortified"
+drives = ["WD-18TB", "WD-18TB1"]
+
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+local_retention = "transient"
+drives = ["WD-18TB1"]
+
+# ── Storage pool (snapshot root: /mnt/btrfs-pool/.snapshots) ──
+
+[[subvolumes]]
+name = "subvol2-pics"
+source = "/mnt/btrfs-pool/subvol2-pics"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+protection = "fortified"
+drives = ["WD-18TB", "WD-18TB1"]
+```
+
+Grouping comments and physical ordering make the repetition visually coherent. The
+`snapshot_root` is still on every block (self-describing), but the human reader processes
+it as "this group shares a root" rather than "why is this repeated 7 times?"
+
+#### 9. Intention comments in generated configs
+
+When the encounter (or any config generator) produces a config, it should embed the
+user's classification as a comment — preserving the *why* alongside the *what*:
+
+```toml
+[[subvolumes]]
+name = "subvol2-pics"
+source = "/mnt/btrfs-pool/subvol2-pics"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+protection = "fortified"           # irreplaceable — survive site loss
+drives = ["WD-18TB", "WD-18TB1"]
+
+[[subvolumes]]
+name = "subvol4-multimedia"
+source = "/mnt/btrfs-pool/subvol4-multimedia"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+protection = "recorded"            # replaceable — local snapshots sufficient
+```
+
+The comments `# irreplaceable — survive site loss` and `# replaceable — local snapshots
+sufficient` came from the encounter's conversation. They are the user's own answers,
+encoded as context for their future self.
+
+Six months later, the user reads their config and doesn't just see *what* they chose —
+they see *why*. The encounter leaves a trace of the conversation in the artifact it
+produced. This turns a config file into a document of intent.
+
+**Implementation:** The `WizardAnswers` struct from 6-H already carries `Importance` and
+`DisasterScope` per subvolume. The config serializer formats these as trailing comments.
+TOML comments are not parsed — they survive round-trips through text editing but are lost
+if the config is regenerated from parsed structs. This is acceptable: intention comments
+are a one-time gift from the encounter, not a maintained data structure.
+
+#### 10. `urd migrate` output experience
+
+Migration is a trust moment. The user is handing their backup configuration to a tool
+and saying "change this for me." The output must be clear enough to trust but concise
+enough to read.
+
+**Exact output format:**
+
+```
+urd migrate
+
+  Config: ~/.config/urd/urd.toml
+  Schema: legacy → v1
+
+  Changes:
+    ✓ Inlined snapshot_root into 9 subvolume blocks
+    ✓ Inlined min_free_bytes onto 9 subvolume blocks
+    ✓ Removed [defaults] — values baked into custom subvolumes
+    ✓ Renamed protection levels (guarded→recorded, protected→sheltered, resilient→fortified)
+    ✓ Removed redundant short_name from 3 subvolumes (matched name)
+    ✓ Omitted 4 general fields that match defaults
+    ⚠ subvol4-multimedia: had protection="recorded" with snapshot_interval="1w" override
+      → Converted to custom (kept your 1w interval)
+
+  Written to: ~/.config/urd/urd.toml
+  Backup saved: ~/.config/urd/urd.toml.legacy
+
+  Next: urd plan — verify the migration looks right
+```
+
+**Rules:**
+- Always save a backup to `{config_path}.legacy` before overwriting. Always. No flag needed.
+  The backup is the safety net that makes automatic migration trustworthy.
+- Print every change as a `✓` line. Print override conversions as `⚠` lines.
+- End with a concrete next step (`urd plan`).
+- If the config is already v1: "Config is already v1 schema. Nothing to migrate."
+- If `--dry-run` is passed: print the changes without writing. Show the generated v1
+  config to stdout.
+
+#### 11. Validation error messages for v1
+
+Error messages are the UX for validation failures. Write them before implementing the
+validation rules — if a great error message can't be written for a rule, the rule might
+be wrong.
+
+**Operational field alongside named protection:**
+```
+Config error: snapshot_interval is not allowed with protection = "fortified"
+
+  Fortified protection derives all operational parameters automatically.
+  To keep snapshot_interval = "1w", remove the protection field (custom policy).
+  To use fortified protection, remove snapshot_interval.
+```
+
+**Named protection without required drives:**
+```
+Config error: sheltered protection needs at least one drive
+
+  Sheltered means your data is sheltered on an external drive.
+  Add a drives list: drives = ["WD-18TB"]
+  Or use recorded for local-only protection.
+```
+
+**Fortified without offsite drive:**
+```
+Config error: fortified protection needs at least one offsite drive
+
+  Fortified means your data survives site loss — fire, theft, flood.
+  At least one drive in your drives list must have role = "offsite".
+  Or use sheltered if drive-failure protection is sufficient.
+```
+
+**Old protection level name in v1 config:**
+```
+Config error: unknown protection level "resilient"
+
+  Did you mean "fortified"? Protection level names changed in config v1:
+    guarded → recorded
+    protected → sheltered
+    resilient → fortified
+  Run urd migrate to update automatically.
+```
+
+**Missing config_version in v1-shaped config** (has snapshot_root on subvolume but no
+version field — probably a hand-edited migration attempt):
+```
+Config error: snapshot_root on [[subvolumes]] requires config_version = 1
+
+  Add config_version = 1 to [general], or run urd migrate to convert automatically.
+```
+
+### What does NOT change in the revised ADR-111
+
+- **All 10 principles** — every one still holds
+- **The structural vs runtime validation distinction**
+- **The template philosophy** (scaffold, don't govern)
+- **The TOML format decision**
+- **The config versioning approach** (one version at a time, `urd migrate`)
+- **The ownership boundary** with ADR-110 (ADR-111 = structure, ADR-110 = semantics)
+
+## Module Map
+
+| Module | Changes | Test Strategy |
+|--------|---------|---------------|
+| `config.rs` | Dual parser (legacy + v1), `snapshot_root` + `min_free_bytes` + `enabled` on `SubvolumeConfig`, remove `[defaults]`/`[local_snapshots]` from v1 path, `protection` field rename, `short_name` optional, `[general]` fields defaultable | Parse tests for both schemas, round-trip tests (v1), validation rejection tests, default-path tests |
+| `types.rs` | Rename `ProtectionLevel` variants (`Guarded`→`Recorded`, etc.), add v1 serde aliases, `protection` field rename in serde, `ResolvedSubvolume` gains `snapshot_root: PathBuf` + `min_free_bytes: Option<u64>` | Derivation tests with new names, parse/display roundtrip, snapshot_root resolution tests |
+| `plan.rs` | Migrate `snapshot_root_for()` / `root_min_free_bytes()` calls to `ResolvedSubvolume` fields | Existing tests, verify snapshot creation with v1 config |
+| `executor.rs` | Migrate `local_snapshot_dir()` / `snapshot_root_for()` / `root_min_free_bytes()` calls to `ResolvedSubvolume` fields | Existing tests, verify backup flow with v1 config |
+| `awareness.rs` | Migrate `snapshot_root_for()` / `root_min_free_bytes()` calls to `ResolvedSubvolume` fields | Existing tests |
+| `commands/migrate.rs` | New command: read legacy config, transform to v1, write backup, print summary | Transform tests with fixture configs, backup-file test, override-conversion test, default-omission test, dry-run test |
+| `main.rs` | Add `migrate` subcommand | — |
+| `preflight.rs` | Update achievability checks for new level names | Existing tests renamed |
+| `voice.rs` | Update any hardcoded protection level display strings | Existing tests updated |
+| `output.rs` | Update protection level references in structured output | Existing tests updated |
+| ADR-111 | Full revision per this design | — (document, not code) |
+| ADR-110 | Update level names, reference revised ADR-111 | — (document, not code) |
+| Example config | New `config/urd.toml.v1.example` alongside legacy | — |
+
+## Effort Estimate
+
+**4 sessions**, calibrated against completed work:
+
+| Session | Deliverable |
+|---------|------------|
+| 1 | **ADR-111 revision** (the document itself) + **P6a** (protection level enum rename in code — recorded/sheltered/fortified). P6a is mechanical (search-and-replace + test updates) and anchors the vocabulary before schema work. |
+| 2 | **P6b** (add `Serialize` to `Config` and all nested types). Clean single-purpose session. |
+| 3 | **v1 parser** (dual-path config loading, `snapshot_root` + `min_free_bytes` inline, `[defaults]` removed, `short_name` optional, `enabled`, `protection` field name) + **`ResolvedSubvolume` migration** (add `snapshot_root` and `min_free_bytes` fields, migrate all 12+ callers in plan.rs, executor.rs, awareness.rs). This is the highest-risk session — touches every module that creates snapshots. |
+| 4 | **`urd migrate`** command + **validation changes** (reject operational fields on named levels in v1, error messages) + **example config update** + **CLAUDE.md update**. |
+
+**Comparison:** UUID fingerprinting was ~1 session (1 module, 10 tests). This touches
+more modules but most changes are mechanical (renames, field moves, parser branching).
+The `ResolvedSubvolume` caller migration (session 3) is the riskiest piece — not because
+it's hard, but because a missed caller means broken backups.
+
+## Sequencing
+
+1. **ADR-111 revision + P6a (session 1).** The document is the spec. Write it before code.
+   P6a (enum rename) is mechanical and anchors the vocabulary.
+2. **P6b (session 2).** Add Serialize to all config types. Clean, single-purpose.
+3. **v1 parser + ResolvedSubvolume migration (session 3).** The dual-path parser is the
+   core structural change. The `ResolvedSubvolume` caller migration is tightly coupled —
+   the v1 parser needs `snapshot_root` on subvolumes, and the callers need `snapshot_root`
+   on `ResolvedSubvolume`. Do both in one session so the system is never in a broken
+   intermediate state.
+4. **`urd migrate` + validation + example config (session 4).** Depends on both parsers
+   existing (reads legacy, writes v1).
+
+Risk-first ordering: sessions 1-2 are low-risk mechanical changes that clear the path.
+Session 3 is highest risk (touches config loading + every module that creates snapshots).
+Session 4 is new logic but isolated (the migrate command).
+
+## Architectural Gates
+
+**ADR-111 itself is the gate.** This design proposes revising an accepted ADR. The revision
+does not change the ADR's principles or architectural direction — it updates the
+specification to match the system. No new ADR needed.
+
+**ADR-110 needs a coordinated update.** The protection level rename affects ADR-110's
+taxonomy section. Update both ADRs in the same session.
+
+**ADR-105 (backward compatibility) is preserved.** On-disk data formats (snapshot names,
+pin files, metrics) are untouched. The config schema has its own versioning (ADR-111
+principle 9), independent of data format contracts.
+
+## Rejected Alternatives
+
+### A. Skip the revision, build 6-H against the legacy schema
+
+Rejected because it creates immediate technical debt: every config generated by the
+encounter becomes a migration target the moment v1 ships. New users would start with
+configs they're told to migrate within months. This contradicts the encounter's promise
+of "set and forget."
+
+### B. Implement v1 without a migration command
+
+Rejected because Urd has exactly one active user with a production config that runs
+nightly. Breaking that config without a migration path violates ADR-105's spirit (even
+though ADR-105 scopes to data formats, not config). More importantly, `urd migrate`
+becomes essential for any future user who upgrades — it's infrastructure, not a
+convenience.
+
+### C. Support both schemas indefinitely (no migration requirement)
+
+Rejected per ADR-111 principle 9: one schema version at a time. Dual-schema support
+accumulates parser complexity and makes every config-touching feature test two code paths
+forever. The cost of `urd migrate` is one command; the cost of permanent dual-schema is
+every future change.
+
+### D. Rename protection levels to purely descriptive terms (local/external/geographic)
+
+Considered `local` / `external` / `geographic` as maximally descriptive names. Rejected
+because they describe the mechanism, not the outcome. `recorded` / `sheltered` /
+`fortified` describe what the user's data *becomes* — recorded in history, sheltered from
+hardware failure, fortified against site loss. The names carry the promise, not the
+implementation. This aligns with Urd's design principle: the user declares intent, Urd
+derives operations.
+
+### E. Change the config field from `protection_level` to `promise`
+
+Considered using `promise = "fortified"` to match Urd's promise model vocabulary. Rejected
+because "promise" is a system concept (Urd promises to deliver a protection level), not a
+user-facing config concept. The user sets a protection level; Urd makes a promise to honor
+it. The config field should name what the user is choosing (`protection`), not what the
+system is doing internally (`promise`).
+
+### F. Make `transient` a named protection level instead of a retention variant
+
+Considered making `protection = "transient"` a fourth named level for space-constrained
+volumes. Rejected because transient describes a *storage constraint* (NVMe is too small
+for local history), not a *protection intent*. A transient subvolume can be sheltered or
+fortified depending on its drives — transient retention with fortified protection is a
+valid and common combination (e.g., htpc-root on NVMe sent to two external drives).
+Making transient a protection level would conflate storage with intent.
+
+### G. Separate `[[space_constraints]]` section with path-based matching
+
+The original ADR-111 proposed a `[[space_constraints]]` section where each entry named a
+filesystem path and a threshold. Subvolumes would be matched to constraints by comparing
+their `snapshot_root` against the constraint's `path`. Rejected because this reintroduces
+cross-referencing by path — the very problem ADR-111 was designed to solve. Path matching
+is fragile (tilde expansion, trailing slashes, canonicalization). A `min_free_bytes` field
+on each subvolume block is simpler, keeps blocks self-describing, and the implementation
+is trivial (check free space on the filesystem containing `snapshot_root`). The cost is
+repetition: subvolumes sharing a root repeat the same threshold. This is the same trade-off
+as `snapshot_root` repetition — self-describing blocks are worth it.
+
+## Assumptions
+
+1. **The protection level rename (recorded/sheltered/fortified) is final.** The vocabulary
+   decisions from 2026-03-31 are treated as resolved. If there's remaining uncertainty
+   about these names, it should be resolved before this work begins. Every session of code
+   that uses the old names is a session of rename work later.
+
+2. **Legacy schema support is temporary.** The dual-parser exists only to provide a
+   migration path. After a reasonable transition period (to be defined — probably until
+   v1.0), the legacy parser can be removed. This assumption affects how much effort to
+   invest in the legacy path.
+
+3. **`urd migrate` can be imperfect on comments.** TOML editing that preserves comments
+   is hard. The migration should preserve structure and meaning perfectly. Comment
+   preservation is best-effort. If comments are lost, the user can re-add them to the
+   cleaner v1 config. This is an acceptable trade-off for a one-time migration.
+
+4. **The encounter (6-H) will only generate v1 configs.** New users should never see the
+   legacy schema. The encounter targets v1 exclusively. This means v1 parser + validation
+   must be complete before 6-H begins.
+
+5. **Named levels are still provisional per ADR-110's maturity model.** The rename doesn't
+   graduate them. `custom` remains the recommended approach for production configs until
+   named levels earn opaque status through operational evidence. The rename makes the names
+   *ready* for graduation — it doesn't trigger it.
+
+## Open Questions
+
+### 1. Should `urd migrate` be interactive or automatic?
+
+**Resolved: Option A (automatic) with backup file and `--dry-run`.**
+
+Read legacy, write v1, save backup to `{config_path}.legacy`, print structured summary
+(see §9 for exact output format). Operational overrides on named levels are converted
+to custom with a `⚠` warning in the summary.
+
+`--dry-run` prints the summary and generated config to stdout without writing. The user
+reviews before committing.
+
+The backup file is not optional. It is the safety net that makes automatic migration
+trustworthy. Interactive config migration is fragile and Urd's convention is
+non-interactive commands with explicit output.
+
+### 2. Should the v1 parser accept old protection level names as aliases?
+
+**Option A: Strict.** v1 only accepts `recorded`/`sheltered`/`fortified`. Old names are
+parse errors. Clean break.
+
+**Option B: Aliases.** v1 accepts both old and new names, with a deprecation warning for
+old names. Softer transition.
+
+**Leaning toward:** Option A. `urd migrate` handles the rename. After migration, the old
+names are gone. Aliases create a permanent parsing complexity for a one-time transition.
+ADR-111 principle 9: one schema version at a time.
+
+### 3. When should the legacy parser be removed?
+
+**Option A: At v1.0.** Clean break at the major version boundary.
+
+**Option B: Two minor versions after v1 schema ships.** Give users time to migrate.
+
+**Option C: Never remove — detection is cheap.** The version field check is one `if`.
+
+**Leaning toward:** Option A. Pre-1.0 is the time for breaking changes. The legacy parser
+is dead code after every user has migrated. For Urd's current single-user state, this is
+immediate; for future users, `urd migrate` is part of the upgrade path.
+
+### 4. Does `[notifications]` gain any new structure in v1?
+
+**Option A: Unchanged.** The notification config structure is fine. It's already
+self-describing and doesn't suffer from the problems ADR-111 fixed (no inheritance, no
+cross-references).
+
+**Option B: Add `sentinel_notifications` section.** Separate sentinel-specific notification
+config from backup notification config.
+
+**Leaning toward:** Option A. The notification config doesn't have the structural problems
+this revision addresses. Don't change what isn't broken.
+
+### 5. Should `protection` field accept `"custom"` explicitly or only as absence?
+
+**Option A: Explicit.** `protection = "custom"` is valid, means "I'm managing this."
+
+**Option B: Absence only.** Omitting `protection` means custom. Writing `protection = "custom"` 
+is redundant but accepted (or rejected as unnecessary).
+
+**Leaning toward:** Option A with the convention that generated configs omit it. Explicit
+`"custom"` is useful as documentation: "I chose this deliberately" vs ambiguous absence.
+The enum already has a `Custom` variant; let it be expressible.

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,6 +5,7 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
+| 010 | Config Schema v1 (ADR-111 revision) | [design](../95-ideas/2026-04-03-design-010-config-schema-v1.md) | - | [adversary](../99-reports/2026-04-03-design-review-010-config-schema-v1.md) | - | - |
 | 009 | `urd drives` subcommand | [design](../95-ideas/2026-04-02-design-009-urd-drives-subcommand.md) | - | [adversary](../99-reports/2026-04-03-design-review-009-006-phase-c-drives.md) | merged | [#72](https://github.com/vonrobak/urd/pull/72) |
 | 008 | Doctor pin-age correlation | [design](../95-ideas/2026-04-02-design-008-doctor-pin-age-correlation.md) | - | [adversary](../99-reports/2026-04-03-design-review-007-008-phase-b-communication.md) | merged | [#70](https://github.com/vonrobak/urd/pull/70) |
 | 007 | Safety gate communication | [design](../95-ideas/2026-04-02-design-007-safety-gate-communication.md) | - | [adversary](../99-reports/2026-04-03-design-review-007-008-phase-b-communication.md) | merged | [#70](https://github.com/vonrobak/urd/pull/70) |

--- a/docs/96-project-supervisor/roadmap.md
+++ b/docs/96-project-supervisor/roadmap.md
@@ -74,6 +74,65 @@ interim error message from "Run `urd doctor`" to "Run `urd drives adopt {label}`
 **Gate:** After Phase C, drives have a user-facing identity layer and reconnection
 closes the anxiety loop. MINOR version bump (new command = new feature).
 
+### Validation gate + UPI 010: Config Schema v1 (parallel tracks)
+
+The test session is calendar-bound (live with v0.9.0 for days), not session-bound.
+UPI 010 sessions 1-2 change internals (enum names, Serialize trait) without affecting
+user-facing behavior. These run in parallel. UPI 010 sessions 3-4 change runtime
+behavior (parser, migrate) and come after the test session findings are addressed.
+
+**Track A: v0.9.0 test session** (calendar time)
+
+```
+Test session goals:
+  1. Live with v0.9.0 for several days (timer, Sentinel, drive cycles)
+  2. Simulate the new-user journey (run commands cold, note confusion)
+  3. Read your own config — can you narrate your protection story?
+  4. Fix systemd timer --auto flag before testing (pending since v0.8.0)
+
+Output: prioritized issue list → targeted fix phase if needed
+```
+
+**Track B: UPI 010 sessions 1-2** (concurrent with test session)
+
+```
+UPI 010 session 1:
+  - Revise ADR-111 document (the spec, not code)
+  - Update ADR-110 level names
+  - P6a: enum rename in code (recorded/sheltered/fortified)
+    Legacy serde aliases preserved — production config unchanged
+
+UPI 010 session 2:
+  - P6b: add Serialize to Config and all nested types
+  - No behavioral change — purely additive
+```
+
+These are safe to run during the test session because they don't change what any
+command outputs, how backups run, or what the Sentinel does.
+
+**Gate:** After the test session, the runtime foundation is validated. After sessions
+1-2, the vocabulary and serialization infrastructure are ready.
+
+### Post-validation: UPI 010 runtime changes + fix phase
+
+```
+Fix test findings          (~0-2 sessions, depending on what surfaces)
+
+UPI 010 session 3:
+  - v1 parser (dual-path config loading)
+  - urd migrate command
+  - v1 validation with guided error messages
+  - Example config update
+
+UPI 010 session 4 (if needed):
+  - Edge cases, round-trip tests, CLAUDE.md update
+
+Migrate own production config → live with v1 for several nightly runs
+```
+
+**Gate:** After migrating and validating your own config on v1, the schema is proven
+in production. The encounter can target v1 with confidence.
+
 ### Phase D: Progressive disclosure + The Encounter
 
 ```
@@ -82,43 +141,52 @@ closes the anxiety loop. MINOR version bump (new command = new feature).
 
 6-H — The Encounter                   (~4-6 sessions)
     Auto-trigger onboarding, auto-detection, Fate Conversation, config generation
+    Design: docs/95-ideas/2026-03-31-design-h-guided-setup-wizard.md (reviewed)
 ```
 
 **Dependencies:** 6-O builds the framework 6-H needs. Both benefit from Phases A-C:
-truthful status (A), honest communication (B), drive identity layer (C).
+truthful status (A), honest communication (B), drive identity layer (C). 6-H targets
+v1 schema exclusively — blocked by UPI 010 completion and production validation.
 
-**Design constraints from Steve reviews (2026-04-02):**
+**Design constraints from Steve reviews (2026-04-02, 2026-04-03):**
 - The encounter is a conversation about what you're afraid of losing, not a config form
 - "Set and forget" vs "delve deeper" — two exits, same quality config
 - Strategy names (3-2-1, GFS, etc.) stay internal — never user-facing
 - Config generation is a pure function — enables CLI, future TUI, future Spindle
+- Generated configs include intention comments from the encounter conversation
+- `[general]` section is minimal — infrastructure paths use XDG defaults
+- Subvolume blocks grouped by snapshot root with visual structure comments
 
 ```
-Phase A: v0.8.1 (~1 session)
+Phase A: v0.8.1 ✓
   004 (token gate) ─┐
   005 (assess + local) ─┘─→ tag v0.8.1
                             │
-Phase B: v0.8.2 (~0.75 session)
+Phase B: v0.8.2 ✓
   007 (deferred) ─┐
   008 (doctor) ───┘─→ tag v0.8.2
                        │
-Phase C: v0.9.0 (~1-2 sessions)
+Phase C: v0.9.0 ✓
   009 (urd drives) ─────┐
   006 (notifications) ──┘─→ tag v0.9.0
                              │
-                      Update 004 message
-                      (doctor → drives adopt)
-                             │
+Parallel tracks:
+  Track A: test session ────────────────────┐
+  Track B: UPI 010 s1 (ADR+P6a) ─ s2 (P6b) │
+                                            │
+Post-validation:                            │
+  Fix test findings ─ UPI 010 s3 (v1 parser + migrate)
+                       │
+  Migrate own config, validate v1
+                       │
 Phase D: (~6-8 sessions)
   6-O (progressive disclosure)
     │
   6-H (the encounter) ─→ v1.0 horizon
 ```
 
-Estimated: ~10-12 sessions remaining to v1.0 readiness.
-
-P6a (enum rename) and P6b (config Serialize) remain deferred patch-tier chores — do
-as quick PRs when convenient. P6b is a prerequisite for 6-H config generation.
+Estimated: ~8-10 sessions remaining to v1.0 readiness. The parallel tracks save
+1-2 sessions of calendar time vs purely sequential execution.
 
 ## Horizon
 
@@ -153,11 +221,13 @@ Source: Steve review "project-trajectory."
 
 ## Strategic Context
 
-**ADR-111 config migration is the largest deferred gate.** The target config architecture
-(explicit drive routing, no inheritance, named levels are opaque) is defined but not
-implemented. Legacy schema (`[defaults]`, `[local_snapshots]`) is in use. The guided setup
-wizard (6-H) will generate ADR-111-schema configs from day one. Full migration machinery
-for existing configs comes after the wizard proves the schema in practice.
+**ADR-111 config schema is designed and sequenced (UPI 010).** The v1 schema is fully
+specified: self-describing subvolume blocks, no `[defaults]`, no `[local_snapshots]`,
+`protection = "fortified"` (renamed levels), minimal `[general]`, intention comments
+in generated configs, guided validation error messages, and `urd migrate` with backup
+file. Design: `docs/95-ideas/2026-04-03-design-010-config-schema-v1.md`. Implementation
+runs in parallel with the test session (sessions 1-2) then sequentially after test
+findings (sessions 3-4). The encounter targets v1 exclusively.
 
 **Vocabulary is frozen.** Current terms — sealed/waning/exposed (promise states),
 recorded/sheltered/fortified (protection levels), thread (snapshot chain),
@@ -182,8 +252,7 @@ Maintained here as context for sequencing decisions.
 - Parallel notification builders in notify.rs and sentinel_runner.rs (maintenance risk)
 - Pipe bytes vs. on-disk size mismatch in space estimation (1.2x margin handles common case)
 - Journal persistence gap: journald may purge user-unit logs
-- P6a: ADR-110 enum rename (recorded/sheltered/fortified) — do as patch when convenient
-- P6b: Config Serialize refactor — do as patch, prerequisite for 6-H config generation
+- P6a + P6b: absorbed by UPI 010 (sessions 1-2)
 - Planner helper functions approaching parameter limit (10 args) — pass `&PlanFilters` instead of destructured bools in next planner change
 
 ## Deferred (no current timeline)

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -25,15 +25,28 @@ tagged and deployed.
 
 Nothing active.
 
-## Next Up
+## Next Up (parallel tracks)
 
-1. **Phase D: Progressive disclosure + The Encounter** — ~6-8 sessions total
-   - 6-O: Progressive disclosure (~2 sessions)
-   - 6-H: The Encounter — auto-trigger onboarding, Fate Conversation, config generation (~4-6 sessions)
-   - Designs: 6-O has design doc; 6-H needs /design
-   - P6b (config Serialize refactor) is a prerequisite for 6-H config generation
-2. **P6a: ADR-110 enum rename** — deferred patch (recorded/sheltered/fortified)
-3. **P6b: Config Serialize refactor** — deferred patch, prerequisite for 6-H
+**Track A: v0.9.0 test session** (calendar time — live with the tool)
+   - Fix systemd timer `--auto` flag first (pending since v0.8.0)
+   - Live with v0.9.0 for several days (timer, Sentinel, drive plug/unplug cycles)
+   - Simulate the new-user journey: run commands cold, note confusion points
+   - Read your own config — can you narrate your protection story?
+   - Output: prioritized issue list → targeted fix phase if needed
+
+**Track B: UPI 010 sessions 1-2** (concurrent — no user-facing changes)
+   - Session 1: Revise ADR-111 document + ADR-110 update + P6a (enum rename)
+   - Session 2: P6b (add Serialize to Config and all nested types)
+   - Design: `docs/95-ideas/2026-04-03-design-010-config-schema-v1.md`
+
+**Then sequential:**
+1. Fix test session findings (~0-2 sessions)
+2. UPI 010 sessions 3-4: v1 parser, `urd migrate`, validation messages, example config
+3. Migrate own production config → validate v1 in real usage
+4. **Phase D: Progressive disclosure + The Encounter** — ~6-8 sessions
+   - 6-O: Progressive disclosure (~2 sessions) — design doc exists
+   - 6-H: The Encounter — Fate Conversation, config generation (~4-6 sessions)
+   - Blocked by: UPI 010 completion and v1 production validation
 
 ## Key Links
 

--- a/docs/99-reports/2026-04-03-design-review-010-config-schema-v1.md
+++ b/docs/99-reports/2026-04-03-design-review-010-config-schema-v1.md
@@ -1,0 +1,268 @@
+---
+upi: "010"
+date: 2026-04-03
+---
+
+# Architectural Adversary Review: Config Schema v1 (UPI 010)
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-03
+**Scope:** Design doc `docs/95-ideas/2026-04-03-design-010-config-schema-v1.md`
+**Mode:** Design review
+**Reviewer:** arch-adversary
+
+## Executive Summary
+
+The design is sound in principle and well-motivated. The v1 schema is cleaner than legacy,
+the migration path is thoughtful, and the protection level rename carries real UX value.
+The two significant findings are both about the migration path: `urd migrate` doing
+default-baking for custom subvolumes can silently change behavior, and the dual-parser
+approach has a hidden complexity in how `ResolvedSubvolume` consumers currently depend on
+`snapshot_root_for()` — a method that doesn't exist in v1's data model.
+
+## What Kills You
+
+For a backup tool, the catastrophic failure mode is **silent data loss**. For a config
+schema migration specifically, the catastrophic failure is **a valid-looking config that
+causes Urd to do the wrong thing silently** — different retention, different drive targets,
+different snapshot intervals — after migration. The user runs `urd migrate`, sees a clean
+summary, and doesn't notice that their subvolume's retention policy quietly changed from
+what `[defaults]` gave them to what the hardcoded fallback gives them.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | **Correctness** | 4 | Migration semantics are mostly right but default-baking has a subtle behavior-change risk (finding #1) |
+| 2 | **Security** | 5 | No new attack surface. Config is not a trust boundary — it's authored by the user. Path handling unchanged. |
+| 3 | **Architectural Excellence** | 4 | Clean separation of concerns. The dual-parser approach is the right call. `snapshot_root_for()` migration is under-specified (finding #2). |
+| 4 | **Systems Design** | 4 | The migration output experience is well-designed. The backup file is the right call. The `--dry-run` path is correct. |
+
+## Design Tensions
+
+### 1. Self-describing blocks vs. DRY config authoring
+
+The design correctly chose self-describing blocks over DRY. The `snapshot_root` repetition
+is the price of eliminating cross-referencing. The acknowledged tension in §7 and the
+grouping-comment mitigation are exactly the right response — acknowledge the cost, mitigate
+it in presentation, don't compromise the principle.
+
+### 2. Clean break vs. graceful transition
+
+The design chose a clean break (v1 rejects old names, `urd migrate` is the bridge). This
+is the right call for a pre-1.0 project with one active user. The alternative — permanent
+aliases — would be the right call for a project with thousands of users. The design matches
+the project's maturity stage.
+
+### 3. Opaque levels vs. the transient exception
+
+The transient exception is a genuine tension. The design resolves it well: transient is a
+storage constraint, not a policy override. But this creates a precedent: "some fields can
+accompany named levels if they're constraints, not overrides." Future features will test
+this boundary. The design should state explicitly that the transient exception is unique
+and will not be extended to other fields without an ADR amendment. Otherwise the opacity
+principle erodes through accumulated exceptions.
+
+## Findings
+
+### #1 — Significant: `urd migrate` default-baking can silently change behavior
+
+**What:** When `urd migrate` removes `[defaults]` and bakes resolved values into custom
+subvolume blocks, the baked values come from the *current* `[defaults]` section. This is
+correct. But the design also says v1 custom subvolumes that omit fields get *hardcoded
+fallbacks* (e.g., `snapshot_interval` defaults to `1d`, `local_retention` defaults to
+`{ daily = 7, weekly = 4 }`).
+
+If the user's legacy `[defaults]` section had `hourly = 24, daily = 30, weekly = 26,
+monthly = 12` for local retention, and a custom subvolume omitted `local_retention`
+entirely, the legacy behavior is: that subvolume gets the defaults section's retention
+(hourly=24, daily=30, weekly=26, monthly=12).
+
+If `urd migrate` bakes these values, the migrated config is correct. But if the user
+*later edits* the v1 config and removes the baked `local_retention` from that subvolume
+(thinking "I'll just use the default"), the v1 hardcoded fallback gives them
+`{ daily = 7, weekly = 4 }` — dramatically less retention than they had before.
+
+**Why it matters:** This is a behavior change that manifests at *edit time*, not at
+*migration time*. The migration itself is correct. The trap is that the v1 defaults are
+less generous than the legacy defaults, and a user who edits their migrated config
+doesn't know this. They delete a line and lose 6 months of retention depth.
+
+**Consequence:** The user edits their config, removes what looks like a redundant line,
+runs `urd backup`, and at the next retention pass, months of weekly/monthly snapshots
+are candidates for deletion that weren't before. This is within two steps of silent
+data loss (edit + retention run).
+
+**Suggested fix:** Two options, not mutually exclusive:
+1. Make the v1 hardcoded fallbacks match what the current `[defaults]` section provides
+   (hourly=24, daily=30, weekly=26, monthly=12). This eliminates the trap entirely at
+   the cost of more generous defaults for new users.
+2. Have `urd migrate` add a comment on baked retention fields: `# was inherited from
+   [defaults] — removing this changes retention`. This preserves the user's awareness.
+
+Option 1 is cleaner. The hardcoded fallbacks should be generous because the cost of
+keeping too many snapshots is disk space; the cost of keeping too few is data loss.
+Fail-open (ADR-107).
+
+### #2 — Significant: `snapshot_root_for()` has 15+ callers that need migration
+
+**What:** The design says "v1 parser eliminates `[local_snapshots]`" and
+"snapshot_root inline on each subvolume block." But it doesn't specify how
+`Config::snapshot_root_for()`, `Config::local_snapshot_dir()`, and
+`Config::root_min_free_bytes()` work in v1.
+
+These methods currently iterate over `local_snapshots.roots` to find the root for a
+subvolume by name. In v1, `local_snapshots` doesn't exist. The root lives on the
+subvolume block itself.
+
+Callers include `plan.rs` (2 calls), `executor.rs` (5 calls), `awareness.rs` (2 calls),
+and `config.rs` internally (3 calls). That's 12+ call sites that need a compatible
+interface.
+
+**Why it matters:** The module map says `config.rs` changes include "remove
+`[local_snapshots]` from v1 path." But it doesn't address the 12+ callers of the
+cross-reference methods. If the v1 parser doesn't populate `local_snapshots.roots` (which
+it shouldn't — the section doesn't exist), these methods return `None` for every subvolume,
+and the planner skips all snapshot creation.
+
+**Consequence:** If implemented naively, the v1 parser produces a config where no
+subvolume has a snapshot root, no snapshots are created, and no sends happen. Backups
+silently stop. This is one bug away from the catastrophic failure mode.
+
+**Suggested fix:** The design should specify that:
+- `ResolvedSubvolume` gains a `snapshot_root: PathBuf` field (populated from the inline
+  field in v1, or from `snapshot_root_for()` in legacy)
+- All callers migrate from `config.snapshot_root_for(&name)` to `resolved.snapshot_root`
+- `Config::snapshot_root_for()` becomes legacy-only (or a thin wrapper that checks v1
+  subvolumes first)
+- This is a mechanical but wide-reaching change that should be in the module map and
+  effort estimate
+
+This is the highest-risk piece of the implementation — not because it's hard, but because
+it touches every module that creates snapshots.
+
+### #3 — Moderate: `[[space_constraints]]` path matching is under-specified
+
+**What:** The design says `[[space_constraints]]` replaces `min_free_bytes` on roots, and
+"multiple subvolumes sharing a snapshot root share one space constraint." But it doesn't
+specify how the matching works.
+
+Currently, `root_min_free_bytes()` iterates `local_snapshots.roots` and checks if the
+subvolume name is in the root's list. In v1, the match would be: "find the
+`[[space_constraints]]` entry whose `path` matches the subvolume's `snapshot_root`."
+
+**Why it matters:** Path matching is fragile. `~/.snapshots` and
+`/home/user/.snapshots` are the same path after tilde expansion but different strings
+before. Trailing slashes, symlinks, and canonicalization all affect string comparison.
+
+**Suggested fix:** Space constraint matching should happen *after* path expansion
+(tilde expansion, canonicalization). The design should state this explicitly. A test
+case: `snapshot_root = "~/.snapshots"` must match `[[space_constraints]] path =
+"~/.snapshots"` even if tilde expands to different absolute paths in different
+contexts (it won't — both expand the same way — but the design should state that
+matching happens on expanded paths).
+
+### #4 — Moderate: The `enabled` field is missing from v1 spec
+
+**What:** The legacy config has `enabled: Option<bool>` on subvolumes, and `[defaults]`
+has `enabled = true`. The v1 field table doesn't include `enabled` at all. The design
+doesn't say whether it's removed, kept with a default, or replaced.
+
+**Why it matters:** If a user has `enabled = false` on a subvolume in legacy config and
+runs `urd migrate`, what happens? The field isn't in the v1 spec, so it's either:
+(a) silently dropped — the subvolume becomes enabled after migration, which is a behavior
+change; or (b) preserved but undocumented — the field works but isn't in the spec.
+
+**Suggested fix:** Add `enabled` to the v1 field table with a default of `true`. Or if
+the field is being removed, the migration must handle it (convert `enabled = false` to
+commenting out the subvolume block, or introduce a different mechanism).
+
+### #5 — Minor: Session 2 is overloaded
+
+**What:** Session 2 includes both P6b (add Serialize to all config types) and the v1
+parser (dual-path loading, snapshot_root inline, [defaults] removal, space_constraints,
+short_name optional, protection field rename). That's two substantial pieces of work.
+
+**Why it matters:** P6b is mechanical (add `#[derive(Serialize)]` to many types, fix any
+that don't serialize cleanly). The v1 parser is structural (new struct definitions, new
+deserialization paths, new validation). Combining them means the session either rushes
+the parser or defers to session 3, which is already allocated to `urd migrate` +
+validation.
+
+**Suggested fix:** Move the v1 parser to session 3 alongside `urd migrate`. They're
+tightly coupled (migrate reads legacy, writes v1 — you need the v1 struct to write to).
+Session 2 becomes P6b only, which is a clean single-purpose session. This extends the
+estimate to 4 sessions (from 3-4) but each session has a coherent deliverable.
+
+### #6 — Commendation: The transient exception reasoning
+
+The reasoning in Rejected Alternative F is precise and load-bearing: "transient describes
+a *storage constraint*, not a *protection intent*." This distinction prevents a category
+error that would have corrupted the protection level taxonomy. A transient subvolume can
+be fortified — that's not a contradiction, it's a real-world configuration (NVMe root
+sent to two offsite drives). Treating transient as a protection level would have made this
+impossible. The design got this exactly right.
+
+### #7 — Commendation: Validation error messages as UX design
+
+Writing the error messages before implementing the validation rules (§10) is an
+underappreciated practice. The messages in the design are specific, actionable, and guide
+the user toward the fix. The "did you mean fortified?" message for old level names in a
+v1 config is particularly good — it catches the most likely migration mistake and offers
+the exact remedy. This should be a standard practice for all future validation work.
+
+## The Simplicity Question
+
+**What could be removed?** Not much. The design is already a revision of an existing ADR,
+not a greenfield design. Every section addresses a real gap between the current ADR-111
+and the current codebase.
+
+**What's earning its keep?**
+- The dual-parser approach (keeps legacy working during transition)
+- The protection level rename (real UX value, not just aesthetics)
+- The `urd migrate` command (infrastructure for every future schema change)
+- Intention comments (the encounter's trace in the config)
+
+**What's borderline?** The `[[space_constraints]]` section adds a new top-level concept.
+The alternative — `min_free_bytes` as an optional field on `[[subvolumes]]` — would be
+simpler and eliminate the path-matching problem (finding #3). The architectural argument
+("space is a filesystem concern") is valid but introduces a cross-reference-by-path that
+partially undoes the self-describing-block principle. Worth reconsidering.
+
+## For the Dev Team
+
+Priority order for implementation:
+
+1. **Decide v1 hardcoded fallback retention values** (finding #1). Before writing any code.
+   If fallbacks match current `[defaults]`, the migration trap disappears. If not, add
+   comments to baked values in migrated configs.
+
+2. **Design the `snapshot_root` migration path on `ResolvedSubvolume`** (finding #2).
+   Before implementing the v1 parser. Add `snapshot_root: PathBuf` to `ResolvedSubvolume`.
+   Map all 12+ callers of `snapshot_root_for()` to the new field. This is the riskiest
+   mechanical change — a missed caller means broken backups.
+
+3. **Add `enabled` to the v1 field table** (finding #4). Quick spec fix.
+
+4. **State that the transient exception is unique** (tension #3). One sentence in the ADR
+   revision: "No other operational field exceptions are anticipated. Extending this
+   precedent requires an ADR amendment."
+
+5. **Specify that space constraint path matching happens on expanded paths** (finding #3).
+   One sentence in the design.
+
+6. **Consider moving v1 parser from session 2 to session 3** (finding #5). Evaluate
+   during implementation — if session 2 feels overloaded, split.
+
+## Open Questions
+
+1. **Should `[[space_constraints]]` be a top-level section or a field on `[[subvolumes]]`?**
+   The design chose the architecturally pure option (filesystem-level concern). The simpler
+   option (subvolume-level field, perhaps `snapshot_root_min_free = "10GB"`) eliminates the
+   cross-reference problem entirely and keeps each block fully self-describing. This is a
+   genuine trade-off worth stress-testing in `/grill-me`.
+
+2. **What happens when `urd migrate` encounters a config with unknown fields?** TOML
+   allows arbitrary fields. If the user has custom comments or experimental fields, the
+   migration should preserve or warn — not silently drop. The design says "comment
+   preservation is best-effort" but doesn't address unknown TOML keys.

--- a/docs/99-reports/2026-04-03-steve-jobs-000-ship-or-test-v09.md
+++ b/docs/99-reports/2026-04-03-steve-jobs-000-ship-or-test-v09.md
@@ -1,0 +1,82 @@
+---
+upi: "000"
+date: 2026-04-03
+mode: vision-filter
+---
+
+# Steve Jobs Review: Ship or Test at v0.9.0?
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-03
+**Scope:** Strategic direction after v0.9.0 — test session vs. roadmap progression
+**Mode:** Vision Filter (project-level)
+
+## The Verdict
+
+Test first. But not aimlessly — test *as* the user who will walk through the encounter, and let what breaks tell you what to build next.
+
+## What's Insanely Great
+
+**The last test-then-fix cycle was the best thing that happened to this project.** The v0.8.0 comprehensive test surfaced six real issues. Phases A–C fixed all of them. The result: v0.9.0 is the most honest, most coherent version of Urd that has ever existed. Status tells the truth. Drives have faces. Communication doesn't gaslight the user. That cycle — real usage revealing real gaps — produced better prioritization than any amount of roadmap planning could have.
+
+**You're asking the right question at the right time.** Most projects barrel forward on the roadmap because the roadmap exists and forward feels like progress. The fact that you're pausing at v0.9.0 to ask "should we validate before we build?" shows the kind of discipline that separates tools that *work* from tools that merely *ship*.
+
+**Phases A–C created a qualitatively different product.** Go back and read the v0.8.0 test results. False degradation. Safety gates that looked like failures. Drives that Urd couldn't identify. Now read the v0.9.0 changelog. Every one of those lies has been replaced with truth. That's not incremental improvement — that's crossing a trust threshold. The tool went from "works but sometimes confuses me" to "I believe what it tells me."
+
+## What's Not Good Enough
+
+**Phase D is the single largest, riskiest feature Urd has attempted.** The Encounter (6-H) is estimated at 4–6 sessions. It involves auto-detection, a conversational wizard, config generation, a new config schema (ADR-111 adjacency), and integration with every module that Phases A–C just fixed. It is the feature where every other feature becomes visible. If something is still broken underneath, the encounter will expose it at the worst possible moment — during a new user's first impression.
+
+Building the encounter on an untested v0.9.0 foundation is exactly the mistake that the v0.8.0 test session caught last time. Phases A–C changed awareness, output, voice, drives, notifications, and the executor. That's half the codebase. You cannot assume all of those changes compose correctly in real usage just because the unit tests pass. 763 tests are necessary. They are not sufficient.
+
+**The roadmap's own sequencing report called for this.** The last Steve review literally said: "Schedule a second physical drive test session after v0.9.0 ships. Verify the full arc before starting the encounter." That wasn't a suggestion. It was item #6 in The Ask. The encounter is too important to build on untested ground. That judgment hasn't changed.
+
+**Progressive disclosure (6-O) before testing is backwards.** 6-O changes how information is presented to the user. If the underlying information has bugs that only surface in real usage, 6-O will paper over them with progressive disclosure — hiding problems behind "show more" rather than fixing them. Test the current information layer first. Then decide what to progressively disclose.
+
+## The Vision
+
+Here's what I'd do. Not "maybe consider" — here's what I'd do:
+
+### Week 1: The real-usage test session
+
+Not a comprehensive 30-test marathon. A focused session with two goals:
+
+**Goal 1: Live with v0.9.0 for a few days.** Let the nightly timer run. Let the Sentinel watch. Plug in a drive, unplug it. Check `urd status` in the morning. Check `urd drives` when a drive is connected and when it's away. Read the notifications. Do what a user does: glance at it, trust it, and occasionally invoke it. Write down every moment where you hesitate, squint, or feel uncertain.
+
+**Goal 2: Simulate the encounter user's journey.** Pretend you've never used Urd. Run `urd` with no arguments. Run `urd status`. Run `urd drives`. Run `urd backup`. What's the experience? Not whether it *works* — whether it *makes sense* to someone who doesn't know the architecture. This is the encounter's dress rehearsal. The encounter can't be better than the tools it introduces.
+
+The output of this session isn't a test matrix. It's a prioritized list: "here's what a new user would stumble on." That list becomes the scope for a targeted fix phase — maybe one session, maybe two. Then you start the encounter with a foundation you've actually stood on.
+
+### Why not just push to Phase D?
+
+Because Phase D is 6–8 sessions of building the most important feature in Urd's lifecycle, and the difference between building it on solid ground vs. building it on "probably fine" ground is the difference between an encounter that delights and an encounter that subtly disappoints.
+
+The original Time Machine shipped late because we refused to ship it broken. The cost of delay was measured in weeks. The cost of shipping a bad first-run experience would have been measured in years of reputation. The encounter *is* Urd's first impression. It gets one chance.
+
+### What about the tech debt items?
+
+P6a (enum rename) and P6b (config Serialize) — do P6b during or right after the test session if there's energy. It's a prerequisite for the encounter's config generation. P6a is cosmetic and can wait forever. Neither is worth a dedicated session.
+
+The known issues list (NVMe accumulation, FileSystemState naming, status string fragility, parallel notification builders, planner parameter limits) — these are real but none are user-facing enough to block the encounter. If the test session surfaces any of them as actual user pain, promote them. Otherwise, they wait.
+
+## The Details
+
+- **The `--auto` flag in the systemd timer is still pending since v0.8.0.** This is a deployment detail, but it means your nightly runs aren't using interval gating. Fix it before the test session so you're testing real autonomous behavior.
+
+- **The CHANGELOG comparison links are stale.** `[Unreleased]` still points to `v0.7.0...HEAD`. Update them to reflect the actual tag progression through v0.9.0. A user browsing the changelog shouldn't see broken links.
+
+- **Check the Sentinel state file schema.** v0.9.0 added reconnection notifications and drive adoption. Does the sentinel state file correctly reflect these new states? If Spindle ever reads this file, it needs to be right.
+
+- **`urd get` for directories is still missing.** If the test session includes a restore scenario (it should), you'll feel this gap viscerally. Don't add it now — but let the test session confirm whether it needs to be pre-encounter or can remain horizon.
+
+## The Ask
+
+1. **Run a focused real-usage session before starting Phase D.** Live with v0.9.0 for a few days. Simulate the new-user journey. Document what feels wrong, not what fails.
+
+2. **Fix the systemd timer `--auto` flag.** You've been running without interval gating since v0.8.0. That's not testing real behavior.
+
+3. **Update CHANGELOG comparison links.** Small detail, but broken links in the changelog undermine the craft signal.
+
+4. **Do P6b (config Serialize) as a quick patch during the test-session week.** It's a prerequisite for the encounter and low-risk. Get it out of the way.
+
+5. **Start Phase D only after the test session's findings are addressed.** If the test session finds nothing — great, you've validated the foundation and can build with confidence. If it finds issues — great, you've caught them before they became the encounter's first impression. Either way, you win.

--- a/docs/99-reports/2026-04-03-steve-jobs-010-config-earns-its-simplicity.md
+++ b/docs/99-reports/2026-04-03-steve-jobs-010-config-earns-its-simplicity.md
@@ -1,0 +1,153 @@
+---
+upi: "010"
+date: 2026-04-03
+mode: design-critique
+---
+
+# Steve Jobs Review: Config Schema v1
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-03
+**Scope:** UPI 010 design doc — ADR-111 revision, config schema v1
+**Mode:** Design Critique
+
+## The Verdict
+
+This is the right work at the right time, and the design understands why — it's building the floor the encounter will stand on, and it's building it with the right materials.
+
+## What's Insanely Great
+
+**The decision to revise ADR-111 instead of building around it is the kind of discipline that makes great products.** Most teams would say "the spec is close enough, we'll adapt as we go." That's how you end up with a setup wizard that generates configs into a schema you've already decided is wrong. The encounter would be lying to every new user on day one. This design prevents that lie from ever existing.
+
+**`protection = "fortified"` is the single best config field in this project.** I want to stop and appreciate what happened here. The user doesn't write `protection_level = "resilient"` — a compound noun that asks them to understand what "level" means in this context and then map "resilient" to a set of operational parameters they can't see. They write `protection = "fortified"`. One word says what they're choosing. The other word says what their data becomes. That's a config field that answers a question instead of asking one. When someone reads their own config six months later, `protection = "fortified"` tells them everything. That's exactly right.
+
+**The transient exception is a design decision that shows product maturity.** `local_retention = "transient"` alongside `protection = "fortified"` — this is the config equivalent of "yes, you can have a small phone with a big screen." Transient is a storage constraint, not a protection intent. The design recognizes that a 128GB NVMe user who wants geographic protection shouldn't be forced to choose between their protection level and their storage reality. That's thinking about the person, not the schema.
+
+**Rejected alternative F is the most important paragraph in the document.** Making transient a protection level would have been the obvious, clean, wrong choice. The fact that the design articulates *why* it's wrong — "conflating storage with intent" — shows that the config system is being designed from the user's mental model, not from the implementer's type system. Protect this thinking.
+
+**The side-by-side legacy vs v1 examples make the delta visceral.** I can look at those two code blocks and instantly feel the difference. The v1 config is something I can hand to someone and say "read this." The legacy config requires a manual. That comparison is worth more than three pages of specification.
+
+## What's Not Good Enough
+
+### The `[general]` section is still a tax form
+
+Look at this:
+
+```toml
+[general]
+config_version = 1
+state_db = "~/.local/share/urd/urd.db"
+metrics_file = "~/.local/share/urd/backup.prom"
+log_dir = "~/.local/share/urd/logs"
+heartbeat_file = "~/.local/share/urd/heartbeat.json"
+run_frequency = "daily"
+```
+
+Six fields. The user cares about exactly one of them: `run_frequency`. The other five are infrastructure paths that 95% of users will never change from defaults. When the encounter generates a config, these five lines are noise — they add visual weight without adding information.
+
+What "great" looks like: every field in `[general]` except `config_version` and `run_frequency` should have sensible defaults. The generated config should be able to omit them entirely. A power user can add them back. But the first config a new user sees should be as short as possible — every line they don't need to read is a line that doesn't confuse them.
+
+This doesn't change the schema — all fields remain valid. It changes what `urd setup` generates and what the defaults are. The encounter should produce the shortest possible config that fully describes the user's protection intent.
+
+### `snapshot_root` is repeated and that's not great
+
+The v1 example has `snapshot_root = "~/.snapshots"` on both `htpc-home` and `htpc-root`. For a user with 9 subvolumes on two filesystems, that's `snapshot_root` repeated 9 times — 7 of them identical. The legacy schema solved this (badly) with `[local_snapshots]`. ADR-111 correctly killed the cross-referencing. But the solution — repeat the path on every block — optimizes for the parser's simplicity, not for the user's reading experience.
+
+I'm not saying bring back `[local_snapshots]`. But I want this tension acknowledged. When the encounter generates a config with 9 subvolumes, will the user look at 9 identical `snapshot_root` lines and feel like the tool is well-designed? Or will they feel like the tool is verbose?
+
+Possible mitigation without violating ADR-111's principles: the encounter generates a comment above each group of subvolumes that share a root. Something like:
+
+```toml
+# ── NVMe (snapshot root: ~/.snapshots) ──────────
+
+[[subvolumes]]
+name = "htpc-home"
+...
+```
+
+The repetition is still there, but the grouping and visual structure help the user parse it. This is a presentation question, not a schema question — and it matters.
+
+### `urd migrate` is under-specified for the user experience
+
+The design says: "automatic, prints every change it made, user reviews the result and edits if needed." But what does that actually look like? When I run `urd migrate`, what do I see?
+
+This matters because migration is a trust moment. The user is handing their backup configuration — the thing that protects their data — to a tool and saying "change this for me." If the output is a wall of text, they won't read it. If it's too terse, they won't trust it.
+
+What "great" looks like:
+
+```
+urd migrate
+
+  Config: ~/.config/urd/urd.toml
+  Schema: legacy → v1
+
+  Changes:
+    ✓ Inlined snapshot_root into 9 subvolume blocks
+    ✓ Moved space constraints to [[space_constraints]]
+    ✓ Removed [defaults] — values baked into custom subvolumes
+    ✓ Renamed protection levels (guarded→recorded, protected→sheltered, resilient→fortified)
+    ⚠ subvol4-multimedia: had protection_level="guarded" with snapshot_interval="1w" override
+      → Converted to custom (kept your 1w interval). Review if you want recorded instead.
+
+  Written to: ~/.config/urd/urd.toml
+  Backup saved: ~/.config/urd/urd.toml.legacy
+
+  Next: urd plan — verify the migration looks right
+```
+
+The backup file is critical. Never overwrite a config without saving the original. The user needs to know they can go back.
+
+### The `[[space_constraints]]` section feels orphaned
+
+In the legacy config, `min_free_bytes` sits right next to the subvolumes it protects — inside the snapshot root entry. In v1, it moves to a separate `[[space_constraints]]` section that references a path. The user now has to mentally connect `path = "~/.snapshots"` in `[[space_constraints]]` to `snapshot_root = "~/.snapshots"` in `[[subvolumes]]`. This is... cross-referencing. The very thing ADR-111 was designed to eliminate.
+
+I understand the architectural argument — space is a filesystem concern, not a subvolume concern. That's true for the system. But for the user, "how full is my snapshot drive" and "where do my snapshots go" are the same thought. Separating them creates a config structure that's architecturally clean but experientially disconnected.
+
+I don't have a clean solution for this. But I want the tension noted. When the encounter generates a config, `[[space_constraints]]` should appear physically near the drives or subvolumes it relates to, not floating at the top of the file. Ordering and proximity matter in a config file — they're the closest thing to information architecture that plain text has.
+
+## The Vision
+
+Here's what the v1 config should feel like to a user who opens it six months after the encounter generated it:
+
+*"Oh right, I have three fortified volumes — those are my photos, recordings, and home directory. They go to both drives. My root partition is custom with transient retention — it just gets shipped to the offsite drive, no local history. My multimedia is recorded — local only, weekly snapshots. Makes sense."*
+
+That's the test. If someone can read their own config and narrate their protection story without consulting documentation, the schema is right. The v1 design is close to this. The protection level names carry meaning. The self-describing blocks are readable. The field names are clear.
+
+What would make it *insanely* great is if the generated config included intention comments — not explaining what the fields do (that's documentation), but recording *why* the user chose what they chose:
+
+```toml
+[[subvolumes]]
+name = "subvol2-pics"
+source = "/mnt/btrfs-pool/subvol2-pics"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+protection = "fortified"           # irreplaceable — survive site loss
+drives = ["WD-18TB", "WD-18TB1"]
+```
+
+That `# irreplaceable — survive site loss` came from the encounter. It's the user's own answer, preserved in their config as a comment. Six months later, they don't just see what they chose — they see *why*. The encounter leaves a trace of the conversation in the artifact it produced.
+
+This is the kind of detail that makes someone *love* a tool.
+
+## The Details
+
+- **`protection` vs `protection_level`**: The rename to drop `_level` is correct. Shorter, cleaner, no loss of meaning. But ensure the error message when someone writes `protection_level` in v1 specifically says "did you mean `protection`?" Don't just say "unknown field" — guide the migration.
+
+- **The field table says `drives` default is `[]` (no external sends).** But what if someone writes `protection = "sheltered"` and forgets `drives`? That's a structural error — sheltered requires at least one drive. The error message for this must be extraordinary. Not "structural validation error: sheltered requires drives field" but something like: "sheltered protection needs a drive to shelter your data on. Add a drives list, or use recorded for local-only protection."
+
+- **Open question 5 (explicit `"custom"` vs absence):** Go with Option A, but make the generated config omit it. Explicit `protection = "custom"` is useful documentation for someone who hand-edits. But generated configs should be minimal — if there's no `protection` field, the user knows it's custom because all the operational fields are visible. Both paths should feel intentional.
+
+- **Open question 1 (`urd migrate` interactivity):** Option A is right. But add the backup file. Always. Automatically. No flag needed. The backup is not optional — it's the safety net that makes automatic migration trustworthy.
+
+- **The v1 example config still has `send_interval = "1d"` on the custom htpc-root block.** But the default is already `1d`. The example should demonstrate when to specify a field (when it differs from default) and when to omit it (when default is fine). Currently, the example teaches the user to be verbose. Show the minimal custom block too.
+
+## The Ask
+
+1. **Make `[general]` fields defaultable.** `state_db`, `metrics_file`, `log_dir`, `heartbeat_file` should all have sensible XDG-compliant defaults. The encounter-generated config should only include `config_version` and `run_frequency` in `[general]`. This is the single highest-impact change for first-impression quality.
+
+2. **Design the `urd migrate` output experience.** The design specifies the transformation but not the output. Write the exact output format — the user should see a clean summary of changes, a saved backup path, and a next-step suggestion. This is a trust moment.
+
+3. **Add intention comments to generated configs.** When the encounter produces a config, include the user's classification as a comment: `# irreplaceable — survive site loss`. The encounter's conversation should leave a trace in its artifact. This is what turns a config file into a document of intent.
+
+4. **Note the `snapshot_root` repetition tension.** Acknowledge it in the ADR revision. The repetition is the right trade-off (self-describing blocks > cross-referencing), but the generated config should use grouping comments and ordering to make it visually coherent.
+
+5. **Write the error messages for v1 validation failures now.** Before implementing, write every error message that v1 validation can produce. The messages are the UX. If you can't write a great error message for a validation rule, the rule might be wrong.

--- a/docs/99-reports/2026-04-03-steve-jobs-010-sequence-the-schema.md
+++ b/docs/99-reports/2026-04-03-steve-jobs-010-sequence-the-schema.md
@@ -1,0 +1,122 @@
+---
+upi: "010"
+date: 2026-04-03
+mode: vision-filter
+---
+
+# Steve Jobs Review: Sequencing the Config Schema v1
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-03
+**Scope:** How UPI 010 (Config Schema v1) fits into the roadmap alongside the test session and Phase D
+**Mode:** Vision Filter (sequencing)
+
+## The Verdict
+
+The test session and UPI 010 are not sequential — they're complementary, and the right move is to interleave them so the encounter arrives on solid ground without adding months to the timeline.
+
+## What's Insanely Great
+
+**The question being asked is the right question.** "How does this fit?" is better than "let's just build it." The project has a pattern now: design, stress-test the design, then build. That pattern produced v0.9.0 — the most honest version of Urd that has ever existed. Maintaining the pattern for the config schema, which is arguably more foundational than anything in Phases A–C, is not conservatism. It's taste.
+
+**UPI 010 absorbs P6a and P6b.** The roadmap previously had three separate items: ADR-111 resolution, P6a (enum rename), and P6b (config Serialize). UPI 010 rolls them into one coherent scope with a clear sequencing plan. That's cleaner than three deferred chores floating around the roadmap. One item, one dependency chain, one gate. Good.
+
+**The design's own sequencing is risk-ordered correctly.** ADR revision → enum rename → Serialize → v1 parser → migrate. Each step depends on the last. The riskiest piece (parser) comes after the mechanical pieces clear the path. This isn't just good engineering — it's good product thinking. If the enum rename surfaces vocabulary problems, you catch them before they're baked into a new parser. If Serialize reveals structural issues in Config, you catch them before building migrate on top.
+
+## What's Not Good Enough
+
+### The current roadmap treats the test session and UPI 010 as sequential
+
+The roadmap says:
+
+```
+test session → ADR-111 resolution → P6b → Phase D
+```
+
+That's a straight line with no parallelism. The test session takes "several days" of living with v0.9.0. During those days, the builder — you — is not building. You're observing, using the tool, noting friction. That's valuable and necessary. But the test session is not CPU-bound. It's calendar-bound.
+
+The ADR-111 document revision (session 1 of UPI 010) is entirely a writing task. It doesn't touch code. It doesn't change behavior. It can happen while you're living with v0.9.0. The enum rename (also session 1) is mechanical and doesn't affect the user experience being tested. P6b (session 2) adds Serialize — again, no behavioral change, no risk to the test session's validity.
+
+Treating these as sequential wastes calendar time. The test session validates the *runtime experience*. UPI 010 sessions 1-2 are *infrastructure preparation* that doesn't change what the user sees.
+
+### The encounter is still 6-8 sessions away
+
+Count the sessions in the current roadmap:
+- Test session: ~1 session (plus calendar days)
+- Fix phase from test findings: ~1 session (estimated)
+- UPI 010: 3-4 sessions
+- Phase D (6-O + 6-H): 6-8 sessions
+
+Total: **11-14 sessions to v1.0 readiness**. That's a lot. The question is whether any of these can overlap without compromising quality.
+
+The answer is yes, but only for the pieces that don't interact. The test session validates runtime. UPI 010 sessions 1-2 are spec and infrastructure. These don't conflict. UPI 010 sessions 3-4 (parser + migrate) change runtime behavior — those should come after the test session findings are addressed.
+
+## The Vision
+
+Here's the sequence I would build:
+
+### Week 1: Test session + UPI 010 foundations (parallel)
+
+**Track A: Living with v0.9.0.** Fix the systemd timer `--auto` flag. Let the nightly runs accumulate. Plug in a drive, unplug it. Run commands. Note friction. This is calendar time, not session time.
+
+**Track B: UPI 010 sessions 1-2.** While living with v0.9.0:
+- Session 1: Write the revised ADR-111 document + do the P6a enum rename. The rename is a codebase-wide search-and-replace that changes internal names. It doesn't change any user-facing behavior — `urd status` still shows the old presentation-layer terms until voice.rs is updated later. The test session is testing the *experience*, not the enum variant names.
+- Session 2: P6b (add Serialize to Config). Again, purely additive — no behavioral change. The test session continues unaffected.
+
+**Why this is safe:** Sessions 1-2 change internal names and add a trait derive. They don't change what any command outputs, how backups run, or what the Sentinel does. The test session is testing the v0.9.0 *experience*. That experience is identical before and after P6a/P6b.
+
+### Week 2: Test findings + UPI 010 runtime changes
+
+**Session 3: Address test session findings.** Whatever the test session surfaced — fix it. This might be zero sessions (everything is fine) or 1-2 sessions (issues found). Either way, the findings are now grounded in real usage.
+
+**Session 4: UPI 010 session 3 — v1 parser + `urd migrate`.** Now we change runtime behavior. The parser gains dual-path config loading. The migrate command exists. The validation messages ship. This comes after the test session because:
+1. The test session might reveal config-related issues that should inform v1 design
+2. The v1 parser is a structural change to config loading — every command is affected
+3. Once v1 ships, you migrate your own config and live with it before building the encounter on top
+
+**Session 5: Migrate your own config, live with v1.** Run `urd migrate` on your production config. Watch a few nightly runs on the v1 schema. This is a mini-validation: does the new schema work in practice? Any issues surface here, not during the encounter.
+
+### Week 3+: Phase D
+
+Now Phase D begins with:
+- A validated v0.9.0 runtime (test session)
+- A complete v1 config schema (UPI 010)
+- A migrated production config running on v1 (personal validation)
+- The encounter targeting the right schema from day one
+
+```
+Week 1:
+  Track A: test session (calendar)  ─────────────────────
+  Track B: UPI 010 s1 (ADR + P6a)  ── s2 (P6b + parser prep)
+                                                          │
+Week 2:                                                   │
+  Test findings fix ── UPI 010 s3 (v1 parser + migrate) ──┘
+  Migrate own config, validate v1                          │
+                                                           │
+Week 3+:                                                   │
+  Phase D: 6-O (progressive disclosure) ─→ 6-H (encounter)
+```
+
+**Estimated total: ~8-10 sessions to v1.0 readiness.** The parallelism saves 1-2 sessions compared to the purely sequential roadmap. More importantly, it saves calendar time — the test session days aren't idle.
+
+## The Details
+
+- **The enum rename (P6a) should use the new names in code but keep the old names in serde for the legacy parser.** This is subtle but important. The Rust enum becomes `Recorded`, `Sheltered`, `Fortified`. The legacy parser still accepts `"guarded"`, `"protected"`, `"resilient"` from TOML. The v1 parser accepts only the new names. This means P6a can ship without breaking the running production config.
+
+- **Don't update the example config until session 3.** The example config (`config/urd.toml.example`) should match the production schema. Update it to v1 alongside the v1 parser, not during the enum rename.
+
+- **The test session should explicitly include a "read my config" test.** Open `urd.toml`. Read it. Can you narrate your protection story? This grounds the config-readability question in real experience before UPI 010 changes the schema.
+
+- **`urd migrate --dry-run` is a natural demo during the test session findings review.** If you've built sessions 1-2 by then, you can show what the migration *would* produce and evaluate it against the test session's readability findings.
+
+## The Ask
+
+1. **Run UPI 010 sessions 1-2 in parallel with the test session.** The ADR revision, enum rename, and Serialize refactor don't change user-facing behavior. They're safe to do while validating the runtime experience. This saves 1-2 weeks of calendar time.
+
+2. **Migrate your own production config as a validation step before Phase D.** Don't just build `urd migrate` — use it. Live with the v1 schema for a few nightly runs. The encounter shouldn't be the first time v1 runs in production.
+
+3. **Update the roadmap to show the parallel tracks.** The current roadmap is a straight line. The parallel structure is more honest about what depends on what — and it shows the path to Phase D is shorter than it looks.
+
+4. **Keep UPI 010 sessions 3-4 after the test session findings are addressed.** The v1 parser and migrate command change runtime behavior. They belong on the other side of the test validation gate.
+
+5. **Add "read my config" as an explicit test session goal.** The config readability question is central to UPI 010's motivation. Ground it in real experience before building the solution.


### PR DESCRIPTION
## Summary

- **UPI 010 design doc**: Config Schema v1 (ADR-111 revision) — self-describing subvolume blocks, protection level rename (recorded/sheltered/fortified), `urd migrate` command, guided validation error messages, intention comments in generated configs
- **Roadmap restructuring**: Parallel tracks — test session (Track A) concurrent with UPI 010 sessions 1-2 (Track B), saving 1-2 sessions of calendar time
- **3 Steve reviews**: Ship-or-test decision, config design critique, sequencing recommendation
- **Adversary review**: 2 significant + 2 moderate findings addressed — default-baking safety, ResolvedSubvolume migration, space constraints simplification, enabled field

## Testing

- Documentation only — no code changes
- cargo clippy: not applicable
- cargo test: not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)