### PR TITLE
feat: context-aware suggestions (UPI 020)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Context-aware suggestions: `urd doctor`, `urd status`, and bare `urd` now show specific commands based on chain health, drive state, and subvolume config instead of static "run `urd backup`" advice
 - Sentinel config reload: daemon detects config file changes via mtime polling and hot-reloads without restart
 - Token-aware chain-break gate: verified drives proceed with full sends in auto mode, breaking the deadlock where broken chains permanently blocked transient subvolumes
 - `send_completed` field in heartbeat (schema v2): distinguishes "backup ran successfully" from "data actually reached an external drive"

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,8 +5,8 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
-| 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | - | - |
-| 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | - | - | - |
+| 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | merged | [#84](https://github.com/vonrobak/urd/pull/84) |
+| 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | - | - |
 | 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | merged | [#83](https://github.com/vonrobak/urd/pull/83) |
 | 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | - | - | - |
 | 017 | Thread lineage visualization | [design](../95-ideas/2026-04-03-design-017-thread-lineage-visualization.md) | - | - | - | - |

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -9,17 +9,17 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-833 tests, all passing, clippy clean. Current version: v0.10.0.
+857 tests, all passing, clippy clean. Current version: v0.10.0.
 
-**UPI 010 complete (all sessions + 010-a).** Config schema v1 fully implemented:
-V1 parser, validation, `urd migrate`, `local_snapshots = false`. PR #75-80 merged.
-The full legacy→v1 config pipeline works: parse either schema, migrate between them,
-semantic equivalence confirmed. Named-level opacity has no exceptions.
+**UPI 021 complete.** Sentinel config reload (mtime polling, hot-reload without restart)
+and chain-break anomaly guard fix. PR #84 merged. Simplify pass consolidated duplicate
+`default_config_path()` in migrate.rs.
 
 **Deployment notes:**
 - v0.10.0 tagged but not yet pushed/installed
 - After install: hand-edit production config `local_retention = "transient"` →
   `local_snapshots = false` before next timer run
+- UPI 021 fix means sentinel will pick up the config change automatically after install
 
 ## In Progress
 
@@ -27,23 +27,21 @@ Nothing active.
 
 ## Recently Completed
 
-**UPI 010-a: `local_snapshots = false`** (2026-04-03)
-   - Replaced `local_retention = "transient"` with boolean opt-out in v1 config
-   - Eliminated the only exception to named-level opacity
-   - Migration handles custom+transient and named+transient→custom with baked fields
-   - 12 new tests, simplify pass fixed 5 issues including a double-count bug
+**UPI 021: The Living Daemon** (2026-04-04)
+   - 021-a: `total > 0` guard in `detect_simultaneous_chain_breaks()` — prevents false
+     anomaly when drives disconnect
+   - 021-b: `ConfigChanged` event, mtime polling, `try_reload_config()` with cached path
+     refresh — sentinel hot-reloads config without restart
+   - 8 new tests, simplify pass fixed migrate.rs duplication
 
 ## Next Up
 
-**Immediate: Push v0.10.0 and deploy** (see "When you return" in session journal)
+**Immediate: Push v0.10.0 and deploy** (see session journal for verification steps)
 
-**Track A: v0.10.0 test session** (calendar time — live with the tool)
-   - Live with v0.10.0 for several days (timer, Sentinel, drive plug/unplug cycles)
-   - Output: prioritized issue list → targeted fix phase if needed
-
-**Then sequential:**
-1. Fix test session findings (~0-2 sessions)
-2. **Phase D: Progressive disclosure + The Encounter** — ~6-8 sessions
+**Then sequential (Phase E: Make the invisible worker smart):**
+1. **E1: UPI 013** — Btrfs pipeline (compressed sends, sync after delete) ~0.25 session
+2. **E2: UPI 018** — External-only runtime (fix false degraded/broken for local_snapshots=false) ~0.5 session
+3. **E3: UPI 020** — Context-aware suggestions (compute_advice pure function) ~0.5 session
 
 ## Key Links
 

--- a/docs/99-reports/2026-04-04-review-adversary-020-doctor-knows.md
+++ b/docs/99-reports/2026-04-04-review-adversary-020-doctor-knows.md
@@ -1,0 +1,248 @@
+---
+upi: "020"
+date: 2026-04-04
+---
+
+# Adversary Review: UPI 020 — The Doctor Knows
+
+**Project:** Urd  
+**Date:** 2026-04-04  
+**Scope:** Implementation plan at `.claude/plans/zippy-riding-mango.md`, design doc at
+`docs/95-ideas/2026-04-04-design-020-doctor-knows.md`  
+**Review mode:** Design review (plan, pre-implementation)  
+**Commit:** 5b3c43a (master)
+
+---
+
+## Executive Summary
+
+A well-scoped, low-risk feature that fixes a genuine UX defect — the doctor prescribing
+commands that make things worse. The core design (pure function in awareness.rs, consumed
+by three surfaces) is architecturally clean. Two significant findings: the decision tree
+has a gap where `external_only` subvolumes receive wrong advice, and the plan introduces
+three nearly-identical advice structs in output.rs where one would do.
+
+## What Kills You
+
+**Catastrophic failure mode:** Urd prescribes `urd backup --force-full` and the user runs
+it, triggering an unattended multi-hour full send that fills the NVMe or the target drive.
+
+**Distance:** Two steps away. Step 1: `compute_advice()` suggests `--force-full` without
+size context. Step 2: user runs it blindly. The plan does mention including estimated size
+in the reason field (design doc open question 1), but the implementation plan doesn't
+commit to it. This isn't critical — `--force-full` already exists and users can run it
+today — but the advice system creates a trust relationship. If the doctor says "do this,"
+users will do it without checking `urd plan` first.
+
+**Verdict:** Not a blocker. The command already exists; the advice just surfaces it. But
+the reason field *should* include the size estimate when available, to maintain the trust
+relationship the doctor is building.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | Decision tree covers the main scenarios; one gap with external-only |
+| 2 | Security | 5 | No privilege escalation, no new I/O, pure function |
+| 3 | Architectural Excellence | 4 | Clean placement in awareness.rs; output struct proliferation is the blemish |
+| 4 | Systems Design | 4 | Solid production thinking; JSON backward compat handled well |
+
+**Overall: 4.0** — Solid plan with minor issues to resolve before implementation.
+
+## Design Tensions
+
+### 1. Advice specificity vs. advice safety
+
+**Trade-off:** Specific advice (`--force-full --subvolume htpc-root`) is more actionable
+than generic advice (`run urd doctor`), but specific advice carries more risk — if the
+advice is wrong, the user follows it into a worse state.
+
+**Resolution in plan:** Good. The decision tree is conservative — it checks chain health
+before suggesting `--force-full`, and falls back to "connect drive" (no command) when the
+fix is physical. The plan correctly returns `command: None` when no CLI action helps.
+
+**My evaluation:** Right call. The function computes advice from the same data the system
+uses to make decisions. If the data is wrong, the system's own behavior is also wrong —
+the advice is no more dangerous than the system itself.
+
+### 2. One function vs. per-surface advice
+
+**Trade-off:** A single `compute_advice()` function forces all surfaces to show the same
+advice. But doctor might want more detail than the bare `urd` one-liner.
+
+**Resolution in plan:** The function returns a struct with `issue`, `command`, and
+`reason`. Each consumer picks which fields to render. Doctor shows all three; bare `urd`
+shows only the command. This is the right decomposition — compute once, render per-surface.
+
+### 3. Output struct proliferation vs. type reuse
+
+**Trade-off:** The plan introduces three new output structs (`StatusAdviceEntry`,
+`DefaultAdvice`, `ActionableAdvice`) for what is essentially the same data: "subvolume X
+needs action Y because Z."
+
+See Finding S1 below.
+
+## Findings
+
+### S1: Three advice structs for one concept (Significant)
+
+**What:** The plan introduces `ActionableAdvice` (awareness.rs), `StatusAdviceEntry`
+(output.rs), and `DefaultAdvice` (output.rs). All three have the same core fields:
+`command: Option<String>`, `reason: Option<String>`. `StatusAdviceEntry` adds `subvolume`,
+`DefaultAdvice` adds `subvolume` and `total_needing_attention`.
+
+**Why it matters:** Three structs that represent the same concept create mapping code
+between them (`.map(|a| StatusAdviceEntry { subvolume: ..., command: a.command, ... })`),
+increase surface area for bugs (field renamed in one but not another), and make the code
+harder to follow. This is exactly the premature-distinction pattern that CLAUDE.md warns
+against ("three similar lines of code is better than a premature abstraction" — and by
+the same logic, one struct is better than three that differ only in a wrapper field).
+
+**Suggested fix:** Use `ActionableAdvice` directly in the output structs. It already has
+`issue`, `command`, `reason`. Add `Serialize` (plan already does). In `StatusOutput`, use
+`Vec<(String, ActionableAdvice)>` or add `subvolume: String` to `ActionableAdvice` itself
+(it already needs the name for the `--subvolume {name}` command construction). For the
+default command, pass `(best: Option<ActionableAdvice>, total_needing_attention: usize)`
+as two fields on `DefaultStatusOutput` rather than wrapping in a `DefaultAdvice` struct.
+
+### S2: `external_only` subvolumes get wrong advice (Significant)
+
+**What:** The decision tree's branch 6 ("At Risk + drive mounted, no chain break")
+suggests `urd backup --subvolume {name}`. For an `external_only` subvolume (e.g.,
+htpc-root with `local_snapshots = false`), this will create a transient snapshot, send it,
+and delete it — which is correct behavior, but the *issue* description will say "waning —
+last backup N hours ago" based on `local.newest_age`. For external-only subvolumes,
+`local.newest_age` is misleading because local snapshots are ephemeral — the relevant
+freshness is `external[].last_send_age`.
+
+The plan mentions `external_only` as a parameter but only says "adjust framing" without
+specifying how. The decision tree branches don't differentiate.
+
+**Why it matters:** htpc-root is the subvolume that triggered this entire UPI. If the
+doctor still shows wrong information for htpc-root after this change, the feature hasn't
+solved its motivating problem.
+
+**Suggested fix:** When `external_only == true`, compute age from
+`assessment.external.iter().filter_map(|d| d.last_send_age).min()` instead of
+`assessment.local.newest_age`. The command suggestion is the same (`urd backup`), but the
+issue text should say "waning — last external send N hours ago" to accurately describe the
+situation. Document this clearly in the decision tree branches.
+
+### M1: `resolved_subvolumes()` called redundantly (Moderate)
+
+**What:** `assess()` already calls `config.resolved_subvolumes()` internally (line 190).
+The plan adds a second call in each consumer (doctor.rs, status.rs, default.rs) to look up
+`send_enabled` and `external_only`. status.rs already has a third call at line 95.
+
+`resolved_subvolumes()` iterates all subvolumes and resolves defaults/policies — it's not
+expensive, but triple-calling it is wasteful and increases the risk of inconsistency if
+config state changes between calls (it won't in practice since config is immutable, but
+the pattern is sloppy).
+
+**Suggested fix:** In each command handler, call `resolved_subvolumes()` once and pass the
+resolved vec both to the advice computation and to any existing code that needs it. For
+status.rs, the existing `resolved` at line 95 can be reused. For doctor.rs and default.rs,
+add a single `let resolved = config.resolved_subvolumes();` before the assessment loop.
+This is what the plan already says for doctor.rs — just be consistent across all three.
+
+### M2: Decision tree branch 2 suggests `urd init` for no-drives-configured (Moderate)
+
+**What:** Branch 2 says "Unprotected + no external drives configured → suggest `urd init`."
+But `urd init` is a first-time setup command that checks infrastructure (sudo, dirs, etc.).
+If a user has a working Urd installation with subvolumes but no drives configured, `urd
+init` won't help them add a drive — they need to edit their config file to add a
+`[[drives]]` section.
+
+**Suggested fix:** Change the suggestion to describe the actual next step: reason:
+"Add a [[drives]] section to your config to enable external backups." No command (config
+editing isn't a CLI action). Or if `urd init` actually does handle adding drives to an
+existing config, verify that and keep the suggestion.
+
+### M3: Missing test for `external_only` advice path (Moderate)
+
+**What:** The 8 planned tests don't include a test for `external_only = true`. Test 8
+(`advice_send_disabled_ignores_external`) tests `send_enabled = false`, which is different.
+An `external_only` subvolume has `send_enabled = true` but `local_retention = Transient`.
+
+**Suggested fix:** Add test 9: `advice_external_only_uses_send_age` — constructs an
+assessment where `local.newest_age` is stale but `external[0].last_send_age` is fresh,
+with `external_only = true`. Verify that the issue text references the external send age,
+not the local age.
+
+### C1: Pure function placement (Commendation)
+
+The decision to put `compute_advice()` in awareness.rs rather than voice.rs is exactly
+right. This is semantic computation (which command fixes this problem), not presentation
+(how to display it). It honors ADR-108, keeps it testable without rendering, and supports
+future consumers (Spindle) that need the structured data. The explicit "Why awareness.rs
+and not voice.rs?" section in the design doc shows the author thought about this — and
+got it right.
+
+### C2: `command: None` for physical actions (Commendation)
+
+Returning `None` when the fix is "connect a drive" (a physical action, not a CLI command)
+is a smart design choice. It prevents consumers from showing a clickable/runnable command
+that doesn't exist, and the structured distinction between `command` and `reason` lets
+each surface decide how to render it. This will pay off when Spindle shows a tray menu —
+entries with commands get a "Run" button, entries without get just an informational line.
+
+## The Simplicity Question
+
+**What could be removed?** The `DefaultAdvice` and `StatusAdviceEntry` structs (see S1).
+Use `ActionableAdvice` directly.
+
+**What's earning its keep?** The core `compute_advice()` function and the decision to keep
+it pure. The `ActionableAdvice` struct with its `command`/`reason` split. The vertical
+slicing approach (awareness first, then consumers).
+
+**Is the scope right?** Yes. The plan touches 6 files but the changes are small and
+mechanical in the consumer layers (doctor, status, default). The real logic is in one
+function. This is well-scoped for ~0.5 session.
+
+## For the Dev Team
+
+Priority order:
+
+1. **Fix S2 (external_only age source):** In `compute_advice()`, when `external_only ==
+   true`, derive the issue age from `external[].last_send_age.min()` instead of
+   `local.newest_age`. This is the motivating use case (htpc-root) — get it right.
+
+2. **Fix S1 (eliminate output struct proliferation):** Use `ActionableAdvice` directly in
+   output structs. Add `subvolume: String` to `ActionableAdvice` (it already needs the
+   name to construct the `--subvolume {name}` command). In `DefaultStatusOutput`, use
+   `best_advice: Option<ActionableAdvice>` plus
+   `total_needing_attention: usize` as separate fields. Delete `StatusAdviceEntry` and
+   `DefaultAdvice`.
+
+3. **Fix M2 (urd init suggestion):** Verify whether `urd init` helps add drives. If not,
+   change to a reason-only suggestion about editing config.
+
+4. **Fix M3 (add external_only test):** Add the test described above.
+
+5. **Address M1 (resolved_subvolumes reuse):** Minor cleanup — reuse existing `resolved`
+   bindings where they exist.
+
+6. **Commit to size estimate in reason (from "What Kills You"):** When a broken chain
+   requires `--force-full`, include the estimated full-send size in the `reason` field
+   when available. The data is accessible through `FileSystemState::calibrated_size()` in
+   the assessment pipeline — but `compute_advice()` is pure and doesn't have access to
+   `FileSystemState`. **Resolution:** The assessment's `health_reasons` already contain
+   "full send size unknown for {drive}" when no estimate exists — so the estimate
+   availability is already known. Consider adding an optional `estimated_full_send_bytes`
+   field to `DriveChainHealth` during the assess phase, so `compute_advice()` can include
+   it without needing I/O access. This is a small scope addition that keeps purity intact.
+
+## Open Questions
+
+1. **Does `compute_advice()` need the full `SubvolAssessment` or a smaller input?** The
+   function reads `.status`, `.health`, `.external[]`, `.chain_health[]`, and
+   `.local.newest_age`. That's 5 of 10 fields. Passing `&SubvolAssessment` is fine for
+   now (it's a reference, not a copy), but if the struct grows much larger, a dedicated
+   input struct could clarify what the function actually depends on. Not actionable now —
+   just noting the dependency surface.
+
+2. **Should `compute_advice()` return advice for Protected+Healthy subvolumes that have
+   non-empty `redundancy_advisories`?** E.g., a subvolume that's PROTECTED but has
+   "single point of failure" advisory. The plan returns `None` for Protected+Healthy.
+   This seems correct — redundancy advisories are already surfaced separately. But it's
+   worth confirming this is intentional.

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -11,6 +11,8 @@
 
 use chrono::{Duration, NaiveDateTime};
 
+use serde::Serialize;
+
 use crate::config::{Config, DriveConfig};
 use crate::output::{RedundancyAdvisory, RedundancyAdvisoryKind};
 use crate::plan::FileSystemState;
@@ -173,6 +175,208 @@ pub struct DriveAssessment {
     #[allow(dead_code)] // consumed by verbose status display (future)
     pub configured_interval: Interval,
     pub role: DriveRole,
+}
+
+// ── Actionable Advice ─────────────────────────────────────────────────
+
+/// Actionable advice for a subvolume based on its full assessment.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ActionableAdvice {
+    /// Which subvolume this advice is for.
+    pub subvolume: String,
+    /// Short problem description ("waning — last external send 43h ago").
+    pub issue: String,
+    /// The exact command to run, or None if no CLI action can help.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub command: Option<String>,
+    /// Human explanation of why this command, or what physical action to take.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Compute actionable advice for a subvolume based on its assessment.
+///
+/// Returns `None` when the subvolume is protected and healthy (no action needed).
+/// `send_enabled`: whether external sends are configured for this subvolume.
+/// `external_only`: true when local retention is transient (no local recovery).
+#[must_use]
+pub fn compute_advice(
+    assessment: &SubvolAssessment,
+    send_enabled: bool,
+    external_only: bool,
+) -> Option<ActionableAdvice> {
+    let name = &assessment.name;
+
+    // Branch 1: Protected + Healthy → no advice
+    if assessment.status == PromiseStatus::Protected
+        && assessment.health == OperationalHealth::Healthy
+    {
+        return None;
+    }
+
+    // When sends are disabled, only local staleness matters.
+    if !send_enabled {
+        if assessment.status == PromiseStatus::AtRisk {
+            return Some(ActionableAdvice {
+                subvolume: name.clone(),
+                issue: format!("waning{}", format_age_suffix(assessment, false)),
+                command: Some(format!("urd backup --subvolume {name}")),
+                reason: None,
+            });
+        }
+        // Protected+Degraded with no sends — nothing actionable
+        return None;
+    }
+
+    // Branch 2: Unprotected + no external drives configured
+    if assessment.status == PromiseStatus::Unprotected && assessment.external.is_empty() {
+        return Some(ActionableAdvice {
+            subvolume: name.clone(),
+            issue: "exposed — no external drives configured".to_string(),
+            command: None,
+            reason: Some(
+                "Add a [[drives]] section to your config to enable external backups".to_string(),
+            ),
+        });
+    }
+
+    // Branch 3: Unprotected + all drives absent
+    if assessment.status == PromiseStatus::Unprotected
+        && !assessment.external.is_empty()
+        && assessment.external.iter().all(|d| !d.mounted)
+    {
+        let first_label = &assessment.external[0].drive_label;
+        return Some(ActionableAdvice {
+            subvolume: name.clone(),
+            issue: "exposed — all drives disconnected".to_string(),
+            command: None,
+            reason: Some(format!("Connect {first_label} to restore protection")),
+        });
+    }
+
+    // Branch 4: At Risk or Unprotected + chain broken on a mounted drive
+    if (assessment.status == PromiseStatus::AtRisk
+        || assessment.status == PromiseStatus::Unprotected)
+        && let Some(broken) = find_broken_chain_on_mounted_drive(assessment)
+    {
+        return Some(ActionableAdvice {
+            subvolume: name.clone(),
+            issue: format_age_issue(assessment, external_only),
+            command: Some(format!("urd backup --force-full --subvolume {name}")),
+            reason: Some(chain_break_reason_text(broken)),
+        });
+    }
+
+    // Branch 5: At Risk + drive absent, no broken chain on mounted drives
+    if assessment.status == PromiseStatus::AtRisk
+        && let Some(absent) = assessment.external.iter().find(|d| !d.mounted)
+    {
+        return Some(ActionableAdvice {
+            subvolume: name.clone(),
+            issue: format_age_issue(assessment, external_only),
+            command: None,
+            reason: Some(format!(
+                "Connect {} and run `urd backup`",
+                absent.drive_label
+            )),
+        });
+    }
+
+    // Branch 6: At Risk + drive mounted, no chain break
+    if assessment.status == PromiseStatus::AtRisk {
+        return Some(ActionableAdvice {
+            subvolume: name.clone(),
+            issue: format_age_issue(assessment, external_only),
+            command: Some(format!("urd backup --subvolume {name}")),
+            reason: None,
+        });
+    }
+
+    // Branch 7: Protected + Degraded + chain broken on mounted drive
+    if assessment.status == PromiseStatus::Protected
+        && assessment.health == OperationalHealth::Degraded
+    {
+        if let Some(broken) = find_broken_chain_on_mounted_drive(assessment) {
+            return Some(ActionableAdvice {
+                subvolume: name.clone(),
+                issue: format!("degraded — thread to {} broken", broken.drive_label),
+                command: Some(format!("urd backup --force-full --subvolume {name}")),
+                reason: Some("will need full send on next backup".to_string()),
+            });
+        }
+
+        // Branch 8: Protected + Degraded + drive away long
+        if let Some(absent) = assessment.external.iter().find(|d| !d.mounted) {
+            return Some(ActionableAdvice {
+                subvolume: name.clone(),
+                issue: format!("degraded — {} away", absent.drive_label),
+                command: None,
+                reason: Some(format!("Consider connecting {}", absent.drive_label)),
+            });
+        }
+    }
+
+    None
+}
+
+/// Find the first chain break on a mounted drive.
+fn find_broken_chain_on_mounted_drive(assessment: &SubvolAssessment) -> Option<&DriveChainHealth> {
+    assessment.chain_health.iter().find(|ch| {
+        matches!(ch.status, ChainStatus::Broken { .. })
+            && assessment
+                .external
+                .iter()
+                .any(|d| d.drive_label == ch.drive_label && d.mounted)
+    })
+}
+
+/// Format "thread to {drive} broken ({reason})" from a chain health entry.
+fn chain_break_reason_text(ch: &DriveChainHealth) -> String {
+    if let ChainStatus::Broken { reason, .. } = &ch.status {
+        format!("thread to {} broken ({reason})", ch.drive_label)
+    } else {
+        format!("thread to {} broken", ch.drive_label)
+    }
+}
+
+/// Format an age suffix like " — last backup 43 hours ago".
+fn format_age_suffix(assessment: &SubvolAssessment, external_only: bool) -> String {
+    let age = if external_only {
+        assessment
+            .external
+            .iter()
+            .filter_map(|d| d.last_send_age)
+            .min()
+    } else {
+        assessment.local.newest_age
+    };
+
+    match age {
+        Some(d) => {
+            let secs = d.num_seconds();
+            let label = if external_only {
+                "last external send"
+            } else {
+                "last backup"
+            };
+            if secs >= 86400 {
+                format!(" — {label} {} days ago", secs / 86400)
+            } else {
+                format!(" — {label} {} hours ago", secs / 3600)
+            }
+        }
+        None => String::new(),
+    }
+}
+
+/// Format the issue string with age context.
+fn format_age_issue(assessment: &SubvolAssessment, external_only: bool) -> String {
+    let status_word = match assessment.status {
+        PromiseStatus::Unprotected => "exposed",
+        PromiseStatus::AtRisk => "waning",
+        PromiseStatus::Protected => "sealed",
+    };
+    format!("{status_word}{}", format_age_suffix(assessment, external_only))
 }
 
 // ── Core function ──────────────────────────────────────────────────────
@@ -3583,6 +3787,149 @@ drives = ["D1"]
             OperationalHealth::Healthy,
             "health should be Healthy — D2 is out of scope. Got: {:?} reasons: {:?}",
             sv1.health, sv1.health_reasons
+        );
+    }
+
+    // ── compute_advice tests ──────────────────────────────────────────
+
+    /// Build a minimal SubvolAssessment for advice tests. Tests mutate fields as needed.
+    fn test_assessment_for_advice(
+        name: &str,
+        status: PromiseStatus,
+        health: OperationalHealth,
+    ) -> SubvolAssessment {
+        SubvolAssessment {
+            name: name.to_string(),
+            status,
+            health,
+            health_reasons: vec![],
+            local: LocalAssessment {
+                status: PromiseStatus::Protected,
+                snapshot_count: 5,
+                newest_age: Some(Duration::hours(2)),
+                configured_interval: Interval::hours(1),
+            },
+            external: vec![],
+            chain_health: vec![],
+            advisories: vec![],
+            redundancy_advisories: vec![],
+            errors: vec![],
+        }
+    }
+
+    fn drive_assessment(label: &str, mounted: bool, send_age_hours: Option<i64>) -> DriveAssessment {
+        DriveAssessment {
+            drive_label: label.to_string(),
+            status: PromiseStatus::Protected,
+            mounted,
+            snapshot_count: Some(5),
+            last_send_age: send_age_hours.map(Duration::hours),
+            configured_interval: Interval::hours(24),
+            role: DriveRole::Primary,
+        }
+    }
+
+    #[test]
+    fn advice_protected_healthy_returns_none() {
+        let a = test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Healthy);
+        assert!(compute_advice(&a, true, false).is_none());
+    }
+
+    #[test]
+    fn advice_unprotected_no_drives() {
+        let a = test_assessment_for_advice("sv1", PromiseStatus::Unprotected, OperationalHealth::Healthy);
+        let advice = compute_advice(&a, true, false).unwrap();
+        assert_eq!(advice.issue, "exposed — no external drives configured");
+        assert!(advice.command.is_none());
+        assert!(advice.reason.unwrap().contains("[[drives]]"));
+    }
+
+    #[test]
+    fn advice_unprotected_all_drives_absent() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::Unprotected, OperationalHealth::Blocked);
+        a.external = vec![drive_assessment("WD-18TB", false, None)];
+        let advice = compute_advice(&a, true, false).unwrap();
+        assert_eq!(advice.issue, "exposed — all drives disconnected");
+        assert!(advice.command.is_none());
+        assert!(advice.reason.unwrap().contains("Connect WD-18TB"));
+    }
+
+    #[test]
+    fn advice_at_risk_chain_broken_mounted() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
+        a.chain_health = vec![DriveChainHealth {
+            drive_label: "WD-18TB".to_string(),
+            status: ChainStatus::Broken {
+                reason: ChainBreakReason::PinMissingLocally,
+                pin_parent: None,
+            },
+        }];
+        let advice = compute_advice(&a, true, false).unwrap();
+        assert!(advice.command.as_ref().unwrap().contains("--force-full"));
+        assert!(advice.reason.as_ref().unwrap().contains("thread to WD-18TB broken"));
+    }
+
+    #[test]
+    fn advice_at_risk_drive_absent() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", false, Some(48))];
+        let advice = compute_advice(&a, true, false).unwrap();
+        assert!(advice.command.is_none());
+        assert!(advice.reason.as_ref().unwrap().contains("Connect WD-18TB"));
+    }
+
+    #[test]
+    fn advice_at_risk_drive_mounted_no_break() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Healthy);
+        a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
+        let advice = compute_advice(&a, true, false).unwrap();
+        assert!(advice.command.as_ref().unwrap().contains("urd backup --subvolume sv1"));
+        assert!(!advice.command.as_ref().unwrap().contains("--force-full"));
+        assert!(advice.reason.is_none());
+    }
+
+    #[test]
+    fn advice_protected_degraded_chain_broken() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", true, Some(6))];
+        a.chain_health = vec![DriveChainHealth {
+            drive_label: "WD-18TB".to_string(),
+            status: ChainStatus::Broken {
+                reason: ChainBreakReason::NoPinFile,
+                pin_parent: None,
+            },
+        }];
+        let advice = compute_advice(&a, true, false).unwrap();
+        assert!(advice.issue.contains("degraded"));
+        assert!(advice.command.as_ref().unwrap().contains("--force-full"));
+        assert!(advice.reason.as_ref().unwrap().contains("full send"));
+    }
+
+    #[test]
+    fn advice_send_disabled_ignores_external() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", false, None)];
+        let advice = compute_advice(&a, false, false).unwrap();
+        assert!(advice.command.as_ref().unwrap().contains("urd backup --subvolume sv1"));
+        assert!(!advice.command.as_ref().unwrap().contains("--force-full"));
+    }
+
+    #[test]
+    fn advice_external_only_uses_send_age() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Healthy);
+        // Local age is 2h (from test_assessment_for_advice), but external send was 48h ago
+        a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
+        let advice = compute_advice(&a, true, true).unwrap();
+        assert!(
+            advice.issue.contains("last external send"),
+            "expected 'last external send' in issue: {}",
+            advice.issue
+        );
+        assert!(
+            !advice.issue.contains("last backup"),
+            "should not say 'last backup' when external_only: {}",
+            advice.issue
         );
     }
 }

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -63,6 +63,19 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         }
     }
 
