### PR TITLE
feat: compressed send pass-through and post-delete sync (UPI 013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Compressed send pass-through: auto-detects `--compressed-data` support (btrfs-progs 5.18+) and enables protocol v2 sends — less CPU, preserves compression on destination
+- Post-delete sync: `btrfs subvolume sync` after each retention delete ensures freed space is visible to the space check before the next snapshot
 - Context-aware suggestions: `urd doctor`, `urd status`, and bare `urd` now show specific commands based on chain health, drive state, and subvolume config instead of static "run `urd backup`" advice
 - Sentinel config reload: daemon detects config file changes via mtime polling and hot-reloads without restart
 - Token-aware chain-break gate: verified drives proceed with full sends in auto mode, breaking the deadlock where broken chains permanently blocked transient subvolumes

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -6,14 +6,14 @@
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
 | 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | merged | [#84](https://github.com/vonrobak/urd/pull/84) |
-| 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | - | - |
+| 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | merged | [#85](https://github.com/vonrobak/urd/pull/85) |
 | 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | merged | [#83](https://github.com/vonrobak/urd/pull/83) |
 | 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | - | - | - |
 | 017 | Thread lineage visualization | [design](../95-ideas/2026-04-03-design-017-thread-lineage-visualization.md) | - | - | - | - |
 | 016 | Emergency space response | [design](../95-ideas/2026-04-03-design-016-emergency-space-response.md) | - | - | - | - |
 | 015 | Change preview in `urd get` | [design](../95-ideas/2026-04-03-design-015-get-change-preview.md) | - | - | - | - |
 | 014 | Skip unchanged subvolumes | [design](../95-ideas/2026-04-03-design-014-skip-unchanged-subvolumes.md) | - | - | - | - |
-| 013 | Btrfs pipeline improvements | [design](../95-ideas/2026-04-03-design-013-btrfs-pipeline-improvements.md) | - | - | - | - |
+| 013 | Btrfs pipeline improvements | [design](../95-ideas/2026-04-03-design-013-btrfs-pipeline-improvements.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-013-btrfs-pipeline-improvements.md) | - | - |
 | 012 | Sentinel drive-gated transient + space monitoring | [design](../95-ideas/2026-04-03-design-012-sentinel-drive-gated-transient.md) | - | - | - | - |
 | 011 | Transient space safety (emergency fix) | [design](../95-ideas/2026-04-03-design-011-transient-space-safety.md) | [steve](../99-reports/2026-04-03-steve-jobs-011-transient-is-a-lie.md) | - | - | - |
 | 010-a | Transient as first-class config concept | [design](../95-ideas/2026-04-03-design-010a-transient-as-first-class-config.md) | [steve](../99-reports/2026-04-03-steve-jobs-010a-boolean-beats-jargon.md) | [adversary](../99-reports/2026-04-03-review-adversary-010a-local-snapshots-boolean.md) | merged | [#80](https://github.com/vonrobak/urd/pull/80) |

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -9,11 +9,11 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-857 tests, all passing, clippy clean. Current version: v0.10.0.
+871 tests, all passing, clippy clean. Current version: v0.10.0.
 
-**UPI 021 complete.** Sentinel config reload (mtime polling, hot-reload without restart)
-and chain-break anomaly guard fix. PR #84 merged. Simplify pass consolidated duplicate
-`default_config_path()` in migrate.rs.
+**UPI 020 complete.** Context-aware suggestions: `compute_advice()` pure function in
+awareness.rs replaces static lookup tables. Doctor, status, and bare `urd` now show
+specific commands based on chain health, drive state, and subvolume config. PR #85 merged.
 
 **Deployment notes:**
 - v0.10.0 tagged but not yet pushed/installed
@@ -27,12 +27,12 @@ Nothing active.
 
 ## Recently Completed
 
-**UPI 021: The Living Daemon** (2026-04-04)
-   - 021-a: `total > 0` guard in `detect_simultaneous_chain_breaks()` — prevents false
-     anomaly when drives disconnect
-   - 021-b: `ConfigChanged` event, mtime polling, `try_reload_config()` with cached path
-     refresh — sentinel hot-reloads config without restart
-   - 8 new tests, simplify pass fixed migrate.rs duplication
+**UPI 020: The Doctor Knows** (2026-04-04)
+   - `ActionableAdvice` struct + 8-branch decision tree in awareness.rs
+   - Doctor shows chain-break reasons and `--force-full` when appropriate
+   - Status/default show inline fix commands or "run urd doctor" for multiple issues
+   - `external_only` flag uses send age for transient subvolumes
+   - 17 new tests, simplify pass fixed 3 issues
 
 ## Next Up
 
@@ -41,7 +41,7 @@ Nothing active.
 **Then sequential (Phase E: Make the invisible worker smart):**
 1. **E1: UPI 013** — Btrfs pipeline (compressed sends, sync after delete) ~0.25 session
 2. **E2: UPI 018** — External-only runtime (fix false degraded/broken for local_snapshots=false) ~0.5 session
-3. **E3: UPI 020** — Context-aware suggestions (compute_advice pure function) ~0.5 session
+3. **E4: UPI 014** — Skip unchanged subvolumes ~0.5 session
 
 ## Key Links
 
@@ -52,16 +52,10 @@ Nothing active.
 | Architecture and code conventions | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
-| Design docs | [95-ideas/](../95-ideas/) |
-| Review reports | [99-reports/](../99-reports/) |
 
 ## Known Issues
 
-- NVMe snapshot accumulation: space guard prevents catastrophic exhaustion but gradual accumulation above 10GB threshold not gated
-- `FileSystemState` trait (11 methods) outgrowing its name — consider rename to `SystemState`
+- htpc-root shows false "degraded"/"broken chain" — awareness doesn't account for `local_snapshots = false` (UPI 018 will fix)
+- WD-18TB and WD-18TB1 share BTRFS UUID from cloning — needs `btrfstune -u` when offsite drive returns
 - Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" matched as raw strings — consider constants
-- Parallel notification builders in notify.rs and sentinel_runner.rs (maintenance risk)
-- RECOVERY column hidden — needs real snapshot depth calculation before it can return
 - Planner helper functions approaching parameter limit (10 args) — pass `&PlanFilters` instead of destructured bools in next planner change
-- ByteSize Display uses `{:.1}` formatting — `urd migrate` emits "10.0GB" not "10GB"; consider clean display mode
-- VersionProbe error message says "failed to read config_version" for TOML syntax errors — UX polish

--- a/docs/99-reports/2026-04-04-review-adversary-013-btrfs-pipeline-improvements.md
+++ b/docs/99-reports/2026-04-04-review-adversary-013-btrfs-pipeline-improvements.md
@@ -1,0 +1,230 @@
+---
+upi: "013"
+date: 2026-04-04
+---
+
+# Architectural Adversary Review: UPI 013 — BTRFS Pipeline Improvements
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-04
+**Scope:** Design review of `docs/95-ideas/2026-04-03-design-013-btrfs-pipeline-improvements.md`
+**Mode:** Design review (4 dimensions)
+**Base commit:** `9974c4c`
+**Reviewer:** arch-adversary
+
+---
+
+## Executive Summary
+
+A clean, well-scoped design with one significant misunderstanding of the executor's
+execution model. 013-a (compressed sends) is straightforward and sound. 013-b (sync
+after delete) has the right instinct but proposes inserting the sync "after the deletion
+loop" — the executor has no deletion loop. Deletes are individual `PlannedOperation`
+items interleaved with creates and sends, each processed in `execute_subvolume`'s single
+`for op in ops` pass. The design needs to reconcile its sync placement with this reality.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss through deleting snapshots that shouldn't
+be deleted, or space exhaustion causing failed sends with partial snapshots.
+
+**Distance from this design:** Far. Neither 013-a nor 013-b introduces new deletion logic
+or modifies retention decisions. 013-a adds a flag to an existing send command. 013-b adds
+a sync that, at worst, is a no-op. Neither change moves closer to the catastrophic failure
+mode. This is a low-risk design.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | **Correctness** | 4 | 013-a is sound. 013-b has the right semantics but the "deletion loop" placement doesn't exist as described — needs adjustment. |
+| 2 | **Security** | 5 | No new trust boundaries, no new paths to sudo, no new user input. Both changes follow existing `Command::arg(&Path)` patterns. |
+| 3 | **Architectural Excellence** | 4 | Clean separation: probe outside `BtrfsOps`, sync inside it. `SystemBtrfs` as a startup-only struct is the right call. |
+| 4 | **Systems Design** | 3 | The sync placement assumes an execution model the code doesn't have. The `--help` probe has a minor portability concern. |
+
+## Design Tensions
+
+### 1. Sync granularity vs. executor structure
+
+The design wants to sync once per "retention batch" — the right instinct for efficiency.
+But the executor processes operations as a flat list: create, create, delete, send, delete,
+delete. There is no "retention batch" boundary visible to the executor. The design must
+choose between:
+
+- **(A) Sync per-delete inside `execute_delete`.** Simple, correct, but calls sync N times
+  for N deletes. Each sync flushes all pending commits, so the 2nd through Nth are near-instant
+  if the first completed. Overhead is N subprocess spawns, not N flushes.
+- **(B) Accumulate "needs sync" state and sync before the first space check.** More complex,
+  requires the executor to track whether any deletes happened since the last sync. Better
+  efficiency but adds state tracking.
+- **(C) Sync once at the end of `execute_subvolume`, after all operations.** Simple, but
+  doesn't help the space check within `execute_delete` — the check runs before the sync
+  would happen.
+
+**Recommendation:** Option A is the pragmatic choice. The subprocess overhead of redundant
+syncs is negligible compared to the actual btrfs commit time. The first sync in a batch does
+the real work; subsequent syncs return quickly. This avoids any executor-level state tracking
+and keeps the change contained within `execute_delete`.
+
+### 2. Probe mechanism: `--help` parsing vs. version comparison
+
+The design probes `btrfs send --help` for the `--compressed-data` string. This is pragmatic
+and avoids maintaining a version-to-feature mapping. The trade-off: it depends on the help
+text being stable across btrfs-progs releases. The alternative (parsing `btrfs version` and
+comparing against 5.18) is more fragile — distribution patching, backport variations, and
+version string format differences make this worse. The design made the right call.
+
+## Findings
+
+### S1 — Significant: The "deletion loop" doesn't exist in the executor
+
+**What:** The design states: "sync_subvolumes is called once per retention batch, not once
+per deleted snapshot. The executor already groups retention deletions by subvolume; the sync
+follows all deletions for a given snapshot root." This is inaccurate.
+
+**Reality:** The executor (`executor.rs:245-404`) processes all operations for a subvolume
+in a single `for op in ops` loop. The planner emits operations in load-bearing order:
+`create → local retention deletes → sends → external retention deletes` (plan.rs:148-150).
+There is no "retention batch" boundary — each `PlannedOperation::DeleteSnapshot` is handled
+individually by `execute_delete`, which includes its own per-delete space check
+(executor.rs:746-773).
+
+**Consequence:** The design's proposed insertion point ("after the deletion loop") doesn't
+map to a real code location. The implementation will need to either:
+1. Add sync inside `execute_delete` (per-delete, option A above), or
+2. Restructure the executor to batch deletes (high-risk refactor for minimal gain).
+
+**Suggested fix:** Revise the design to place `sync_subvolumes` inside `execute_delete`,
+called after a successful `delete_subvolume` and before the space check. This is the
+minimal change that achieves correct space accounting.
+
+### S2 — Significant: `--help` probe runs under `sudo` unnecessarily
+
+**What:** The design's probe calls `Command::new("sudo").arg(btrfs_path).arg("send").arg("--help")`.
+The `btrfs send --help` command doesn't require root privileges — it just prints usage
+text and exits. Running it under sudo means:
+
+1. If the sudoers configuration requires a password (TTY prompt), the probe blocks or fails
+   at startup — before any backup logic runs.
+2. On systems with `sudo` rate-limiting or logging, this adds an unnecessary privileged
+   invocation.
+3. The probe happens at process startup, potentially before the user expects any sudo
+   interaction.
+
+**Consequence:** On misconfigured or partially-configured systems, the probe could cause
+a startup hang or confusing error before Urd has done anything useful. The fail-open
+`unwrap_or(false)` handles the error case, but a hung process waiting for a password
+prompt is not a graceful failure.
+
+**Suggested fix:** Run `btrfs send --help` without `sudo`. The help text is identical
+regardless of privileges. If `btrfs` isn't in PATH, the probe returns false — correct
+behavior. Keep sudo exclusively for actual btrfs operations as ADR-101 intends.
+
+### M1 — Moderate: Probe output assumption — stdout vs. stderr
+
+**What:** The design combines stdout and stderr: `let combined = [o.stdout, o.stderr].concat()`.
+This is defensive, but the comment "exits non-zero on older btrfs-progs" deserves
+verification. On modern btrfs-progs (5.x+), `btrfs send --help` exits 0 and prints to
+stdout. On very old versions, behavior varies. The design handles this correctly by
+combining both streams, but the `unwrap_or(false)` on the outer `map` already handles
+complete failure.
+
+**Suggested fix:** This is fine as-is. Just noting that the combined-stream approach is
+belt-and-suspenders — the code is correct, the comment could be more precise about which
+versions exhibit non-zero exit.
+
+### M2 — Moderate: `MockBtrfsCall::SendReceive` needs `compressed_data` field
+
+**What:** The design correctly notes that `MockBtrfsCall::SendReceive` should gain a
+`compressed_data: bool` field. However, the `BtrfsOps::send_receive` trait signature
+doesn't change — `compressed_data` is an internal implementation detail of `RealBtrfs`,
+not a trait parameter. The mock has no way to know whether the real implementation would
+have injected the flag.
+
+**Consequence:** The mock can't actually verify flag injection through the trait interface.
+Tests can only verify that `RealBtrfs` has the `supports_compressed_data` field set
+correctly. The flag injection itself is only testable via integration tests or by
+inspecting the `Command` — which is the existing pattern for all btrfs.rs tests.
+
+**Suggested fix:** Drop `compressed_data` from `MockBtrfsCall::SendReceive`. The mock
+tests should verify the probe logic (unit tests on `SystemBtrfs::probe` with crafted
+help text). The actual flag injection in `send_receive` is a 3-line conditional that
+follows the existing pattern — the risk of it being wrong is minimal and not worth
+complicating the mock interface.
+
+### C1 — Commendation: `SystemBtrfs` as a separate startup-only struct
+
+The decision to separate capability probing (`SystemBtrfs::probe`) from operation
+execution (`BtrfsOps` trait / `RealBtrfs`) is well-reasoned. The rejected alternatives
+(probe in constructor, probe in trait) are correctly identified as violations of existing
+conventions. This keeps the trait clean as an operation contract and puts I/O where
+callers can see it.
+
+### C2 — Commendation: Sync failure semantics
+
+The fail-open treatment of sync failure is exactly right. A failed sync leaves behavior
+identical to today's code (no sync at all). The ADR-107 analysis is precise: "not worse
+than today" is the correct bar for a fail-open decision. The log line at `warn!` level
+ensures visibility without blocking the run.
+
+### C3 — Commendation: No config knob for `--compressed-data`
+
+The rejection of a config flag is well-argued. Protocol v2 compressed sends are strictly
+better — there's no user-facing trade-off. Auto-detection via probe is the right UX:
+the user never needs to know this feature exists, and it activates automatically when
+the system supports it. This is "invisible worker" behavior at its best.
+
+## Also Noted
+
+- The `info!` vs `debug!` open question (OQ2): `debug!` is better. The flag's presence is
+  a system capability, not per-transfer context. Log at `info!` once during probe, `debug!`
+  per send.
+- Assumption 4 (sudoers covers `btrfs subvolume sync`): correct — the typical grant is
+  `NOPASSWD: /usr/bin/btrfs *`, which covers all subcommands.
+- The design says 013-b should be built first — agree, it's simpler and purely additive.
+
+## The Simplicity Question
+
+Nothing to cut. Both sub-items are minimal changes to existing patterns. The `SystemBtrfs`
+struct is the only new type, and it earns its keep by keeping the probe out of `RealBtrfs`.
+The design's scope discipline is good — it resists adding anything that isn't directly
+needed.
+
+If anything, the mock changes could be *simpler* than proposed (see M2) — dropping the
+`compressed_data` field from `MockBtrfsCall` removes complexity without losing meaningful
+test coverage.
+
+## For the Dev Team
+
+Priority-ordered action items for `/post-review`:
+
+1. **Revise 013-b sync placement.** The executor has no "deletion loop" to place the sync
+   after. Place `sync_subvolumes` inside `execute_delete`, after the successful
+   `delete_subvolume` call and before the space recheck (executor.rs:744-773). This makes
+   each delete self-contained: delete → sync → check space. Redundant syncs after the first
+   are near-instant (btrfs commits are already flushed).
+
+2. **Remove `sudo` from the `--help` probe.** Run `btrfs send --help` directly, not through
+   sudo. Help text doesn't require privileges and running it unprivileged avoids startup
+   hangs on misconfigured sudoers.
+
+3. **Drop `compressed_data` from `MockBtrfsCall::SendReceive`.** The trait interface doesn't
+   expose the flag — the mock can't meaningfully verify it. Test the probe logic directly
+   (crafted help text → `supports_compressed_data` bool) instead.
+
+4. **Log probe result at `info!`, per-send flag at `debug!`.** Log "compressed data
+   pass-through available" once at startup (info), "using --compressed-data" per send
+   (debug).
+
+## Open Questions
+
+1. **Is the per-delete sync overhead acceptable?** On a typical nightly run, retention
+   deletes 1-5 snapshots per subvolume. That's 1-5 sync calls, with the first doing real
+   work and the rest returning near-instantly. For the emergency space-recovery path
+   (potentially dozens of deletes), the overhead is higher but still bounded by real commit
+   time. Monitor after first production run. If the overhead is measurable, batch-sync can
+   be added later as an optimization — the per-delete approach is correct by construction.
+
+2. **Does `btrfs send --help` work without `sudo` on all target systems?** Almost certainly
+   yes — the help subcommand is client-side text rendering, not a privileged operation. But
+   worth a quick manual check on the production host before committing to the no-sudo probe.

--- a/src/btrfs.rs
+++ b/src/btrfs.rs
@@ -29,6 +29,49 @@ pub trait BtrfsOps {
     fn delete_subvolume(&self, path: &Path) -> crate::error::Result<()>;
     fn subvolume_exists(&self, path: &Path) -> bool;
     fn filesystem_free_bytes(&self, path: &Path) -> crate::error::Result<u64>;
+    fn sync_subvolumes(&self, path: &Path) -> crate::error::Result<()>;
+}
+
+// ── SystemBtrfs (startup-only capability probe) ────────────────────────
+
+/// Probes the system's btrfs-progs for capabilities at startup.
+/// Separate from `BtrfsOps` — the trait is for operations, not negotiation.
+pub struct SystemBtrfs {
+    pub supports_compressed_data: bool,
+}
+
+/// Check whether btrfs send help text contains `--compressed-data`.
+#[must_use]
+fn detect_compressed_data_support(output: &[u8]) -> bool {
+    String::from_utf8_lossy(output).contains("--compressed-data")
+}
+
+impl SystemBtrfs {
+    /// Probe btrfs-progs capabilities. Runs `btrfs send --help` without sudo
+    /// (help text doesn't require privileges). Safe to call at startup.
+    #[must_use]
+    pub fn probe(btrfs_path: &str) -> Self {
+        let supports = Command::new(btrfs_path)
+            .args(["send", "--help"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .map(|o| {
+                let combined = [o.stdout, o.stderr].concat();
+                detect_compressed_data_support(&combined)
+            })
+            .unwrap_or(false);
+
+        if supports {
+            log::info!("btrfs send: compressed data pass-through available");
+        } else {
+            log::info!("btrfs send: compressed data pass-through not available");
+        }
+
+        SystemBtrfs {
+            supports_compressed_data: supports,
+        }
+    }
 }
 
 // ── RealBtrfs ───────────────────────────────────────────────────────────
@@ -39,14 +82,16 @@ pub struct RealBtrfs {
     /// this to display transfer progress. Not part of the `BtrfsOps` trait —
     /// progress display is a presentation concern, not a correctness contract.
     bytes_counter: Arc<AtomicU64>,
+    supports_compressed_data: bool,
 }
 
 impl RealBtrfs {
     #[must_use]
-    pub fn new(btrfs_path: &str, bytes_counter: Arc<AtomicU64>) -> Self {
+    pub fn new(btrfs_path: &str, bytes_counter: Arc<AtomicU64>, supports_compressed_data: bool) -> Self {
         Self {
             btrfs_path: btrfs_path.to_string(),
             bytes_counter,
+            supports_compressed_data,
         }
     }
 }
@@ -101,6 +146,10 @@ impl BtrfsOps for RealBtrfs {
             .env("LC_ALL", "C")
             .arg(&self.btrfs_path)
             .arg("send");
+        if self.supports_compressed_data {
+            send_cmd.arg("--compressed-data");
+            log::debug!("btrfs send: using --compressed-data pass-through");
+        }
         if let Some(p) = parent {
             send_cmd.arg("-p").arg(p);
         }
@@ -324,6 +373,41 @@ impl BtrfsOps for RealBtrfs {
     fn filesystem_free_bytes(&self, path: &Path) -> crate::error::Result<u64> {
         crate::drives::filesystem_free_bytes(path)
     }
+
+    fn sync_subvolumes(&self, path: &Path) -> crate::error::Result<()> {
+        log::debug!(
+            "Running: sudo {} subvolume sync {}",
+            self.btrfs_path,
+            path.display()
+        );
+        let output = Command::new("sudo")
+            .env("LC_ALL", "C")
+            .arg(&self.btrfs_path)
+            .args(["subvolume", "sync"])
+            .arg(path)
+            .output()
+            .map_err(|e| UrdError::Btrfs {
+                context: BtrfsErrorContext {
+                    operation: BtrfsOperation::Sync,
+                    exit_code: None,
+                    stderr: format!("failed to spawn btrfs: {e}"),
+                    bytes_transferred: None,
+                },
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(UrdError::Btrfs {
+                context: BtrfsErrorContext {
+                    operation: BtrfsOperation::Sync,
+                    exit_code: output.status.code(),
+                    stderr,
+                    bytes_transferred: None,
+                },
+            });
+        }
+        Ok(())
+    }
 }
 
 // ── MockBtrfs ───────────────────────────────────────────────────────────
@@ -343,6 +427,9 @@ pub enum MockBtrfsCall {
     DeleteSubvolume {
         path: PathBuf,
     },
+    SyncSubvolumes {
+        path: PathBuf,
+    },
 }
 
 /// Mock implementation of `BtrfsOps` for testing.
@@ -353,6 +440,7 @@ pub struct MockBtrfs {
     pub fail_creates: RefCell<HashSet<PathBuf>>,
     pub fail_sends: RefCell<HashSet<PathBuf>>,
     pub fail_deletes: RefCell<HashSet<PathBuf>>,
+    pub fail_syncs: RefCell<HashSet<PathBuf>>,
     pub existing_subvolumes: RefCell<HashSet<PathBuf>>,
     pub free_bytes: RefCell<u64>,
     pub mock_bytes_transferred: RefCell<Option<u64>>,
@@ -369,6 +457,7 @@ impl MockBtrfs {
             fail_creates: RefCell::new(HashSet::new()),
             fail_sends: RefCell::new(HashSet::new()),
             fail_deletes: RefCell::new(HashSet::new()),
+            fail_syncs: RefCell::new(HashSet::new()),
             existing_subvolumes: RefCell::new(HashSet::new()),
             free_bytes: RefCell::new(1_000_000_000_000), // 1TB default
             mock_bytes_transferred: RefCell::new(None),
@@ -459,6 +548,25 @@ impl BtrfsOps for MockBtrfs {
 
     fn filesystem_free_bytes(&self, _path: &Path) -> crate::error::Result<u64> {
         Ok(*self.free_bytes.borrow())
+    }
+
+    fn sync_subvolumes(&self, path: &Path) -> crate::error::Result<()> {
+        self.calls
+            .borrow_mut()
+            .push(MockBtrfsCall::SyncSubvolumes {
+                path: path.to_path_buf(),
+            });
+        if self.fail_syncs.borrow().contains(path) {
+            return Err(UrdError::Btrfs {
+                context: BtrfsErrorContext {
+                    operation: BtrfsOperation::Sync,
+                    exit_code: Some(1),
+                    stderr: format!("mock: sync failed for {}", path.display()),
+                    bytes_transferred: None,
+                },
+            });
+        }
+        Ok(())
     }
 }
 
@@ -575,5 +683,45 @@ mod tests {
 
         let result = mock.delete_subvolume(&path);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn mock_sync_records_call() {
+        let mock = MockBtrfs::new();
+        let path = PathBuf::from("/snap/home");
+
+        mock.sync_subvolumes(&path).unwrap();
+
+        let calls = mock.calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], MockBtrfsCall::SyncSubvolumes { path });
+    }
+
+    #[test]
+    fn probe_detects_compressed_data_in_help() {
+        let help = b"Usage: btrfs send [-e] [-p parent] [-c clone-src] [--compressed-data] <subvol> [<subvol>...]";
+        assert!(detect_compressed_data_support(help));
+    }
+
+    #[test]
+    fn probe_returns_false_when_flag_absent() {
+        let help = b"Usage: btrfs send [-e] [-p parent] [-c clone-src] <subvol> [<subvol>...]";
+        assert!(!detect_compressed_data_support(help));
+    }
+
+    #[test]
+    fn probe_returns_false_on_empty_output() {
+        assert!(!detect_compressed_data_support(b""));
+    }
+
+    #[test]
+    fn mock_sync_failure_injection() {
+        let mock = MockBtrfs::new();
+        let path = PathBuf::from("/snap/home");
+        mock.fail_syncs.borrow_mut().insert(path.clone());
+
+        let result = mock.sync_subvolumes(&path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("mock: sync failed"));
     }
 }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -148,7 +148,8 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 
     // Set up executor with live byte counter for progress display
     let bytes_counter = Arc::new(AtomicU64::new(0));
-    let btrfs = RealBtrfs::new(&config.general.btrfs_path, bytes_counter.clone());
+    let sys = crate::btrfs::SystemBtrfs::probe(&config.general.btrfs_path);
+    let btrfs = RealBtrfs::new(&config.general.btrfs_path, bytes_counter.clone(), sys.supports_compressed_data);
 
     let mut executor = Executor::new(&btrfs, state_db.as_ref(), &config, &shutdown);
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -397,6 +397,13 @@ fn handle_incomplete_deletions(
         "Potentially incomplete snapshots on external drives:".bold()
     );
 
+    let sys = crate::btrfs::SystemBtrfs::probe(&config.general.btrfs_path);
+    let btrfs = RealBtrfs::new(
+        &config.general.btrfs_path,
+        std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        sys.supports_compressed_data,
+    );
+
     for inc in incompletes {
         println!(
             "  {} {} on {} (not pinned, may be from interrupted transfer)",
@@ -411,10 +418,6 @@ fn handle_incomplete_deletions(
         let mut input = String::new();
         std::io::stdin().read_line(&mut input)?;
         if input.trim().eq_ignore_ascii_case("y") {
-            let btrfs = RealBtrfs::new(
-                &config.general.btrfs_path,
-                std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            );
             let path = std::path::Path::new(&inc.path);
             match btrfs.delete_subvolume(path) {
                 Ok(()) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ pub enum BtrfsOperation {
     Send,
     Receive,
     Delete,
+    Sync,
 }
 
 impl fmt::Display for BtrfsOperation {
@@ -20,6 +21,7 @@ impl fmt::Display for BtrfsOperation {
             Self::Send => write!(f, "send"),
             Self::Receive => write!(f, "receive"),
             Self::Delete => write!(f, "delete"),
+            Self::Sync => write!(f, "sync"),
         }
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -743,6 +743,17 @@ impl<'a> Executor<'a> {
 
         match self.btrfs.delete_subvolume(path) {
             Ok(()) => {
+                // Sync pending deletions so freed space is visible to the space check.
+                // Fail-open (ADR-107): sync failure leaves behavior identical to today.
+                if let Some(snapshot_root) = path.parent()
+                    && let Err(e) = self.btrfs.sync_subvolumes(snapshot_root)
+                {
+                    log::warn!(
+                        "btrfs subvolume sync failed for {}: {e} — space check may be pessimistic",
+                        snapshot_root.display()
+                    );
+                }
+
                 // After deletion, check if min_free_bytes is now satisfied.
                 // Applies to both external drives and local snapshot roots.
                 if let Some(ref key) = recovery_key {
@@ -1172,10 +1183,11 @@ source = "/data/b"
         assert_eq!(result.subvolume_results[0].send_type, SendType::Incremental);
 
         let calls = mock.calls();
-        assert_eq!(calls.len(), 3);
+        assert_eq!(calls.len(), 4);
         assert!(matches!(calls[0], MockBtrfsCall::CreateSnapshot { .. }));
         assert!(matches!(calls[1], MockBtrfsCall::SendReceive { .. }));
         assert!(matches!(calls[2], MockBtrfsCall::DeleteSubvolume { .. }));
+        assert!(matches!(calls[3], MockBtrfsCall::SyncSubvolumes { .. }));
     }
 
     #[test]
@@ -2792,6 +2804,138 @@ local_retention = "transient"
         assert!(!calls.iter().any(|c| matches!(
             c,
             MockBtrfsCall::DeleteSubvolume { path } if *path == old_parent,
+        )));
+    }
+
+    #[test]
+    fn sync_called_after_delete() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/snap/sv-a/20260301-a"),
+                    reason: "expired".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/snap/sv-a/20260302-a"),
+                    reason: "expired".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        executor.execute(&plan, "full");
+
+        // Verify: Delete → Sync → Delete → Sync
+        let calls = mock.calls();
+        let relevant: Vec<_> = calls
+            .iter()
+            .filter(|c| {
+                matches!(
+                    c,
+                    MockBtrfsCall::DeleteSubvolume { .. } | MockBtrfsCall::SyncSubvolumes { .. }
+                )
+            })
+            .collect();
+        assert_eq!(relevant.len(), 4);
+        assert!(matches!(
+            relevant[0],
+            MockBtrfsCall::DeleteSubvolume { path } if *path == PathBuf::from("/snap/sv-a/20260301-a")
+        ));
+        assert!(matches!(
+            relevant[1],
+            MockBtrfsCall::SyncSubvolumes { path } if *path == PathBuf::from("/snap/sv-a")
+        ));
+        assert!(matches!(
+            relevant[2],
+            MockBtrfsCall::DeleteSubvolume { path } if *path == PathBuf::from("/snap/sv-a/20260302-a")
+        ));
+        assert!(matches!(
+            relevant[3],
+            MockBtrfsCall::SyncSubvolumes { path } if *path == PathBuf::from("/snap/sv-a")
+        ));
+    }
+
+    #[test]
+    fn sync_failure_does_not_abort_run() {
+        let mock = MockBtrfs::new();
+        // Fail sync for the snapshot root
+        mock.fail_syncs
+            .borrow_mut()
+            .insert(PathBuf::from("/snap/sv-a"));
+
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/snap/sv-a/20260301-a"),
+                    reason: "expired".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/a"),
+                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    subvolume_name: "sv-a".to_string(),
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        // Both delete and create succeed despite sync failure
+        let sv = &result.subvolume_results[0];
+        assert_eq!(sv.operations[0].result, OpResult::Success); // delete
+        assert_eq!(sv.operations[1].result, OpResult::Success); // create
+    }
+
+    #[test]
+    fn sync_called_for_external_deletes() {
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::DeleteSnapshot {
+                path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260301-a"),
+                reason: "expired".to_string(),
+                subvolume_name: "sv-a".to_string(),
+            }],
+            timestamp: ts,
+            skipped: vec![],
+        };
+
+        executor.execute(&plan, "full");
+
+        // Sync should be called on the external snapshot root
+        let calls = mock.calls();
+        assert!(calls.iter().any(|c| matches!(
+            c,
+            MockBtrfsCall::SyncSubvolumes { path } if *path == PathBuf::from("/mnt/test/.snapshots/sv-a")
         )));
     }
 }


### PR DESCRIPTION
## Summary

- **013-a:** Auto-detect `--compressed-data` support at startup via `btrfs send --help` probe (no sudo). Protocol v2 sends preserve compression and reduce CPU — no config knob, strictly better when available.
- **013-b:** `btrfs subvolume sync` after each retention delete ensures freed space is visible before the space check that gates the next snapshot. Fail-open per ADR-107.
- `SystemBtrfs` probe struct separates capability detection from `BtrfsOps` operations trait.
- Simplify pass: hoisted probe out of per-deletion loop in init.rs, fixed garbled Unicode in comment.

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 879 tests, all pass (+8 new)
- cargo build --release: pass
- Integration tests: not applicable (requires real btrfs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)