### PR TITLE
docs: transient space safety — brainstorm, designs, and review (UPI 011, 010-a, 012)

### DIFF
--- a/docs/95-ideas/2026-04-03-brainstorm-011-transient-space-safety.md
+++ b/docs/95-ideas/2026-04-03-brainstorm-011-transient-space-safety.md
@@ -1,0 +1,236 @@
+# Brainstorm 011: Transient Subvolume Space Safety
+
+**Status:** raw
+**Date:** 2026-04-03
+**Trigger:** Fifth NVMe space exhaustion incident. htpc-root configured as transient
+but `urd backup` (manual) created 3 local snapshots that nearly filled the 118GB NVMe.
+Pin files now reference deleted snapshots (user manually deleted to recover).
+
+## Problem Statement
+
+Transient retention is a deletion policy, not a creation policy. The planner creates
+local snapshots unconditionally for all subvolumes. The create-then-delete architecture
+has a fundamental gap: if external drives aren't mounted, unsent protection keeps all
+local snapshots alive indefinitely. Manual runs (`urd backup`) bypass interval checks
+entirely (`skip_intervals: !args.auto`), making accumulation even faster.
+
+**Five incidents in 10 days.** Space guard (`min_free_bytes`) prevents the absolute
+worst outcome but doesn't prevent accumulation up to the threshold. The 118GB NVMe
+cannot sustain any htpc-root local snapshot history alongside htpc-home.
+
+**Secondary damage:** Pin files (`.last-external-parent-*`) now reference snapshots
+the user manually deleted. Next incremental send will either fail or fall back to
+full send, wasting time and external drive space.
+
+## Ideas
+
+### 1. Transient-aware creation gate in `plan_local_snapshot()`
+
+Make `plan_local_snapshot()` aware of transient retention. If `local_retention` is
+`Transient`, only create a snapshot when:
+- An external send is actually possible (at least one configured drive is mounted), OR
+- No local snapshot exists at all (first-ever snapshot)
+
+This turns transient from "create aggressively, delete aggressively" into "create only
+when useful." The planner already has access to drive availability through `fs`.
+
+**Modules touched:** `plan.rs` (add transient check to `plan_local_snapshot`)
+
+### 2. External-only mode as first-class config
+
+Instead of transient being a retention hack, introduce `mode = "external-only"` at the
+subvolume level. External-only subvolumes:
+- Never create local snapshots except as transient intermediaries for sends
+- Create a local snapshot, send it, delete it — all in one executor pass
+- If no drive is mounted, skip entirely (no local accumulation)
+
+This makes the intent explicit in config rather than inferring it from retention policy.
+
+**Modules touched:** `types.rs` (new mode enum), `plan.rs`, `executor.rs`, `config.rs`
+
+### 3. Snapshot budget per filesystem
+
+Instead of `min_free_bytes` (reactive threshold), give each filesystem a snapshot
+budget: maximum number of snapshots OR maximum total exclusive data. The planner
+refuses to create when the budget is exhausted.
+
+This prevents gradual accumulation above the space guard threshold. Could be
+per-subvolume or per-snapshot-root (all subvolumes on the same filesystem share
+a budget).
+
+**Modules touched:** `plan.rs`, `types.rs`, `config.rs`
+
+### 4. Transient snapshot cap: hard limit of 1
+
+For transient subvolumes, enforce a hard cap of 1 local snapshot at any time. The
+planner refuses to create a second snapshot if one already exists (regardless of
+`skip_intervals`, `force`, or send state). This is simpler than idea #1 — no need
+to check drive availability — and directly prevents accumulation.
+
+The one surviving snapshot is either the chain parent (pinned) or the latest unsent.
+Either way, the space cost is bounded to exactly one snapshot's worth.
+
+**Modules touched:** `plan.rs` (add count check to `plan_local_snapshot` for transient)
+
+### 5. Atomic send-and-delete in executor
+
+For transient subvolumes, restructure the executor to treat snapshot creation, send,
+and local deletion as a single atomic unit of work:
+1. Create snapshot
+2. Send to all available drives
+3. Update pin files
+4. Delete the snapshot (and old pin parent) immediately
+
+If no drives are available, step 1 is skipped entirely. No window for accumulation.
+
+**Modules touched:** `executor.rs` (new transient execution path)
+
+### 6. Drive-availability preflight for transient subvolumes
+
+Add a preflight check: before planning any operations for a transient subvolume,
+verify at least one configured drive is mounted. If none are mounted, skip the entire
+subvolume (no local snapshot, no retention, nothing). Log it as a skip reason.
+
+This is similar to idea #1 but happens at the subvolume level, before
+`plan_local_snapshot()` is even called.
+
+**Modules touched:** `plan.rs` (add preflight before the local operations block)
+
+### 7. Pin file recovery / orphan detection
+
+Address the secondary damage: when a pin file references a snapshot that no longer
+exists on the local filesystem, detect this condition and handle it gracefully:
+- Log a warning: "chain parent deleted, next send will be full"
+- Clear the stale pin file (forces full send, which is correct)
+- Or: scan external drive for the most recent snapshot and derive new pin from that
+
+This doesn't prevent the space problem but prevents cascading damage from manual
+recovery actions.
+
+**Modules touched:** `chain.rs` (pin validation), `plan.rs` (stale pin handling),
+potentially `executor.rs` (pre-send pin check)
+
+### 8. `urd backup --auto` awareness for transient
+
+Make `--auto` the only mode that creates snapshots for transient subvolumes. Manual
+`urd backup` (without `--auto`) would skip transient subvolumes entirely, with a
+message: "htpc-root is transient — use `urd backup --auto` or wait for the scheduled
+run." This prevents the most dangerous scenario: repeated manual runs creating
+snapshots that can't be sent.
+
+**Modules touched:** `plan.rs` or `commands/backup.rs` (filter transient from manual)
+
+### 9. Volume-aware snapshot scheduling
+
+The planner currently treats each subvolume independently. Introduce volume awareness:
+subvolumes that share a filesystem (same snapshot root or same mount point) should
+coordinate. When htpc-root and htpc-home share the NVMe, the planner can:
+- Prioritize htpc-home snapshots (higher data-change rate)
+- Refuse htpc-root snapshots when htpc-home needs the space
+- Apply the `min_free_bytes` budget considering all subvolumes on the volume
+
+**Modules touched:** `plan.rs` (volume grouping), `config.rs` (volume detection),
+`types.rs` (volume type)
+
+### 10. Sentinel drive-gated transient backup
+
+Instead of the nightly timer creating transient snapshots blindly, have the Sentinel
+trigger transient backups only when the target drive is detected. Sentinel already
+knows about drive plug/unplug events. When WD-18TB1 is plugged in:
+1. Sentinel triggers backup for htpc-root
+2. Snapshot created, sent, cleaned up
+3. Drive removed — no orphan snapshots
+
+This aligns transient backup timing with drive availability rather than a fixed schedule.
+
+**Modules touched:** `sentinel.rs` (new event→action mapping), `sentinel_runner.rs`
+
+### 11. Filesystem pressure notifications
+
+Extend Sentinel's monitoring to track filesystem free space on snapshot roots. When
+NVMe free space drops below a configurable threshold (higher than `min_free_bytes`),
+emit an early warning notification before the space guard kicks in. The Discord alert
+saved the day this time — make it part of Urd's own notification system.
+
+**Modules touched:** `sentinel.rs` (new event type), `notify.rs` (space alert template)
+
+### 12. `local_snapshots = false` — explicit opt-out
+
+Instead of inferring "no local snapshots" from `local_retention = "transient"`, add
+an explicit `local_snapshots = false` config field. When false:
+- Planner never creates local snapshots
+- Send operations use a temporary snapshot (created, sent, deleted atomically)
+- No retention logic needed — nothing to retain
+
+This is the clearest expression of intent: "I do not want local snapshots for this
+subvolume, period."
+
+**Modules touched:** `types.rs`, `config.rs`, `plan.rs`, `executor.rs`
+
+### 13. Retroactive space reclaim command
+
+`urd reclaim` — emergency command that identifies and deletes snapshots to recover
+space, prioritizing:
+1. Transient subvolume snapshots (should be zero anyway)
+2. Snapshots beyond retention policy
+3. Oldest snapshots on the most constrained filesystem
+
+This doesn't prevent the problem but gives the user a safer alternative to manually
+running `sudo btrfs subvolume delete`.
+
+**Modules touched:** new command in `commands/`, uses `plan.rs` and `retention.rs`
+
+### 14. Pin file self-healing with filesystem truth
+
+Strengthen ADR-102 (filesystem is truth): before any incremental send, verify the
+pin file's referenced snapshot actually exists as a local subvolume. If it doesn't:
+- Check if the snapshot exists on the external drive
+- If yes: the next send must be full (no local parent), but pin the new snapshot
+- If no: full send from scratch, log the chain break
+- Either way: remove the stale pin file
+
+This makes pin files eventually consistent with filesystem reality, regardless of
+manual interventions.
+
+**Modules touched:** `executor.rs` (pre-send validation), `chain.rs` (pin healing)
+
+### 15. Two-phase transient: snapshot-in-tmpfs
+
+Wild idea: for transient subvolumes, don't create the snapshot on the source
+filesystem at all. Use `btrfs send` piped directly to `btrfs receive` on the external
+drive, without materializing the read-only snapshot on the source. BTRFS might not
+support this directly, but the conceptual direction is: minimize source filesystem
+impact for subvolumes that don't need local history.
+
+**Feasibility:** Unknown. BTRFS requires a snapshot to exist for `send`. But the
+snapshot could be created in a separate BTRFS filesystem mounted as tmpfs-backed
+loopback? Probably too exotic.
+
+### 16. Aggressive transient retention in same planning pass
+
+Currently, `plan_local_snapshot()` creates and `plan_local_retention()` deletes in
+the same plan — but unsent protection prevents deletion of anything newer than the
+oldest pin. For transient subvolumes, modify unsent protection: instead of protecting
+ALL unsent snapshots, protect only the NEWEST one. This caps accumulation at
+pin + 1 newest, regardless of how many manual runs happened.
+
+**Modules touched:** `plan.rs` (transient-specific unsent protection logic)
+
+## Handoff to Architecture
+
+1. **Idea #4 (transient cap of 1)** — Simplest fix with highest leverage: directly
+   prevents accumulation without checking drive state or restructuring execution.
+
+2. **Idea #1 (transient-aware creation gate)** — More principled: don't create what
+   you can't send. Addresses root cause but requires planner to reason about drive
+   availability, which is currently an executor concern.
+
+3. **Idea #14 (pin file self-healing)** — Addresses the secondary damage from this
+   incident and all future manual interventions. Independent of the space fix.
+
+4. **Idea #6 (drive-availability preflight)** — Clean integration point: skip
+   transient subvolumes entirely when drives aren't mounted. Pairs well with #4.
+
+5. **Idea #10 (Sentinel drive-gated backup)** — Long-term ideal: transient backups
+   triggered by drive presence, not schedules. Requires Sentinel to trigger backups,
+   which is a larger architectural step.

