### PR TITLE
refactor: UPI 010 P6a — rename protection levels (recorded/sheltered/fortified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Protection level vocabulary: guarded→recorded, protected→sheltered, resilient→fortified — names now describe what the data *becomes*, not a generic safety adjective
+- ADR-111 revised with complete v1 schema specification, field tables, migration spec, and validation error messages
+- ADR-110 updated with new level names and implementation gate progress
+
 ## [0.9.0] - 2026-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-04-03
+
 ### Changed
 - Protection level vocabulary: guarded→recorded, protected→sheltered, resilient→fortified — names now describe what the data *becomes*, not a generic safety adjective
 - ADR-111 revised with complete v1 schema specification, field tables, migration spec, and validation error messages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/config/urd.toml.example
+++ b/config/urd.toml.example
@@ -118,22 +118,22 @@ min_free_bytes = "100GB"
 # derived values when you need finer control.
 #
 # Levels (with daily timer):
-#   guarded   — local snapshots only, minimal retention (d:7, w:4)
-#   protected — local + 1 external drive, full retention
-#   resilient — local + 2+ external drives, full retention
+#   recorded  — local snapshots only, minimal retention (d:7, w:4)
+#   sheltered — local + 1 external drive, full retention
+#   fortified — local + 2+ external drives + offsite, full retention
 #   custom    — manual config (default, no derivation)
 #
 # "drives" restricts which external drives serve a subvolume's promise.
 # Omit to use all configured drives.
 
-# ─── Resilient: irreplaceable data on multiple drives ─────────────────
+# ─── Fortified: irreplaceable data on multiple drives ─────────────────
 
 [[subvolumes]]
 name = "htpc-home"
 short_name = "htpc-home"
 source = "/home"
 priority = 1
-protection_level = "resilient"
+protection_level = "fortified"
 drives = ["WD-18TB", "WD-18TB1"]   # Active workstation — keep off small test drive
 
 [[subvolumes]]
@@ -141,7 +141,7 @@ name = "subvol3-opptak"
 short_name = "opptak"
 source = "/mnt/btrfs-pool/subvol3-opptak"
 priority = 1
-protection_level = "resilient"
+protection_level = "fortified"
 drives = ["WD-18TB", "WD-18TB1"]   # ~3.4TB — exceeds 2TB-backup capacity
 
 [[subvolumes]]
@@ -149,31 +149,31 @@ name = "subvol2-pics"
 short_name = "pics"
 source = "/mnt/btrfs-pool/subvol2-pics"
 priority = 2
-protection_level = "resilient"
+protection_level = "fortified"
 drives = ["WD-18TB", "WD-18TB1"]   # Photos are irreplaceable
 
-# ─── Protected: important data on at least one drive ──────────────────
+# ─── Sheltered: important data on at least one drive ──────────────────
 
 [[subvolumes]]
 name = "subvol1-docs"
 short_name = "docs"
 source = "/mnt/btrfs-pool/subvol1-docs"
 priority = 2
-protection_level = "protected"
+protection_level = "sheltered"
 
 [[subvolumes]]
 name = "subvol7-containers"
 short_name = "containers"
 source = "/mnt/btrfs-pool/subvol7-containers"
 priority = 2
-protection_level = "protected"
+protection_level = "sheltered"
 
 [[subvolumes]]
 name = "subvol5-music"
 short_name = "music"
 source = "/mnt/btrfs-pool/subvol5-music"
 priority = 3
-protection_level = "protected"
+protection_level = "sheltered"
 
 # ─── Transient: send to external, don't keep local history ───────────
 # Transient retention keeps only the pinned snapshot needed for incremental
@@ -189,14 +189,14 @@ local_retention = "transient"      # Delete local after send, keep only chain pa
 send_interval = "1d"
 drives = ["WD-18TB1"]              # Send to offsite drive only
 
-# ─── Guarded: local snapshots only ────────────────────────────────────
+# ─── Recorded: local snapshots only ───────────────────────────────────
 
 [[subvolumes]]
 name = "subvol4-multimedia"
 short_name = "multimedia"
 source = "/mnt/btrfs-pool/subvol4-multimedia"
 priority = 3
-protection_level = "guarded"
+protection_level = "recorded"
 snapshot_interval = "1w"           # Override: large volume, weekly is sufficient
 
 [[subvolumes]]
@@ -204,5 +204,5 @@ name = "subvol6-tmp"
 short_name = "tmp"
 source = "/mnt/btrfs-pool/subvol6-tmp"
 priority = 3
-protection_level = "guarded"
+protection_level = "recorded"
 local_retention = { daily = 7 }    # Override: cache data, minimal history needed

--- a/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
+++ b/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
@@ -3,11 +3,11 @@
 > **TL;DR:** Protection promises are named levels that map to concrete operational policies.
 > The user declares intent; Urd derives operations. Named levels are opaque — no per-field
 > overrides. `Custom` means the user manages all parameters explicitly. Named levels must
-> earn opaque status through operational track record; the current taxonomy
-> (guarded/protected/resilient) is provisional and subject to rework.
+> earn opaque status through operational track record. Current taxonomy:
+> recorded/sheltered/fortified (renamed 2026-04-03 from guarded/protected/resilient).
 
-**Date:** 2026-03-26 (revised 2026-03-27, addendum 2026-03-31)
-**Status:** Accepted (taxonomy provisional — see Maturity Model)
+**Date:** 2026-03-26 (revised 2026-03-27, addendum 2026-03-31, vocabulary 2026-04-03)
+**Status:** Accepted (taxonomy renamed 2026-04-03 — see Maturity Model)
 **Depends on:** ADR-100 (planner/executor separation), ADR-108 (pure function modules),
 ADR-109 (config boundary validation), ADR-111 (config system architecture)
 **Ownership:** This ADR is authoritative for protection promise *semantics* — what levels
@@ -31,9 +31,14 @@ Protection promises bridge this gap: the user declares what they want; Urd deriv
 
 A subsequent design review (2026-03-27) found that the original override semantics
 (voiding/weakening overrides on named levels) created contradictory configs and noisy
-preflight warnings. The review also found the current three-level taxonomy insufficiently
-mature — "guarded" vs "protected" are near-synonyms that don't communicate the operational
+preflight warnings. The review also found the original three-level taxonomy insufficiently
+mature — "guarded" vs "protected" were near-synonyms that didn't communicate the operational
 axis (local-only vs external copies). These findings led to the revised design below.
+
+A vocabulary session (2026-04-03) renamed the levels to communicate the operational axis:
+recorded (data is recorded locally), sheltered (data is sheltered on external drive),
+fortified (data is fortified across geography). The names describe what the data *becomes*,
+not the mechanism.
 
 ## Decision
 
@@ -54,31 +59,26 @@ distinction, and preflight warnings from intentional deviations.
 No code path treats it as lesser. It is the appropriate — and currently recommended —
 choice when named levels haven't earned their keep through operational evidence.
 
-### Current taxonomy (provisional)
+### Current taxonomy
 
 The current named levels are:
 
 ```rust
 pub enum ProtectionLevel {
-    Guarded,    // Local snapshots only. For: temp data, caches, build artifacts.
-    Protected,  // Local + at least one external drive current. For: documents, photos.
-    Resilient,  // Local + multiple external drives current. For: irreplaceable data.
+    Recorded,   // Local snapshots only. For: temp data, caches, build artifacts.
+    Sheltered,  // Local + at least one external drive current. For: documents, photos.
+    Fortified,  // Local + multiple external drives + offsite. For: irreplaceable data.
     Custom,     // User manages all parameters manually.
 }
 ```
 
-**This taxonomy is provisional.** The design review identified that:
+The names communicate the operational axis — what the data *becomes*:
+- **Recorded:** data is recorded in history (local snapshots exist on this machine)
+- **Sheltered:** data is sheltered from hardware failure (survives drive loss)
+- **Fortified:** data is fortified against site loss (survives fire, theft, flood)
 
-- "Guarded" and "protected" are near-synonyms that don't communicate the actual
-  operational difference (local-only vs external copies).
-- "Protected" and "resilient" are operationally identical except for `min_external_drives`.
-  This may be insufficient to justify two distinct opaque levels.
-- Level names should communicate operational meaning to the user — the naming axis should
-  make the promise legible without reading documentation.
-
-The taxonomy will be reworked in a future design session once more operational experience
-exists. Until then, `custom` with explicit parameters is the recommended approach for
-production configs.
+Until named levels earn opaque status through operational evidence (see Maturity Model),
+`custom` with explicit parameters remains the recommended approach for production configs.
 
 ### Outcome targets per level
 
@@ -87,9 +87,9 @@ frequencies. These targets are primary policy, defensible independent of awarene
 
 | Level | Local max age | External max age | Min external drives | Retention floor |
 |-------|--------------|------------------|--------------------|-----------------------|
-| `guarded` | 48h | — (no external) | 0 | daily=7, weekly=4 |
-| `protected` | 24h | 48h | 1 | daily=30, weekly=26, monthly=12 |
-| `resilient` | 24h | 48h | 2 | daily=30, weekly=26, monthly=12 |
+| `recorded` | 48h | — (no external) | 0 | daily=7, weekly=4 |
+| `sheltered` | 24h | 48h | 1 | daily=30, weekly=26, monthly=12 |
+| `fortified` | 24h | 48h | 2 | daily=30, weekly=26, monthly=12 |
 | `custom` | (from config) | (from config) | (from config) | (from config) |
 
 ### Pure derivation function
@@ -121,7 +121,7 @@ contains only identity and the level itself:
 name = "subvol3-opptak"
 source = "/mnt/btrfs-pool/subvol3-opptak"
 snapshot_root = "/mnt/btrfs-pool/.snapshots"
-protection_level = "resilient"
+protection_level = "fortified"
 drives = ["WD-18TB", "WD-18TB1"]
 ```
 
@@ -156,7 +156,7 @@ A promise is achievable if the derived policy can be fulfilled given run frequen
 topology, and retention alignment. Achievability has two tiers:
 
 **Structural unachievability (hard error — refuse to start):** The config makes it
-impossible to fulfill the promise. Examples: a `resilient` subvolume with only 1 drive
+impossible to fulfill the promise. Examples: a `fortified` subvolume with only 1 drive
 in its `drives` list (needs 2), or a named level with `drives` omitted when the level
 requires external sends. These are authoring mistakes, not runtime conditions — the
 config is wrong. Caught by `Config::validate()` (ADR-109, ADR-111).
@@ -242,20 +242,20 @@ desk.
 
 ## Addendum: Offsite Freshness Contract (2026-03-31)
 
-**Context:** Design 6-E (Promise Redundancy Encoding) makes the resilient level's geographic
+**Context:** Design 6-E (Promise Redundancy Encoding) makes the fortified level's geographic
 requirement explicit. This addendum documents the offsite freshness contract and confirms
 that it preserves the invariants above.
 
-### Resilient requires offsite
+### Fortified requires offsite
 
-The resilient level encodes geographic redundancy: at least one configured drive must have
-`role = "offsite"`. A resilient subvolume with no offsite-role drive triggers a preflight
-advisory (`resilient-without-offsite`). This is an achievability gap, not a structural
+The fortified level encodes geographic redundancy: at least one configured drive must have
+`role = "offsite"`. A fortified subvolume with no offsite-role drive triggers a preflight
+advisory (`fortified-without-offsite`). This is an achievability gap, not a structural
 error — backups proceed but the promise cannot be fully met (ADR-109).
 
 ### Offsite freshness thresholds
 
-For resilient subvolumes, the newest successful send to any offsite-role drive determines
+For fortified subvolumes, the newest successful send to any offsite-role drive determines
 an offsite freshness status:
 
 | Offsite age (days) | Offsite freshness status |
@@ -268,8 +268,8 @@ The overall subvolume status is `min(local_status, best_external_status, offsite
 Offsite freshness is an additional constraint — it does not replace per-drive freshness
 assessment.
 
-These thresholds define what "resilient" means operationally: **monthly-or-better offsite
-rotation.** Users with longer rotation cycles must use `protection_level = "custom"`.
+These thresholds define what "fortified" means operationally: **monthly-or-better offsite
+rotation.** Users with longer rotation cycles must use custom protection.
 The thresholds are fixed (not user-configurable), consistent with the opacity principle
 for named levels.
 
@@ -286,9 +286,9 @@ additional constraint based on protection level.
 
 ### Scope
 
-- Only resilient subvolumes are affected. Protected, guarded, and custom are unchanged.
+- Only fortified subvolumes are affected. Sheltered, recorded, and custom are unchanged.
 - The existing 7-day "consider cycling" advisory is replaced by structured offsite freshness
-  degradation for resilient subvolumes. Protected subvolumes keep the existing advisory.
+  degradation for fortified subvolumes. Sheltered subvolumes keep the existing advisory.
 - See Design 6-E (`docs/95-ideas/2026-03-31-design-e-promise-redundancy-encoding.md`) for
   full rationale and review findings.
 
@@ -296,14 +296,14 @@ additional constraint based on protection level.
 
 This ADR is considered implemented when:
 
-- [ ] `ProtectionLevel` enum and `derive_policy()` exist in `types.rs`
-- [ ] `protection_level`, `drives`, `run_frequency` config fields are parsed and validated
-- [ ] Config validation rejects operational fields alongside named protection levels
-- [ ] `resolve_subvolume()` branches on protection level with custom fallthrough
-- [ ] Achievability preflight checks are active
-- [ ] `--confirm-retention-change` flag gates retention tightening
-- [ ] `urd status` shows promise level column
-- [ ] Pin-protection safety tests pass with derived retention
+- [x] `ProtectionLevel` enum and `derive_policy()` exist in `types.rs`
+- [x] `protection_level`, `drives`, `run_frequency` config fields are parsed and validated
+- [ ] Config validation rejects operational fields alongside named protection levels (v1 schema, ADR-111)
+- [x] `resolve_subvolume()` branches on protection level with custom fallthrough
+- [x] Achievability preflight checks are active
+- [x] `--confirm-retention-change` flag gates retention tightening
+- [x] `urd status` shows promise level column
+- [x] Pin-protection safety tests pass with derived retention
 
 ## Related
 

--- a/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
+++ b/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
@@ -7,7 +7,10 @@
 > with explicit parameters are the honest default.
 
 **Date:** 2026-03-27
-**Status:** Accepted — not yet implemented (see Implementation Gates)
+**Revised:** 2026-04-03 (v1 schema specification, vocabulary alignment, field tables,
+migration spec, validation messages)
+**Status:** Accepted — sessions 1-2 implemented (P6a rename, P6b serialize), sessions 3-4
+pending (v1 parser, `urd migrate`)
 **Depends on:** ADR-108 (pure function modules), ADR-109 (config boundary validation)
 **Partially supersedes:** ADR-110 (override semantics replaced; see ADR-110 revision)
 **Modifies:** ADR-103 (defaults inheritance removed), ADR-104 (defaults inheritance removed)
@@ -25,14 +28,14 @@ subvolume-to-snapshot-root mapping lived in a separate section. A design review
 (2026-03-27, journal) identified five structural problems:
 
 1. **Two masters.** Protection levels declared intent, but operational overrides could
-   contradict them. A `guarded` subvolume with `snapshot_interval = "1w"` claimed guarded
-   protection while operating below the guarded baseline. Preflight warned every run.
+   contradict them. A `recorded` subvolume with `snapshot_interval = "1w"` claimed recorded
+   protection while operating below the recorded baseline. Preflight warned every run.
 
 2. **Vestigial `[defaults]`.** All subvolumes had protection levels, so the defaults section
    never influenced any resolved value. Dead config that implied it was doing something.
 
-3. **Semantic inversion.** Protected subvolumes (no explicit `drives`) sent to all 3 drives.
-   Resilient subvolumes (explicit list) sent to 2. The level names suggested resilient had
+3. **Semantic inversion.** Sheltered subvolumes (no explicit `drives`) sent to all 3 drives.
+   Fortified subvolumes (explicit list) sent to 2. The level names suggested fortified had
    more redundancy, but the topology was inverted.
 
 4. **Cross-reference fragility.** `[local_snapshots]` mapped subvolume names to snapshot
@@ -52,17 +55,36 @@ Each section and each subvolume block is readable in isolation. No hidden inheri
 no cross-section joins, no implicit defaults that change behavior at a distance. The
 operator reads the config and knows what Urd will do.
 
-### Subvolume identity
+### Schema version semantics
 
-Each subvolume block carries all its own identity and location:
+- **Legacy (unversioned):** The current schema. `[defaults]`, `[local_snapshots]`,
+  `short_name` required, operational overrides on named levels permitted. No
+  `config_version` field. Urd accepts this schema today.
+
+- **v1:** The target schema. `config_version = 1` required in `[general]`. Self-describing
+  subvolume blocks, no `[defaults]`, no `[local_snapshots]`, named levels fully opaque.
+
+- **Parser behavior:** When `config_version` is absent, Urd reads the legacy schema (the
+  current code path). When `config_version = 1`, Urd reads the v1 schema. The parser does
+  NOT accept both simultaneously — it branches on the version field. One schema version at
+  a time (Principle 9).
+
+- **`urd migrate`:** Transforms legacy → v1. See Migration section below.
+
+### Subvolume identity (v1)
+
+Each subvolume block carries all its own identity, location, and space constraints:
 
 ```toml
 [[subvolumes]]
-name = "subvol1-docs"                        # Required. On-disk contract (snapshot dirs).
-source = "/mnt/btrfs-pool/subvol1-docs"      # Required. Path to the live subvolume.
-snapshot_root = "/mnt/btrfs-pool/.snapshots"  # Required. Where local snapshots are stored.
-short_name = "docs"                           # Optional. Display/snapshot name. Defaults to name.
-priority = 2                                  # Optional. Execution order. Hardcoded default: 2.
+name = "subvol3-opptak"                          # Required. On-disk contract (ADR-105).
+source = "/mnt/btrfs-pool/subvol3-opptak"        # Required. Path to live subvolume.
+snapshot_root = "/mnt/btrfs-pool/.snapshots"      # Required. Where local snapshots live.
+short_name = "opptak"                             # Optional. Defaults to name.
+priority = 1                                      # Optional. Default: 2.
+protection = "fortified"                          # Optional. Omit for custom.
+drives = ["WD-18TB", "WD-18TB1"]                  # Required when protection needs external.
+min_free_bytes = "50GB"                           # Optional. Skip snapshots when space low.
 ```
 
 - `name` is a backward-compatibility contract (ADR-105). Snapshot directories on disk are
@@ -77,47 +99,55 @@ priority = 2                                  # Optional. Execution order. Hardc
 
 ### Space constraints
 
-Free-space thresholds are a filesystem-level concern, not a subvolume property:
+Space constraints are a per-subvolume `min_free_bytes` field. When free space on a
+subvolume's `snapshot_root` filesystem drops below its threshold, Urd skips snapshot
+creation. This keeps each block fully self-describing — no cross-referencing between
+sections, no path-matching.
 
-```toml
-[[space_constraints]]
-path = "~/.snapshots"
-min_free_bytes = "10GB"
-
-[[space_constraints]]
-path = "/mnt/btrfs-pool/.snapshots"
-min_free_bytes = "50GB"
-```
-
-When free space on a snapshot root's filesystem drops below its threshold, Urd skips
-snapshot creation on that root. This prevents filesystem exhaustion and congestion — a
-first-class safety mechanism, not a subvolume-level detail.
+When multiple subvolumes share a `snapshot_root`, each declares its own threshold (or
+omits it). At runtime, the space check is per-subvolume: "does the filesystem containing
+this subvolume's `snapshot_root` have at least `min_free_bytes` free?" Subvolumes sharing
+a root naturally share the filesystem check — no deduplication needed.
 
 ### No `[defaults]` section
 
 The `[defaults]` section is removed. Subvolume parameters come from one of two sources:
 
-1. **Named protection level** — opaque, all parameters derived (see ADR-110 revision).
+1. **Named protection level** — opaque, all parameters derived (see ADR-110).
 2. **Explicit values** — the operator specifies all parameters directly (custom policy).
 
 When a custom subvolume omits a field, hardcoded fallbacks in the binary provide sensible
 values. These are documented but not user-editable at runtime. The config file is the
 primary artifact; hardcoded fallbacks are a safety net, not a configuration mechanism.
 
+### Protection levels (v1)
+
+The config field is `protection` (not `protection_level`). Values:
+
+| Level | What it means | Legacy name |
+|-------|--------------|-------------|
+| `recorded` | Data is recorded locally. Snapshots exist on this machine. | `guarded` |
+| `sheltered` | Data is sheltered on an external drive. Survives drive failure. | `protected` |
+| `fortified` | Data is fortified across geography. Survives site loss. | `resilient` |
+| `custom` | Operator specifies all parameters. First-class, not fallback. | `custom` |
+
+Named levels are opaque sealed policies (ADR-110 is authoritative for this rule).
+When `protection` is set to a named level, operational fields (`snapshot_interval`,
+`send_interval`, `send_enabled`, `local_retention`, `external_retention`) are **not
+permitted** — config validation rejects them as structural errors. The level derives all
+operational parameters.
+
+**Exception: transient retention with named levels.** `local_retention = "transient"` is
+permitted alongside named levels because transient is a storage constraint (the NVMe is
+too small for local history), not a policy override. The named level still derives all
+other parameters. This exception is unique — extending it to other fields would erode
+the opacity principle and requires an ADR amendment.
+
 ### Templates as scaffolding
 
 Templates generate complete config blocks at setup time (e.g., via `urd init`). The
 resulting config is self-contained — changes to templates don't affect existing configs.
 Templates are a development-time tool, not a runtime inheritance layer.
-
-### Named levels are opaque
-
-Named protection levels are opaque sealed policies (ADR-110 is authoritative for this rule).
-When `protection_level` is set to a named level, operational fields (`snapshot_interval`,
-`send_interval`, `local_retention`, `external_retention`) are **not permitted** — config
-validation rejects them as structural errors. The level derives all operational parameters.
-
-See ADR-110 for the maturity model governing when named levels become available.
 
 ### Explicit drive routing
 
@@ -130,27 +160,16 @@ drives = ["WD-18TB", "WD-18TB1"]
 ```
 
 If `drives` is omitted, no external sends occur (regardless of `send_enabled`). There is
-no implicit "send to all drives" behavior. This prevents the semantic inversion where
-unnamed drive lists produce more redundancy than explicitly listed ones.
-
-Long-term trajectory: intent-based routing where the planner resolves the mapping from
-protection level + drive topology. Explicit lists are the honest foundation that makes
-this possible later.
+no implicit "send to all drives" behavior.
 
 ### `send_enabled` as pause button
 
 The `drives` list defines *where* to send. `send_enabled` controls *whether* to send.
-Setting it to `false` pauses external sends without losing the drive configuration — the
-operator can resume by flipping one field.
+Setting it to `false` pauses external sends without losing the drive configuration.
 
 **Resolution rules:** `send_enabled` is `Option<bool>` in the parsed config. During config
 resolution: `Some(true)` or `Some(false)` = explicit operator choice. `None` = derived as
-`true` if `drives` is non-empty, `false` otherwise. `send_enabled` is only meaningful when
-`drives` is non-empty — without drives, no sends occur regardless of `send_enabled`.
-Specifying `send_enabled` without `drives` is not a validation error, just irrelevant.
-
-Templates don't include `send_enabled`. It only appears in the config when the operator
-actively uses it as a pause mechanism.
+`true` if `drives` is non-empty, `false` otherwise.
 
 ### Structural vs runtime validation
 
@@ -159,43 +178,286 @@ Config validation distinguishes two error categories (extends ADR-109):
 **Hard errors (refuse to start):**
 - TOML syntax errors, missing required fields, invalid types
 - Structural contradictions (drive name in `drives` that doesn't exist in `[[drives]]`)
-- Config version mismatch (see versioning below)
+- Operational fields alongside named protection levels (transient exception only)
+- Old protection level names in v1 config
+- Config version mismatch
 
 **Soft errors (run what you can, report clearly):**
 - Drive not mounted — skip sends to that drive
 - Filesystem below `min_free_bytes` — skip snapshots on that root
 - Source path doesn't exist — skip that subvolume
 
-The executor produces a structured run result describing what succeeded, what was skipped,
-and why. This feeds into heartbeat, metrics, and status output. The principle: validate
-structure at load time, isolate failures at runtime, always produce a structured result
-that makes partial outcomes legible.
+## Complete Field Reference (v1)
 
-### Config versioning
-
-The config file carries a version field:
+### `[general]` section
 
 ```toml
 [general]
 config_version = 1
+run_frequency = "daily"
 ```
 
-Urd only reads the current schema version. An older version produces a clear error
-directing the operator to run `urd migrate`. The `migrate` command transforms old configs
-to the current schema. No runtime support for old versions — one schema version at a time.
+| Field | Required? | Default | Notes |
+|-------|-----------|---------|-------|
+| `config_version` | Yes (v1) | — | Must be `1`. Absent = legacy schema. |
+| `run_frequency` | No | `daily` | How often Urd runs. |
+| `state_db` | No | `~/.local/share/urd/urd.db` | SQLite database path. |
+| `metrics_file` | No | `~/.local/share/urd/backup.prom` | Prometheus textfile path. |
+| `log_dir` | No | `~/.local/share/urd/logs` | Log directory. |
+| `btrfs_path` | No | `/usr/sbin/btrfs` | Path to btrfs binary. |
+| `heartbeat_file` | No | `~/.local/share/urd/heartbeat.json` | Health signal path. |
 
-This keeps the config parser clean (one code path, not accumulated version branches) at
-the cost of requiring the operator to run `migrate` after updates that change the schema.
-The trade-off is appropriate: Urd is in active development with a hands-on operator, and
-existing snapshots provide the safety net.
+### `[[drives]]` section
 
-Note: this versioning applies to the config schema only. On-disk data formats (snapshot
-names, pin files, metrics) follow ADR-105's backward compatibility contracts separately.
+```toml
+[[drives]]
+label = "WD-18TB"
+mount_path = "/run/media/user/WD-18TB"
+snapshot_root = ".snapshots"
+role = "primary"
+uuid = "647693ed-490e-4c09-8816-189ba2baf03f"
+max_usage_percent = 90
+min_free_bytes = "500GB"
+```
 
-### Format
+| Field | Required? | Default | Notes |
+|-------|-----------|---------|-------|
+| `label` | Yes | — | Unique identifier. Used in subvolume `drives` lists. |
+| `mount_path` | Yes | — | Where the drive mounts. |
+| `snapshot_root` | Yes | — | Relative path under `mount_path` for snapshots. |
+| `role` | Yes | — | `primary`, `offsite`, or `test`. |
+| `uuid` | No | — | BTRFS filesystem UUID. Strongly recommended. |
+| `max_usage_percent` | No | — | Skip sends when usage exceeds this. |
+| `min_free_bytes` | No | — | Skip sends when free space drops below this. |
 
-TOML. Standard in the Rust ecosystem, human-editable, explicit typing, supports comments.
-No reason to change.
+Drive tokens (`.urd-drive-token`) are a runtime identity mechanism managed by Urd
+automatically — not config fields. See `urd drives adopt`.
+
+### `[[subvolumes]]` section
+
+For custom subvolumes (no `protection` field):
+
+```toml
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+min_free_bytes = "10GB"
+local_retention = "transient"
+drives = ["WD-18TB1"]
+```
+
+| Field | Required? | Default | Notes |
+|-------|-----------|---------|-------|
+| `name` | Yes | — | On-disk contract (ADR-105). Directory name. |
+| `source` | Yes | — | Path to live subvolume. |
+| `snapshot_root` | Yes | — | Where local snapshots are stored. |
+| `short_name` | No | `name` | Snapshot name suffix. Only when different from `name`. |
+| `priority` | No | `2` | Execution order (lower = first). |
+| `protection` | No | — | Named level. Omit for custom. |
+| `enabled` | No | `true` | Set `false` to exclude without removing. |
+| `snapshot_interval` | No | `1d` | How often to snapshot. |
+| `send_interval` | No | `1d` | How often to send externally. |
+| `send_enabled` | No | `true` if `drives` non-empty | Pause button for sends. |
+| `local_retention` | No | `{ hourly = 24, daily = 30, weekly = 26, monthly = 12 }` | Graduated retention or `"transient"`. |
+| `external_retention` | No | `{ daily = 30, weekly = 26 }` | Graduated retention for drives. |
+| `min_free_bytes` | No | — | Skip snapshots when free space low. |
+| `drives` | No | `[]` | Which drives to send to. Omit = no sends. |
+
+**Validation:** When `protection` is set to a named level, operational fields
+(`snapshot_interval`, `send_interval`, `send_enabled`, `local_retention`,
+`external_retention`) are rejected as structural errors. Exception: `local_retention =
+"transient"` is permitted (storage constraint, not policy override). Only identity fields
+(`name`, `source`, `snapshot_root`, `short_name`, `priority`), `drives`, `enabled`, and
+`min_free_bytes` are permitted alongside named levels.
+
+### `[notifications]` section
+
+```toml
+[notifications]
+enabled = true
+min_urgency = "warning"
+
+[[notifications.channels]]
+type = "desktop"
+
+[[notifications.channels]]
+type = "webhook"
+url = "https://ntfy.sh/my-backups"
+
+[[notifications.channels]]
+type = "command"
+path = "/usr/local/bin/notify-script"
+args = ["--json"]
+
+[[notifications.channels]]
+type = "log"
+```
+
+Unchanged from current implementation.
+
+## Example Configs
+
+### Legacy (current schema)
+
+```toml
+# No config_version — legacy schema
+
+[general]
+state_db = "~/.local/share/urd/urd.db"
+metrics_file = "~/.local/share/urd/backup.prom"
+log_dir = "~/.local/share/urd/logs"
+run_frequency = "daily"
+
+[local_snapshots]
+roots = [
+  { path = "~/.snapshots", subvolumes = ["htpc-home", "htpc-root"], min_free_bytes = "10GB" },
+  { path = "/mnt/btrfs-pool/.snapshots", subvolumes = ["docs", "pics"], min_free_bytes = "50GB" }
+]
+
+[defaults]
+snapshot_interval = "1d"
+send_interval = "1d"
+[defaults.local_retention]
+hourly = 24
+daily = 30
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/run/media/user/WD-18TB"
+snapshot_root = ".snapshots"
+role = "primary"
+uuid = "647693ed-490e-4c09-8816-189ba2baf03f"
+
+[[subvolumes]]
+name = "htpc-home"
+short_name = "htpc-home"
+source = "/home"
+protection_level = "fortified"
+drives = ["WD-18TB", "WD-18TB1"]
+```
+
+### v1 (target schema)
+
+```toml
+[general]
+config_version = 1
+run_frequency = "daily"
+
+# ── Drives ───────────────────────────────────────
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/run/media/user/WD-18TB"
+snapshot_root = ".snapshots"
+role = "primary"
+uuid = "647693ed-490e-4c09-8816-189ba2baf03f"
+max_usage_percent = 90
+min_free_bytes = "500GB"
+
+# ── NVMe volumes (snapshot root: ~/.snapshots) ───
+
+[[subvolumes]]
+name = "htpc-home"
+source = "/home"
+snapshot_root = "~/.snapshots"
+min_free_bytes = "10GB"
+protection = "fortified"
+drives = ["WD-18TB", "WD-18TB1"]
+
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+min_free_bytes = "10GB"
+local_retention = "transient"
+drives = ["WD-18TB1"]
+
+# ── Storage pool (snapshot root: /mnt/btrfs-pool/.snapshots) ──
+
+[[subvolumes]]
+name = "subvol2-pics"
+source = "/mnt/btrfs-pool/subvol2-pics"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+min_free_bytes = "50GB"
+protection = "fortified"
+drives = ["WD-18TB", "WD-18TB1"]
+```
+
+Key differences: `config_version = 1` present, `[general]` minimal (infrastructure paths
+default), no `[defaults]`, no `[local_snapshots]`, `snapshot_root` and `min_free_bytes`
+inline on each subvolume, `protection` replaces `protection_level` with new level names,
+`short_name` omitted where it equals `name`.
+
+## Migration (`urd migrate`)
+
+Transforms legacy config → v1. The migration is mechanical:
+
+1. Inject `config_version = 1` into `[general]`
+2. Inline `snapshot_root` from `[local_snapshots]` into each subvolume block
+3. Inline `min_free_bytes` from root entries onto subvolumes in that root
+4. Remove `[local_snapshots]` section
+5. Remove `[defaults]` — for custom subvolumes, bake resolved values into the block
+6. Make `short_name` optional — remove where it equals `name`
+7. Rename `protection_level` → `protection`, rename level values
+8. If named levels have operational overrides, convert to custom with a warning
+9. Omit `[general]` fields that match defaults
+
+**Rules:**
+- Always save backup to `{config_path}.legacy` before overwriting
+- Print structured summary with `✓` for changes, `⚠` for override conversions
+- End with concrete next step (`urd plan`)
+- `--dry-run` prints without writing
+- Already-v1: "Config is already v1 schema. Nothing to migrate."
+
+## Validation Error Messages (v1)
+
+**Operational field alongside named protection:**
+```
+Config error: snapshot_interval is not allowed with protection = "fortified"
+
+  Fortified protection derives all operational parameters automatically.
+  To keep snapshot_interval = "1w", remove the protection field (custom policy).
+  To use fortified protection, remove snapshot_interval.
+```
+
+**Named protection without required drives:**
+```
+Config error: sheltered protection needs at least one drive
+
+  Sheltered means your data is sheltered on an external drive.
+  Add a drives list: drives = ["WD-18TB"]
+  Or use recorded for local-only protection.
+```
+
+**Fortified without offsite drive:**
+```
+Config error: fortified protection needs at least one offsite drive
+
+  Fortified means your data survives site loss — fire, theft, flood.
+  At least one drive in your drives list must have role = "offsite".
+  Or use sheltered if drive-failure protection is sufficient.
+```
+
+**Old protection level name in v1 config:**
+```
+Config error: unknown protection level "resilient"
+
+  Did you mean "fortified"? Protection level names changed in config v1:
+    guarded → recorded
+    protected → sheltered
+    resilient → fortified
+  Run urd migrate to update automatically.
+```
+
+**Missing config_version in v1-shaped config:**
+```
+Config error: snapshot_root on [[subvolumes]] requires config_version = 1
+
+  Add config_version = 1 to [general], or run urd migrate to convert automatically.
+```
 
 ## Consequences
 
@@ -213,7 +475,7 @@ No reason to change.
 - More verbose configs — each custom subvolume must specify all parameters rather than
   inheriting from defaults. Templates mitigate this at setup time.
 - Removing `[local_snapshots]` means `snapshot_root` is repeated for subvolumes sharing
-  a root. This is intentional — repetition in config is preferable to cross-referencing.
+  a root. Grouping comments mitigate readability impact.
 - Strict versioning means the operator must run `urd migrate` after schema-changing
   updates. A stale config prevents backups until migrated.
 
@@ -223,44 +485,40 @@ No reason to change.
   `Config::validate()` (ADR-109).
 - `name` is an on-disk contract — it must never be derived or defaulted (ADR-105).
 - Schema changes require incrementing `config_version` and updating `urd migrate`.
-- Hardcoded fallback values must be documented in `urd --help` or `urd config show`.
+- Hardcoded fallback values must be documented in help text.
 
 ## Implementation Gates
 
-This ADR describes a **target architecture**. The current implementation uses the legacy
-config schema. This ADR is considered implemented when:
+**Already implemented:**
+- [x] `ProtectionLevel` enum and `derive_policy()` exist in `types.rs`
+- [x] `protection_level`, `drives`, `run_frequency` config fields parsed and validated
+- [x] `resolve_subvolume()` branches on protection level with custom fallthrough
+- [x] Achievability preflight checks active
+- [x] `urd status` shows protection level
+- [x] Pin-protection safety tests pass with derived retention
+- [x] Transient retention as `local_retention` variant
+- [x] Drive `role` field (primary/offsite/test)
+- [x] Drive UUID verification
+- [x] Notification config parsing
+- [x] `Serialize` on `Interval`, `RunFrequency`, `DriveRole`, `GraduatedRetention`
+- [x] Protection level rename: `recorded` / `sheltered` / `fortified` in enum and parsing (P6a)
 
-- [ ] `config_version` field added to `[general]`; parser checks version before proceeding
-- [ ] `urd migrate` command transforms old config schema to current version
-- [ ] `snapshot_root` field added to `[[subvolumes]]`; subvolume block is self-describing
-- [ ] `[local_snapshots]` section eliminated; `snapshot_root_for()` reads from subvolume config
-- [ ] `[[space_constraints]]` section added; `min_free_bytes` checked per filesystem path
-- [ ] `[defaults]` section removed; custom subvolumes specify all parameters or use hardcoded
-      fallbacks
-- [ ] `short_name` made optional with default-to-`name` behavior
-- [ ] Config validation rejects operational fields alongside named protection levels (ADR-110)
-- [ ] `send_enabled` resolved as `Option<bool>` per resolution rules above
-- [ ] Existing tests updated to use new config schema
-- [ ] Hardcoded fallback values documented in `urd --help` or `urd config show`
-
-### Required vs optional fields for custom subvolumes
-
-| Field | Required? | Hardcoded fallback |
-|-------|-----------|-------------------|
-| `name` | Required | — |
-| `source` | Required | — |
-| `snapshot_root` | Required | — |
-| `short_name` | Optional | Defaults to `name` |
-| `priority` | Optional | `2` |
-| `snapshot_interval` | Optional | `1d` |
-| `send_interval` | Optional | `1d` |
-| `send_enabled` | Optional | `true` if `drives` non-empty, `false` otherwise |
-| `local_retention` | Optional | `{ daily = 7, weekly = 4 }` |
-| `external_retention` | Optional | `{ daily = 30, weekly = 26 }` |
-| `drives` | Optional | `[]` (no external sends) |
-
-For named protection levels, only identity fields (`name`, `source`, `snapshot_root`,
-`short_name`, `priority`) and `drives` are permitted. All operational fields are derived.
+**Remaining gates for v1:**
+- [ ] `config_version` field in `[general]`; parser branches on version
+- [ ] v1 parser: `[general]` fields defaultable (state_db, metrics_file, log_dir, heartbeat_file)
+- [ ] v1 parser: `snapshot_root` and `min_free_bytes` on subvolume blocks; `[local_snapshots]` eliminated
+- [ ] v1 parser: `[defaults]` section eliminated; custom subvolumes use hardcoded fallbacks
+- [ ] v1 parser: `short_name` optional, defaults to `name`
+- [ ] v1 parser: `protection` field (renamed from `protection_level`)
+- [ ] v1 parser: `enabled` field with default `true`
+- [ ] v1 validation: reject operational fields alongside named `protection` (transient exception only)
+- [ ] v1 validation: error messages guide the user (see Validation Error Messages above)
+- [ ] `ResolvedSubvolume` gains `snapshot_root: PathBuf` and `min_free_bytes: Option<u64>`
+- [ ] All callers of `snapshot_root_for()` / `local_snapshot_dir()` / `root_min_free_bytes()` migrated to `ResolvedSubvolume`
+- [ ] `Config` and all nested types derive `Serialize` (P6b prerequisite)
+- [ ] `urd migrate` command: legacy → v1 transformation with backup file
+- [ ] `--confirm-retention-change` flag gates retention tightening on level changes
+- [ ] Hardcoded fallback values documented in help text
 
 ## Principles
 
@@ -283,8 +541,8 @@ These govern future config system decisions:
    mythic voice belongs in the presentation layer.
 9. **One schema version at a time.** `urd migrate` handles transitions. Tidiness over
    grace periods.
-10. **Space constraints are a filesystem concern.** Free-space thresholds on paths, not on
-    subvolumes. A first-class safety mechanism.
+10. **Space constraints are per-subvolume, not per-filesystem.** Each block declares its own
+    threshold. Self-describing over deduplicated.
 
 ## Related
 
@@ -293,4 +551,5 @@ These govern future config system decisions:
 - ADR-105: Backward compatibility (scoped to data formats, not config schema)
 - ADR-109: Config boundary validation (extended with structural/runtime distinction)
 - ADR-110: Protection promises (override semantics superseded; maturity model added)
-- Journal: `docs/98-journals/2026-03-27-config-design-review.md` — full design discussion
+- Design: `docs/95-ideas/2026-04-03-design-010-config-schema-v1.md` — full v1 schema design
+- Journal: `docs/98-journals/2026-03-27-config-design-review.md` — original design discussion

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -8,7 +8,7 @@
 | 012 | Sentinel drive-gated transient + space monitoring | [design](../95-ideas/2026-04-03-design-012-sentinel-drive-gated-transient.md) | - | - | - | - |
 | 011 | Transient space safety (emergency fix) | [design](../95-ideas/2026-04-03-design-011-transient-space-safety.md) | [steve](../99-reports/2026-04-03-steve-jobs-011-transient-is-a-lie.md) | - | - | - |
 | 010-a | Transient as first-class config concept | [design](../95-ideas/2026-04-03-design-010a-transient-as-first-class-config.md) | - | - | - | - |
-| 010 | Config Schema v1 (ADR-111 revision) | [design](../95-ideas/2026-04-03-design-010-config-schema-v1.md) | - | [adversary](../99-reports/2026-04-03-design-review-010-config-schema-v1.md) | - | - |
+| 010 | Config Schema v1 (ADR-111 revision) | [design](../95-ideas/2026-04-03-design-010-config-schema-v1.md) | - | [adversary](../99-reports/2026-04-03-design-review-010-config-schema-v1.md) | s1 merged | [#75](https://github.com/vonrobak/urd/pull/75) |
 | 009 | `urd drives` subcommand | [design](../95-ideas/2026-04-02-design-009-urd-drives-subcommand.md) | - | [adversary](../99-reports/2026-04-03-design-review-009-006-phase-c-drives.md) | merged | [#72](https://github.com/vonrobak/urd/pull/72) |
 | 008 | Doctor pin-age correlation | [design](../95-ideas/2026-04-02-design-008-doctor-pin-age-correlation.md) | - | [adversary](../99-reports/2026-04-03-design-review-007-008-phase-b-communication.md) | merged | [#70](https://github.com/vonrobak/urd/pull/70) |
 | 007 | Safety gate communication | [design](../95-ideas/2026-04-02-design-007-safety-gate-communication.md) | - | [adversary](../99-reports/2026-04-03-design-review-007-008-phase-b-communication.md) | merged | [#70](https://github.com/vonrobak/urd/pull/70) |

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -9,17 +9,16 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-763 tests, all passing, clippy clean. Current version: v0.9.0.
+764 tests, all passing, clippy clean. Current version: v0.9.1.
 
-**Phase C complete (UPI 009 + 006).** `urd drives` subcommand lists configured drives
-with status, token state, free space, and role. `urd drives adopt <label>` resets a
-drive's token relationship. Sentinel emits reconnection notifications with token-aware
-dispatch (identity-suspect drives get "needs adoption" guidance). PR #72 merged, v0.9.0
-tagged and deployed.
+**UPI 010 session 1 complete (P6a).** Protection level vocabulary renamed:
+guarded→recorded, protected→sheltered, resilient→fortified. Serde aliases preserve
+legacy config backward compat. ADR-111 revised with complete v1 schema specification.
+PR #75 merged, v0.9.1 tagged and deployed.
 
 **Deployment notes:**
 - Systemd timer needs `--auto` added to `ExecStart` line (pending since v0.8.0)
-- v0.9.0 deployed via `cargo install --path .`
+- v0.9.1 deployed via `cargo install --path .`
 
 ## In Progress
 
@@ -29,24 +28,19 @@ Nothing active.
 
 **Track A: v0.9.0 test session** (calendar time — live with the tool)
    - Fix systemd timer `--auto` flag first (pending since v0.8.0)
-   - Live with v0.9.0 for several days (timer, Sentinel, drive plug/unplug cycles)
-   - Simulate the new-user journey: run commands cold, note confusion points
-   - Read your own config — can you narrate your protection story?
+   - Live with v0.9.1 for several days (timer, Sentinel, drive plug/unplug cycles)
    - Output: prioritized issue list → targeted fix phase if needed
 
-**Track B: UPI 010 sessions 1-2** (concurrent — no user-facing changes)
-   - Session 1: Revise ADR-111 document + ADR-110 update + P6a (enum rename)
-   - Session 2: P6b (add Serialize to Config and all nested types)
-   - Design: `docs/95-ideas/2026-04-03-design-010-config-schema-v1.md`
+**Track B: UPI 010 session 2** (concurrent — no user-facing changes)
+   - P6b: add Serialize to Config and all nested types
+   - Clean single-purpose session, low risk
+   - Plan: `.claude/plans/whimsical-honking-snowglobe.md`
 
 **Then sequential:**
 1. Fix test session findings (~0-2 sessions)
 2. UPI 010 sessions 3-4: v1 parser, `urd migrate`, validation messages, example config
 3. Migrate own production config → validate v1 in real usage
 4. **Phase D: Progressive disclosure + The Encounter** — ~6-8 sessions
-   - 6-O: Progressive disclosure (~2 sessions) — design doc exists
-   - 6-H: The Encounter — Fate Conversation, config generation (~4-6 sessions)
-   - Blocked by: UPI 010 completion and v1 production validation
 
 ## Key Links
 
@@ -59,7 +53,6 @@ Nothing active.
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
 | Design docs | [95-ideas/](../95-ideas/) |
 | Review reports | [99-reports/](../99-reports/) |
-| Historic roadmap (pre-UPI) | [archived](../90-archive/96-project-supervisor/2026-04-01-historic-roadmap.md) |
 
 ## Known Issues
 

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -706,12 +706,12 @@ fn compute_health(
 
 // ── Offsite freshness overlay ──────────────────────────────────────────
 
-/// Offsite freshness thresholds for resilient subvolumes.
+/// Offsite freshness thresholds for fortified subvolumes.
 /// These are fixed (not user-configurable) per ADR-110 addendum.
 const OFFSITE_AT_RISK_DAYS: i64 = 30;
 const OFFSITE_UNPROTECTED_DAYS: i64 = 90;
 
-/// Post-processing overlay: degrade resilient subvolumes with stale offsite copies.
+/// Post-processing overlay: degrade fortified subvolumes with stale offsite copies.
 ///
 /// This is NOT part of `assess()` — awareness remains protection-level-blind per
 /// ADR-110 Invariant 6. Call this after `assess()` returns.
@@ -726,7 +726,7 @@ pub fn overlay_offsite_freshness(assessments: &mut [SubvolAssessment], config: &
             .find(|s| s.name == assessment.name)
             .and_then(|s| s.protection_level);
 
-        if protection_level != Some(ProtectionLevel::Resilient) {
+        if protection_level != Some(ProtectionLevel::Fortified) {
             continue;
         }
 
@@ -735,7 +735,7 @@ pub fn overlay_offsite_freshness(assessments: &mut [SubvolAssessment], config: &
             assessment.status = offsite_freshness;
             assessment
                 .advisories
-                .push("offsite copy stale — resilient promise degraded".to_string());
+                .push("offsite copy stale — fortified promise degraded".to_string());
         }
     }
 }
@@ -795,9 +795,9 @@ pub fn compute_redundancy_advisories(
         let protection_level = subvol.protection_level;
 
         // ── NoOffsiteProtection ────────────────────────────────────────
-        // Resilient subvolume where none of its effective drives has offsite role.
+        // Fortified subvolume where none of its effective drives has offsite role.
         // Per-subvolume check: respects drive scoping via `drives = [...]` in config.
-        if protection_level == Some(ProtectionLevel::Resilient) && subvol.send_enabled {
+        if protection_level == Some(ProtectionLevel::Fortified) && subvol.send_enabled {
             let has_offsite = match &subvol.drives {
                 Some(drive_list) => drive_list.iter().any(|label| {
                     config
@@ -855,10 +855,10 @@ pub fn compute_redundancy_advisories(
         }
 
         // ── SinglePointOfFailure ────────────────────────────────────────
-        // Protected or resilient subvolume with exactly 1 non-test drive.
+        // Sheltered or fortified subvolume with exactly 1 non-test drive.
         if matches!(
             protection_level,
-            Some(ProtectionLevel::Protected) | Some(ProtectionLevel::Resilient)
+            Some(ProtectionLevel::Sheltered) | Some(ProtectionLevel::Fortified)
         ) && subvol.send_enabled
         {
             let mut non_test_drives = effective_drives
@@ -2786,7 +2786,7 @@ send_enabled = false
 
     // ── Offsite freshness overlay tests ─────────────────────────────
 
-    fn resilient_config() -> Config {
+    fn fortified_config() -> Config {
         let toml_str = r#"
 [general]
 state_db = "/tmp/urd.db"
@@ -2885,7 +2885,7 @@ drives = ["primary-drive", "offsite-drive"]
 
     #[test]
     fn overlay_fresh_offsite_stays_protected() {
-        let config = resilient_config();
+        let config = fortified_config();
         let drives = vec![primary_drive_assessment(), offsite_drive_assessment(Some(10))];
         let mut assessments = vec![make_assessment("sv1", PromiseStatus::Protected, drives)];
 
@@ -2897,7 +2897,7 @@ drives = ["primary-drive", "offsite-drive"]
 
     #[test]
     fn overlay_stale_offsite_degrades_to_at_risk() {
-        let config = resilient_config();
+        let config = fortified_config();
         let drives = vec![primary_drive_assessment(), offsite_drive_assessment(Some(31))];
         let mut assessments = vec![make_assessment("sv1", PromiseStatus::Protected, drives)];
 
@@ -2909,7 +2909,7 @@ drives = ["primary-drive", "offsite-drive"]
 
     #[test]
     fn overlay_very_stale_offsite_degrades_to_unprotected() {
-        let config = resilient_config();
+        let config = fortified_config();
         let drives = vec![primary_drive_assessment(), offsite_drive_assessment(Some(91))];
         let mut assessments = vec![make_assessment("sv1", PromiseStatus::Protected, drives)];
 
@@ -2920,7 +2920,7 @@ drives = ["primary-drive", "offsite-drive"]
 
     #[test]
     fn overlay_no_offsite_send_is_unprotected() {
-        let config = resilient_config();
+        let config = fortified_config();
         let drives = vec![primary_drive_assessment(), offsite_drive_assessment(None)];
         let mut assessments = vec![make_assessment("sv1", PromiseStatus::Protected, drives)];
 
@@ -2930,7 +2930,7 @@ drives = ["primary-drive", "offsite-drive"]
     }
 
     #[test]
-    fn overlay_skips_non_resilient() {
+    fn overlay_skips_non_fortified() {
         // Use the base test_config() which has no protection_level set
         let config = test_config();
         let drives = vec![DriveAssessment {
@@ -2946,7 +2946,7 @@ drives = ["primary-drive", "offsite-drive"]
 
         overlay_offsite_freshness(&mut assessments, &config);
 
-        // Should remain Protected — not resilient, so overlay doesn't apply
+        // Should remain Protected — not fortified, so overlay doesn't apply
         assert_eq!(assessments[0].status, PromiseStatus::Protected);
         assert!(assessments[0].advisories.is_empty());
     }
@@ -2955,7 +2955,7 @@ drives = ["primary-drive", "offsite-drive"]
     fn overlay_independent_of_primary_status() {
         // Primary drive is AT RISK, offsite is fresh — overall should be AT RISK
         // (independent constraints, minimum wins)
-        let config = resilient_config();
+        let config = fortified_config();
         let mut primary = primary_drive_assessment();
         primary.status = PromiseStatus::AtRisk;
         let drives = vec![primary, offsite_drive_assessment(Some(5))];
@@ -2970,7 +2970,7 @@ drives = ["primary-drive", "offsite-drive"]
 
     #[test]
     fn overlay_two_offsite_drives_best_wins() {
-        let config = resilient_config();
+        let config = fortified_config();
         let stale_offsite = DriveAssessment {
             drive_label: "offsite-old".to_string(),
             status: PromiseStatus::AtRisk,
@@ -2992,7 +2992,7 @@ drives = ["primary-drive", "offsite-drive"]
 
     #[test]
     fn overlay_boundary_30_days_is_protected() {
-        let config = resilient_config();
+        let config = fortified_config();
         let drives = vec![primary_drive_assessment(), offsite_drive_assessment(Some(30))];
         let mut assessments = vec![make_assessment("sv1", PromiseStatus::Protected, drives)];
 
@@ -3005,7 +3005,7 @@ drives = ["primary-drive", "offsite-drive"]
     fn overlay_already_unprotected_no_redundant_advisory() {
         // If the subvolume is already Unprotected (e.g., local snapshots stale),
         // the overlay should not add its advisory — Unprotected < Unprotected is false.
-        let config = resilient_config();
+        let config = fortified_config();
         let drives = vec![primary_drive_assessment(), offsite_drive_assessment(Some(91))];
         let mut assessments =
             vec![make_assessment("sv1", PromiseStatus::Unprotected, drives)];
@@ -3023,7 +3023,7 @@ drives = ["primary-drive", "offsite-drive"]
     fn overlay_equal_status_no_change() {
         // If offsite freshness matches current status, overlay should not update or add advisory.
         // Offsite at 31 days = AtRisk; assessment already AtRisk.
-        let config = resilient_config();
+        let config = fortified_config();
         let drives = vec![primary_drive_assessment(), offsite_drive_assessment(Some(31))];
         let mut assessments = vec![make_assessment("sv1", PromiseStatus::AtRisk, drives)];
 
@@ -3038,8 +3038,8 @@ drives = ["primary-drive", "offsite-drive"]
 
     // ── Redundancy advisory tests ──────────────────────────────────────
 
-    /// Config with resilient subvolume but only primary drives (no offsite).
-    fn resilient_no_offsite_config() -> Config {
+    /// Config with fortified subvolume but only primary drives (no offsite).
+    fn fortified_no_offsite_config() -> Config {
         let toml_str = r#"
 [general]
 state_db = "/tmp/urd.db"
@@ -3089,10 +3089,10 @@ drives = ["drive-a", "drive-b"]
     }
 
     #[test]
-    fn redundancy_no_offsite_for_resilient() {
+    fn redundancy_no_offsite_for_fortified() {
         use crate::output::RedundancyAdvisoryKind;
 
-        let config = resilient_no_offsite_config();
+        let config = fortified_no_offsite_config();
         let now = dt(2026, 4, 1, 12, 0);
         let mut fs = MockFileSystemState::new();
         fs.local_snapshots
@@ -3156,7 +3156,7 @@ drives = ["drive-a", "drive-b"]
 
     #[test]
     fn redundancy_no_advisory_when_offsite_exists() {
-        let config = resilient_config();
+        let config = fortified_config();
         let now = dt(2026, 4, 1, 12, 0);
         let mut fs = MockFileSystemState::new();
         fs.local_snapshots
@@ -3173,7 +3173,7 @@ drives = ["drive-a", "drive-b"]
     }
 
     /// Config with protected subvolume and exactly 1 drive.
-    fn protected_single_drive_config() -> Config {
+    fn sheltered_single_drive_config() -> Config {
         let toml_str = r#"
 [general]
 state_db = "/tmp/urd.db"
@@ -3219,7 +3219,7 @@ protection_level = "protected"
     fn redundancy_single_point_of_failure() {
         use crate::output::RedundancyAdvisoryKind;
 
-        let config = protected_single_drive_config();
+        let config = sheltered_single_drive_config();
         let now = dt(2026, 4, 1, 12, 0);
         let mut fs = MockFileSystemState::new();
         fs.local_snapshots
@@ -3241,7 +3241,7 @@ protection_level = "protected"
 
     #[test]
     fn redundancy_no_spof_with_two_drives() {
-        let config = resilient_no_offsite_config(); // 2 primary drives
+        let config = fortified_no_offsite_config(); // 2 primary drives
         let now = dt(2026, 4, 1, 12, 0);
         let mut fs = MockFileSystemState::new();
         fs.local_snapshots
@@ -3262,8 +3262,8 @@ protection_level = "protected"
     }
 
     #[test]
-    fn redundancy_guarded_subvolumes_excluded() {
-        // Guarded subvolumes have send_enabled=false, so all advisory checks
+    fn redundancy_recorded_subvolumes_excluded() {
+        // Recorded subvolumes have send_enabled=false, so all advisory checks
         // gate on send_enabled and naturally exclude them. Verify this invariant.
         let toml_str = r#"
 [general]

--- a/src/config.rs
+++ b/src/config.rs
@@ -656,7 +656,7 @@ send_interval = "2h"
             .iter()
             .find(|s| s.name == "htpc-home")
             .unwrap();
-        assert_eq!(htpc.protection_level, Some(ProtectionLevel::Resilient));
+        assert_eq!(htpc.protection_level, Some(ProtectionLevel::Fortified));
         assert_eq!(htpc.drives, Some(vec!["WD-18TB".into(), "WD-18TB1".into()]));
         assert_eq!(htpc.priority, 1);
 
@@ -666,7 +666,7 @@ send_interval = "2h"
             .iter()
             .find(|s| s.name == "subvol6-tmp")
             .unwrap();
-        assert_eq!(tmp.protection_level, Some(ProtectionLevel::Guarded));
+        assert_eq!(tmp.protection_level, Some(ProtectionLevel::Recorded));
 
         // Verify validation passes
         let mut config = config;
@@ -1099,7 +1099,7 @@ protection_level = "protected"
             config.subvolumes[0].resolved(&config.defaults, config.general.run_frequency);
 
         // Should use derived values from "protected" + daily timer, not defaults
-        assert_eq!(resolved.protection_level, Some(ProtectionLevel::Protected));
+        assert_eq!(resolved.protection_level, Some(ProtectionLevel::Sheltered));
         assert_eq!(resolved.snapshot_interval, Interval::days(1)); // derived from timer
         assert_eq!(resolved.send_interval, Interval::days(1)); // derived from timer
         assert!(resolved.send_enabled);

--- a/src/output.rs
+++ b/src/output.rs
@@ -163,7 +163,7 @@ pub struct StatusAssessment {
     /// Reasons for non-healthy operational health (empty when healthy).
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub health_reasons: Vec<String>,
-    /// Promise level from config (e.g., "protected", "resilient"), or None for custom/unset.
+    /// Promise level from config (e.g., "sheltered", "fortified"), or None for custom/unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub promise_level: Option<String>,
     pub local_snapshot_count: usize,

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -99,7 +99,7 @@ fn check_retention_send_compatibility(
 ///
 /// Transient retention without send_enabled is nonsensical — snapshots would be created
 /// and immediately deleted with no external copy. Transient with a named protection level
-/// (Guarded/Protected/Resilient) is also invalid since named levels imply graduated retention.
+/// (Recorded/Sheltered/Fortified) is also invalid since named levels imply graduated retention.
 fn check_transient_validity(
     subvol: &crate::config::ResolvedSubvolume,
     checks: &mut Vec<PreflightCheck>,
@@ -166,7 +166,7 @@ fn check_send_without_drives(
 /// Three categories of problems:
 /// 1. **Drive count**: not enough drives for the promise level.
 /// 2. **Voiding overrides**: explicit settings that make the promise impossible
-///    (e.g., `send_enabled = false` on a `protected` subvolume).
+///    (e.g., `send_enabled = false` on a `sheltered` subvolume).
 /// 3. **Weakening overrides**: explicit settings that degrade below the derived
 ///    baseline (e.g., longer snapshot interval, tighter retention).
 fn check_promise_achievability(
@@ -210,14 +210,14 @@ fn check_promise_achievability(
         });
     }
 
-    // ── Resilient without offsite ──────────────────────────────────
-    if level == ProtectionLevel::Resilient
+    // ── Fortified without offsite ─────────────────────────────────
+    if level == ProtectionLevel::Fortified
         && !drives_in_scope.iter().any(|d| d.role == DriveRole::Offsite)
     {
         checks.push(PreflightCheck {
-            name: "resilient-without-offsite",
+            name: "fortified-without-offsite",
             message: format!(
-                "{}: resilient promise requires at least one drive with role = \"offsite\"",
+                "{}: fortified promise requires at least one drive with role = \"offsite\"",
                 subvol.name,
             ),
         });
@@ -542,10 +542,10 @@ mod tests {
     // ── Promise achievability ────────────────────────────────────────
 
     #[test]
-    fn resilient_needs_two_drives() {
+    fn fortified_needs_two_drives() {
         let mut sv = test_subvolume("recordings");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Resilient);
-        // Only one drive configured — resilient needs 2
+        sv.protection_level = Some(crate::types::ProtectionLevel::Fortified);
+        // Only one drive configured — fortified needs 2
         let config = test_config(vec![sv], vec![test_drive()]);
         let results: Vec<_> = preflight_checks(&config)
             .into_iter()
@@ -557,9 +557,9 @@ mod tests {
     }
 
     #[test]
-    fn protected_needs_one_drive() {
+    fn sheltered_needs_one_drive() {
         let mut sv = test_subvolume("documents");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Protected);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Sheltered);
         // No drives at all
         let config = test_config(vec![sv], vec![]);
         let results: Vec<_> = preflight_checks(&config)
@@ -572,9 +572,9 @@ mod tests {
     }
 
     #[test]
-    fn guarded_no_drive_requirement() {
+    fn recorded_no_drive_requirement() {
         let mut sv = test_subvolume("logs");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Guarded);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Recorded);
         let config = test_config(vec![sv], vec![]);
         let results: Vec<_> = preflight_checks(&config)
             .into_iter()
@@ -585,9 +585,9 @@ mod tests {
     }
 
     #[test]
-    fn send_disabled_voids_protected_promise() {
+    fn send_disabled_voids_sheltered_promise() {
         let mut sv = test_subvolume("documents");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Protected);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Sheltered);
         sv.send_enabled = Some(false);
         let config = test_config(vec![sv], vec![test_drive()]);
         let results: Vec<_> = preflight_checks(&config)
@@ -601,9 +601,9 @@ mod tests {
     }
 
     #[test]
-    fn empty_drives_list_voids_protected_promise() {
+    fn empty_drives_list_voids_sheltered_promise() {
         let mut sv = test_subvolume("documents");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Protected);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Sheltered);
         sv.drives = Some(vec![]);
         let config = test_config(vec![sv], vec![test_drive()]);
         let results: Vec<_> = preflight_checks(&config)
@@ -618,8 +618,8 @@ mod tests {
     #[test]
     fn weakening_snapshot_interval_warns() {
         let mut sv = test_subvolume("documents");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Protected);
-        // Protected + daily timer derives 24h snapshot interval.
+        sv.protection_level = Some(crate::types::ProtectionLevel::Sheltered);
+        // Sheltered + daily timer derives 24h snapshot interval.
         // Set a longer one to trigger the warning.
         sv.snapshot_interval = Some("2d".parse().unwrap());
         let config = test_config(vec![sv], vec![test_drive()]);
@@ -639,8 +639,8 @@ mod tests {
     #[test]
     fn weakening_retention_warns() {
         let mut sv = test_subvolume("documents");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Protected);
-        // Protected derives hourly=24, daily=30. Set tighter retention.
+        sv.protection_level = Some(crate::types::ProtectionLevel::Sheltered);
+        // Sheltered derives hourly=24, daily=30. Set tighter retention.
         sv.local_retention = Some(LocalRetentionConfig::Graduated(GraduatedRetention {
             hourly: Some(6),
             daily: Some(7),
@@ -717,7 +717,7 @@ mod tests {
     fn transient_with_named_level_warns() {
         let mut sv = test_subvolume("root");
         sv.local_retention = Some(LocalRetentionConfig::Transient);
-        sv.protection_level = Some(crate::types::ProtectionLevel::Guarded);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Recorded);
         let config = test_config(vec![sv], vec![test_drive()]);
         let results: Vec<_> = preflight_checks(&config)
             .into_iter()
@@ -759,7 +759,7 @@ mod tests {
         );
     }
 
-    // ── Resilient without offsite ───────────────────────────────────
+    // ── Fortified without offsite ──────────────────────────────────
 
     fn offsite_drive() -> DriveConfig {
         DriveConfig {
@@ -774,16 +774,16 @@ mod tests {
     }
 
     #[test]
-    fn resilient_without_offsite_warns() {
+    fn fortified_without_offsite_warns() {
         let mut sv = test_subvolume("recordings");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Resilient);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Fortified);
         // Two primary drives — no offsite
         let mut drive2 = test_drive();
         drive2.label = "drive-2".to_string();
         let config = test_config(vec![sv], vec![test_drive(), drive2]);
         let results: Vec<_> = preflight_checks(&config)
             .into_iter()
-            .filter(|c| c.name == "resilient-without-offsite")
+            .filter(|c| c.name == "fortified-without-offsite")
             .collect();
 
         assert_eq!(results.len(), 1);
@@ -791,40 +791,40 @@ mod tests {
     }
 
     #[test]
-    fn resilient_with_offsite_no_warning() {
+    fn fortified_with_offsite_no_warning() {
         let mut sv = test_subvolume("recordings");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Resilient);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Fortified);
         let config = test_config(vec![sv], vec![test_drive(), offsite_drive()]);
         let results: Vec<_> = preflight_checks(&config)
             .into_iter()
-            .filter(|c| c.name == "resilient-without-offsite")
+            .filter(|c| c.name == "fortified-without-offsite")
             .collect();
 
         assert!(results.is_empty());
     }
 
     #[test]
-    fn protected_without_offsite_no_warning() {
+    fn sheltered_without_offsite_no_warning() {
         let mut sv = test_subvolume("documents");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Protected);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Sheltered);
         let config = test_config(vec![sv], vec![test_drive()]);
         let results: Vec<_> = preflight_checks(&config)
             .into_iter()
-            .filter(|c| c.name == "resilient-without-offsite")
+            .filter(|c| c.name == "fortified-without-offsite")
             .collect();
 
         assert!(results.is_empty());
     }
 
     #[test]
-    fn resilient_with_scoped_offsite_drive_passes() {
+    fn fortified_with_scoped_offsite_drive_passes() {
         let mut sv = test_subvolume("recordings");
-        sv.protection_level = Some(crate::types::ProtectionLevel::Resilient);
+        sv.protection_level = Some(crate::types::ProtectionLevel::Fortified);
         sv.drives = Some(vec!["test-drive".to_string(), "offsite-drive".to_string()]);
         let config = test_config(vec![sv], vec![test_drive(), offsite_drive()]);
         let results: Vec<_> = preflight_checks(&config)
             .into_iter()
-            .filter(|c| c.name == "resilient-without-offsite")
+            .filter(|c| c.name == "fortified-without-offsite")
             .collect();
 
         assert!(results.is_empty());

--- a/src/types.rs
+++ b/src/types.rs
@@ -261,12 +261,18 @@ impl fmt::Display for DriveRole {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ProtectionLevel {
-    /// Local snapshots only. For: temp data, caches, build artifacts.
-    Guarded,
-    /// Local + at least one external drive current. For: documents, photos.
-    Protected,
-    /// Local + multiple external drives current. For: irreplaceable data.
-    Resilient,
+    /// Data is recorded locally. Snapshots exist on this machine.
+    /// For: temp data, caches, build artifacts.
+    #[serde(alias = "guarded")]
+    Recorded,
+    /// Data is sheltered on an external drive. Survives drive failure.
+    /// For: documents, photos.
+    #[serde(alias = "protected")]
+    Sheltered,
+    /// Data is fortified across geography. Survives site loss.
+    /// For: irreplaceable data.
+    #[serde(alias = "resilient")]
+    Fortified,
     /// User manages all parameters manually.
     Custom,
 }
@@ -274,9 +280,9 @@ pub enum ProtectionLevel {
 impl fmt::Display for ProtectionLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Guarded => write!(f, "guarded"),
-            Self::Protected => write!(f, "protected"),
-            Self::Resilient => write!(f, "resilient"),
+            Self::Recorded => write!(f, "recorded"),
+            Self::Sheltered => write!(f, "sheltered"),
+            Self::Fortified => write!(f, "fortified"),
             Self::Custom => write!(f, "custom"),
         }
     }
@@ -362,7 +368,7 @@ pub fn derive_policy(level: ProtectionLevel, freq: RunFrequency) -> Option<Deriv
         return None;
     }
 
-    let guarded_retention = ResolvedGraduatedRetention {
+    let recorded_retention = ResolvedGraduatedRetention {
         hourly: 0,
         daily: 7,
         weekly: 4,
@@ -383,7 +389,7 @@ pub fn derive_policy(level: ProtectionLevel, freq: RunFrequency) -> Option<Deriv
         monthly: 0,
     };
 
-    let guarded_external_retention = ResolvedGraduatedRetention {
+    let recorded_external_retention = ResolvedGraduatedRetention {
         hourly: 0,
         daily: 7,
         weekly: 4,
@@ -392,15 +398,15 @@ pub fn derive_policy(level: ProtectionLevel, freq: RunFrequency) -> Option<Deriv
 
     match (level, freq) {
         // ── Timer mode ──────────────────────────────────────────────
-        (ProtectionLevel::Guarded, RunFrequency::Timer { interval }) => Some(DerivedPolicy {
+        (ProtectionLevel::Recorded, RunFrequency::Timer { interval }) => Some(DerivedPolicy {
             snapshot_interval: interval,
             send_interval: interval,
             send_enabled: false,
-            local_retention: guarded_retention,
-            external_retention: guarded_external_retention,
+            local_retention: recorded_retention,
+            external_retention: recorded_external_retention,
             min_external_drives: 0,
         }),
-        (ProtectionLevel::Protected, RunFrequency::Timer { interval }) => Some(DerivedPolicy {
+        (ProtectionLevel::Sheltered, RunFrequency::Timer { interval }) => Some(DerivedPolicy {
             snapshot_interval: interval,
             send_interval: interval,
             send_enabled: true,
@@ -408,7 +414,7 @@ pub fn derive_policy(level: ProtectionLevel, freq: RunFrequency) -> Option<Deriv
             external_retention: full_external_retention,
             min_external_drives: 1,
         }),
-        (ProtectionLevel::Resilient, RunFrequency::Timer { interval }) => Some(DerivedPolicy {
+        (ProtectionLevel::Fortified, RunFrequency::Timer { interval }) => Some(DerivedPolicy {
             snapshot_interval: interval,
             send_interval: interval,
             send_enabled: true,
@@ -418,15 +424,15 @@ pub fn derive_policy(level: ProtectionLevel, freq: RunFrequency) -> Option<Deriv
         }),
 
         // ── Sentinel mode ───────────────────────────────────────────
-        (ProtectionLevel::Guarded, RunFrequency::Sentinel) => Some(DerivedPolicy {
+        (ProtectionLevel::Recorded, RunFrequency::Sentinel) => Some(DerivedPolicy {
             snapshot_interval: Interval::hours(4),
             send_interval: Interval::hours(4),
             send_enabled: false,
-            local_retention: guarded_retention,
-            external_retention: guarded_external_retention,
+            local_retention: recorded_retention,
+            external_retention: recorded_external_retention,
             min_external_drives: 0,
         }),
-        (ProtectionLevel::Protected, RunFrequency::Sentinel) => Some(DerivedPolicy {
+        (ProtectionLevel::Sheltered, RunFrequency::Sentinel) => Some(DerivedPolicy {
             snapshot_interval: Interval::hours(1),
             send_interval: Interval::hours(4),
             send_enabled: true,
@@ -434,7 +440,7 @@ pub fn derive_policy(level: ProtectionLevel, freq: RunFrequency) -> Option<Deriv
             external_retention: full_external_retention,
             min_external_drives: 1,
         }),
-        (ProtectionLevel::Resilient, RunFrequency::Sentinel) => Some(DerivedPolicy {
+        (ProtectionLevel::Fortified, RunFrequency::Sentinel) => Some(DerivedPolicy {
             snapshot_interval: Interval::hours(1),
             send_interval: Interval::hours(2),
             send_enabled: true,
@@ -1094,18 +1100,18 @@ mod tests {
 
     #[test]
     fn protection_level_display() {
-        assert_eq!(ProtectionLevel::Guarded.to_string(), "guarded");
-        assert_eq!(ProtectionLevel::Protected.to_string(), "protected");
-        assert_eq!(ProtectionLevel::Resilient.to_string(), "resilient");
+        assert_eq!(ProtectionLevel::Recorded.to_string(), "recorded");
+        assert_eq!(ProtectionLevel::Sheltered.to_string(), "sheltered");
+        assert_eq!(ProtectionLevel::Fortified.to_string(), "fortified");
         assert_eq!(ProtectionLevel::Custom.to_string(), "custom");
     }
 
     #[test]
     fn protection_level_serde_roundtrip() {
         let levels = vec![
-            ProtectionLevel::Guarded,
-            ProtectionLevel::Protected,
-            ProtectionLevel::Resilient,
+            ProtectionLevel::Recorded,
+            ProtectionLevel::Sheltered,
+            ProtectionLevel::Fortified,
             ProtectionLevel::Custom,
         ];
         for level in levels {
@@ -1113,6 +1119,16 @@ mod tests {
             let parsed: ProtectionLevel = serde_json::from_str(&json).unwrap();
             assert_eq!(parsed, level);
         }
+    }
+
+    #[test]
+    fn protection_level_legacy_aliases_parse() {
+        let guarded: ProtectionLevel = serde_json::from_str("\"guarded\"").unwrap();
+        assert_eq!(guarded, ProtectionLevel::Recorded);
+        let protected: ProtectionLevel = serde_json::from_str("\"protected\"").unwrap();
+        assert_eq!(protected, ProtectionLevel::Sheltered);
+        let resilient: ProtectionLevel = serde_json::from_str("\"resilient\"").unwrap();
+        assert_eq!(resilient, ProtectionLevel::Fortified);
     }
 
     // ── RunFrequency tests ─────────────────────────────────────────
@@ -1175,25 +1191,25 @@ mod tests {
     }
 
     #[test]
-    fn derive_policy_guarded_timer() {
+    fn derive_policy_recorded_timer() {
         let daily = RunFrequency::Timer {
             interval: Interval::days(1),
         };
-        let p = derive_policy(ProtectionLevel::Guarded, daily).unwrap();
+        let p = derive_policy(ProtectionLevel::Recorded, daily).unwrap();
         assert_eq!(p.snapshot_interval, Interval::days(1));
         assert!(!p.send_enabled);
         assert_eq!(p.min_external_drives, 0);
         assert_eq!(p.local_retention.daily, 7);
         assert_eq!(p.local_retention.weekly, 4);
-        assert_eq!(p.local_retention.hourly, 0); // no hourly for guarded
+        assert_eq!(p.local_retention.hourly, 0); // no hourly for recorded
     }
 
     #[test]
-    fn derive_policy_protected_timer() {
+    fn derive_policy_sheltered_timer() {
         let daily = RunFrequency::Timer {
             interval: Interval::days(1),
         };
-        let p = derive_policy(ProtectionLevel::Protected, daily).unwrap();
+        let p = derive_policy(ProtectionLevel::Sheltered, daily).unwrap();
         assert_eq!(p.snapshot_interval, Interval::days(1));
         assert_eq!(p.send_interval, Interval::days(1));
         assert!(p.send_enabled);
@@ -1207,34 +1223,36 @@ mod tests {
     }
 
     #[test]
-    fn derive_policy_resilient_timer() {
+    fn derive_policy_fortified_timer() {
         let daily = RunFrequency::Timer {
             interval: Interval::days(1),
         };
-        let p = derive_policy(ProtectionLevel::Resilient, daily).unwrap();
+        let p = derive_policy(ProtectionLevel::Fortified, daily).unwrap();
         assert_eq!(p.min_external_drives, 2);
         assert!(p.send_enabled);
-        // Same retention as protected
-        let protected = derive_policy(ProtectionLevel::Protected, daily).unwrap();
-        assert_eq!(p.local_retention, protected.local_retention);
-        assert_eq!(p.external_retention, protected.external_retention);
+        // Same retention as sheltered
+        let sheltered = derive_policy(ProtectionLevel::Sheltered, daily).unwrap();
+        assert_eq!(p.local_retention, sheltered.local_retention);
+        assert_eq!(p.external_retention, sheltered.external_retention);
     }
 
     #[test]
     fn derive_policy_sentinel_variants() {
-        let guarded = derive_policy(ProtectionLevel::Guarded, RunFrequency::Sentinel).unwrap();
-        assert_eq!(guarded.snapshot_interval, Interval::hours(4));
-        assert!(!guarded.send_enabled);
+        let recorded = derive_policy(ProtectionLevel::Recorded, RunFrequency::Sentinel).unwrap();
+        assert_eq!(recorded.snapshot_interval, Interval::hours(4));
+        assert!(!recorded.send_enabled);
 
-        let protected = derive_policy(ProtectionLevel::Protected, RunFrequency::Sentinel).unwrap();
-        assert_eq!(protected.snapshot_interval, Interval::hours(1));
-        assert_eq!(protected.send_interval, Interval::hours(4));
-        assert!(protected.send_enabled);
+        let sheltered =
+            derive_policy(ProtectionLevel::Sheltered, RunFrequency::Sentinel).unwrap();
+        assert_eq!(sheltered.snapshot_interval, Interval::hours(1));
+        assert_eq!(sheltered.send_interval, Interval::hours(4));
+        assert!(sheltered.send_enabled);
 
-        let resilient = derive_policy(ProtectionLevel::Resilient, RunFrequency::Sentinel).unwrap();
-        assert_eq!(resilient.snapshot_interval, Interval::hours(1));
-        assert_eq!(resilient.send_interval, Interval::hours(2));
-        assert_eq!(resilient.min_external_drives, 2);
+        let fortified =
+            derive_policy(ProtectionLevel::Fortified, RunFrequency::Sentinel).unwrap();
+        assert_eq!(fortified.snapshot_interval, Interval::hours(1));
+        assert_eq!(fortified.send_interval, Interval::hours(2));
+        assert_eq!(fortified.min_external_drives, 2);
     }
 
     #[test]
@@ -1243,7 +1261,7 @@ mod tests {
         let freq = RunFrequency::Timer {
             interval: Interval::hours(6),
         };
-        let p = derive_policy(ProtectionLevel::Protected, freq).unwrap();
+        let p = derive_policy(ProtectionLevel::Sheltered, freq).unwrap();
         assert_eq!(p.snapshot_interval, Interval::hours(6));
         assert_eq!(p.send_interval, Interval::hours(6));
         // Retention stays the same regardless of timer interval

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -2743,9 +2743,9 @@ mod tests {
         colored::control::set_override(false);
         let mut data = test_status_output();
         // Set a promise level but all statuses are PROTECTED — no conflict
-        data.assessments[0].promise_level = Some("protected".to_string());
+        data.assessments[0].promise_level = Some("sheltered".to_string());
         data.assessments[1].status = "PROTECTED".to_string();
-        data.assessments[1].promise_level = Some("resilient".to_string());
+        data.assessments[1].promise_level = Some("fortified".to_string());
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
             !output.contains("PROTECTION"),


### PR DESCRIPTION
## Summary

- **Vocabulary rename:** guarded→recorded, protected→sheltered, resilient→fortified — names now describe what the data *becomes*, not generic safety adjectives
- **Serde aliases** on enum variants ensure legacy configs (using old names) continue to parse without migration
- **ADR-111 revised** with complete v1 schema specification: field tables, example configs, migration spec, validation error messages, updated implementation gates
- **ADR-110 updated** with new level names, vocabulary rationale, and implementation gate progress

This is UPI 010 session 1 — the vocabulary anchor before v1 config schema work begins in sessions 2-4.

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 764 tests, all passing
- cargo build --release: pass
- Legacy alias test added: old names ("guarded", "protected", "resilient") deserialize correctly via serde aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)