### PR TITLE
feat: external-only runtime experience (UPI 018)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SendType::Deferred` (Prometheus metric value 3): distinguishes intentional no-send from blocked-by-gate deferral
 - Deferred synthesis in backup summary: subvolumes with no local snapshots to send now surface actionable guidance instead of silent skips
 - `SkipCategory::NoSnapshotsAvailable` for structured classification of send-blocked skips
+- External-only runtime: subvolumes with `local_snapshots = false` no longer show false "degraded" health or "broken chain" warnings — status table shows em-dash for LOCAL and "ext-only" for THREAD, plan output uses `[EXT]` skip tag
 
 ### Fixed
 - False "all chains broke simultaneously" anomaly when a drive disconnects (total=0 was treated as all-broken)

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -8,12 +8,12 @@
 | 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | merged | [#84](https://github.com/vonrobak/urd/pull/84) |
 | 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | merged | [#85](https://github.com/vonrobak/urd/pull/85) |
 | 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | merged | [#83](https://github.com/vonrobak/urd/pull/83) |
-| 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | - | - | - |
+| 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | [adversary](../99-reports/2026-04-05-review-adversary-018-external-only-runtime.md) | - | - |
 | 017 | Thread lineage visualization | [design](../95-ideas/2026-04-03-design-017-thread-lineage-visualization.md) | - | - | - | - |
 | 016 | Emergency space response | [design](../95-ideas/2026-04-03-design-016-emergency-space-response.md) | - | - | - | - |
 | 015 | Change preview in `urd get` | [design](../95-ideas/2026-04-03-design-015-get-change-preview.md) | - | - | - | - |
 | 014 | Skip unchanged subvolumes | [design](../95-ideas/2026-04-03-design-014-skip-unchanged-subvolumes.md) | - | - | - | - |
-| 013 | Btrfs pipeline improvements | [design](../95-ideas/2026-04-03-design-013-btrfs-pipeline-improvements.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-013-btrfs-pipeline-improvements.md) | - | - |
+| 013 | Btrfs pipeline improvements | [design](../95-ideas/2026-04-03-design-013-btrfs-pipeline-improvements.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-013-btrfs-pipeline-improvements.md) | merged | [#86](https://github.com/vonrobak/urd/pull/86) |
 | 012 | Sentinel drive-gated transient + space monitoring | [design](../95-ideas/2026-04-03-design-012-sentinel-drive-gated-transient.md) | - | - | - | - |
 | 011 | Transient space safety (emergency fix) | [design](../95-ideas/2026-04-03-design-011-transient-space-safety.md) | [steve](../99-reports/2026-04-03-steve-jobs-011-transient-is-a-lie.md) | - | - | - |
 | 010-a | Transient as first-class config concept | [design](../95-ideas/2026-04-03-design-010a-transient-as-first-class-config.md) | [steve](../99-reports/2026-04-03-steve-jobs-010a-boolean-beats-jargon.md) | [adversary](../99-reports/2026-04-03-review-adversary-010a-local-snapshots-boolean.md) | merged | [#80](https://github.com/vonrobak/urd/pull/80) |

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -9,17 +9,18 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-871 tests, all passing, clippy clean. Current version: v0.10.0.
+879 tests, all passing, clippy clean. Current version: v0.10.0.
 
-**UPI 020 complete.** Context-aware suggestions: `compute_advice()` pure function in
-awareness.rs replaces static lookup tables. Doctor, status, and bare `urd` now show
-specific commands based on chain health, drive state, and subvolume config. PR #85 merged.
+**UPI 013 complete.** Compressed send pass-through (`--compressed-data` auto-detected at
+startup, no config knob) and post-delete sync (`btrfs subvolume sync` after each retention
+delete for accurate space accounting). PR #86 merged.
 
 **Deployment notes:**
 - v0.10.0 tagged but not yet pushed/installed
 - After install: hand-edit production config `local_retention = "transient"` →
   `local_snapshots = false` before next timer run
 - UPI 021 fix means sentinel will pick up the config change automatically after install
+- Pre-deploy check for 013: run `btrfs send --help` as unprivileged user to verify no-sudo probe
 
 ## In Progress
 
@@ -27,21 +28,21 @@ Nothing active.
 
 ## Recently Completed
 
-**UPI 020: The Doctor Knows** (2026-04-04)
-   - `ActionableAdvice` struct + 8-branch decision tree in awareness.rs
-   - Doctor shows chain-break reasons and `--force-full` when appropriate
-   - Status/default show inline fix commands or "run urd doctor" for multiple issues
-   - `external_only` flag uses send age for transient subvolumes
-   - 17 new tests, simplify pass fixed 3 issues
+**UPI 013: Btrfs Pipeline Improvements** (2026-04-05)
+   - 013-a: `SystemBtrfs::probe()` detects `--compressed-data` support, `RealBtrfs` injects flag
+   - 013-b: Per-delete `sync_subvolumes` in executor, fail-open (ADR-107)
+   - Simplify pass: hoisted probe out of loop in init.rs
+   - 8 new tests
 
 ## Next Up
 
 **Immediate: Push v0.10.0 and deploy** (see session journal for verification steps)
 
 **Then sequential (Phase E: Make the invisible worker smart):**
-1. **E1: UPI 013** — Btrfs pipeline (compressed sends, sync after delete) ~0.25 session
-2. **E2: UPI 018** — External-only runtime (fix false degraded/broken for local_snapshots=false) ~0.5 session
-3. **E4: UPI 014** — Skip unchanged subvolumes ~0.5 session
+1. **E2: UPI 018** — External-only runtime (fix false degraded/broken for local_snapshots=false) ~0.5 session
+2. **E4: UPI 014** — Skip unchanged subvolumes ~0.5 session
+
+**9 unreleased changes in CHANGELOG.md — consider `/release` soon.**
 
 ## Key Links
 

--- a/docs/99-reports/2026-04-05-review-adversary-018-external-only-runtime.md
+++ b/docs/99-reports/2026-04-05-review-adversary-018-external-only-runtime.md
@@ -1,0 +1,279 @@
+---
+upi: "018"
+date: 2026-04-05
+---
+
+# Architectural Adversary Review: External-Only Runtime Experience (UPI 018)
+
+**Scope:** Design review of `docs/97-plans/2026-04-05-plan-018-external-only-runtime.md`
+**Design:** `docs/95-ideas/2026-04-03-design-018-external-only-runtime.md`
+**Reviewer:** arch-adversary
+**Commit:** 6c79b73 (master)
+
+## Executive Summary
+
+A well-scoped, low-risk UX fix that makes `local_snapshots = false` a first-class runtime
+mode. The plan corrects a real problem (false degraded health causing user anxiety for a
+correctly configured subvolume) with minimal machinery. The architecture note catching
+`NoPinFile` vs `PinMissingLocally` is a genuine save — the design would have shipped with
+a bug for the common case. One significant finding on the space-check path, one moderate
+finding on sentinel health transitions, and a commendation for the skip-reason design.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — deleting snapshots that shouldn't be
+deleted, or failing to create backups without the user knowing.
+
+**Distance from this plan:** Far. UPI 018 touches the health *display* model and rendering
+pipeline. It does not modify retention, deletion, pin protection, or the executor's send/
+delete paths. The only mutation to backup-critical logic is in `compute_health()`, which
+affects `OperationalHealth` (informational), not `PromiseStatus` (the protection guarantee).
+A bug in this plan could make a subvolume *look* healthier than it is, but cannot cause
+data loss or prevent backups.
+
+**Nearest danger:** If `is_transient` were incorrectly set to `true` for a non-transient
+subvolume, `compute_health()` would suppress a real chain-break degradation. The user
+would see "healthy" when their chain is actually broken, and wouldn't know to investigate.
+This is cosmetic harm (misleading status), not data harm (the backup still runs, just as a
+full send). Distance: two bugs (wrong `is_transient` + user doesn't notice the full send
+in backup output).
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| Correctness | 4 | Sound approach; `NoPinFile` catch is critical. One gap in space-check path. |
+| Security | 5 | No privilege boundaries crossed. No path construction. No new inputs. |
+| Architecture | 4 | Respects all module boundaries. `external_only` plumbed through output struct, not leaked into awareness. |
+| Systems Design | 4 | Sentinel transition effect is acknowledged but untested. Otherwise thorough. |
+
+## Design Tensions
+
+### 1. Health model truthfulness vs. user experience
+
+**Trade-off:** The chain IS broken (physically, the next send will be full). The plan
+suppresses the degradation signal for a specific reason+config combination, making the
+health model less honest about physical state in exchange for less anxiety about an expected
+condition.
+
+**Resolution:** Correct. The design document's rejected alternative ("make `assess_chain_health()`
+return `Intact`") would have been the wrong place — that function should remain honest about
+physical state. Moving the exception to `compute_health()` (which interprets physical state as
+operational concern) is the right layer. The chain assessment says "chain is broken," the health
+model says "but that's fine for this config." Two separate judgments at two separate layers.
+
+### 2. Boolean parameter vs. richer type
+
+**Trade-off:** `is_transient: bool` is the 8th parameter to `compute_health()`. This is
+debt. The function already has 7 parameters and status.md notes "parameter limit approaching
+10 — pass `&PlanFilters`." Adding another bool pushes closer to that limit.
+
+**Resolution:** Acceptable for now. The plan correctly identifies `is_transient: bool` as
+minimal. A `SubvolumeMode` enum or `&PlanFilters` struct would be cleaner but is a larger
+refactor that belongs in a dedicated cleanup pass. The debt is documented.
+
+### 3. Two skip reason strings vs. runtime classification
+
+**Trade-off:** The plan changes the skip reason string at the source (`plan.rs`) for
+transient subvolumes, rather than classifying the same string differently downstream.
+
+**Resolution:** Good call. The architecture note explains it well: classification in
+`from_reason()` happens without config context, so trying to distinguish "no local snapshots
+because transient" from "no local snapshots because something went wrong" would require
+either passing config through the classification boundary or doing string-based heuristics.
+Changing the source string is cleaner.
+
+## Findings
+
+### Finding 1: Space-check `chain_broken` also fires on `NoPinFile` for transient (Significant)
+
+**What:** In `compute_health()` lines 823-826, the space-estimation logic checks if the
+chain is broken:
+
+```rust
+let chain_broken = chain_health
+    .iter()
+    .any(|ch| ch.drive_label == da.drive_label
+        && matches!(&ch.status, ChainStatus::Broken { reason, .. }
+            if *reason != ChainBreakReason::NoDriveData));
+```
+
+For a transient subvolume, this evaluates to `true` (because `NoPinFile` ≠ `NoDriveData`).
+The `chain_broken` variable then affects the space estimation path at line 832:
+
+```rust
+None if chain_broken => {
+    // Chain broken (full send needed) but no size estimate —
+    // can't verify space. Fail open but surface the uncertainty.
+    all_space_blocked = false;
+}
+```
+
+Currently this is fail-open (sets `all_space_blocked = false`), so it's not harmful — but
+it means the space-check logic thinks a full send is needed when really an incremental is
+expected. If this code path ever becomes more sophisticated (e.g., using full-send size
+estimates for space checking), the incorrect `chain_broken = true` for transient subvolumes
+would produce wrong space estimates.
+
+**Consequence today:** None. Fail-open means no behavior change. But the `chain_broken`
+variable carries a false signal for transient subvolumes, and the "full send size unknown"
+reason string (lines 862-871) would also fire for transient subvolumes, adding a misleading
+health reason.
+
+Wait — lines 862-871 are inside the chain-broken degradation loop that the plan IS fixing.
+Let me re-read... Yes, the plan's `continue` in the degradation loop (lines 850-873) means
+the "full send size unknown" reason is also suppressed. Good. But the space-check
+`chain_broken` at line 824 is a separate code path that runs BEFORE the degradation loop.
+
+**Suggested fix:** Apply the same `is_transient` exception to the `chain_broken` check at
+line 824:
+
+```rust
+let chain_broken = chain_health.iter().any(|ch| {
+    ch.drive_label == da.drive_label
+        && matches!(&ch.status, ChainStatus::Broken { reason, .. }
+            if *reason != ChainBreakReason::NoDriveData
+                && !(is_transient
+                    && (*reason == ChainBreakReason::NoPinFile
+                        || *reason == ChainBreakReason::PinMissingLocally)))
+});
+```
+
+Or more readably, extract a helper `fn is_expected_transient_break(is_transient: bool,
+reason: &ChainBreakReason) -> bool` and use it in both locations.
+
+### Finding 2: Sentinel health transition on deploy (Moderate)
+
+**What:** When UPI 018 is deployed with the sentinel running, the first assessment tick
+after deploy will produce `OperationalHealth::Healthy` for `htpc-root`, where the previous
+tick stored `OperationalHealth::Degraded` in `last_health_states`. This triggers
+`has_health_changes()` → `build_health_notifications()` → a `HealthRecovered` notification.
+
+**Consequence:** The user gets a notification saying `htpc-root` health recovered from
+"degraded" to "healthy" — which is technically true but misleading. Nothing changed in the
+real world; only the health model got smarter. For a single subvolume this is cosmetic. But
+if multiple external-only subvolumes exist, the user gets a notification storm of false
+recoveries.
+
+**Suggested fix:** This is a known pattern in any monitoring system (deploy causes metric
+discontinuity). Options:
+
+- **Accept it** — document in the plan that deploy will produce one recovery notification
+  per external-only subvolume. For a single htpc-root, this is fine.
+- **Suppress first-tick transitions on sentinel restart** — but the sentinel already handles
+  this (`has_initial_assessment` guard). The issue is mid-run code change, not restart.
+
+Recommendation: Accept and document. This is a one-time event, not recurring. Add a note to
+the plan's risk flags.
+
+### Finding 3: `external_only` condition inconsistency between awareness and status (Moderate)
+
+**What:** The plan uses two different conditions for "external-only":
+
+- **Step 2 (awareness.rs):** `is_transient` (just `local_retention.is_transient()`) — no
+  check for `send_enabled`.
+- **Step 3 (commands/status.rs):** `is_transient() && send_enabled` — requires both.
+
+This means a transient subvolume with `send_enabled = false` would:
+- Get the health model relaxation (Step 2) — `NoPinFile` chain break suppressed
+- NOT get the `external_only = true` flag (Step 3) — still shows "0" in LOCAL, full chain
+  break rendering in THREAD
+
+The health model says "healthy" but the status table still shows broken chain status. This
+is arguably correct (transient + no sends = useless config, already UNPROTECTED by line 521)
+but the inconsistency is confusing: why would a "healthy" subvolume show a broken chain?
+
+**Consequence:** Edge case. Transient + no sends is already flagged by preflight as a
+misconfiguration. But the inconsistency between health model and display could confuse a
+user debugging config issues.
+
+**Suggested fix:** Make the awareness check match: `is_transient && send_enabled`. A
+transient subvolume without sends has no chain health to relax — it has no drives to check
+chains against. This aligns the conditions and makes the code self-documenting. The
+`send_enabled` early return at line 790 already covers this (`compute_health` returns
+early before reaching the chain-break loop), so this may be a non-issue in practice —
+verify by tracing the code path.
+
+### Finding 4: `NoSnapshotsAvailable` becomes dead category for transient (Minor)
+
+**What:** After Step 6, transient subvolumes emit `"external-only — sends on next backup"`
+(→ `ExternalOnly`), and non-transient subvolumes emit `"no local snapshots to send"`
+(→ `NoSnapshotsAvailable`). The `NoSnapshotsAvailable` category was added in UPI 019 for
+the deferred-send reporting pipeline.
+
+In practice, a non-transient subvolume with zero local snapshots is an unusual state (only
+if ALL snapshots were deleted externally or on first run before any snapshot). This means
+`NoSnapshotsAvailable` is now a very rare category — it's not dead, but it's edge-case only.
+
+**Consequence:** None. The code is correct. Just noting that `NoSnapshotsAvailable` vs
+`ExternalOnly` might be confusing for future maintainers who see two "no snapshots" categories.
+
+**Suggested fix:** Add a one-line comment to `NoSnapshotsAvailable` in `output.rs`:
+`/// Genuinely unexpected: non-transient subvolume with zero local snapshots.`
+
+### Commendation: NoPinFile discovery
+
+The architecture note catching that external-only subvolumes produce `NoPinFile` (not
+`PinMissingLocally`) is the kind of codebase investigation that prevents a subtle bug. The
+design document was wrong about this — it assumed `PinMissingLocally` was the common case.
+The plan's exploration traced the actual code path (`assess_chain_health` line 751:
+`Ok(None)` → `NoPinFile`) and correctly identified that both reasons need exemption. Without
+this catch, the deployed fix would have only handled the edge case and missed the common
+case entirely — external-only subvolumes would still show as degraded.
+
+### Commendation: Skip reason at the source
+
+Changing the skip reason string in `plan.rs` rather than adding classification heuristics
+in `from_reason()` is the right design. It keeps the classification layer dumb (exact string
+match) and puts the knowledge about why a skip happened where the skip decision is made
+(the planner, which has config context). This follows the existing pattern where other skip
+reasons are descriptive strings that classify cleanly.
+
+## The Simplicity Question
+
+**What's earning its keep:** Everything. The plan adds one bool field to a struct, one enum
+variant, one parameter to a function, and rendering branches gated by the new flag. No new
+modules, no new abstractions, no new traits. This is the minimum machinery to fix the
+problem.
+
+**What could be simpler:** Nothing obvious. The plan is already lean. If anything, the
+`render_external_only_group()` function in Step 6 could be eliminated by making
+`ExternalOnly` use the same rendering path as `LocalOnly` (the bodies are identical
+modulo label text) — extract a shared `render_named_group(tag, label, items)` helper.
+But this is polish, not simplification.
+
+## For the Dev Team
+
+Priority order:
+
+1. **Step 2 — also fix the space-check `chain_broken` (Finding 1).** In `compute_health()`,
+   the `chain_broken` variable at line 824 should also exclude `NoPinFile`/`PinMissingLocally`
+   for transient subvolumes. Add the `is_transient` parameter to this check. Consider
+   extracting a small helper: `fn is_expected_transient_break(...)` used in both the
+   space-check and the degradation loop. Add one test:
+   `external_only_space_check_treats_chain_as_intact`.
+
+2. **Step 2 — verify `send_enabled` early return (Finding 3).** Trace whether a transient +
+   `send_enabled = false` subvolume can reach the chain-break loop in `compute_health()`.
+   Line 790 returns early when `!send_enabled`, so the `is_transient` check likely never
+   fires for that case. If confirmed, document this in the plan as a "doesn't matter because
+   of the early return" note, and the inconsistency is resolved.
+
+3. **Risk flags — add deploy notification note (Finding 2).** Add to risk flags: "First
+   sentinel tick after deploy will emit a HealthRecovered notification for htpc-root
+   (Degraded → Healthy). One-time event, not recurring. No action needed."
+
+4. **Step 1 — clarify `NoSnapshotsAvailable` comment (Finding 4).** Update the doc comment
+   to clarify when this category fires vs. `ExternalOnly`.
+
+## Open Questions
+
+1. **Does `compute_health()` early-return at line 790 prevent the `is_transient` check from
+   ever firing for `send_enabled = false` subvolumes?** I believe yes (the function returns
+   before reaching the chain-break loop), but the plan should confirm this by tracing the
+   code path. If confirmed, Finding 3 is a non-issue.
+
+2. **Are there other consumers of `OperationalHealth` besides status rendering, bare `urd`,
+   and sentinel health transitions?** If heartbeat.rs or metrics.rs serialize the health
+   value, the transition from Degraded → Healthy would also appear there. This is correct
+   behavior (the health model improved), but worth noting for monitoring dashboard consumers.

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -547,6 +547,7 @@ pub fn assess(
             fs,
             &subvol.name,
             local_space_tight.is_some(),
+            subvol.local_retention.is_transient(),
         );
 
         assessments.push(SubvolAssessment {
@@ -765,10 +766,21 @@ fn assess_chain_health(
     }
 }
 
+/// Whether a chain break is expected and non-actionable for this subvolume.
+/// External-only subvolumes never have local pin files (NoPinFile) or may
+/// have leftover pins from a previous config (PinMissingLocally). Both are
+/// by-design, not problems.
+fn is_expected_chain_break(is_transient: bool, reason: &ChainBreakReason) -> bool {
+    is_transient
+        && (*reason == ChainBreakReason::NoPinFile
+            || *reason == ChainBreakReason::PinMissingLocally)
+}
+
 /// Compute operational health for a subvolume.
 ///
 /// Pure function: chain health + drive state + space info in, health out.
 /// Checks (in priority order): blocked conditions, then degraded conditions.
+#[allow(clippy::too_many_arguments)]
 fn compute_health(
     send_enabled: bool,
     chain_health: &[DriveChainHealth],
@@ -777,6 +789,7 @@ fn compute_health(
     fs: &dyn FileSystemState,
     subvol_name: &str,
     local_space_tight: bool,
+    is_transient: bool,
 ) -> (OperationalHealth, Vec<String>) {
     let mut reasons: Vec<String> = Vec::new();
     let mut worst = OperationalHealth::Healthy;
@@ -821,9 +834,12 @@ fn compute_health(
                 .or_else(|| fs.last_send_size(subvol_name, &da.drive_label, "full"));
 
             // Check if chain is broken on this drive (full send will be needed)
-            let chain_broken = chain_health
-                .iter()
-                .any(|ch| ch.drive_label == da.drive_label && matches!(&ch.status, ChainStatus::Broken { reason, .. } if *reason != ChainBreakReason::NoDriveData));
+            let chain_broken = chain_health.iter().any(|ch| {
+                ch.drive_label == da.drive_label
+                    && matches!(&ch.status, ChainStatus::Broken { reason, .. }
+                        if *reason != ChainBreakReason::NoDriveData
+                            && !is_expected_chain_break(is_transient, reason))
+            });
 
             match est_size {
                 Some(size) if free.saturating_sub(min_free) < size => {
@@ -851,6 +867,7 @@ fn compute_health(
     for ch in chain_health {
         if let ChainStatus::Broken { reason, .. } = &ch.status
             && *reason != ChainBreakReason::NoDriveData
+            && !is_expected_chain_break(is_transient, reason)
         {
             reasons.push(format!(
                 "chain broken on {} \u{2014} next send will be full",
@@ -1094,7 +1111,7 @@ pub fn compute_redundancy_advisories(
                     subvolume: assessment.name.clone(),
                     drive: None,
                     detail: format!(
-                        "{} lives only on external drives while local copies are transient",
+                        "{} lives only on external drives \u{2014} local snapshots are disabled",
                         assessment.name,
                     ),
                 });
@@ -2988,7 +3005,173 @@ send_enabled = false
         assert_eq!(results[0].status, PromiseStatus::Unprotected);
     }
 
-    // ── Offsite freshness overlay tests ─────────────────────────────
+    // ── External-only health model tests (UPI 018) ���────────────────
+
+    #[test]
+    fn external_only_no_pin_file_is_healthy() {
+        let config = transient_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // Mounted drive with external snapshots, no pin file (expected for transient)
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv-transient".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "svt")],
+        );
+        fs.send_times.insert(
+            ("sv-transient".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(
+            results[0].health,
+            OperationalHealth::Healthy,
+            "transient subvol with NoPinFile should be Healthy, got: {:?}",
+            results[0].health_reasons
+        );
+    }
+
+    #[test]
+    fn external_only_pin_missing_locally_is_healthy() {
+        let config = transient_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // Mounted drive with external snapshots, pin file exists but parent missing locally
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv-transient".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "svt")],
+        );
+        fs.send_times.insert(
+            ("sv-transient".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        // Pin file references a snapshot that's been cleaned up (transient)
+        let local_dir = std::path::PathBuf::from("/snap/sv-transient");
+        fs.pin_files.insert(
+            (local_dir, "WD-18TB".to_string()),
+            snap(dt(2026, 3, 23, 10, 0), "svt"),
+        );
+        // No local snapshots (parent missing locally)
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(
+            results[0].health,
+            OperationalHealth::Healthy,
+            "transient subvol with PinMissingLocally should be Healthy, got: {:?}",
+            results[0].health_reasons
+        );
+    }
+
+    #[test]
+    fn external_only_pin_missing_on_drive_still_degrades() {
+        let config = transient_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // Local snapshot exists so pin can be checked
+        let parent = snap(dt(2026, 3, 23, 13, 30), "svt");
+        fs.local_snapshots.insert(
+            "sv-transient".to_string(),
+            vec![parent.clone()],
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv-transient".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "svt")],
+        );
+        fs.send_times.insert(
+            ("sv-transient".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        // Pin file references snapshot present locally but missing on drive
+        let local_dir = std::path::PathBuf::from("/snap/sv-transient");
+        fs.pin_files.insert(
+            (local_dir, "WD-18TB".to_string()),
+            parent,
+        );
+        // Parent snapshot is in local list (added above) but NOT in external list
+        // This triggers PinMissingOnDrive — a real problem even for transient
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(
+            results[0].health,
+            OperationalHealth::Degraded,
+            "PinMissingOnDrive should still degrade transient subvols"
+        );
+    }
+
+    #[test]
+    fn non_transient_no_pin_file_still_degrades() {
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv1".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "sv1")],
+        );
+        // No pin file — chain broken for non-transient
+        fs.send_times.insert(
+            ("sv1".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(
+            results[0].health,
+            OperationalHealth::Degraded,
+            "NoPinFile should still degrade non-transient subvols"
+        );
+    }
+
+    #[test]
+    fn external_only_space_check_treats_chain_as_intact() {
+        let config = transient_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv-transient".to_string()),
+            vec![snap(dt(2026, 3, 23, 12, 0), "svt")],
+        );
+        fs.send_times.insert(
+            ("sv-transient".to_string(), "WD-18TB".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        // No pin file (NoPinFile) — but transient so should be treated as intact
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        // Should not contain "full send size unknown" — chain treated as intact for transient
+        assert!(
+            !results[0]
+                .health_reasons
+                .iter()
+                .any(|r| r.contains("full send size unknown")),
+            "transient subvol should not report full send size unknown for NoPinFile"
+        );
+    }
+
+    // ── Offsite freshness overlay tests ─��───────────────────────────
 
     fn fortified_config() -> Config {
         let toml_str = r#"
@@ -3610,6 +3793,37 @@ local_retention = "transient"
             !advisories.iter().any(|a| a.kind
                 == crate::output::RedundancyAdvisoryKind::TransientNoLocalRecovery),
             "mounted drive should prevent transient advisory: {advisories:?}"
+        );
+    }
+
+    #[test]
+    fn advisory_transient_no_recovery_uses_disabled_vocabulary() {
+        let config = transient_single_drive_config();
+        let now = dt(2026, 4, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
+        fs.send_times.insert(
+            ("sv1".to_string(), "ext-drive".to_string()),
+            dt(2026, 3, 30, 12, 0),
+        );
+
+        let assessments = assess(&config, now, &fs);
+        let advisories = compute_redundancy_advisories(&config, &assessments);
+
+        let advisory = advisories
+            .iter()
+            .find(|a| a.kind == crate::output::RedundancyAdvisoryKind::TransientNoLocalRecovery)
+            .expect("should have TransientNoLocalRecovery advisory");
+        assert!(
+            advisory.detail.contains("local snapshots are disabled"),
+            "advisory should say 'local snapshots are disabled', got: {}",
+            advisory.detail
+        );
+        assert!(
+            !advisory.detail.contains("transient"),
+            "advisory should not expose 'transient' vocabulary, got: {}",
+            advisory.detail
         );
     }
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -624,7 +624,7 @@ fn build_empty_plan_explanation(
             SkipCategory::SpaceExceeded => has_space = true,
             SkipCategory::DriveNotMounted => has_not_mounted = true,
             SkipCategory::IntervalNotElapsed => has_interval = true,
-            SkipCategory::NoSnapshotsAvailable | SkipCategory::Other => {}
+            SkipCategory::NoSnapshotsAvailable | SkipCategory::ExternalOnly | SkipCategory::Other => {}
         }
     }
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -103,6 +103,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
                     &sv.local_retention,
                     &sv.snapshot_interval,
                 ));
+                sa.external_only = sv.local_retention.is_transient() && sv.send_enabled;
             }
             sa
         })

--- a/src/output.rs
+++ b/src/output.rs
@@ -182,6 +182,9 @@ pub struct StatusAssessment {
     /// Compact retention summary, e.g. "31d / 7mo / 19mo" or "none (transient)".
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retention_summary: Option<String>,
+    /// True when subvolume uses transient local retention with sends enabled (external-only mode).
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub external_only: bool,
     pub errors: Vec<String>,
 }
 
@@ -205,6 +208,7 @@ impl StatusAssessment {
             advisories: a.advisories.clone(),
             redundancy_advisories: a.redundancy_advisories.clone(),
             retention_summary: None,
+            external_only: false,
             errors: a.errors.clone(),
         }
     }
@@ -291,6 +295,10 @@ pub struct DefaultStatusOutput {
 
 fn is_zero(n: &usize) -> bool {
     *n == 0
+}
+
+fn is_false(b: &bool) -> bool {
+    !b
 }
 
 impl DefaultStatusOutput {
@@ -583,16 +591,17 @@ pub enum SkipCategory {
     /// Distinct from `Disabled` (which means `enabled = false` — does nothing).
     LocalOnly,
     SpaceExceeded,
-    /// Send was planned but no local snapshots exist to send.
-    /// Distinct from `Other` — this is an actionable deferral, not an unknown skip.
+    /// Non-transient subvolume with zero local snapshots (unexpected — e.g., first run or external deletion).
     NoSnapshotsAvailable,
+    /// External-only subvolume — local snapshots are transient, sends happen on next backup.
+    ExternalOnly,
     Other,
 }
 
 impl SkipCategory {
     /// Classify a skip reason string into a category.
     ///
-    /// Matches against the 14 known patterns from plan.rs. Unknown patterns
+    /// Matches against the 16 known patterns from plan.rs. Unknown patterns
     /// fall to `Other`. A completeness test in the test module ensures all
     /// known patterns classify correctly.
     #[must_use]
@@ -616,6 +625,8 @@ impl SkipCategory {
             Self::SpaceExceeded
         } else if reason == "no local snapshots to send" {
             Self::NoSnapshotsAvailable
+        } else if reason.starts_with("external-only") {
+            Self::ExternalOnly
         } else {
             Self::Other
         }
@@ -1407,10 +1418,10 @@ mod tests {
         );
     }
 
-    /// Completeness test: all 15 known plan.rs skip patterns classify to their
+    /// Completeness test: all 16 known plan.rs skip patterns classify to their
     /// expected category. Prevents silent regressions when new patterns are added.
     #[test]
-    fn classify_all_15_patterns() {
+    fn classify_all_16_patterns() {
         let patterns = vec![
             ("disabled", SkipCategory::Disabled),
             ("send disabled", SkipCategory::LocalOnly),
@@ -1445,6 +1456,10 @@ mod tests {
                 SkipCategory::IntervalNotElapsed,
             ),
             ("no local snapshots to send", SkipCategory::NoSnapshotsAvailable),
+            (
+                "external-only \u{2014} sends on next backup",
+                SkipCategory::ExternalOnly,
+            ),
             (
                 "20260329-0404-htpc-home already on WD-18TB",
                 SkipCategory::Other,

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -97,7 +97,7 @@ pub fn plan(
 ) -> crate::error::Result<BackupPlan> {
     let mut operations = Vec::new();
     // Skip reason strings are classified by output::SkipCategory::from_reason().
-    // When adding new patterns, update output::tests::classify_all_14_patterns.
+    // When adding new patterns, update output::tests::classify_all_16_patterns.
     let mut skipped = Vec::new();
 
     let resolved = config.resolved_subvolumes();
@@ -477,10 +477,12 @@ fn plan_external_send(
 
     // Find the snapshot to send (newest local)
     let Some(snap_to_send) = local_snaps.iter().max() else {
-        skipped.push((
-            subvol.name.clone(),
-            "no local snapshots to send".to_string(),
-        ));
+        let reason = if subvol.local_retention.is_transient() {
+            "external-only \u{2014} sends on next backup".to_string()
+        } else {
+            "no local snapshots to send".to_string()
+        };
+        skipped.push((subvol.name.clone(), reason));
         return;
     };
 
@@ -2741,5 +2743,38 @@ local_retention = "transient"
             .collect();
         assert_eq!(creates.len(), 1, "skip_intervals + local_only should create snapshot");
         assert!(sends.is_empty(), "local_only should suppress sends even with skip_intervals");
+    }
+
+    #[test]
+    fn plan_external_only_skip_reason() {
+        let config = transient_config();
+        let mut fs = MockFileSystemState::new();
+        // Mounted drive, no local snapshots (transient cleaned them up)
+        fs.mounted_drives.insert("D1".to_string());
+
+        let now = NaiveDate::from_ymd_opt(2026, 3, 23)
+            .unwrap()
+            .and_hms_opt(14, 0, 0)
+            .unwrap();
+
+        let filters = PlanFilters::default();
+        let result = plan(&config, now, &filters, &fs).unwrap();
+
+        // Should have the external-only skip reason, not "no local snapshots to send"
+        let skip = result
+            .skipped
+            .iter()
+            .find(|(name, _)| name == "sv1")
+            .expect("sv1 should be in skipped list");
+        assert!(
+            skip.1.starts_with("external-only"),
+            "transient subvol should use 'external-only' skip reason, got: {}",
+            skip.1
+        );
+        assert!(
+            !skip.1.contains("no local snapshots"),
+            "transient subvol should not use 'no local snapshots' reason, got: {}",
+            skip.1
+        );
     }
 }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -226,10 +226,14 @@ fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
         row.push(assessment.name.clone());
 
         // LOCAL column with temporal context
-        let local_cell = format_count_with_age(
-            assessment.local_snapshot_count,
-            assessment.local_newest_age_secs,
-        );
+        let local_cell = if assessment.external_only {
+            "\u{2014}".to_string() // em-dash, same as absent drives
+        } else {
+            format_count_with_age(
+                assessment.local_snapshot_count,
+                assessment.local_newest_age_secs,
+            )
+        };
         row.push(local_cell);
 
         // Per-drive columns (connected drives only)
@@ -253,12 +257,15 @@ fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
         }
 
         // Thread health (interactive rendering — Display impl feeds daemon JSON, do not change it)
-        let thread = data
-            .chain_health
-            .iter()
-            .find(|c| c.subvolume == assessment.name)
-            .map(|c| render_thread_status(&c.health))
-            .unwrap_or_else(|| "\u{2014}".to_string());
+        let thread = if assessment.external_only {
+            "ext-only".dimmed().to_string()
+        } else {
+            data.chain_health
+                .iter()
+                .find(|c| c.subvolume == assessment.name)
+                .map(|c| render_thread_status(&c.health))
+                .unwrap_or_else(|| "\u{2014}".to_string())
+        };
         row.push(thread);
 
         rows.push(row);
@@ -367,7 +374,7 @@ fn render_redundancy_advisories(data: &StatusOutput, out: &mut String) {
             ),
             RedundancyAdvisoryKind::TransientNoLocalRecovery => (
                 format!(
-                    "{} lives only on external drives while local copies are transient.",
+                    "{} lives only on external drives \u{2014} local snapshots are disabled.",
                     advisory.subvolume,
                 ),
                 "Recovery requires a connected drive.".to_string(),
@@ -778,6 +785,7 @@ fn render_skipped_block(skipped: &[crate::output::SkippedSubvolume], out: &mut S
         } else if skip.category != SkipCategory::IntervalNotElapsed
             && skip.category != SkipCategory::Disabled
             && skip.category != SkipCategory::LocalOnly
+            && skip.category != SkipCategory::ExternalOnly
         {
             actionable_skips.push(skip);
         }
@@ -1172,6 +1180,7 @@ fn render_plan_skipped_grouped(skipped: &[SkippedSubvolume], out: &mut String) {
         SkipCategory::LocalOnly,
         SkipCategory::SpaceExceeded,
         SkipCategory::NoSnapshotsAvailable,
+        SkipCategory::ExternalOnly,
         SkipCategory::Other,
     ];
 
@@ -1184,8 +1193,9 @@ fn render_plan_skipped_grouped(skipped: &[SkippedSubvolume], out: &mut String) {
         match cat {
             SkipCategory::DriveNotMounted => render_drive_not_mounted_group(&items, out),
             SkipCategory::IntervalNotElapsed => render_interval_group(&items, out),
-            SkipCategory::Disabled => render_disabled_group(&items, out),
-            SkipCategory::LocalOnly => render_local_only_group(&items, out),
+            SkipCategory::Disabled => render_named_group(&items, cat, "Disabled", out),
+            SkipCategory::LocalOnly => render_named_group(&items, cat, "Local only", out),
+            SkipCategory::ExternalOnly => render_named_group(&items, cat, "External only", out),
             SkipCategory::SpaceExceeded
             | SkipCategory::NoSnapshotsAvailable
             | SkipCategory::Other => {
@@ -1253,26 +1263,19 @@ fn render_interval_group(items: &[&SkippedSubvolume], out: &mut String) {
     .ok();
 }
 
-/// Render Disabled skips as an inline comma-separated name list.
-fn render_disabled_group(items: &[&SkippedSubvolume], out: &mut String) {
+/// Render a skip group as: `[TAG]  Label: name1, name2`.
+fn render_named_group(
+    items: &[&SkippedSubvolume],
+    category: &SkipCategory,
+    label: &str,
+    out: &mut String,
+) {
     let names: Vec<&str> = items.iter().map(|s| s.name.as_str()).collect();
     writeln!(
         out,
         "  {}  {} {}",
-        skip_tag(&SkipCategory::Disabled),
-        "Disabled:".dimmed(),
-        names.join(", "),
-    )
-    .ok();
-}
-
-fn render_local_only_group(items: &[&SkippedSubvolume], out: &mut String) {
-    let names: Vec<&str> = items.iter().map(|s| s.name.as_str()).collect();
-    writeln!(
-        out,
-        "  {}  {} {}",
-        skip_tag(&SkipCategory::LocalOnly),
-        "Local only:".dimmed(),
+        skip_tag(category),
+        format!("{label}:").dimmed(),
         names.join(", "),
     )
     .ok();
@@ -1287,6 +1290,7 @@ fn skip_tag(category: &SkipCategory) -> String {
         SkipCategory::Disabled => "[OFF]  ".dimmed().to_string(),
         SkipCategory::LocalOnly => "[LOCAL]".dimmed().to_string(),
         SkipCategory::NoSnapshotsAvailable => "[NOSRC]".yellow().to_string(),
+        SkipCategory::ExternalOnly => "[EXT]  ".dimmed().to_string(),
         SkipCategory::Other => "[SKIP] ".dimmed().to_string(),
     }
 }
@@ -2667,6 +2671,7 @@ mod tests {
                     advisories: vec![],
                     redundancy_advisories: vec![],
                     retention_summary: None,
+                    external_only: false,
                     errors: vec![],
                 },
                 StatusAssessment {
@@ -2691,6 +2696,7 @@ mod tests {
                     advisories: vec![],
                     redundancy_advisories: vec![],
                     retention_summary: None,
+                    external_only: false,
                     errors: vec![],
                 },
             ],
@@ -2939,6 +2945,61 @@ mod tests {
         );
     }
 
+    // ── External-only status table tests (UPI 018) ─────────────────
+
+    #[test]
+    fn status_table_external_only_shows_em_dash_local() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        // Make first subvol external-only
+        data.assessments[0].external_only = true;
+        data.assessments[0].local_snapshot_count = 0;
+        data.assessments[0].local_newest_age_secs = None;
+        let output = render_status(&data, OutputMode::Interactive);
+        // The LOCAL column for htpc-home should show em-dash, not "0"
+        // Split into lines and find the htpc-home row
+        let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
+        assert!(
+            home_line.contains('\u{2014}'),
+            "external_only LOCAL should show em-dash, got: {home_line}"
+        );
+        assert!(
+            !home_line.contains(" 0 "),
+            "external_only LOCAL should not show '0', got: {home_line}"
+        );
+    }
+
+    #[test]
+    fn status_table_external_only_shows_ext_only_thread() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        data.assessments[0].external_only = true;
+        let output = render_status(&data, OutputMode::Interactive);
+        let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
+        assert!(
+            home_line.contains("ext-only"),
+            "external_only THREAD should show 'ext-only', got: {home_line}"
+        );
+    }
+
+    #[test]
+    fn status_table_normal_subvol_unchanged() {
+        colored::control::set_override(false);
+        let data = test_status_output();
+        let output = render_status(&data, OutputMode::Interactive);
+        let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
+        // Normal subvol should show count (47) not em-dash for LOCAL
+        assert!(
+            home_line.contains("47"),
+            "normal subvol LOCAL should show count, got: {home_line}"
+        );
+        // Should show chain health, not ext-only
+        assert!(
+            home_line.contains("unbroken"),
+            "normal subvol THREAD should show chain health, got: {home_line}"
+        );
+    }
+
     // ── Status advice rendering tests ────────────────────────────────
 
     #[test]
@@ -3107,6 +3168,7 @@ mod tests {
                 advisories: vec![],
                 redundancy_advisories: vec![],
                 retention_summary: None,
+                external_only: false,
                 errors: vec![],
             }],
             transitions: vec![],
@@ -3733,6 +3795,61 @@ mod tests {
         assert!(
             output.contains("htpc-home"),
             "should show subvolume name"
+        );
+    }
+
+    #[test]
+    fn plan_skip_external_only_renders_grouped() {
+        colored::control::set_override(false);
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![],
+            skipped: vec![SkippedSubvolume {
+                name: "htpc-root".to_string(),
+                reason: "external-only \u{2014} sends on next backup".to_string(),
+                category: SkipCategory::ExternalOnly,
+            }],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 0,
+                deletions: 0,
+                skipped: 1,
+                estimated_total_bytes: None,
+            },
+            warnings: vec![],
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("[EXT]"),
+            "external-only should use [EXT] tag: {output}"
+        );
+        assert!(
+            output.contains("External only:"),
+            "should have 'External only:' group header: {output}"
+        );
+        assert!(
+            output.contains("htpc-root"),
+            "should show subvolume name: {output}"
+        );
+    }
+
+    #[test]
+    fn backup_skipped_block_hides_external_only() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.skipped = vec![SkippedSubvolume {
+            name: "htpc-root".to_string(),
+            reason: "external-only \u{2014} sends on next backup".to_string(),
+            category: SkipCategory::ExternalOnly,
+        }];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("external-only"),
+            "external-only skips should be hidden in backup summary: {output}"
+        );
+        assert!(
+            !output.contains("[EXT]"),
+            "external-only tag should be hidden in backup summary: {output}"
         );
     }
 
@@ -4669,6 +4786,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn advisory_transient_no_recovery_uses_disabled_vocabulary() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        data.redundancy_advisories
+            .push(crate::output::RedundancyAdvisory {
+            kind: crate::output::RedundancyAdvisoryKind::TransientNoLocalRecovery,
+            subvolume: "htpc-root".to_string(),
+            drive: None,
+            detail: "htpc-root lives only on external drives \u{2014} local snapshots are disabled"
+                .to_string(),
+        });
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("local snapshots are disabled"),
+            "advisory should say 'local snapshots are disabled': {output}"
+        );
+        assert!(
+            !output.contains("transient"),
+            "advisory should not contain 'transient': {output}"
+        );
+    }
+
     // ── Default status tests ───────────────────────────────────────────
 
     fn test_default_all_sealed() -> DefaultStatusOutput {
@@ -5318,6 +5458,7 @@ mod tests {
             advisories: vec![],
             redundancy_advisories: vec![],
             retention_summary: None,
+            external_only: false,
             errors: vec![],
         }];
 
@@ -5349,6 +5490,7 @@ mod tests {
                 advisories: vec![],
                 redundancy_advisories: vec![],
                 retention_summary: None,
+                external_only: false,
                 errors: vec![],
             },
             StatusAssessment {
@@ -5371,6 +5513,7 @@ mod tests {
                 advisories: vec![],
                 redundancy_advisories: vec![],
                 retention_summary: None,
+                external_only: false,
                 errors: vec![],
             },
         ];
@@ -5402,6 +5545,7 @@ mod tests {
                 advisories: vec![],
                 redundancy_advisories: vec![],
                 retention_summary: None,
+                external_only: false,
                 errors: vec![],
             },
             StatusAssessment {
@@ -5424,6 +5568,7 @@ mod tests {
                 advisories: vec![],
                 redundancy_advisories: vec![],
                 retention_summary: None,
+                external_only: false,
                 errors: vec![],
             },
         ];
@@ -5454,6 +5599,7 @@ mod tests {
             advisories: vec![],
             redundancy_advisories: vec![],
             retention_summary: None,
+            external_only: false,
             errors: vec![],
         }];
 


### PR DESCRIPTION
## Summary

- **Health model fix**: subvolumes with `local_snapshots = false` no longer report false "degraded" health or "broken chain" warnings — `NoPinFile` and `PinMissingLocally` are exempted for transient subvolumes via `is_expected_chain_break()` helper
- **Status table**: LOCAL column shows em-dash, THREAD column shows "ext-only" instead of misleading chain health for external-only subvolumes
- **Plan output**: new `ExternalOnly` skip category with `[EXT]` tag and grouped rendering, hidden from backup summary (non-actionable)
- **Advisory text**: "local snapshots are disabled" replaces internal "transient" vocabulary in redundancy advisories

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 892 tests, all pass (13 new)
- Integration tests: not applicable (no btrfs operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)