### PR TITLE
feat: skip unchanged subvolumes via BTRFS generation comparison (UPI 014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deferred synthesis in backup summary: subvolumes with no local snapshots to send now surface actionable guidance instead of silent skips
 - `SkipCategory::NoSnapshotsAvailable` for structured classification of send-blocked skips
 - External-only runtime: subvolumes with `local_snapshots = false` no longer show false "degraded" health or "broken chain" warnings — status table shows em-dash for LOCAL and "ext-only" for THREAD, plan output uses `[EXT]` skip tag
+- Skip unchanged subvolumes: compares BTRFS generation counters to avoid creating identical snapshots for quiet subvolumes — shown as `[SAME]` in plan output with elapsed time, overrideable via `--force-snapshot`
 
 ### Fixed
 - False "all chains broke simultaneously" anomaly when a drive disconnects (total=0 was treated as all-broken)

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -8,11 +8,11 @@
 | 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | merged | [#84](https://github.com/vonrobak/urd/pull/84) |
 | 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | merged | [#85](https://github.com/vonrobak/urd/pull/85) |
 | 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | merged | [#83](https://github.com/vonrobak/urd/pull/83) |
-| 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | [adversary](../99-reports/2026-04-05-review-adversary-018-external-only-runtime.md) | - | - |
+| 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | [adversary](../99-reports/2026-04-05-review-adversary-018-external-only-runtime.md) | merged | [#87](https://github.com/vonrobak/urd/pull/87) |
 | 017 | Thread lineage visualization | [design](../95-ideas/2026-04-03-design-017-thread-lineage-visualization.md) | - | - | - | - |
 | 016 | Emergency space response | [design](../95-ideas/2026-04-03-design-016-emergency-space-response.md) | - | - | - | - |
 | 015 | Change preview in `urd get` | [design](../95-ideas/2026-04-03-design-015-get-change-preview.md) | - | - | - | - |
-| 014 | Skip unchanged subvolumes | [design](../95-ideas/2026-04-03-design-014-skip-unchanged-subvolumes.md) | - | - | - | - |
+| 014 | Skip unchanged subvolumes | [design](../95-ideas/2026-04-03-design-014-skip-unchanged-subvolumes.md) | - | [adversary](../99-reports/2026-04-05-design-review-014-skip-unchanged-subvolumes.md) | - | - |
 | 013 | Btrfs pipeline improvements | [design](../95-ideas/2026-04-03-design-013-btrfs-pipeline-improvements.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-013-btrfs-pipeline-improvements.md) | merged | [#86](https://github.com/vonrobak/urd/pull/86) |
 | 012 | Sentinel drive-gated transient + space monitoring | [design](../95-ideas/2026-04-03-design-012-sentinel-drive-gated-transient.md) | - | - | - | - |
 | 011 | Transient space safety (emergency fix) | [design](../95-ideas/2026-04-03-design-011-transient-space-safety.md) | [steve](../99-reports/2026-04-03-steve-jobs-011-transient-is-a-lie.md) | - | - | - |

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -9,11 +9,12 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-879 tests, all passing, clippy clean. Current version: v0.10.0.
+892 tests, all passing, clippy clean. Current version: v0.10.0.
 
-**UPI 013 complete.** Compressed send pass-through (`--compressed-data` auto-detected at
-startup, no config knob) and post-delete sync (`btrfs subvolume sync` after each retention
-delete for accurate space accounting). PR #86 merged.
+**UPI 018 complete.** External-only runtime: subvolumes with `local_snapshots = false`
+no longer show false "degraded" health or "broken chain" warnings. Health model exempts
+expected chain breaks for transient subvolumes. Status table, plan output, and advisories
+all treat external-only as first-class. PR #87 merged.
 
 **Deployment notes:**
 - v0.10.0 tagged but not yet pushed/installed
@@ -21,6 +22,7 @@ delete for accurate space accounting). PR #86 merged.
   `local_snapshots = false` before next timer run
 - UPI 021 fix means sentinel will pick up the config change automatically after install
 - Pre-deploy check for 013: run `btrfs send --help` as unprivileged user to verify no-sudo probe
+- First sentinel tick after deploy will emit one-time HealthRecovered for htpc-root (expected)
 
 ## In Progress
 
@@ -28,21 +30,23 @@ Nothing active.
 
 ## Recently Completed
 
-**UPI 013: Btrfs Pipeline Improvements** (2026-04-05)
-   - 013-a: `SystemBtrfs::probe()` detects `--compressed-data` support, `RealBtrfs` injects flag
-   - 013-b: Per-delete `sync_subvolumes` in executor, fail-open (ADR-107)
-   - Simplify pass: hoisted probe out of loop in init.rs
-   - 8 new tests
+**UPI 018: External-Only Runtime** (2026-04-05)
+   - `is_expected_chain_break()` helper exempts NoPinFile/PinMissingLocally for transient
+   - Status table: em-dash LOCAL, "ext-only" THREAD for external-only subvols
+   - Plan output: `[EXT]` skip tag with grouped rendering, hidden from backup summary
+   - Advisory text: "local snapshots are disabled" (not "transient")
+   - Simplify: extracted `render_named_group()`, fixed doc comments
+   - 13 new tests
 
 ## Next Up
 
 **Immediate: Push v0.10.0 and deploy** (see session journal for verification steps)
 
 **Then sequential (Phase E: Make the invisible worker smart):**
-1. **E2: UPI 018** — External-only runtime (fix false degraded/broken for local_snapshots=false) ~0.5 session
-2. **E4: UPI 014** — Skip unchanged subvolumes ~0.5 session
+1. **E4: UPI 014** — Skip unchanged subvolumes ~0.5 session
+2. **E5: UPI 016-auto** — Emergency space response (automatic mode) ~0.5 session
 
-**9 unreleased changes in CHANGELOG.md — consider `/release` soon.**
+**11 unreleased changes in CHANGELOG.md — consider `/release` soon.**
 
 ## Key Links
 
@@ -56,7 +60,7 @@ Nothing active.
 
 ## Known Issues
 
-- htpc-root shows false "degraded"/"broken chain" — awareness doesn't account for `local_snapshots = false` (UPI 018 will fix)
 - WD-18TB and WD-18TB1 share BTRFS UUID from cloning — needs `btrfstune -u` when offsite drive returns
 - Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" matched as raw strings — consider constants
 - Planner helper functions approaching parameter limit (10 args) — pass `&PlanFilters` instead of destructured bools in next planner change
+- `compute_health` at 8 params — consider struct grouping in next awareness.rs change

--- a/docs/99-reports/2026-04-05-design-review-014-skip-unchanged-subvolumes.md
+++ b/docs/99-reports/2026-04-05-design-review-014-skip-unchanged-subvolumes.md
@@ -1,0 +1,273 @@
+---
+upi: "014"
+date: 2026-04-05
+---
+
+# Architectural Adversary Review: UPI 014 — Skip Unchanged Subvolumes
+
+**Scope:** Design review of implementation plan
+`docs/97-plans/2026-04-05-plan-014-skip-unchanged-subvolumes.md` and design doc
+`docs/95-ideas/2026-04-03-design-014-skip-unchanged-subvolumes.md`
+
+**Reviewer:** arch-adversary
+**Commit:** `1461a6f`
+**Mode:** Design review (4 dimensions)
+
+---
+
+## Executive Summary
+
+A well-scoped, low-risk feature with a sound design. The plan correctly identifies the
+insertion point, respects fail-open semantics, and avoids config surface area. One
+significant finding: the plan's error-handling pattern for generation fetch failures
+silently swallows the second error when *both* calls fail, which obscures diagnostic
+information. One moderate finding: the plan doesn't account for a match arm in
+`backup.rs` that must be updated for the new `SkipCategory` variant. Overall, this is
+ready to build with minor revisions.
+
+## What Kills You
+
+**Catastrophic failure mode for Urd:** silent data loss through deleting snapshots that
+shouldn't be deleted.
+
+**Proximity of this feature:** Far. UPI 014 *skips creating* snapshots — it never
+deletes anything. The worst case is a false skip (subvolume changed but generation
+comparison incorrectly says it didn't), which means a missed snapshot. This is data
+*staleness*, not data *loss*. The existing snapshot remains, and the next run with a
+different generation will create a new one. The fail-open design means generation
+comparison errors always proceed to create — correct bias.
+
+**Distance to catastrophic failure:** 3+ bugs away. A generation skip cannot cause
+deletion; it can only prevent creation. This is the right side of the safety boundary.
+
+---
+
+## Scorecard
+
+| Dimension | Score | Rationale |
+|-----------|-------|-----------|
+| **Correctness** | 4 | Sound logic, correct fail-open bias, good test coverage plan. Minor gap in error-reporting fidelity. |
+| **Security** | 5 | No new sudo paths, no new privilege boundaries. Path passed as `&Path` to `Command::arg()` — no injection vector. |
+| **Architectural Excellence** | 4 | Respects module boundaries cleanly. The standalone-function deviation from design doc is well-justified and follows existing patterns. |
+| **Systems Design** | 4 | Correct production behavior. Two minor gaps: dual-error logging and downstream match exhaustiveness. |
+
+---
+
+## Design Tensions
+
+### 1. BtrfsOps trait vs standalone function
+
+**Trade-off:** The plan deviates from the design doc by using a standalone
+`btrfs::subvolume_generation()` instead of extending the `BtrfsOps` trait.
+
+**Evaluation:** Correct call. `BtrfsOps` is the executor's abstraction — it exists so
+the executor can be tested without real btrfs. The planner uses `FileSystemState` as its
+abstraction, and `RealFileSystemState` already delegates to module-level functions in
+`drives::` and `chain::`. Adding generation as a standalone in `btrfs::` follows the
+exact same pattern. Extending `BtrfsOps` would require `MockBtrfs` changes in the
+executor test suite for a feature the executor never uses — pure noise.
+
+### 2. Generation check position: inside vs outside `should_create`
+
+**Trade-off:** The plan places generation comparison *inside* the `if should_create`
+block. This means generation is only checked when the interval has already elapsed (or
+is bypassed). An alternative would be checking generation *before* the interval, making
+it a first-class gating decision.
+
+**Evaluation:** Inside is correct. The interval check is cheap (pure datetime comparison)
+and filtering by interval first avoids two `btrfs subvolume show` calls for subvolumes
+whose interval hasn't elapsed yet. On a system with 10 subvolumes where only 2 have
+elapsed intervals, this saves 16 subprocess calls per plan run. The plan gets this right.
+
+### 3. Suppressing `Unchanged` in backup summary
+
+**Trade-off:** The plan suppresses `Unchanged` skips in `render_skipped_block()` (backup
+summary), showing them only in plan output.
+
+**Evaluation:** Correct for the invisible worker mode. Autonomous nightly runs should not
+surface "docs didn't change" as information worth reading. The plan output (invoked norn)
+shows it because the user explicitly asked "what would you do?" — that's the right context
+for this detail.
+
+---
+
+## Findings
+
+### S1: Incomplete match arm in `backup.rs::build_empty_plan_explanation` (Significant)
+
+**What:** `backup.rs:622-627` has a match on `SkipCategory` that lists all current
+variants. Adding `SkipCategory::Unchanged` will produce a compiler error unless this
+match is updated. The plan's Step 3 and Step 6 don't mention this file.
+
+```rust
+match SkipCategory::from_reason(reason) {
+    SkipCategory::Disabled | SkipCategory::LocalOnly => has_disabled = true,
+    SkipCategory::SpaceExceeded => has_space = true,
+    SkipCategory::DriveNotMounted => has_not_mounted = true,
+    SkipCategory::IntervalNotElapsed => has_interval = true,
+    SkipCategory::NoSnapshotsAvailable | SkipCategory::ExternalOnly | SkipCategory::Other => {}
+}
+```
+
+**Consequence:** Build failure. The compiler catches this, so it's not a correctness
+risk — but it's a plan gap. The fix is trivial (add `Unchanged` to the no-op arm), but
+the plan should account for it so the build step doesn't require ad-hoc decisions.
+
+**Fix:** Add `SkipCategory::Unchanged` to the last match arm in
+`backup.rs:build_empty_plan_explanation()`, alongside `NoSnapshotsAvailable`,
+`ExternalOnly`, and `Other`. An unchanged subvolume is not a reason the plan is empty —
+if everything is unchanged, the explanation should mention that all subvolumes are
+unchanged (but this is a separate future enhancement, not a UPI 014 requirement).
+
+---
+
+### S2: Dual generation failure loses diagnostic information (Significant)
+
+**What:** The plan's error-handling pattern:
+
+```rust
+(Err(e), _) | (_, Err(e)) => {
+    log::warn!("...: failed to read generation, proceeding: {e}");
+}
+```
+
+When *both* source and snapshot generation calls fail, the `(Err(e), _)` arm matches
+first, logging only the source error. The snapshot error is silently discarded.
+
+**Consequence:** In production, if `btrfs subvolume show` starts failing systemically
+(e.g., btrfs-progs upgrade changed output format, permission issue), the user sees
+warnings about source generation but never about snapshot generation. This makes
+diagnosis harder — the user might investigate the source subvolume specifically when
+the issue is global.
+
+**Fix:** Match on `(Err(e1), Err(e2))` as a separate arm that logs both errors, before
+the single-error arms:
+
+```rust
+(Ok(sg), Ok(ng)) if sg == ng => { /* skip */ }
+(Err(e1), Err(e2)) => {
+    log::warn!("...: failed to read source generation: {e1}");
+    log::warn!("...: failed to read snapshot generation: {e2}");
+}
+(Err(e), _) => {
+    log::warn!("...: failed to read source generation, proceeding: {e}");
+}
+(_, Err(e)) => {
+    log::warn!("...: failed to read snapshot generation, proceeding: {e}");
+}
+_ => {}
+```
+
+This preserves all diagnostic information at negligible code cost.
+
+---
+
+### M1: Serialization contract — new enum variant in JSON output (Moderate)
+
+**What:** `SkipCategory` derives `Serialize` with `#[serde(rename_all = "snake_case")]`.
+Adding `Unchanged` will produce `"unchanged"` in JSON output. This JSON is consumed by
+the sentinel daemon and potentially external monitoring.
+
+**Consequence:** Not a breaking change — consumers should already handle unknown skip
+categories gracefully. But the plan's "ADR Gates: None" section should acknowledge this
+as a minor interface addition. The sentinel's match on skip categories (if any) may need
+updating.
+
+**Fix:** Note in the plan that the sentinel daemon's skip category handling (if it
+matches on specific categories) should be checked. Add `"unchanged"` to any sentinel
+tests that enumerate skip categories. This is likely a no-op if the sentinel uses a
+catch-all, but worth verifying during build.
+
+---
+
+### M2: Test 8 (`create_when_generation_fetch_fails`) should test both failure modes (Moderate)
+
+**What:** The plan lists one test for generation fetch failure (test 8), but there are
+three distinct failure scenarios: (a) source generation fails, (b) snapshot generation
+fails, (c) both fail. The plan only describes one test.
+
+**Consequence:** If the match arm ordering is wrong (e.g., `(_, Err(e))` before
+`(Err(e), _)`), the wrong error gets logged. Without testing both single-failure cases,
+this can't be caught.
+
+**Fix:** Split test 8 into three tests:
+- `create_when_source_generation_fails` — source in `fail_generations`, snapshot has generation
+- `create_when_snapshot_generation_fails` — source has generation, snapshot in `fail_generations`
+- `create_when_both_generation_fetches_fail` — both in `fail_generations`
+
+All three should assert `CreateSnapshot` is emitted (fail open), and optionally verify
+log output if the test framework supports it.
+
+---
+
+### Commendation: Generation check placement and fail-open bias
+
+The insertion point — inside `if should_create`, after interval check — is exactly right.
+It avoids unnecessary subprocess calls when the interval hasn't elapsed, it naturally
+handles the "no prior snapshots" case (the `if let Some(newest)` guard), and it inherits
+the existing `force` and `skip_intervals` bypass semantics without special-casing them.
+The fail-open design (any error → proceed to create) correctly biases toward the safe
+side: a false-positive snapshot wastes space; a false-negative skip loses a change point.
+For a backup tool, this is the right error.
+
+---
+
+### Commendation: No config surface area
+
+The design correctly rejects a `snapshot_on_change` config field. Smart defaults with a
+CLI escape hatch is the right pattern for a feature that has no legitimate "turn it off"
+use case in normal operation. This keeps the config surface area exactly where it is and
+avoids the "should I enable this?" cognitive load for users.
+
+---
+
+## The Simplicity Question
+
+**What could be removed?** Nothing. This is already minimal — one parsing function, one
+trait method, one planner check, one enum variant, one CLI flag, one voice arm. The plan
+doesn't introduce new types, new modules, or new abstractions.
+
+**What's earning its keep?** The `FileSystemState` trait indirection earns its keep here
+by allowing generation comparison to be tested without real btrfs — exactly what it was
+designed for. The `SkipCategory` enum earns its keep by giving voice.rs enough information
+to render differently without parsing reason strings.
+
+**What isn't?** The `fail_generations: HashSet<PathBuf>` field on `MockFileSystemState`
+is marginally worthwhile — it could be simulated by simply not inserting a path into the
+`generations` HashMap (absent = error). But having an explicit failure injection is
+consistent with the existing `fail_local_snapshots` and `fail_pin_reads` patterns. Keep
+it for consistency.
+
+---
+
+## For the Dev Team
+
+Priority-ordered action items:
+
+1. **Add `SkipCategory::Unchanged` to the match in `backup.rs:622-627`** — file:
+   `src/commands/backup.rs`, function: `build_empty_plan_explanation()`. Add `Unchanged`
+   to the no-op arm. Without this, the build fails.
+
+2. **Split the error-handling match arm** — file: `src/plan.rs`, in the generation
+   comparison block. Match `(Err, Err)` separately from `(Err, _)` and `(_, Err)` to
+   preserve both error messages in diagnostic logs.
+
+3. **Expand test 8 into three tests** — file: `src/plan.rs` tests. Test source-only
+   failure, snapshot-only failure, and dual failure separately. This is ~15 lines of
+   additional test code.
+
+4. **Note the JSON serialization addition** — not blocking, but verify during build that
+   sentinel daemon code handles the new `"unchanged"` category value gracefully.
+
+---
+
+## Open Questions
+
+1. **Does the sentinel match on specific `SkipCategory` values?** If so, it needs an
+   update. If it uses a catch-all or doesn't consume skip categories at all, no change
+   needed. Worth checking `src/sentinel.rs` and `src/sentinel_runner.rs` during build.
+
+2. **Tag naming (`[SAME]` vs `[UNCHANGED]` vs `[IDLE]`):** The plan flags this as a
+   build-time decision. It's a UX choice, not an architectural one — any of the three
+   works. `[SAME]` aligns with existing tag widths; `[IDLE]` might mislead (the
+   subvolume isn't idle, it just hasn't changed since the last snapshot).

--- a/src/btrfs.rs
+++ b/src/btrfs.rs
@@ -410,6 +410,64 @@ impl BtrfsOps for RealBtrfs {
     }
 }
 
+// ── Standalone generation query ────────────────────────────────────────
+
+/// Parse the `Generation:` field from `btrfs subvolume show` output.
+#[must_use]
+pub fn parse_generation(output: &str) -> Option<u64> {
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if let Some(value) = trimmed.strip_prefix("Generation:") {
+            return value.trim().parse().ok();
+        }
+    }
+    None
+}
+
+/// Query the BTRFS generation counter for a subvolume or snapshot.
+///
+/// Standalone function (not on `BtrfsOps` trait) — same pattern as
+/// `crate::drives::filesystem_free_bytes`. All btrfs subprocess calls
+/// remain in `btrfs.rs` (invariant #2).
+pub fn subvolume_generation(path: &Path) -> crate::error::Result<u64> {
+    let output = Command::new("sudo")
+        .env("LC_ALL", "C")
+        .arg("btrfs")
+        .args(["subvolume", "show"])
+        .arg(path)
+        .output()
+        .map_err(|e| UrdError::Btrfs {
+            context: BtrfsErrorContext {
+                operation: BtrfsOperation::Show,
+                exit_code: None,
+                stderr: e.to_string(),
+                bytes_transferred: None,
+            },
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(UrdError::Btrfs {
+            context: BtrfsErrorContext {
+                operation: BtrfsOperation::Show,
+                exit_code: output.status.code(),
+                stderr,
+                bytes_transferred: None,
+            },
+        });
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    parse_generation(&stdout).ok_or_else(|| UrdError::Btrfs {
+        context: BtrfsErrorContext {
+            operation: BtrfsOperation::Show,
+            exit_code: None,
+            stderr: "Generation field not found in btrfs subvolume show output".to_string(),
+            bytes_transferred: None,
+        },
+    })
+}
+
 // ── MockBtrfs ───────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -723,5 +781,48 @@ mod tests {
         let result = mock.sync_subvolumes(&path);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("mock: sync failed"));
+    }
+
+    // ── parse_generation tests ─────────────────────────────────────────
+
+    #[test]
+    fn parse_generation_valid() {
+        let output = "\
+/data/home
+\tName: \t\t\thome
+\tUUID: \t\t\tabc-123
+\tParent UUID: \t\t-
+\tReceived UUID: \t\t-
+\tCreation time: \t\t2026-03-22 14:40:00 +0100
+\tSubvolume ID: \t\t256
+\tGeneration: \t\t12847
+\tGen at creation: \t1
+\tParent ID: \t\t5
+\tTop level ID: \t\t5
+\tFlags: \t\t\t-
+\tSend transid: \t\t0
+\tSend time: \t\t2026-03-22 14:40:00 +0100
+\tReceive transid: \t0
+\tReceive time: \t\t-
+\tSnapshot(s):
+";
+        assert_eq!(parse_generation(output), Some(12847));
+    }
+
+    #[test]
+    fn parse_generation_missing_field() {
+        let output = "\
+/data/home
+\tName: \t\t\thome
+\tUUID: \t\t\tabc-123
+\tSubvolume ID: \t\t256
+";
+        assert_eq!(parse_generation(output), None);
+    }
+
+    #[test]
+    fn parse_generation_malformed_value() {
+        let output = "\tGeneration: \t\tabc\n";
+        assert_eq!(parse_generation(output), None);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -133,6 +133,10 @@ pub struct PlanArgs {
     /// Show automated-run plan (apply interval gating)
     #[arg(long)]
     pub auto: bool,
+
+    /// Create snapshots even for unchanged subvolumes
+    #[arg(long)]
+    pub force_snapshot: bool,
 }
 
 #[derive(clap::Args, Debug)]
@@ -170,6 +174,10 @@ pub struct BackupArgs {
     /// Automated run — apply interval gating. Without this flag, Urd backs up immediately.
     #[arg(long)]
     pub auto: bool,
+
+    /// Create snapshots even for unchanged subvolumes
+    #[arg(long)]
+    pub force_snapshot: bool,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -37,6 +37,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         local_only: args.local_only,
         external_only: args.external_only,
         skip_intervals: !args.auto,
+        force_snapshot: args.force_snapshot,
     };
 
     let mode = if args.dry_run {
@@ -624,7 +625,7 @@ fn build_empty_plan_explanation(
             SkipCategory::SpaceExceeded => has_space = true,
             SkipCategory::DriveNotMounted => has_not_mounted = true,
             SkipCategory::IntervalNotElapsed => has_interval = true,
-            SkipCategory::NoSnapshotsAvailable | SkipCategory::ExternalOnly | SkipCategory::Other => {}
+            SkipCategory::NoSnapshotsAvailable | SkipCategory::ExternalOnly | SkipCategory::Unchanged | SkipCategory::Other => {}
         }
     }
 

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -18,6 +18,7 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
         local_only: args.local_only,
         external_only: args.external_only,
         skip_intervals: !args.auto,
+        force_snapshot: args.force_snapshot,
     };
 
     let state_db = StateDb::open(&config.general.state_db).ok();

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,7 @@ pub enum BtrfsOperation {
     Send,
     Receive,
     Delete,
+    Show,
     Sync,
 }
 
@@ -21,6 +22,7 @@ impl fmt::Display for BtrfsOperation {
             Self::Send => write!(f, "send"),
             Self::Receive => write!(f, "receive"),
             Self::Delete => write!(f, "delete"),
+            Self::Show => write!(f, "show"),
             Self::Sync => write!(f, "sync"),
         }
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -595,13 +595,15 @@ pub enum SkipCategory {
     NoSnapshotsAvailable,
     /// External-only subvolume — local snapshots are transient, sends happen on next backup.
     ExternalOnly,
+    /// Subvolume has not changed since the last snapshot (same BTRFS generation).
+    Unchanged,
     Other,
 }
 
 impl SkipCategory {
     /// Classify a skip reason string into a category.
     ///
-    /// Matches against the 16 known patterns from plan.rs. Unknown patterns
+    /// Matches against the 17 known patterns from plan.rs. Unknown patterns
     /// fall to `Other`. A completeness test in the test module ensures all
     /// known patterns classify correctly.
     #[must_use]
@@ -627,6 +629,8 @@ impl SkipCategory {
             Self::NoSnapshotsAvailable
         } else if reason.starts_with("external-only") {
             Self::ExternalOnly
+        } else if reason.starts_with("unchanged") {
+            Self::Unchanged
         } else {
             Self::Other
         }
@@ -1418,10 +1422,10 @@ mod tests {
         );
     }
 
-    /// Completeness test: all 16 known plan.rs skip patterns classify to their
+    /// Completeness test: all 17 known plan.rs skip patterns classify to their
     /// expected category. Prevents silent regressions when new patterns are added.
     #[test]
-    fn classify_all_16_patterns() {
+    fn classify_all_17_patterns() {
         let patterns = vec![
             ("disabled", SkipCategory::Disabled),
             ("send disabled", SkipCategory::LocalOnly),
@@ -1471,6 +1475,10 @@ mod tests {
             (
                 "send to WD-18TB skipped: calibrated size ~4.5 GB exceeds WD-18TB available",
                 SkipCategory::SpaceExceeded,
+            ),
+            (
+                "unchanged \u{2014} no changes since last snapshot (21h ago)",
+                SkipCategory::Unchanged,
             ),
         ];
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -64,6 +64,9 @@ pub trait FileSystemState {
     /// Returns `(estimated_bytes, measured_at)` or None if not calibrated.
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)>;
 
+    /// Get the BTRFS generation counter for a subvolume or snapshot path.
+    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64>;
+
     /// Get the timestamp of the most recent successful send (full or incremental)
     /// for a subvolume to a specific drive. Returns None if no send history exists.
     fn last_successful_send_time(
@@ -84,6 +87,8 @@ pub struct PlanFilters {
     /// When true, bypass interval gating for snapshots and sends.
     /// Used by manual `urd backup` (default) — automated runs set this to false.
     pub skip_intervals: bool,
+    /// When true, create snapshots even if the subvolume has not changed.
+    pub force_snapshot: bool,
 }
 
 // ── Planner ─────────────────────────────────────────────────────────────
@@ -97,7 +102,7 @@ pub fn plan(
 ) -> crate::error::Result<BackupPlan> {
     let mut operations = Vec::new();
     // Skip reason strings are classified by output::SkipCategory::from_reason().
-    // When adding new patterns, update output::tests::classify_all_16_patterns.
+    // When adding new patterns, update output::tests::classify_all_17_patterns.
     let mut skipped = Vec::new();
 
     let resolved = config.resolved_subvolumes();
@@ -156,7 +161,7 @@ pub fn plan(
                 &local_snaps,
                 now,
                 force,
-                filters.skip_intervals,
+                filters,
                 min_free,
                 fs,
                 &mut operations,
@@ -275,7 +280,7 @@ fn plan_local_snapshot(
     local_snaps: &[SnapshotName],
     now: NaiveDateTime,
     force: bool,
-    skip_intervals: bool,
+    filters: &PlanFilters,
     min_free: u64,
     fs: &dyn FileSystemState,
     operations: &mut Vec<PlannedOperation>,
@@ -317,7 +322,7 @@ fn plan_local_snapshot(
         );
     }
 
-    let should_create = if force || skip_intervals {
+    let should_create = if force || filters.skip_intervals {
         true
     } else if let Some(newest) = newest {
         let elapsed = now.signed_duration_since(newest.datetime());
@@ -327,6 +332,54 @@ fn plan_local_snapshot(
     };
 
     if should_create {
+        // Generation comparison: skip if subvolume hasn't changed since last snapshot.
+        // Fail open — if either generation query fails, proceed with snapshot.
+        if !filters.force_snapshot && !force
+            && let Some(newest) = newest
+        {
+            let snap_path = local_dir.join(newest.as_str());
+            match (
+                fs.subvolume_generation(&subvol.source),
+                fs.subvolume_generation(&snap_path),
+            ) {
+                (Ok(sg), Ok(ng)) if sg == ng => {
+                    let elapsed = now.signed_duration_since(newest.datetime());
+                    let mins = elapsed.num_minutes();
+                    skipped.push((
+                        subvol.name.clone(),
+                        format!(
+                            "unchanged \u{2014} no changes since last snapshot ({} ago)",
+                            format_duration_short(mins)
+                        ),
+                    ));
+                    return;
+                }
+                (Err(e1), Err(e2)) => {
+                    log::warn!(
+                        "{}: failed to read source generation: {e1}",
+                        subvol.name
+                    );
+                    log::warn!(
+                        "{}: failed to read snapshot generation: {e2}",
+                        subvol.name
+                    );
+                }
+                (Err(e), _) => {
+                    log::warn!(
+                        "{}: failed to read source generation, proceeding: {e}",
+                        subvol.name
+                    );
+                }
+                (_, Err(e)) => {
+                    log::warn!(
+                        "{}: failed to read snapshot generation, proceeding: {e}",
+                        subvol.name
+                    );
+                }
+                _ => {} // generations differ — proceed
+            }
+        }
+
         let snap_name = SnapshotName::new(now, &subvol.short_name);
         // Check if this exact snapshot already exists
         if local_snaps.iter().any(|s| s.as_str() == snap_name.as_str()) {
@@ -781,6 +834,10 @@ impl FileSystemState for RealFileSystemState<'_> {
             .and_then(|db| db.calibrated_size(subvol_name).ok().flatten())
     }
 
+    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
+        crate::btrfs::subvolume_generation(path)
+    }
+
     fn last_successful_send_time(
         &self,
         subvol_name: &str,
@@ -845,6 +902,10 @@ pub struct MockFileSystemState {
     pub fail_local_snapshots: HashSet<String>,
     /// (local_dir, drive_label) pairs for which read_pin_file() should return an error.
     pub fail_pin_reads: HashSet<(PathBuf, String)>,
+    /// Generation counters for subvolume/snapshot paths.
+    pub generations: std::collections::HashMap<PathBuf, u64>,
+    /// Paths for which subvolume_generation() should return an error.
+    pub fail_generations: HashSet<PathBuf>,
 }
 
 #[cfg(test)]
@@ -862,6 +923,8 @@ impl MockFileSystemState {
             send_times: std::collections::HashMap::new(),
             fail_local_snapshots: HashSet::new(),
             fail_pin_reads: HashSet::new(),
+            generations: std::collections::HashMap::new(),
+            fail_generations: HashSet::new(),
         }
     }
 }
@@ -968,6 +1031,28 @@ impl FileSystemState for MockFileSystemState {
             .filter(|((sv, _, st), _)| sv == subvol_name && st == send_type)
             .map(|(_, &bytes)| bytes)
             .max()
+    }
+
+    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
+        if self.fail_generations.contains(path) {
+            return Err(crate::error::UrdError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "mock: generation query failed",
+                ),
+            });
+        }
+        self.generations
+            .get(path)
+            .copied()
+            .ok_or_else(|| crate::error::UrdError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "mock: no generation configured",
+                ),
+            })
     }
 
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)> {
@@ -2775,6 +2860,215 @@ local_retention = "transient"
             !skip.1.contains("no local snapshots"),
             "transient subvol should not use 'no local snapshots' reason, got: {}",
             skip.1
+        );
+    }
+
+    // ── Generation comparison tests (UPI 014) ──────────────────────────
+
+    #[test]
+    fn skip_when_generation_equal() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        // Source and snapshot have same generation → skip
+        fs.generations
+            .insert(PathBuf::from("/data/sv1"), 500);
+        fs.generations
+            .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 0, "should skip unchanged subvolume");
+        let skip = result.skipped.iter().find(|(name, _)| name == "sv1");
+        assert!(skip.is_some(), "sv1 should be in skipped list");
+        assert!(
+            skip.unwrap().1.starts_with("unchanged"),
+            "reason should start with 'unchanged', got: {}",
+            skip.unwrap().1
+        );
+    }
+
+    #[test]
+    fn create_when_generation_different() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        // Source gen differs from snapshot gen → create
+        fs.generations
+            .insert(PathBuf::from("/data/sv1"), 501);
+        fs.generations
+            .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "should create snapshot when generation differs");
+    }
+
+    #[test]
+    fn create_when_no_prior_snapshots() {
+        let config = test_config();
+        let fs = MockFileSystemState::new();
+        // No existing snapshots → create (no generation to compare)
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "should create snapshot when none exist");
+    }
+
+    #[test]
+    fn create_when_source_generation_fails() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        // Source generation fails, snapshot has generation → fail open, create
+        fs.fail_generations
+            .insert(PathBuf::from("/data/sv1"));
+        fs.generations
+            .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "should create snapshot when source generation fails (fail open)");
+    }
+
+    #[test]
+    fn create_when_snapshot_generation_fails() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        // Source has generation, snapshot generation fails → fail open, create
+        fs.generations
+            .insert(PathBuf::from("/data/sv1"), 500);
+        fs.fail_generations
+            .insert(PathBuf::from("/snap/sv1/20260322-1440-one"));
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "should create snapshot when snapshot generation fails (fail open)");
+    }
+
+    #[test]
+    fn create_when_both_generation_fetches_fail() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        // Both fail → fail open, create
+        fs.fail_generations
+            .insert(PathBuf::from("/data/sv1"));
+        fs.fail_generations
+            .insert(PathBuf::from("/snap/sv1/20260322-1440-one"));
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "should create snapshot when both generation queries fail (fail open)");
+    }
+
+    #[test]
+    fn force_snapshot_overrides_generation() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        // Same generation, but force_snapshot → create anyway
+        fs.generations
+            .insert(PathBuf::from("/data/sv1"), 500);
+        fs.generations
+            .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
+
+        let filters = PlanFilters {
+            force_snapshot: true,
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "force_snapshot should override generation check");
+    }
+
+    #[test]
+    fn force_subvolume_overrides_generation() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        // Same generation, but --subvolume filter → force, skip gen check
+        fs.generations
+            .insert(PathBuf::from("/data/sv1"), 500);
+        fs.generations
+            .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
+
+        let filters = PlanFilters {
+            subvolume: Some("sv1".to_string()),
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 1, "--subvolume filter should override generation check");
+    }
+
+    #[test]
+    fn skip_intervals_still_checks_generation() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
+        // Same generation + skip_intervals (manual run) → still skip unchanged
+        fs.generations
+            .insert(PathBuf::from("/data/sv1"), 500);
+        fs.generations
+            .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
+
+        let filters = PlanFilters {
+            skip_intervals: true,
+            ..PlanFilters::default()
+        };
+        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == "sv1"))
+            .collect();
+        assert_eq!(creates.len(), 0, "skip_intervals should not override generation check");
+        let skip = result.skipped.iter().find(|(name, _)| name == "sv1");
+        assert!(
+            skip.is_some() && skip.unwrap().1.starts_with("unchanged"),
+            "should report unchanged reason"
         );
     }
 }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -786,6 +786,7 @@ fn render_skipped_block(skipped: &[crate::output::SkippedSubvolume], out: &mut S
             && skip.category != SkipCategory::Disabled
             && skip.category != SkipCategory::LocalOnly
             && skip.category != SkipCategory::ExternalOnly
+            && skip.category != SkipCategory::Unchanged
         {
             actionable_skips.push(skip);
         }
@@ -1181,6 +1182,7 @@ fn render_plan_skipped_grouped(skipped: &[SkippedSubvolume], out: &mut String) {
         SkipCategory::SpaceExceeded,
         SkipCategory::NoSnapshotsAvailable,
         SkipCategory::ExternalOnly,
+        SkipCategory::Unchanged,
         SkipCategory::Other,
     ];
 
@@ -1196,7 +1198,8 @@ fn render_plan_skipped_grouped(skipped: &[SkippedSubvolume], out: &mut String) {
             SkipCategory::Disabled => render_named_group(&items, cat, "Disabled", out),
             SkipCategory::LocalOnly => render_named_group(&items, cat, "Local only", out),
             SkipCategory::ExternalOnly => render_named_group(&items, cat, "External only", out),
-            SkipCategory::SpaceExceeded
+            SkipCategory::Unchanged
+            | SkipCategory::SpaceExceeded
             | SkipCategory::NoSnapshotsAvailable
             | SkipCategory::Other => {
                 render_individual_skips(&items, cat, out);
@@ -1291,6 +1294,7 @@ fn skip_tag(category: &SkipCategory) -> String {
         SkipCategory::LocalOnly => "[LOCAL]".dimmed().to_string(),
         SkipCategory::NoSnapshotsAvailable => "[NOSRC]".yellow().to_string(),
         SkipCategory::ExternalOnly => "[EXT]  ".dimmed().to_string(),
+        SkipCategory::Unchanged => "[SAME] ".dimmed().to_string(),
         SkipCategory::Other => "[SKIP] ".dimmed().to_string(),
     }
 }
@@ -6234,6 +6238,50 @@ mod tests {
         assert!(
             output.contains("already adopted"),
             "already current: {output}"
+        );
+    }
+
+    // ── Unchanged skip rendering tests (UPI 014) ───────────────────────
+
+    #[test]
+    fn plan_output_renders_unchanged_tag() {
+        let data = PlanOutput {
+            timestamp: "2026-03-22 15:00".to_string(),
+            operations: vec![],
+            skipped: vec![SkippedSubvolume {
+                name: "sv1".to_string(),
+                reason: "unchanged \u{2014} no changes since last snapshot (21h ago)".to_string(),
+                category: SkipCategory::Unchanged,
+            }],
+            summary: PlanSummaryOutput {
+                snapshots: 0,
+                sends: 0,
+                deletions: 0,
+                skipped: 1,
+                estimated_total_bytes: None,
+            },
+            warnings: vec![],
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("[SAME]"),
+            "plan output should contain [SAME] tag, got: {output}"
+        );
+    }
+
+    #[test]
+    fn backup_summary_suppresses_unchanged() {
+        let skipped = vec![SkippedSubvolume {
+            name: "sv1".to_string(),
+            reason: "unchanged \u{2014} no changes since last snapshot (21h ago)".to_string(),
+            category: SkipCategory::Unchanged,
+        }];
+        let mut out = String::new();
+        render_skipped_block(&skipped, &mut out);
+        // Unchanged is positive info — should be suppressed in backup summary
+        assert!(
+            !out.contains("unchanged"),
+            "backup summary should suppress unchanged skips, got: {out}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Compares BTRFS generation counters between source subvolume and newest snapshot to skip unchanged subvolumes — eliminates identical snapshot accumulation for quiet subvolumes (docs, photos, music)
- Adds `--force-snapshot` CLI flag to `urd plan` and `urd backup` to override generation gating
- New `SkipCategory::Unchanged` with `[SAME]` tag in plan output, suppressed in backup summary (positive info, not actionable)
- Fail-open semantics: generation query failures proceed with snapshot creation (ADR-107)
- Simplify pass: refactored `plan_local_snapshot` to take `&PlanFilters` instead of destructured bools

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 906 tests, all passing (11 new)
- Integration tests: not applicable (generation queries require real BTRFS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)