### PR TITLE
docs: UPI 019-021 designs from v0.10.0 test session

### DIFF
--- a/docs/95-ideas/2026-04-04-design-019-honest-worker.md
+++ b/docs/95-ideas/2026-04-04-design-019-honest-worker.md
@@ -1,0 +1,345 @@
+---
+upi: "019"
+status: proposed
+date: 2026-04-04
+---
+
+# Design: The Honest Worker (UPI 019)
+
+> **TL;DR:** Fix the deadlock where broken chains on token-verified drives permanently
+> block sends in auto mode, and make the backup result pipeline distinguish "completed
+> successfully" from "needed work but couldn't do it." Three changes: token-aware
+> full-send gate, honest run results, and unified deferred reporting.
+
+## Problem
+
+Live testing of v0.10.0 revealed a deadlock cycle for transient (`local_snapshots = false`)
+subvolumes on space-constrained drives:
+
+1. NVMe space pressure forces user to manually delete snapshots
+2. Pin parent snapshot gets deleted, breaking the incremental chain
+3. Full-send safety gate blocks chain-break sends in `--auto` mode (systemd timer)
+4. Nightly run reports `success: true` per-subvolume and `RunResult::Success` overall
+5. Heartbeat records `PROTECTED` (accurate at run time, stale within hours)
+6. Prometheus metric `backup_success{htpc-root} = 1` — monitoring sees green
+7. Next nightly: same. Data ages from PROTECTED → AT RISK → UNPROTECTED
+
+The user must manually run `urd backup --force-full` to break the cycle, but nothing in
+the system tells them this. The doctor suggests `urd backup` (which would be gated again).
+
+**Root cause analysis:**
+
+The full-send gate (v0.4.2, UPI 004) was designed to catch hardware swaps — cloned or
+replaced drives where a full send could overwrite good data. It checks
+`FullSendReason::ChainBroken` + `FullSendPolicy::SkipAndNotify`. But the gate cannot
+distinguish "chain broke because user deleted snapshots for space" from "chain broke
+because someone plugged in a different drive."
+
+Meanwhile, the drive identity system (tokens, UUID verification) already answers this
+question. WD-18TB's token is `verified` — the system knows this is the right drive.
+The gate adds no safety value on a verified drive; it only creates a deadlock.
+
+**Relationship to UPI 018:** UPI 018 fixes the *presentation* of external-only subvolumes
+(status table, skip tags, health model for PinMissingLocally). This design fixes the
+*behavioral* problem (gate logic, run result truthfulness, deferred reporting). They are
+complementary — 018 makes external-only look right, 019 makes it work right. Build 019
+first because it affects data safety; 018 is presentation polish.
+
+## Proposed Design
+
+### Change 1: Token-aware full-send gate
+
+**Module:** `executor.rs` (lines 312-333)
+
+The chain-break gate currently has a binary decision: `FullSendPolicy::Allow` (manual)
+or `FullSendPolicy::SkipAndNotify` (auto). Replace this with a three-way decision that
+considers drive token state.
+
+**Current logic:**
+```
+if reason == ChainBroken && policy == SkipAndNotify → Deferred
+```
+
+**Proposed logic:**
+```
+if reason == ChainBroken && policy == SkipAndNotify {
+    if drive_token_state == Verified → Proceed (log info, not warn)
+    else → Deferred (existing behavior)
+}
+```
+
+**Implementation:** The executor needs to know the token state for each drive at send
+time. Two options:
+
+**Option A: Pass token state through the plan.** The planner already resolves drives.
+Add `token_verified: bool` to `PlannedOperation::SendFull`. The executor reads it.
+
+**Option B: Pass a token lookup to the executor.** The executor receives a
+`HashMap<String, TokenState>` at construction time (or per-run). Looks up the drive
+label at gate time.
+
+**Chosen: Option A.** The plan is the single source of truth for "what operations to
+perform." Embedding token state in the planned operation is cleaner than giving the
+executor external state. The planner already has config + filesystem access to determine
+token state. This follows ADR-100 (planner decides, executor executes).
+
+**Changes to plan.rs:** In the send planning path (around line 479), when a full send is
+planned with `FullSendReason::ChainBroken`, look up the drive's token state via
+`FileSystemState::drive_token_state()` and include it in the planned operation.
+
+**Changes to types.rs:** Add `token_verified: bool` field to the `SendFull` variant of
+`PlannedOperation` (or to a shared `SendMetadata` struct if one exists).
+
+**Changes to executor.rs:** The gate condition becomes:
+```rust
+if *reason == FullSendReason::ChainBroken
+    && self.full_send_policy == FullSendPolicy::SkipAndNotify
+    && !token_verified
+{
+    // Existing deferred behavior
+}
+// If token_verified, proceed with the full send (log at info level)
+```
+
+**Log message when proceeding:** `"Chain-break full send for {subvol} to {drive}: proceeding (drive identity verified)"`
+at `INFO` level (not WARN — this is working correctly).
+
+**Test strategy for Change 1:**
+- `chain_break_gated_on_unverified_drive` — existing behavior preserved
+- `chain_break_proceeds_on_verified_drive` — the new path
+- `chain_break_gated_on_unknown_token` — absent drive still gated
+- `first_send_always_allowed` — regression: FirstSend and NoPinFile unaffected
+- `force_full_bypasses_gate_regardless` — regression: --force-full still works
+
+### Change 2: Honest run results
+
+**Modules:** `executor.rs`, `commands/backup.rs`, `heartbeat.rs`, `metrics.rs`
+
+The problem: a subvolume where a send was *needed* but *couldn't happen* (gated, no
+snapshots, drive token issue) currently reports `success: true`. This masks degradation.
+
+**Proposed: introduce `degrading` result state.**
+
+The executor already has `OpResult::Deferred`. The issue is that `Deferred` doesn't set
+`subvol_success = false`. And the "no local snapshots to send" path in the planner doesn't
+even produce an operation — it's a skip, which never reaches the executor.
+
+**Two changes needed:**
+
+**2a: Planner marks "expected send not possible" explicitly.**
+
+When the planner skips a send for a subvolume that has `send_enabled = true` and all
+drives for that subvolume are mounted (i.e., the send *should* happen but can't), it
+should produce a skip with a distinct category. The existing "no local snapshots to send"
+skip should be categorized as `SkipCategory::NoSnapshotsAvailable` (new variant) instead
+of `Other`.
+
+In `commands/backup.rs`, after execution, check: for each subvolume with `send_enabled`
+and at least one mounted target drive, did any send actually complete? If not, and the
+subvolume has deferred entries OR was skipped with `NoSnapshotsAvailable`, the run result
+for that subvolume should be flagged as `degrading`.
+
+**2b: Heartbeat uses post-run awareness assessment, not per-subvolume success.**
+
+Currently `heartbeat.rs` line 107-126 derives `backup_success` from `sv.success` and
+`promise_status` from the awareness assessment. The `promise_status` field is already
+correct — it reflects the assessment at run time. But `backup_success: true` alongside
+`promise_status: "PROTECTED"` gives consumers a false sense of security when the data
+will degrade within hours.
+
+**Proposed:** Add `send_completed: bool` field to `SubvolumeHeartbeat`:
+```rust
+pub struct SubvolumeHeartbeat {
+    pub name: String,
+    pub backup_success: Option<bool>,  // keep for backward compat
+    pub promise_status: String,
+    pub pin_failures: u32,
+    pub send_completed: bool,          // new: did any send actually transfer data?
+}
+```
+
+This field is `true` only when at least one send succeeded for this subvolume. Consumers
+can alert on `backup_success && !send_completed && send_enabled` — "the run worked but
+your data didn't actually get copied anywhere."
+
+**Heartbeat schema:** Bump `schema_version` to 2. The new field defaults to `true` for
+backward compatibility (old heartbeats without the field assume sends completed).
+
+**2c: Prometheus metric for send state.**
+
+`backup_send_type` already exists with values 0=full, 1=incremental, 2=no send. Value 2
+doesn't distinguish "no send needed" from "send needed but blocked." Add value 3=deferred:
+
+```
+backup_send_type{subvolume="htpc-root"} 3
+```
+
+This is backward-compatible — existing alert rules that check `!= 1` (not incremental)
+will still fire. New rules can distinguish 2 (intentional, e.g. interval not elapsed)
+from 3 (unintentional deferral).
+
+**Test strategy for Change 2:**
+- `heartbeat_send_completed_true_on_successful_send`
+- `heartbeat_send_completed_false_on_deferred_send`
+- `heartbeat_send_completed_false_on_no_snapshots_skip`
+- `metric_send_type_deferred_value_3`
+- Backward compat: `heartbeat_v1_defaults_send_completed_true`
+
+### Change 3: Unified deferred reporting
+
+**Module:** `commands/backup.rs` (lines 318, 357-363)
+
+Currently, only `OpResult::Deferred` operations populate the `deferred` field. But
+the "no local snapshots to send" path never creates an operation — it's a planner skip.
+This means htpc-root gets no deferred entry while htpc-home does, despite the same root
+cause.
+
+**Proposed: post-execution deferred synthesis.**
+
+After execution, in `commands/backup.rs`, scan the skip list for actionable skips
+(category `NoSnapshotsAvailable` or any case where a send-enabled subvolume with mounted
+drives produced zero successful sends). Synthesize deferred entries for these:
+
+```rust
+// After executor returns, check for subvolumes that needed sends but got none
+for sv_summary in &mut subvolume_summaries {
+    if sv_summary.sends.is_empty()
+        && sv_summary.deferred.is_empty()
+        && sv_summary.errors.is_empty()
+        && subvol_needs_send(&config, &sv_summary.name, &mounted_drives)
+    {
+        // Check skip list for this subvolume
+        if let Some(skip) = skipped.iter().find(|s|
+            s.name == sv_summary.name
+            && s.category == SkipCategory::NoSnapshotsAvailable
+        ) {
+            sv_summary.deferred.push(DeferredInfo {
+                reason: "no local snapshots available for send".to_string(),
+                suggestion: format!(
+                    "Run `urd backup --force-full --subvolume {}` to create and send",
+                    sv_summary.name
+                ),
+            });
+        }
+    }
+}
+```
+
+The helper `subvol_needs_send()` checks: `send_enabled && at least one target drive mounted`.
+
+**Test strategy for Change 3:**
+- `no_snapshots_skip_produces_deferred_entry`
+- `local_only_skip_does_not_produce_deferred`
+- `interval_skip_does_not_produce_deferred`
+- `drive_unmounted_skip_does_not_produce_deferred`
+
+## Module Map
+
+| Module | Changes | Tests |
+|--------|---------|-------|
+| `types.rs` | Add `token_verified: bool` to SendFull planned operation | 0 (type change) |
+| `plan.rs` | Look up token state for chain-break full sends. New `NoSnapshotsAvailable` skip category string. | 2 |
+| `executor.rs` | Token-aware gate: proceed on verified drives | 5 |
+| `output.rs` | Add `SkipCategory::NoSnapshotsAvailable`. Add `send_completed` to heartbeat-related output types. | 2 |
+| `commands/backup.rs` | Post-execution deferred synthesis. Send-completed computation. | 4 |
+| `heartbeat.rs` | Add `send_completed: bool`, bump schema_version | 3 |
+| `metrics.rs` | Add `send_type = 3` for deferred sends | 1 |
+
+**Total: ~17 tests, 7 files modified**
+
+## Effort Estimate
+
+~1 session. Comparable to UPI 007+008 combined (safety gate communication + doctor pin-age):
+multiple modules touched, behavioral change with test coverage, but no new modules or
+architectural changes. The executor gate change is the riskiest piece — build and test it
+first.
+
+## Sequencing
+
+1. **Change 1 (token-aware gate):** This is the load-bearing fix that breaks the deadlock.
+   Build types.rs + plan.rs + executor.rs together. Test with MockBtrfs.
+2. **Change 3 (unified deferred):** Build in backup.rs. Depends on the SkipCategory
+   addition from Change 1's plan.rs work.
+3. **Change 2 (honest results):** Heartbeat + metrics changes. These consume data from
+   Changes 1 and 3, so build last.
+
+Risk-first: Change 1 touches the safety gate, which is defense-in-depth critical. Test
+thoroughly before proceeding.
+
+## Architectural Gates
+
+**ADR-105 (backward compatibility):** The heartbeat schema_version bump (1→2) and new
+Prometheus metric value (send_type=3) are additive changes. Existing consumers ignore
+unknown fields (heartbeat) and unknown values (metrics). No ADR needed — this is within
+the existing backward-compat contract.
+
+**ADR-106 (defense-in-depth):** The token-aware gate *relaxes* the full-send gate for
+verified drives. This must not weaken the protection against hardware swaps. The gate
+still fires for unverified/unknown/missing tokens. Document this in the executor's gate
+comment block. No new ADR needed — the existing ADR-106 layers (unsent protection,
+planner exclusion, executor re-check) remain intact.
+
+**ADR-107 (fail-open backups):** Allowing full sends to verified drives is consistent
+with "backups fail open" — when in doubt, send the data. The gate was an exception to
+fail-open for safety reasons. Making it smarter (token-aware) aligns it with ADR-107.
+
+## Rejected Alternatives
+
+**A: Exempt all transient subvolumes from the gate.** Too broad. A transient subvolume
+sending to an *unverified* drive should still be gated. The token state is what matters,
+not the retention policy.
+
+**B: Add `--auto-full` flag to the systemd timer.** Operational workaround that doesn't
+fix the root cause. Users would need to remember to add the flag, and it would apply to
+all subvolumes (not just verified drives).
+
+**C: Sentinel detects the deadlock and notifies.** Useful as a *supplement* (Design
+Group B covers this via doctor suggestions) but doesn't fix the underlying problem. The
+nightly should just work.
+
+**D: Change run result to "partial" when sends are deferred.** Considered using
+`RunResult::Partial` for deferred-only runs. Rejected because Partial implies "some
+succeeded, some failed" — deferred is neither. The `send_completed` field on the heartbeat
+is more precise and doesn't overload existing semantics.
+
+## Assumptions
+
+1. **Drive token state is available at plan time.** The planner has access to
+   `FileSystemState` which can read token files. This is verified — `drives.rs` already
+   reads tokens and the planner receives `&dyn FileSystemState`.
+
+2. **Token verification is reliable.** If a drive's token is `Verified`, it is the same
+   drive that was previously used. This relies on the token system from v0.4.0/v0.4.2.
+   If tokens can be spoofed or corrupted, the gate relaxation is unsafe. Tokens are
+   written by Urd itself to a `.urd-drive-token` file — spoofing requires root access
+   to the drive, which is equivalent to having physical access.
+
+3. **Heartbeat consumers handle unknown fields gracefully.** The homelab monitoring stack
+   reads heartbeat.json. Adding `send_completed` must not break existing parsing. JSON
+   parsing with `serde` default values handles this (unknown fields ignored by default).
+
+4. **`backup_send_type = 3` won't trigger false alerts.** Existing Prometheus alert rules
+   likely check for `!= 1` (not incremental) rather than `== 0` (failure). Value 3 would
+   fire these alerts, which is *correct* — a deferred send is something the user should
+   know about. Verify with the homelab alert configuration.
+
+## Open Questions
+
+1. **Should the token-aware gate log at INFO or WARN?** Option A: INFO — the system is
+   working correctly, no user attention needed. Option B: WARN — a full send is expensive
+   and the user should know it's happening. Leaning toward INFO: the gate exists to prevent
+   *unsafe* sends, not *expensive* ones. A safe full send is just a send.
+
+2. **Should `send_completed` consider *all* configured drives or just mounted ones?** If
+   htpc-root sends to WD-18TB (mounted, verified, send succeeds) but WD-18TB1 is absent,
+   is `send_completed = true`? Yes — data reached at least one external location. The
+   absence of WD-18TB1 is a separate concern (drive away).
+
+3. **How does this interact with UPI 018's PinMissingLocally exception?** 018 makes the
+   health model stop calling PinMissingLocally "degraded" for transient subvolumes. 019
+   makes the executor stop *blocking* sends on verified drives. Both changes help
+   external-only subvolumes; neither depends on the other. But if 018 lands first, the
+   health model will say "healthy" while the send is still blocked (until 019 lands).
+   If 019 lands first, the send unblocks but status still shows "degraded." **Recommendation:**
+   Build 019 first (data safety), then 018 (presentation). The brief window of "degraded
+   but actually sending" is less harmful than "healthy-looking but not sending."

--- a/docs/95-ideas/2026-04-04-design-020-doctor-knows.md
+++ b/docs/95-ideas/2026-04-04-design-020-doctor-knows.md
@@ -1,0 +1,255 @@
+---
+upi: "020"
+status: proposed
+date: 2026-04-04
+---
+
+# Design: The Doctor Knows (UPI 020)
+
+> **TL;DR:** Make every suggestion Urd produces context-aware: the doctor should never
+> prescribe a command that would fail. One shared function computes the right next action
+> given the full diagnostic picture, and every surface (doctor, status, bare `urd`) uses it.
+
+## Problem
+
+`urd doctor` for htpc-root says:
+```
+✗ htpc-root waning — last backup 13 hours ago
+  → Run `urd backup` to refresh.
+```
+
+Following this advice creates a new snapshot, hits the chain-break full-send gate, and
+leaves the user worse off (more NVMe usage, no data transferred). The doctor knows the
+chain is broken (the verify section shows it) but doesn't connect this knowledge to its
+suggestion.
+
+The same issue exists across every suggestion surface:
+- **Bare `urd`:** "htpc-root waning." → suggests `urd status` but doesn't mention the fix
+- **`urd status`:** "Run `urd doctor` to diagnose." → correct but adds a hop
+- **`urd doctor`:** "Run `urd backup` to refresh." → actively wrong when chain is broken
+
+The suggestion system (voice.rs `suggest_next_action()`, lines 2402-2430) uses a static
+lookup table based on `SuggestionContext` enums. It has no access to per-subvolume state
+like chain health, drive token status, or external-only mode. The doctor suggestion
+(commands/doctor.rs lines 105-145) is similarly static — it maps promise status to a
+hardcoded string without consulting the verify results.
+
+## Proposed Design
+
+### Core change: `ActionableAdvice` computed from full diagnostic state
+
+Introduce a pure function that takes the complete assessment for a subvolume and produces
+specific, actionable advice. This function is called by every surface that shows
+suggestions.
+
+**Module:** `awareness.rs` (new public function — pure, no I/O, fits ADR-108)
+
+```rust
+/// Actionable advice for a subvolume based on its full assessment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActionableAdvice {
+    /// Short problem description ("waning — last external send 43h ago")
+    pub issue: String,
+    /// The exact command to run, or None if no action can help right now
+    pub command: Option<String>,
+    /// Human explanation of why this command ("thread to WD-18TB broken, needs full send")
+    pub reason: Option<String>,
+}
+
+/// Compute actionable advice for a subvolume that needs attention.
+///
+/// Returns `None` for subvolumes that are PROTECTED and healthy — they need no advice.
+/// For everything else, produces the most specific helpful suggestion possible.
+pub fn compute_advice(
+    assessment: &SubvolAssessment,
+    send_enabled: bool,
+    external_only: bool,
+) -> Option<ActionableAdvice> { ... }
+```
+
+**Decision logic (in priority order):**
+
+1. **UNPROTECTED + no drives configured:** "Configure an external drive with `urd init`"
+2. **UNPROTECTED + all drives absent:** "Connect {drive_name} to restore protection"
+3. **AT RISK + chain broken on a mounted drive:** "Run `urd backup --force-full --subvolume {name}`"
+   with reason "thread to {drive} broken — needs full send (~{size} estimated)"
+4. **AT RISK + drive just absent:** "Connect {drive_name} and run `urd backup`"
+5. **AT RISK + no chain break, drive mounted:** "Run `urd backup --subvolume {name}`"
+6. **PROTECTED but degraded (chain broken):** Same as #3 but lower urgency framing
+7. **PROTECTED but degraded (drive away long):** "Consider connecting {drive_name}"
+
+The function needs the assessment's `chain_health`, `external` (drive assessments), and
+`status` fields — all already present on `SubvolAssessment`.
+
+**Why awareness.rs and not voice.rs?** Voice renders text; it shouldn't compute advice.
+The advice is semantic (which command fixes this problem) not presentational (how to
+display it). Multiple consumers need the same logic (doctor, status suggestions, bare
+`urd`, future Spindle). Putting it in awareness keeps it pure and testable.
+
+### Change 1: Doctor uses `compute_advice()`
+
+**Module:** `commands/doctor.rs` (lines 105-145)
+
+Replace the static suggestion mapping:
+```rust
+// Before:
+PromiseStatus::AtRisk => (
+    Some(format!("waning — {age}")),
+    Some("Run `urd backup` to refresh.".to_string()),
+)
+
+// After:
+PromiseStatus::AtRisk | PromiseStatus::Unprotected => {
+    let advice = awareness::compute_advice(assessment, send_enabled, external_only);
+    (
+        advice.as_ref().map(|a| a.issue.clone()),
+        advice.as_ref().and_then(|a| a.command.clone())
+            .map(|cmd| format!("Run `{cmd}`.")),
+    )
+}
+```
+
+The doctor also needs access to the resolved subvolume config to determine `send_enabled`
+and `external_only`. The doctor already has the config (it loads it at line 25). Add a
+lookup from the assessment name to the resolved subvolume.
+
+**For degraded subvolumes (healthy promise but operational issues):** The doctor currently
+doesn't show degraded-but-protected subvolumes. Consider adding them with a `⚠` icon and
+the advice from `compute_advice()` when the advice includes a command. This surfaces
+"chain broken but still protected" before it becomes "waning."
+
+### Change 2: Status suggestion becomes context-aware
+
+**Module:** `voice.rs` (lines 2383-2430)
+
+The current suggestion system returns a static string. Replace with a dynamic suggestion
+that can reference specific subvolumes when there's a single clear action.
+
+**Current:**
+```
+Run `urd doctor` to diagnose.
+```
+
+**Proposed for single-subvolume issues:**
+```
+htpc-root waning — run `urd backup --force-full --subvolume htpc-root` to fix.
+```
+
+**Proposed for multiple issues:**
+```
+2 subvolumes need attention — run `urd doctor` for details.
+```
+
+**Implementation:** The status command already has assessments. Pass the `ActionableAdvice`
+list (computed in commands/status.rs) to the voice renderer via the `StatusOutput` struct.
+Add an `advice: Vec<(String, ActionableAdvice)>` field to `StatusOutput`. Voice.rs renders
+the most urgent advice item as the suggestion, or falls back to the generic "run doctor"
+message when there are multiple.
+
+### Change 3: Bare `urd` shows the fix, not just the problem
+
+**Module:** `commands/default.rs`, `voice.rs`
+
+The bare `urd` command currently shows "htpc-root waning." with the suggestion "Run `urd
+status` for details." When there's a single actionable fix, show it directly:
+
+```
+8 of 9 sealed. htpc-root waning. Run `urd backup --force-full --subvolume htpc-root`.
+```
+
+**Implementation:** The default command already computes assessments (it calls
+`awareness::assess()`). Add `compute_advice()` calls for non-protected subvolumes. Pass
+the best advice to `DefaultStatusOutput`. Voice renders it inline when there's exactly one
+actionable subvolume, or as a separate suggestion line when there are multiple.
+
+## Module Map
+
+| Module | Changes | Tests |
+|--------|---------|-------|
+| `awareness.rs` | New `compute_advice()` function + `ActionableAdvice` type | 8: one per decision branch + edge cases |
+| `output.rs` | Add `advice` field to `StatusOutput` and `DefaultStatusOutput` | 0 (type addition) |
+| `commands/doctor.rs` | Replace static suggestion with `compute_advice()` call | 3: chain-broken suggestion, absent-drive suggestion, healthy-no-suggestion |
+| `commands/status.rs` | Compute advice, pass to output struct | 1: integration |
+| `commands/default.rs` | Compute advice, pass to output struct | 1: integration |
+| `voice.rs` | Render advice in status suggestion and bare `urd` | 3: single-issue inline, multi-issue generic, no-issue silent |
+
+**Total: ~16 tests, 6 files modified**
+
+## Effort Estimate
+
+~0.5 session. The core function (`compute_advice`) is pure and straightforward — it's
+a decision tree over existing assessment data. The integration points (doctor, status,
+default) are small changes. Comparable to UPI 005 (status truth).
+
+## Sequencing
+
+1. **awareness.rs:** Build `compute_advice()` with full test coverage. This is the
+   foundation — everything else consumes it.
+2. **commands/doctor.rs:** Integrate into doctor. Test with the broken-chain scenario.
+3. **commands/status.rs + voice.rs:** Status suggestion integration.
+4. **commands/default.rs + voice.rs:** Bare `urd` integration.
+
+Steps 2-4 can be done in any order after step 1.
+
+**Dependency on UPI 019:** `compute_advice()` should know about the token-aware gate
+from 019. When the gate is relaxed for verified drives (019), the advice should adjust:
+instead of "run --force-full" it might say "backup will run on next timer" (if the drive
+is verified). However, this function should be useful *without* 019 — "run --force-full"
+is valid advice even before the gate is made token-aware. Build 020 to give correct
+advice for the current system, and update it when 019 lands.
+
+## Architectural Gates
+
+None. This is a pure function addition to an existing module, with integration into
+existing command output structs. No new contracts, no ADR changes.
+
+## Rejected Alternatives
+
+**A: Embed advice logic in voice.rs.** Voice.rs is the rendering layer. Advice
+computation requires understanding chain health, drive states, and protection levels —
+that's awareness-layer logic. Putting it in voice would violate ADR-108 (pure modules)
+and make it untestable without rendering.
+
+**B: Make doctor re-run verify internally.** The doctor already runs verify when
+`--thorough` is passed. For the basic doctor, the assessment's `chain_health` field
+(populated by awareness) is sufficient to detect broken chains. No need to re-run verify.
+
+**C: Add a dedicated `urd fix` command.** Considered a command that auto-detects and
+fixes common issues (like running --force-full for broken chains). Deferred — the
+suggestion system guides users to existing commands first. A `urd fix` command is a
+Phase F idea that needs its own design workflow.
+
+## Assumptions
+
+1. **`SubvolAssessment` has enough data for advice computation.** The assessment includes
+   `chain_health` (chain status per drive), `external` (drive assessments with mounted
+   state), and `status` (promise status). This is sufficient for all advice branches.
+
+2. **Single-action advice is possible for most scenarios.** The decision tree assumes
+   there's usually one clear "next step." For complex scenarios (multiple broken chains
+   on different drives), the advice may need to suggest `urd doctor --thorough` instead
+   of a specific fix.
+
+3. **Consumers (Spindle) will benefit from the structured advice.** The `ActionableAdvice`
+   struct is designed to be serializable — Spindle can show the `command` field as a
+   clickable action in the tray menu.
+
+## Open Questions
+
+1. **Should advice include estimated full-send size?** Option A: Include it when available
+   ("~33GB full send"). This helps the user decide whether to run the command now or
+   wait for a better time. Option B: Omit it — the size is an estimate and might be wrong,
+   creating false expectations. Leaning toward A: the estimate is already shown in `urd plan`
+   output, so the user sees it somewhere. Including it in the advice is consistent.
+
+2. **Should the doctor show degraded-but-protected subvolumes?** Currently the doctor only
+   flags AT RISK and UNPROTECTED. A subvolume with a broken chain that's still PROTECTED
+   (because the last send was recent enough) doesn't appear. Option A: Show it as a ⚠
+   warning: "htpc-home — thread broken, will need full send (~42GB) on next backup."
+   Option B: Don't show it — the user will see it when it becomes AT RISK. Leaning toward
+   A: early warning is better than surprising the user with a 42GB full send.
+
+3. **Should advice be part of the JSON output for non-TTY consumers?** Option A: Include
+   `advice` in the JSON output (useful for Spindle and monitoring scripts). Option B: Keep
+   advice interactive-only (voice.rs only). Leaning toward A: the whole point is that the
+   advice is computed from structured data, and structured consumers benefit from it.

--- a/docs/95-ideas/2026-04-04-design-021-living-daemon.md
+++ b/docs/95-ideas/2026-04-04-design-021-living-daemon.md
@@ -1,0 +1,275 @@
+---
+upi: "021"
+status: proposed
+date: 2026-04-04
+---
+
+# Design: The Living Daemon (UPI 021)
+
+> **TL;DR:** Make the sentinel reload its config when the file changes, and fix the
+> chain anomaly detection that fires for zero-chain transitions (drive disconnect events
+> masquerading as simultaneous chain breaks).
+
+## Problem
+
+Two issues discovered in v0.10.0 live testing:
+
+**F4: Sentinel uses stale config after migration.** The sentinel loads `Config` once at
+construction (`SentinelRunner::new()`, sentinel_runner.rs line 53) and never reloads. After
+the user migrated from legacy to v1 config (adding `drives = [...]` scoping to htpc-home
+and subvol2-pics), the sentinel continued using the old config. Result: sentinel-state.json
+reports htpc-home and subvol2-pics as degraded for "2TB-backup away for 10 days" — a drive
+those subvolumes don't even use in the new config.
+
+This directly affects Spindle: the tray icon's `visual_state` shows 3 degraded (should
+be 1), and the `promise_states` array has phantom health reasons. Any consumer of
+sentinel-state.json sees a false picture.
+
+**F7: "All 0 chains broke" anomaly on drive disconnect.** The sentinel logged:
+```
+Drive anomaly: all 0 chains broke on 2TB-backup simultaneously
+Drive anomaly: all 0 chains broke on WD-18TB simultaneously
+```
+
+The `detect_simultaneous_chain_breaks()` function (sentinel.rs lines 783-820) compares
+chain snapshots between assessments. `build_chain_snapshots()` (lines 753-770) only
+includes chains for *mounted* drives. When a drive is disconnected between assessments,
+all its chains vanish from the current snapshot. The detection code sees "previously had
+N intact chains, now has 0 intact and 0 total" — and fires the anomaly.
+
+The guard condition `prev_count >= 2 && intact == 0` triggers because `total == 0` (drive
+gone) satisfies `intact == 0`. The code correctly reports `total_chains: total` which is 0,
+producing the nonsensical "all 0 chains broke" message.
+
+## Proposed Design
+
+### Change 1: Config reload on file change
+
+**Module:** `sentinel_runner.rs`
+
+Add config file mtime tracking to the sentinel's event loop. On each poll cycle (every 5
+seconds), check if the config file's mtime has changed. If it has, attempt to reload.
+
+**Implementation:**
+
+Add to `SentinelRunner`:
+```rust
+struct SentinelRunner {
+    config: Config,
+    config_path: PathBuf,           // new: path to config file
+    last_config_mtime: Option<SystemTime>,  // new: last known mtime
+    // ... existing fields
+}
+```
+
+Add to `collect_events()` (lines 113-125):
+```rust
+fn detect_config_change(&mut self) -> Option<SentinelEvent> {
+    let mtime = std::fs::metadata(&self.config_path)
+        .ok()
+        .and_then(|m| m.modified().ok());
+
+    if mtime != self.last_config_mtime {
+        self.last_config_mtime = mtime;
+        Some(SentinelEvent::ConfigChanged)
+    } else {
+        None
+    }
+}
+```
+
+Add new event variant to `SentinelEvent` (sentinel.rs):
+```rust
+pub enum SentinelEvent {
+    DriveConnected(String),
+    DriveDisconnected(String),
+    HeartbeatUpdated,
+    Tick,
+    Shutdown,
+    ConfigChanged,  // new
+}
+```
+
+Add handler in `process_events()`:
+```rust
+SentinelEvent::ConfigChanged => {
+    match Config::load(&self.config_path) {
+        Ok(new_config) => {
+            log::warn!("Config reloaded — reassessing");
+            self.config = new_config;
+            // Force immediate re-assessment
+            if let Err(e) = self.execute_assess() {
+                log::error!("Post-reload assessment failed: {e}");
+            }
+        }
+        Err(e) => {
+            log::error!(
+                "Config file changed but reload failed: {e}. \
+                 Keeping previous config."
+            );
+        }
+    }
+}
+```
+
+**Why mtime polling, not inotify?** The sentinel already polls every 5 seconds
+(`POLL_INTERVAL`). Adding an mtime check to the existing poll loop is ~1 line of code
+and zero new dependencies. inotify would add `notify` or `inotify` crate dependency for
+marginal benefit (5-second latency is fine for config changes). The sentinel's design is
+poll-based by intent (sentinel.rs state machine). Introducing inotify changes the
+concurrency model for negligible gain.
+
+**Edge cases:**
+
+- **Config file deleted:** `std::fs::metadata()` returns `Err` → `mtime = None` → differs
+  from last mtime → triggers reload → `Config::load()` fails → error logged, old config
+  kept. Correct behavior.
+- **Config file written atomically (temp + rename):** mtime changes once on rename.
+  Single reload. Correct.
+- **Config file written in-place (partial write):** mtime changes mid-write → reload
+  attempt → parse fails → error logged, old config kept. On next poll, mtime unchanged
+  (write completed), no retry. On next *actual* save, mtime changes, reload succeeds.
+  Safe but may require two saves to pick up a change that was written in-place. Acceptable
+  — config editors almost never save partially.
+- **Sentinel startup:** Initialize `last_config_mtime` from the file's current mtime in
+  `new()`. No reload on first poll.
+
+**What about the state machine?** `ConfigChanged` needs to be added to `sentinel_transition()`
+(sentinel.rs). The state machine should pass it through to an `Assess` action, similar to
+how `Tick` is handled when assessment is due. The transition is simple: any state +
+ConfigChanged → same state + [Assess].
+
+**Test strategy:**
+- `config_reload_triggers_reassessment` — mock filesystem, change config, verify assess called
+- `config_reload_failure_keeps_old_config` — invalid config file, verify old config preserved
+- `config_mtime_unchanged_no_reload` — same mtime, verify no reload
+- `config_reload_updates_drive_scoping` — the actual bug: after reload, subvol2-pics no longer
+  shows 2TB-backup in health reasons
+
+### Change 2: Fix chain anomaly guard for disconnected drives
+
+**Module:** `sentinel.rs` (lines 807-817)
+
+The anomaly detection fires when `prev_count >= 2 && intact == 0`. When a drive disconnects,
+`total == 0` (no chains in current snapshot for that drive). Add a guard: don't fire when
+`total == 0`.
+
+**Current (line 811):**
+```rust
+if prev_count >= 2 && intact == 0 {
+    anomalies.push(DriveAnomaly {
+        drive_label: drive.to_string(),
+        total_chains: total,
+    });
+}
+```
+
+**Proposed:**
+```rust
+if prev_count >= 2 && intact == 0 && total > 0 {
+    anomalies.push(DriveAnomaly {
+        drive_label: drive.to_string(),
+        total_chains: total,
+    });
+}
+```
+
+**Why `total > 0`?** When `total == 0`, the drive has no chains in the current assessment.
+This means the drive is unmounted (filtered out by `build_chain_snapshots`). A disconnected
+drive is not an anomaly — it's an expected event that the sentinel already handles via
+`DriveDisconnected`. The anomaly detector should only fire when the drive is still present
+(`total > 0`) but all its chains broke (`intact == 0`).
+
+**Test strategy:**
+- `drive_disconnect_no_anomaly` — drive in previous, absent in current, no anomaly
+- `existing_all_break_still_detected` — regression: all chains broken on mounted drive
+  still fires
+- `drive_disconnect_then_reconnect_clean` — drive returns with all chains intact, no anomaly
+
+## Module Map
+
+| Module | Changes | Tests |
+|--------|---------|-------|
+| `sentinel.rs` | Add `ConfigChanged` event variant. Add transition rule. Fix anomaly guard `total > 0`. | 4 (1 transition + 3 anomaly) |
+| `sentinel_runner.rs` | Add config path + mtime tracking. Add `detect_config_change()`. Handle `ConfigChanged` in `process_events()`. | 4 (reload success, reload failure, no-change, scoping fix) |
+
+**Total: ~8 tests, 2 files modified**
+
+## Effort Estimate
+
+~0.25 session. The anomaly fix is a one-line guard. The config reload is ~30 lines of code
+in sentinel_runner.rs plus a new event variant and transition in sentinel.rs. Similar to the
+sentinel fixes in UPI 006 (drive reconnection notifications) — small, focused changes to
+an existing system.
+
+## Sequencing
+
+1. **Change 2 (anomaly guard):** One-line fix, independent, eliminates false anomaly
+   notifications immediately.
+2. **Change 1 (config reload):** Builds on the sentinel event system. Test with the
+   drive-scoping scenario from F4.
+
+Both changes are independent — they can be built in either order or parallel.
+
+## Architectural Gates
+
+**ADR-108 (pure-function module pattern):** The sentinel state machine (sentinel.rs) is
+pure. Adding `ConfigChanged` as an event variant and a transition rule preserves purity —
+the state machine doesn't load the config, it just emits an `Assess` action. The runner
+(sentinel_runner.rs) handles the I/O of loading the config. Compliant.
+
+**Sentinel state file schema:** No schema change. The state file's `promise_states` array
+will show different (correct) data after a config reload, but the schema structure is
+unchanged. Schema version stays at 3.
+
+## Rejected Alternatives
+
+**A: Use inotify/fswatch for config changes.** Adds a crate dependency and changes the
+concurrency model. The sentinel polls every 5 seconds already. Mtime check in the poll
+loop is simpler, zero-dependency, and sufficient. Config changes are rare events — 5-second
+latency is imperceptible.
+
+**B: Restart sentinel on config change (systemd path unit).** External solution: add a
+systemd `.path` unit that watches urd.toml and restarts the sentinel service. This works
+but is fragile (user must remember to install the path unit) and loses sentinel state
+(uptime counters, circuit breaker). In-process reload preserves state.
+
+**C: Re-read config on every assessment tick.** The sentinel assesses every ~5 minutes
+(adaptive). Re-reading config on every tick adds unnecessary I/O. Mtime check is
+cheaper — only read the file when it actually changed.
+
+**D: For the anomaly fix, track drive presence separately.** Instead of `total > 0`, could
+cross-reference `mounted_drives` in the anomaly detector. This is equivalent but more
+complex — `total > 0` already encodes "drive is present in current assessment."
+
+## Assumptions
+
+1. **Config file path is available to the sentinel runner.** Currently, the config path
+   is resolved in `commands/sentinel.rs` (the CLI command) and only the parsed `Config` is
+   passed to `SentinelRunner::new()`. The path needs to be plumbed through. This is a
+   minor interface change — add `config_path: PathBuf` parameter to `SentinelRunner::new()`.
+
+2. **Config::load() is safe to call mid-run.** The config loader reads the file, parses
+   TOML, validates, and returns a `Config`. It has no side effects and doesn't modify global
+   state. Safe to call from the sentinel's poll loop.
+
+3. **State machine transitions are synchronous.** Adding `ConfigChanged` as an event doesn't
+   change the sentinel's single-threaded polling model. The reload and re-assessment happen
+   within the same poll iteration. No concurrency concerns.
+
+## Open Questions
+
+1. **Should the sentinel log the diff between old and new config?** Option A: Just log
+   "Config reloaded — reassessing." Simple, sufficient. Option B: Log what changed:
+   "Config reloaded — drive scoping changed for htpc-home, subvol2-pics." More informative
+   but requires diffing two Config structs, which adds complexity. Leaning toward A for
+   now — the user knows what they changed.
+
+2. **Should the first poll after startup skip the mtime check?** Currently proposed:
+   initialize `last_config_mtime` in `new()` so the first poll sees no change. But if the
+   config was modified between the `urd sentinel run` command and the first poll (unlikely
+   but possible), the change would be missed until the next modification. Option A:
+   Initialize from file (current proposal). Option B: Initialize to `None` — first poll
+   always "detects" a change and reloads. This causes one unnecessary reload on every
+   startup but guarantees freshness. Leaning toward A — the config was just read by the
+   CLI command that created the runner, so it's fresh.

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,6 +5,9 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
+| 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | - | - | - |
+| 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | - | - | - |
+| 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | - | - | - |
 | 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | - | - | - |
 | 017 | Thread lineage visualization | [design](../95-ideas/2026-04-03-design-017-thread-lineage-visualization.md) | - | - | - | - |
 | 016 | Emergency space response | [design](../95-ideas/2026-04-03-design-016-emergency-space-response.md) | - | - | - | - |

--- a/docs/99-reports/2026-04-04-steve-jobs-000-self-healing-worker.md
+++ b/docs/99-reports/2026-04-04-steve-jobs-000-self-healing-worker.md
@@ -1,0 +1,295 @@
+---
+upi: "000"
+date: 2026-04-04
+mode: design-critique
+---
+
+# Steve Jobs Review: The Invisible Worker Is Lying
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-04
+**Scope:** v0.10.0 live testing findings — system behavior under real conditions
+**Mode:** Design critique with design sketches for remediation
+
+## The Verdict
+
+Urd's invisible worker is doing its job 90% of the time, and *lying about the other
+10%.* A backup system that says "success" while data ages toward unprotected isn't
+just a bug — it's a betrayal of the user's trust. This is the single most important
+thing to fix before anything else ships.
+
+## What's Insanely Great
+
+Let me be clear about what's working, because this is a solid foundation:
+
+**The incremental send pipeline is beautiful.** Five subvolumes sent in 31 seconds,
+four of them with 123 bytes of delta. That's a system that knows the difference between
+"something changed" and "nothing changed" — and handles both with zero drama. 843MB of
+container data in 26 seconds alongside four no-op sends. That's the invisible worker
+doing exactly what it should.
+
+**The sentinel is *actually* invisible.** 3.5MB of memory. 17 seconds of CPU over
+43 hours. That daemon is so light the system doesn't know it exists. That's what
+background software should be. The circuit breaker, the 300-second tick, the
+notification deferral — all evidence of thoughtful restraint.
+
+**The space-recovery optimization is inspired.** The executor doesn't delete 26
+snapshots when one will do. It checks: "Is there enough space? Then stop deleting."
+That's not an optimization — that's a philosophical stance. Don't destroy data you
+don't have to. I love this.
+
+**The structured JSON output is clean and complete.** Every field meaningful, no
+noise, machine-readable by default in non-TTY. The presentation layer switch between
+interactive and daemon modes is exactly right. You've built a tool that can be consumed
+by both humans and machines without compromising either.
+
+## What's Not Good Enough
+
+### 1. The Worker Lies About Its Failures
+
+Here is what happened at 04:00 this morning. Urd ran. htpc-root had zero local
+snapshots (the user deleted them because they were eating the NVMe alive — which is
+*why* transient mode exists). The planner said "no local snapshots to send." The
+executor said "success: true." The heartbeat said "PROTECTED." Prometheus said
+`backup_success = 1`.
+
+Every surface said everything was fine. Everything was not fine.
+
+htpc-root is AT RISK right now. It will drift to UNPROTECTED. And if the nightly runs
+again tonight? Same thing. "Success." Same lie. Tomorrow? Same. This continues
+*forever* until someone manually intervenes with a `--force-full` flag that nothing
+in the system suggests they should use.
+
+This is the worst kind of software failure. Not a crash — crashes are honest. This
+is a system that looks healthy while data protection degrades behind a green dashboard.
+
+When we shipped the first iPod, we had a battery indicator. It didn't show "full"
+when the battery was dying. That would have been unforgivable. This is the same thing.
+
+### 2. The Full-Send Gate Creates a Deadlock
+
+The full-send gate was a good idea when it was built. "Don't automatically send 40GB
+to a drive that might be cloned or swapped." Correct instinct. But the gate doesn't
+know *why* the chain broke. It treats "user deleted snapshots to free disk space" the
+same as "someone plugged in a different hard drive."
+
+WD-18TB's identity token is *verified*. The system knows exactly who that drive is.
+And yet it refuses to send to it. That's like refusing to let someone into their own
+house because their key looks different — while their fingerprint is confirmed.
+
+The gate should *use the information it already has.* If the drive token is verified,
+the chain break is from snapshot deletion, not hardware swap. Proceed.
+
+### 3. The Doctor Gives Bad Advice
+
+When you ask your doctor "what's wrong with me?" and they say "you're a bit tired,
+try sleeping more" — but actually you have a broken bone — that's malpractice.
+
+`urd doctor` says: "waning — last backup 13 hours ago. Run `urd backup` to refresh."
+
+If you run `urd backup`, here's what happens: a new snapshot is created, the send is
+gated, nothing reaches the external drive, the snapshot sits on the NVMe eating space,
+and htpc-root is *worse off than before you asked the doctor.* The doctor's own
+prescription makes the patient sicker.
+
+The doctor *knows* the chain is broken (the verify section shows it). But the
+suggestion doesn't connect these facts.
+
+### 4. The Sentinel Doesn't Know Its Config Changed
+
+The sentinel was started with an old config. The user migrated to v1, added drive
+scoping. The sentinel still thinks htpc-home sends to 2TB-backup. It doesn't. This
+produces false degradation warnings that would flow through to Spindle.
+
+A daemon that doesn't reload its config is a daemon that drifts from reality. In a
+backup system, drifting from reality is the one thing you cannot do.
+
+## The Vision
+
+Here's what I want to see. Three design groups that turn these findings into coherent
+solutions. I'm sketching shapes, not blueprints — the design workflow fills in the
+rest.
+
+### Design Group A: "The Honest Worker" (F1 + F2 + F3)
+
+**The principle:** The invisible worker never lies. If it can't complete its job, it
+says so clearly — and if it can fix the problem itself, it does.
+
+**Design sketch ��� Token-aware chain healing:**
+
+The full-send gate should have three modes, not two:
+
+| Drive token state | Chain break behavior in auto mode |
+|---|---|
+| Verified | **Proceed with full send.** Identity confirmed. The break is from snapshot lifecycle, not hardware swap. |
+| Missing/Mismatched | **Gate the send.** This is what the gate was built for. |
+| Unknown (drive absent) | **Skip.** Can't verify, can't send. |
+
+This is not "weakening" the gate. This is making it *smarter.* The gate still catches
+the thing it was designed to catch (hardware swaps). It stops catching the thing it
+shouldn't (routine space management on transient subvolumes).
+
+**Design sketch — Honest run results:**
+
+A run where a subvolume's send was needed but couldn't happen is not "success." It's
+not "failure" either. It's a *new state*: **degrading.**
+
+I don't care what you call it internally. But the external signals need to distinguish:
+
+| Actual situation | Run result | Heartbeat status | Metric |
+|---|---|---|---|
+| Send completed | success | PROTECTED | 1 |
+| Send intentionally deferred (interval) | success | PROTECTED | 1 |
+| Send needed but gated/blocked | **degrading** | **AT RISK** | **3** (new value) |
+| Send failed | failure | depends on state | 0 |
+
+The heartbeat should reflect the *post-run state*, not the *run execution state.*
+"Did the run succeed?" and "Is the data safe?" are different questions. The heartbeat
+answers the second one.
+
+**Design sketch — Unified deferred reporting:**
+
+Every subvolume that needs a send but doesn't get one — for any reason — must produce
+a deferred entry with:
+1. What: "htpc-root send to WD-18TB not completed"
+2. Why: "no local snapshots existed at plan time" / "chain-break full send gated"
+3. How to fix: "Run `urd backup --force-full --subvolume htpc-root`"
+
+No silent skips. No empty arrays where deferred entries should be. The planner's
+"no local snapshots to send" skip for a send-enabled subvolume is not the same as
+"multimedia doesn't send because it's local-only." One is a problem. The other is
+configuration. Report them differently.
+
+### Design Group B: "The Doctor Knows" (F6 + related)
+
+**The principle:** Every suggestion Urd makes should be one the user can follow
+successfully. If following the suggestion would fail, the suggestion is wrong.
+
+**Design sketch — Context-aware suggestions:**
+
+The doctor should compose its suggestions from the full diagnostic picture, not
+from a lookup table:
+
+```
+htpc-root:
+  waning — last external send to WD-18TB was 43 hours ago.
+  Thread broken — WD-18TB will need a full send (~33GB).
+  → Run `urd backup --force-full --subvolume htpc-root`
+```
+
+The suggestion system needs to know:
+- Is the chain broken? → append `--force-full`
+- Is a specific drive the problem? → append `--subvolume`
+- Is the drive mounted? → don't suggest sending to an absent drive
+
+This same logic applies everywhere suggestions appear: `urd doctor`, the bare `urd`
+default command, the status next-action hints. One function that computes the right
+suggestion given the current state. Don't duplicate this logic — compute it once,
+render it everywhere.
+
+**Extend to the default command:** When the user types bare `urd` and sees "htpc-root
+waning," that line should carry the same intelligence. Not just "waning" — "waning,
+and here's the one command that fixes it." Progressive disclosure: the one-liner
+mentions the problem, `urd status` shows the detail, `urd doctor` explains the full
+picture and the fix.
+
+### Design Group C: "The Living Daemon" (F4 + F7 + sentinel polish)
+
+**The principle:** The sentinel is the source of truth for system state. It must
+never present stale or incorrect information.
+
+**Design sketch — Config reload on change:**
+
+The sentinel should watch the config file and reload when it changes. Not on every
+tick — that's wasteful. Watch the file's mtime, or use inotify if you want to be
+elegant. When the config changes:
+
+1. Reload
+2. Re-assess immediately (don't wait for next tick)
+3. Log: "Config reloaded — reassessing"
+
+If the config is invalid after a change, log the error but *keep running with the
+old config.* Don't crash. Don't silently use a broken config. Log it and wait for
+the user to fix it.
+
+This isn't just about drive scoping. Every time a user edits their config, the
+sentinel should adapt. Especially now that `urd migrate` exists — a user migrates
+their config and the sentinel should just... know.
+
+**Design sketch — Sentinel anomaly messages:**
+
+"All 0 chains broke on WD-18TB simultaneously" — this message is saying "I detected
+an anomaly that doesn't exist." If zero chains broke, there is no anomaly. Fix the
+guard condition: don't fire the anomaly notification when the count is zero. When
+the count is positive, say "All N chains broke on WD-18TB simultaneously — possible
+drive swap."
+
+## The Details
+
+**The plan vs executor deletion count.** `urd plan` says 26 deletions. `urd backup
+--dry-run` says 5. Both are correct. Neither explains the discrepancy. The plan should
+say: "26 eligible for deletion (executor will stop early if space permits)." One
+sentence. No confusion. This is a Phase D progressive-disclosure concern — don't
+block the urgent fixes on it, but write it down.
+
+**"no local snapshots to send" as a skip category.** This is currently `category:
+"other"` — a junk drawer. For a transient subvolume, this is a *critical state
+signal*, not an "other." It should have its own category:
+`no_snapshots_available` or `transient_empty`. The category system exists so
+consumers (Spindle, monitoring) can distinguish actionable from informational skips.
+"Other" tells them nothing.
+
+**The retention summary for htpc-root says "none (transient)."** That's technically
+true but misses the point. htpc-root has external retention (daily=30, weekly=26).
+The user doesn't keep local snapshots, but they *do* keep external ones. The summary
+should say something like "external only: 30d / 26w" — reflecting what protection
+actually exists.
+
+**The heartbeat schema says htpc-root `backup_success: true`.** The word "backup"
+implies data was backed up. It wasn't. If the heartbeat means "this subvolume's
+operations completed without errors," call it `operations_success` or
+`run_success`. Or better: add `send_completed: bool` alongside it so consumers
+can alert on the thing that actually matters.
+
+**Sentinel `visual_state` counts.** The sentinel reports `safety_counts: {ok: 8,
+aging: 1, gap: 0}` and `health_counts: {healthy: 6, degraded: 3, blocked: 0}`.
+But two of those three "degraded" are phantom degradation from the stale config.
+When the config reload fix lands, verify these counts correct themselves. These
+numbers drive Spindle's tray icon — they must be accurate.
+
+## The Ask
+
+**Group these into three design specs and build them in this order:**
+
+1. **Design Group A: "The Honest Worker"** — Token-aware chain healing + honest
+   run results + unified deferred reporting. This is the most urgent because it
+   affects data safety. One design spec housing F1, F2, and F3. Build this first.
+   Touches: `executor.rs` (gate logic, deferred reporting), `plan.rs` (skip
+   category), `commands/backup.rs` (run result computation), `heartbeat.rs`,
+   metrics.
+
+2. **Design Group B: "The Doctor Knows"** — Context-aware suggestions across
+   doctor, default command, and status. One design spec housing F6 and the
+   suggestion system refinement. Can follow Group A quickly since it's mostly
+   presentation logic. Touches: `voice.rs`, `output.rs`, `commands/doctor.rs`,
+   the suggestion function.
+
+3. **Design Group C: "The Living Daemon"** — Sentinel config reload + anomaly
+   message fix. One design spec housing F4 and F7. This is lower urgency since
+   the immediate workaround is restarting the sentinel. But it's architecturally
+   important for Spindle. Touches: `sentinel_runner.rs`, `sentinel.rs`.
+
+**Don't block on each other.** Groups A and B share no modules with Group C. Build
+A first. B can follow immediately. C can be parallel or sequential.
+
+**Quick win while designs are in progress:** Restart the sentinel now.
+`systemctl --user restart urd-sentinel` fixes F4 immediately. And run
+`urd backup --force-full` to heal the broken chains. Your data shouldn't be AT RISK
+while you're designing the fix.
+
+**One more thing.** The testing session itself was excellent work. Most teams ship
+software and hope it works. Running a systematic live test, observing the nightly,
+tracing the journal, finding the deadlock cycle — that's how you build a tool people
+trust with their data. The findings are a gift. Every one of them makes the product
+better. The fact that the invisible worker was lying is uncomfortable, but now you
+know. And now you can fix it.


### PR DESCRIPTION
## Summary

- **Steve review** of v0.10.0 live testing findings — identified three design groups from 7 findings
- **UPI 019 "The Honest Worker"**: Token-aware full-send gate (proceed on verified drives), honest run results (`send_completed` in heartbeat, metric value 3 for deferred), unified deferred reporting for planner-level skips
- **UPI 020 "The Doctor Knows"**: `compute_advice()` pure function in awareness.rs — context-aware suggestions across doctor, status, and bare `urd` (never prescribe a command that would fail)
- **UPI 021 "The Living Daemon"**: Sentinel config reload via mtime polling (zero new deps), fix "all 0 chains broke" anomaly guard for drive disconnect events
- **Registry** updated with UPI 019-021 entries

## Testing

- Docs-only change — no cargo checks needed
- Designs validated against exact source code (executor gate logic, planner skip paths, sentinel event system, heartbeat schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)