### PR TITLE
feat: token-aware chain-break gate and honest run results (UPI 019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Token-aware chain-break gate: verified drives proceed with full sends in auto mode, breaking the deadlock where broken chains permanently blocked transient subvolumes
+- `send_completed` field in heartbeat (schema v2): distinguishes "backup ran successfully" from "data actually reached an external drive"
+- `SendType::Deferred` (Prometheus metric value 3): distinguishes intentional no-send from blocked-by-gate deferral
+- Deferred synthesis in backup summary: subvolumes with no local snapshots to send now surface actionable guidance instead of silent skips
+- `SkipCategory::NoSnapshotsAvailable` for structured classification of send-blocked skips
+
 ## [0.10.0] - 2026-04-03
 
 ### Added

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -7,7 +7,7 @@
 |-----|-------|--------|---------------|------------------|----|-----|
 | 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | - | - | - |
 | 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | - | - | - |
-| 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | - | - | - |
+| 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | - | - |
 | 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | - | - | - |
 | 017 | Thread lineage visualization | [design](../95-ideas/2026-04-03-design-017-thread-lineage-visualization.md) | - | - | - | - |
 | 016 | Emergency space response | [design](../95-ideas/2026-04-03-design-016-emergency-space-response.md) | - | - | - | - |

--- a/docs/99-reports/2026-04-04-review-adversary-019-honest-worker.md
+++ b/docs/99-reports/2026-04-04-review-adversary-019-honest-worker.md
@@ -1,0 +1,239 @@
+---
+upi: "019"
+date: 2026-04-04
+---
+
+# Arch-Adversary Review: The Honest Worker (UPI 019)
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Scope:** Implementation plan `docs/97-plans/2026-04-04-plan-019-honest-worker.md`
+**Design:** `docs/95-ideas/2026-04-04-design-019-honest-worker.md`
+**Mode:** Design review (plan, no code yet)
+**Commit:** a412d28 (master, v0.10.0)
+
+---
+
+## Executive Summary
+
+The plan is sound and well-researched. The architecture note correcting the design's
+"Option A" into a post-plan stamp is the right call — it preserves the planner's purity
+contract. One significant finding: Step 8's deferred synthesis targets `SubvolumeSummary`
+entries, but the deadlock scenario it exists to fix (htpc-root with `local_snapshots = false`)
+produces zero planned operations, meaning no `SubvolumeSummary` will exist for it. The
+synthesis must create entries from the skip list, not search existing entries.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — the user believes data is protected
+when it isn't. This is precisely what UPI 019 fixes: the system reports "success" while
+data ages toward unprotected.
+
+**Distance from catastrophe:** The plan doesn't touch retention, pin files, or deletion
+logic. The safety gate relaxation (Step 3) is the closest to the failure mode — if
+`token_verified` were incorrectly set to `true` on an unverified drive, a full send could
+overwrite data on a drive swap. Distance: two bugs (wrong verification result + wrong stamp).
+The plan mitigates this well: only explicit `Available` from `verify_drive_token()` counts.
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 3 | Step 8 misidentifies where deferred entries should be synthesized; heartbeat `send_completed` default for empty runs is debatable |
+| **Security** | 4 | Gate relaxation is well-bounded; token verification chain is traced correctly |
+| **Architecture** | 4 | Post-plan stamp preserves purity boundary; module boundaries respected throughout |
+| **Systems Design** | 3 | Homelab heartbeat consumer impact under-specified; the `DriveAvailability::Available` overload creates semantic ambiguity |
+
+## Design Tensions
+
+### 1. Reusing `DriveAvailability::Available` for two distinct meanings
+
+`verify_drive_token()` returns `Available` for three cases: (a) tokens match, (b) drive has
+a token but SQLite doesn't (self-heal), (c) can't read token file (fail-open). The plan
+treats all three as "verified" in Step 4.
+
+Case (c) is the problem. If the token file is unreadable (permissions, corruption), the plan
+stamps `token_verified = true`, and a chain-break full send proceeds to a drive whose identity
+is *unknown*, not verified. This contradicts the plan's own statement: "Only an explicit token
+match counts as verified."
+
+**Resolution:** The plan should distinguish (a) from (b) and (c). Either `verify_drive_token()`
+gets a new return variant (`TokenVerified`), or the stamp logic in backup.rs uses a separate
+tracking set populated only for the explicit-match path (line 362-373 in drives.rs). The
+self-heal path (b) is arguably safe (drive has a token, SQLite didn't), but fail-open (c) is
+not identity verification.
+
+**Severity:** Significant. One bug away from full-sending to an unverified drive.
+
+### 2. `send_completed: true` as default for absent field AND empty runs
+
+The plan sets `default_send_completed()` to `true` for backward compat (old heartbeats
+without the field). It also defaults to `true` for empty runs. These are two different
+semantic decisions masquerading as one serde default.
+
+For backward compat, `true` is the safe default — don't alarm consumers about old data.
+For empty runs, `true` is misleading — no execution happened, so saying "sends completed"
+is vacuously true but pragmatically confusing. A monitoring rule checking
+`backup_success && !send_completed` would never fire for empty runs because
+`backup_success` is `None`, so the practical impact is low. But it's worth being explicit
+in the plan about *why* empty runs get `true`.
+
+### 3. Separate tracking in `SubvolumeResult.send_type` vs heartbeat `send_completed`
+
+The plan introduces `SendType::Deferred` (metric value 3) AND `send_completed: bool` in
+heartbeat. These are two signals for the same underlying fact ("sends didn't happen but
+should have"). The justification is that they serve different consumers (Prometheus vs
+heartbeat/JSON), which is valid. But there's a risk of divergence: if one is updated and
+the other isn't in a future change, the system gives contradictory signals. The plan should
+note this as a future maintenance concern — perhaps both should be derived from the same
+source data.
+
+## Findings
+
+### 1. Step 8 deferred synthesis targets the wrong data structure — Significant
+
+**What:** Step 8 says "for each `SubvolumeSummary` where `sends.is_empty()` && `deferred.is_empty()`
+&& `errors.is_empty()`, check the `skipped` list..." But the deadlock scenario (htpc-root,
+`local_snapshots = false`, no local snapshots) produces **zero planned operations** for that
+subvolume. The executor only creates `SubvolumeResult` entries for subvolumes that appear in
+`plan.operations` (executor.rs line 188: `group_by_subvolume`). With zero operations, htpc-root
+has no `SubvolumeResult` and no `SubvolumeSummary`. The synthesis pass will never find it.
+
+**Consequence:** The entire deferred synthesis feature — Change 3 from the design, meant to
+make htpc-root's blocked sends visible — doesn't fire for the exact scenario it was built to fix.
+htpc-root's "no local snapshots to send" skip remains invisible in the backup summary, which is
+the status quo.
+
+**Fix:** The synthesis must work from the skip list outward, not from execution results inward.
+After building `subvolumes` from `result.subvolume_results`, scan `skipped` for entries with
+`category == NoSnapshotsAvailable`. For each one, check if a `SubvolumeSummary` already exists.
+If not, create a minimal `SubvolumeSummary` with `success: true`, empty sends/errors, and the
+synthesized `DeferredInfo`. This makes the deferred visible in the summary output even when the
+executor never touched the subvolume.
+
+### 2. `DriveAvailability::Available` from fail-open path treated as "verified" — Significant
+
+**What:** `verify_drive_token()` returns `Available` when it can't read the token file
+(drives.rs:331-334). The plan's Step 4 adds all drives returning `Available` to the
+`verified` set. This means a drive with a corrupted/unreadable token file would be treated
+as identity-verified, and the chain-break gate would be bypassed.
+
+**Consequence:** On a system where the token file is unreadable (permissions issue after a
+drive remount, filesystem error), a chain-break full send proceeds without identity
+verification. The send itself isn't necessarily harmful (the drive may be correct), but it
+violates the plan's stated invariant that only "explicit token match counts as verified."
+
+**Fix:** Track verified drives separately from the existing `blocked`/wildcard filtering.
+Instead of using the `_ => None` catch-all in the `filter_map` (backup.rs:185), explicitly
+match `Available` and track only drives where `verify_drive_token` took the token-match path
+(drives.rs:362-373). Two options:
+- (a) Have `verify_drive_token` return a new `TokenVerified` variant for the explicit match,
+  distinguished from the fail-open `Available`. This is the cleanest but adds an enum variant.
+- (b) Call `read_drive_token()` separately in backup.rs before calling `verify_drive_token()`.
+  If `read_drive_token()` returns `Ok(Some(_))` and `verify_drive_token()` returns `Available`,
+  the token matched. Otherwise, it's a fail-open or self-heal.
+- (c) Accept the current behavior as consistent with ADR-107 (fail-open). A drive where the
+  token file is unreadable is a malfunction, and fail-open says "proceed." Document this as
+  a deliberate design choice, not an oversight.
+
+Option (c) is defensible but should be explicit in the plan rather than implicit.
+
+### 3. Heartbeat schema bump to 2 impacts sentinel_runner.rs tests — Moderate
+
+**What:** `sentinel_runner.rs` constructs `Heartbeat` structs in tests (around line 1094)
+with `schema_version: 1`. After Step 7 bumps `SCHEMA_VERSION` to 2, these test structs
+won't match what `build_from_run` produces. The new `send_completed` field must be added
+to these test structs, or they'll fail to compile (missing field) or silently use the wrong
+default.
+
+**Consequence:** Compilation failure or test mismatch. Not a production issue, but the plan
+doesn't list `sentinel_runner.rs` in files touched.
+
+**Fix:** Add `sentinel_runner.rs` to Step 7's file list. Update its `make_heartbeat` helper
+to include `send_completed: true` (matching the serde default).
+
+### 4. Plan correctly identifies the purity boundary correction — Commendation
+
+**What:** The plan's Architecture Note catches a fundamental error in the design: "Option A"
+assumed the planner could look up token state, but `RealFileSystemState::drive_availability()`
+never returns token variants, and the planner doesn't hold `StateDb`. The plan's resolution —
+post-plan stamp in backup.rs — is exactly right. It preserves the planner as a pure function
+(ADR-100/108) while carrying the token state into the executor via the plan data structure.
+
+**Why it matters:** This is the kind of course correction that prevents a purity boundary
+violation from compounding. If token lookup had been added to the planner, it would have
+required `StateDb` access, breaking the pure-function contract and making the planner
+untestable without a database. Getting this right upfront saves a future architectural fix.
+
+### 5. `NoSnapshotsAvailable` category is well-scoped — Commendation
+
+**What:** The plan adds a targeted `SkipCategory` variant for "no local snapshots to send"
+instead of overloading `Other` or trying to classify it from context. The category is matched
+by exact string, keeping the skip-text-to-category boundary clean.
+
+**Why it matters:** Skip classification via string matching is inherently fragile (known issue
+in status.md: "status string fragility"). Adding a new category for a new semantic meaning,
+rather than reusing an existing one, avoids the enum-semantic-overload trap that bit
+`OpResult::Skipped` previously.
+
+## Also Noted
+
+- Step 2 says "keep the text identical" for the skip reason at plan.rs:480, then documents
+  it as a change. Remove the confusing framing — it's a no-op that reads like a change.
+- The plan mentions `commands/plan_cmd.rs` needs `token_verified` in its pattern match (Step 1
+  risk section) but doesn't list it as a file to modify. Add it to Step 1 or Step 2.
+- Step 7 proposes checking `operation == "send_incremental" || operation == "send_full"` via
+  string matching. The existing code does this (backup.rs:323), but it's worth noting this
+  compounds the string-matching fragility. Not worth fixing now, but it's technical debt.
+
+## The Simplicity Question
+
+The plan is already lean — 8 steps, 7 files, ~17 tests. Nothing feels speculative. The
+three changes map cleanly to the three problems in the design.
+
+If forced to cut 20%, I'd defer Change 2 (heartbeat `send_completed` + `SendType::Deferred`)
+to a follow-up. Change 1 (unblock the deadlock) and Change 3 (make deferred visible) are
+the core fix. Change 2 adds observability that's valuable but not urgent — the existing
+`promise_status` field in the heartbeat already degrades correctly over time, and the
+Prometheus `send_type` distinction (2 vs 3) is a refinement, not a fix.
+
+That said, all three changes are small enough to ship together. The question is whether the
+session estimate holds if all three land — 17 tests across 7 files with the Step 8 fix is
+borderline for one session.
+
+## For the Dev Team
+
+Priority order:
+
+1. **Fix Step 8 deferred synthesis** (Significant). Change the synthesis to create
+   `SubvolumeSummary` entries from the skip list for subvolumes absent from execution results.
+   Check `skipped` for `NoSnapshotsAvailable` entries, verify `send_enabled` is true for
+   that subvolume, and synthesize a `SubvolumeSummary` with the `DeferredInfo`. The current
+   design of searching existing `SubvolumeSummary` entries misses the exact case it's
+   built for.
+
+2. **Decide on `Available` semantics for token-verified stamp** (Significant). Either:
+   (a) add a `TokenVerified` variant to `DriveAvailability` for the explicit match path,
+   (b) double-check `read_drive_token()` returns `Ok(Some(_))` before marking verified, or
+   (c) document that fail-open paths are deliberately treated as verified per ADR-107.
+   Choose one and make it explicit in the plan.
+
+3. **Add `sentinel_runner.rs` to Step 7** (Moderate). Update `make_heartbeat` test helper
+   with the new `send_completed` field.
+
+4. **Add `commands/plan_cmd.rs` to Step 1** (Minor). Pattern match on `SendFull` needs
+   `token_verified`.
+
+## Open Questions
+
+1. Is there a scenario where htpc-root has planned operations but still gets the "no local
+   snapshots" skip? E.g., if the planner creates a local snapshot AND tries to send, but
+   the snapshot creation itself produces the snapshot used by the send. The planner creates
+   a snapshot name at plan time and plans the send with that name — does this work for
+   transient subvolumes? If yes, the "no local snapshots" skip might only fire when the
+   nightly run finds zero existing snapshots and doesn't create one (because
+   `local_snapshots = false` means no snapshot creation). Confirming this edge is important
+   for test design.
+
+2. Does the homelab ADR-021 need updating for `schema_version: 2` and `send_type: 3`?
+   CLAUDE.md says external interface changes require a homelab ADR update. The plan's Risk
+   Flag 2 addresses this partially but doesn't flag it as a concrete TODO.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -157,20 +157,28 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         executor.set_full_send_policy(FullSendPolicy::SkipAndNotify);
     }
 
