### PR TITLE
docs: v0.11.0 testing, analysis, and UPI 022 design

### DIFF
--- a/docs/95-ideas/2026-04-05-design-022-honest-nightly.md
+++ b/docs/95-ideas/2026-04-05-design-022-honest-nightly.md
@@ -1,0 +1,450 @@
+---
+upi: "022"
+status: proposed
+date: 2026-04-05
+---
+
+# Design: The Honest Nightly (UPI 022)
+
+> **TL;DR:** Four surgical fixes to make v0.11.0's nightly run honest: (1) transient
+> cleanup stops protecting snapshots for absent drives, (2) sentinel suppresses vacuous
+> "0 chains broke" warnings, (3) "send disabled" becomes "local only", (4) config
+> scopes htpc-root to its actual drive. Ships as v0.11.1. No new modules, no config
+> schema changes, no new user concepts.
+
+## Problem
+
+The first v0.11.0 nightly (run #29, 2026-04-05) revealed four issues that undermine
+user trust, one of which is a data safety risk:
+
+**1. Transient snapshots accumulate for absent drives (CRITICAL).** htpc-root has
+`local_snapshots = false` but 2 local snapshots exist on a 118GB NVMe with 26GB free.
+Root cause: `plan_local_retention()` protects snapshots as "unsent" for ALL configured
+drives, including absent ones. WD-18TB1 (offsite) and 2TB-backup (test) are absent
+indefinitely — their sends never complete — so unsent protection never releases. This
+is the exact accumulation pattern that caused the catastrophic NVMe exhaustion.
+
+**2. Sentinel logs "all 0 chains broke" warnings.** `detect_simultaneous_chain_breaks()`
+fires when a drive transitions from mounted to unmounted, producing "Drive anomaly:
+all 0 chains broke on 2TB-backup simultaneously". The `total_chains` field is 0 — a
+vacuously true anomaly that teaches the user to ignore sentinel warnings.
+
+**3. "send disabled" text for local-only subvolumes.** subvol4-multimedia and subvol6-tmp
+show `"send disabled"` in skip reasons. They're local-only by design, not disabled.
+The text implies something is broken.
+
+**4. htpc-root assessed against all drives.** htpc-root has no explicit `drives` config,
+so `awareness.rs` evaluates it against all 3 drives. With WD-18TB1 and 2TB-backup
+absent, htpc-root is permanently "degraded" — a state the user can't fix without
+connecting drives they don't intend to connect.
+
+## Relationship to UPI 011
+
+UPI 011 ("Transient Space Safety") was designed on 2026-04-03 and proposes three
+changes: (1) drive-availability preflight for transient snapshot creation, (2) transient
+cap of 1, (3) pin file self-healing. It was reviewed by Steve but never implemented.
+
+This design **subsumes UPI 011's scope** with a simpler approach informed by production
+data. The key insight from the first nightly: the problem is not that snapshots are
+created — it's that they're protected indefinitely for absent drives. UPI 011's
+Changes 1 and 2 are defense-in-depth that become unnecessary when the root cause (Change
+3-equivalent: absent-drive protection) is fixed directly.
+
+**What we take from UPI 011:** The core insight that transient retention must be
+drive-availability-aware. UPI 011's Change 1 (skip creation when no drive mounted) is
+a good secondary guard that we include. UPI 011's Change 3 (pin self-healing) is
+valuable but orthogonal — deferred to a separate patch.
+
+**What we simplify:** UPI 011's Change 2 (cap of 1) is dropped. With the
+absent-drive fix, the snapshot count naturally stays at 1-2 during the send window
+and drops to 1 after cleanup. A hard cap that overrides pin protection (violating
+ADR-106) is unnecessary when the protection logic itself is correct.
+
+## Proposed Design
+
+### Fix 1: Transient retention ignores absent drives
+
+**Where:** `plan_local_retention()` in `plan.rs`, lines 426-448 — the protected set
+construction.
+
+**What changes:** When building the unsent-protection set for a transient subvolume,
+only consider pins for drives that are currently mounted. Absent drives can't receive
+sends, so protecting snapshots for them is pointless — and on space-constrained
+filesystems, dangerous.
+
+```rust
+// In plan_local_retention(), the protected-set construction block.
+// Current code (lines 426-448):
+let protected = if subvol.send_enabled {
+    let oldest_pin = pinned.iter().min();
+    let mut expanded = pinned.clone();
+    // ... expands to all snapshots newer than oldest pin
+    expanded
+} else {
+    pinned.clone()
+};
+
+// Changed: add `mounted_drives` parameter, filter for transient
+let protected = if subvol.send_enabled {
+    let effective_pinned = if subvol.local_retention.is_transient() {
+        // For transient subvolumes, only protect pins for mounted drives.
+        // Absent drives will get full sends when they return — protecting
+        // snapshots for them indefinitely risks space exhaustion.
+        pinned.iter()
+            .filter(|snap| {
+                // A pin is "mounted" if its drive is currently available.
+                // Pin files are named .last-external-parent-{DRIVE_LABEL}.
+                // We need to check if the drive that created this pin is mounted.
+                // This requires the mounted_drives set as input.
+                mounted_pin_snapshots.contains(snap)
+            })
+            .cloned()
+            .collect::<HashSet<_>>()
+    } else {
+        pinned.clone()
+    };
+    let oldest_pin = effective_pinned.iter().min();
+    let mut expanded = effective_pinned.clone();
+    match oldest_pin {
+        Some(oldest) => {
+            for snap in local_snaps {
+                if snap > oldest {
+                    expanded.insert(snap.clone());
+                }
+            }
+        }
+        None if subvol.local_retention.is_transient() => {
+            // Transient + no mounted pins = nothing to protect.
+            // All snapshots eligible for deletion.
+        }
+        None => {
+            // Non-transient: no pins at all — protect everything.
+            for snap in local_snaps {
+                expanded.insert(snap.clone());
+            }
+        }
+    }
+    expanded
+} else {
+    pinned.clone()
+};
+```
+
+**Concrete implementation:** The `plan_local_retention` function currently receives
+`pinned: &HashSet<SnapshotName>` — the set of all pinned snapshots from all drives.
+We need to split this into mounted and unmounted pins.
+
+**New parameter:** `mounted_pins: &HashSet<SnapshotName>` — pins from mounted drives only.
+
+**How to compute it:** In the caller (`plan()` main loop), we already call
+`chain::find_pinned_snapshots(local_dir, &drive_labels)` which reads all pin files.
+We also already know which drives are mounted (from `fs.drive_availability()`). Filter
+the pinned set to only drives where `DriveAvailability::Available`.
+
+```rust
+// In the plan() main loop, after building `pinned`:
+let mounted_pins: HashSet<SnapshotName> = config.drives.iter()
+    .filter(|d| {
+        subvol.drives.as_ref().map_or(true, |allowed| allowed.contains(&d.label))
+    })
+    .filter(|d| matches!(fs.drive_availability(d), DriveAvailability::Available))
+    .filter_map(|d| chain::read_pin_file(&local_dir, &d.label).ok().flatten())
+    .map(|pin| pin.name)
+    .collect();
+```
+
+Then pass `mounted_pins` to `plan_local_retention()`. For non-transient subvolumes,
+the function uses `pinned` (all pins) as before. For transient, it uses `mounted_pins`.
+
+**Risk:** If a drive reconnects between runs, the old chain parent may have been deleted.
+The next send will be a full send. For offsite drives that return monthly, a full send
+is expected anyway. For the primary drive (WD-18TB), it's always mounted, so its pins
+are always in the mounted set. Acceptable tradeoff.
+
+**Test strategy:** Unit tests with `MockFileSystemState`:
+- Transient + 1 mounted drive + 1 absent drive: only mounted drive's pin protected
+- Transient + no mounted drives: no pins protected, all old snapshots eligible for delete
+- Non-transient + absent drives: ALL pins protected (unchanged behavior)
+- Transient + all drives mounted: same as current behavior (all pins protected)
+- Edge: transient + no pins at all + no mounted drives: no snapshots protected
+
+Also include UPI 011's Change 1 (skip snapshot creation for transient when no drives
+mounted):
+
+**Where:** `plan()` main loop, before calling `plan_local_snapshot()`.
+
+```rust
+if subvol.local_retention.is_transient()
+    && !local_snaps.is_empty()
+    && !any_drive_mounted
+{
+    skipped.push((
+        subvol.name.clone(),
+        "no drive available for send — snapshot deferred".to_string(),
+    ));
+    // Still run retention to clean up excess snapshots
+    plan_local_retention(...);
+    continue; // skip to next subvolume
+}
+```
+
+This prevents creating new snapshots when no drive can receive them, while still
+running retention to clean up any accumulated snapshots from before the fix.
+
+~8-10 new tests.
+
+### Fix 2: Sentinel guards on chain delta
+
+**Where:** `detect_simultaneous_chain_breaks()` in `sentinel.rs`, line 819.
+
+**What changes:** Add a guard that the broken count is meaningful.
+
+Current guard:
+```rust
+if prev_count >= 2 && intact == 0 && total > 0 {
+```
+
+Changed:
+```rust
+let broken = prev_count.saturating_sub(intact);
+if broken >= 2 && total > 0 {
+```
+
+This computes the actual number of chains that broke. If 0 chains broke (prev_count == 0
+or intact == prev_count), no anomaly. If 1 chain broke, no anomaly (could be a normal
+chain break). If 2+ chains broke simultaneously, anomaly — likely a drive swap or
+mass corruption.
+
+Also fix the log message to report the correct count. In `sentinel_runner.rs` line 369:
+
+Current:
+```rust
+"Drive anomaly: all {} chains broke on {} simultaneously",
+anomaly.total_chains,
+```
+
+Changed:
+```rust
+"Drive anomaly: {} chains broke on {} simultaneously",
+anomaly.broken_count,
+```
+
+**Struct change:** Add `broken_count: usize` to `DriveAnomaly` (sentinel.rs). The
+`total_chains` field is still useful for the notification body.
+
+**Test strategy:** Unit tests for `detect_simultaneous_chain_breaks`:
+- Previous 0, current 0 → no anomaly
+- Previous 3, current 0, total > 0 → anomaly (broken = 3)
+- Previous 3, current 3 → no anomaly (broken = 0)
+- Previous 1, current 0 → no anomaly (broken = 1, below threshold)
+- Previous 2, current 0, total 0 → no anomaly (drive disconnected)
+
+~4-5 new tests.
+
+### Fix 3: "send disabled" → "local only"
+
+**Where:** `plan.rs`, line 265.
+
+**What changes:** One string:
+
+```rust
+// Before:
+skipped.push((subvol.name.clone(), "send disabled".to_string()));
+// After:
+skipped.push((subvol.name.clone(), "local only".to_string()));
+```
+
+The `SkipCategory` in `output.rs` already uses `LocalOnly` as the enum variant. The
+reason text now matches the category.
+
+**Test strategy:** Update any existing test that asserts on "send disabled" string.
+Grep for the string to find affected tests. ~1-2 test updates.
+
+### Fix 4: Config — scope htpc-root drives
+
+**Where:** `~/.config/urd/urd.toml`, htpc-root section.
+
+**What changes:** Add explicit drive scoping:
+
+```toml
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+min_free_bytes = "10GB"
+priority = 3
+snapshot_interval = "1d"
+send_interval = "1d"
+local_snapshots = false
+drives = ["WD-18TB"]
+external_retention = { daily = 30, monthly = 0, weekly = 26 }
+```
+
+This is a config edit, not a code change. Effects:
+
+1. `awareness.rs` only assesses htpc-root against WD-18TB → health becomes "healthy"
+   when WD-18TB is connected (no more false "degraded" from absent WD-18TB1/2TB-backup).
+
+2. `plan_local_retention()` only reads WD-18TB's pin file → the mounted-pins set
+   always contains WD-18TB's pin (it's always connected) → transient cleanup works
+   correctly even without Fix 1. Fix 1 is still needed for the general case.
+
+3. htpc-root stops sending to WD-18TB1 and 2TB-backup. This is the correct intent —
+   htpc-root needs one reliable external copy, not copies on every drive.
+
+**No code change. No test change. No migration.**
+
+## Module Map
+
+| Module | Changes | Test Strategy |
+|--------|---------|---------------|
+| `plan.rs` | Filter pinned set for transient subvolumes by drive mount state; skip transient snapshot creation when no drives mounted | ~8-10 unit tests with MockFileSystemState |
+| `sentinel.rs` | Guard on chain delta instead of absolute count; add `broken_count` to `DriveAnomaly` | ~4-5 unit tests |
+| `sentinel_runner.rs` | Update log message to use `broken_count` | Covered by sentinel.rs tests |
+| `plan.rs` (line 265) | Change "send disabled" to "local only" | ~1-2 test updates |
+| Config file | Add `drives = ["WD-18TB"]` to htpc-root | Manual verification via `urd status` |
+
+**Modules NOT touched:** `types.rs`, `config.rs`, `retention.rs`, `awareness.rs`,
+`executor.rs`, `voice.rs`, `output.rs`, `chain.rs`, `btrfs.rs`.
+
+## Effort Estimate
+
+**~0.5 session.** Calibrated against:
+- UPI 004 (token gate): 1 module, 5 tests, half session
+- UPI 005 (status truth): 2 modules, 12 tests, half session
+
+This is 2 modules (plan.rs, sentinel.rs) + 1 string change + 1 config edit, with
+~13-17 new tests. The changes are surgical — no new types, no new modules, no config
+schema changes.
+
+## Sequencing
+
+1. **Fix 4 first (config edit).** Zero risk. Immediate effect: htpc-root becomes
+   "healthy" in status, reduces drive scope so subsequent code changes have cleaner
+   test conditions. Do this before writing code.
+
+2. **Fix 1 second (transient absent-drive fix).** Highest code complexity and highest
+   data safety impact. The protection-set filtering is the critical logic that must be
+   right. Write tests first, then implement.
+
+3. **Fix 3 third (string change).** Trivial. One line. Do it while the plan.rs file is
+   open from Fix 1.
+
+4. **Fix 2 last (sentinel guard).** Independent of the other fixes. Lower risk — the
+   sentinel warning is annoying but not dangerous.
+
+**Risk ordering rationale:** Fix 4 de-risks Fix 1 by scoping htpc-root to one drive.
+Fix 1 is then testable against a simpler scenario (1 mounted drive vs 3 with 2 absent).
+Fixes 3 and 2 are independent cleanup.
+
+## Architectural Gates
+
+**None.** All changes operate within existing module boundaries:
+
+- Planner remains pure (Fix 1 adds conditions, not I/O)
+- Sentinel remains pure (Fix 2 modifies detection logic, no I/O)
+- No new on-disk contracts
+- No config schema changes (Fix 4 uses existing `drives` field)
+- ADR-106 (pin protection) is respected — we're not overriding pins, we're
+  correctly scoping which pins are relevant for transient retention
+- ADR-107 (fail-closed deletions) is respected — graduated subvolumes still
+  protect all pins; only transient subvolumes scope to mounted drives
+
+## Rejected Alternatives
+
+### Transient cap of 1 (UPI 011 Change 2)
+
+Hard-caps transient subvolumes at 1 local snapshot regardless of pin state. Rejected
+because:
+- Overrides pin protection (violates ADR-106) — could delete a snapshot that's the
+  chain parent for a mounted drive mid-send
+- Unnecessary when the root cause (absent-drive protection) is fixed
+- The emergency pre-flight (UPI 016) already exists as a space-based safety net
+
+### Rename `local_snapshots = false` to `local_retention = "minimal"`
+
+Adds config vocabulary to explain an implementation detail. Rejected because:
+- `local_snapshots = false` is the user's language ("don't store snapshots on my drive")
+- With Fix 1, the behavior matches the intent: 0-1 transient snapshots, cleaned up
+  after send
+- Renaming a config field requires migration, docs updates, and teaches users a new
+  concept for no behavioral benefit
+
+### Rotation interval for drives (Idea 5d from brainstorm)
+
+Adds `rotation_interval = "30d"` to drive config for expected-absence thresholds.
+Rejected because:
+- Introduces a new config concept for a problem solvable with one config line (Fix 4)
+- Adds complexity to awareness.rs for a single-user edge case
+- Can be designed later if real users need it post-v1.0
+
+### Role-based health weighting (Idea 5b from brainstorm)
+
+Uses drive roles to weight health computation. Rejected because:
+- Same reasoning as rotation intervals — overengineered for the current problem
+- The `drives` field already provides explicit scoping
+- Role semantics are still evolving (role field was added recently)
+
+### Unify plan and dry-run (Idea 6d from brainstorm)
+
+Merge `urd backup --dry-run` and `urd plan` into one code path. Rejected for this patch
+because:
+- Different user intents ("what's due?" vs "rehearse this action")
+- Larger refactor than the other fixes
+- The divergence is a UX concern, not a safety concern
+- Can be addressed with a one-sentence footer in dry-run output (deferred)
+
+## Assumptions
+
+1. **WD-18TB is always connected when nightly runs.** Fix 4 scopes htpc-root to only
+   WD-18TB. If WD-18TB is disconnected during a nightly, htpc-root will skip sends
+   (correct) and skip snapshot creation (correct — no drive to send to). The existing
+   "no backup drives connected" blocked state handles this.
+
+2. **Full sends to returning drives are acceptable.** Fix 1 allows old chain parents
+   to be deleted even if an absent drive still has that parent as its latest. When the
+   drive returns, it gets a full send. For an offsite drive returning monthly, a full
+   send is expected. For 2TB-backup (test drive), full sends are fine.
+
+3. **The `DriveAnomaly` struct can be extended.** Adding `broken_count: usize` to
+   `DriveAnomaly` is additive — no existing consumers break.
+
+4. **Existing tests don't assert on "send disabled" text broadly.** A grep will confirm.
+   If tests exist, they need updating as part of Fix 3.
+
+## Open Questions
+
+### Q1: Should Fix 1's absent-drive scoping apply to the executor's transient cleanup too?
+
+**Option A (planner only):** Only change `plan_local_retention()`. The executor's
+`attempt_transient_cleanup` continues to require all planned sends to succeed.
+
+**Option B (planner + executor):** Also change `attempt_transient_cleanup` to consider
+only mounted drives when evaluating "all sends succeeded."
+
+**Recommendation: Option A for this patch.** The executor's cleanup is a bonus
+optimization — the planner is the authority for retention. With Fix 1 in the planner,
+the next run will delete any snapshots the executor didn't clean up. The executor
+change can follow if needed.
+
+### Q2: Should Fix 1 also skip snapshot creation for transient when no drives are mounted?
+
+**Option A (retention-only fix):** Only change the protection set calculation. Snapshots
+are still created on interval; they just get cleaned up faster.
+
+**Option B (retention + creation skip):** Also skip `plan_local_snapshot()` for transient
+subvolumes when no drives are mounted (UPI 011's Change 1).
+
+**Recommendation: Option B.** Creating a snapshot that can't be sent is pointless for
+a transient subvolume. It just creates work for the retention cleanup to undo. Include
+the creation skip as a secondary guard. Already incorporated in the design above.
+
+### Q3: Should the sentinel `broken >= 2` threshold be configurable?
+
+**Option A (hardcoded threshold):** Always require 2+ chains to break simultaneously.
+
+**Option B (configurable):** Add a threshold to sentinel config.
+
+**Recommendation: Option A.** The threshold of 2 is the minimum for "this is suspicious."
+1 chain breaking is normal (pin file deleted, manual intervention). 2+ simultaneous
+is a drive-level event. No need for configuration.

--- a/docs/95-ideas/2026-04-05-v011-production-fixes.md
+++ b/docs/95-ideas/2026-04-05-v011-production-fixes.md
@@ -1,0 +1,441 @@
+# v0.11.0 Production Fixes — Brainstorm
+
+> **Status:** raw
+> **Date:** 2026-04-05
+> **Source:** v0.11.0 test report + Steve Jobs product review ("First Nightly Tells the Truth")
+> **Inputs:**
+>   - `docs/99-reports/2026-04-05-testing-urd-v0.11.0.md`
+>   - `docs/99-reports/2026-04-05-steve-jobs-000-first-nightly-truth.md`
+
+---
+
+## Problem Space
+
+Seven findings from the first nightly run on v0.11.0, ranging from a critical contract
+violation to minor text fixes. Grouped by the underlying tension each represents.
+
+---
+
+## 1. local_snapshots = false contract (CRITICAL)
+
+**The tension:** The send pipeline requires a local snapshot to exist. Transient retention
+keeps snapshots for chain continuity. But the user said "false" and expects zero.
+
+**Root cause (from code analysis):** htpc-root has no explicit `drives` config, so it
+evaluates against ALL drives (WD-18TB, WD-18TB1, 2TB-backup). The transient planner
+protects snapshots that are "unsent" to ANY drive. WD-18TB1 and 2TB-backup are absent —
+their sends can never complete — so the "unsent" protection keeps accumulating snapshots
+that can never be cleaned up until those drives return. The executor's
+`attempt_transient_cleanup` only fires when ALL planned sends succeed, which can't happen
+with absent drives. This is the real bug: **transient retention protects snapshots for
+absent drives indefinitely.**
+
+### Idea 1a: Transient cleanup ignores absent drives
+
+Modify `plan_local_retention()` in `plan.rs` to exclude absent drives from the "unsent"
+protection calculation. If a drive isn't mounted, its unsent snapshots aren't blocking
+cleanup — they'll get a full send when the drive returns anyway.
+
+**Concretely:** In `expand_protected_snapshots()` (plan.rs ~lines 426-448), filter the
+pin files to only mounted drives. Unmounted drives can't receive sends, so protecting
+snapshots for them is pointless — and in the transient case, dangerous.
+
+**Risk:** If a drive comes back before the next run, the chain parent is gone and a full
+send is required. For an offsite drive that returns monthly, this is fine. For a daily
+drive that was briefly disconnected during a run, this could be annoying.
+
+### Idea 1b: Post-send immediate delete for transient (the "create-send-delete" pattern)
+
+After a successful send in the executor, immediately delete the local snapshot if:
+- Subvolume is transient
+- The snapshot is NOT the current pin parent for any mounted drive
+- All mounted-drive sends succeeded
+
+This gives the "create, send, delete" lifecycle Steve described. The current
+`attempt_transient_cleanup` already does something similar but only for old pin parents.
+Extend it to also delete the just-sent snapshot if a newer one will become the pin.
+
+Wait — this would delete the snapshot the pin points to, breaking the chain. The pin
+parent must survive. So the minimum is always 1 local snapshot (the current pin). The
+old pin parent is what should be deleted immediately.
+
+### Idea 1c: Rename the config field honestly
+
+Instead of `local_snapshots = false`, use `local_retention = "pipeline"` or
+`local_retention = "minimal"`. Document clearly: "One local snapshot exists at any time
+for send pipeline continuity. It is deleted as soon as a newer one is sent."
+
+This doesn't fix the accumulation bug (1a does that), but it fixes the contract
+dishonesty. The user knows what "minimal" means — it means "as few as physically
+possible, not zero."
+
+### Idea 1d: Transient cap — hard limit on local snapshot count
+
+Add a `max_local_snapshots` field (or hardcode for transient) that the executor enforces
+as a ceiling. If transient subvolume has more than N local snapshots (e.g., 2), force-
+delete the oldest regardless of pin protection. This is a safety net, not the primary
+mechanism.
+
+**Risk:** Violates ADR-106 (defense-in-depth pin protection). Could delete a pinned
+snapshot needed for chain continuity. But for transient subvolumes on space-constrained
+drives, the alternative is catastrophic: the drive fills up, ALL backups fail.
+
+### Idea 1e: Space-triggered transient cleanup
+
+Don't count snapshots — measure space. If the snapshot root filesystem drops below
+`min_free_bytes`, transient cleanup becomes aggressive: delete everything except the
+single most recent pin parent, even for absent drives. This connects to emergency
+space response (UPI 016) — the pre-flight thinning logic.
+
+The emergency pre-flight already does this for the `urd backup` path. Extend it to run
+as part of normal transient retention for snapshot roots where `min_free_bytes` is
+breaching or close to breaching.
+
+### Idea 1f: External-only subvolumes don't create snapshots on interval
+
+Radical approach: transient subvolumes only create a snapshot when a send is actually
+going to happen. Instead of "create on interval, send later", do "check if send is due,
+if yes create+send+delete in one atomic sequence."
+
+This eliminates the window where a snapshot exists but hasn't been sent. The local
+snapshot count is 0 between sends and 1 during a send.
+
+**Risk:** Breaks the separation between planner and executor — the planner would need to
+know about drive availability to decide whether to snapshot. Currently the planner is
+pure (config + state in, plan out). This idea requires the planner to consider runtime
+drive state.
+
+### Idea 1g: Combine 1a + 1c + 1d as defense-in-depth
+
+- 1a: Fix the root cause (absent drives don't block transient cleanup)
+- 1c: Fix the contract (rename to honest language)
+- 1d: Add a hard cap as safety net (never more than 2 for transient)
+
+Three layers, each addressing a different failure mode.
+
+---
+
+## 2. urd get stdout mixing
+
+**The tension:** Test report found JSON metadata concatenated with file content on stdout.
+
+**Code analysis reveals:** The code already sends metadata to stderr (`eprint!()`) and
+file content to stdout (`std::io::copy()`). The test report finding was an artifact of
+running through `cargo run --` which captures both streams. The actual behavior IS
+pipe-safe.
+
+### Idea 2a: Verify and close — this may not be a real bug
+
+Run `urd get /etc/hostname --at yesterday > /tmp/restored 2>/dev/null` and check if the
+file is clean. If yes, the bug doesn't exist — the test methodology was flawed. Update
+the test report.
+
+### Idea 2b: If it IS a bug, add explicit stream separation
+
+If some code path does mix streams, ensure every `render_get()` output goes through
+`eprint!()` and file content through `std::io::copy()` to stdout. No exceptions.
+
+### Idea 2c: Add --quiet flag for get
+
+Even if streams are correctly separated, `urd get --quiet` suppresses all metadata
+(even stderr). For scripts that want zero noise.
+
+---
+
+## 3. Sentinel "0 chains broke" warning
+
+**The tension:** A warning that fires when nothing happened teaches users to ignore
+warnings.
+
+**Code analysis:** The detection logic requires `prev_count >= 2 && intact == 0 && total > 0`.
+The log message interpolates: "all {prev_count} chains broke on {drive}". The "0" in
+"all 0 chains" suggests prev_count was being reported as 0, which shouldn't satisfy the
+`>= 2` guard. This may be a different code path, or the count being displayed is the
+current count (0) not the previous count.
+
+### Idea 3a: Guard on prev_count > 0
+
+The most direct fix. If the previous tick had 0 chains, there's nothing to break.
+Change the guard from `prev_count >= 2` to also require that the current delta is
+meaningful. Or simply: if `prev_count == 0`, skip the detection entirely.
+
+### Idea 3b: Guard on chain delta
+
+Instead of checking absolute counts, check the delta: `broken_count = prev_count - intact`.
+If `broken_count == 0`, no anomaly. If `broken_count >= 2`, anomaly. This handles all
+edge cases cleanly.
+
+### Idea 3c: Don't report drive anomalies for freshly disconnected drives
+
+The "0 chains broke" may fire when a drive was just disconnected (total briefly > 0
+in the transition). Add a grace period: if a drive transitioned from mounted to unmounted
+within the last tick, suppress anomaly detection for one tick.
+
+### Idea 3d: Report the right number
+
+If the guard is correct but the display is wrong, fix the log message to show
+`prev_count` not `intact`: "all {prev_count} chains broke" not "all {intact} chains
+broke". The user wants to know how many chains WERE intact, not how many ARE intact (0).
+
+---
+
+## 4. "send disabled" text
+
+**The tension:** The text says something is disabled (sounds broken). The reality is
+the subvolume is local-only by design (sounds intentional).
+
+### Idea 4a: Change string in plan.rs
+
+```rust
+// plan.rs line 265, change:
+"send disabled"
+// to:
+"local only — not sent to external drives"
+```
+
+One line. Five seconds. Matches the `local_only` category already in place.
+
+### Idea 4b: Shorter alternative
+
+"local only" — without the explanation. The category carries the semantics.
+
+### Idea 4c: Context-aware text
+
+If the subvolume has never been configured for sends: "local only".
+If it was previously sent but sends were disabled: "sends paused".
+This distinction matters for `urd status` — a user who intentionally configured local-only
+sees confirmation, a user who paused sends sees a reminder.
+
+---
+
+## 5. htpc-root health assessment scoping
+
+**The tension:** htpc-root sends to all drives (no explicit `drives` config), so it's
+assessed against all drives. Absent drives cause permanent "degraded" that the user
+can't fix without connecting drives they don't want to connect.
+
+**Code analysis:** `awareness.rs` lines 459-466 — when `subvol.drives` is `None`, it uses
+ALL configured drives. This is correct for "send to all drives" but wrong for "assess
+health against all drives" because some drives are intentionally absent.
+
+### Idea 5a: Config fix — add explicit drives to htpc-root
+
+```toml
+[[subvolumes]]
+name = "htpc-root"
+drives = ["WD-18TB"]
+```
+
+Simplest fix. htpc-root only needs WD-18TB (primary). The offsite and test drives are
+nice-to-have, not required for health. Changes one config line, zero code.
+
+**Tradeoff:** htpc-root stops sending to WD-18TB1 and 2TB-backup. When those drives
+return, they won't get htpc-root updates. If the user WANTS htpc-root on all drives
+but doesn't want to be nagged about absent ones, this doesn't work.
+
+### Idea 5b: Drive roles in health assessment
+
+Use drive `role` field to weight health. An absent "primary" drive is a real problem.
+An absent "offsite" drive is expected. An absent "test" drive is irrelevant.
+
+`compute_health()` in awareness.rs could:
+- Always factor in primary drives
+- Factor in offsite drives only after a configurable threshold (e.g., 30 days absent)
+- Ignore test drives entirely for health computation
+
+### Idea 5c: Per-drive health weight in config
+
+```toml
+[[drives]]
+label = "2TB-backup"
+role = "test"
+health_weight = "ignore"    # or "advisory" or "required"
+```
+
+Explicit: this drive's absence doesn't degrade anyone's health.
+
+### Idea 5d: "Expected absence" concept
+
+A drive that's `role = "offsite"` is expected to be absent most of the time. Instead
+of degrading health when an offsite drive is away for 8 days, degrade only when it
+exceeds its expected rotation interval:
+
+```toml
+[[drives]]
+label = "WD-18TB1"
+role = "offsite"
+rotation_interval = "30d"   # expected to return every 30 days
+```
+
+If absent < 30d: healthy. If absent > 30d: degraded. This matches the user's actual
+mental model: "I rotate the offsite drive monthly."
+
+### Idea 5e: Assess against "required minimum" not "all configured"
+
+Instead of degrading when ANY drive is absent, degrade when the minimum redundancy
+isn't met. A fortified subvolume with 2 drives configured needs at least 1 healthy.
+A sheltered subvolume with 3 drives needs at least 1 healthy. Only degrade when the
+count drops below the protection level's requirement.
+
+This is more principled than per-drive config — the protection level defines the
+requirement, the drives provide the capacity. If you have 3 drives and need 1, losing
+2 is fine.
+
+### Idea 5f: Distinguish "degraded (can't fix)" from "degraded (connect drive)"
+
+Instead of one "degraded" state, split:
+- `degraded` — something is wrong that needs attention
+- `reduced` — fewer copies than ideal, but still within safety bounds
+
+htpc-root with WD-18TB connected but WD-18TB1 and 2TB-backup absent would be "reduced"
+(2 of 3 copies missing, but the primary is healthy). This lets the user mentally file
+it as "acknowledged, not urgent" vs "degraded" which sounds like action needed.
+
+---
+
+## 6. Plan vs dry-run divergence
+
+**The tension:** Two commands that answer "what will happen" show different answers.
+
+### Idea 6a: Make dry-run include deletions
+
+`urd backup --dry-run` should show the complete plan including retention deletions.
+Currently it omits them. The user asking "what will this backup do?" deserves the full
+picture.
+
+### Idea 6b: Add a --no-retention flag to plan
+
+`urd plan --no-retention` shows only snapshots and sends (matching current dry-run
+behavior). `urd plan` shows everything (current behavior). This makes plan the
+superset and gives the user explicit control.
+
+### Idea 6c: Explain the difference in output
+
+At the bottom of `urd backup --dry-run`, add:
+"Note: Retention deletions not shown. Run `urd plan` for the full picture including cleanup."
+
+### Idea 6d: Unify them
+
+`urd backup --dry-run` calls `urd plan` internally. Same output, same code path.
+Eliminate the divergence entirely.
+
+---
+
+## 7. Retention preview misleading sizes
+
+**The tension:** Pre-dedup sizes are technically correct but practically terrifying.
+
+### Idea 7a: Remove size estimates entirely
+
+If you can't show accurate numbers, don't show numbers. "92 snapshots" is honest.
+"315TB" is misleading. Better to have a gap than a lie.
+
+### Idea 7b: Show calibrated delta size instead
+
+Use the calibration data (incremental send size between consecutive snapshots) as the
+per-snapshot estimate. If subvol3-opptak's last incremental send was 88MB, show
+`92 snapshots × ~88MB ≈ 8.1GB`. This is still an approximation (deltas vary), but
+it's within an order of magnitude of reality.
+
+### Idea 7c: Show both with explanation
+
+```
+Estimated disk usage: ~8GB incremental (315TB pre-dedup)
+Note: BTRFS CoW deduplication typically reduces actual usage by 95-99%.
+```
+
+### Idea 7d: Show actual disk usage from btrfs
+
+`btrfs qgroup show` can show exclusive data per subvolume. For snapshot dirs, this
+gives the real on-disk footprint. Expensive to compute, but accurate.
+
+### Idea 7e: Flag as "not available" when calibration is full-send-based
+
+The calibration data for subvol3-opptak (3.4TB per snapshot) is from full-send
+measurement, not incremental. If calibration only has full-send data, show
+"estimated size not available (calibrate with incremental sends for better estimates)"
+instead of a misleading full-send number.
+
+---
+
+## 8. Lock file cleanup
+
+**The tension:** A stale lock file signals a tool that doesn't clean up after itself.
+
+### Idea 8a: Delete lock on clean exit
+
+At the end of a successful backup run, delete the lock file. Only leave it on crash
+or kill (where it serves as a tombstone for diagnostics).
+
+### Idea 8b: Keep the lock, add "completed_at" field
+
+```json
+{"pid":2115074,"started":"...","trigger":"auto","completed_at":"...","result":"success"}
+```
+
+The lock becomes a last-run record, not a stale artifact. It's informational, not
+misleading.
+
+### Idea 8c: Do nothing — it's fine
+
+The PID check handles stale locks correctly. The lock file is in `~/.local/share/urd/`,
+not somewhere the user looks. The "untidy" concern is aesthetic, not functional. Maybe
+this isn't worth a code change.
+
+---
+
+## 9. Uncomfortable ideas
+
+### Idea 9a: Transient subvolumes use tmpfs
+
+Instead of creating htpc-root snapshots on the NVMe, create them in a tmpfs mount
+point. Snapshots exist only in RAM during the send. After send completes, they vanish.
+Zero disk footprint.
+
+**Why this is uncomfortable:** BTRFS snapshots can't live on tmpfs — they're subvolumes
+on the BTRFS filesystem. This is physically impossible with current btrfs architecture.
+But the *principle* — "the local copy shouldn't persist on any physical medium" — is the
+right aspiration.
+
+### Idea 9b: Stream-send without snapshot
+
+`btrfs send` requires a read-only snapshot as source. What if we could send directly
+from the live subvolume? This would eliminate the "create local snapshot" step entirely.
+BTRFS doesn't support this today, but the idea of "send from live" is the logical
+endpoint of "I don't want local copies."
+
+### Idea 9c: Invert the model — external drives create the snapshots
+
+Instead of "create local snapshot, send to drive", what if the external drive's
+`btrfs receive` created the snapshot directly from the live subvolume via a pipe? The
+snapshot would only exist on the external drive, never locally. This is closer to how
+rsync-based backups work — the destination has the copy, not the source.
+
+Again, BTRFS architecture doesn't support this directly (`btrfs send` requires a
+read-only subvolume). But it reveals the tension: the tool's architecture requires
+local snapshots, but the user's intent is to not have them.
+
+---
+
+## Handoff to Architecture
+
+**1. Idea 1g (transient defense-in-depth: 1a + 1c + 1d)** — Addresses the critical
+htpc-root issue from three angles: fix the absent-drive accumulation bug, rename the
+config honestly, and add a hard cap safety net. This is the most important item and
+needs immediate design work because it touches planner, config, and executor.
+
+**2. Idea 5d (expected-absence with rotation interval)** — Elegantly solves the
+htpc-root degraded noise AND the offsite drive assessment problem. Role-based health
+weighting (5b) is simpler but less principled; rotation interval captures the user's
+actual mental model.
+
+**3. Idea 6d (unify plan and dry-run)** — Eliminates a persistent UX confusion with
+a clean architectural merge. If `backup --dry-run` IS `plan`, the divergence can't exist.
+
+**4. Idea 7b (delta-based size estimates)** — Calibration already captures incremental
+send sizes. Using those instead of full-snapshot sizes makes retention-preview trustworthy
+instead of terrifying. Low implementation effort, high trust impact.
+
+**5. Idea 2a (verify urd get is actually pipe-safe)** — Before designing a fix, verify
+the bug exists. Code analysis suggests it's already correct (metadata to stderr, content
+to stdout). If confirmed, this is a test-report correction, not a code change.

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,6 +5,7 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
+| 022 | The Honest Nightly (transient fix + sentinel guard + text fix + config scope) | [design](../95-ideas/2026-04-05-design-022-honest-nightly.md) | - | - | - | - |
 | 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | merged | [#84](https://github.com/vonrobak/urd/pull/84) |
 | 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | merged | [#85](https://github.com/vonrobak/urd/pull/85) |
 | 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | merged | [#83](https://github.com/vonrobak/urd/pull/83) |

--- a/docs/99-reports/2026-04-05-steve-jobs-000-first-nightly-truth.md
+++ b/docs/99-reports/2026-04-05-steve-jobs-000-first-nightly-truth.md
@@ -1,0 +1,204 @@
+---
+upi: "000"
+date: 2026-04-05
+mode: product-review
+---
+
+# Steve Jobs Review: The First Nightly Tells the Truth
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-05
+**Scope:** v0.11.0 post-deployment product review — first nightly run results, full command surface
+**Mode:** Product Review
+
+## The Verdict
+
+v0.11.0 deployed and the first nightly ran. The invisible worker is genuinely intelligent
+now — compressed sends, skip-unchanged, space-aware deletion halting, chain-break recovery
+with drive verification — and it all worked. But Urd is lying to the user about htpc-root,
+and that lie is the exact shape of the catastrophic failure that almost destroyed this
+project. Fix it before celebrating.
+
+## What's Insanely Great
+
+**The nightly was smart.** Run #29 did exactly what Phase E promised. It detected that
+htpc-home and htpc-root had broken chains, verified the drive identity, and proceeded with
+compressed full sends — 27GB and 22GB — without human intervention. Five subvolumes were
+skipped because nothing changed. Retention deletions stopped early because there was already
+enough free space. The run took 9 minutes and 31 seconds, and every one of those seconds was
+spent on work that mattered. Compare that to run #28 the previous night: 31 seconds, because
+there was nothing to do. The invisible worker now has judgment, not just a schedule.
+
+**Skip-unchanged is the feature that doesn't exist.** That's the highest compliment I can
+give a backup feature. subvol2-pics hasn't changed in 7 hours — no snapshot created, no
+send attempted. subvol5-music hasn't changed in a day — same. The user didn't configure
+this. They didn't ask for it. They'll never see it happen. They'll just notice that their
+backup runs are faster and their drives have more free space. This is north star #2 in its
+purest form: reduced attention to zero.
+
+**The context-aware suggestions are right.** Three subvolumes are degraded. Status output
+doesn't just say "degraded" — it says "Consider connecting WD-18TB1." That's the answer
+to the obvious follow-up question, delivered before the user asks it. This is what "guide
+through affordances, not error messages" looks like in practice.
+
+**Drive token verification works and it's invisible.** Run #29 log: "Chain-break full send
+for htpc-home to WD-18TB: proceeding (drive identity verified)." The system confirmed it
+was talking to the right drive before sending 27GB. The cloned-drive catastrophe from v0.8
+testing (F2.3 — 1.3TB of full sends planned to the wrong drive) would now be caught. This
+is the kind of safety that the user should never have to think about. It just works.
+
+**The space-aware executor is elegant.** "Free space on WD-18TB is now 4.2TB (>= 500.0GB),
+stopping further deletions." Twenty planned deletions skipped because the first one freed
+enough space. This is not an optimization — it's respect for the user's data. Don't delete
+history you don't need to delete. Don't thin archives because a schedule says so when the
+drive has four terabytes free. The fail-closed deletion philosophy is now *smart* about
+when closed is the right answer.
+
+## What's Not Good Enough
+
+**htpc-root is lying.** The config says `local_snapshots = false`. The user set this because
+local htpc-root snapshots on the 118GB NVMe caused a catastrophic storage failure. The
+status output says `"external_only": true` and `"retention_summary": "none (transient)"`.
+Everything in the UI tells the user: "I'm not keeping local copies of your root filesystem."
+
+There are two local copies of the root filesystem sitting on the NVMe right now.
+
+The nightly log proves it: "Creating snapshot: / -> ~/.snapshots/htpc-root/20260405-0401-htpc-root".
+Two snapshots. On a drive with 26GB free. Each root filesystem snapshot contains everything
+under `/` — system packages, caches, logs, container images. The CoW deduplication between
+them might keep the exclusive data small today, but a chain break, a failed cleanup, one
+more snapshot accumulating — and you're back in the catastrophic failure that motivated the
+entire emergency feature.
+
+This isn't a bug report. This is a product integrity issue. When a user sets
+`local_snapshots = false`, they are making a statement: "I understand the risk and I don't
+want local copies." When the system ignores that statement, it breaks the most fundamental
+contract a backup tool has: do what I told you to do with my data.
+
+I understand the engineering reason. The send pipeline needs a local snapshot to exist before
+it can send. The pin parent stays for chain continuity. So "false" doesn't mean "zero" — it
+means "as few as the pipeline requires." But that's the engineer's truth, not the user's
+truth. The user's truth is: I said false and there are two snapshots on my NVMe.
+
+**The `urd get` experience is broken for piping.** When someone types
+`urd get /etc/hostname --at yesterday`, they get:
+
+```
+{"subvolume":"htpc-root","snapshot":"20260404-0400-htpc-root",...}fedora-htpc
+```
+
+JSON metadata concatenated with file content on stdout. If you pipe that to a file, you get
+a corrupt restore. The most critical user journey in any backup tool — "get my file back" —
+has a footgun in its default mode.
+
+I know there's a `-o` flag. I know the interactive mode probably renders this better with
+metadata on stderr. But the daemon mode path — which is what scripts and pipes use — mixes
+data streams. This is the kind of thing that works in a demo and fails at 2am when someone
+is desperately trying to recover a config file they just destroyed.
+
+**The post-delete sync isn't in sudoers.** Every nightly run produces this warning:
+"btrfs subvolume sync failed: sudo: a terminal is required to read the password." This is
+Phase E feature 013 — post-delete sync for accurate space reporting — deployed but broken
+in the autonomous context. The invisible worker is telling you, every night, that part of
+its new intelligence doesn't work. The fix is one line in the sudoers file, but the fact
+that it shipped without that line means the deployment checklist missed it.
+
+**The sentinel logs spurious warnings.** "Drive anomaly: all 0 chains broke on 2TB-backup
+simultaneously." Zero chains broke. That's not an anomaly — that's nothing. When I see a
+warning in a log, I want it to mean something. A warning that fires when nothing happened
+teaches the user to ignore warnings. That's the most dangerous habit a backup tool can
+create.
+
+## The Vision
+
+Last review, I said deploy before designing The Encounter. You deployed. The first nightly
+ran. And it told you something you didn't know: the contract around `local_snapshots = false`
+isn't what you think it is.
+
+This is exactly why I said to live with it first. Production tells truths that tests can't.
+
+Here's what I see now. The invisible worker is ready. Phase E's features are working — not
+just technically, but *as a product*. Skip-unchanged saves real work. Compressed sends move
+real data faster. Space-aware deletion respects real drives. Context-aware suggestions answer
+real questions. The intelligence is there.
+
+But The Encounter — the moment a new user meets Urd — requires something that isn't there
+yet: *the ability to explain what "transient" means in human terms*. If I'm a new user
+running `urd status` and I see htpc-root with `retention_summary: "none (transient)"` next
+to `local_snapshot_count: 2`, I don't know what to make of that. None? But there are two.
+Transient? What does that mean? When do they go away?
+
+The Encounter conversation needs to answer these questions before they're asked. When the
+Fate Conversation discovers that someone's root filesystem lives on a small NVMe, Urd should
+say: "I'll keep temporary copies just long enough to send them to your external drive, then
+clean them up immediately. You'll never accumulate root snapshots on this drive." And then
+it must actually do that.
+
+The promise model works because it says "PROTECTED" and the user believes it. The moment
+the user discovers that "false" doesn't mean false, or "none" doesn't mean none, the
+promise model loses its power. Trust is the product. Protect it.
+
+## The Details
+
+**"send disabled" as a skip reason for local-only subvolumes.** Better than v0.8's
+`[OFF] Disabled`, but still not right. subvol4-multimedia and subvol6-tmp are actively
+snapshotted — they have 6 and 13 local snapshots respectively. "Send disabled" sounds
+like something is wrong. "Local only — not sent to external drives" tells the truth.
+The category `local_only` is correct; the reason text `"send disabled"` doesn't match it.
+
+**The plan vs dry-run divergence persists from v0.8.** `urd plan` shows 25 deletions.
+`urd backup --dry-run` shows 6. Same feature, two answers. The user who runs both will
+be confused. Either they should show the same operations, or the difference should be
+explained. A user typing `urd backup --dry-run` is asking "what exactly will happen when
+I type this without --dry-run?" and the answer should be complete.
+
+**Retention preview shows pre-dedup sizes that are misleading.** "subvol3-opptak: 92
+snapshots, estimated 315TB total." The user's drive is 18TB. The number is technically
+correct — it's the sum of full snapshot sizes before CoW dedup. But it's worse than useless;
+it's actively frightening. Either show delta-based estimates (the actual disk impact) or
+don't show estimates at all. A number that's off by 20x erodes trust in every other number
+Urd shows.
+
+**The lock file persists after runs complete.** `{"pid":2115074,"started":"2026-04-05T04:01:09",
+"trigger":"auto"}` — from a process that finished hours ago. The stale lock doesn't block
+anything (the PID check handles that), but it's untidy. A tool that leaves artifacts after
+it finishes doesn't feel like a tool that cleans up after itself. And for a tool whose
+entire job is managing filesystem state, that matters.
+
+**htpc-root "degraded" reasons are noisy.** "WD-18TB1 away for 13 days, 2TB-backup away
+for 13 days." htpc-root sends to all drives because it has no explicit `drives` config.
+The 2TB-backup is a test drive that may never return. WD-18TB1 is offsite intentionally.
+The user knows this. The degradation is technically correct but practically meaningless —
+it's crying wolf every time the user checks status. This connects to the assess() scoping
+issue from v0.8 testing: htpc-root shouldn't be assessed against drives it was never
+designed to need.
+
+## The Ask
+
+1. **Fix the `local_snapshots = false` contract.** This is not negotiable. When the user
+   says false, the system must honor that intent. The engineering solution — "create, send,
+   delete old pin parent, keep exactly one" — exists and is straightforward. Or redefine the
+   contract honestly: rename it to `local_retention = "minimal"` and document that one
+   snapshot exists for chain continuity. But don't call it "false" and keep two. That's a
+   lie, and lies in backup tools have consequences measured in lost data.
+
+2. **Fix `urd get` stdout in daemon mode.** Metadata to stderr, content to stdout. This is
+   the restore path — the most important user journey. It must be pipe-safe by default.
+
+3. **Add `btrfs subvolume sync` to the sudoers deployment instructions.** One line. The
+   feature is already deployed; it just can't run.
+
+4. **Suppress the "0 chains broke" sentinel warning.** If the chain count is zero, there
+   is no anomaly. Don't log one.
+
+5. **Change "send disabled" to "local only — not sent to external drives."** The category
+   is already right; match the reason text to it.
+
+6. **Scope htpc-root's health assessment.** Either add explicit `drives` config to htpc-root
+   so it's only assessed against drives it actually sends to, or make the assess() logic
+   aware that some drives are optional for some subvolumes. The current "degraded" state
+   is permanent and unfixable without connecting drives the user may not want to connect.
+
+7. **Then start designing The Encounter.** With the contract fixed, the restore path clean,
+   and the nightly running honestly. The Encounter is Urd's first impression. It must be
+   built on a foundation that tells the truth.

--- a/docs/99-reports/2026-04-05-steve-jobs-000-fix-the-lie-first.md
+++ b/docs/99-reports/2026-04-05-steve-jobs-000-fix-the-lie-first.md
@@ -1,0 +1,184 @@
+---
+upi: "000"
+date: 2026-04-05
+mode: vision-filter
+---
+
+# Steve Jobs Review: Fix the Lie First
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-05
+**Scope:** Brainstorm `docs/95-ideas/2026-04-05-v011-production-fixes.md` — roadmap slotting
+**Mode:** Vision Filter
+
+## The Verdict
+
+The brainstorm correctly identified the root cause of the critical bug and produced solid
+ideas, but it's trying to solve seven problems at once. Three of these are worth doing before
+The Encounter. The rest are either already solved, not real problems, or should wait.
+
+## What's Insanely Great
+
+**The root cause analysis for the transient accumulation bug is exceptional.** "Transient
+retention protects snapshots for absent drives indefinitely." That's not a surface-level bug
+report — that's understanding a system well enough to name the exact mechanism that will
+eventually destroy someone's NVMe. The brainstorm didn't just say "snapshots accumulate." It
+traced the path: absent drives → unsent protection → unbounded accumulation → catastrophic
+failure. That's the kind of analysis that produces fixes that actually work, not patches that
+defer the same failure to a Tuesday at 3am.
+
+**Idea 1a is the insight.** Transient cleanup ignoring absent drives is not just a fix — it's
+a principle. It says: "If a drive can't receive a send right now, holding hostage a snapshot
+on a space-constrained filesystem doesn't protect anything. It endangers everything." That
+reframes the problem from "how do we keep the minimum snapshots" to "what is snapshot
+retention actually protecting, and does that protection still apply when the drive is gone?"
+
+**The discovery that `urd get` is already pipe-safe is exactly the right kind of finding.**
+The brainstorm said "before designing a fix, verify the bug exists." That restraint — checking
+before building — is what separates engineering from busywork. If it's confirmed, cross it off
+and move on. Don't build a fix for a bug that doesn't exist.
+
+## What's Not Good Enough
+
+**Idea 1g (combine 1a + 1c + 1d) is overthinking it.** Three layers sounds like defense-in-depth.
+It's actually three changes for one bug. Let me break this down:
+
+- **1a (ignore absent drives in transient cleanup):** This is the fix. It addresses the root
+  cause directly. With this in place, htpc-root snapshots get cleaned up after successful sends
+  to mounted drives. The count stays at 1 (the current pin parent). Done.
+
+- **1c (rename `local_snapshots = false` to something honest):** I disagree. `local_snapshots = false`
+  is the right name. The user's intent is "I don't want local snapshots." Urd's job is to
+  honor that intent as closely as the physics allow. One transient snapshot existing during
+  the send pipeline is an implementation detail the user shouldn't need to know about — like
+  how the iPod's click wheel generates more events when you spin faster. You don't explain
+  the engineering. You make the thing do what the user expects. With 1a fixed, the user will
+  see 1 snapshot briefly during the nightly, then 0 until the next run. That IS `false` in
+  any meaningful sense. Don't rename it. Fix the behavior.
+
+- **1d (hard cap):** A safety net for a bug you've already fixed is a safety net for your own
+  lack of confidence in the fix. If 1a works — and the analysis says it will — the cap never
+  triggers. If you need the cap, 1a didn't work, and you should fix 1a, not add a cap. I'll
+  concede one exception: the emergency pre-flight (UPI 016) already exists as a space-based
+  safety net. That's the right layer to catch edge cases, and it's already built. Don't add
+  a second safety net.
+
+**Idea 5d (rotation interval) is too much mechanism for a solved problem.** The brainstorm
+correctly identifies that htpc-root shouldn't be assessed against drives it doesn't need.
+But rotation intervals are a new config concept, a new user-facing field, a new thing to
+explain in The Encounter. For what? So that an offsite drive can be absent for 29 days
+without nagging but nags on day 31?
+
+Here's what's actually happening: htpc-root has no `drives` config, so it sends to everything.
+The user doesn't want to send htpc-root to everything. They want it on WD-18TB. **Idea 5a —
+add `drives = ["WD-18TB"]` to htpc-root's config — is the right answer.** One line. Zero code.
+Zero new concepts. The user explicitly declares their intent, and the system honors it. That's
+the entire design philosophy of v1 config: self-describing, explicit, no inheritance magic.
+
+If someday a real user says "I want Urd to know my offsite drive comes back monthly and
+only nag me if I'm late," then design rotation intervals. Not before. Don't build concepts
+for one config line.
+
+**Idea 5b (role-based health weighting) has a seed of something good, but for later.** The
+insight that "test" drives shouldn't affect health computation is real. But today, there's
+one test drive (2TB-backup) and the fix is to scope htpc-root's drives list. Post-v1.0,
+when Urd has real users with real drive topologies, role-aware health might earn its
+complexity. Park it.
+
+**The brainstorm treats the plan vs dry-run divergence as bigger than it is.** Seven ideas
+across three categories for what is, at its core, a display discrepancy. Idea 6d (unify them)
+is clean in theory but blurs two distinct user intents: "show me what the system would do"
+(plan) vs "rehearse this specific action" (dry-run). These are different questions. The Mac
+had both "About This Mac" and "System Profiler" — same data, different depth, different intent.
+Don't merge them. Idea 6c (explain the difference) is the right call. One sentence in the
+dry-run footer. Move on.
+
+## The Vision
+
+Here's how I'd slot these into the roadmap. You have three categories:
+
+**Do now (before The Encounter):**
+1. Fix the transient accumulation bug (Idea 1a). This is data safety. Ship it.
+2. Add `drives = ["WD-18TB"]` to htpc-root config (Idea 5a). One config line. Eliminates the
+   permanent degraded state and, critically, also fixes the transient accumulation by reducing
+   htpc-root's drive scope to only mounted drives. These two changes together mean htpc-root
+   goes from "2 snapshots accumulating because of absent drives, permanently degraded" to
+   "1 snapshot max, healthy." That's the whole story.
+3. Fix the sentinel 0-chains warning (Idea 3b — guard on chain delta). The sentinel is the
+   always-on nervous system. Its warnings must mean something. A spurious warning in the log
+   every time a drive disconnects trains the user to ignore the logs. Five lines of code.
+4. Change "send disabled" to "local only" (Idea 4b). One string. Matches the category. Done.
+
+**Verify and close:**
+5. Confirm `urd get` is pipe-safe (Idea 2a). If it is, update the test report and close. If
+   it isn't, fix it — but the code analysis says it's fine.
+
+**Park (post-Encounter or never):**
+- 1c (rename config field) — Unnecessary if 1a works. The behavior IS the contract.
+- 1d (transient cap) — Emergency pre-flight is the safety net. Don't add another.
+- 1e (space-triggered transient cleanup) — Already exists as emergency pre-flight.
+- 1f (snapshot-on-demand for transient) — Breaks planner purity for marginal benefit.
+- 5b/5c/5d/5e/5f — Overengineered solutions to a one-line config fix. Park all of them.
+- 6a/6b/6d (plan/dry-run changes) — 6c (one-sentence footer) is sufficient.
+- 7a-7e (retention preview sizes) — Real issue but doesn't affect data safety or user
+  attention. The retention preview is a power-user diagnostic tool. Fix it when you're
+  polishing, not when you're fixing safety.
+- 8a/8b/8c (lock file) — 8c is correct: do nothing. The lock file works. It's in a
+  directory nobody looks at. This is the definition of an aesthetic concern that doesn't
+  serve either north star.
+- 9a/9b/9c (uncomfortable ideas) — Good thinking exercises, physically impossible.
+  The tension they reveal is real (btrfs requires local snapshots for sends), and 1a
+  is the practical resolution.
+
+**Updated roadmap would look like:**
+
+```
+v0.11.1 patch: transient fix (1a) + config fix (5a) + sentinel guard (3b) + text fix (4b)
+    → validate with 2-3 nightlies
+    → then: Phase D (Progressive Disclosure + The Encounter)
+```
+
+One patch release. Four changes. Two that matter for data safety, two that matter for trust.
+Then The Encounter, built on a foundation that tells the truth.
+
+## The Details
+
+**On Idea 1c specifically:** The brainstorm suggests `local_retention = "pipeline"` or
+`local_retention = "minimal"`. Both of these are engineer words. A user who cares about their
+root filesystem filling up doesn't think in "pipeline retention." They think in "don't store
+snapshots on my small drive." `local_snapshots = false` is the user's language. Don't
+translate it into yours.
+
+**On Idea 5f (degraded vs reduced):** I see the appeal of splitting health states to
+reduce alarm fatigue. But the vocabulary is frozen. Adding "reduced" is a new concept the
+user must learn, and the distinction between "degraded" and "reduced" is subtle enough to
+confuse rather than clarify. The real fix is to not report degradation when there's no
+degradation. Scope the drives (5a), and the false alarm goes away entirely.
+
+**On the brainstorm's uncomfortable ideas (9a-9c):** I appreciate these. Not because they're
+buildable — they aren't — but because they name the fundamental tension: BTRFS requires a
+local snapshot to send, but the user doesn't want local snapshots. The right answer is to
+make the local snapshot's existence as brief and invisible as possible. Idea 1a does that.
+The user's experience approaches zero-local even though the physics require one-transient.
+That gap between user experience and engineering reality is exactly where product design lives.
+
+## The Ask
+
+1. **Ship Idea 1a.** Fix `expand_protected_snapshots()` to exclude absent drives from the
+   unsent protection set for transient subvolumes. This is the critical data safety fix. Design
+   it, build it, verify it in 2-3 nightlies.
+
+2. **Edit htpc-root config: `drives = ["WD-18TB"]`.** One line. Stops the false degraded state.
+   Reduces htpc-root's drive scope so the transient fix (1a) works cleanly. Do this today —
+   it's a config change, not a code change.
+
+3. **Ship the sentinel guard (3b) and text fix (4b) in the same patch.** Small, obvious,
+   high-trust-impact changes. Bundle them with 1a as v0.11.1.
+
+4. **Verify `urd get` piping and close (2a).** Ten-second test. If it works, update the
+   test report.
+
+5. **Add the dry-run footer (6c):** "Retention deletions not shown. Run `urd plan` for the
+   full picture." One line in voice.rs. Ship with v0.11.1 if it's easy, otherwise park.
+
+6. **Then design The Encounter.** Not before. The foundation must be honest first.

--- a/docs/99-reports/2026-04-05-steve-jobs-000-phase-e-ships.md
+++ b/docs/99-reports/2026-04-05-steve-jobs-000-phase-e-ships.md
@@ -1,0 +1,168 @@
+---
+upi: "000"
+date: 2026-04-05
+mode: vision-filter
+---
+
+# Steve Jobs Review: Phase E Ships — Is the Foundation Ready for the Encounter?
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-05
+**Scope:** Project-level vision check after v0.11.0 / Phase E completion
+**Mode:** Vision Filter
+
+## The Verdict
+
+Phase E delivered real substance — the invisible worker is now genuinely intelligent — but
+the project is approaching its most important moment, The Encounter, and it hasn't deployed
+a single line of Phase E code to production yet. You've built a beautiful engine and left it
+on the workbench. Deploy it. Run it. Let it surprise you. The Encounter cannot be designed
+in a vacuum — it must be designed from the experience of living with this version.
+
+## What's Insanely Great
+
+**The emergency command gets the framing exactly right.** "Urd sees a crisis." Not "Error:
+filesystem usage exceeds configured threshold." Not "WARNING: space critical." A crisis.
+Something the norn recognizes and names. Then it tells you what it will do, what it will
+preserve, and asks permission. This is exactly the kind of moment where the mythic voice
+earns its existence — not decorating routine output, but lending gravity to a moment that
+deserves gravity. The user's disk is full and their backups are stuck. They need to feel
+like someone competent is in control. "Urd sees a crisis" does that. Protect this.
+
+**The promise model is proving itself.** Six features shipped in Phase E and not one of
+them required the user to learn a new concept. Skip unchanged? Invisible. Compressed
+sends? Invisible. Emergency thinning? Automatic. Context-aware suggestions? Appears when
+relevant. This is north star #2 working at scale: every feature reduces the attention the
+user spends on backups. The architecture is delivering on the vision. That's rare.
+
+**The discipline of "invisible worker" vs "invoked norn" held through six features.** The
+automatic emergency pre-flight runs silently, under the lock, re-plans afterward. The
+interactive emergency command speaks, explains, asks. Same retention logic underneath. Two
+different modes of existence, properly separated. This is a design principle that survived
+contact with implementation, which means it's real, not aspirational.
+
+**921 tests.** That's not a number — that's trust. When you tell someone to type `y` to
+delete 39 snapshots, you better be right about which 39. The three-layer pin protection
+surviving through an emergency feature — structurally enforced, not just documented — is
+the kind of engineering that earns the right to delete things.
+
+## What's Not Good Enough
+
+**You haven't deployed v0.10.0 or v0.11.0.** This is the single biggest concern. You've
+built eleven features since the last deployed version. Eleven. The catastrophic storage
+failure that motivated the emergency command happened during development. What happens if
+the next one happens before you deploy the feature that prevents it? You're sitting on
+your own insurance policy. Ship it.
+
+Beyond the risk: The Encounter is next. You're about to design the first experience a new
+user has with Urd. That design must be informed by the real behavior of everything you just
+built — how skip-unchanged looks in the actual nightly log, whether the doctor suggestions
+make sense when a real drive is actually disconnected, how the emergency pre-flight behaves
+when your NVMe really does fill up. You cannot design a first impression from test output.
+You need to live with this version.
+
+**The emergency output lost something from the design doc.** The design doc's mockup says:
+
+```
+This will delete 39 snapshots from home, freeing approximately 8.2 GB.
+```
+
+The implementation says:
+
+```
+This will delete 39 snapshots.
+```
+
+I understand why — btrfs shared extents make size estimation unreliable, and the plan
+acknowledged this as R4. But the user who's staring at "1.8 GB free" and being asked to
+delete 39 snapshots desperately wants to know: "will this fix it?" The answer "39 snapshots"
+doesn't tell them. Even a rough estimate with an "approximately" caveat is better than
+silence. "Freeing approximately 4-8 GB" with a footnote about shared extents would be
+honest and useful. Without it, the user is making a trust decision with incomplete
+information. That's not worthy of the experience you designed.
+
+**The design doc also showed a progress bar. The implementation doesn't have one.** When
+you're deleting 39 snapshots and each one takes a few seconds, staring at a blank terminal
+is anxiety-inducing. The user just said "yes, delete my history." They need feedback that
+it's working. A simple counter — `Deleting... 12/39` — would transform the experience
+from "did it freeze?" to "it's working."
+
+**"The nightly timer will resume normal operation."** This line from the design doc is
+missing from the implementation's result output. It's the most important line. The user
+didn't run `urd emergency` because they enjoy deleting snapshots. They ran it because their
+backups were broken. The answer to "did this fix it?" isn't "Freed 8.2 GB." It's "Your
+backups will work again tonight."
+
+## The Vision
+
+Phase E is the invisible worker done right. Phase D is where Urd becomes something people
+talk about.
+
+Here's what I see. A person installs Urd on a new machine. They type `urd` and instead of
+a help page, Urd says: "I see you have BTRFS volumes but no backup configuration. Want to
+tell me what matters to you?" And then a conversation starts — not about retention policies
+and snapshot intervals, but about photos and code and documents and "what would hurt to
+lose." At the end, Urd writes a config and says: "I'll check on your data every four hours.
+If something goes wrong, I'll tell you. Try `urd status` anytime you want to know if your
+data is safe."
+
+That's The Encounter. And the reason I'm confident it can work is that everything behind
+it — the promise model, the awareness computation, the sentinel, the emergency recovery,
+the context-aware suggestions — already exists. You've built the nervous system. Phase D
+puts a face on it.
+
+But you have to deploy first. You have to live with v0.11.0 running on your actual system,
+backing up your actual data, and telling you the truth about your actual drives. The
+Encounter's design will be ten times better if it's informed by a week of living with
+Phase E's output.
+
+## The Details
+
+**"No crisis detected."** — This is good but could be warmer. When someone types
+`urd emergency` they're worried. "No crisis detected. All snapshot roots are within their
+free-space thresholds." is accurate but clinical. Consider: "No crisis. Your snapshot roots
+have room to breathe." The norn is reassuring, not just reporting.
+
+**"Chain parents pinned: 3"** — In the emergency output. "Chain parents" is internal
+vocabulary. The user doesn't think in chain parents. They think in "what's keeping my
+external backups working." Try: "3 snapshots pinned for external drives."
+
+**Per-subvolume detail** — "home: 40 snapshots, keep 5, delete 35" — The formatting uses
+engineering language. "keep 5, delete 35" is the implementer's mental model (two lists). The
+user's mental model is: "How much of my history am I losing?" Something like "home: 40 →
+5 snapshots (keeping your newest and 4 chain parents)" tells the human story.
+
+**"5 unsent snapshots will be deleted."** — Correct but alarming without context. The user
+doesn't know if that's bad. Add one sentence: "Your next external backup will rebuild the
+chain automatically." That turns a warning into guidance.
+
+**The `[y/N]` prompt** — Good default-to-no. But consider: this is a destructive operation
+on backup data. The user should type the full word "yes", not just "y". Make the gravity
+match the action. When Apple asks you to type your Apple ID to disable Find My, it's not
+because they think you might accidentally type your email — it's because they want you to
+pause and think. Same principle. "Type 'yes' to proceed:"
+
+## The Ask
+
+1. **Deploy v0.11.0 this week.** Not next session. This week. Install it, run a nightly,
+   verify the output. Live with it before designing The Encounter. The deployment notes in
+   status.md are clear — the path is known. Walk it.
+
+2. **Add a progress counter to emergency deletions.** Simple `Deleting... 12/39` on stderr.
+   Five minutes of work, transforms the experience from anxious to confident.
+
+3. **Add the "your backups will work again" closing line.** After emergency results, tell
+   the user what this means for their future, not just their past.
+
+4. **Refine the emergency voice.** "Chain parents" → "snapshots pinned for external drives."
+   "keep 5, delete 35" → "40 → 5 snapshots." The unsent warning needs a reassurance line.
+   These are individually small but collectively they're the difference between a tool that
+   informs and a tool that guides.
+
+5. **Update the roadmap.** Phase E is complete. 016-interactive shipped (not deferred to
+   Phase F as the roadmap says). Clean the map so the next session starts from truth.
+
+6. **Then — and only then — design The Encounter.** With real production data behind you,
+   with the emergency command actually available if something goes wrong, with a week of
+   nightly logs showing skip-unchanged and compressed sends working. Design from experience,
+   not from imagination.

--- a/docs/99-reports/2026-04-05-testing-urd-v0.11.0.md
+++ b/docs/99-reports/2026-04-05-testing-urd-v0.11.0.md
@@ -1,0 +1,574 @@
+# Urd v0.11.0 Comprehensive Test Report
+
+> **Date:** 2026-04-05
+> **Version:** urd 0.11.0 (confirmed via `urd --version`)
+> **Context:** First nightly run after v0.11.0 deployment (run #29, 2026-04-05T04:01:11).
+> Phase E features: compressed sends (013), external-only runtime (018), context-aware
+> suggestions (020), skip unchanged subvolumes (014), emergency space response (016),
+> sentinel fixes (021).
+>
+> **Method:** All commands run from development build (`cargo run --`), interpreting
+> JSON output. No TTY formatting visible — all observations are from structured data.
+
+---
+
+## Phase 0: Post-Nightly Baseline
+
+### T0.1 — Version confirmed
+
+```
+urd --version → urd 0.11.0
+```
+
+**Result:** PASS.
+
+### T0.2 — Status baseline
+
+All 9 subvolumes report `PROTECTED`. WD-18TB connected (4.2TB free). WD-18TB1 absent.
+2TB-backup absent.
+
+| Subvolume | Status | Health | Promise Level | Local Snaps | External (WD-18TB) |
+|-----------|--------|--------|---------------|-------------|-------------------|
+| subvol3-opptak | PROTECTED | degraded | fortified | 31 | 7 (1d ago) |
+| htpc-home | PROTECTED | healthy | fortified | 9 | 8 (7h ago) |
+| subvol2-pics | PROTECTED | healthy | fortified | 17 | 9 (1d ago) |
+| subvol1-docs | PROTECTED | healthy | sheltered | 31 | 9 (1d ago) |
+| subvol7-containers | PROTECTED | healthy | sheltered | 32 | 9 (1d ago) |
+| subvol5-music | PROTECTED | degraded | sheltered | 16 | 9 (1d ago) |
+| subvol4-multimedia | PROTECTED | healthy | recorded | 6 | — |
+| subvol6-tmp | PROTECTED | healthy | (custom) | 13 | — |
+| htpc-root | PROTECTED | degraded | (custom) | 2 | 5 (7h ago) |
+
+**Degraded reasons:**
+- subvol3-opptak: WD-18TB1 away for 8 days
+- subvol5-music: WD-18TB1 away for 8 days
+- htpc-root: WD-18TB1 away for 13 days, 2TB-backup away for 13 days
+
+**Chain health:** All 7 send-enabled subvolumes show "Incremental" — all chains intact.
+23 total pins.
+
+**Result:** PASS. System healthy after first v0.11.0 nightly.
+
+### T0.3 — History review
+
+Last 5 runs:
+
+| Run | Time | Mode | Result | Duration |
+|-----|------|------|--------|----------|
+| 29 | 2026-04-05 04:01 | full | success | 9m 31s |
+| 28 | 2026-04-04 04:00 | full | success | 31s |
+| 27 | 2026-04-03 20:25 | full | success | 12s |
+| 26 | 2026-04-03 04:00 | full | success | 2s |
+| 25 | 2026-04-02 22:20 | full | success | 23s |
+
+**Observation:** Run #29 (9m 31s) was dramatically longer than run #28 (31s). This is
+because run #29 was the first run on v0.11.0 with compressed sends and new chain-break
+behavior. The log reveals two full sends: htpc-home (27GB, 350s) and htpc-root (22GB, 215s).
+Both were chain-break full sends that v0.11.0 allowed because drive identity was verified.
+
+**Result:** PASS. Nightly timer firing consistently at ~04:00.
+
+### T0.4 — Nightly run #29 detailed analysis
+
+From journalctl:
+
+1. **Compressed data pass-through detected** — `btrfs send: compressed data pass-through available`.
+   UPI 013 feature working.
+
+2. **Chain-break full sends auto-proceeded:**
+   - htpc-home → WD-18TB: full send, 27.1GB, 350s. "Chain-break full send for htpc-home to WD-18TB: proceeding (drive identity verified)"
+   - htpc-root → WD-18TB: full send, 22.0GB, 215s. Same pattern.
+   - Both used `--compressed-data` flag. ✓
+
+3. **Skip-unchanged working:** subvol2-pics, subvol1-docs, subvol7-containers, subvol5-music
+   all show "already on WD-18TB" in skipped reasons — no redundant sends.
+
+4. **Post-delete sync issue:** Two `btrfs subvolume sync` failures with "sudo: a terminal
+   is required to read the password". The sync command for post-delete space reclamation
+   requires sudo but the sudoers config doesn't cover `btrfs subvolume sync`. The warning
+   message "space check may be pessimistic" is accurate — sync failure doesn't block
+   operations, just means free-space readings may lag.
+
+5. **Space-aware deletion skipping:** Executor correctly stopped further deletions once
+   free space exceeded thresholds: "Free space on WD-18TB is now 4.2TB (>= 500.0GB),
+   stopping further deletions" — avoiding unnecessary retention cleanup.
+
+6. **Sentinel notification deferral:** "Sentinel is running — deferring notification dispatch".
+   Backup correctly delegates notification to the sentinel daemon. ✓
+
+**Result:** PASS with one issue (sync sudo).
+
+---
+
+## Phase 1: Plan and Dry-Run Testing
+
+### T1.1 — Manual plan
+
+`urd plan` shows: 4 snapshots, 6 sends, 25 deletions, 19 skipped.
+Estimated total: ~1.0GB.
+
+Key observations:
+- All sends are incremental to WD-18TB. ✓
+- **Skip-unchanged (UPI 014):** subvol2-pics, subvol1-docs, subvol5-music, subvol4-multimedia,
+  subvol6-tmp all show `"unchanged — no changes since last snapshot"`. Feature working correctly.
+- Retention thinning: graduated daily/weekly deletions for subvol6-tmp and others.
+- htpc-root plans a send with `estimated_bytes: 72407457` (~69MB incremental).
+
+**Result:** PASS. Plan is coherent and all new features visible.
+
+### T1.2 — Auto plan
+
+`urd plan --auto` shows: 0 snapshots, 6 sends, 25 deletions, 23 skipped.
+
+Difference from manual: No new snapshots planned (interval not elapsed — next in ~16h33m).
+But sends are still planned because unsent snapshots from the nightly exist.
+
+**Observation:** The auto plan correctly gates snapshot creation on intervals but still
+plans sends for snapshots that haven't been sent yet. This is correct behavior — the
+nightly created snapshots but many subvolumes had their sends skipped (already on drive).
+
+**Result:** PASS.
+
+### T1.3 — Backup dry-run
+
+`urd backup --dry-run` shows: 4 snapshots, 6 sends, 6 deletions, 19 skipped.
+
+**Plan vs dry-run divergence (carried from v0.8 F0.4):** Plan shows 25 deletions,
+dry-run shows only 6. The 19-deletion difference is retention thinning that plan includes
+but backup dry-run omits. This divergence still exists from v0.8.
+
+**UX note:** For a user trying to understand "what will happen if I run backup?", the
+dry-run answer differs from the plan answer. Both are called "plan" views but show
+different scopes of work.
+
+**Result:** PASS (functional). UX divergence noted.
+
+### T1.4 — Skip categories in JSON
+
+The skip reasons include rich categories:
+- `"unchanged"` — UPI 014 skip-unchanged working
+- `"drive_not_mounted"` — clear
+- `"local_only"` — replaces the misleading `[OFF] Disabled` from v0.8 (F0.3)
+- `"interval_not_elapsed"` — with countdown ("next in ~16h33m")
+- `"other"` — "20260403-2025-music already on WD-18TB" (already-sent skip)
+
+**Improvement from v0.8:** The `local_only` category resolves F0.3 from v0.8 testing.
+The old `[OFF] Disabled` label was misleading for subvolumes that are actively snapshotted
+locally but not sent anywhere. Now clearly labeled as `"send disabled"` with `local_only`
+category.
+
+**Remaining issue:** The `"send disabled"` reason text could be more descriptive —
+`"local-only — no external drives configured"` would better match the vocabulary design.
+
+**Result:** PASS. F0.3 from v0.8 resolved in JSON output.
+
+---
+
+## Phase 2: Feature Verification (Phase E)
+
+### T2.1 — Compressed sends (UPI 013)
+
+Nightly log confirms:
+- Probe: `btrfs send: compressed data pass-through available`
+- Usage: `btrfs send --compressed-data` for both full sends
+
+htpc-home full send: 27.1GB in 350s ≈ 77MB/s.
+htpc-root full send: 22.0GB in 215s ≈ 102MB/s.
+
+**Result:** PASS. Compressed sends operational.
+
+### T2.2 — Skip unchanged subvolumes (UPI 014)
+
+Plan output shows 5 subvolumes skipped with `"unchanged"` category:
+- subvol2-pics: "unchanged — no changes since last snapshot (7h26m ago)"
+- subvol1-docs: "unchanged — no changes since last snapshot (7h26m ago)"
+- subvol5-music: "unchanged — no changes since last snapshot (1d ago)"
+- subvol4-multimedia: "unchanged — no changes since last snapshot (1d ago)"
+- subvol6-tmp: "unchanged — no changes since last snapshot (7h26m ago)"
+
+This is generation-based detection. The "(Xh ago)" suffix tells the user when the
+last snapshot was taken — useful context.
+
+**Result:** PASS. Skip-unchanged operational and informative.
+
+### T2.3 — Emergency space response (UPI 016)
+
+`urd emergency` exists as a command. Help shows: "Guided emergency space recovery".
+No `--dry-run` flag — this is an interactive guided command.
+
+Cannot fully test without TTY (interactive prompts), but the command exists and is
+reachable. The nightly log shows no emergency triggers, which is correct — space is
+healthy.
+
+**Result:** PARTIAL (command exists, cannot exercise interactive flow).
+
+### T2.4 — External-only runtime (UPI 018)
+
+Config confirms `htpc-root` has `local_snapshots = false`. Status shows:
+- `"external_only": true` in htpc-root assessment
+- `"retention_summary": "none (transient)"`
+- `"local_snapshot_count": 2`
+
+**CRITICAL FINDING F2.4:** htpc-root has `local_snapshots = false` in config but
+**2 local snapshots exist** (`20260404-0400-htpc-root`, `20260405-0401-htpc-root`).
+The nightly log confirms: "Creating snapshot: / -> ~/.snapshots/htpc-root/20260405-0401-htpc-root".
+
+**Urd is still creating local htpc-root snapshots despite `local_snapshots = false`.**
+
+The snapshots are on the NVMe root drive (118GB, 79% used, 26GB free). Each htpc-root
+snapshot is a full root filesystem snapshot. This is the exact pattern that caused
+the catastrophic storage failure — snapshot accumulation on a space-constrained system drive.
+
+Currently only 2 snapshots exist (retention thinning appears to be working), but:
+1. The config says `local_snapshots = false` — the user's explicit intent is zero local snapshots
+2. The snapshot_root is `~/.snapshots` which lives on the NVMe
+3. The retention_summary says "none (transient)" but snapshots are being created and kept
+4. With 26GB free and each root snapshot potentially large, this is a live risk
+
+**Root cause hypothesis:** The executor creates snapshots as a prerequisite for sends.
+Even with `local_snapshots = false`, htpc-root needs a local snapshot to send to
+WD-18TB. The snapshots are created for the send pipeline, and "transient" retention
+keeps the minimum needed for chain continuity. But the user's expectation from
+`local_snapshots = false` is **zero persistent local copies** — "create, send, delete"
+should be the pattern.
+
+**Risk assessment:**
+- 2 snapshots × ~20GB = ~40GB potential on 118GB drive with 26GB free
+- If retention fails or gets behind, snapshots accumulate → catastrophic failure
+- The current 2-snapshot state may be correct (pin + latest), but the config contract
+  says "false" and the user expects zero
+
+**Result:** FAIL. Config contract violated. See Findings section.
+
+### T2.5 — Context-aware suggestions (UPI 020)
+
+Status output includes an `"advice"` array:
+```json
+{
+  "subvolume": "subvol3-opptak",
+  "issue": "degraded — WD-18TB1 away",
+  "reason": "Consider connecting WD-18TB1"
+}
+```
+
+Three advisories, all for degraded subvolumes suggesting WD-18TB1 connection.
+Clear, actionable, relevant.
+
+**Result:** PASS. Context-aware suggestions present and useful.
+
+### T2.6 — Sentinel health (UPI 021)
+
+Sentinel running since 17h21m. PID 929060. Tick interval: 900s (15m).
+Circuit breaker: closed, 0 failures. Visual state icon: "warning" (due to degraded subvolumes).
+
+Promise states match status output exactly. 6 healthy, 3 degraded, 0 blocked.
+
+**Sentinel log anomaly:** Two entries from 2026-04-02:
+- "Drive anomaly: all 0 chains broke on 2TB-backup simultaneously"
+- "Drive anomaly: all 0 chains broke on WD-18TB simultaneously"
+
+Both say "all 0 chains broke" — this is a spurious warning. When a drive has 0 chains,
+reporting that "all 0 broke simultaneously" is vacuously true but misleading. Should be
+suppressed when chain count is 0.
+
+**Result:** PASS (functional). Spurious "0 chains broke" warning noted.
+
+---
+
+## Phase 3: Drive and Infrastructure Checks
+
+### T3.1 — Drive status
+
+```json
+WD-18TB:    connected, token verified, 4.2TB free, role: primary
+WD-18TB1:   absent, token unknown, role: offsite
+2TB-backup: absent, token recorded (last seen 2026-04-02), role: test
+```
+
+Token states are differentiated: "verified" (seen and confirmed on mounted drive),
+"recorded" (in SQLite but drive not mounted), "unknown" (never tokened).
+
+**Result:** PASS. Drive state clearly communicated.
+
+### T3.2 — Doctor thorough
+
+35 OK, 14 warnings, 0 failures. All WD-18TB threads pass all 5 checks (pin-file,
+pin-exists-local, pin-exists-drive, orphans, stale-pin). All 14 warnings are "Drive
+not mounted — skipping" for WD-18TB1 and 2TB-backup.
+
+No preflight warnings. No issues. Sentinel confirmed running.
+
+**Improvement from v0.8:** No more "UUID contradiction" warning (WD-18TB UUID issue).
+No htpc-root chain break issues on WD-18TB.
+
+**Result:** PASS.
+
+### T3.3 — Verify thread integrity
+
+Same as doctor verify section: 35 OK, 14 warnings, 0 failures. All send-enabled
+subvolumes have intact chains on WD-18TB.
+
+**Result:** PASS.
+
+### T3.4 — Heartbeat
+
+```json
+{
+  "schema_version": 2,
+  "timestamp": "2026-04-05T04:10:42",
+  "stale_after": "2026-04-07T04:10:42",
+  "run_result": "success",
+  "run_id": 29,
+  "notifications_dispatched": true
+}
+```
+
+All subvolumes show `backup_success: true`. htpc-home and htpc-root show
+`send_completed: true` (the two full sends). Others show `send_completed: false`
+(skipped — already sent or unchanged).
+
+Stale threshold: 48h from last run. Appropriate for a daily schedule.
+
+**Result:** PASS. Heartbeat schema clean and informative.
+
+### T3.5 — File restore (urd get)
+
+```
+urd get /etc/hostname --at yesterday
+```
+
+Output:
+```json
+{
+  "subvolume": "htpc-root",
+  "snapshot": "20260404-0400-htpc-root",
+  "snapshot_date": "2026-04-04 04:00",
+  "file_path": "etc/hostname",
+  "file_size": 12
+}
+fedora-htpc
+```
+
+**Observation:** The JSON metadata is printed followed immediately by the file content
+(`fedora-htpc`). This is a mixed-mode output — structured metadata concatenated with
+raw file content. For piping (`urd get ... | cat`), the JSON preamble would corrupt
+the restored file. The `-o` flag writes to a file instead, which avoids this issue.
+
+**UX finding F3.5:** `urd get` without `-o` mixes JSON metadata with file content on
+stdout. This makes the default restore path unusable for piping. Either:
+- (a) Print metadata to stderr, content to stdout (pipe-safe default)
+- (b) Only print metadata when `--verbose` is set
+- (c) Always require `-o` for output (break pipe workflow entirely)
+
+**Result:** PASS (functional). UX issue with mixed stdout.
+
+### T3.6 — Retention preview
+
+`urd retention-preview --all` shows graduated policies for all subvolumes.
+htpc-root shows `"transient"` with empty recovery windows — consistent with config.
+
+**Observation:** subvol3-opptak shows calibrated disk usage estimate of 315TB total
+for 92 snapshots at 3.4TB per snapshot. subvol5-music shows 102TB total for 92 snapshots
+at 1.1TB per snapshot. These numbers are per-snapshot full sizes from calibration, not
+deltas — the actual disk usage with CoW deduplication will be far lower. The presentation
+doesn't clarify this distinction.
+
+**UX finding F3.6:** Retention preview shows raw calibrated sizes that massively overstate
+actual disk usage due to BTRFS CoW. "315TB estimated for subvol3-opptak" is alarming but
+misleading. Should note these are pre-dedup estimates or use delta-based estimates if available.
+
+**Result:** PASS (functional). Size estimates misleading.
+
+### T3.7 — Lock file
+
+Lock file from run #29: `{"pid":2115074,"started":"2026-04-05T04:01:09","trigger":"auto"}`.
+Trigger correctly shows "auto" for the nightly timer run.
+
+**Result:** PASS.
+
+---
+
+## Phase 4: UX Assessment
+
+### Overall JSON-first experience
+
+Every command outputs structured JSON. This is excellent for programmatic consumption
+(monitoring, dashboards, scripting) but means the CLI has **no human-readable presentation
+layer** for interactive use. The v0.8 testing showed human-formatted tables and status
+lines — the current output is pure JSON.
+
+**Key question:** Has the presentation layer (voice.rs) been bypassed? Or does the
+current binary always output JSON? If this is intentional (machine-first output with
+a future TUI layer on top), it should be documented. If it's a regression, the mythic
+voice that was part of Urd's identity has been lost.
+
+**Finding F4.1 — JSON-only output.** All tested commands produce raw JSON:
+- `urd status` — JSON object (no table, no promise-state summary)
+- `urd plan` — JSON operations array (no briefing, no human summary)
+- `urd doctor` — JSON checks (no severity summary)
+- `urd history` — JSON runs (no formatted table)
+- `urd verify` — JSON checks
+- `urd drives` — JSON
+- `urd get` — JSON metadata + raw content
+
+This may be because we're running `cargo run --` (debug build) rather than the installed
+binary, or because the output format changed. But in v0.8 testing, the same `cargo run --`
+approach showed human-formatted output.
+
+**Impact:** Without a presentation layer, the user cannot quickly answer "is my data
+safe?" by glancing at status output. They must parse JSON mentally. The mythic voice,
+protection summaries, and status tables that define Urd's character are absent.
+
+### What works well
+
+1. **Skip-unchanged messaging** — "unchanged — no changes since last snapshot (7h26m ago)"
+   is informative and saves work.
+2. **Context-aware advice** — Targeted suggestions in status ("Consider connecting WD-18TB1")
+   are actionable.
+3. **Drive token states** — "verified" / "recorded" / "unknown" differentiation is clear.
+4. **Chain health reporting** — All-incremental status is easy to verify.
+5. **Space-aware behavior** — Executor stops deletions when space is sufficient, saving
+   unnecessary operations.
+6. **Sentinel notification deferral** — Backup correctly hands off to sentinel.
+
+### What needs attention
+
+1. **htpc-root local snapshots** (CRITICAL) — Config says false, snapshots exist
+2. **JSON-only output** — No human-readable layer visible
+3. **Mixed stdout in `urd get`** — JSON + content concatenated
+4. **Retention preview sizes** — Pre-dedup estimates are alarming
+5. **Post-delete sync requires sudo** — `btrfs subvolume sync` not in sudoers
+6. **Sentinel "0 chains broke" warning** — Vacuously true, should be suppressed
+
+---
+
+## Phase 5: htpc-root Deep Dive
+
+This is the most critical finding. The user has been explicit that htpc-root local
+snapshot accumulation caused a catastrophic storage failure.
+
+### Current state
+
+- Config: `local_snapshots = false`
+- Actual local snapshots: 2 (`20260404-0400`, `20260405-0401`)
+- Snapshot root: `~/.snapshots/htpc-root/` on NVMe (118GB, 79% used, 26GB free)
+- Pin files: 3 (WD-18TB, WD-18TB1, 2TB-backup)
+- Retention summary: "none (transient)"
+- Status: `external_only: true`
+
+### Nightly behavior
+
+Run #29 log shows:
+1. Created snapshot: `/ -> ~/.snapshots/htpc-root/20260405-0401-htpc-root`
+2. Chain-break full send to WD-18TB: 22GB, 215s
+3. Pin updated to `20260404-0400-htpc-root`
+
+The snapshot was created, sent, and the previous snapshot is retained (pinned for
+chain continuity). So htpc-root always has 2 local snapshots: the current pin parent
+and the latest.
+
+### Risk calculation
+
+| Scenario | Snapshots | Est. disk use | NVMe free after |
+|----------|-----------|---------------|-----------------|
+| Normal (2 snaps) | 2 | ~10-20GB shared | 6-16GB |
+| Missed cleanup (3 snaps) | 3 | ~15-30GB shared | 0-11GB |
+| Chain break + retry (4 snaps) | 4 | ~20-40GB shared | 0-6GB |
+
+The NVMe has 26GB free. With CoW sharing between snapshots, 2 snapshots may only
+consume a few GB of exclusive data. But a chain break or failed cleanup could push
+this over the edge.
+
+### What `local_snapshots = false` should mean
+
+The user's intent: htpc-root lives on external drives. Local copies are temporary —
+create, send, delete. The "transient" retention and `external_only: true` flags
+suggest the system understands this intent, but the execution still accumulates
+snapshots.
+
+**Recommendation:** After a successful send, the previous local snapshot (the old
+pin parent) should be immediately deleted. Only the current pin parent should survive.
+If `local_snapshots = false`, the lifecycle should be: create → send → update pin →
+delete old pin parent → result: exactly 1 local snapshot at any time.
+
+---
+
+## Summary
+
+| Test | Status | Notes |
+|------|--------|-------|
+| T0.1 | PASS | v0.11.0 confirmed |
+| T0.2 | PASS | Baseline: 9 PROTECTED, 3 degraded, all chains intact |
+| T0.3 | PASS | History clean, nightly consistent |
+| T0.4 | PASS* | Nightly successful, compressed sends working, sync sudo issue |
+| T1.1 | PASS | Plan coherent, all Phase E features visible |
+| T1.2 | PASS | Auto plan correctly gates snapshots |
+| T1.3 | PASS | Dry-run functional, plan divergence persists from v0.8 |
+| T1.4 | PASS | Skip categories improved from v0.8 (F0.3 resolved) |
+| T2.1 | PASS | Compressed sends operational |
+| T2.2 | PASS | Skip-unchanged operational and informative |
+| T2.3 | PARTIAL | Emergency command exists, interactive flow untestable |
+| T2.4 | **FAIL** | htpc-root creating local snapshots despite `local_snapshots = false` |
+| T2.5 | PASS | Context-aware suggestions present and useful |
+| T2.6 | PASS | Sentinel healthy, spurious "0 chains broke" warning |
+| T3.1 | PASS | Drive states clear |
+| T3.2 | PASS | Doctor thorough clean |
+| T3.3 | PASS | All threads intact |
+| T3.4 | PASS | Heartbeat healthy |
+| T3.5 | PASS* | Restore works, mixed stdout issue |
+| T3.6 | PASS* | Retention preview functional, sizes misleading |
+| T3.7 | PASS | Lock trigger correct |
+
+## Findings
+
+### Severity: Critical
+
+**F2.4 — htpc-root local snapshots created despite `local_snapshots = false`.** Config
+explicitly sets `local_snapshots = false` but nightly run #29 created a local snapshot
+on the 118GB NVMe (26GB free). Two local htpc-root snapshots currently exist. This is
+the exact pattern that caused the catastrophic storage failure. The "transient" retention
+keeps snapshots for chain continuity, but the user's expectation is zero persistent local
+copies. Either:
+1. The send pipeline must delete the old pin parent immediately after successful send
+2. Or `local_snapshots = false` needs redefinition — "false means at-most-1, not zero"
+   — and this needs to be communicated to the user
+
+### Severity: Moderate
+
+**F4.1 — JSON-only output.** All commands produce raw JSON with no human-readable
+presentation layer. The mythic voice and status tables from Urd's design are absent.
+Users cannot quickly assess "is my data safe?" from the raw output. This may be a
+regression or an intentional machine-first approach — either way, the invoked-norn
+experience described in the design vision is not present.
+
+**F3.5 — Mixed stdout in `urd get`.** JSON metadata concatenated with raw file content
+on stdout makes the default restore path unpipeable. Metadata should go to stderr or
+be suppressed without `--verbose`.
+
+**F0.4 (carried) — Plan vs dry-run divergence.** `urd plan` shows 25 deletions while
+`urd backup --dry-run` shows 6. Different scopes of "what will happen" with no
+indication to the user.
+
+### Severity: Low
+
+**F3.6 — Retention preview sizes misleading.** Shows pre-deduplication full-snapshot
+sizes (315TB for opptak, 102TB for music) that massively overstate actual disk usage.
+Should clarify these are worst-case estimates.
+
+**F2.6a — Sentinel "0 chains broke" warning.** "Drive anomaly: all 0 chains broke on
+2TB-backup simultaneously" — vacuously true, should be suppressed when chain count is 0.
+
+**F0.4a — Post-delete sync requires sudo.** `btrfs subvolume sync` fails in nightly
+context because it's not in sudoers. Logged as warning, doesn't block operations, but
+means space readings may be pessimistic after deletions.
+
+### Regression check vs v0.8
+
+| v0.8 Finding | v0.11 Status |
+|-------------|-------------|
+| F0.3 — `[OFF] Disabled` misleading | **RESOLVED** — now `local_only` category |
+| F0.0 — UUID contradiction for cloned drives | Not observed in current doctor output |
+| F1.1 — Silent drive reconnection | Not testable (no drive events during test) |
+| F2.3 — Cloned drive identity crisis | Not testable (WD-18TB1 not available) |
+| T3.3 — assess() scoping bug | **Appears improved** — htpc-home and subvol2-pics show healthy despite 2TB-backup absent (they have explicit `drives` config excluding 2TB-backup). However, htpc-root still degrades for WD-18TB1 and 2TB-backup (no explicit drives scoping — sends to all) |
+| T0.4 — Plan vs dry-run divergence | **Still present** |


### PR DESCRIPTION
## Summary

- Comprehensive v0.11.0 test report covering first nightly run (run #29) — all Phase E features verified working in production
- Critical finding: transient retention protects snapshots for absent drives indefinitely, causing htpc-root local snapshot accumulation despite `local_snapshots = false`
- Three Steve Jobs product reviews narrowing 30+ brainstorm ideas to 4 actionable patch fixes
- UPI 022 design ("The Honest Nightly"): transient absent-drive fix, sentinel chain-delta guard, "local only" text, htpc-root config scope

## Artifacts

| Document | Purpose |
|----------|---------|
| `docs/99-reports/2026-04-05-testing-urd-v0.11.0.md` | Full test report (37 tests, 5 phases) |
| `docs/99-reports/2026-04-05-steve-jobs-000-first-nightly-truth.md` | Product review of test results |
| `docs/99-reports/2026-04-05-steve-jobs-000-fix-the-lie-first.md` | Vision filter on brainstorm |
| `docs/99-reports/2026-04-05-steve-jobs-000-phase-e-ships.md` | Pre-deploy vision check |
| `docs/95-ideas/2026-04-05-v011-production-fixes.md` | Brainstorm (30+ ideas) |
| `docs/95-ideas/2026-04-05-design-022-honest-nightly.md` | UPI 022 design (4 fixes for v0.11.1) |

## Testing

- Documentation only — no code changes
- Quality gate: not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)