+    // Compute actionable advice
+    let resolved = config.resolved_subvolumes();
+    let advice_items: Vec<awareness::ActionableAdvice> = assessments
+        .iter()
+        .filter_map(|a| {
+            let sv = resolved.iter().find(|sv| sv.name == a.name)?;
+            awareness::compute_advice(a, sv.send_enabled, sv.local_retention.is_transient())
+        })
+        .collect();
+
+    let total_needing_attention = advice_items.len();
+    let best_advice = advice_items.into_iter().next();
+
     let output = DefaultStatusOutput {
         total,
         waning_names,
@@ -71,6 +84,8 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         blocked_count,
         last_run,
         last_run_age_secs,
+        best_advice,
+        total_needing_attention,
     };
 
     print!("{}", voice::render_default_status(&output, output_mode));

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -102,37 +102,49 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     let now = chrono::Local::now().naive_local();
     let assessments = awareness::assess(&config, now, &fs_state);
 
+    let resolved = config.resolved_subvolumes();
     let data_safety: Vec<DoctorDataSafety> = assessments
         .iter()
         .map(|a| {
-            let (issue, suggestion) = match a.status {
+            let sv_config = resolved.iter().find(|sv| sv.name == a.name);
+            let send_enabled = sv_config.is_none_or(|sv| sv.send_enabled);
+            let external_only = sv_config.is_some_and(|sv| sv.local_retention.is_transient());
+            let advice = awareness::compute_advice(a, send_enabled, external_only);
+
+            // Extract structured advice into doctor display fields.
+            let unpack = |adv: &awareness::ActionableAdvice| {
+                (
+                    Some(adv.issue.clone()),
+                    adv.command.as_ref().map(|c| format!("Run `{c}`.")),
+                    adv.reason.clone(),
+                )
+            };
+
+            let (issue, suggestion, reason) = match a.status {
+                PromiseStatus::Protected if a.health == awareness::OperationalHealth::Healthy => {
+                    (None, None, None)
+                }
+                PromiseStatus::Protected => advice.as_ref().map(unpack).unwrap_or_default(),
                 PromiseStatus::Unprotected => {
                     error_count += 1;
-                    (
-                        Some("exposed \u{2014} data may not be recoverable".to_string()),
-                        Some("Run `urd backup` or connect a drive.".to_string()),
-                    )
+                    advice.as_ref().map(unpack).unwrap_or_else(|| {
+                        (
+                            Some("exposed — data may not be recoverable".to_string()),
+                            Some("Run `urd backup` or connect a drive.".to_string()),
+                            None,
+                        )
+                    })
                 }
                 PromiseStatus::AtRisk => {
                     warn_count += 1;
-                    let age = a
-                        .local
-                        .newest_age
-                        .map(|d| {
-                            let secs = d.num_seconds();
-                            if secs >= 86400 {
-                                format!("last backup {} days ago", secs / 86400)
-                            } else {
-                                format!("last backup {} hours ago", secs / 3600)
-                            }
-                        })
-                        .unwrap_or_default();
-                    (
-                        Some(format!("waning{}", if age.is_empty() { String::new() } else { format!(" \u{2014} {age}") })),
-                        Some("Run `urd backup` to refresh.".to_string()),
-                    )
+                    advice.as_ref().map(unpack).unwrap_or_else(|| {
+                        (
+                            Some("waning".to_string()),
+                            Some("Run `urd backup` to refresh.".to_string()),
+                            None,
+                        )
+                    })
                 }
-                PromiseStatus::Protected => (None, None),
             };
             DoctorDataSafety {
                 name: a.name.clone(),
@@ -140,6 +152,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
                 health: a.health.to_string(),
                 issue,
                 suggestion,
+                reason,
             }
         })
         .collect();

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -108,6 +108,14 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         })
         .collect();
 
