### PR TITLE
feat: guided emergency space recovery (UPI 016)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-04-05
+
 ### Added
 - Compressed send pass-through: auto-detects `--compressed-data` support (btrfs-progs 5.18+) and enables protocol v2 sends — less CPU, preserves compression on destination
 - Post-delete sync: `btrfs subvolume sync` after each retention delete ensures freed space is visible to the space check before the next snapshot
@@ -261,7 +263,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/vonrobak/urd/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/vonrobak/urd/compare/v0.9.1...v0.10.0
 [0.9.1]: https://github.com/vonrobak/urd/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/vonrobak/urd/compare/v0.8.2...v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SkipCategory::NoSnapshotsAvailable` for structured classification of send-blocked skips
 - External-only runtime: subvolumes with `local_snapshots = false` no longer show false "degraded" health or "broken chain" warnings — status table shows em-dash for LOCAL and "ext-only" for THREAD, plan output uses `[EXT]` skip tag
 - Skip unchanged subvolumes: compares BTRFS generation counters to avoid creating identical snapshots for quiet subvolumes — shown as `[SAME]` in plan output with elapsed time, overrideable via `--force-snapshot`
+- `urd emergency` command: guided emergency space recovery — assesses snapshot roots, previews aggressive thinning (keep latest + pinned only), executes with confirmation
+- Automatic emergency pre-flight: backup command detects critically low space (<50% of `min_free_bytes`) and runs emergency retention under the advisory lock before planning
+- Doctor space trend warning: `urd doctor` warns when snapshot roots approach free-space thresholds, suggests `urd emergency`
+- Shared pin re-check helper (`chain::is_pinned_at_delete_time`): single implementation of ADR-106 defense-in-depth layer 3, used by executor and emergency paths
 
 ### Fixed
 - False "all chains broke simultaneously" anomaly when a drive disconnects (total=0 was treated as all-broken)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -10,9 +10,9 @@
 | 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | merged | [#83](https://github.com/vonrobak/urd/pull/83) |
 | 018 | External-only runtime experience | [design](../95-ideas/2026-04-03-design-018-external-only-runtime.md) | - | [adversary](../99-reports/2026-04-05-review-adversary-018-external-only-runtime.md) | merged | [#87](https://github.com/vonrobak/urd/pull/87) |
 | 017 | Thread lineage visualization | [design](../95-ideas/2026-04-03-design-017-thread-lineage-visualization.md) | - | - | - | - |
-| 016 | Emergency space response | [design](../95-ideas/2026-04-03-design-016-emergency-space-response.md) | - | - | - | - |
+| 016 | Emergency space response | [design](../95-ideas/2026-04-03-design-016-emergency-space-response.md) | - | [adversary](../99-reports/2026-04-05-design-review-016-emergency-space-response.md) | - | - |
 | 015 | Change preview in `urd get` | [design](../95-ideas/2026-04-03-design-015-get-change-preview.md) | - | - | - | - |
-| 014 | Skip unchanged subvolumes | [design](../95-ideas/2026-04-03-design-014-skip-unchanged-subvolumes.md) | - | [adversary](../99-reports/2026-04-05-design-review-014-skip-unchanged-subvolumes.md) | - | - |
+| 014 | Skip unchanged subvolumes | [design](../95-ideas/2026-04-03-design-014-skip-unchanged-subvolumes.md) | - | [adversary](../99-reports/2026-04-05-design-review-014-skip-unchanged-subvolumes.md) | merged | [#88](https://github.com/vonrobak/urd/pull/88) |
 | 013 | Btrfs pipeline improvements | [design](../95-ideas/2026-04-03-design-013-btrfs-pipeline-improvements.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-013-btrfs-pipeline-improvements.md) | merged | [#86](https://github.com/vonrobak/urd/pull/86) |
 | 012 | Sentinel drive-gated transient + space monitoring | [design](../95-ideas/2026-04-03-design-012-sentinel-drive-gated-transient.md) | - | - | - | - |
 | 011 | Transient space safety (emergency fix) | [design](../95-ideas/2026-04-03-design-011-transient-space-safety.md) | [steve](../99-reports/2026-04-03-steve-jobs-011-transient-is-a-lie.md) | - | - | - |

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -9,12 +9,12 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-892 tests, all passing, clippy clean. Current version: v0.10.0.
+906 tests, all passing, clippy clean. Current version: v0.10.0.
 
-**UPI 018 complete.** External-only runtime: subvolumes with `local_snapshots = false`
-no longer show false "degraded" health or "broken chain" warnings. Health model exempts
-expected chain breaks for transient subvolumes. Status table, plan output, and advisories
-all treat external-only as first-class. PR #87 merged.
+**UPI 014 complete.** Skip unchanged subvolumes: BTRFS generation comparison avoids
+creating identical snapshots for quiet subvolumes. Plan output shows `[SAME]` tag with
+elapsed time. `--force-snapshot` overrides. Fail-open on generation query failures.
+PR #88 merged.
 
 **Deployment notes:**
 - v0.10.0 tagged but not yet pushed/installed
@@ -30,23 +30,22 @@ Nothing active.
 
 ## Recently Completed
 
-**UPI 018: External-Only Runtime** (2026-04-05)
-   - `is_expected_chain_break()` helper exempts NoPinFile/PinMissingLocally for transient
-   - Status table: em-dash LOCAL, "ext-only" THREAD for external-only subvols
-   - Plan output: `[EXT]` skip tag with grouped rendering, hidden from backup summary
-   - Advisory text: "local snapshots are disabled" (not "transient")
-   - Simplify: extracted `render_named_group()`, fixed doc comments
-   - 13 new tests
+**UPI 014: Skip Unchanged Subvolumes** (2026-04-05)
+   - `parse_generation()` + `subvolume_generation()` standalone in btrfs.rs
+   - Generation comparison in `plan_local_snapshot()` with fail-open semantics
+   - `SkipCategory::Unchanged` with `[SAME]` tag, suppressed in backup summary
+   - `--force-snapshot` flag on `urd plan` and `urd backup`
+   - Simplify: refactored `plan_local_snapshot` to take `&PlanFilters` (parameter sprawl fix)
+   - 11 new tests
 
 ## Next Up
 
 **Immediate: Push v0.10.0 and deploy** (see session journal for verification steps)
 
 **Then sequential (Phase E: Make the invisible worker smart):**
-1. **E4: UPI 014** — Skip unchanged subvolumes ~0.5 session
-2. **E5: UPI 016-auto** — Emergency space response (automatic mode) ~0.5 session
+1. **E5: UPI 016-auto** — Emergency space response (automatic mode) ~0.5 session
 
-**11 unreleased changes in CHANGELOG.md — consider `/release` soon.**
+**12 unreleased changes in CHANGELOG.md — consider `/release` soon.**
 
 ## Key Links
 
@@ -62,5 +61,4 @@ Nothing active.
 
 - WD-18TB and WD-18TB1 share BTRFS UUID from cloning — needs `btrfstune -u` when offsite drive returns
 - Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" matched as raw strings — consider constants
-- Planner helper functions approaching parameter limit (10 args) — pass `&PlanFilters` instead of destructured bools in next planner change
 - `compute_health` at 8 params — consider struct grouping in next awareness.rs change

--- a/docs/99-reports/2026-04-05-design-review-016-emergency-space-response.md
+++ b/docs/99-reports/2026-04-05-design-review-016-emergency-space-response.md
@@ -1,0 +1,338 @@
+---
+upi: "016"
+date: 2026-04-05
+---
+
+# Design Review: UPI 016 — Emergency Space Response (Implementation Plan)
+
+**Scope:** `docs/97-plans/2026-04-05-plan-016-emergency-space-response.md`
+**Design:** `docs/95-ideas/2026-04-03-design-016-emergency-space-response.md`
+**Mode:** Design review (plan, pre-implementation)
+**Reviewer:** arch-adversary
+**Commit:** e744da4 (master)
+
+---
+
+## Executive Summary
+
+The plan is well-structured and correctly sequences a feature that addresses a real
+catastrophic failure the project has already experienced. The core retention function is
+sound — simple, pure, and safe by construction. Two findings need attention before build:
+the emergency command duplicates the executor's pin re-check logic (creating a second
+code path that must stay in sync with the defense-in-depth contract), and the pre-flight
+emergency path in backup.rs runs *before* the advisory lock, which means two concurrent
+backup invocations could both run emergency retention simultaneously.
+
+---
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — deleting snapshots that shouldn't be
+deleted, particularly pinned snapshots that are the last reference for incremental send
+chains.
+
+**Proximity:** The plan is **two bugs away** from this. The `emergency_retention()` function
+structurally prevents it (pin set is a mandatory argument). The two remaining paths to the
+catastrophe are: (1) a caller passes an incorrect or incomplete pinned set, or (2) the
+defense-in-depth re-check (layer 3) has a bug in its duplicated implementation. Finding F1
+addresses the second path.
+
+---
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | **Correctness** | 4 | Core retention logic is sound; lock ordering issue (F2) and unsent protection gap (F3) need resolution |
+| 2 | **Security** | 5 | No new privilege surface; all btrfs calls through `BtrfsOps`; no path construction from user input |
+| 3 | **Architectural Excellence** | 4 | Clean separation of pure logic and I/O; pin re-check duplication (F1) is the main blemish |
+| 4 | **Systems Design** | 4 | Handles crash, concurrent runs, and non-TTY correctly (with F2 fix); notification threading is clean |
+
+---
+
+## Design Tensions
+
+### T1: Direct `BtrfsOps` calls vs. going through the executor
+
+The plan chooses to call `BtrfsOps::delete_subvolume()` directly from the emergency command,
+bypassing the executor. The rationale is sound: emergency is not a backup run, so the
+executor's operation grouping, space-recovery tracking, and progress reporting are irrelevant.
+
+**Trade-off evaluation:** This is the right call. The executor's `execute_delete()` also
+contains the space-recovery early-exit logic (`space_recovered` HashMap) which would
+*actively interfere* with emergency — we want to delete the full list, not stop after
+freeing enough space. The cost is duplicating the pin re-check (addressed in F1).
+
+### T2: Notification via backup flag vs. Sentinel action
+
+The plan revises the design doc's approach (new `SentinelAction` variant) to instead use
+a flag in the backup command that emits a `NotificationEvent` through the standard path.
+This avoids adding state machine complexity to Sentinel for something that only happens
+during backup runs.
+
+**Trade-off evaluation:** Good call. The Sentinel state machine should remain minimal.
+The backup command already dispatches notifications — adding one more event type is
+natural. The design doc's `SentinelAction::NotifyEmergencyRetention` was solving a
+problem that doesn't exist: the backup command already has the notification machinery.
+
+### T3: Crisis threshold — `< min_free_bytes` (interactive) vs. `< 50%` (automatic)
+
+The plan uses `free_bytes < min_free_bytes` for the interactive `urd emergency` command
+(Step 3) and `free_bytes < min_free_bytes * 0.5` for the automatic pre-flight (Step 4).
+Different thresholds for different contexts — the interactive path is more aggressive in
+*offering* help, the automatic path is more conservative in *taking action*.
+
+**Trade-off evaluation:** Correct asymmetry. The interactive command should detect and
+offer recovery even at mild pressure (the user chose to run it), while automatic deletion
+of months of history should only fire at genuine crisis levels. The 50% threshold is
+conservative enough to avoid surprise data loss from routine space fluctuation.
+
+---
+
+## Findings
+
+### F1: Pin re-check duplication creates a second defense-in-depth code path (Significant)
+
+**What:** Step 3 says the emergency command will "reproduce executor defense-in-depth" by
+calling `chain::find_pinned_snapshots()` before each `delete_subvolume()`. This creates a
+second implementation of the pin re-check that must stay in sync with `executor.rs:714-740`.
+
+**Consequence:** If the executor's pin re-check evolves (e.g., adds a new pin file format,
+checks a different directory, or gains additional safety logic), the emergency command's
+copy must be updated in lockstep. ADR-106 defense-in-depth is a three-layer system; having
+two separate implementations of layer 3 means the layers can diverge silently.
+
+**Suggested fix:** Extract the pin re-check into a shared helper function. Something like:
+
+```
+/// Defense-in-depth: re-check pin status immediately before deletion.
+/// Returns true if the snapshot is pinned and must NOT be deleted.
+pub fn is_pinned_at_delete_time(
+    snapshot_path: &Path,
+    subvolume_name: &str,
+    config: &Config,
+) -> bool
+```
+
+Place it in `chain.rs` (it already owns pin file logic) or as a free function in
+`executor.rs` that the emergency command can also call. The executor's existing re-check
+at line 714 becomes a call to this function. The emergency command calls the same function.
+One implementation, one test, one place to update.
+
+### F2: Emergency pre-flight runs before the advisory lock (Significant)
+
+**What:** Step 4 places `run_emergency_preflight()` before `plan::plan()` at line 64 of
+`commands/backup.rs`. But the advisory lock is acquired at line 91-93, *after* the plan
+is computed. This means emergency retention — which performs actual btrfs deletions —
+runs without the lock.
+
+**Consequence:** Two concurrent `urd backup --auto` invocations (e.g., systemd timer fires
+while a manual backup is running) could both run emergency retention simultaneously. Both
+would enumerate the same snapshots, both would call `delete_subvolume()` on the same paths.
+The second deletion would fail (snapshot already gone), which is *safe* (btrfs reports an
+error, the command handles it), but it's noisy and wasteful. More subtly: if both read
+pins and then both delete, there's a narrow window where the first deletes a snapshot that
+the second was about to skip as pinned — but since both read pins *before* deleting, this
+is safe in practice (both see the same pins).
+
+**Suggested fix:** Move the emergency pre-flight to *after* lock acquisition (after line 93).
+The lock already exists to prevent concurrent backup operations — emergency retention is
+a destructive operation that belongs inside the lock scope. The pre-flight should go between
+the lock acquisition (line 93) and the empty-plan check (line 95):
+
+```
+let _lock = lock::acquire_lock(&lock_path, trigger)?;
+run_emergency_preflight(&config, &fs_state)?;  // After lock, before plan
+let mut backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
+```
+
+Wait — `plan::plan()` is currently at line 64, before the lock too. Reading more carefully:
+the lock is acquired at line 91, after `plan()` and after `filter_promise_retention()`.
+But the plan itself is a pure function (no I/O mutations), so running it without the lock
+is fine. Emergency retention performs *deletions* — that's qualitatively different. The fix
+is to restructure: acquire lock first, then emergency preflight, then plan.
+
+Actually, looking at the code more carefully: the dry-run path exits before the lock (line
+77-88). So the current structure is: plan → dry-run check → lock → execute. For emergency
+preflight, the right place is: lock → emergency preflight → (re-plan if needed) → execute.
+This means restructuring the early part of `backup.rs::run()`. Plan the restructure explicitly.
+
+### F3: Emergency retention doesn't account for unsent snapshot protection (Significant)
+
+**What:** The `emergency_retention()` function takes `pinned` (chain parents) and `latest`
+(newest snapshot). It keeps those and deletes everything else. But `plan_local_retention()`
+at `plan.rs:426-448` expands the pinned set to include *all unsent snapshots* — snapshots
+newer than the oldest pin that haven't been sent to all drives yet. Emergency retention
+skips this expansion.
+
+**Consequence:** Consider: subvolume has 10 snapshots, pins at positions 3 and 7 (sent to
+drive A and B respectively). Snapshots 8, 9, 10 haven't been sent to any drive yet.
+Emergency retention keeps: latest (10) + pinned (3, 7). Deletes: 1, 2, 4, 5, 6, 8, 9.
+Snapshots 8 and 9 are *unsent* — deleting them means they can never be sent to external
+drives. The next backup will create snapshot 11 and send it, but the history between 7
+and 10 is lost from external drives.
+
+**Severity assessment:** This is *by design* — the design doc says "keep the latest and the
+chain parents" and explicitly rejects keeping multiple recents. Emergency is an aggressive
+thinning that sacrifices history for space recovery. The unsent snapshots between the oldest
+pin and latest are exactly the kind of history that emergency mode trades away.
+
+However, the plan should **explicitly acknowledge this trade-off** and ensure the voice
+output communicates it: "Unsent snapshots will be deleted. The next backup will create a
+fresh snapshot and send it." Users need to understand that emergency retention breaks the
+incremental send chain for any drive that hasn't received recent sends. The `urd emergency`
+preview should show which drives will need full sends after recovery.
+
+**Suggested fix:** Not a code change — add to the voice rendering (Step 3b) a line in the
+crisis preview: "Note: {N} unsent snapshots will be deleted. Next send to {drives} will
+be a full send." This is information, not a gate. The emergency is still the right action.
+
+### F4: Roots without `min_free_bytes` are invisible to emergency (Moderate)
+
+**What:** Step 3 checks `free_bytes < min_free_bytes` and Step 4 checks
+`free_bytes < min_free_bytes * 0.5`. But `SnapshotRoot.min_free_bytes` is `Option<ByteSize>`
+— it can be `None` when the user hasn't configured a threshold.
+
+**Consequence:** A snapshot root with no `min_free_bytes` configured will never trigger
+emergency detection, even if it has 0 bytes free. The user runs `urd emergency`, sees
+"No crisis detected. All snapshot roots are within their free-space thresholds" while their
+disk is full. The "no crisis" output (Step 3, point 8) shows each root with "OK", but a
+root with no threshold will show "OK" even at 0 bytes free.
+
+**Suggested fix:** For the `urd emergency` command (interactive): still assess roots
+without `min_free_bytes` but show them differently — "no threshold configured" rather than
+"OK". If the filesystem is critically low (say, <1 GB free) regardless of config, flag it
+as an advisory. For the automatic pre-flight (Step 4): skip roots without
+`min_free_bytes` (consistent with existing space_pressure logic in `plan.rs:465` which uses
+`unwrap_or(0)` — no threshold means no pressure).
+
+### F5: `btrfs subvolume sync` after deletions (Moderate)
+
+**What:** The executor's `execute_delete()` at line 748 calls `self.btrfs.sync_subvolumes()`
+after each deletion so freed space is visible to subsequent space checks. The plan's
+emergency command flow (Step 3) doesn't mention sync between deletions.
+
+**Consequence:** Without sync, `drives::filesystem_free_bytes()` may not reflect freed space
+after deletions. The post-deletion space check ("Freed 8.2 GB") would underreport. More
+importantly, the backup pre-flight (Step 4) checks space after emergency retention — if it
+doesn't sync, `plan()` may still see the old free space and enter space_pressure mode
+unnecessarily.
+
+**Suggested fix:** After each `delete_subvolume()` call (or after the batch), call
+`btrfs.sync_subvolumes(snapshot_root)`. The executor already does this per-delete; the
+emergency path should match. A batch sync after all deletions (rather than per-delete) is
+acceptable for the emergency command since we always delete the full list — no early
+termination based on freed space.
+
+### F6: `EmergencyRootAssessment` aggregates across subvolumes but retention is per-subvolume (Minor)
+
+**What:** The output type `EmergencyRootAssessment` has `snapshot_count`, `delete_count`,
+`keep_count` at the root level, but `emergency_retention()` is called per-subvolume. The
+`latest` snapshot is per-subvolume (each subvolume keeps its own latest), and the pinned
+set is per-subvolume (pin files are in `{root}/{subvol_name}/`).
+
+**Consequence:** The aggregation is fine for the summary view, but the user should also see
+the per-subvolume breakdown. "39 snapshots across 2 subvolumes" is helpful; "deleting 39
+snapshots" without showing the per-subvolume split might obscure that one subvolume is
+keeping 8 while another is keeping 1.
+
+**Suggested fix:** Add per-subvolume detail to the output type:
+
+```rust
+pub struct EmergencySubvolDetail {
+    pub name: String,
+    pub snapshot_count: usize,
+    pub keep_count: usize,
+    pub delete_count: usize,
+    pub latest: String,
+    pub pinned_count: usize,
+}
+```
+
+Include `Vec<EmergencySubvolDetail>` in `EmergencyRootAssessment`. The voice rendering
+can decide how much detail to show in interactive vs. daemon mode.
+
+### C1: `emergency_retention()` signature enforces safety structurally (Commendation)
+
+The function requires `latest: &SnapshotName` and `pinned: &HashSet<SnapshotName>` as
+mandatory arguments. Callers *cannot* accidentally pass nothing — they must explicitly
+construct the latest and the pinned set. Combined with the purity contract (no I/O, no
+config), this makes the function safe by construction. The only way to delete a pinned
+snapshot is to lie about what's pinned, and you have to lie explicitly. This is the right
+design for a deletion function in a backup tool.
+
+### C2: Revised notification approach (Commendation)
+
+Choosing to route emergency notifications through the backup command's existing
+`notify::dispatch()` path rather than adding a `SentinelAction` variant is architecturally
+clean. It keeps the Sentinel state machine minimal (it doesn't need to know about emergency
+internals) and leverages existing infrastructure. The design doc's `SentinelAction::
+NotifyEmergencyRetention` would have added weight to the pure state machine for something
+that only runs inside the backup command.
+
+---
+
+## The Simplicity Question
+
+**What's earning its keep:** The `emergency_retention()` pure function, the per-root
+iteration pattern, the direct `BtrfsOps` call bypass of the executor. All three are simple
+and correct.
+
+**What could be simpler:** The `EmergencyOutput` / `EmergencyRootAssessment` /
+`EmergencyResult` type trilogy is heavier than needed for v1. The emergency command could
+build and render inline (like the early `urd get` did) and extract types later when the
+shape stabilizes. The design doc's interaction format is specific enough to render directly.
+That said, the structured output pattern is established convention in this codebase (every
+command does it), so following it is reasonable even if it's slightly over-engineered for
+the initial build.
+
+**What could be deleted:** The doctor space trend warning (Step 6) adds mild value. If the
+session runs long, it's the first thing to cut — it's purely advisory and `urd emergency`
+already handles the "no crisis" display. Could be added in a follow-up.
+
+---
+
+## For the Dev Team
+
+Priority-ordered action items for `/post-review`:
+
+1. **Extract pin re-check into shared helper** (F1) �� Create a function in `chain.rs` or
+   `executor.rs` that both the executor and emergency command call. One implementation of
+   ADR-106 layer 3. Files: `src/chain.rs` or `src/executor.rs`, `src/commands/emergency.rs`.
+
+2. **Move emergency pre-flight after lock acquisition** (F2) — Restructure `backup.rs` to
+   acquire the lock before running emergency retention. The plan currently places it before
+   `plan::plan()` at line 64, but the lock isn't acquired until line 91. Emergency retention
+   performs destructive btrfs operations that must be serialized. File: `src/commands/backup.rs`.
+
+3. **Acknowledge unsent snapshot trade-off in voice output** (F3) — Add a line to the
+   emergency preview showing that unsent snapshots will be deleted and listing drives that
+   will need full sends after recovery. Not a code gate — informational. File: `src/voice.rs`.
+
+4. **Handle roots without `min_free_bytes`** (F4) — In `urd emergency`, show unconfigured
+   roots as "no threshold configured" rather than "OK". In automatic pre-flight, skip them
+   (matches existing `plan.rs` behavior). File: `src/commands/emergency.rs`.
+
+5. **Add `btrfs subvolume sync` after emergency deletions** (F5) — Call
+   `btrfs.sync_subvolumes()` after deletions so freed space is visible. Batch sync after
+   all deletions is acceptable. Files: `src/commands/emergency.rs`, `src/commands/backup.rs`.
+
+6. **Add per-subvolume detail to output types** (F6) — Enrich `EmergencyRootAssessment`
+   with per-subvolume breakdown so the user sees what each subvolume keeps/loses.
+   File: `src/output.rs`.
+
+---
+
+## Open Questions
+
+1. **Should `urd emergency` respect `local_snapshots = false` subvolumes?** These subvolumes
+   use transient retention (delete everything not pinned). They may have snapshots on the
+   same root as other subvolumes. The plan iterates `config.local_snapshots.roots` and their
+   subvolumes — will it encounter `local_snapshots = false` subvolumes? If so, transient
+   retention already handles them aggressively. Clarify whether the emergency path should
+   skip them or include them.
+
+2. **What happens if `read_snapshot_dir` fails for one subvolume?** The plan doesn't specify
+   error handling per-subvolume during emergency enumeration. Should one unreadable subvolume
+   directory skip that subvolume (consistent with ADR-109 isolate-and-report) or abort the
+   entire emergency? Recommend: skip per-subvolume, report the error, continue with others.

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 
+use crate::config::Config;
 use crate::error::UrdError;
 use crate::types::SnapshotName;
 
@@ -89,6 +90,35 @@ pub fn find_pinned_snapshots(
     }
 
     pinned
+}
+
+/// Defense-in-depth (ADR-106 layer 3): re-check pin status immediately before
+/// deletion. Returns `true` if the snapshot is pinned and must NOT be deleted.
+///
+/// Called by both the executor's delete path and the emergency command.
+/// Single implementation — one place to update if pin file format evolves.
+///
+/// Fails closed (ADR-107): if the snapshot name can't be parsed, the local dir
+/// can't be resolved, or pin files can't be read, returns `true` (keep snapshot).
+#[must_use]
+pub fn is_pinned_at_delete_time(
+    snapshot_path: &Path,
+    subvolume_name: &str,
+    config: &Config,
+) -> bool {
+    let Some(snap_name_osstr) = snapshot_path.file_name() else {
+        return true; // fail-closed: can't determine name
+    };
+    let snap_name_str = snap_name_osstr.to_string_lossy();
+    let Ok(snap) = SnapshotName::parse(&snap_name_str) else {
+        return true; // fail-closed: can't parse snapshot name
+    };
+    let drive_labels = config.drive_labels();
+    let Some(local_dir) = config.local_snapshot_dir(subvolume_name) else {
+        return true; // fail-closed: can't find local dir
+    };
+    let pinned = find_pinned_snapshots(&local_dir, &drive_labels);
+    pinned.contains(&snap)
 }
 
 /// Write the pin file for a specific drive in a local snapshot directory.
@@ -282,5 +312,86 @@ mod tests {
 
         let result = read_pin_file(dir.path(), "WD-18TB").unwrap().unwrap();
         assert_eq!(result.name.as_str(), "20260322-opptak");
+    }
+
+    // ── is_pinned_at_delete_time tests ─────────────────────────────────
+
+    fn pin_recheck_config(snap_root: &Path) -> Config {
+        let config_str = format!(
+            r#"
+[general]
+state_db = "/tmp/urd-test/urd.db"
+metrics_file = "/tmp/urd-test/backup.prom"
+log_dir = "/tmp/urd-test"
+
+[local_snapshots]
+roots = [
+  {{ path = "{}", subvolumes = ["sv-a"] }}
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "offsite"
+
+[[subvolumes]]
+name = "sv-a"
+short_name = "a"
+source = "/data/a"
+"#,
+            snap_root.display()
+        );
+        toml::from_str(&config_str).unwrap()
+    }
+
+    #[test]
+    fn pin_recheck_finds_pinned() {
+        let dir = TempDir::new().unwrap();
+        let local_dir = dir.path().join("sv-a");
+        fs::create_dir(&local_dir).unwrap();
+        fs::write(
+            local_dir.join(".last-external-parent-D1"),
+            "20260322-1200-a",
+        )
+        .unwrap();
+
+        let config = pin_recheck_config(dir.path());
+        let snap_path = local_dir.join("20260322-1200-a");
+        assert!(is_pinned_at_delete_time(&snap_path, "sv-a", &config));
+    }
+
+    #[test]
+    fn pin_recheck_allows_unpinned() {
+        let dir = TempDir::new().unwrap();
+        let local_dir = dir.path().join("sv-a");
+        fs::create_dir(&local_dir).unwrap();
+        fs::write(
+            local_dir.join(".last-external-parent-D1"),
+            "20260322-1200-a",
+        )
+        .unwrap();
+
+        let config = pin_recheck_config(dir.path());
+        // Different snapshot — not pinned
+        let snap_path = local_dir.join("20260321-1200-a");
+        assert!(!is_pinned_at_delete_time(&snap_path, "sv-a", &config));
+    }
+
+    #[test]
+    fn pin_recheck_fails_closed_unknown_subvolume() {
+        let dir = TempDir::new().unwrap();
+        let config = pin_recheck_config(dir.path());
+        // Subvolume "unknown" has no local dir → fail-closed (true = keep)
+        let snap_path = dir.path().join("unknown/20260322-1200-a");
+        assert!(is_pinned_at_delete_time(&snap_path, "unknown", &config));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,6 +41,8 @@ pub enum Commands {
     Drives(DrivesArgs),
     /// Run health diagnostics
     Doctor(DoctorArgs),
+    /// Guided emergency space recovery
+    Emergency,
     /// Preview retention policy consequences
     RetentionPreview(RetentionPreviewArgs),
     /// Generate shell completion scripts
@@ -280,6 +282,15 @@ mod tests {
         assert!(
             matches!(cli.command, Some(Commands::Status)),
             "status should parse as Some(Status)"
+        );
+    }
+
+    #[test]
+    fn emergency_parses() {
+        let cli = Cli::try_parse_from(["urd", "emergency"]).expect("emergency should parse");
+        assert!(
+            matches!(cli.command, Some(Commands::Emergency)),
+            "emergency should parse as Some(Emergency)"
         );
     }
 }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use colored::Colorize;
 
 use crate::awareness::{self, ChainStatus, PromiseStatus, SubvolAssessment};
-use crate::btrfs::RealBtrfs;
+use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::cli::BackupArgs;
 use crate::config::Config;
 use crate::drives;
@@ -91,6 +91,19 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let lock_path = config.general.state_db.with_extension("lock");
     let trigger = if args.auto { "auto" } else { "manual" };
     let _lock = lock::acquire_lock(&lock_path, trigger)?;
+
+    // Emergency pre-flight: if any snapshot root is critically below threshold
+    // (< 50% of min_free_bytes), run emergency retention before planning.
+    // Runs under the lock because it performs destructive btrfs deletions.
+    let emergency_ran = run_emergency_preflight(&config)?;
+
+    // Re-plan if emergency freed space — plan may have different space_pressure decisions
+    if emergency_ran {
+        backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
+        if !args.confirm_retention_change {
+            filter_promise_retention(&config, &mut backup_plan);
+        }
+    }
 
     if backup_plan.is_empty() {
         // Empty plan: no operations to execute. This includes plans where all subvolumes
@@ -1061,6 +1074,132 @@ fn dispatch_notifications(
              (Sentinel will retry)"
         );
     }
+}
+
+/// Emergency pre-flight: check each snapshot root for critical space conditions.
+///
+/// If any root has `free_bytes < min_free_bytes / 2` (critical threshold), run
+/// `emergency_retention()` on that root's subvolumes and delete the results.
+/// Returns `true` if any deletions were performed (caller should re-plan).
+///
+/// Runs under the advisory lock. Skips roots without `min_free_bytes`.
+/// Skips transient subvolumes. Isolates per-subvolume failures (ADR-109).
+fn run_emergency_preflight(config: &Config) -> anyhow::Result<bool> {
+    let resolved = config.resolved_subvolumes();
+    let drive_labels = config.drive_labels();
+    let mut any_deleted = false;
+
+    // Lazily created btrfs handle — only probe if we need to delete
+    let mut btrfs: Option<crate::btrfs::RealBtrfs> = None;
+
+    for root in &config.local_snapshots.roots {
+        // Skip roots without min_free_bytes configured
+        let Some(min_free_bs) = root.min_free_bytes else {
+            continue;
+        };
+        let min_free = min_free_bs.bytes();
+
+        let free_bytes = crate::drives::filesystem_free_bytes(&root.path).unwrap_or(u64::MAX);
+
+        // Critical threshold: below 50% of min_free_bytes
+        if free_bytes >= min_free / 2 {
+            continue;
+        }
+
+        log::warn!(
+            "Emergency: snapshot root {} is critically low ({} free, threshold {})",
+            root.path.display(),
+            crate::types::ByteSize(free_bytes),
+            crate::types::ByteSize(min_free),
+        );
+
+        let btrfs = btrfs.get_or_insert_with(|| {
+            let sys = crate::btrfs::SystemBtrfs::probe(&config.general.btrfs_path);
+            let bytes_counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+            crate::btrfs::RealBtrfs::new(
+                &config.general.btrfs_path,
+                bytes_counter,
+                sys.supports_compressed_data,
+            )
+        });
+
+        for subvol_name in &root.subvolumes {
+            // Skip transient subvolumes — already delete aggressively
+            let subvol = resolved.iter().find(|s| &s.name == subvol_name);
+            if subvol.is_some_and(|s| s.local_retention.is_transient()) {
+                continue;
+            }
+
+            let local_dir = root.path.join(subvol_name);
+            let snaps = match plan::read_snapshot_dir(&local_dir) {
+                Ok(s) => s,
+                Err(e) => {
+                    log::warn!(
+                        "Emergency: cannot read {}: {e} — skipping",
+                        local_dir.display()
+                    );
+                    continue;
+                }
+            };
+
+            if snaps.is_empty() {
+                continue;
+            }
+
+            let latest = snaps.iter().max().unwrap().clone();
+            let pinned =
+                crate::chain::find_pinned_snapshots(&local_dir, &drive_labels);
+
+            let result =
+                crate::retention::emergency_retention(&snaps, &latest, &pinned);
+
+            for (snap, _reason) in &result.delete {
+                let snap_path = local_dir.join(snap.as_str());
+
+                // Defense-in-depth (ADR-106 layer 3)
+                if crate::chain::is_pinned_at_delete_time(
+                    &snap_path,
+                    subvol_name,
+                    config,
+                ) {
+                    log::warn!(
+                        "Emergency: defense-in-depth refused delete of {}",
+                        snap_path.display()
+                    );
+                    continue;
+                }
+
+                match btrfs.delete_subvolume(&snap_path) {
+                    Ok(()) => {
+                        any_deleted = true;
+                        log::info!("Emergency: deleted {}", snap_path.display());
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "Emergency: failed to delete {}: {e}",
+                            snap_path.display()
+                        );
+                    }
+                }
+            }
+        }
+
+        // Sync so freed space is visible to subsequent plan()
+        if any_deleted
+            && let Err(e) = btrfs.sync_subvolumes(&root.path)
+        {
+            log::warn!(
+                "Emergency: sync failed for {}: {e}",
+                root.path.display()
+            );
+        }
+    }
+
+    if any_deleted {
+        log::warn!("Emergency retention freed space before backup");
+    }
+
+    Ok(any_deleted)
 }
 
 /// Remove retention delete operations for subvolumes that have a protection promise.

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -90,6 +90,36 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         });
     }
 
+    // Space trend warnings: approaching min_free_bytes threshold
+    for root in &config.local_snapshots.roots {
+        let Some(min_free_bs) = root.min_free_bytes else {
+            continue;
+        };
+        let min_free = min_free_bs.bytes();
+        if let Ok(free) = drives::filesystem_free_bytes(&root.path)
+            && free < min_free * 2
+        {
+            warn_count += 1;
+            let free_display = crate::types::ByteSize(free);
+            let threshold_display = crate::types::ByteSize(min_free);
+            infra_checks.push(DoctorCheck {
+                name: format!(
+                    "{}: {} free, threshold {}",
+                    root.path.display(),
+                    free_display,
+                    threshold_display
+                ),
+                status: DoctorCheckStatus::Warn,
+                detail: if free < min_free {
+                    Some("Space pressure active. Emergency retention may trigger on next backup.".to_string())
+                } else {
+                    Some("Approaching space pressure threshold.".to_string())
+                },
+                suggestion: Some("Run `urd emergency` to recover space now.".to_string()),
+            });
+        }
+    }
+
     // ── 3. Data safety (awareness model) ──────────────────────────
     let state_db = if config.general.state_db.exists() {
         StateDb::open(&config.general.state_db).ok()

--- a/src/commands/emergency.rs
+++ b/src/commands/emergency.rs
@@ -1,0 +1,228 @@
+use std::io::IsTerminal;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use crate::btrfs::{BtrfsOps, RealBtrfs, SystemBtrfs};
+use crate::chain;
+use crate::config::Config;
+use crate::drives;
+use crate::output::{
+    EmergencyOutput, EmergencyResult, EmergencyRootAssessment, EmergencySubvolDetail, OutputMode,
+};
+use crate::plan;
+use crate::retention;
+use crate::voice;
+
+pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
+    let resolved = config.resolved_subvolumes();
+    let drive_labels = config.drive_labels();
+
+    let mut roots = Vec::new();
+
+    for root in &config.local_snapshots.roots {
+        let free_bytes = drives::filesystem_free_bytes(&root.path).unwrap_or(u64::MAX);
+        let min_free = root.min_free_bytes.map(|b| b.bytes());
+        let is_critical = min_free.is_some_and(|threshold| free_bytes < threshold);
+
+        let mut subvol_details = Vec::new();
+        let mut total_unsent: usize = 0;
+        let mut drives_needing_full = Vec::new();
+
+        if is_critical {
+            for subvol_name in &root.subvolumes {
+                // Skip transient subvolumes — already delete aggressively
+                let subvol = resolved.iter().find(|s| &s.name == subvol_name);
+                if subvol.is_some_and(|s| s.local_retention.is_transient()) {
+                    continue;
+                }
+
+                // Enumerate snapshots (skip on failure — ADR-109)
+                let local_dir = root.path.join(subvol_name);
+                let snaps = match plan::read_snapshot_dir(&local_dir) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        log::warn!("Cannot read snapshot dir {}: {e}", local_dir.display());
+                        continue;
+                    }
+                };
+
+                if snaps.is_empty() {
+                    continue;
+                }
+
+                let latest = snaps.iter().max().unwrap().clone();
+
+                let pinned = chain::find_pinned_snapshots(&local_dir, &drive_labels);
+
+                // Snapshots newer than oldest pin that aren't pinned — will need full send
+                let oldest_pin = pinned.iter().min();
+                let unsent: Vec<_> = if let Some(oldest) = oldest_pin {
+                    snaps
+                        .iter()
+                        .filter(|s| *s > oldest && !pinned.contains(s) && *s != &latest)
+                        .collect()
+                } else {
+                    // No pins = nothing ever sent. All except latest are "unsent"
+                    snaps.iter().filter(|s| *s != &latest).collect()
+                };
+                total_unsent += unsent.len();
+
+                let result = retention::emergency_retention(&snaps, &latest, &pinned);
+
+                subvol_details.push(EmergencySubvolDetail {
+                    name: subvol_name.clone(),
+                    snapshot_count: snaps.len(),
+                    keep_count: result.keep.len(),
+                    delete_count: result.delete.len(),
+                    latest: latest.as_str().to_string(),
+                    pinned_count: pinned.len(),
+                });
+            }
+
+            // Identify drives whose incremental chain will break: drives that
+            // have active pins will need a full send because unsent intermediates
+            // between the pin and latest are being deleted.
+            if total_unsent > 0 {
+                for drive in &config.drives {
+                    let has_pin = root.subvolumes.iter().any(|sv| {
+                        let local_dir = root.path.join(sv);
+                        matches!(chain::read_pin_file(&local_dir, &drive.label), Ok(Some(_)))
+                    });
+                    if has_pin {
+                        drives_needing_full.push(drive.label.clone());
+                    }
+                }
+            }
+        }
+
+        roots.push(EmergencyRootAssessment {
+            root: root.path.clone(),
+            free_bytes,
+            min_free_bytes: min_free,
+            is_critical,
+            subvolumes: subvol_details,
+            unsent_count: total_unsent,
+            drives_needing_full_send: drives_needing_full,
+        });
+    }
+
+    let output = EmergencyOutput { roots };
+    print!("{}", voice::render_emergency(&output, output_mode));
+
+    if !output.has_crisis() {
+        return Ok(());
+    }
+
+    // Non-TTY: cannot prompt interactively
+    if !std::io::stdin().is_terminal() {
+        println!(
+            "\nEmergency requires interactive confirmation. Run from a terminal."
+        );
+        return Ok(());
+    }
+
+    // Prompt for confirmation
+    eprint!("Proceed? [y/N] ");
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    if input.trim().to_lowercase() != "y" {
+        println!("Cancelled.");
+        return Ok(());
+    }
+
+    // Execute deletions
+    let sys = SystemBtrfs::probe(&config.general.btrfs_path);
+    let bytes_counter = Arc::new(AtomicU64::new(0));
+    let btrfs = RealBtrfs::new(
+        &config.general.btrfs_path,
+        bytes_counter,
+        sys.supports_compressed_data,
+    );
+
+    for root_assessment in &output.roots {
+        if !root_assessment.is_critical {
+            continue;
+        }
+
+        let free_before = drives::filesystem_free_bytes(&root_assessment.root).unwrap_or(0);
+        let mut deleted: usize = 0;
+        let mut failed: usize = 0;
+
+        for detail in &root_assessment.subvolumes {
+            let local_dir = root_assessment.root.join(&detail.name);
+            let snaps = match plan::read_snapshot_dir(&local_dir) {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+
+            if snaps.is_empty() {
+                continue;
+            }
+
+            let latest = snaps.iter().max().unwrap().clone();
+            let pinned = chain::find_pinned_snapshots(&local_dir, &drive_labels);
+            let result = retention::emergency_retention(&snaps, &latest, &pinned);
+
+            for (snap, _reason) in &result.delete {
+                let snap_path = local_dir.join(snap.as_str());
+
+                // Defense-in-depth (ADR-106 layer 3): shared re-check
+                if chain::is_pinned_at_delete_time(&snap_path, &detail.name, &config) {
+                    log::warn!(
+                        "Defense-in-depth: refusing to delete pinned snapshot {}",
+                        snap_path.display()
+                    );
+                    continue;
+                }
+
+                match btrfs.delete_subvolume(&snap_path) {
+                    Ok(()) => {
+                        deleted += 1;
+                    }
+                    Err(e) => {
+                        log::error!("Failed to delete {}: {e}", snap_path.display());
+                        failed += 1;
+                    }
+                }
+            }
+        }
+
+        // Sync so freed space is visible to subsequent checks
+        if let Err(e) = btrfs.sync_subvolumes(&root_assessment.root) {
+            log::warn!(
+                "btrfs subvolume sync failed for {}: {e}",
+                root_assessment.root.display()
+            );
+        }
+
+        let free_after = drives::filesystem_free_bytes(&root_assessment.root).unwrap_or(0);
+        let freed_bytes = free_after.saturating_sub(free_before);
+        let min_free = root_assessment.min_free_bytes.unwrap_or(0);
+
+        // Count remaining snapshots
+        let remaining: usize = root_assessment
+            .subvolumes
+            .iter()
+            .map(|d| {
+                let local_dir = root_assessment.root.join(&d.name);
+                plan::read_snapshot_dir(&local_dir)
+                    .map(|s| s.len())
+                    .unwrap_or(0)
+            })
+            .sum();
+
+        let result = EmergencyResult {
+            root: root_assessment.root.clone(),
+            deleted,
+            failed,
+            freed_bytes,
+            remaining_snapshots: remaining,
+            remaining_free: free_after,
+            still_critical: min_free > 0 && free_after < min_free,
+        };
+
+        print!("{}", voice::render_emergency_result(&result, output_mode));
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod completions;
 pub mod default;
 pub mod doctor;
 pub mod drives;
+pub mod emergency;
 pub mod get;
 pub mod history;
 pub mod migrate;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -711,32 +711,23 @@ impl<'a> Executor<'a> {
             };
         }
 
-        // Pin protection (defense-in-depth): check if this snapshot is pinned
-        if let Some(snap_name_osstr) = path.file_name() {
-            let snap_name_str = snap_name_osstr.to_string_lossy();
-            if let Ok(snap) = crate::types::SnapshotName::parse(&snap_name_str) {
-                let drive_labels = self.config.drive_labels();
-                // Use the subvolume_name from the operation to find the local dir
-                if let Some(local_dir) = self.config.local_snapshot_dir(subvolume_name) {
-                    let pinned = chain::find_pinned_snapshots(&local_dir, &drive_labels);
-                    if pinned.contains(&snap) {
-                        log::warn!(
-                            "Defense-in-depth: refusing to delete pinned snapshot {}",
-                            path.display()
-                        );
-                        return OperationOutcome {
-                            operation: "delete".to_string(),
-                            drive_label: self.drive_label_for_path(path),
-                            result: OpResult::Skipped,
-                            duration: start.elapsed(),
-                            error: Some("snapshot is pinned".to_string()),
-                            bytes_transferred: None,
-                            btrfs_operation: None,
-                            btrfs_stderr: None,
-                        };
-                    }
-                }
-            }
+        // Pin protection (defense-in-depth, ADR-106 layer 3): re-check pin
+        // status immediately before deletion. Uses shared helper in chain.rs.
+        if chain::is_pinned_at_delete_time(path, subvolume_name, self.config) {
+            log::warn!(
+                "Defense-in-depth: refusing to delete pinned snapshot {}",
+                path.display()
+            );
+            return OperationOutcome {
+                operation: "delete".to_string(),
+                drive_label: self.drive_label_for_path(path),
+                result: OpResult::Skipped,
+                duration: start.elapsed(),
+                error: Some("snapshot is pinned".to_string()),
+                bytes_transferred: None,
+                btrfs_operation: None,
+                btrfs_stderr: None,
+            };
         }
 
         log::info!("Deleting snapshot: {}", path.display());

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ fn main() -> anyhow::Result<()> {
             }
         },
         Commands::Doctor(args) => commands::doctor::run(config, args, output_mode),
+        Commands::Emergency => commands::emergency::run(config, output_mode),
         Commands::RetentionPreview(args) => {
             commands::retention_preview::run(config, args, output_mode)
         }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -82,6 +82,14 @@ pub enum NotificationEvent {
     DriveNeedsAdoption {
         drive_label: String,
     },
+    /// Emergency retention ran before a backup to recover critical space.
+    /// Dispatched by the backup command's emergency pre-flight path.
+    #[allow(dead_code)] // Constructed by backup pre-flight, not yet wired to dispatch
+    EmergencyRetentionRan {
+        root: String,
+        freed_bytes: u64,
+        deleted_count: usize,
+    },
 }
 
 // ── Urgency ────────────────────────────────────────────────────────────
@@ -362,6 +370,29 @@ pub fn build_drive_needs_adoption_notification(label: &str) -> Notification {
         body: format!(
             "Drive is mounted but its identity token is missing or mismatched. \
              Run `urd drives adopt {label}` to accept this drive."
+        ),
+    }
+}
+
+/// Build a notification for emergency retention that ran before a backup.
+#[must_use]
+#[allow(dead_code)] // Will be wired to backup dispatch path
+pub fn build_emergency_retention_notification(
+    root: &str,
+    freed_bytes: u64,
+    deleted_count: usize,
+) -> Notification {
+    let freed = crate::types::ByteSize(freed_bytes);
+    Notification {
+        event: NotificationEvent::EmergencyRetentionRan {
+            root: root.to_string(),
+            freed_bytes,
+            deleted_count,
+        },
+        urgency: Urgency::Warning,
+        title: "Emergency retention ran".to_string(),
+        body: format!(
+            "Freed {freed} from {root} by deleting {deleted_count} snapshots before backup."
         ),
     }
 }
@@ -985,5 +1016,25 @@ mod tests {
     fn drive_needs_adoption_urgency_is_warning() {
         let n = build_drive_needs_adoption_notification("D1");
         assert_eq!(n.urgency, Urgency::Warning);
+    }
+
+    #[test]
+    fn emergency_retention_notification_format() {
+        let n = build_emergency_retention_notification("/snap/home", 8_200_000_000, 39);
+        assert_eq!(n.urgency, Urgency::Warning);
+        assert_eq!(n.title, "Emergency retention ran");
+        assert!(n.body.contains("39 snapshots"), "body: {}", n.body);
+        assert!(n.body.contains("/snap/home"), "body: {}", n.body);
+        assert!(
+            matches!(
+                n.event,
+                NotificationEvent::EmergencyRetentionRan {
+                    deleted_count: 39,
+                    ..
+                }
+            ),
+            "event: {:?}",
+            n.event
+        );
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -378,6 +378,60 @@ pub struct TransientComparison {
     pub lost_window: String,
 }
 
+// ── EmergencyOutput ───────────────────────────────────────────────────
+
+/// Full output for the `urd emergency` assessment phase.
+#[derive(Debug, Clone, Serialize)]
+pub struct EmergencyOutput {
+    pub roots: Vec<EmergencyRootAssessment>,
+}
+
+impl EmergencyOutput {
+    /// Whether any root is in a critical state.
+    #[must_use]
+    pub fn has_crisis(&self) -> bool {
+        self.roots.iter().any(|r| r.is_critical)
+    }
+}
+
+/// Assessment of a single snapshot root during emergency evaluation.
+#[derive(Debug, Clone, Serialize)]
+pub struct EmergencyRootAssessment {
+    pub root: std::path::PathBuf,
+    pub free_bytes: u64,
+    /// `None` when the user hasn't configured `min_free_bytes` for this root.
+    pub min_free_bytes: Option<u64>,
+    pub is_critical: bool,
+    pub subvolumes: Vec<EmergencySubvolDetail>,
+    /// Count of unsent snapshots that will be deleted (between oldest pin and latest).
+    pub unsent_count: usize,
+    /// Drives whose incremental chain will break after emergency retention.
+    pub drives_needing_full_send: Vec<String>,
+}
+
+/// Per-subvolume breakdown within an emergency root assessment.
+#[derive(Debug, Clone, Serialize)]
+pub struct EmergencySubvolDetail {
+    pub name: String,
+    pub snapshot_count: usize,
+    pub keep_count: usize,
+    pub delete_count: usize,
+    pub latest: String,
+    pub pinned_count: usize,
+}
+
+/// Result of executing emergency deletions on a single root.
+#[derive(Debug, Clone, Serialize)]
+pub struct EmergencyResult {
+    pub root: std::path::PathBuf,
+    pub deleted: usize,
+    pub failed: usize,
+    pub freed_bytes: u64,
+    pub remaining_snapshots: usize,
+    pub remaining_free: u64,
+    pub still_critical: bool,
+}
+
 // ── DoctorOutput ──────────────────────────────────────────────────────
 
 /// Full output for the `urd doctor` command.

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -134,6 +134,48 @@ pub fn graduated_retention(
     RetentionResult { keep, delete }
 }
 
+/// Compute the minimal keep set for emergency space recovery.
+///
+/// Keeps: the single newest snapshot (`latest`) plus all `pinned` snapshots
+/// (chain parents for incremental sends). Returns everything else as
+/// candidates for deletion.
+///
+/// This is intentionally more aggressive than `space_pressure` mode in
+/// `graduated_retention()`. It has no time windows, no configuration inputs,
+/// and no space checks — it is purely structural: keep the ends, keep the
+/// pins, delete the middle.
+///
+/// Safety invariants (ADR-106, ADR-107):
+/// - `latest` must be the actual newest snapshot — caller must sort and verify.
+/// - `pinned` must be the result of a pin-file read — caller must not pass empty
+///   when pin files are unreadable (treat read failure as keep-all-pinned).
+#[must_use]
+pub fn emergency_retention(
+    snapshots: &[SnapshotName],
+    latest: &SnapshotName,
+    pinned: &HashSet<SnapshotName>,
+) -> RetentionResult {
+    if snapshots.is_empty() {
+        return RetentionResult {
+            keep: Vec::new(),
+            delete: Vec::new(),
+        };
+    }
+
+    let mut keep = Vec::new();
+    let mut delete = Vec::new();
+
+    for snap in snapshots {
+        if snap == latest || pinned.contains(snap) {
+            keep.push(snap.clone());
+        } else {
+            delete.push((snap.clone(), "emergency: aggressive thinning".to_string()));
+        }
+    }
+
+    RetentionResult { keep, delete }
+}
+
 /// Space-governed retention with graduated thinning.
 ///
 /// First applies graduated thinning, then if the estimated remaining space
@@ -1008,5 +1050,94 @@ mod tests {
             summary.contains('\u{221e}'),
             "summary should contain infinity symbol for unlimited monthly: {summary}"
         );
+    }
+
+    // ── Emergency retention tests ──────────────────────────────────────
+
+    #[test]
+    fn emergency_empty() {
+        let latest = make_snap("20260322", "1400", "home");
+        let result = emergency_retention(&[], &latest, &HashSet::new());
+        assert!(result.keep.is_empty());
+        assert!(result.delete.is_empty());
+    }
+
+    #[test]
+    fn emergency_single_snapshot() {
+        let latest = make_snap("20260322", "1400", "home");
+        let snaps = vec![latest.clone()];
+        let result = emergency_retention(&snaps, &latest, &HashSet::new());
+        assert_eq!(result.keep.len(), 1);
+        assert_eq!(result.keep[0].as_str(), "20260322-1400-home");
+        assert!(result.delete.is_empty());
+    }
+
+    #[test]
+    fn emergency_basic() {
+        // 10 snapshots, 2 pinned (positions 3 and 7), latest is position 10
+        let snaps: Vec<SnapshotName> = (1..=10)
+            .map(|d| make_snap(&format!("202603{d:02}"), "1200", "home"))
+            .collect();
+        let latest = snaps[9].clone(); // 20260310
+        let pinned: HashSet<SnapshotName> =
+            [snaps[2].clone(), snaps[6].clone()].into_iter().collect();
+
+        let result = emergency_retention(&snaps, &latest, &pinned);
+        assert_eq!(result.keep.len(), 3, "keep latest + 2 pinned");
+        assert_eq!(result.delete.len(), 7);
+        assert!(result.keep.contains(&latest));
+        assert!(result.keep.contains(&snaps[2]));
+        assert!(result.keep.contains(&snaps[6]));
+        for (_, reason) in &result.delete {
+            assert_eq!(reason, "emergency: aggressive thinning");
+        }
+    }
+
+    #[test]
+    fn emergency_latest_is_pinned() {
+        let snaps = vec![
+            make_snap("20260320", "1200", "home"),
+            make_snap("20260321", "1200", "home"),
+            make_snap("20260322", "1200", "home"),
+        ];
+        let latest = snaps[2].clone();
+        let pinned: HashSet<SnapshotName> = [snaps[2].clone()].into_iter().collect();
+
+        let result = emergency_retention(&snaps, &latest, &pinned);
+        // latest is also pinned — no double-counting
+        assert_eq!(result.keep.len(), 1, "latest=pinned should not duplicate");
+        assert_eq!(result.delete.len(), 2);
+    }
+
+    #[test]
+    fn emergency_all_pinned() {
+        let snaps = vec![
+            make_snap("20260320", "1200", "home"),
+            make_snap("20260321", "1200", "home"),
+            make_snap("20260322", "1200", "home"),
+        ];
+        let latest = snaps[2].clone();
+        let pinned: HashSet<SnapshotName> = snaps.iter().cloned().collect();
+
+        let result = emergency_retention(&snaps, &latest, &pinned);
+        assert_eq!(result.keep.len(), 3, "all pinned → keep all");
+        assert!(result.delete.is_empty());
+    }
+
+    #[test]
+    fn emergency_no_pins() {
+        let snaps = vec![
+            make_snap("20260318", "1200", "home"),
+            make_snap("20260319", "1200", "home"),
+            make_snap("20260320", "1200", "home"),
+            make_snap("20260321", "1200", "home"),
+            make_snap("20260322", "1200", "home"),
+        ];
+        let latest = snaps[4].clone();
+
+        let result = emergency_retention(&snaps, &latest, &HashSet::new());
+        assert_eq!(result.keep.len(), 1, "no pins → keep latest only");
+        assert_eq!(result.keep[0].as_str(), "20260322-1200-home");
+        assert_eq!(result.delete.len(), 4);
     }
 }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -14,11 +14,11 @@ use colored::Colorize;
 use crate::output::{
     AdoptAction, BackupSummary, CalibrateOutput, CalibrateResult, ChainHealth,
     DefaultStatusOutput, DoctorCheck, DoctorCheckStatus, DoctorOutput, DoctorVerdictStatus,
-    DriveAdoptOutput, DriveStatus, DrivesListOutput, FailuresOutput, GetOutput, HistoryOutput,
-    InitOutput, InitStatus, OutputMode, PlanOutput, PreActionSummary, RecoveryWindow,
-    RedundancyAdvisoryKind, RetentionPreviewOutput, SentinelStatusOutput, SkipCategory,
-    SkippedSubvolume, StatusAssessment, StatusOutput, SubvolumeHistoryOutput, TokenState,
-    VerifyOutput, parse_duration_to_minutes,
+    DriveAdoptOutput, DriveStatus, DrivesListOutput, EmergencyOutput, EmergencyResult,
+    FailuresOutput, GetOutput, HistoryOutput, InitOutput, InitStatus, OutputMode, PlanOutput,
+    PreActionSummary, RecoveryWindow, RedundancyAdvisoryKind, RetentionPreviewOutput,
+    SentinelStatusOutput, SkipCategory, SkippedSubvolume, StatusAssessment, StatusOutput,
+    SubvolumeHistoryOutput, TokenState, VerifyOutput, parse_duration_to_minutes,
 };
 use crate::plan::format_duration_short;
 use crate::types::{ByteSize, DriveRole};
@@ -1928,6 +1928,207 @@ fn format_tick_description(tick_secs: u64, promise_states: &[crate::output::Sent
     format!("{tick_str} — {state_desc}")
 }
 
+// ── Emergency ─────────────────────────────────────────────────────────
+
+/// Render the emergency assessment (before user confirms).
+#[must_use]
+pub fn render_emergency(data: &EmergencyOutput, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => render_emergency_interactive(data),
+        OutputMode::Daemon => serde_json::to_string_pretty(data).unwrap_or_default(),
+    }
+}
+
+fn render_emergency_interactive(data: &EmergencyOutput) -> String {
+    let mut out = String::new();
+
+    if !data.has_crisis() {
+        writeln!(out).ok();
+        writeln!(
+            out,
+            "{}",
+            "No crisis detected.".green()
+        )
+        .ok();
+        writeln!(out).ok();
+        for root in &data.roots {
+            let free = ByteSize(root.free_bytes);
+            let status = match root.min_free_bytes {
+                Some(threshold) => format!(
+                    "{} free (threshold: {})  {}",
+                    free,
+                    ByteSize(threshold),
+                    "OK".green()
+                ),
+                None => format!("{} free (no threshold configured)", free),
+            };
+            writeln!(out, "  {}  — {}", root.root.display(), status).ok();
+        }
+        return out;
+    }
+
+    writeln!(out).ok();
+    writeln!(out, "{}", "Urd sees a crisis.".red().bold()).ok();
+
+    for root in &data.roots {
+        if !root.is_critical {
+            continue;
+        }
+
+        let free = ByteSize(root.free_bytes);
+        let threshold = ByteSize(root.min_free_bytes.unwrap_or(0));
+        let total_snaps: usize = root.subvolumes.iter().map(|s| s.snapshot_count).sum();
+        let total_delete: usize = root.subvolumes.iter().map(|s| s.delete_count).sum();
+        let total_keep: usize = root.subvolumes.iter().map(|s| s.keep_count).sum();
+        let total_pinned: usize = root.subvolumes.iter().map(|s| s.pinned_count).sum();
+
+        writeln!(out).ok();
+        writeln!(
+            out,
+            "{} — {} free (threshold: {})",
+            root.root.display().to_string().bold(),
+            free.to_string().red(),
+            threshold
+        )
+        .ok();
+        writeln!(
+            out,
+            "  {} snapshots across {} subvolumes",
+            total_snaps,
+            root.subvolumes.len()
+        )
+        .ok();
+
+        // Per-subvolume detail
+        for sv in &root.subvolumes {
+            writeln!(
+                out,
+                "    {}: {} snapshots, keep {}, delete {}",
+                sv.name, sv.snapshot_count, sv.keep_count, sv.delete_count
+            )
+            .ok();
+        }
+
+        writeln!(out, "  Chain parents pinned: {}", total_pinned).ok();
+
+        // Unsent snapshot advisory (F3)
+        if root.unsent_count > 0 {
+            writeln!(out).ok();
+            writeln!(
+                out,
+                "  {} unsent snapshots will be deleted.",
+                root.unsent_count
+            )
+            .ok();
+            if !root.drives_needing_full_send.is_empty() {
+                writeln!(
+                    out,
+                    "  Next send to {} will be a full send.",
+                    root.drives_needing_full_send.join(", ")
+                )
+                .ok();
+            }
+        }
+
+        writeln!(out).ok();
+        writeln!(
+            out,
+            "  This will delete {} snapshots.",
+            total_delete.to_string().yellow()
+        )
+        .ok();
+        writeln!(
+            out,
+            "  Your newest snapshot and all chain parents will be preserved."
+        )
+        .ok();
+        writeln!(out, "  {} snapshots will remain.", total_keep).ok();
+    }
+
+    // Show non-critical roots
+    let non_critical: Vec<_> = data.roots.iter().filter(|r| !r.is_critical).collect();
+    if !non_critical.is_empty() {
+        writeln!(out).ok();
+        for root in non_critical {
+            let free = ByteSize(root.free_bytes);
+            let status = match root.min_free_bytes {
+                Some(threshold) => format!(
+                    "{} free (threshold: {})  {}",
+                    free,
+                    ByteSize(threshold),
+                    "OK".green()
+                ),
+                None => format!("{} free (no threshold configured)", free),
+            };
+            writeln!(out, "  {}  — {}", root.root.display(), status).ok();
+        }
+    }
+
+    writeln!(out).ok();
+    out
+}
+
+/// Render the result of emergency deletions.
+#[must_use]
+pub fn render_emergency_result(data: &EmergencyResult, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => render_emergency_result_interactive(data),
+        OutputMode::Daemon => serde_json::to_string_pretty(data).unwrap_or_default(),
+    }
+}
+
+fn render_emergency_result_interactive(data: &EmergencyResult) -> String {
+    let mut out = String::new();
+
+    writeln!(out).ok();
+    if data.failed == 0 {
+        writeln!(
+            out,
+            "Freed {}. {} snapshots remain in {}.",
+            ByteSize(data.freed_bytes).to_string().green(),
+            data.remaining_snapshots,
+            data.root.display()
+        )
+        .ok();
+    } else {
+        writeln!(
+            out,
+            "Deleted {} snapshots ({} failed). Freed {}.",
+            data.deleted,
+            data.failed.to_string().red(),
+            ByteSize(data.freed_bytes)
+        )
+        .ok();
+        writeln!(out, "{} snapshots remain.", data.remaining_snapshots).ok();
+    }
+
+    writeln!(
+        out,
+        "{} now has {} free.",
+        data.root.display(),
+        ByteSize(data.remaining_free)
+    )
+    .ok();
+
+    if data.still_critical {
+        writeln!(out).ok();
+        writeln!(
+            out,
+            "{}",
+            "Still below threshold. Only pinned and latest snapshots remain."
+                .yellow()
+        )
+        .ok();
+        writeln!(
+            out,
+            "Manual intervention may be needed."
+        )
+        .ok();
+    }
+
+    out
+}
+
 // ── Doctor ────────────────────────────────────────────────────────────
 
 /// Render doctor output.
@@ -2645,11 +2846,12 @@ mod tests {
     use crate::awareness::ActionableAdvice;
     use crate::output::{
         BackupSummary, CalibrateEntry, CalibrateOutput, CalibrateResult, ChainHealth,
-        ChainHealthEntry, DeferredInfo, DisconnectedDrive, DriveInfo, HistoryOutput, HistoryRun,
-        InitCheck, InitDriveStatus, InitOutput, InitPinFile, InitSnapshotCount, InitStatus,
-        LastRunInfo, PlanOperationEntry, PlanOutput, PlanSummaryOutput, SendSummary, SkipCategory,
-        SkippedSubvolume, StatusAssessment, StatusDriveAssessment, SubvolumeSummary,
-        TransitionEvent, VerifyCheck, VerifyDrive, VerifyOutput, VerifySubvolume,
+        ChainHealthEntry, DeferredInfo, DisconnectedDrive, DriveInfo, EmergencyRootAssessment,
+        EmergencySubvolDetail, HistoryOutput, HistoryRun, InitCheck, InitDriveStatus, InitOutput,
+        InitPinFile, InitSnapshotCount, InitStatus, LastRunInfo, PlanOperationEntry, PlanOutput,
+        PlanSummaryOutput, SendSummary, SkipCategory, SkippedSubvolume, StatusAssessment,
+        StatusDriveAssessment, SubvolumeSummary, TransitionEvent, VerifyCheck, VerifyDrive,
+        VerifyOutput, VerifySubvolume,
     };
 
     fn test_status_output() -> StatusOutput {
@@ -6282,6 +6484,120 @@ mod tests {
         assert!(
             !out.contains("unchanged"),
             "backup summary should suppress unchanged skips, got: {out}"
+        );
+    }
+
+    // ── Emergency rendering tests ──────────────────────────────────────
+
+    #[test]
+    fn render_emergency_no_crisis() {
+        let data = EmergencyOutput {
+            roots: vec![
+                EmergencyRootAssessment {
+                    root: std::path::PathBuf::from("/snap/home"),
+                    free_bytes: 12_000_000_000,
+                    min_free_bytes: Some(10_000_000_000),
+                    is_critical: false,
+                    subvolumes: vec![],
+                    unsent_count: 0,
+                    drives_needing_full_send: vec![],
+                },
+                EmergencyRootAssessment {
+                    root: std::path::PathBuf::from("/mnt/data"),
+                    free_bytes: 3_000_000_000,
+                    min_free_bytes: None,
+                    is_critical: false,
+                    subvolumes: vec![],
+                    unsent_count: 0,
+                    drives_needing_full_send: vec![],
+                },
+            ],
+        };
+        let output = render_emergency(&data, OutputMode::Interactive);
+        assert!(output.contains("No crisis detected"), "should show no crisis: {output}");
+        assert!(output.contains("OK"), "should show OK for configured root: {output}");
+        assert!(
+            output.contains("no threshold configured"),
+            "should show unconfigured root: {output}"
+        );
+    }
+
+    #[test]
+    fn render_emergency_crisis() {
+        let data = EmergencyOutput {
+            roots: vec![EmergencyRootAssessment {
+                root: std::path::PathBuf::from("/snap/home"),
+                free_bytes: 1_800_000_000,
+                min_free_bytes: Some(10_000_000_000),
+                is_critical: true,
+                subvolumes: vec![
+                    EmergencySubvolDetail {
+                        name: "home".to_string(),
+                        snapshot_count: 40,
+                        keep_count: 5,
+                        delete_count: 35,
+                        latest: "20260403-1200-home".to_string(),
+                        pinned_count: 2,
+                    },
+                    EmergencySubvolDetail {
+                        name: "root".to_string(),
+                        snapshot_count: 7,
+                        keep_count: 4,
+                        delete_count: 3,
+                        latest: "20260403-1200-root".to_string(),
+                        pinned_count: 1,
+                    },
+                ],
+                unsent_count: 5,
+                drives_needing_full_send: vec!["WD-18TB".to_string()],
+            }],
+        };
+        let output = render_emergency(&data, OutputMode::Interactive);
+        assert!(output.contains("crisis"), "should show crisis: {output}");
+        assert!(output.contains("delete 35"), "should show delete count: {output}");
+        assert!(
+            output.contains("5 unsent snapshots"),
+            "should show unsent advisory: {output}"
+        );
+        assert!(
+            output.contains("WD-18TB"),
+            "should show drives needing full send: {output}"
+        );
+    }
+
+    #[test]
+    fn render_emergency_result_success() {
+        let data = EmergencyResult {
+            root: std::path::PathBuf::from("/snap/home"),
+            deleted: 35,
+            failed: 0,
+            freed_bytes: 8_200_000_000,
+            remaining_snapshots: 5,
+            remaining_free: 10_000_000_000,
+            still_critical: false,
+        };
+        let output = render_emergency_result(&data, OutputMode::Interactive);
+        assert!(output.contains("Freed"), "should show freed: {output}");
+        assert!(output.contains("5 snapshots remain"), "should show remaining: {output}");
+        assert!(!output.contains("Still below"), "should not show still critical: {output}");
+    }
+
+    #[test]
+    fn render_emergency_result_still_critical() {
+        let data = EmergencyResult {
+            root: std::path::PathBuf::from("/snap/home"),
+            deleted: 10,
+            failed: 2,
+            freed_bytes: 2_000_000_000,
+            remaining_snapshots: 3,
+            remaining_free: 3_000_000_000,
+            still_critical: true,
+        };
+        let output = render_emergency_result(&data, OutputMode::Interactive);
+        assert!(output.contains("2 failed"), "should show failures: {output}");
+        assert!(
+            output.contains("Still below threshold"),
+            "should show still critical: {output}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- **`urd emergency` command**: interactive guided space recovery — assesses snapshot roots, previews aggressive thinning (keep latest + pinned only), shows unsent snapshot impact and drives needing full sends, executes with explicit confirmation
- **Automatic pre-flight**: backup command detects critically low space (<50% of `min_free_bytes`) and runs emergency retention under advisory lock before planning, then re-plans to reflect freed space
- **Shared pin re-check**: `chain::is_pinned_at_delete_time()` replaces inline executor code — single implementation of ADR-106 defense-in-depth layer 3
- **Doctor space warning**: warns when snapshot roots approach free-space thresholds, suggests `urd emergency`

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 921 tests, all pass (15 new)
- Integration tests: not applicable (requires real BTRFS drives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)