--- a/docs/95-ideas/2026-04-03-design-010a-transient-as-first-class-config.md
+++ b/docs/95-ideas/2026-04-03-design-010a-transient-as-first-class-config.md
@@ -1,0 +1,237 @@
+---
+upi: "010-a"
+status: proposed
+date: 2026-04-03
+---
+
+# Design: Transient as First-Class Config Concept (UPI 010-a)
+
+> **TL;DR:** Evolve `local_retention = "transient"` from a retention policy hack into a
+> first-class subvolume concept in the v1 config schema. The config should express the
+> user's intent — "back up externally, don't keep local history" — not require them to
+> understand retention mechanics. This is a vocabulary and schema change for UPI 010,
+> not a behavioral change (UPI 011 fixes the behavior).
+
+## Problem
+
+Today, a user who wants external-only backups for a space-constrained subvolume writes:
+
+```toml
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+local_retention = "transient"
+send_interval = "1d"
+drives = ["WD-18TB1"]
+```
+
+This works but has two problems:
+
+1. **The vocabulary is wrong.** "Transient" describes an implementation detail (how
+   retention works), not the user's intent (external-only backup). A user reading this
+   config can't tell what "transient" means without consulting documentation. Compare
+   to Time Machine's "exclude from local snapshots" — immediate clarity.
+
+2. **The config doesn't match the mental model.** The user thinks "don't keep local
+   snapshots." But `local_retention = "transient"` actually means "create local
+   snapshots, send them, delete them afterward, keep pinned chain parents." The gap
+   between intent and mechanism caused five space exhaustion incidents because the
+   mechanism had bugs the user couldn't reason about from the config.
+
+3. **Transient is an exception to named level opacity.** UPI 010's design (lines 187-196)
+   carves out a special exception: `local_retention = "transient"` is permitted alongside
+   named protection levels because it's a "storage constraint, not a policy override."
+   This exception is architecturally clean but conceptually fragile — it requires users to
+   understand why transient is special when no other operational override is allowed.
+
+## Proposed Design
+
+### Option A: `local_snapshots = false`
+
+Replace `local_retention = "transient"` with an explicit opt-out:
+
+```toml
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+local_snapshots = false
+drives = ["WD-18TB1"]
+```
+
+**Semantics:**
+- `local_snapshots = false` means: no persistent local snapshots. Urd creates a
+  temporary local snapshot for sends, then deletes it. The user never sees local
+  snapshots for this subvolume.
+- `local_snapshots = true` (default) means: normal local snapshot behavior, governed
+  by `local_retention`.
+- When `local_snapshots = false`, `local_retention` is rejected as a structural error
+  (the fields are mutually exclusive — you can't configure retention for something
+  that doesn't persist).
+
+**Interaction with named levels:**
+- Named levels imply `local_snapshots = true` (they define retention behavior).
+- To use a named level with no local snapshots: `protection = "sheltered"` +
+  `local_snapshots = false`. This is cleaner than the transient exception — it's an
+  explicit opt-out, not a retention mode masquerading as a storage constraint.
+- Validation: `local_snapshots = false` requires `drives` to be non-empty (if you
+  don't keep local and don't send external, you're not backing up at all).
+
+**Migration:** `urd migrate` transforms `local_retention = "transient"` →
+`local_snapshots = false`. Simple, mechanical, lossless.
+
+### Option B: `mode = "external-only"`
+
+Introduce a subvolume mode that governs the entire backup strategy:
+
+```toml
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+mode = "external-only"
+drives = ["WD-18TB1"]
+```
+
+**Semantics:**
+- `mode = "external-only"` — no local snapshots, send to configured drives
+- `mode = "local-only"` — local snapshots only, no sends (replaces `send_enabled = false`
+  or the `recorded` protection level's behavior)
+- `mode = "full"` (default) — local snapshots + sends (the standard behavior)
+
+**Interaction with named levels:** Mode could replace or complement named levels. A
+`protection = "sheltered"` subvolume could have an implied `mode = "full"`. But this
+creates two axes of configuration (`mode` + `protection`) that overlap in confusing ways.
+
+### Recommendation: Option A
+
+Option A is simpler, more composable, and more honest about what it does. It answers
+the question "do you want local snapshots?" with a boolean. Option B introduces a new
+axis (mode) that partially overlaps with protection levels and retention — more concepts
+for the user to learn without proportional benefit.
+
+`local_snapshots = false` reads like English. It's self-documenting. It composes cleanly
+with named levels. And it maps directly to the behavioral change in UPI 011 (the planner
+checks "are local snapshots enabled?" rather than "is retention transient?").
+
+### Internal implementation
+
+The internal enum would evolve but `Transient` stays as the internal representation.
+The config field name changes; the planner behavior (UPI 011) remains the same:
+
+```rust
+// In types.rs — LocalRetentionPolicy stays as-is for the planner
+// In config.rs — v1 parser maps `local_snapshots = false` to LocalRetentionPolicy::Transient
+// In v1 parser — `local_retention = "transient"` is rejected (use `local_snapshots = false`)
+```
+
+This means UPI 011's behavioral fix works with both legacy and v1 configs — the internal
+representation is the same, only the config surface changes.
+
+## Module Map
+
+| Module | Changes | Test Strategy |
+|--------|---------|---------------|
+| `config.rs` | v1 parser: accept `local_snapshots` field, reject `local_retention = "transient"` in v1, map to internal `Transient` | Parser tests: v1 `local_snapshots = false` → Transient; v1 `local_retention = "transient"` → error; legacy unchanged. ~4-5 tests. |
+| `types.rs` | No structural changes — `LocalRetentionPolicy::Transient` remains. Possibly add `SubvolumeConfig::local_snapshots: Option<bool>` for v1 deserialization. | Minimal — the type already exists. |
+| ADR-111 | Update v1 field tables: add `local_snapshots`, note `local_retention = "transient"` deprecated in v1. Remove the transient exception clause. | Review only. |
+
+**Modules NOT touched:** `plan.rs`, `executor.rs`, `chain.rs` — behavior is UPI 011's
+domain. This design only changes the config surface.
+
+## Effort Estimate
+
+**~0.25 session as part of UPI 010 session 3 (v1 parser).** The parser change is
+mechanical — one new field, one mapping, one validation rule. Most of the work is
+updating the ADR-111 field tables and migration logic, which is already being done in
+UPI 010. This should be folded into UPI 010 session 3, not a separate session.
+
+## Sequencing
+
+1. **UPI 011 ships first** (behavioral fix). Uses `local_retention.is_transient()` internally.
+   Works with both legacy and v1 configs.
+2. **UPI 010 session 3** adds v1 parser support for `local_snapshots = false`, mapping to
+   the same internal `Transient` representation. The behavioral fix is already in place.
+3. **`urd migrate`** transforms `local_retention = "transient"` → `local_snapshots = false`
+   as part of the legacy → v1 migration.
+
+This sequencing means the emergency fix (011) is unblocked by the config redesign,
+and the config redesign benefits from the fix being already in place.
+
+## Architectural Gates
+
+**ADR-111 revision needed.** The v1 field tables must include `local_snapshots` and
+remove the transient exception clause. This is already in scope for UPI 010 — the
+revision is additive, not a new ADR.
+
+## Rejected Alternatives
+
+### Keep `local_retention = "transient"` in v1
+
+The simplest option — don't change the config surface at all. Rejected because:
+- The vocabulary is wrong (retention vs. intent)
+- The transient exception to named level opacity is architecturally fragile
+- Five incidents prove users can't reason about "transient" from the config alone
+- v1 is the opportunity to fix vocabulary; post-v1 changes break migration contracts
+
+### `send_only = true` instead of `local_snapshots = false`
+
+Describes the same thing from the opposite direction. Rejected because:
+- `send_only` implies sends are always happening, which isn't true (drive must be mounted)
+- `local_snapshots = false` is more accurate — it describes what the user observes
+  (no local snapshots), not what the system does (send only)
+
+### Mode enum (Option B above)
+
+Already discussed. Rejected for overlapping with protection levels and adding a new
+axis of config complexity without proportional benefit.
+
+## Assumptions
+
+1. **UPI 010's v1 parser uses a branching strategy (version field → different parser
+   path).** This is stated in the UPI 010 design. The `local_snapshots` field is only
+   valid in v1; legacy configs keep `local_retention = "transient"`.
+
+2. **The internal `Transient` representation is stable.** UPI 011 builds on it. This
+   design maps a new config surface to the same internal representation.
+
+3. **`urd migrate` handles the transformation mechanically.** The migration from
+   `local_retention = "transient"` to `local_snapshots = false` is lossless and
+   unambiguous.
+
+## Open Questions
+
+### Q1: Should `local_snapshots = false` be permitted without `drives`?
+
+**Option A (require drives):** If you're not keeping local snapshots and not sending
+anywhere, you're not backing up. Reject at validation time.
+
+**Option B (allow it):** Maybe the user is temporarily disabling a subvolume's backups
+while keeping it in the config. `enabled = false` already serves this purpose though.
+
+**Recommendation: Option A.** `local_snapshots = false` + no `drives` is a
+misconfiguration. Catch it early with a clear error.
+
+### Q2: Should the field be `local_snapshots` (boolean) or `local_history` (boolean)?
+
+`local_snapshots` is precise but technical. `local_history` is more user-facing but
+slightly less accurate (snapshots are the mechanism, history is the concept). The
+config schema aims for precision (`source`, `snapshot_root`, `send_interval`) so
+`local_snapshots` is consistent with the existing vocabulary.
+
+### Q3: What about the transient exception in named levels?
+
+Currently UPI 010 design (lines 187-196) allows `local_retention = "transient"` alongside
+named levels as a unique exception. With `local_snapshots = false`, this becomes:
+
+```toml
+protection = "sheltered"
+local_snapshots = false
+```
+
+Is this still an exception to named level opacity, or is it clean? It's a boolean opt-out
+of local storage, not an operational parameter override. It feels cleaner — but the
+principle "named levels are opaque" means ANY field that modifies behavior alongside a
+named level needs justification.
+
+**Recommendation:** Allow it. `local_snapshots` is a storage constraint (physical
+reality), not a policy preference. The justification is the same as the original transient
+exception, but the expression is more honest.

--- a/docs/95-ideas/2026-04-03-design-011-transient-space-safety.md
+++ b/docs/95-ideas/2026-04-03-design-011-transient-space-safety.md
@@ -1,0 +1,362 @@
+---
+upi: "011"
+status: proposed
+date: 2026-04-03
+---
+
+# Design: Transient Space Safety (UPI 011)
+
+> **TL;DR:** Fix the broken promise that transient subvolumes won't accumulate local
+> snapshots. Three reinforcing changes: (1) skip local snapshot creation for transient
+> subvolumes when no configured drive is mounted, (2) hard-cap transient subvolumes at
+> 1 local snapshot, (3) detect and clear stale pin files that reference deleted snapshots.
+> This is a production bug fix — five NVMe exhaustion incidents in ten days.
+
+## Problem
+
+`local_retention = "transient"` promises: "delete local after send, keep only chain
+parent." But transient is a deletion policy, not a creation policy. The planner creates
+local snapshots unconditionally for all subvolumes in `plan_local_snapshot()` — it has
+no awareness of transient retention.
+
+Three compounding failures:
+
+1. **Creation is transient-unaware.** `plan_local_snapshot()` creates snapshots for
+   transient subvolumes on every run that passes interval/space checks. Manual runs
+   (`urd backup` without `--auto`) bypass interval checks entirely
+   (`skip_intervals: !args.auto`), so every manual run creates a new snapshot.
+
+2. **Unsent protection blocks transient cleanup.** When no configured drive is mounted,
+   snapshots can't be sent. `plan_local_retention()` protects all snapshots newer than
+   the oldest pin (or all snapshots if no pin exists). Transient cleanup never fires
+   because there's nothing to clean up — everything is protected.
+
+3. **Pin files reference deleted snapshots.** After manual deletion of accumulated
+   snapshots, pin files (`.last-external-parent-{DRIVE}`) point to non-existent
+   snapshots. The planner classifies this as `ChainBroken` and autonomous mode skips
+   the send entirely (`FullSendPolicy::SkipAndNotify`). The stale pin persists across
+   runs — the chain stays broken until manual `--force-full`.
+
+**Result:** On the 118GB NVMe hosting both htpc-root and htpc-home, three manual
+`urd backup` runs created three htpc-root snapshots. External drive wasn't mounted.
+Unsent protection kept all three. NVMe approached exhaustion. User manually deleted
+snapshots, breaking the incremental chain. Fifth incident in ten days.
+
+## Proposed Design
+
+Three changes that reinforce each other. Each is independently valuable but together
+they make transient subvolumes genuinely safe on space-constrained volumes.
+
+### Change 1: Drive-availability preflight for transient subvolumes
+
+**Where:** `plan.rs`, in the main `plan()` loop, before the local operations block.
+
+**Logic:** For transient subvolumes (`subvol.local_retention.is_transient()`), check
+whether at least one configured drive is available before creating a local snapshot.
+If no drive is available, skip the entire local operations block (no create, no
+retention) and log a skip reason.
+
+```
+// Pseudocode — in plan() loop, before `if !filters.external_only`
+if subvol.local_retention.is_transient() && !filters.external_only {
+    let any_drive_available = config.drives.iter()
+        .filter(|d| subvol.drives.as_ref().map_or(true, |allowed| allowed.contains(&d.label)))
+        .any(|d| matches!(fs.drive_availability(d), DriveAvailability::Available));
+
+    if !any_drive_available && !local_snaps.is_empty() {
+        // At least one snapshot exists (chain parent) — no need to create more
+        skipped.push((subvol.name.clone(), "transient: no configured drive mounted".into()));
+        // Still run retention to clean up any excess snapshots
+        plan_local_retention(config, subvol, &local_dir, &local_snaps, now, &pinned, fs, &mut operations);
+        // Skip to external operations (which will also skip — drives aren't mounted)
+        continue to external block;
+    }
+    // If no snapshots exist at all, allow creation of the first one
+    // (needed for the very first backup before any drive has been plugged in)
+}
+```
+
+**Why this module:** The planner decides what operations to run (ADR-100). Drive
+availability is already queried through `fs.drive_availability()` in the external
+operations block. Using it in the local block for transient subvolumes is a natural
+extension — the planner is asking "is this snapshot useful?" not "is the drive ready
+for I/O?"
+
+**Edge case — first-ever snapshot:** If `local_snaps` is empty and no drive is
+available, we still allow creation of one snapshot. This ensures the first backup
+works even if the user hasn't plugged in the drive yet. Change 2 (cap of 1) prevents
+accumulation from this edge case.
+
+**Edge case — `--external-only` filter:** If the user runs `urd backup --external-only`,
+the local operations block is already skipped. No interaction with this change.
+
+**Edge case — `--force` or specific subvolume:** Even with `--force` or
+`--subvolume htpc-root`, the preflight still applies. Force overrides *intervals*,
+not *drive availability*. A forced snapshot on a transient subvolume with no drive
+mounted is still useless.
+
+### Change 2: Transient snapshot cap of 1
+
+**Where:** `plan_local_snapshot()` in `plan.rs`.
+
+**Logic:** After the space guard check, before interval logic, add a transient cap
+check. If the subvolume is transient and at least one local snapshot already exists,
+skip creation regardless of interval, force, or skip_intervals.
+
+```
+// In plan_local_snapshot(), after space guard, before interval check
+if subvol.local_retention.is_transient() && !local_snaps.is_empty() {
+    skipped.push((
+        subvol.name.clone(),
+        "transient: snapshot exists (cap of 1)".into(),
+    ));
+    return;
+}
+```
+
+**Why this is defense in depth, not redundant:** Change 1 prevents creation when no
+drive is available. Change 2 prevents creation when a snapshot already exists,
+regardless of drive state. Together they handle:
+
+- Drive mounted but previous snapshot not yet sent → cap prevents second
+- Drive not mounted → preflight prevents creation AND cap prevents accumulation
+- Race condition: drive unmounts between preflight check and snapshot creation →
+  cap still prevents accumulation on next run
+- Bug in preflight logic → cap still prevents accumulation
+
+**Interaction with interval logic:** The cap check comes BEFORE the interval check.
+For transient subvolumes, the interval is irrelevant when a snapshot already exists —
+the only question is "was it sent?" The interval logic is preserved for the case where
+`local_snaps` is empty (first snapshot timing).
+
+**Parameter change:** `plan_local_snapshot()` needs access to `subvol.local_retention`.
+It currently receives `subvol: &ResolvedSubvolume` so this is already available — no
+signature change needed.
+
+### Change 3: Pin file self-healing
+
+**Where:** `executor.rs`, in the send execution path, before attempting incremental send.
+Also `chain.rs` for a pin validation helper.
+
+**Logic:** Before an incremental send, verify that the pin file's referenced snapshot
+exists as a local subvolume. If it doesn't:
+
+1. Log a warning: "chain parent {name} no longer exists locally — clearing stale pin"
+2. Delete the stale pin file
+3. Reclassify the send as `FullSendReason::ChainBroken` (already happens in planner,
+   but the pin file now gets cleaned up so next run sees `NoPinFile` instead of
+   repeating `ChainBroken`)
+
+**New function in `chain.rs`:**
+
+```rust
+/// Validate that a pin file's referenced snapshot exists on the local filesystem.
+/// Returns `Ok(true)` if valid, `Ok(false)` if stale (and removes the pin file).
+pub fn validate_pin_file(
+    local_snapshot_dir: &Path,
+    drive_label: &str,
+) -> Result<bool> {
+    let Some(pin) = read_pin_file(local_snapshot_dir, drive_label)? else {
+        return Ok(true); // No pin file — nothing to validate
+    };
+    let snap_path = local_snapshot_dir.join(pin.name.as_str());
+    if snap_path.exists() {
+        Ok(true)
+    } else {
+        // Stale pin — referenced snapshot was deleted
+        let pin_path = match pin.source {
+            PinSource::DriveSpecific => {
+                local_snapshot_dir.join(format!(".last-external-parent-{drive_label}"))
+            }
+            PinSource::Legacy => {
+                local_snapshot_dir.join(".last-external-parent")
+            }
+        };
+        log::warn!(
+            "Stale pin file {} references non-existent snapshot {} — removing",
+            pin_path.display(),
+            pin.name,
+        );
+        std::fs::remove_file(&pin_path).map_err(|e| {
+            UrdError::Io(format!("failed to remove stale pin {}: {e}", pin_path.display()))
+        })?;
+        Ok(false)
+    }
+}
+```
+
+**Where to call it:** Two options considered:
+
+- **Option A: In executor, before send.** The executor already re-reads pin files for
+  transient cleanup (executor.rs:887). Adding a validation call before send is natural
+  and keeps the "filesystem is truth" check close to the I/O.
+
+- **Option B: In planner, when reading pins.** This would make the planner's
+  `ChainBroken` classification also clear the pin. But the planner is a pure function
+  (ADR-108) — it must not delete files.
+
+**Decision: Option A.** The planner classifies; the executor heals. The planner already
+correctly produces `ChainBroken` when the parent is missing. The executor's job is to
+execute operations AND maintain filesystem invariants. Pin file cleanup is I/O — it
+belongs in the executor.
+
+**Call site:** In `execute_send()`, before the send attempt, after resolving the parent
+path. If validation returns false (stale pin removed), the send should proceed as full
+(the planner already classified it as full — this just cleans up the pin so the next
+run doesn't see the same stale state).
+
+**ADR-102 alignment:** "Filesystem is truth." If the filesystem says a snapshot doesn't
+exist, the pin file is lying. Self-healing corrects the lie.
+
+**ADR-107 alignment:** "Deletions fail closed." We only delete the *pin file* (metadata),
+not a snapshot. And we only delete it when we can confirm the referenced snapshot
+doesn't exist. This is fail-closed: we're refusing to trust a pin that points to nothing.
+
+## Module Map
+
+| Module | Changes | Test Strategy |
+|--------|---------|---------------|
+| `plan.rs` | Drive-availability preflight for transient in `plan()` loop; transient cap of 1 in `plan_local_snapshot()` | Unit tests with `MockFileSystemState`: transient + no drives = no create; transient + 1 existing = no create; transient + 0 existing = create; transient + drive available = create; non-transient unaffected. ~8-10 new tests. |
+| `chain.rs` | New `validate_pin_file()` function | Unit tests with `tempfile::TempDir`: valid pin → true; stale pin → false + file removed; no pin → true; legacy pin stale → removed. ~4-5 new tests. |
+| `executor.rs` | Call `validate_pin_file()` before send; handle stale pin recovery | Integration-style tests with `MockBtrfs`: stale pin → full send proceeds; valid pin → incremental unchanged. ~3-4 new tests. |
+
+**Modules NOT touched:** `types.rs`, `config.rs`, `retention.rs`, `awareness.rs`,
+`voice.rs`, `output.rs`. No new types, no config changes, no output changes.
+
+## Effort Estimate
+
+**~0.5-1 session.** Calibrated against:
+- UPI 004 (token gate): 1 module extended, 5 tests, half session → this is 3 modules,
+  ~15-19 tests, slightly more
+- UPI 008 (doctor pin-age): 2 modules, 6 tests, quarter session → this is more complex
+  but same pattern (read state, validate, fix)
+
+The changes are surgical — no new modules, no new types, no config changes. The bulk
+of the work is tests.
+
+## Sequencing
+
+1. **Change 2 first (transient cap of 1).** Simplest change, immediately prevents
+   accumulation. One check in `plan_local_snapshot()`, several tests. Can be verified
+   immediately: run `urd plan` with transient subvolume + existing snapshot → skip.
+
+2. **Change 1 second (drive preflight).** Depends on understanding the cap behavior to
+   write correct edge-case tests (especially the "first snapshot" case). Slightly more
+   complex because it queries drive availability in a new location.
+
+3. **Change 3 last (pin self-healing).** Independent of changes 1 and 2 but less urgent
+   (the planner already handles stale pins gracefully via `ChainBroken`). This change
+   makes recovery automatic rather than requiring `--force-full`.
+
+**Risk ordering rationale:** Change 2 has the highest leverage and lowest risk. If we
+ship only change 2, accumulation is prevented. Changes 1 and 3 are defense in depth and
+chain repair — important but not blocking.
+
+## Architectural Gates
+
+**None.** All changes operate within existing module boundaries and existing architectural
+invariants:
+
+- Planner remains pure (changes 1 and 2 add conditions, not I/O)
+- Executor performs I/O (change 3 deletes a pin file, which is executor's domain)
+- `BtrfsOps` is not touched
+- No new on-disk contracts — pin file format unchanged, snapshot names unchanged
+- No config changes — existing `local_retention = "transient"` gains correct behavior
+
+## Rejected Alternatives
+
+### "External-only mode" as a new config concept
+
+Brainstorm idea #2. Instead of making transient smarter, introduce `mode = "external-only"`
+that explicitly means "no local snapshots." Rejected for this design because:
+- Adds config surface area for a problem solvable without it
+- Requires a config migration (existing `local_retention = "transient"` would need
+  updating)
+- The config vocabulary change is better addressed in UPI 010 (config schema v1)
+- This design fixes the bug; the vocabulary improvement is a separate concern
+
+### Block manual `urd backup` for transient subvolumes
+
+Brainstorm idea #8. Rejected because it punishes the user. `urd backup` should back up
+everything — the system should make that safe, not restrict it. The preflight + cap
+achieve safety without restricting the user's commands.
+
+### Aggressive transient retention (protect only newest unsent)
+
+Brainstorm idea #16. Modifying unsent protection for transient subvolumes to only protect
+the newest snapshot. Rejected because:
+- Changes the safety invariant of unsent protection (currently protects ALL unsent)
+- The cap of 1 achieves the same result (can't accumulate) without weakening protection
+- Riskier: if the logic has a bug, you could delete an unsent snapshot
+
+### Snapshot budget per filesystem
+
+Brainstorm idea #3. A general-purpose mechanism for limiting snapshots per volume.
+Rejected as over-engineering for this problem:
+- Adds config complexity (`max_snapshots` or `max_exclusive_bytes`)
+- Requires filesystem-level awareness the planner doesn't currently have
+- The transient cap of 1 solves the specific problem without generalizing
+
+## Assumptions
+
+1. **`fs.drive_availability()` is callable from the local operations block.** The
+   planner already calls it in the external operations block (plan.rs:186). No
+   technical barrier to calling it earlier — it reads mount state, not btrfs state.
+
+2. **A transient subvolume with 0 local snapshots should be allowed to create one.**
+   The first-ever snapshot must be created before any send can happen. Without this
+   exception, a new transient subvolume could never start its chain.
+
+3. **Pin file deletion is safe when the referenced snapshot doesn't exist.** The pin
+   file is metadata about chain state. If the chain parent is gone, the pin is a lie.
+   Deleting it causes the next send to be full, which is the correct recovery.
+
+4. **The planner's `ChainBroken` classification already handles the send correctly.**
+   Verified in plan.rs:593-595 — when pin exists but parent is missing locally or
+   externally, the send is classified as `ChainBroken`. The executor gates this in
+   auto mode via `FullSendPolicy::SkipAndNotify`. Change 3 clears the stale pin so
+   the NEXT run sees `NoPinFile` instead, which is a cleaner state.
+
+5. **The space guard (`min_free_bytes`) remains as a last-resort safety net.** This
+   design doesn't remove or modify the space guard. It adds prevention above the
+   threshold — the space guard catches anything this design misses.
+
+## Open Questions
+
+### Q1: Should the transient cap apply when `--force` is used?
+
+**Option A (cap always applies):** Even `urd backup --subvolume htpc-root` (which sets
+`force = true`) respects the cap. Rationale: force overrides intervals, not safety
+invariants. The cap exists to prevent space exhaustion, which force doesn't change.
+
+**Option B (force overrides cap):** `--force` or `--subvolume` bypasses the cap,
+allowing a second transient snapshot. Rationale: the user explicitly asked for this
+specific subvolume — honor the request.
+
+**Recommendation: Option A.** Force already doesn't override the space guard (by
+explicit design — see plan.rs:287 comment). The cap is the same class of safety check.
+A forced transient snapshot that can't be sent is still useless and still dangerous.
+
+### Q2: Should pin self-healing run for all subvolumes or only transient?
+
+**Option A (all subvolumes):** Any subvolume can have stale pins from manual intervention.
+Self-healing should be universal.
+
+**Option B (transient only):** Transient subvolumes are the ones most likely to have
+manual deletions (because they're the ones causing space problems). Limit blast radius.
+
+**Recommendation: Option A.** The validation is cheap (one `path.exists()` check per
+drive per subvolume) and the benefit applies universally. A graduated subvolume can
+also have a stale pin if someone manually deletes a snapshot.
+
+### Q3: What skip reason text should the preflight produce?
+
+The skip reason appears in `urd plan` and `urd backup` output. Options:
+
+- `"transient: no configured drive available"` — precise but jargon-heavy
+- `"no drive for send — skipping transient snapshot"` — clearer intent
+- `"htpc-root: drive WD-18TB1 not mounted (transient — skipping local snapshot)"` —
+  names the specific drive
+
+**Recommendation:** Include the drive name(s) so the user knows what to plug in. The
+skip message is guidance, not just status.

--- a/docs/95-ideas/2026-04-03-design-012-sentinel-drive-gated-transient.md
+++ b/docs/95-ideas/2026-04-03-design-012-sentinel-drive-gated-transient.md
@@ -1,0 +1,343 @@
+---
+upi: "012"
+status: proposed
+date: 2026-04-03
+---
+
+# Design: Sentinel Drive-Gated Transient Backup + Space Pressure Monitoring (UPI 012)
+
+> **TL;DR:** Two Sentinel enhancements for the horizon: (1) trigger transient subvolume
+> backups when their configured drive appears, aligning backup timing with drive
+> availability instead of a fixed schedule; (2) monitor filesystem free space on snapshot
+> roots and emit early-warning notifications before the space guard kicks in. Both extend
+> the Sentinel's event-driven model — no new daemons, no new processes.
+
+## Problem
+
+### Problem 1: Transient backups on a schedule are architecturally wrong
+
+The nightly timer creates snapshots for all subvolumes at ~04:00, including transient
+ones. For transient subvolumes (external-only by intent), this means:
+
+- If the drive is mounted at 04:00: snapshot → send → cleanup. Works correctly.
+- If the drive is NOT mounted at 04:00: snapshot created, can't send, unsent protection
+  keeps it. Space wasted until the drive appears and the next backup run fires.
+
+UPI 011 fixes the acute problem (don't create when drive isn't mounted). But the
+schedule-driven approach is still conceptually wrong for transient subvolumes. The
+optimal behavior is: **back up when the drive appears, not when the clock ticks.**
+
+The Sentinel already detects drive mount events (`DriveMounted { label }`) and has
+infrastructure for triggering backups on state changes (sentinel.rs:268-300). It checks
+whether any subvolume needs a send to the newly mounted drive. But it currently treats
+this as a generic "something might be overdue" trigger — it doesn't distinguish
+transient subvolumes that specifically need the drive to be useful.
+
+### Problem 2: No filesystem space monitoring
+
+The fifth NVMe exhaustion was caught by an external Discord alert from the homelab
+monitoring stack — not by Urd itself. Urd has a reactive space guard
+(`min_free_bytes` prevents snapshot creation below threshold) but no proactive warning.
+The user learns about space pressure only when the space guard activates and skips
+a snapshot, which appears as a skip reason in backup output that nobody reads at 04:00.
+
+The Sentinel monitors drive availability and promise states on a timer. It does not
+monitor filesystem free space on snapshot roots. On a constrained volume like the 118GB
+NVMe, the gap between "healthy" and "space guard firing" can be crossed in a single
+backup cycle.
+
+## Proposed Design
+
+### Enhancement 1: Drive-gated transient backup trigger
+
+**New Sentinel behavior:** When a `DriveMounted` event fires for a drive that is
+configured for at least one transient subvolume, the Sentinel triggers a targeted
+backup for those transient subvolumes immediately.
+
+**Event flow:**
+
+```
+udev: drive WD-18TB1 appears
+  → Sentinel: DriveMounted { label: "WD-18TB1" }
+    → Sentinel checks: any transient subvolumes with this drive in their `drives` list?
+      → yes: emit Action::TriggerTransientBackup { label: "WD-18TB1", subvolumes: ["htpc-root"] }
+        → sentinel_runner: spawn `urd backup --auto --subvolume htpc-root`
+      → no: standard drive reconnection flow (notification, assessment)
+```
+
+**Key design decisions:**
+
+- **Targeted backup, not full backup.** Only back up the transient subvolumes that
+  need this specific drive. Don't trigger a full backup on every drive plug — that
+  would be noisy and could overwhelm the circuit breaker.
+
+- **`--auto` mode.** The triggered backup runs in auto mode, which means interval
+  checks apply. If the transient subvolume was already backed up recently (within its
+  `send_interval`), the trigger is a no-op. This prevents rapid-fire backups if someone
+  plugs and unplugs a drive repeatedly.
+
+- **Circuit breaker applies.** The existing circuit breaker (15min initial, exponential
+  backoff) prevents cascade failures. A failed drive-gated backup counts as a failure
+  and extends the backoff window.
+
+- **Coexists with timer-based backups.** The nightly timer still runs for all subvolumes.
+  If the drive happens to be mounted at 04:00, the timer handles transient subvolumes
+  normally. Drive-gated triggers are additive — they provide faster response when drives
+  appear between scheduled runs.
+
+**Sentinel state machine changes:**
+
+```rust
+// New action variant
+enum Action {
+    // ... existing variants ...
+    TriggerTransientBackup {
+        label: String,
+        subvolumes: Vec<String>,
+    },
+}
+
+// In process_event for DriveMounted:
+// After existing logic, add:
+let transient_subvols = config.resolved_subvolumes()
+    .iter()
+    .filter(|sv| sv.local_retention.is_transient())
+    .filter(|sv| sv.drives.as_ref().map_or(false, |d| d.contains(&label)))
+    .map(|sv| sv.name.clone())
+    .collect::<Vec<_>>();
+
+if !transient_subvols.is_empty() {
+    actions.push(Action::TriggerTransientBackup {
+        label,
+        subvolumes: transient_subvols,
+    });
+}
+```
+
+**sentinel_runner.rs changes:**
+
+```rust
+// Handle the new action
+Action::TriggerTransientBackup { label, subvolumes } => {
+    for subvol in &subvolumes {
+        log::info!(
+            "Drive {label} mounted — triggering transient backup for {subvol}"
+        );
+    }
+    // Spawn: urd backup --auto --subvolume <name>
+    // (one per subvolume, or --subvolume flag could accept multiple)
+    self.trigger_backup(Some(&subvolumes[0])).await?;
+}
+```
+
+### Enhancement 2: Filesystem space pressure monitoring
+
+**New Sentinel behavior:** On each `AssessmentTick`, check free space on each snapshot
+root. If free space drops below a configurable warning threshold (higher than
+`min_free_bytes`), emit a notification.
+
+**Config addition (v1 schema, optional):**
+
+```toml
+[general]
+space_warning_threshold = "15GB"    # Warn when any snapshot root drops below this
+```
+
+Or per snapshot root if different volumes have different sizes. For simplicity, start
+with a single global threshold.
+
+**Event flow:**
+
+```
+AssessmentTick fires
+  → Sentinel checks free space on each unique snapshot root
+    → snapshot_root "/.snapshots": 8.2 GB free, threshold 15 GB
+      → Emit Action::NotifySpacePressure {
+            snapshot_root: "/.snapshots",
+            free_bytes: 8_800_000_000,
+            threshold_bytes: 15_000_000_000,
+            subvolumes: ["htpc-root", "htpc-home"],
+        }
+```
+
+**Notification content (voice.rs):**
+
+```
+⚠ Storage pressure on /.snapshots
+  8.2 GB free — below 15 GB warning threshold
+  Subvolumes affected: htpc-root, htpc-home
+  
+  Consider: review retention, check for stale snapshots, 
+  or run `urd plan` to see pending cleanup.
+```
+
+**Dedup:** The notification should fire once per assessment cycle where the condition
+is true, but not repeat every tick. Use the same cooldown mechanism as other Sentinel
+notifications. The notification should re-fire if free space drops further (e.g., at
+50% of the warning threshold) as an escalation.
+
+**Sentinel state machine changes:**
+
+```rust
+// New event type (or fold into AssessmentTick processing)
+// New action variant
+enum Action {
+    // ... existing variants ...
+    NotifySpacePressure {
+        snapshot_root: PathBuf,
+        free_bytes: u64,
+        threshold_bytes: u64,
+        subvolumes: Vec<String>,
+    },
+}
+```
+
+## Module Map
+
+| Module | Changes | Test Strategy |
+|--------|---------|---------------|
+| `sentinel.rs` | New `TriggerTransientBackup` action; space pressure check in assessment tick; new `NotifySpacePressure` action | State machine tests: DriveMounted + transient subvol → trigger action; DriveMounted + non-transient → no trigger; space below threshold → notify; space above → no notify; dedup across ticks. ~8-10 tests. |
+| `sentinel_runner.rs` | Handle `TriggerTransientBackup` (spawn targeted backup); handle `NotifySpacePressure` (format + dispatch notification) | Integration tests with mock runner: verify backup command spawned with correct args; verify notification dispatched. ~4-5 tests. |
+| `notify.rs` | New notification template for space pressure | Template test: correct message formatting. ~2 tests. |
+| `voice.rs` | Space pressure notification rendering | Voice rendering test. ~1-2 tests. |
+| `config.rs` | `space_warning_threshold` field (optional, v1 only or both) | Parser tests. ~2 tests. |
+| `types.rs` | `ByteSize` already exists; possibly new config field type | Minimal. |
+
+**Modules NOT touched:** `plan.rs`, `executor.rs`, `chain.rs`, `retention.rs`,
+`awareness.rs`. These are backup-path modules; this design extends monitoring only.
+
+## Effort Estimate
+
+**~1-1.5 sessions total.** Calibrated against:
+- UPI 006 (drive reconnection notifications): 1 Sentinel action + notification template,
+  ~0.5-1 session → Enhancement 1 is similar scope (1 new action, 1 runner handler)
+- Enhancement 2 adds another action + config field + notification template → ~0.5 session
+
+Could be split: Enhancement 1 first (higher impact), Enhancement 2 second.
+
+## Sequencing
+
+This is horizon work — not in the active arc.
+
+**Prerequisites:**
+- UPI 011 must ship first (transient behavioral fix). Without 011, drive-gated triggers
+  would create snapshots that can't be safely managed.
+- Sentinel active mode design should be reviewed. Enhancement 1 is effectively the first
+  use case of "Sentinel triggers backups." If the active mode design has broader
+  requirements (permission model, user opt-in, rate limiting), those should inform this.
+
+**Recommended order:**
+1. UPI 011 (emergency fix) — immediate
+2. UPI 010 (config schema v1) — already in progress
+3. UPI 012 Enhancement 1 (drive-gated transient) — after Sentinel active mode design
+4. UPI 012 Enhancement 2 (space pressure) — can ship independently, lower priority
+
+## Architectural Gates
+
+### Enhancement 1: Sentinel active mode precedent
+
+The Sentinel currently reacts to events by assessing state and sending notifications.
+Enhancement 1 makes it trigger backups — a qualitative change from observer to actor.
+This should be reviewed against the Sentinel's design philosophy:
+
+- **Permission model:** Should the user explicitly opt in to Sentinel-triggered backups?
+  Currently the Sentinel runs as a user service — it has the same permissions. But
+  "monitoring" and "acting" are psychologically different to users.
+- **Failure isolation:** If the triggered backup fails, how does it affect the Sentinel?
+  The circuit breaker handles rate limiting, but error propagation needs design.
+- **Observability:** Triggered backups should be visible in `urd status` or logs. The
+  user should know "this backup was triggered by drive insertion at 14:23" vs "this
+  backup ran at the scheduled 04:00."
+
+**Recommendation:** This gate is advisory, not blocking. The existing circuit breaker
+and `--auto` mode provide sufficient safety for a first implementation. But document the
+precedent: Enhancement 1 is the first instance of Sentinel-as-actor, and future active
+mode features should follow the same pattern.
+
+### Enhancement 2: No gates
+
+Space monitoring is read-only observation + notification. No new contracts, no new
+actions beyond notification dispatch.
+
+## Rejected Alternatives
+
+### Dedicated transient backup daemon
+
+A separate process that watches for drive events and triggers transient backups.
+Rejected because:
+- The Sentinel already watches for drive events
+- Another daemon adds operational complexity (two services to manage, coordinate, debug)
+- The Sentinel's circuit breaker and assessment infrastructure are needed anyway
+
+### Polling-based space monitoring (cron)
+
+A cron job or separate timer that checks space and alerts. Rejected because:
+- The Sentinel already runs on a tick cycle
+- Adding space checks to the existing assessment tick is zero additional infrastructure
+- Cron-based monitoring doesn't integrate with Urd's notification system
+
+### Space pressure triggers aggressive retention
+
+When space is low, automatically thin snapshots more aggressively. Rejected because:
+- "Deletions fail closed" (ADR-107) — automatic deletion under pressure is the opposite
+  of fail-closed
+- The space guard already prevents new snapshots; aggressive retention deletes existing
+  ones, which could remove the user's recovery options
+- Notification is the right response: inform the human, let them decide
+
+## Assumptions
+
+1. **Sentinel can spawn `urd backup` processes.** The runner already has infrastructure
+   for spawning subprocesses (it runs assessments). Spawning a backup is architecturally
+   the same — a subprocess with arguments.
+
+2. **The circuit breaker is sufficient rate limiting for drive-gated triggers.** A user
+   plugging and unplugging a drive rapidly should not trigger unlimited backups. The
+   15-minute initial cooldown + exponential backoff handles this.
+
+3. **Filesystem free space checks are cheap.** `statvfs()` is a constant-time operation.
+   Adding it to the assessment tick (every ~5 minutes) has negligible performance impact.
+
+4. **A single global `space_warning_threshold` is sufficient for v1.** Per-root thresholds
+   are a future enhancement if users have volumes of wildly different sizes.
+
+## Open Questions
+
+### Q1: Should drive-gated triggers work for non-transient subvolumes too?
+
+**Option A (transient only):** Only transient subvolumes benefit from drive-gated
+triggers. Non-transient subvolumes have local snapshots ready to send whenever the
+nightly timer runs.
+
+**Option B (all subvolumes with pending sends):** Any subvolume with an unsent
+snapshot gets triggered when its drive appears. This is closer to "back up when
+possible" — the universal ideal.
+
+**Recommendation: Start with Option A, design for Option B.** Transient subvolumes
+have the strongest need (they can't create useful local snapshots without the drive).
+Non-transient subvolumes benefit less (they already have local history). But the
+implementation should be extensible — the trigger logic should check "does this
+subvolume need a send to this drive?" not "is this subvolume transient?"
+
+### Q2: What's the right space warning threshold default?
+
+No default is universally right. Options:
+- **Fixed default (10GB):** Simple but wrong for large volumes.
+- **Percentage of volume (10%):** Scales but 10% of 10TB is 1TB, which isn't "pressure."
+- **No default (opt-in):** Safest — no notification noise until configured.
+- **Derived from `min_free_bytes`:** Warning at 2x the space guard threshold.
+
+**Recommendation: Derived from `min_free_bytes` × 2, opt-in via config.** If the user
+has set `min_free_bytes = 10GB`, warn at 20GB. If not set, no warning. This ties the
+warning to the user's own sense of "how much space is too little" without inventing a
+new threshold.
+
+### Q3: Should triggered backups appear differently in output?
+
+When `urd status` shows the last backup, should "triggered by drive WD-18TB1 at 14:23"
+be distinguishable from "scheduled run at 04:00"? The trigger source is already captured
+in the lock metadata (`lock.rs` tracks trigger source). Extending this to backup history
+(state.rs) would provide observability.
+
+**Recommendation: Yes, but defer.** Track the trigger source in state.db for future
+use. Don't change the status output now — that's UPI 002 (output polish) territory.

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,6 +5,9 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
+| 012 | Sentinel drive-gated transient + space monitoring | [design](../95-ideas/2026-04-03-design-012-sentinel-drive-gated-transient.md) | - | - | - | - |
+| 011 | Transient space safety (emergency fix) | [design](../95-ideas/2026-04-03-design-011-transient-space-safety.md) | [steve](../99-reports/2026-04-03-steve-jobs-011-transient-is-a-lie.md) | - | - | - |
+| 010-a | Transient as first-class config concept | [design](../95-ideas/2026-04-03-design-010a-transient-as-first-class-config.md) | - | - | - | - |
 | 010 | Config Schema v1 (ADR-111 revision) | [design](../95-ideas/2026-04-03-design-010-config-schema-v1.md) | - | [adversary](../99-reports/2026-04-03-design-review-010-config-schema-v1.md) | - | - |
 | 009 | `urd drives` subcommand | [design](../95-ideas/2026-04-02-design-009-urd-drives-subcommand.md) | - | [adversary](../99-reports/2026-04-03-design-review-009-006-phase-c-drives.md) | merged | [#72](https://github.com/vonrobak/urd/pull/72) |
 | 008 | Doctor pin-age correlation | [design](../95-ideas/2026-04-02-design-008-doctor-pin-age-correlation.md) | - | [adversary](../99-reports/2026-04-03-design-review-007-008-phase-b-communication.md) | merged | [#70](https://github.com/vonrobak/urd/pull/70) |

--- a/docs/99-reports/2026-04-03-steve-jobs-011-transient-is-a-lie.md
+++ b/docs/99-reports/2026-04-03-steve-jobs-011-transient-is-a-lie.md
@@ -1,0 +1,176 @@
+---
+upi: "011"
+date: 2026-04-03
+mode: vision-filter
+---
+
+# Steve Jobs Review: Brainstorm 011 — Transient Space Safety
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-03
+**Scope:** Brainstorm 011: 16 ideas for preventing transient subvolume space exhaustion
+**Mode:** Vision Filter
+
+## The Verdict
+
+"Transient" is a lie Urd tells itself, and the user has nearly lost their system five
+times because of it. This isn't a brainstorm about improvements — this is a brainstorm
+about fixing a broken promise. Some of these ideas fix the promise. Most of them are
+band-aids, safety nets, or interesting distractions. I'm going to be direct about which
+is which.
+
+## What's Insanely Great
+
+The problem statement is the best part of this brainstorm. "Transient retention is a
+deletion policy, not a creation policy." That sentence is the diagnosis. Everything flows
+from it.
+
+The brainstorm also correctly identifies pin file corruption as secondary damage — not an
+afterthought but a direct consequence that compounds the original failure. That kind of
+chain-of-failure thinking is exactly how you build reliable systems.
+
+And I'll say this: the fact that the homelab's Discord alert caught this before disaster
+is the system working as designed. The invisible worker failed, but the monitoring layer
+saved the data. That's defense in depth. It shouldn't have been needed, but it worked.
+
+## Priority Scores and Grouping
+
+Let me score every idea, then group the ones worth designing.
+
+### Tier 1: Fix the broken promise (build these)
+
+| Idea | Score | Rationale |
+|------|-------|-----------|
+| **#6 — Drive-availability preflight** | **92** | The cleanest expression of the correct behavior. If you can't send, don't snapshot. Period. This is not a "check" — this IS what transient means. |
+| **#14 — Pin file self-healing** | **88** | This isn't optional. Pin files that reference ghosts are a data integrity time bomb. The next send after manual intervention must be correct, not lucky. |
+| **#4 — Transient cap of 1** | **85** | Defense in depth. Even if #6 has a bug, even if drive detection lies, you can never have more than one snapshot. Belt AND suspenders. |
+
+### Tier 2: Right direction, needs design scrutiny
+
+| Idea | Score | Rationale |
+|------|-------|-----------|
+| **#1 — Transient-aware creation gate** | **70** | Correct instinct, but #6 does the same thing more cleanly at the subvolume level rather than buried inside a helper function. Subsumed by #6. |
+| **#16 — Aggressive transient retention** | **65** | Smart safety net — "protect only the newest unsent" caps accumulation even when creation slips through. But this is fixing the retention side when the creation side is the real problem. |
+| **#5 — Atomic send-and-delete** | **60** | Appealing conceptually, but "atomic" is a dangerous word in systems that shell out to `sudo btrfs`. The executor already has transient cleanup. Making the existing path work correctly is better than a new execution mode. |
+| **#10 — Sentinel drive-gated backup** | **55** | This is the long-term right answer for transient subvolumes. But it requires Sentinel active mode, which is explicitly in the horizon section, not the active arc. Don't build the penthouse before the foundation is solid. |
+
+### Tier 3: Interesting but wrong priority
+
+| Idea | Score | Rationale |
+|------|-------|-----------|
+| **#2 — External-only mode** | **45** | This is what transient *should have been* from the start. But renaming the concept doesn't fix the bug — #6 does. Consider this for UPI 010 config schema redesign, not for the emergency fix. |
+| **#11 — Filesystem pressure notifications** | **40** | The Discord alert already saved the day. Making it native to Urd is nice but doesn't prevent the problem. This is a "reduce attention" feature, not a "make data safer" feature, and right now data safety is on fire. |
+| **#12 — `local_snapshots = false`** | **40** | Same as #2 — correct concept, wrong timing. This belongs in the config v1 design conversation, not in the emergency fix. |
+| **#9 — Volume-aware scheduling** | **35** | Architecturally fascinating, practically a research project. The 118GB NVMe problem has a simpler solution: don't create snapshots you can't send. Volume awareness is a v2.0 concern. |
+| **#3 — Snapshot budget** | **30** | Adds config surface area to solve a problem that #6 + #4 solve without any new config. More knobs is not the answer here. |
+| **#8 — Auto-only transient** | **25** | This punishes the user for running `urd backup` manually. "You can't do that" is never the right answer. The right answer is making manual runs safe. |
+| **#13 — `urd reclaim`** | **20** | An emergency tool for a problem that shouldn't happen. If #6 and #4 work, this is never needed. If they don't work, you have bigger problems than a CLI command can solve. |
+| **#7 — Pin file recovery** | **15** | Subsumed entirely by #14, which does everything this does and more. |
+| **#15 — Snapshot in tmpfs** | **5** | I appreciate the ambition, but this is solving the wrong problem with exotic infrastructure. BTRFS doesn't work this way. Park it. |
+
+## Design Groups
+
+Here's how these should be grouped for design work:
+
+### Group A: "Transient means what it says" (emergency fix)
+
+**Ideas: #6 + #4 + #14**
+**Priority: IMMEDIATE — this is a production bug causing repeated incidents**
+
+These three ideas form a complete fix:
+
+- **#6 (drive preflight)** prevents the creation of useless snapshots. This is the
+  primary fix. If no configured drive is mounted, a transient subvolume produces zero
+  local operations.
+- **#4 (cap of 1)** is the safety net. Even if drive detection is wrong, even if the
+  user finds some way to create extra snapshots, you can never have more than one.
+  Defense in depth isn't paranoia — it's what five incidents in ten days earns you.
+- **#14 (pin self-healing)** repairs the damage from this incident and makes the system
+  resilient to future manual interventions. Filesystem is truth (ADR-102) — enforce it.
+
+One design spec. One implementation session. One PR. These are not three features —
+they are three aspects of one fix: "transient subvolumes must not accumulate local
+snapshots, and when humans intervene, the chain must self-correct."
+
+### Group B: "Transient as a first-class concept" (config v1 integration)
+
+**Ideas: #2 + #12 (informing UPI 010)**
+**Priority: Fold into UPI 010 config schema v1 design**
+
+The current config says `local_retention = "transient"` and the user has to infer what
+that means. The v1 config should express the intent directly. Whether that's
+`mode = "external-only"` or `local_snapshots = false` or something else — that's a
+design conversation for UPI 010. Don't build it now, but don't lose the insight: the
+config vocabulary should match the user's mental model, not the implementation's
+internal retention enum.
+
+### Group C: "Event-driven transient" (horizon)
+
+**Ideas: #10 + #11**
+**Priority: After Sentinel active mode is designed**
+
+The truly elegant solution is that transient backups happen when drives appear, not on
+a schedule. But that's Sentinel active mode, and the roadmap correctly places that in
+the horizon. These ideas should inform that design when the time comes.
+
+## The Vision
+
+Here's what bothers me about this whole situation. Urd's north star says "does it reduce
+the attention the user needs to spend on backups?" And yet the user has had to manually
+intervene in a near-disaster *five times in ten days*. That's not reducing attention —
+that's demanding it.
+
+The fix isn't complicated. A transient subvolume is a promise: "I will back up your data
+externally without costing you local space." Right now, Urd breaks that promise silently,
+then relies on a separate monitoring system to catch the failure. That's not acceptable
+for a tool whose entire identity is "silence means data is safe."
+
+When Group A ships, a transient subvolume should be genuinely invisible. No local
+accumulation. No orphaned pins. No panicked manual deletions. The user configures
+`local_retention = "transient"`, and from that moment on, Urd handles it. That's the
+promise. Keep it.
+
+## The Details
+
+- The brainstorm problem statement says "five incidents in 10 days." That number should
+  make everyone uncomfortable. It means the space guard from incident #1 was a patch, not
+  a fix. Each subsequent incident was an escalation that proved the patch insufficient.
+  Group A isn't just a fix — it's an acknowledgment that the original fix was incomplete.
+
+- Idea #8 suggests blocking manual `urd backup` for transient subvolumes. Never do this.
+  When a user types `urd backup`, they want *all* their data backed up. Telling them "no,
+  not that one" breaks trust. The right behavior is: if the drive is mounted, create →
+  send → clean up. If it's not, skip gracefully with a clear message. The user should
+  never have to think about which subvolumes are transient when running a manual backup.
+
+- The pin file situation is more dangerous than it looks. A stale pin doesn't just cause
+  a full send (wasting time and space). If the referenced snapshot name happens to match
+  a *different* snapshot on the external drive (name collision after deletion and
+  recreation), you could get a corrupt incremental. #14's "verify the pin target exists
+  locally" check eliminates this entire class of failure.
+
+- The brainstorm correctly notes that `skip_intervals: !args.auto` makes manual runs
+  dangerous for transient subvolumes. But the real insight is simpler: for transient,
+  interval doesn't matter at all. The only question is "can I send?" If yes, create and
+  send. If no, skip. The interval logic is irrelevant to transient's purpose.
+
+## The Ask
+
+1. **Design Group A immediately as a single spec** — #6 (drive preflight) + #4 (cap of 1)
+   + #14 (pin self-healing). This is a production bug. Five incidents. Fix it with the
+   urgency it deserves. Patch-tier workflow: design is the bug fix, not a feature.
+
+2. **Carry #2 and #12 into UPI 010 config schema conversations** — the vocabulary
+   insight ("external-only" vs "transient retention") should inform how v1 config
+   expresses subvolume intent. Don't build now, don't lose the idea.
+
+3. **Note #10 and #11 for Sentinel active mode design** — when Sentinel gets the ability
+   to trigger backups, "drive appears → back up transient subvolumes" should be the
+   first use case.
+
+4. **After Group A ships, update the catastrophic failure memory** — five incidents with
+   the same root cause is a pattern. The fix should be documented as a resolved pattern,
+   not an open wound.
+
+5. **Kill #8, #15, #3, and #13** — they either punish the user, add complexity without
+   proportional benefit, or solve problems that won't exist after Group A.


### PR DESCRIPTION
## Summary

- **Brainstorm 011:** 16 ideas for preventing transient subvolume space exhaustion (fifth NVMe incident)
- **UPI 011 design:** Emergency fix — drive-availability preflight, transient cap of 1, pin file self-healing
- **UPI 010-a design:** `local_snapshots = false` as first-class v1 config concept (fold into UPI 010 session 3)
- **UPI 012 design:** Sentinel drive-gated transient backup + filesystem space pressure monitoring (horizon)
- **Steve Jobs review:** Vision filter scoring all 16 ideas, grouping into immediate/v1/horizon tracks
- **Registry:** Updated with UPI 011, 010-a, 012

## Testing

- Documentation only — no code changes, no quality gate needed
- P6a code changes in working tree are intentionally excluded (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)