-    // Verify drive tokens: collect suspicious drives, then filter sends in one pass.
+    // Verify drive tokens: collect suspicious drives and verified drives in one pass.
+    // A drive is "verified" only when its token file is readable AND tokens match.
+    // This excludes fail-open paths (unreadable token file) from being treated as verified.
     if let Some(ref db) = state_db {
-        let blocked: std::collections::BTreeSet<String> = config
-            .drives
-            .iter()
-            .filter(|d| drives::is_drive_mounted(d))
-            .filter_map(|drive| match drives::verify_drive_token(drive, db) {
+        let mut blocked = std::collections::BTreeSet::new();
+        let mut verified = std::collections::BTreeSet::new();
+
+        for drive in config.drives.iter().filter(|d| drives::is_drive_mounted(d)) {
+            // Pre-check: can we read the token file?
+            let has_readable_token = matches!(
+                drives::read_drive_token(drive),
+                Ok(Some(_))
+            );
+
+            match drives::verify_drive_token(drive, db) {
                 drives::DriveAvailability::TokenMismatch { expected, found } => {
                     log::warn!(
                         "Drive {} has a token mismatch (expected {}, found {}) — \
                          skipping sends to this drive",
                         drive.label, expected, found,
                     );
-                    Some(drive.label.clone())
+                    blocked.insert(drive.label.clone());
                 }
                 drives::DriveAvailability::TokenExpectedButMissing => {
                     log::warn!(
@@ -180,11 +188,18 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
                          Run `urd drives adopt {}` to accept this drive.",
                         drive.label, drive.label, drive.label,
                     );
-                    Some(drive.label.clone())
+                    blocked.insert(drive.label.clone());
                 }
-                _ => None,
-            })
-            .collect();
+                drives::DriveAvailability::Available if has_readable_token => {
+                    // Token file exists and matches — drive identity confirmed.
+                    verified.insert(drive.label.clone());
+                }
+                _ => {
+                    // TokenMissing (first use), fail-open, or no token file:
+                    // neither blocked nor verified.
+                }
+            }
+        }
 
         if !blocked.is_empty() {
             // Only sends are blocked for token-suspicious drives. Retention deletes
@@ -198,6 +213,20 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
                     if blocked.contains(drive_label)
                 )
             });