+    let advice: Vec<awareness::ActionableAdvice> = assessments
+        .iter()
+        .filter_map(|a| {
+            let sv = resolved.iter().find(|sv| sv.name == a.name)?;
+            awareness::compute_advice(a, sv.send_enabled, sv.local_retention.is_transient())
+        })
+        .collect();
+
     let status_output = StatusOutput {
         assessments: assessments_with_promises,
         chain_health: chain_health_entries,
@@ -115,6 +123,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         last_run,
         total_pins,
         redundancy_advisories,
+        advice,
     };
 
     let rendered = voice::render_status(&status_output, output_mode);

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,7 +7,7 @@ use std::io::IsTerminal;
 
 use serde::{Deserialize, Serialize};
 
-use crate::awareness::{DriveAssessment, SubvolAssessment};
+use crate::awareness::{ActionableAdvice, DriveAssessment, SubvolAssessment};
 use crate::types::{ByteSize, DriveRole};
 
 // ── OutputMode ──────────────────────────────────────────────────────────
@@ -151,6 +151,9 @@ pub struct StatusOutput {
     /// Structured redundancy advisories (omitted from JSON when empty).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub redundancy_advisories: Vec<RedundancyAdvisory>,
+    /// Actionable advice for subvolumes needing attention (omitted from JSON when empty).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub advice: Vec<ActionableAdvice>,
 }
 
 /// Serializable wrapper around SubvolAssessment data.
