### PR TITLE
feat: sentinel config reload and anomaly guard (UPI 021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Sentinel config reload: daemon detects config file changes via mtime polling and hot-reloads without restart
 - Token-aware chain-break gate: verified drives proceed with full sends in auto mode, breaking the deadlock where broken chains permanently blocked transient subvolumes
 - `send_completed` field in heartbeat (schema v2): distinguishes "backup ran successfully" from "data actually reached an external drive"
 - `SendType::Deferred` (Prometheus metric value 3): distinguishes intentional no-send from blocked-by-gate deferral
 - Deferred synthesis in backup summary: subvolumes with no local snapshots to send now surface actionable guidance instead of silent skips
 - `SkipCategory::NoSnapshotsAvailable` for structured classification of send-blocked skips
+
+### Fixed
+- False "all chains broke simultaneously" anomaly when a drive disconnects (total=0 was treated as all-broken)
+- Duplicate default config path logic in `urd migrate` consolidated to single implementation
 
 ## [0.10.0] - 2026-04-03
 

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,9 +5,9 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
-| 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | - | - | - |
+| 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | - | - |
 | 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | - | - | - |
-| 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | - | - |
+| 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | merged | [#83](https://github.com/vonrobak/urd/pull/83) |
 | 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | - | - | - |
 | 017 | Thread lineage visualization | [design](../95-ideas/2026-04-03-design-017-thread-lineage-visualization.md) | - | - | - | - |
 | 016 | Emergency space response | [design](../95-ideas/2026-04-03-design-016-emergency-space-response.md) | - | - | - | - |

--- a/docs/96-project-supervisor/roadmap.md
+++ b/docs/96-project-supervisor/roadmap.md
@@ -22,22 +22,13 @@ UPI 010: v0.9.1-v0.10.0 ✓  (config v1, migrate, local_snapshots=false)
 **Goal:** Validate v0.10.0 in production, make the invisible worker intelligent, then
 build the first-encounter experience. Three phases remain before v1.0.
 
-### Test session (calendar time — now)
+### Test session findings (v0.10.0)
 
-Live with v0.10.0 for several days: nightly timer, sentinel, drive plug/unplug cycles.
-Output: prioritized issue list. Fix findings before moving on.
+Test session complete. Two sentinel bugs found (F4: stale config after migration,
+F7: false "all 0 chains broke" anomaly on drive disconnect). UPI 019 (honest worker)
+built and merged. UPIs 020, 021 designed from findings.
 
-```
-Test session goals:
-  1. Live with v0.10.0 (timer, Sentinel, drive cycles)
-  2. Watch htpc-root: does "degraded" / "broken" cause anxiety? (→ UPI 018)
-  3. Read your own config — can you narrate your protection story?
-  4. Note anything surprising or confusing
-
-Output: prioritized issue list → targeted fix phase if needed
-```
-
-### Phase E: Make the invisible worker smart (~2 sessions)
+### Phase E: Make the invisible worker smart (~3 sessions)
 
 **Question:** "Is the invisible worker intelligent?"
 
@@ -45,13 +36,22 @@ These features make the nightly run better without user interaction. They serve
 north star #2 (reduce attention) and prepare the runtime for the encounter's first
 impression. Sequenced by dependency and module overlap.
 
+**E0: Sentinel fixes — UPI 021** (~0.25 session, patch tier)
+
+```
+021-a: Fix anomaly guard — one-line `total > 0` guard in sentinel.rs
+021-b: Config reload on file change — mtime polling, ConfigChanged event
+Modules: sentinel.rs, sentinel_runner.rs
+Ship immediately — fixes two live production bugs. No module overlap with E1-E4.
+```
+
 **E1: Btrfs pipeline — UPI 013** (~0.25 session, patch tier)
 
 ```
 013-a: --compressed-data on sends (auto-detect, enable by default)
 013-b: btrfs subvolume sync after deletions (before space check)
 Modules: btrfs.rs, executor.rs
-Ship during or right after test session — invisible, zero UX surface.
+Ship right after 021 — invisible, zero UX surface.
 ```
 
 **E2: External-only runtime — UPI 018** (~0.5 session, patch tier)
@@ -59,10 +59,23 @@ Ship during or right after test session — invisible, zero UX surface.
 ```
 Fix false "degraded" / "broken chain" / "[SKIP]" for local_snapshots = false.
 Modules: awareness.rs, output.rs, voice.rs, commands/status.rs, plan.rs
-Depends on: nothing. Fixes a product bug visible in the test session now.
+Depends on: nothing. Fixes a product bug visible in the test session.
 ```
 
-**E3: Skip unchanged subvolumes — UPI 014** (~0.5 session, standard tier)
+**E3: Context-aware suggestions — UPI 020** (~0.5 session, standard tier)
+
+```
+compute_advice() pure function in awareness.rs — doctor, status, bare `urd`
+all give correct next-action advice based on chain health and drive state.
+Modules: awareness.rs, output.rs, voice.rs, commands/doctor.rs,
+         commands/status.rs, commands/default.rs
+Depends on: 018 (external-only awareness informs advice for local_snapshots=false).
+         019 merged — advice can reference honest results + token-aware gate.
+This is the bridge to Phase D: when a new user types `urd doctor` after setup,
+the advice must be correct. Last piece of the "is Urd telling the truth?" arc.
+```
+
+**E4: Skip unchanged subvolumes — UPI 014** (~0.5 session, standard tier)
 
 ```
 Default behavior: skip snapshot creation when generation number unchanged.
@@ -72,7 +85,7 @@ Ship before the encounter — "Urd created 4 snapshots (5 unchanged)" is a
 better first impression than 9 identical snapshots.
 ```
 
-**E4: Emergency space response (automatic mode only) — UPI 016-auto** (~0.5 session)
+**E5: Emergency space response (automatic mode only) — UPI 016-auto** (~0.5 session)
 
 ```
 Pre-backup thinning when space is critically low (< 50% of min_free_bytes).
@@ -82,40 +95,46 @@ Deferred: interactive `urd emergency` command → post-encounter (full design wo
 ```
 
 **Sequencing rationale:**
-- 013 first: invisible correctness, validates during test session. Also 013-b (sync)
-  improves space accuracy that 016-auto depends on.
-- 018 second: fixes a product bug the test session is actively observing. Blocks on
-  nothing but benefits from 013 being merged (fewer in-flight changes).
-- 014 third: adds intelligence. Touches plan.rs and voice.rs (shared with 018). Sequence
-  after 018 to avoid merge conflicts in voice.rs rendering code.
-- 016-auto last in Phase E: depends on 013-b for accurate space readings. Smallest scope
-  of the deferred 016 — just the retention function + executor integration.
+- 021 first: bugfix for two live production issues. Isolated to sentinel modules —
+  zero overlap with anything else. Patch tier, ship immediately.
+- 013 second: invisible correctness. 013-b (sync) improves space accuracy that 016-auto
+  depends on.
+- 018 third: fixes a product bug. Blocks on nothing but benefits from 013 being merged.
+- 020 after 018: `compute_advice()` needs external-only awareness from 018 to give
+  correct advice for `local_snapshots = false` subvolumes. Both touch awareness.rs and
+  voice.rs — sequencing avoids rework. 020 completes the "is Urd telling the truth?"
+  arc that started in Phase A — every invoked surface gives correct advice. This is the
+  real gate for Phase D: the encounter must land on a product that doesn't mislead.
+- 014 after 020: adds intelligence. voice.rs suggestion code is stable after 020 lands.
+- 016-auto last: depends on 013-b for accurate space readings.
 
 **Module overlap resolution:**
-- awareness.rs: only 018 (017 deferred to Phase F)
-- voice.rs + output.rs: 018 then 014. Both add rendering; 018's SkipCategory::ExternalOnly
-  and 014's SkipCategory::Unchanged are independent enum variants.
+- awareness.rs: 018 then 020. 018 fixes external-only assessment; 020 consumes it.
+- voice.rs + output.rs: 018 → 020 → 014. All add rendering. Sequencing avoids
+  merge conflicts in suggestion code.
+- sentinel.rs + sentinel_runner.rs: only 021. No overlap with E1-E4.
 - btrfs.rs: 013 adds sync + compressed-data probe, 014 adds subvolume_generation. Additive.
 
 ```
-Test session (calendar days)
+E0:  021 (sentinel fixes, 0.25 session)
      │
 E1:  013 (btrfs pipeline, 0.25 session) ─── tag v0.11.0
      │
 E2:  018 (external-only runtime, 0.5 session)
      │
-E3:  014 (skip unchanged, 0.5 session)
+E3:  020 (context-aware suggestions, 0.5 session)
      │
-E4:  016-auto (emergency pre-backup thinning, 0.5 session)
+E4:  014 (skip unchanged, 0.5 session)
      │
-     ├── Fix any test session findings (~0-1 session)
+E5:  016-auto (emergency pre-backup thinning, 0.5 session)
      │
 Phase D: The Encounter (~6-8 sessions)
 ```
 
-**Gate:** After Phase E, the nightly run is smarter (skips unchanged, compressed sends,
-accurate space tracking, correct external-only presentation, emergency thinning). The
-encounter can generate configs with confidence that the runtime handles all cases well.
+**Gate:** After Phase E, the nightly run is smarter (correct sentinel behavior, skips
+unchanged, compressed sends, accurate space tracking, correct external-only presentation,
+context-aware suggestions, emergency thinning). The encounter can generate configs with
+confidence that the runtime handles all cases well.
 
 ### Phase D: Progressive disclosure + The Encounter
 

--- a/docs/99-reports/2026-04-04-review-adversary-021-living-daemon.md
+++ b/docs/99-reports/2026-04-04-review-adversary-021-living-daemon.md
@@ -1,0 +1,215 @@
+---
+upi: "021"
+date: 2026-04-04
+---
+
+# Adversary Review: The Living Daemon (UPI 021)
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-04
+**Scope:** Implementation plan `docs/97-plans/2026-04-04-plan-021-living-daemon.md`
+**Mode:** Design review (plan, no code yet)
+**Commit:** 2be8fb3 (master)
+
+---
+
+## Executive Summary
+
+A well-scoped plan for two independent sentinel fixes. The anomaly guard (021-a) is trivially
+correct. The config reload (021-b) is architecturally sound — it preserves the pure state
+machine / I/O runner separation. One significant finding: the runner caches config-derived paths
+(`heartbeat_path`, `state_file_path`) that will go stale after a config reload. This needs to
+be addressed in the plan or it creates a subtle inconsistency where half the runner reads the
+new config and half reads cached fields from the old one.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss via incorrect backup decisions.
+
+**Proximity:** Distant. This plan modifies the sentinel (monitoring daemon), not the
+planner/executor/retention pipeline. The sentinel doesn't delete or create snapshots. The
+worst-case outcome of a config reload bug is incorrect promise state reporting — misleading
+but not destructive. The anomaly guard fix reduces false noise, correctly. Neither change is
+within two bugs of data loss.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | Anomaly fix is trivially correct. Config reload has one stale-path issue (F1). |
+| 2 | Security | 5 | No privilege boundaries involved. Config path comes from CLI arg (trusted). |
+| 3 | Architectural Excellence | 4 | Pure state machine preserved. Config reload in runner pre-pass is clean. |
+| 4 | Systems Design | 3 | Stale cached paths after reload (F1), and drive set coherence gap (F2). |
+
+## Design Tensions
+
+**T1: Pre-pass reload vs. new action type.**
+
+The plan chose to reload config in a `process_events()` pre-pass rather than adding a
+`ReloadConfig` action to the state machine. This is the right call. A `ReloadConfig` action
+would either (a) force the pure state machine to know about config loading (violates ADR-108),
+or (b) require the runner to handle it specially in `execute_actions()` before `Assess` runs.
+The pre-pass is simpler and keeps the action vocabulary small. The trade-off: if a future
+event also needs pre-processing, `process_events()` grows a pattern of pre-passes. Acceptable
+for now — one pre-pass is not a pattern yet.
+
+**T2: Mtime polling vs. inotify.**
+
+Design and plan both chose mtime polling. Correct trade-off. The sentinel polls every 5 seconds
+already. Adding inotify for a <1/day event (config change) adds a dependency and a concurrency
+model change for zero user-visible benefit. The 5-second latency is imperceptible for config
+changes.
+
+## Findings
+
+### F1: Stale cached paths after config reload — Significant
+
+**What:** `SentinelRunner::new()` caches `heartbeat_path` (line 55) and `state_file_path`
+(line 54) from the initial config. After `try_reload_config()` swaps `self.config`, these
+cached fields still point to the old paths. The runner then uses inconsistent sources:
+
+- `detect_heartbeat_event()` (line 196): reads `self.heartbeat_path` — **stale after reload**
+- `execute_assess()` (line 271): reads `self.config.general.heartbeat_file` — **fresh**
+- `execute_assess()` (line 326): reads `self.heartbeat_path` — **stale after reload**
+- `write_state_file()` (line 503): writes to `self.state_file_path` — **stale after reload**
+
+If a config reload changes `heartbeat_file` or `state_db` paths (which determine these cached
+values), the sentinel will read heartbeat from the old path but check overdue from the new path.
+The state file gets written to the old location.
+
+**Consequence:** In practice, path changes in a config reload are unlikely — users change
+subvolume scoping, protection levels, or drive lists, not infrastructure paths. But the
+inconsistency is a latent bug that will confuse a future developer reading the code. And if
+it does manifest, the sentinel silently monitors the wrong heartbeat file.
+
+**Fix:** In `try_reload_config()`, after swapping `self.config`, update the cached fields:
+```
+self.heartbeat_path = self.config.general.heartbeat_file.clone();
+self.state_file_path = sentinel_state_path(&self.config);
+```
+Two lines. Eliminates the inconsistency entirely.
+
+### F2: Drive set coherence after config reload — Moderate
+
+**What:** When config changes drive scoping (the actual F4 bug scenario),
+`self.state.mounted_drives` may contain labels for drives that no longer exist in the new
+config's `drives` list. The `detect_drive_events()` function (line 170-191) computes
+`current` from `self.config.drives` — after reload, this is the new drive list. Drives in
+`self.state.mounted_drives` that aren't in the new config will appear in the `difference`
+and emit `DriveUnmounted` events. This is actually *correct behavior* — it cleans up stale
+drive state. But it's not mentioned in the plan, and it means a config reload that removes
+a drive will generate a spurious "Drive unmounted" log entry + notification even though the
+drive didn't physically unmount.
+
+**Consequence:** Cosmetic. The sentinel logs "Drive unmounted: X" for a drive that was
+removed from config, not physically disconnected. The post-reload `Assess` then produces
+correct promise states (the design's goal). No data safety impact.
+
+**Fix:** Accept this behavior — it's actually fine. Add a comment in `try_reload_config()`
+noting that stale drives in `mounted_drives` will be cleaned up by the next
+`detect_drive_events()` cycle. This transforms a "why did this happen?" into a documented
+behavior.
+
+### F3: Config path plumbing — alternative simpler approach — Moderate
+
+**What:** The plan plumbs `config_override: Option<&Path>` through three call sites (main.rs
+→ commands/sentinel.rs → SentinelRunner::new()) and exposes `config::default_config_path()`
+as `pub(crate)`. An alternative: store the resolved config path *on the Config struct itself*
+during `Config::load()`. This is one change in one file — Config gains a `source_path: PathBuf`
+field. Every consumer that needs the path gets it from the config they already have.
+
+**Trade-off evaluation:** The plan's approach is more explicit (you see the path flowing
+through). The Config-carries-its-path approach is simpler (one field, no plumbing) but
+changes Config's semantics — it becomes aware of where it was loaded from. For a config
+struct that's used as a pure data carrier everywhere, adding a "where I came from" field
+is a mild semantic leak. The plan's explicit plumbing is fine. This is a "noted alternative,"
+not a defect.
+
+**Fix:** No change needed. The plan's approach works. If the plumbing feels heavy during
+implementation, consider the alternative.
+
+### C1: Anomaly guard fix is exactly right — Commendation
+
+The `total > 0` guard is the minimal correct fix. It encodes precisely the semantic
+distinction: "drive is present with broken chains" vs. "drive is absent." The plan's
+regression test (`all_chains_break_on_present_drive_still_detected`) proves the fix doesn't
+suppress real anomalies. The test for the exact bug scenario
+(`drive_disconnect_no_anomaly` with `prev_count=3, intact=0, total=0`) directly validates
+the production failure. Well-targeted.
+
+### C2: Pre-pass reload preserves state machine purity — Commendation
+
+The plan's evolution in Step 3.7 — working through the design's suggestion, recognizing
+the ordering problem (reload must happen before Assess), and arriving at the pre-pass — shows
+good architectural thinking. The result honors ADR-108 cleanly: the state machine says
+"something changed, assess" (pure logic), the runner says "I'll reload first, then assess"
+(I/O). The state machine never touches Config.
+
+## Also Noted
+
+- The plan mentions extracting mtime comparison into a pure helper for testing, then decides
+  against it. Good call — a free function for a 5-line method is premature abstraction.
+- Test 3 (`drive_disconnect_then_reconnect_no_anomaly`) tests the stateless nature of the
+  detection. Useful for documentation value but not testing new behavior — the existing
+  `detect_chain_breaks_new_drive_no_anomaly` already covers "drive not in previous state."
+  Consider whether it earns its keep or is redundant.
+
+## The Simplicity Question
+
+**What could be removed?** Nothing. The plan is already minimal — one-line fix + ~30 lines
+of config reload. The plumbing across 5 files is unavoidable given the current architecture
+(config path isn't carried by Config). The test count (8) is proportional.
+
+**What's earning its keep?** The mtime polling approach earns its keep by avoiding a crate
+dependency. The pre-pass reload earns its keep by avoiding a new action type. The
+`ConfigChanged` event in the state machine earns its keep by making the reload testable and
+visible in state machine tests.
+
+## For the Dev Team
+
+Priority order:
+
+1. **[Fix] `src/sentinel_runner.rs` — update cached paths after config reload.**
+   In `try_reload_config()`, after `self.config = new_config`, add:
+   ```
+   self.heartbeat_path = self.config.general.heartbeat_file.clone();
+   self.state_file_path = sentinel_state_path(&self.config);
+   ```
+   **Why:** Prevents stale heartbeat/state-file paths after reload. Two lines, eliminates
+   the only correctness gap in the plan.
+
+2. **[Document] `src/sentinel_runner.rs` — note drive set cleanup behavior.**
+   Add a comment in `try_reload_config()` explaining that stale drives in
+   `mounted_drives` will be cleaned up by the next `detect_drive_events()` cycle. Not a
+   code change — prevents future confusion about spurious "Drive unmounted" logs after
+   config reload.
+
+3. **[Consider] Test 3 redundancy.** `drive_disconnect_then_reconnect_no_anomaly` may
+   overlap with existing `detect_chain_breaks_new_drive_no_anomaly`. If the scenarios are
+   materially different (they test different transitions: disconnect vs. first-appearance),
+   keep both. If identical, drop one.
+
+## Open Questions
+
+1. **Config reload notification to Spindle consumers.** The sentinel-state.json doesn't
+   record *when* or *why* a config was reloaded. Spindle (future) would benefit from knowing
+   "config reloaded at T" to explain sudden promise state changes in the UI. Is this worth
+   adding to the state file schema now, or defer until Spindle needs it? Leaning toward
+   defer — schema changes should be driven by consumers, and Spindle doesn't exist yet.
+
+2. **What if `heartbeat_path` changes and the old heartbeat file still exists?** After
+   reload, `detect_heartbeat_event()` uses the updated path (if F1 is fixed). The old
+   heartbeat file is orphaned. The sentinel won't detect heartbeat changes from the old
+   path — correct behavior. But the `last_heartbeat_mtime` now refers to the old file's
+   mtime. On first poll with the new path, `metadata()` returns the *new* file's mtime
+   (or None if it doesn't exist). If different from the cached value → spurious
+   `BackupCompleted` event. Fix: reset `last_heartbeat_mtime` in `try_reload_config()`
+   when the heartbeat path changes:
+   ```
+   if self.heartbeat_path != self.config.general.heartbeat_file {
+       self.last_heartbeat_mtime = std::fs::metadata(&self.config.general.heartbeat_file)
+           .ok().and_then(|m| m.modified().ok());
+   }
+   ```
+   This is the same pattern as `new()` — re-baseline mtime for the new path. Low priority
+   since heartbeat path changes are rare, but it's the correct thing to do.

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -75,11 +75,7 @@ pub fn run(config_path: Option<&Path>, args: &MigrateArgs) -> anyhow::Result<()>
 fn resolve_config_path(path: Option<&Path>) -> anyhow::Result<PathBuf> {
     match path {
         Some(p) => Ok(p.to_path_buf()),
-        None => {
-            let config_dir = dirs::config_dir()
-                .ok_or_else(|| anyhow::anyhow!("could not determine XDG config directory"))?;
-            Ok(config_dir.join("urd").join("urd.toml"))
-        }
+        None => Ok(crate::config::default_config_path()?),
     }
 }
 

--- a/src/commands/sentinel.rs
+++ b/src/commands/sentinel.rs
@@ -1,13 +1,15 @@
 // CLI handlers for `urd sentinel run` and `urd sentinel status`.
 
+use std::path::Path;
+
 use crate::config::Config;
 use crate::output::{OutputMode, SentinelStatusOutput};
 use crate::sentinel_runner::{self, is_pid_alive, read_sentinel_state_file, sentinel_state_path};
 use crate::voice;
 
 /// Start the sentinel daemon (foreground, for systemd).
-pub fn run_daemon(config: Config) -> anyhow::Result<()> {
-    let mut runner = sentinel_runner::SentinelRunner::new(config)?;
+pub fn run_daemon(config: Config, config_override: Option<&Path>) -> anyhow::Result<()> {
+    let mut runner = sentinel_runner::SentinelRunner::new(config, config_override)?;
     runner.run()
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -930,7 +930,7 @@ fn validate_name_safe(name: &str, label: &str) -> crate::error::Result<()> {
     Ok(())
 }
 
-fn default_config_path() -> crate::error::Result<PathBuf> {
+pub(crate) fn default_config_path() -> crate::error::Result<PathBuf> {
     let config_dir = dirs::config_dir()
         .ok_or_else(|| UrdError::Config("could not determine XDG config directory".to_string()))?;
     Ok(config_dir.join("urd").join("urd.toml"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,7 +81,7 @@ fn main() -> anyhow::Result<()> {
         Commands::Verify(args) => commands::verify::run(config, args, output_mode),
         Commands::Get(args) => commands::get::run(config, args, output_mode),
         Commands::Sentinel(args) => match args.command {
-            cli::SentinelCommands::Run => commands::sentinel::run_daemon(config),
+            cli::SentinelCommands::Run => commands::sentinel::run_daemon(config, cli.config.as_deref()),
             cli::SentinelCommands::Status => commands::sentinel::status(config, output_mode),
         },
         Commands::Drives(args) => match args.action {

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -29,6 +29,8 @@ pub enum SentinelEvent {
     AssessmentTick,
     /// A backup run completed (detected via heartbeat change).
     BackupCompleted,
+    /// Config file changed on disk — runner should reload and reassess.
+    ConfigChanged,
     /// Graceful shutdown requested (SIGTERM/SIGINT).
     Shutdown,
 }
@@ -381,6 +383,10 @@ pub fn sentinel_transition(
         SentinelEvent::BackupCompleted => {
             // A backup just finished — re-assess to pick up new promise states
             // and dispatch any notifications the backup left undispatched.
+            actions.push(SentinelAction::Assess);
+        }
+
+        SentinelEvent::ConfigChanged => {
             actions.push(SentinelAction::Assess);
         }
 
@@ -807,8 +813,10 @@ pub fn detect_simultaneous_chain_breaks(
     let mut anomalies = Vec::new();
     for (drive, &prev_count) in &prev_intact {
         let &(intact, total) = curr.get(drive).unwrap_or(&(0, 0));
-        // Drive had >= 2 intact chains before, and now has 0
-        if prev_count >= 2 && intact == 0 {
+        // Drive had >= 2 intact chains before, and now has 0.
+        // Guard: total > 0 ensures we don't fire when a drive simply disconnected
+        // (disconnect removes chains from the current snapshot, leaving total == 0).
+        if prev_count >= 2 && intact == 0 && total > 0 {
             anomalies.push(DriveAnomaly {
                 drive_label: drive.to_string(),
                 total_chains: total,
@@ -957,6 +965,14 @@ mod tests {
         let (_, actions) = sentinel_transition(&state, &SentinelEvent::Shutdown);
 
         assert_eq!(actions, vec![SentinelAction::Exit]);
+    }
+
+    #[test]
+    fn transition_config_changed_triggers_assess() {
+        let state = fresh_state();
+        let (_, actions) = sentinel_transition(&state, &SentinelEvent::ConfigChanged);
+
+        assert_eq!(actions, vec![SentinelAction::Assess]);
     }
 
     // ── Drive tracking ──────────────────────────────────────────────────
@@ -1642,6 +1658,65 @@ mod tests {
         let anomalies = detect_simultaneous_chain_breaks(&prev, &curr);
         assert_eq!(anomalies.len(), 1);
         assert_eq!(anomalies[0].drive_label, "D1");
+    }
+
+    // ── Drive disconnect anomaly guard (021-a) ─────────────────────────
+
+    #[test]
+    fn drive_disconnect_no_anomaly() {
+        // Drive D1 had 3 intact chains, then disconnects (absent from current).
+        // prev_count=3, intact=0, total=0 — should NOT fire (drive just left).
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+        let curr = vec![]; // D1 absent — no chains in current snapshot
+
+        assert!(detect_simultaneous_chain_breaks(&prev, &curr).is_empty());
+    }
+
+    #[test]
+    fn all_chains_break_on_present_drive_still_detected() {
+        // Regression: D1 present with 3 broken chains — anomaly must still fire.
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+        let curr = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: false },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: false },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: false },
+        ];
+
+        let anomalies = detect_simultaneous_chain_breaks(&prev, &curr);
+        assert_eq!(anomalies.len(), 1);
+        assert_eq!(anomalies[0].drive_label, "D1");
+        assert_eq!(anomalies[0].total_chains, 3);
+    }
+
+    #[test]
+    fn drive_disconnect_then_reconnect_no_anomaly() {
+        // Two transitions: D1 disappears (no anomaly), then returns intact (no anomaly).
+        // Each call is stateless — only compares two snapshots.
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+
+        // Transition 1: D1 disconnects
+        let curr_disconnected: Vec<ChainSnapshot> = vec![];
+        assert!(detect_simultaneous_chain_breaks(&prev, &curr_disconnected).is_empty());
+
+        // Transition 2: D1 returns with all chains intact
+        let curr_reconnected = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+        assert!(detect_simultaneous_chain_breaks(&curr_disconnected, &curr_reconnected).is_empty());
     }
 
     // ── Health snapshot tests (VFM-B) ──────────────────────────────────

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -9,7 +9,7 @@
 // Review: docs/99-reports/2026-03-27-sentinel-session2-design-review.md
 
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
@@ -47,15 +47,28 @@ pub struct SentinelRunner {
     shutdown: Arc<AtomicBool>,
     /// When the last BackupOverdue notification was sent (M2 debounce).
     last_overdue_notified: Option<Instant>,
+    /// Path to the config file (for reload detection).
+    config_path: PathBuf,
+    /// Last observed config file mtime (for change detection).
+    last_config_mtime: Option<SystemTime>,
 }
 
 impl SentinelRunner {
-    pub fn new(config: Config) -> anyhow::Result<Self> {
+    pub fn new(config: Config, config_override: Option<&Path>) -> anyhow::Result<Self> {
         let state_file_path = sentinel_state_path(&config);
         let heartbeat_path = config.general.heartbeat_file.clone();
 
         // S1 fix: read current heartbeat mtime as baseline — no event on startup.
         let last_heartbeat_mtime = std::fs::metadata(&heartbeat_path)
+            .ok()
+            .and_then(|m| m.modified().ok());
+
+        // Resolve config path for reload detection.
+        let config_path = match config_override {
+            Some(p) => p.to_path_buf(),
+            None => crate::config::default_config_path()?,
+        };
+        let last_config_mtime = std::fs::metadata(&config_path)
             .ok()
             .and_then(|m| m.modified().ok());
 
@@ -73,6 +86,8 @@ impl SentinelRunner {
             started,
             shutdown: Arc::new(AtomicBool::new(false)),
             last_overdue_notified: None,
+            config_path,
+            last_config_mtime,
         })
     }
 
@@ -122,11 +137,23 @@ impl SentinelRunner {
             events.push(event);
         }
 
+        if let Some(event) = self.detect_config_change() {
+            events.push(event);
+        }
+
         events
     }
 
     /// Process events through the state machine, coalescing Assess actions (M1 fix).
     fn process_events(&mut self, events: Vec<SentinelEvent>) {
+        // Pre-pass: reload config before state machine processes ConfigChanged.
+        // This ensures the Assess action (emitted by the transition) uses the new config.
+        for event in &events {
+            if matches!(event, SentinelEvent::ConfigChanged) {
+                self.try_reload_config();
+            }
+        }
+
         let mut all_actions = Vec::new();
 
         for event in &events {
@@ -218,6 +245,56 @@ impl SentinelRunner {
             }
             None => Some(SentinelEvent::AssessmentTick), // First tick immediately
             _ => None,
+        }
+    }
+
+    /// Detect config file mtime change. Returns ConfigChanged if the file
+    /// was modified (or appeared/disappeared) since last check.
+    fn detect_config_change(&mut self) -> Option<SentinelEvent> {
+        let mtime = std::fs::metadata(&self.config_path)
+            .ok()
+            .and_then(|m| m.modified().ok());
+        if mtime != self.last_config_mtime {
+            self.last_config_mtime = mtime;
+            Some(SentinelEvent::ConfigChanged)
+        } else {
+            None
+        }
+    }
+
+    /// Attempt to reload config from disk. On success, swap config and update
+    /// cached paths. On failure, log and keep old config.
+    fn try_reload_config(&mut self) {
+        match Config::load(Some(&self.config_path)) {
+            Ok(new_config) => {
+                log::warn!("Config reloaded — reassessing");
+
+                // F1 fix: re-baseline heartbeat mtime if path changed — prevents
+                // spurious BackupCompleted from stale mtime referring to old file.
+                if self.heartbeat_path != new_config.general.heartbeat_file {
+                    self.last_heartbeat_mtime = std::fs::metadata(
+                        &new_config.general.heartbeat_file,
+                    )
+                    .ok()
+                    .and_then(|m| m.modified().ok());
+                }
+
+                // F1 fix: update cached paths derived from config.
+                self.config = new_config;
+                self.heartbeat_path = self.config.general.heartbeat_file.clone();
+                self.state_file_path = sentinel_state_path(&self.config);
+
+                // F2 note: stale drives in self.state.mounted_drives (from old
+                // config) will be cleaned up by the next detect_drive_events()
+                // cycle, which computes current drives from self.config.drives.
+                // This may emit spurious "Drive unmounted" logs for drives removed
+                // from config — correct cleanup behavior, not a bug.
+            }
+            Err(e) => {
+                log::error!(
+                    "Config file changed but reload failed: {e}. Keeping previous config."
+                );
+            }
         }
     }
 
@@ -1227,5 +1304,120 @@ mod tests {
         assert_eq!(notifs.len(), 2);
         assert!(matches!(&notifs[0].event, NotificationEvent::HealthDegraded { subvolume, .. } if subvolume == "sv1"));
         assert!(matches!(&notifs[1].event, NotificationEvent::HealthRecovered { subvolume, .. } if subvolume == "sv2"));
+    }
+
+    // ── Config reload detection (021-b) ────────────────────────────────
+
+    /// Write a minimal valid v1 config to `path`, using `dir` for all filesystem paths.
+    fn write_test_config(path: &std::path::Path, dir: &std::path::Path) {
+        let source = dir.join("source");
+        let snap_root = dir.join("snapshots");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&snap_root).unwrap();
+
+        let config_text = format!(
+            r#"[general]
+config_version = 1
+run_frequency = "daily"
+state_db = "{dir}/urd.db"
+metrics_file = "{dir}/backup.prom"
+heartbeat_file = "{dir}/heartbeat.json"
+
+[[subvolumes]]
+name = "test-sv"
+source = "{source}"
+snapshot_root = "{snap_root}"
+min_free_bytes = "1GB"
+protection = "recorded"
+"#,
+            dir = dir.display(),
+            source = source.display(),
+            snap_root = snap_root.display(),
+        );
+        std::fs::write(path, config_text).unwrap();
+    }
+
+    /// Build a SentinelRunner from a temp config file.
+    fn make_test_runner(
+        config_path: &std::path::Path,
+    ) -> SentinelRunner {
+        let config = Config::load(Some(config_path)).unwrap();
+        SentinelRunner::new(config, Some(config_path)).unwrap()
+    }
+
+    #[test]
+    fn config_mtime_unchanged_no_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("urd.toml");
+        write_test_config(&config_path, dir.path());
+
+        let mut runner = make_test_runner(&config_path);
+
+        // No file change — detect should return None.
+        assert!(runner.detect_config_change().is_none());
+    }
+
+    #[test]
+    fn config_mtime_changed_emits_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("urd.toml");
+        write_test_config(&config_path, dir.path());
+
+        let mut runner = make_test_runner(&config_path);
+
+        // Touch the file to change mtime.
+        std::thread::sleep(Duration::from_millis(50));
+        let content = std::fs::read_to_string(&config_path).unwrap();
+        std::fs::write(&config_path, &content).unwrap();
+
+        assert_eq!(
+            runner.detect_config_change(),
+            Some(SentinelEvent::ConfigChanged),
+        );
+
+        // Second call without further change — should return None.
+        assert!(runner.detect_config_change().is_none());
+    }
+
+    #[test]
+    fn config_reload_failure_keeps_old_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("urd.toml");
+        write_test_config(&config_path, dir.path());
+
+        let mut runner = make_test_runner(&config_path);
+        let original_state_db = runner.config.general.state_db.clone();
+
+        // Overwrite with invalid TOML.
+        std::fs::write(&config_path, "this is not valid toml [[[").unwrap();
+        runner.try_reload_config();
+
+        // Config should be unchanged.
+        assert_eq!(runner.config.general.state_db, original_state_db);
+    }
+
+    #[test]
+    fn config_reload_success_updates_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("urd.toml");
+        write_test_config(&config_path, dir.path());
+
+        let mut runner = make_test_runner(&config_path);
+
+        // Write a new valid config with a different state_db path.
+        let new_dir = dir.path().join("new");
+        std::fs::create_dir_all(&new_dir).unwrap();
+        write_test_config(&config_path, &new_dir);
+
+        runner.try_reload_config();
+
+        // Config should reflect new values.
+        let expected_db = new_dir.join("urd.db");
+        assert_eq!(runner.config.general.state_db, expected_db);
+        // Cached paths should also be updated.
+        assert_eq!(
+            runner.state_file_path,
+            sentinel_state_path(&runner.config),
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **021-a:** Fixed false "all chains broke simultaneously" anomaly when a drive disconnects — added `total > 0` guard to `detect_simultaneous_chain_breaks()` so absent drives (total=0) don't trigger false positives
- **021-b:** Sentinel now hot-reloads config on file mtime change — `ConfigChanged` event through pure state machine, runner handles reload + cached path refresh (heartbeat path, state file path)
- Consolidated duplicate `default_config_path()` logic in `migrate.rs` (simplify pass)
- Updated roadmap with test session findings and Phase E sequencing (E0-E5)

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 857 tests, all passing
- Integration tests: not applicable (sentinel I/O requires live system)
- New tests: 8 (3 anomaly guard, 1 state machine transition, 4 runner config reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)