+        }
+
+        // Stamp token_verified on SendFull operations for verified drives.
+        // This allows the executor's chain-break gate to proceed on known-good drives.
+        for op in &mut backup_plan.operations {
+            if let PlannedOperation::SendFull {
+                drive_label,
+                token_verified,
+                ..
+            } = op
+                && verified.contains(drive_label.as_str())
+            {
+                *token_verified = true;
+            }
         }
     }
 
@@ -308,7 +337,7 @@ fn build_backup_summary(
     duration: Duration,
     preflight_warnings: &[preflight::PreflightCheck],
 ) -> BackupSummary {
-    let subvolumes: Vec<SubvolumeSummary> = result
+    let mut subvolumes: Vec<SubvolumeSummary> = result
         .subvolume_results
         .iter()
         .map(|sv| {
@@ -386,6 +415,40 @@ fn build_backup_summary(
             reason: reason.clone(),
         })
         .collect();
+
+    // Synthesize deferred entries for subvolumes that needed sends but had no snapshots.
+    // Works from the skip list outward: adds to existing SubvolumeSummary or creates synthetic.
+    for skip in &skipped {
+        if skip.category != SkipCategory::NoSnapshotsAvailable {
+            continue;
+        }
+        let deferred_info = DeferredInfo {
+            reason: "no local snapshots available for send".to_string(),
+            suggestion: format!(
+                "Run `urd backup --force-full --subvolume {}` to create and send",
+                skip.name
+            ),
+        };
+        if let Some(sv) = subvolumes.iter_mut().find(|sv| sv.name == skip.name) {
+            // Subvolume has execution results (e.g., CreateSnapshot succeeded)
+            // but no sends completed — add deferred entry
+            if sv.sends.is_empty() && sv.deferred.is_empty() {
+                sv.deferred.push(deferred_info);
+            }
+        } else {
+            // Subvolume has zero planned operations (space guard, snapshot exists)
+            // — create a synthetic SubvolumeSummary
+            subvolumes.push(SubvolumeSummary {
+                name: skip.name.clone(),
+                success: true, // not a failure — data exists, just can't send
+                duration_secs: 0.0,
+                sends: vec![],
+                errors: vec![],
+                structured_errors: vec![],
+                deferred: vec![deferred_info],
+            });
+        }
+    }
 
     let mut warnings = Vec::new();
 
@@ -560,7 +623,7 @@ fn build_empty_plan_explanation(
             SkipCategory::SpaceExceeded => has_space = true,
             SkipCategory::DriveNotMounted => has_not_mounted = true,
             SkipCategory::IntervalNotElapsed => has_interval = true,
-            SkipCategory::Other => {}
+            SkipCategory::NoSnapshotsAvailable | SkipCategory::Other => {}
         }
     }
 
@@ -847,6 +910,7 @@ pub(crate) fn format_completion_line(
         SendType::Full => "full",
         SendType::Incremental => "incremental",
         SendType::NoSend => "no-send",
+        SendType::Deferred => "deferred",
     };
     format!(
         "  ✓ {} → {}: {} in {} ({})",
@@ -1715,6 +1779,7 @@ mod tests {
                     subvolume_name: "sv1".to_string(),
                     pin_on_success: None,
                     reason: FullSendReason::FirstSend,
+                    token_verified: false,
                 },
                 PlannedOperation::SendIncremental {
                     parent: PathBuf::from("/snaps/sv2/20260328-0400-sv2"),
@@ -1772,6 +1837,7 @@ mod tests {
                 subvolume_name: "sv1".to_string(),
                 pin_on_success: None,
                 reason: FullSendReason::FirstSend,
+                token_verified: false,
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
@@ -1798,6 +1864,7 @@ mod tests {
                 subvolume_name: "sv1".to_string(),
                 pin_on_success: None,
                 reason: FullSendReason::FirstSend,
+                token_verified: false,
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
@@ -1834,6 +1901,7 @@ mod tests {
                 subvolume_name: "sv1".to_string(),
                 pin_on_success: None,
                 reason: FullSendReason::FirstSend,
+                token_verified: false,
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
@@ -2160,5 +2228,139 @@ mod tests {
             }),
             "should not fire FirstSendToDrive for previously unmounted drive"
         );
+    }
+
+    // ── Deferred synthesis tests ──────────────────────────────────────
+
+    fn empty_plan_with_skips(skipped: Vec<(&str, &str)>) -> BackupPlan {
+        use chrono::NaiveDate;
+        BackupPlan {
+            operations: vec![],
+            timestamp: NaiveDate::from_ymd_opt(2026, 3, 24)
+                .unwrap()
+                .and_hms_opt(4, 0, 0)
+                .unwrap(),
+            skipped: skipped
+                .into_iter()
+                .map(|(n, r)| (n.to_string(), r.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn no_snapshots_skip_produces_deferred_on_existing_summary() {
+        // Subvolume has a CreateSnapshot result but no sends (the deadlock scenario)
+        let plan = empty_plan_with_skips(vec![
+            ("htpc-root", "no local snapshots to send"),
+        ]);
+        // Add a CreateSnapshot operation to the plan so executor produces a SubvolumeResult
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::CreateSnapshot {
+                source: PathBuf::from("/data"),
+                dest: PathBuf::from("/snap/htpc-root/20260324-0400-root"),
+                subvolume_name: "htpc-root".to_string(),
+            }],
+            ..plan
+        };
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![make_subvol_result(
+                "htpc-root", true, vec![
+                    make_outcome("snapshot", None, OpResult::Success, None, None),
+                ], SendType::NoSend, 0,
+            )],
+            run_id: Some(1),
+        };
+
+        let summary = build_backup_summary(
+            &plan, &result, &empty_assessments(),
+            vec![], Duration::from_secs(1), &[],
+        );
+
+        let sv = summary.subvolumes.iter().find(|s| s.name == "htpc-root").unwrap();
+        assert_eq!(sv.deferred.len(), 1, "should have synthesized deferred entry");
+        assert!(sv.deferred[0].reason.contains("no local snapshots"));
+        assert!(sv.deferred[0].suggestion.contains("--force-full"));
+    }
+
+    #[test]
+    fn no_snapshots_skip_creates_synthetic_summary() {
+        // Subvolume has zero operations (space guard blocked everything)
+        let plan = empty_plan_with_skips(vec![
+            ("htpc-root", "no local snapshots to send"),
+        ]);
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![], // no results for htpc-root
+            run_id: Some(1),
+        };
+
+        let summary = build_backup_summary(
+            &plan, &result, &empty_assessments(),
+            vec![], Duration::from_secs(1), &[],
+        );
+
+        let sv = summary.subvolumes.iter().find(|s| s.name == "htpc-root").unwrap();
+        assert!(sv.success, "synthetic summary should be success");
+        assert_eq!(sv.deferred.len(), 1);
+        assert!(sv.deferred[0].suggestion.contains("htpc-root"));
+    }
+
+    #[test]
+    fn local_only_skip_does_not_produce_deferred() {
+        let plan = empty_plan_with_skips(vec![("sv", "send disabled")]);
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![],
+            run_id: Some(1),
+        };
+
+        let summary = build_backup_summary(
+            &plan, &result, &empty_assessments(),
+            vec![], Duration::from_secs(1), &[],
+        );
+
+        assert!(
+            summary.subvolumes.is_empty(),
+            "local-only skip should not create synthetic summary"
+        );
+    }
+
+    #[test]
+    fn interval_skip_does_not_produce_deferred() {
+        let plan = empty_plan_with_skips(vec![
+            ("sv", "send to WD-18TB not due (next in ~2h30m)"),
+        ]);
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![],
+            run_id: Some(1),
+        };
+
+        let summary = build_backup_summary(
+            &plan, &result, &empty_assessments(),
+            vec![], Duration::from_secs(1), &[],
+        );
+
+        assert!(summary.subvolumes.is_empty());
+    }
+
+    #[test]
+    fn drive_unmounted_skip_does_not_produce_deferred() {
+        let plan = empty_plan_with_skips(vec![
+            ("sv", "drive WD-18TB not mounted"),
+        ]);
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![],
+            run_id: Some(1),
+        };
+
+        let summary = build_backup_summary(
+            &plan, &result, &empty_assessments(),
+            vec![], Duration::from_secs(1), &[],
+        );
+
+        assert!(summary.subvolumes.is_empty());
     }
 }

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -134,6 +134,7 @@ mod tests {
             )),
             subvolume_name: subvol.to_string(),
             reason: crate::types::FullSendReason::FirstSend,