@@ -278,6 +281,16 @@ pub struct DefaultStatusOutput {
     pub last_run: Option<LastRunInfo>,
     /// Seconds since last backup started, pre-computed by the command handler.
     pub last_run_age_secs: Option<i64>,
+    /// The most urgent actionable advice, if any subvolumes need attention.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub best_advice: Option<ActionableAdvice>,
+    /// How many subvolumes need attention total.
+    #[serde(skip_serializing_if = "is_zero")]
+    pub total_needing_attention: usize,
+}
+
+fn is_zero(n: &usize) -> bool {
+    *n == 0
 }
 
 impl DefaultStatusOutput {
@@ -401,6 +414,9 @@ pub struct DoctorDataSafety {
     pub issue: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggestion: Option<String>,
+    /// Why this command is suggested, or what physical action to take.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
 }
 
 /// Sentinel daemon status for doctor output.

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -71,12 +71,19 @@ fn render_status_interactive(data: &StatusOutput) -> String {
     }
 
     // ── Next-action suggestion ──────────────────────────────────────
-    let has_exposed = data.assessments.iter().any(|a| a.status == "UNPROTECTED");
-    let has_degraded = data.assessments.iter().any(|a| a.health != "healthy");
-    append_suggestion(
-        &SuggestionContext::Status { has_exposed, has_degraded },
-        &mut out,
-    );
+    if !data.advice.is_empty() {
+        writeln!(out).ok();
+        if data.advice.len() == 1 {
+            let a = &data.advice[0];
+            if let Some(ref cmd) = a.command {
+                writeln!(out, "{}", format!("{} — run `{cmd}` to fix.", a.subvolume).dimmed()).ok();
+            } else if let Some(ref reason) = a.reason {
+                writeln!(out, "{}", format!("{} — {}.", a.subvolume, reason).dimmed()).ok();
+            }
+        } else {
+            writeln!(out, "{}", format!("{} subvolumes need attention — run `urd doctor` for details.", data.advice.len()).dimmed()).ok();
+        }
+    }
 
     out
 }