+            token_verified: false,
         }
     }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -40,16 +40,19 @@ pub enum SendType {
     Full,
     Incremental,
     NoSend,
+    /// A send was needed but deliberately deferred by a safety gate.
+    Deferred,
 }
 
 impl SendType {
-    /// Prometheus metric value: 0=full, 1=incremental, 2=no send
+    /// Prometheus metric value: 0=full, 1=incremental, 2=no send, 3=deferred
     #[must_use]
     pub fn metric_value(&self) -> u8 {
         match self {
             Self::Full => 0,
             Self::Incremental => 1,
             Self::NoSend => 2,
+            Self::Deferred => 3,
         }
     }
 }
@@ -305,18 +308,22 @@ impl<'a> Executor<'a> {
                     drive_label,
                     pin_on_success,
                     reason,
+                    token_verified,
                     ..
                 } => {
                     planned_send_drives.insert(drive_label.clone());
-                    // Gate chain-break full sends in autonomous mode.
+                    // Gate chain-break full sends in autonomous mode,
+                    // unless the drive's identity has been verified via token.
                     if *reason == FullSendReason::ChainBroken
                         && self.full_send_policy == FullSendPolicy::SkipAndNotify
+                        && !token_verified
                     {
                         log::warn!(
                             "Skipping chain-break full send for {} to {}: \
                              use `urd backup --force-full` to override",
                             subvol_name, drive_label,
                         );
+                        send_type = SendType::Deferred;
                         OperationOutcome {
                             operation: "send_full".to_string(),
                             drive_label: Some(drive_label.clone()),
@@ -332,6 +339,13 @@ impl<'a> Executor<'a> {
                             btrfs_stderr: None,
                         }
                     } else {
+                        if *reason == FullSendReason::ChainBroken && *token_verified {
+                            log::info!(
+                                "Chain-break full send for {} to {}: \
+                                 proceeding (drive identity verified)",
+                                subvol_name, drive_label,
+                            );
+                        }
                         let (result, pin_failed) = self.execute_send(
                             snapshot,
                             None,
@@ -1233,6 +1247,7 @@ source = "/data/b"
                     subvolume_name: "sv-a".to_string(),
                     pin_on_success: None,
                     reason: FullSendReason::FirstSend,
+                    token_verified: false,
                 },
             ],
             timestamp: ts,
@@ -1282,6 +1297,7 @@ source = "/data/b"
                 subvolume_name: "sv-a".to_string(),
                 pin_on_success: Some((pin_path.clone(), snap_name)),
                 reason: FullSendReason::FirstSend,
+                token_verified: false,
             }],
             timestamp: ts,
             skipped: vec![],
@@ -1443,6 +1459,7 @@ source = "/data/b"
                 subvolume_name: "sv-a".to_string(),
                 pin_on_success: None,
                 reason: FullSendReason::FirstSend,
+                token_verified: false,
             }],
             timestamp: ts,
             skipped: vec![],
@@ -1624,6 +1641,7 @@ source = "/data/b"
                 subvolume_name: "sv-a".to_string(),
                 pin_on_success: Some((pin_path, snap_name)),
                 reason: FullSendReason::FirstSend,
+                token_verified: false,
             }],
             timestamp: ts,
             skipped: vec![],
@@ -1766,6 +1784,7 @@ source = "/data/b"
                 subvolume_name: "sv-a".to_string(),
                 pin_on_success: None,
                 reason: FullSendReason::FirstSend,
+                token_verified: false,
             }],
             timestamp: ts,
             skipped: vec![],
@@ -1821,6 +1840,7 @@ source = "/data/b"
                     subvolume_name: "sv-a".to_string(),
                     pin_on_success: None,
                     reason: FullSendReason::FirstSend,
+                    token_verified: false,
                 },
             ],
             timestamp: ts,
@@ -1868,6 +1888,7 @@ source = "/data/b"
                     subvolume_name: "sv-a".to_string(),
                     pin_on_success: None,
                     reason: FullSendReason::FirstSend,
+                    token_verified: false,
                 },
             ],
             timestamp: ts,
@@ -1997,6 +2018,7 @@ source = "/data/sv1"
                 subvolume_name: "sv-a".to_string(),
                 pin_on_success: None,
                 reason: FullSendReason::ChainBroken,
+                token_verified: false,
             }],
             timestamp: ts,
             skipped: vec![],
@@ -2015,6 +2037,11 @@ source = "/data/sv1"
 
         assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Deferred);
         assert!(result.subvolume_results[0].success, "deferred is not a failure");
+        assert_eq!(
+            result.subvolume_results[0].send_type,
+            SendType::Deferred,
+            "gated chain-break send should report SendType::Deferred"
+        );
         assert_eq!(result.overall, RunResult::Success, "deferred-only run is success");
         assert!(mock.calls().is_empty(), "btrfs should not be called");
         assert!(
@@ -2025,6 +2052,11 @@ source = "/data/sv1"
                 .contains("chain-break full send gated"),
             "message should indicate gating"
         );
+    }
+
+    #[test]
+    fn send_type_deferred_metric_value_is_3() {
+        assert_eq!(SendType::Deferred.metric_value(), 3);
     }
 
     #[test]
@@ -2068,6 +2100,97 @@ source = "/data/sv1"
         assert_eq!(result.subvolume_results[0].operations[0].result, OpResult::Success);
     }
 