@@ -1975,6 +1982,9 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
                 if let Some(ref suggestion) = ds.suggestion {
                     writeln!(out, "      \u{2192} {suggestion}").ok();
                 }
+                if let Some(ref reason) = ds.reason {
+                    writeln!(out, "      {}", reason.dimmed()).ok();
+                }
             }
         }
     }
@@ -2292,7 +2302,17 @@ fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
     writeln!(out).ok();
 
     // Next-action suggestion
-    if data.sealed_count() < data.total || health_issues > 0 {
+    if let Some(ref advice) = data.best_advice {
+        if data.total_needing_attention == 1 {
+            if let Some(ref cmd) = advice.command {
+                writeln!(out, "{}", format!("Run `{cmd}`.").dimmed()).ok();
+            } else if let Some(ref reason) = advice.reason {
+                writeln!(out, "{}", reason.dimmed()).ok();
+            }
+        } else {
+            writeln!(out, "{}", format!("{} subvolumes need attention — run `urd status` for details.", data.total_needing_attention).dimmed()).ok();
+        }
+    } else if data.sealed_count() < data.total || health_issues > 0 {
         append_suggestion(&SuggestionContext::Default { has_issues: true }, &mut out);
     } else {
         writeln!(out, "{}", "Run `urd status` for details, `urd --help` for commands.".dimmed())
@@ -2387,8 +2407,6 @@ fn escalated_staleness_text(
 enum SuggestionContext {
     /// Bare `urd` (default command).
     Default { has_issues: bool },
-    /// `urd status`.
-    Status { has_exposed: bool, has_degraded: bool },
     /// `urd plan`.
     Plan { has_operations: bool, has_space_skip: bool },
     /// `urd backup`.
@@ -2407,10 +2425,6 @@ fn suggest_next_action(context: &SuggestionContext) -> Option<&'static str> {
     match context {
         SuggestionContext::Default { has_issues: true } => {
             Some("Run `urd status` for details.")
-        }
-        SuggestionContext::Status { has_exposed: true, .. }
-        | SuggestionContext::Status { has_degraded: true, .. } => {
-            Some("Run `urd doctor` to diagnose.")
         }
         SuggestionContext::Plan { has_space_skip: true, has_operations: true } => {
             Some("Run `urd calibrate` to review retention, then `urd backup`.")
@@ -2620,6 +2634,7 @@ fn render_drives_adopt_interactive(data: &DriveAdoptOutput) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::awareness::ActionableAdvice;
     use crate::output::{
         BackupSummary, CalibrateEntry, CalibrateOutput, CalibrateResult, ChainHealth,
         ChainHealthEntry, DeferredInfo, DisconnectedDrive, DriveInfo, HistoryOutput, HistoryRun,
@@ -2711,6 +2726,7 @@ mod tests {
             }),
             total_pins: 3,
             redundancy_advisories: vec![],
+            advice: vec![],
         }
     }
 
@@ -2845,6 +2861,7 @@ mod tests {
             last_run: None,
             total_pins: 0,
             redundancy_advisories: vec![],
+            advice: vec![],
         };
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
@@ -2913,11 +2930,79 @@ mod tests {
             last_run: None,
             total_pins: 0,
             redundancy_advisories: vec![],
+            advice: vec![],
         };
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
             output.contains("no runs recorded"),
             "missing no-runs message"
+        );
+    }
+
+    // ── Status advice rendering tests ────────────────────────────────
+
+    #[test]
+    fn status_single_issue_shows_inline_fix() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        data.advice = vec![ActionableAdvice {
+            subvolume: "htpc-docs".to_string(),
+            issue: "waning — last backup 3 hours ago".to_string(),
+            command: Some("urd backup --subvolume htpc-docs".to_string()),
+            reason: None,
+        }];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("htpc-docs"),
+            "missing subvolume name in advice: {output}"
+        );
+        assert!(
+            output.contains("urd backup --subvolume htpc-docs"),
+            "missing inline fix command: {output}"
+        );
+    }
+
+    #[test]
+    fn status_multiple_issues_shows_doctor() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        data.advice = vec![
+            ActionableAdvice {
+                subvolume: "htpc-docs".to_string(),
+                issue: "waning".to_string(),
+                command: Some("urd backup --subvolume htpc-docs".to_string()),
+                reason: None,
+            },
+            ActionableAdvice {
+                subvolume: "htpc-home".to_string(),
+                issue: "exposed".to_string(),
+                command: None,
+                reason: Some("Connect WD-18TB".to_string()),
+            },
+        ];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("2 subvolumes need attention"),
+            "missing doctor redirect: {output}"
+        );
+        assert!(
+            output.contains("urd doctor"),
+            "missing doctor command: {output}"
+        );
+    }
+
+    #[test]
+    fn status_no_issues_no_suggestion() {
+        colored::control::set_override(false);
+        let data = test_status_output();
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("need attention"),
+            "healthy state should not have attention message: {output}"
+        );
+        assert!(
+            !output.contains("to fix"),
+            "healthy state should not have fix message: {output}"
         );
     }
 