+    fn chain_broken_verified_plan() -> BackupPlan {
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        BackupPlan {
+            operations: vec![PlannedOperation::SendFull {
+                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
+                drive_label: "TEST-DRIVE".to_string(),
+                subvolume_name: "sv-a".to_string(),
+                pin_on_success: None,
+                reason: FullSendReason::ChainBroken,
+                token_verified: true,
+            }],
+            timestamp: ts,
+            skipped: vec![],
+        }
+    }
+
+    #[test]
+    fn chain_break_proceeds_on_verified_drive() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_full_send_policy(FullSendPolicy::SkipAndNotify);
+
+        let result = executor.execute(&chain_broken_verified_plan(), "full");
+
+        assert_eq!(
+            result.subvolume_results[0].operations[0].result,
+            OpResult::Success,
+            "verified drive should proceed with chain-break full send"
+        );
+        assert!(
+            !mock.calls().is_empty(),
+            "btrfs should be called for verified drive"
+        );
+    }
+
+    #[test]
+    fn chain_break_gated_on_unknown_token() {
+        // token_verified: false with SkipAndNotify → deferred (same as unverified)
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_full_send_policy(FullSendPolicy::SkipAndNotify);
+
+        let result = executor.execute(&chain_broken_plan(), "full");
+
+        assert_eq!(
+            result.subvolume_results[0].operations[0].result,
+            OpResult::Deferred,
+        );
+        assert!(mock.calls().is_empty(), "btrfs should not be called");
+    }
+
+    #[test]
+    fn first_send_always_allowed_regardless_of_token() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_full_send_policy(FullSendPolicy::SkipAndNotify);
+
+        // FirstSend with token_verified: false should still proceed
+        let result = executor.execute(&simple_plan(), "full");
+
+        assert_eq!(result.overall, RunResult::Success);
+        assert!(!mock.calls().is_empty(), "first send should always proceed");
+    }
+
+    #[test]
+    fn force_full_bypasses_gate_regardless_of_token() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+        // Default policy is Allow (equivalent to --force-full)
+
+        // ChainBroken + token_verified: false + Allow → should proceed
+        let result = executor.execute(&chain_broken_plan(), "full");
+
+        assert_eq!(
+            result.subvolume_results[0].operations[0].result,
+            OpResult::Success,
+        );
+    }
+
     #[test]
     fn deferred_with_failure_reports_partial() {
         let mock = MockBtrfs::new();
@@ -2095,6 +2218,7 @@ source = "/data/sv1"
                     subvolume_name: "sv-a".to_string(),
                     pin_on_success: None,
                     reason: FullSendReason::ChainBroken,
+                    token_verified: false,
                 },
                 // sv-b: snapshot create that will fail
                 PlannedOperation::CreateSnapshot {
@@ -2514,6 +2638,7 @@ local_retention = "transient"
                 subvolume_name: "sv-t".to_string(),
                 pin_on_success: Some((pin_path, snap_name)),
                 reason: FullSendReason::FirstSend,
+                token_verified: false,
             }],
             timestamp: test_ts(),
             skipped: vec![],
@@ -2583,6 +2708,7 @@ local_retention = "transient"
                     subvolume_name: "sv-t".to_string(),
                     pin_on_success: Some((pin_b, snap_name)),
                     reason: FullSendReason::FirstSend,
+                    token_verified: false,
                 },
             ],
             timestamp: test_ts(),

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -16,10 +16,10 @@ use serde::{Deserialize, Serialize};
 use crate::awareness::SubvolAssessment;
 use crate::config::Config;
 use crate::error::UrdError;
-use crate::executor::ExecutionResult;
+use crate::executor::{ExecutionResult, SendType};
 
 /// Current schema version. Bump when adding fields (never remove fields).
-const SCHEMA_VERSION: u32 = 1;
+const SCHEMA_VERSION: u32 = 2;
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -35,11 +35,11 @@ pub struct Heartbeat {
     /// Whether notifications were dispatched for this heartbeat.
     /// Used for crash recovery: if false on next read, re-compute and re-send.
     /// Defaults to true for backward compat with pre-notification heartbeats.
-    #[serde(default = "default_dispatched")]
+    #[serde(default = "default_true")]
     pub notifications_dispatched: bool,
 }
 
-fn default_dispatched() -> bool {
+fn default_true() -> bool {
     true
 }
 
@@ -55,6 +55,11 @@ pub struct SubvolumeHeartbeat {
     /// Defaults to 0 for backward compat with pre-pin-tracking heartbeats.
     #[serde(default)]
     pub pin_failures: u32,
+    /// Whether at least one send operation completed successfully for this subvolume.
+    /// `false` when sends were needed but couldn't happen (deferred, no snapshots).
+    /// Defaults to `true` for backward compat (schema v1 heartbeats without this field).
+    #[serde(default = "default_true")]
+    pub send_completed: bool,
 }
 
 // ── Builder ─────────────────────────────────────────────────────────────
@@ -115,11 +120,16 @@ fn build_subvolume_entries(
                 r.subvolume_results.iter().find(|sv| sv.name == a.name)
             });
 
+            let send_completed = sv_result.is_some_and(|sv| {
+                matches!(sv.send_type, SendType::Full | SendType::Incremental)
+            });
+
             SubvolumeHeartbeat {
                 name: a.name.clone(),
                 backup_success: sv_result.map(|sv| sv.success),
                 promise_status: a.status.to_string(),
                 pin_failures: sv_result.map(|sv| sv.pin_failures).unwrap_or(0),
+                send_completed,
             }
         })
         .collect()
@@ -362,7 +372,7 @@ mod tests {
         let json = serde_json::to_string_pretty(&heartbeat).unwrap();
         let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed.schema_version, 1);
+        assert_eq!(parsed.schema_version, 2);
         assert_eq!(parsed.timestamp, "2026-03-24T02:05:00");
         assert_eq!(parsed.run_result, "partial");
         assert_eq!(parsed.run_id, Some(42));
@@ -371,9 +381,13 @@ mod tests {
         assert_eq!(parsed.subvolumes[0].name, "home");
         assert_eq!(parsed.subvolumes[0].backup_success, Some(true));
         assert_eq!(parsed.subvolumes[0].promise_status, "PROTECTED");
+        // "home" has send_type: Incremental → send_completed: true
+        assert!(parsed.subvolumes[0].send_completed);
         assert_eq!(parsed.subvolumes[1].name, "docs");
         assert_eq!(parsed.subvolumes[1].backup_success, Some(false));
         assert_eq!(parsed.subvolumes[1].promise_status, "AT RISK");
+        // "docs" has send_type: NoSend → send_completed: false
+        assert!(!parsed.subvolumes[1].send_completed);
     }
 
     // ── stale_after ─────────────────────────────────────────────────────
@@ -443,7 +457,7 @@ mod tests {
         assert!(!dir.path().join("heartbeat.json.tmp").exists());
         // File exists and is valid
         let read_back = read(&path).unwrap();
-        assert_eq!(read_back.schema_version, 1);
+        assert_eq!(read_back.schema_version, 2);
         assert_eq!(read_back.timestamp, "2026-03-24T02:00:00");
     }
 
@@ -464,5 +478,130 @@ mod tests {
     #[test]
     fn read_nonexistent_returns_none() {
         assert!(read(Path::new("/tmp/nonexistent-heartbeat-test.json")).is_none());
+    }
+
+    // ── send_completed tests ───────────────────────────────────────────
+
+    fn make_operation(name: &str, result: crate::executor::OpResult) -> crate::executor::OperationOutcome {
+        crate::executor::OperationOutcome {
+            operation: name.to_string(),
+            drive_label: Some("TEST".to_string()),
+            result,
+            duration: std::time::Duration::ZERO,
+            error: None,
+            bytes_transferred: None,
+            btrfs_operation: None,
+            btrfs_stderr: None,
+        }
+    }
+
+    #[test]
+    fn heartbeat_send_completed_true_on_successful_send() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let assessments = test_assessments();
+
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![SubvolumeResult {
+                name: "home".to_string(),
+                success: true,
+                operations: vec![make_operation(
+                    "send_incremental",
+                    crate::executor::OpResult::Success,
+                )],
+                duration: std::time::Duration::from_secs(5),
+                send_type: SendType::Incremental,
+                pin_failures: 0,
+                transient_cleanup: TransientCleanupOutcome::NotApplicable,
+            }],
+            run_id: Some(1),
+        };
+
+        let hb = build_from_run(&config, now, &result, &assessments);
+        assert!(hb.subvolumes[0].send_completed);
+    }
+
+    #[test]
+    fn heartbeat_send_completed_false_on_deferred_send() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let assessments = test_assessments();
+
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![SubvolumeResult {
+                name: "home".to_string(),
+                success: true,
+                operations: vec![make_operation(
+                    "send_full",
+                    crate::executor::OpResult::Deferred,
+                )],
+                duration: std::time::Duration::from_secs(0),
+                send_type: SendType::Deferred,
+                pin_failures: 0,
+                transient_cleanup: TransientCleanupOutcome::NotApplicable,
+            }],
+            run_id: Some(1),
+        };
+
+        let hb = build_from_run(&config, now, &result, &assessments);
+        assert!(!hb.subvolumes[0].send_completed);
+    }
+
+    #[test]
+    fn heartbeat_send_completed_false_on_no_send_operations() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let assessments = test_assessments();
+
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![SubvolumeResult {
+                name: "home".to_string(),
+                success: true,
+                operations: vec![make_operation(
+                    "snapshot",
+                    crate::executor::OpResult::Success,
+                )],
+                duration: std::time::Duration::from_secs(1),
+                send_type: SendType::NoSend,
+                pin_failures: 0,
+                transient_cleanup: TransientCleanupOutcome::NotApplicable,
+            }],
+            run_id: Some(1),
+        };
+
+        let hb = build_from_run(&config, now, &result, &assessments);
+        assert!(!hb.subvolumes[0].send_completed);
+    }
+
+    #[test]
+    fn heartbeat_v1_backward_compat_defaults_send_completed_true() {
+        // Schema v1 JSON without send_completed field should default to true
+        let json = r#"{
+            "schema_version": 1,
+            "timestamp": "2026-03-24T02:00:00",
+            "stale_after": "2026-03-24T04:00:00",
+            "run_result": "success",
+            "run_id": 1,
+            "subvolumes": [
+                {
+                    "name": "home",
+                    "backup_success": true,
+                    "promise_status": "PROTECTED",
+                    "pin_failures": 0
+                }
+            ],
+            "notifications_dispatched": true
+        }"#;
+        let parsed: Heartbeat = serde_json::from_str(json).unwrap();
+        assert!(
+            parsed.subvolumes[0].send_completed,
+            "v1 heartbeat without send_completed should default to true"
+        );
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -180,7 +180,7 @@ fn format_metrics(data: &MetricsData) -> String {
     writeln!(out).unwrap();
     writeln!(
         out,
-        "# HELP backup_send_type Send type: 0=full, 1=incremental, 2=no send"
+        "# HELP backup_send_type Send type: 0=full, 1=incremental, 2=no send, 3=deferred"
     )
     .unwrap();
     writeln!(out, "# TYPE backup_send_type gauge").unwrap();

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -566,6 +566,7 @@ mod tests {
                     promise_status: status.to_string(),
                     backup_success: *success,
                     pin_failures,
+                    send_completed: true,
                 })
                 .collect(),
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -567,6 +567,9 @@ pub enum SkipCategory {
     /// Distinct from `Disabled` (which means `enabled = false` — does nothing).
     LocalOnly,
     SpaceExceeded,
+    /// Send was planned but no local snapshots exist to send.
+    /// Distinct from `Other` — this is an actionable deferral, not an unknown skip.
+    NoSnapshotsAvailable,
     Other,
 }
 