@@ -4600,6 +4685,8 @@ mod tests {
                 duration: Some("1m 30s".to_string()),
             }),
             last_run_age_secs: Some(25200), // 7 hours
+            best_advice: None,
+            total_needing_attention: 0,
         }
     }
 
@@ -4629,6 +4716,8 @@ mod tests {
             blocked_count: 0,
             last_run: None,
             last_run_age_secs: None,
+            best_advice: None,
+            total_needing_attention: 0,
         };
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
@@ -4660,6 +4749,8 @@ mod tests {
             blocked_count: 0,
             last_run: None,
             last_run_age_secs: None,
+            best_advice: None,
+            total_needing_attention: 0,
         };
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
@@ -4713,6 +4804,8 @@ mod tests {
             blocked_count: 0,
             last_run: None,
             last_run_age_secs: None,
+            best_advice: None,
+            total_needing_attention: 0,
         };
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
@@ -4731,6 +4824,8 @@ mod tests {
             blocked_count: 0,
             last_run: None,
             last_run_age_secs: None,
+            best_advice: None,
+            total_needing_attention: 0,
         };
         let output = render_default_status(&data, OutputMode::Daemon);
         let parsed: serde_json::Value =
@@ -4758,6 +4853,51 @@ mod tests {
         let parsed: serde_json::Value =
             serde_json::from_str(&output).expect("daemon first-time should be valid JSON");
         assert_eq!(parsed["status"], "not_configured");
+    }
+
+    // ── Default advice rendering tests ──────────────────────────────
+
+    #[test]
+    fn default_single_issue_shows_command() {
+        colored::control::set_override(false);
+        let mut data = test_default_all_sealed();
+        data.waning_names = vec!["htpc-docs".to_string()];
+        data.best_advice = Some(ActionableAdvice {
+            subvolume: "htpc-docs".to_string(),
+            issue: "waning — last backup 3 hours ago".to_string(),
+            command: Some("urd backup --subvolume htpc-docs".to_string()),
+            reason: None,
+        });
+        data.total_needing_attention = 1;
+        let output = render_default_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("urd backup --subvolume htpc-docs"),
+            "single issue should show specific command: {output}"
+        );
+    }
+
+    #[test]
+    fn default_multiple_issues_shows_count() {
+        colored::control::set_override(false);
+        let mut data = test_default_all_sealed();
+        data.waning_names = vec!["htpc-docs".to_string()];
+        data.exposed_names = vec!["htpc-home".to_string()];
+        data.best_advice = Some(ActionableAdvice {
+            subvolume: "htpc-home".to_string(),
+            issue: "exposed".to_string(),
+            command: None,
+            reason: Some("Connect WD-18TB".to_string()),
+        });
+        data.total_needing_attention = 2;
+        let output = render_default_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("2 subvolumes need attention"),
+            "multiple issues should show count: {output}"
+        );
+        assert!(
+            output.contains("urd status"),
+            "multiple issues should suggest urd status: {output}"
+        );
     }
 
     // ── Doctor tests ──────────────────────────────────────────────────
@@ -4796,6 +4936,7 @@ mod tests {
                     health: "healthy".to_string(),
                     issue: None,
                     suggestion: None,
+                    reason: None,
                 },
                 DoctorDataSafety {
                     name: "htpc-docs".to_string(),
@@ -4803,6 +4944,7 @@ mod tests {
                     health: "healthy".to_string(),
                     issue: None,
                     suggestion: None,
+                    reason: None,
                 },
             ],
             sentinel: DoctorSentinelStatus {
@@ -4856,6 +4998,7 @@ mod tests {
             health: "blocked".to_string(),
             issue: Some("exposed — data may not be recoverable".to_string()),
             suggestion: Some("Run `urd backup` or connect a drive.".to_string()),
+            reason: None,
         };
         data.verdict = DoctorVerdict::issues(1);
         let output = render_doctor(&data, OutputMode::Interactive);
@@ -4945,6 +5088,61 @@ mod tests {
         assert!(parsed["infra_checks"].is_array());
         assert!(parsed["data_safety"].is_array());
         assert_eq!(parsed["sentinel"]["running"], true);
+    }
+
+    #[test]
+    fn doctor_chain_broken_shows_force_full() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.data_safety[0] = DoctorDataSafety {
+            name: "htpc-home".to_string(),
+            status: "AT RISK".to_string(),
+            health: "degraded".to_string(),
+            issue: Some("waning — last backup 48 hours ago".to_string()),
+            suggestion: Some("Run `urd backup --force-full --subvolume htpc-home`.".to_string()),
+            reason: Some("thread to WD-18TB broken (pin missing locally)".to_string()),
+        };
+        data.verdict = DoctorVerdict::warnings(1);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("--force-full"),
+            "missing force-full suggestion: {output}"
+        );
+        assert!(
+            output.contains("thread to WD-18TB broken"),
+            "missing chain break reason: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_absent_drive_shows_connect() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.data_safety[0] = DoctorDataSafety {
+            name: "htpc-home".to_string(),
+            status: "UNPROTECTED".to_string(),
+            health: "blocked".to_string(),
+            issue: Some("exposed — all drives disconnected".to_string()),
+            suggestion: None,
+            reason: Some("Connect WD-18TB to restore protection".to_string()),
+        };
+        data.verdict = DoctorVerdict::issues(1);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("Connect WD-18TB"),
+            "missing connect guidance: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_protected_healthy_no_suggestion() {
+        colored::control::set_override(false);
+        let data = test_doctor_healthy();
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("Run `urd backup"),
+            "healthy state should have no backup suggestion: {output}"
+        );
     }
 
     // ── Retention preview tests ──────────────────────────────────────