@@ -595,6 +598,8 @@ impl SkipCategory {
             || reason.contains("skipped: calibrated size ~")
         {
             Self::SpaceExceeded
+        } else if reason == "no local snapshots to send" {
+            Self::NoSnapshotsAvailable
         } else {
             Self::Other
         }
@@ -1339,6 +1344,14 @@ mod tests {
     }
 
     #[test]
+    fn classify_no_snapshots_available() {
+        assert_eq!(
+            SkipCategory::from_reason("no local snapshots to send"),
+            SkipCategory::NoSnapshotsAvailable
+        );
+    }
+
+    #[test]
     fn classify_other() {
         assert_eq!(
             SkipCategory::from_reason(
@@ -1362,7 +1375,7 @@ mod tests {
         );
         assert_eq!(
             SkipCategory::from_reason("no local snapshots to send"),
-            SkipCategory::Other
+            SkipCategory::NoSnapshotsAvailable
         );
         assert_eq!(
             SkipCategory::from_reason("20260329-0404-htpc-home already on WD-18TB"),
@@ -1415,7 +1428,7 @@ mod tests {
                 "send to WD-18TB not due (next in ~2h30m)",
                 SkipCategory::IntervalNotElapsed,
             ),
-            ("no local snapshots to send", SkipCategory::Other),
+            ("no local snapshots to send", SkipCategory::NoSnapshotsAvailable),
             (
                 "20260329-0404-htpc-home already on WD-18TB",
                 SkipCategory::Other,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -604,6 +604,7 @@ fn plan_external_send(
             subvolume_name: subvol.name.clone(),
             pin_on_success: pin_info,
             reason,
+            token_verified: false, // stamped by backup.rs after plan creation
         });
     }
 }
@@ -1238,6 +1239,44 @@ priority = 2
             sends[0],
             PlannedOperation::SendFull { reason: FullSendReason::ChainBroken, .. }
         ));
+    }
+
+    #[test]
+    fn chain_broken_plan_defaults_token_verified_false() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        let parent = snap("20260322-1400-one");
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![parent.clone(), snap("20260322-1500-one")],
+        );
+        // Pin points to parent, but parent is NOT on external drive → ChainBroken
+        fs.mounted_drives.insert("D1".to_string());
+        fs.pin_files
+            .insert((PathBuf::from("/snap/sv1"), "D1".to_string()), parent);
+
+        let filters = PlanFilters {
+            subvolume: Some("sv1".to_string()),
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let send = result
+            .operations
+            .iter()
+            .find(|op| matches!(op, PlannedOperation::SendFull { .. }))
+            .expect("should have a full send");
+        match send {
+            PlannedOperation::SendFull {
+                reason,
+                token_verified,
+                ..
+            } => {
+                assert_eq!(*reason, FullSendReason::ChainBroken);
+                assert!(!token_verified, "planner must default token_verified to false");
+            }
+            _ => unreachable!(),
+        }
     }
 
     #[test]

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -1091,7 +1091,7 @@ mod tests {
 
     fn make_heartbeat(timestamp: &str, stale_after: &str) -> heartbeat::Heartbeat {
         heartbeat::Heartbeat {
-            schema_version: 1,
+            schema_version: 2,
             timestamp: timestamp.to_string(),
             stale_after: stale_after.to_string(),
             run_result: "success".to_string(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -647,6 +647,10 @@ pub enum PlannedOperation {
         pin_on_success: Option<(PathBuf, SnapshotName)>,
         /// Why this is a full send instead of incremental.
         reason: FullSendReason,
+        /// Whether the target drive's identity has been verified via drive session token.
+        /// Set by `commands/backup.rs` after plan creation (planner doesn't access tokens).
+        /// When true, the executor's chain-break gate allows the send to proceed.
+        token_verified: bool,
     },
     DeleteSnapshot {
         path: PathBuf,
@@ -686,6 +690,7 @@ impl fmt::Display for PlannedOperation {
                 drive_label,
                 pin_on_success,
                 reason,
+                token_verified,
                 ..
             } => {
                 let pin_suffix = if pin_on_success.is_some() {
@@ -693,9 +698,14 @@ impl fmt::Display for PlannedOperation {
                 } else {
                     ""
                 };
+                let verified_suffix = if *token_verified {
+                    " (verified)"
+                } else {
+                    ""
+                };
                 write!(
                     f,
-                    "SEND    {} -> {} (full \u{2014} {reason}){pin_suffix}",
+                    "SEND    {} -> {} (full \u{2014} {reason}){pin_suffix}{verified_suffix}",
                     snapshot.display(),
                     drive_label
                 )

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1164,6 +1164,7 @@ fn render_plan_skipped_grouped(skipped: &[SkippedSubvolume], out: &mut String) {
         SkipCategory::Disabled,
         SkipCategory::LocalOnly,
         SkipCategory::SpaceExceeded,
+        SkipCategory::NoSnapshotsAvailable,
         SkipCategory::Other,
     ];
 
@@ -1178,7 +1179,9 @@ fn render_plan_skipped_grouped(skipped: &[SkippedSubvolume], out: &mut String) {
             SkipCategory::IntervalNotElapsed => render_interval_group(&items, out),
             SkipCategory::Disabled => render_disabled_group(&items, out),
             SkipCategory::LocalOnly => render_local_only_group(&items, out),
-            SkipCategory::SpaceExceeded | SkipCategory::Other => {
+            SkipCategory::SpaceExceeded
+            | SkipCategory::NoSnapshotsAvailable
+            | SkipCategory::Other => {
                 render_individual_skips(&items, cat, out);
             }
         }
@@ -1276,6 +1279,7 @@ fn skip_tag(category: &SkipCategory) -> String {
         SkipCategory::DriveNotMounted => "[AWAY]".dimmed().to_string(),
         SkipCategory::Disabled => "[OFF]  ".dimmed().to_string(),
         SkipCategory::LocalOnly => "[LOCAL]".dimmed().to_string(),
+        SkipCategory::NoSnapshotsAvailable => "[NOSRC]".yellow().to_string(),
         SkipCategory::Other => "[SKIP] ".dimmed().to_string(),
     }
 }


### PR DESCRIPTION
## Summary

- **Token-aware gate:** Chain-break full sends now proceed on verified drives in auto mode, breaking the deadlock where transient subvolumes with broken chains were permanently blocked by the safety gate
- **Honest results:** `SendType::Deferred` (metric 3) and `send_completed` in heartbeat (schema v2) distinguish "no send needed" from "send needed but blocked"
- **Deferred synthesis:** Subvolumes skipped with "no local snapshots to send" surface actionable `--force-full` guidance instead of silent skips
- **15 new tests** covering gate behavior, heartbeat fields, metric values, and deferred synthesis paths

## Design lineage

- Design: `docs/95-ideas/2026-04-04-design-019-honest-worker.md`
- Plan: `docs/97-plans/2026-04-04-plan-019-honest-worker.md`
- Adversary review: `docs/99-reports/2026-04-04-review-adversary-019-honest-worker.md`

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 849 tests, all passing
- Integration tests: not applicable (no btrfs operations changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)