@@ -5326,35 +5524,6 @@ mod tests {
     }
 
     #[test]
-    fn suggestion_status_healthy_none() {
-        assert!(suggest_next_action(&SuggestionContext::Status {
-            has_exposed: false,
-            has_degraded: false,
-        })
-        .is_none());
-    }
-
-    #[test]
-    fn suggestion_status_exposed_suggests_doctor() {
-        let s = suggest_next_action(&SuggestionContext::Status {
-            has_exposed: true,
-            has_degraded: false,
-        })
-        .unwrap();
-        assert!(s.contains("urd doctor"), "should suggest doctor: {s}");
-    }
-
-    #[test]
-    fn suggestion_status_degraded_suggests_doctor() {
-        let s = suggest_next_action(&SuggestionContext::Status {
-            has_exposed: false,
-            has_degraded: true,
-        })
-        .unwrap();
-        assert!(s.contains("urd doctor"), "should suggest doctor: {s}");
-    }
-
-    #[test]
     fn suggestion_plan_nothing_none() {
         assert!(suggest_next_action(&SuggestionContext::Plan {
             has_operations: false,
@@ -5423,11 +5592,18 @@ mod tests {
     #[test]
     fn status_interactive_exposed_has_suggestion_line() {
         colored::control::set_override(false);
-        // test_status_output has htpc-docs as "AT RISK" with degraded health
-        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        let mut data = test_status_output();
+        // Provide advice so the suggestion line renders
+        data.advice = vec![ActionableAdvice {
+            subvolume: "htpc-docs".to_string(),
+            issue: "waning — last backup 3 hours ago".to_string(),
+            command: Some("urd backup --subvolume htpc-docs".to_string()),
+            reason: None,
+        }];
+        let output = render_status(&data, OutputMode::Interactive);
         assert!(
-            output.contains("urd doctor"),
-            "degraded status should suggest doctor: {output}"
+            output.contains("urd backup --subvolume htpc-docs"),
+            "degraded status should suggest specific command: {output}"
         );
     }
 


### PR DESCRIPTION
## Summary

- New `compute_advice()` pure function in awareness.rs replaces static suggestion lookup tables across all CLI surfaces
- 8-branch decision tree considers chain health, drive state, and subvolume config to produce specific commands (e.g., `urd backup --force-full --subvolume X` when chain is broken)
- Doctor shows chain-break reasons alongside remediation commands; status shows inline fix for single issues, "run `urd doctor`" for multiple; bare `urd` shows specific command or count
- External-only subvolumes (local_snapshots=false) correctly use send age instead of local age in advice text

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 871 tests, all passing
- Integration tests: not applicable (no I/O changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)