### PR TITLE
fix: transient retention ignores absent drives (UPI 022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-04-05
+
 ### Fixed
 - Transient snapshots accumulating for absent drives — retention now only protects pins from mounted drives, preventing space exhaustion on constrained filesystems
 - Sentinel "all N chains broke" phrasing — detection now reports actual broken count and fires on 2+ broken chains (delta-based), not only when all chains break

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Transient snapshots accumulating for absent drives — retention now only protects pins from mounted drives, preventing space exhaustion on constrained filesystems
+- Sentinel "all N chains broke" phrasing — detection now reports actual broken count and fires on 2+ broken chains (delta-based), not only when all chains break
+- "send disabled" skip text for local-only subvolumes replaced with "local only"
+
+### Added
+- Transient snapshot creation skipped when no drives are available for send (defense-in-depth)
+
 ## [0.11.0] - 2026-04-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,7 +5,7 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
-| 022 | The Honest Nightly (transient fix + sentinel guard + text fix + config scope) | [design](../95-ideas/2026-04-05-design-022-honest-nightly.md) | - | - | - | - |
+| 022 | The Honest Nightly (transient fix + sentinel guard + text fix + config scope) | [design](../95-ideas/2026-04-05-design-022-honest-nightly.md) | [review](../99-reports/2026-04-05-design-review-022-honest-nightly.md) | - | - | - |
 | 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | merged | [#84](https://github.com/vonrobak/urd/pull/84) |
 | 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | merged | [#85](https://github.com/vonrobak/urd/pull/85) |
 | 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | merged | [#83](https://github.com/vonrobak/urd/pull/83) |

--- a/docs/99-reports/2026-04-05-design-review-022-honest-nightly.md
+++ b/docs/99-reports/2026-04-05-design-review-022-honest-nightly.md
@@ -1,0 +1,260 @@
+---
+upi: "022"
+date: 2026-04-05
+---
+
+# Arch-Adversary Design Review: The Honest Nightly (UPI 022)
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-05
+**Scope:** Implementation plan at `docs/97-plans/2026-04-05-plan-022-honest-nightly.md`, design at `docs/95-ideas/2026-04-05-design-022-honest-nightly.md`
+**Mode:** Design review (plan before code)
+**Commit:** ffcdfed (master, v0.11.0)
+
+---
+
+## Executive Summary
+
+The plan is well-scoped and correctly identifies the root cause: transient retention
+protects snapshots for absent drives indefinitely, recreating the exact accumulation
+pattern that caused the catastrophic NVMe exhaustion. The fix is architecturally sound —
+it adds drive-availability awareness to the protection-set computation without violating
+ADR-106 (pin protection) or ADR-107 (fail-closed deletions). One finding requires a
+code-level fix before shipping: the `mounted_pins` filter must include `TokenMissing`
+drives, not just `Available`, to avoid silently unprotecting chain parents for first-use
+drives.
+
+## What Kills You
+
+**Catastrophic failure mode:** Silent data loss — deleting a snapshot that is the only
+remaining chain parent for a mounted drive, causing the next send to fail or (worse)
+succeed with a full send the user doesn't expect on a space-constrained drive.
+
+**Distance from this plan:** The critical path is Step 4's semantic inversion: transient
++ no mounted pins = protect nothing. If the `mounted_pins` set incorrectly excludes a
+drive that CAN receive sends, a chain parent gets deleted while the drive is connected.
+The next send would be a full send instead of incremental. Not silent data loss, but
+unexpected space consumption and send time. **One filtering bug away from incorrect
+retention.**
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | **Correctness** | 4 | Root cause correctly identified. Fix logic is sound. One filter gap (TokenMissing) must be addressed. |
+| 2 | **Security** | 5 | No new privilege escalation paths. No new sudo calls. No path construction changes. |
+| 3 | **Architectural Excellence** | 5 | Respects all module boundaries. Planner stays pure. No new types or modules needed. Graduated retention explicitly unchanged. |
+| 4 | **Systems Design** | 4 | Production scenario well-analyzed. Executor interaction correctly scoped to "planner only" (Option A). One edge case (TokenMissing) missed. |
+
+**Overall: 4.5 / 5** — Surgical, well-reasoned, correctly scoped. Fix the filter gap
+and this ships clean.
+
+## Design Tensions
+
+### T1: Transient semantics inversion (protect-everything → protect-nothing)
+
+**Trade-off:** The plan changes "no pins + send_enabled = protect all snapshots" to
+"no *mounted* pins + transient = protect nothing." This trades a conservative default
+(never delete what might matter) for a correct one (don't protect snapshots for drives
+that can't receive them).
+
+**Was this the right call?** Yes. The conservative default caused the exact problem —
+indefinite accumulation on a 118GB NVMe. The inversion is scoped precisely: only
+transient subvolumes, only when evaluating mounted-drive pins. Graduated retention
+keeps the old behavior. The design doc's rationale is sound: if no mounted drive has a
+pin, there's nothing to protect *for*, because absent drives will get full sends when
+they return anyway.
+
+**Residual risk:** A race where a drive mounts between planner and executor. The planner
+sees no mounted pins, plans deletions, and the executor runs them. Then the drive mounts
+and wants an incremental send, but the chain parent is gone. Mitigated by: (a) the
+advisory lock prevents concurrent runs, (b) if it did happen, the result is a full send,
+not data loss. Acceptable.
+
+### T2: Planner-only vs planner+executor (Option A vs B)
+
+**Trade-off:** The plan changes only the planner's protection-set computation, leaving
+the executor's `attempt_transient_cleanup` unchanged. The executor still reads ALL drive
+pin files (including absent drives) when deciding what to clean up.
+
+**Was this the right call?** Yes, for this patch. The executor's cleanup is a "timing
+optimization" (executor.rs:842) that accelerates deletions the planner would produce on
+the next run. It has its own safety re-check (re-reads pin files, fail-closed on parse
+errors). Changing it in the same patch adds risk for marginal benefit — the planner will
+catch anything the executor misses on the next run. The executor change can follow if the
+cleanup's ALL-drives pin read becomes a practical issue (unlikely for 1-3 drives).
+
+### T3: `broken >= 2` broadens anomaly detection
+
+**Trade-off:** The old logic required ALL chains to break (`intact == 0`). The new logic
+fires when 2+ chains break regardless of survivors. This catches a scenario the old
+logic missed (4→2 intact = 2 broke simultaneously) but also fires in scenarios the old
+logic intentionally ignored.
+
+**Was this the right call?** Yes. Two chains breaking simultaneously on the same drive IS
+suspicious regardless of how many survive. The threshold of 2 prevents noise from single
+chain breaks (normal operational events). The old `intact == 0` requirement was an
+artifact of the original design, not a deliberate threshold.
+
+## Findings
+
+### S1 — Significant: `mounted_pins` filter excludes `TokenMissing` drives
+
+**What:** Step 2 computes `mounted_pins` by filtering for
+`DriveAvailability::Available` only:
+
+```rust
+.filter(|d| matches!(fs.drive_availability(d), DriveAvailability::Available))
+```
+
+**Why it matters:** `DriveAvailability::TokenMissing` drives proceed with sends
+(plan.rs:243-246 falls through to `plan_external_send`). If a first-use drive has
+`TokenMissing` status, sends succeed and a pin file is created. But that pin won't
+be in `mounted_pins` because the filter excludes non-`Available` drives. For transient
+subvolumes, this means the chain parent for a TokenMissing drive could be deleted while
+the drive is connected — the next send would be a full send instead of incremental.
+
+**Consequence:** Not silent data loss (the snapshot exists on the drive), but unexpected
+full sends on drives that just received an incremental send. For large subvolumes this
+could exhaust drive space or take hours.
+
+**Suggested fix:** Change the filter to:
+
+```rust
+.filter(|d| matches!(
+    fs.drive_availability(d),
+    DriveAvailability::Available | DriveAvailability::TokenMissing
+))
+```
+
+And apply the same filter to `any_drive_mounted`. Both computations must agree on which
+drives are "usable for sends."
+
+**Distance from catastrophic failure:** 2 steps — filter bug → chain parent deleted →
+full send (not data loss, but operational disruption on space-constrained drives).
+
+### S2 — Significant: Missing test for `TokenMissing` drive interaction
+
+**What:** The test strategy (Step 4, tests 3-8) covers mounted/absent/no-pins scenarios
+but none test a `TokenMissing` drive. Given S1, this is the exact edge case that needs
+a test.
+
+**Suggested fix:** Add test:
+- `transient_token_missing_drive_pin_protected` — 1 drive with
+  `DriveAvailability::TokenMissing`, pin exists. Assert: pin IS in `mounted_pins`,
+  snapshot IS protected.
+
+### M1 — Moderate: Step 3 `continue` suppresses per-drive skip entries
+
+**What:** When no drives are mounted for a transient subvolume, the `continue` at Step 3
+skips the external block entirely. This means the plan output won't contain individual
+"drive X not mounted" skip entries — only the single "transient — no drives available
+for send" entry.
+
+**Why it matters:** Downstream consumers of plan output (voice.rs rendering, dry-run
+display) may use per-drive skip entries for drive-specific advice. The aggregated skip
+loses information about which specific drives are absent. For a user with 3 drives where
+2 are intentionally absent, the message doesn't tell them which drives were checked.
+
+**Suggested fix:** This is acceptable as-is for v0.11.1 — the single message is more
+informative than three redundant "not mounted" entries. Note it for potential enhancement
+if users request drive-specific detail in transient skip reasons.
+
+### M2 — Moderate: Sentinel detection bug root cause is unclear
+
+**What:** The design doc states the bug is `detect_simultaneous_chain_breaks` firing
+"when prev_count=0 (vacuously true when 0 chains were intact previously)." But the
+detection logic iterates `prev_intact` (a BTreeMap populated only when
+`snap.chain_intact` is true). A drive with 0 intact chains in the previous state would
+have no entry in `prev_intact` and would never be visited.
+
+The actual log message ("all 0 chains broke on 2TB-backup simultaneously" with
+`total_chains: 0`) would require `total > 0` to fail — but `total > 0` is an explicit
+guard (line 819).
+
+**Why it matters:** If the root cause is misidentified, the fix might not address the
+real issue. The proposed `broken >= 2` logic is strictly better regardless (it eliminates
+a class of false positives), but the plan should verify: (a) is the bug from a version
+before the `total > 0` guard was added? (b) is it from a different code path? (c) was
+the log message observed in a development build without the guard?
+
+**Suggested fix:** Before implementing, reproduce the exact scenario with the current
+code and verify the bug exists in the shipped v0.11.0 binary. If the `total > 0` guard
+already prevents it, the `broken >= 2` change is still an improvement but should be
+documented as a refinement, not a bug fix. Adjust the log message fix regardless (the
+"all N chains" phrasing is misleading when not all broke).
+
+### C1 — Commendation: Correct scoping of the semantic change
+
+The plan explicitly preserves graduated retention behavior unchanged. The `effective_pinned`
+dispatch — `if transient { mounted_pins } else { pinned }` — is the minimal intervention
+that fixes transient without touching graduated. This is exactly right. Graduated
+subvolumes have different failure modes (they keep many snapshots, space pressure is
+gradual), and protecting absent-drive pins is the correct conservative default for them.
+The plan names this explicitly in Risk Flag 1 and tests it in test 6
+(`graduated_absent_drive_pins_still_protected`). This is disciplined.
+
+### C2 — Commendation: Production-informed design
+
+This plan was born from an actual nightly run (run #29), not hypothetical analysis. The
+four fixes map directly to four observed symptoms, each with a concrete scenario. The
+design doc includes the exact NVMe free space (26GB of 118GB), the exact drives involved,
+and the exact log messages. This is how you design bug fixes — from the incident, not from
+the spec.
+
+### C3 — Commendation: UPI 011 subsumption is well-reasoned
+
+Absorbing UPI 011's scope while simplifying it is the right call. UPI 011's "cap of 1"
+violated ADR-106 (overriding pin protection). The plan correctly identifies that fixing
+the root cause (absent-drive protection) makes the cap unnecessary. Taking UPI 011's
+creation-skip guard (defense in depth) while dropping the cap shows good judgment about
+which safety layers add value and which add risk.
+
+## The Simplicity Question
+
+**What could be removed?** Nothing. The plan is already minimal — 4 fixes, ~15 lines of
+new logic, 2 additive struct fields, 1 string change, 1 config edit. There are no new
+types, no new modules, no new abstractions. The `mounted_pins` set is computed inline
+from existing data, not reified into a new type. This is the right level of machinery.
+
+**What's earning its keep?** The `any_drive_mounted` boolean (Step 2) seems like it could
+be derived from `mounted_pins.is_empty()` — but it can't. A drive can be mounted (sends
+proceed) without having a pin file (no send has succeeded yet). So `any_drive_mounted`
+answers "can any drive receive a send?" while `mounted_pins.is_empty()` answers "has any
+mounted drive already received a send?" Both questions matter for different guards.
+
+## For the Dev Team
+
+Priority-ordered action items:
+
+1. **Fix S1 (filter gap).** In Step 2, change the `mounted_pins` and `any_drive_mounted`
+   filters to include `DriveAvailability::TokenMissing`:
+   ```rust
+   .filter(|d| matches!(
+       fs.drive_availability(d),
+       DriveAvailability::Available | DriveAvailability::TokenMissing
+   ))
+   ```
+   Both computations. File: `src/plan.rs`, Step 2 of plan.
+
+2. **Add S2 test.** Add test `transient_token_missing_drive_pin_protected` to Step 4's
+   test suite. Use `drive_availability_overrides` with `DriveAvailability::TokenMissing`.
+
+3. **Verify M2 (sentinel bug).** Before implementing Step 6, run the sentinel detection
+   function with the exact scenario from run #29 to confirm the bug exists in the
+   shipped code. If the `total > 0` guard already prevents it, document the change as
+   a refinement.
+
+4. **Proceed with all other steps as planned.** No changes needed to Steps 1, 3, 4
+   (logic), 5, 7.
+
+## Open Questions
+
+1. **Was the "all 0 chains broke" log observed with v0.11.0 or an earlier build?** If
+   the `total > 0` guard was added after the observation, the bug is already fixed in
+   shipped code. The `broken >= 2` change is still worth shipping as a refinement.
+
+2. **Should `any_drive_mounted` also consider `TokenMissing`?** The answer is yes (per
+   S1), but confirm: are there scenarios where a `TokenMissing` drive should NOT trigger
+   snapshot creation for transient subvolumes? (I believe the answer is no — if the drive
+   can receive sends, creating a snapshot for it is correct.)

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -2449,7 +2449,7 @@ mod tests {
 
     #[test]
     fn local_only_skip_does_not_produce_deferred() {
-        let plan = empty_plan_with_skips(vec![("sv", "send disabled")]);
+        let plan = empty_plan_with_skips(vec![("sv", "local only")]);
         let result = ExecutionResult {
             overall: RunResult::Success,
             subvolume_results: vec![],

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -67,11 +67,12 @@ pub enum NotificationEvent {
         from: String,
         to: String,
     },
-    /// All incremental chains on a drive broke simultaneously.
+    /// Multiple incremental chains on a drive broke simultaneously.
     /// Strong signal for drive swap or mass pin file loss.
     DriveAnomalyDetected {
         drive_label: String,
         total_chains: usize,
+        broken_count: usize,
     },
     /// A drive transitioned from absent to connected.
     DriveReconnected {

--- a/src/output.rs
+++ b/src/output.rs
@@ -664,7 +664,7 @@ impl SkipCategory {
     pub fn from_reason(reason: &str) -> Self {
         if reason == "disabled" {
             Self::Disabled
-        } else if reason == "send disabled" {
+        } else if reason == "local only" {
             Self::LocalOnly
         } else if reason.starts_with("drive ")
             && reason.ends_with(" not mounted")
@@ -1377,7 +1377,7 @@ mod tests {
     #[test]
     fn classify_local_only() {
         assert_eq!(
-            SkipCategory::from_reason("send disabled"),
+            SkipCategory::from_reason("local only"),
             SkipCategory::LocalOnly
         );
     }
@@ -1476,13 +1476,13 @@ mod tests {
         );
     }
 
-    /// Completeness test: all 17 known plan.rs skip patterns classify to their
+    /// Completeness test: all 18 known plan.rs skip patterns classify to their
     /// expected category. Prevents silent regressions when new patterns are added.
     #[test]
-    fn classify_all_17_patterns() {
+    fn classify_all_18_patterns() {
         let patterns = vec![
             ("disabled", SkipCategory::Disabled),
-            ("send disabled", SkipCategory::LocalOnly),
+            ("local only", SkipCategory::LocalOnly),
             ("drive WD-18TB not mounted", SkipCategory::DriveNotMounted),
             (
                 "drive WD-18TB UUID mismatch (expected abc, found def)",
@@ -1533,6 +1533,10 @@ mod tests {
             (
                 "unchanged \u{2014} no changes since last snapshot (21h ago)",
                 SkipCategory::Unchanged,
+            ),
+            (
+                "transient \u{2014} no drives available for send",
+                SkipCategory::Other,
             ),
         ];
 

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -91,6 +91,16 @@ pub struct PlanFilters {
     pub force_snapshot: bool,
 }
 
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/// Check if a drive is in scope for a subvolume (respects `drives` field).
+fn is_drive_in_scope(subvol: &ResolvedSubvolume, drive_label: &str) -> bool {
+    subvol
+        .drives
+        .as_ref()
+        .is_none_or(|allowed| allowed.iter().any(|a| a == drive_label))
+}
+
 // ── Planner ─────────────────────────────────────────────────────────────
 
 /// Generate a backup plan based on config, current time, filters, and filesystem state.
@@ -102,7 +112,7 @@ pub fn plan(
 ) -> crate::error::Result<BackupPlan> {
     let mut operations = Vec::new();
     // Skip reason strings are classified by output::SkipCategory::from_reason().
-    // When adding new patterns, update output::tests::classify_all_17_patterns.
+    // When adding new patterns, update output::tests::classify_all_18_patterns.
     let mut skipped = Vec::new();
 
     let resolved = config.resolved_subvolumes();
@@ -149,11 +159,70 @@ pub fn plan(
         // Get pinned snapshots
         let pinned = fs.pinned_snapshots(&local_dir, &drive_labels);
 
+        // Drives in scope for this subvolume that can currently receive sends.
+        // Include TokenMissing: those drives proceed with sends (line ~308),
+        // so their pins represent valid chain parents that must be protected.
+        let usable_drives: Vec<&DriveConfig> = config
+            .drives
+            .iter()
+            .filter(|d| is_drive_in_scope(subvol, &d.label))
+            .filter(|d| {
+                matches!(
+                    fs.drive_availability(d),
+                    DriveAvailability::Available | DriveAvailability::TokenMissing
+                )
+            })
+            .collect();
+
+        // Mounted-only pins for transient retention scoping.
+        let mounted_pins: HashSet<SnapshotName> = usable_drives
+            .iter()
+            .filter_map(|d| match fs.read_pin_file(&local_dir, &d.label) {
+                Ok(Some(snap)) => Some(snap),
+                Ok(None) => None,
+                Err(e) => {
+                    log::warn!(
+                        "Failed to read pin file for drive {:?} in {}: {e}",
+                        d.label,
+                        local_dir.display()
+                    );
+                    None
+                }
+            })
+            .collect();
+
+        let any_drive_mounted = !usable_drives.is_empty();
+
         // ── Local operations ────────────────────────────────────────
         // LOAD-BEARING ORDER: Operations are emitted as create → send → delete.
         // The executor relies on this ordering within each subvolume.
         // Do not reorder without updating the executor contract in PLAN.md.
         if !filters.external_only {
+            // Transient subvolumes: skip snapshot creation when no drives can
+            // receive sends. Creating a snapshot that can't be sent is pointless;
+            // retention will clean up any accumulated snapshots below.
+            if subvol.local_retention.is_transient()
+                && subvol.send_enabled
+                && !local_snaps.is_empty()
+                && !any_drive_mounted
+            {
+                skipped.push((
+                    subvol.name.clone(),
+                    "transient \u{2014} no drives available for send".to_string(),
+                ));
+                plan_local_retention(
+                    subvol,
+                    &local_dir,
+                    &local_snaps,
+                    now,
+                    &pinned,
+                    &mounted_pins,
+                    fs,
+                    &mut operations,
+                );
+                continue;
+            }
+
             let min_free = subvol.min_free_bytes.unwrap_or(0);
             plan_local_snapshot(
                 subvol,
@@ -173,6 +242,7 @@ pub fn plan(
                 &local_snaps,
                 now,
                 &pinned,
+                &mounted_pins,
                 fs,
                 &mut operations,
             );
@@ -181,10 +251,7 @@ pub fn plan(
         // ── External operations ─────────────────────────────────────
         if !filters.local_only && subvol.send_enabled {
             for drive in &config.drives {
-                // Skip drives not in subvol.drives when specified
-                if let Some(ref allowed) = subvol.drives
-                    && !allowed.iter().any(|d| d == &drive.label)
-                {
+                if !is_drive_in_scope(subvol, &drive.label) {
                     continue;
                 }
 
@@ -262,7 +329,7 @@ pub fn plan(
                 plan_external_retention(subvol, drive, now, fs, &pinned, &mut operations);
             }
         } else if !filters.local_only && !subvol.send_enabled {
-            skipped.push((subvol.name.clone(), "send disabled".to_string()));
+            skipped.push((subvol.name.clone(), "local only".to_string()));
         }
     }
 
@@ -412,6 +479,7 @@ fn plan_local_retention(
     local_snaps: &[SnapshotName],
     now: NaiveDateTime,
     pinned: &HashSet<SnapshotName>,
+    mounted_pins: &HashSet<SnapshotName>,
     fs: &dyn FileSystemState,
     operations: &mut Vec<PlannedOperation>,
 ) {
@@ -420,12 +488,18 @@ fn plan_local_retention(
     }
 
     // Protect unsent snapshots from retention deletion.
-    // If send is enabled, snapshots newer than the oldest pin may not have been
-    // sent to all drives yet. Deleting them would lose the only local copy before
-    // it reaches external storage — one step from silent data loss.
+    // For transient subvolumes, only consider pins from mounted drives —
+    // absent drives can't receive sends, and protecting their pins indefinitely
+    // causes space exhaustion on constrained filesystems.
+    // For graduated subvolumes, protect ALL pins (conservative default).
     let protected = if subvol.send_enabled {
-        let oldest_pin = pinned.iter().min();
-        let mut expanded = pinned.clone();
+        let effective_pinned = if subvol.local_retention.is_transient() {
+            mounted_pins.clone()
+        } else {
+            pinned.clone()
+        };
+        let oldest_pin = effective_pinned.iter().min();
+        let mut expanded = effective_pinned.clone();
         match oldest_pin {
             Some(oldest) => {
                 for snap in local_snaps {
@@ -434,8 +508,12 @@ fn plan_local_retention(
                     }
                 }
             }
+            None if subvol.local_retention.is_transient() => {
+                // Transient + no mounted pins = nothing to protect.
+                // Full sends when drives return.
+            }
             None => {
-                // No pins at all — nothing has ever been sent externally.
+                // Non-transient: no pins at all — nothing has ever been sent.
                 // Protect all local snapshots until the first send succeeds.
                 for snap in local_snaps {
                     expanded.insert(snap.clone());
@@ -1437,7 +1515,7 @@ send_enabled = false
             result
                 .skipped
                 .iter()
-                .any(|(_, reason)| reason.contains("send disabled"))
+                .any(|(_, reason)| reason.contains("local only"))
         );
     }
 
@@ -2487,7 +2565,11 @@ local_retention = "transient"
     }
 
     #[test]
-    fn transient_no_pins_keeps_everything() {
+    fn transient_mounted_drive_no_pin_deletes_all() {
+        // Key semantic change from UPI 022: transient + mounted drive + no pin
+        // means nothing to protect. Previously this protected everything (unsent-
+        // protected). Now, with no pin, no send has succeeded — protecting
+        // indefinitely causes accumulation on constrained filesystems.
         let config = transient_config();
         let mut fs = MockFileSystemState::new();
         fs.local_snapshots.insert(
@@ -2517,8 +2599,8 @@ local_retention = "transient"
 
         assert_eq!(
             deletes.len(),
-            0,
-            "no pins means all snapshots are unsent-protected"
+            2,
+            "transient + no pins = nothing to protect, all deletable"
         );
     }
 
@@ -2659,6 +2741,381 @@ local_retention = "transient"
             deletes[0].contains("20260319"),
             "deleted snapshot should be the one older than both pins: {deletes:?}"
         );
+    }
+
+    // ── Transient absent-drive tests (UPI 022) ──────────────────────────
+
+    #[test]
+    fn transient_no_drives_skips_snapshot_creation() {
+        let config = transient_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![snap("20260322-1000-one")],
+        );
+        // Drive NOT mounted — transient should skip snapshot creation
+        // (no drive to send to, creating a snapshot is pointless)
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { .. }))
+            .collect();
+        assert_eq!(creates.len(), 0, "should not create snapshot when no drives mounted");
+
+        let skip = result
+            .skipped
+            .iter()
+            .find(|(name, _)| name == "sv1")
+            .expect("sv1 should have a skip entry");
+        assert!(
+            skip.1.contains("transient"),
+            "skip reason should mention transient: {}",
+            skip.1
+        );
+    }
+
+    #[test]
+    fn transient_no_drives_first_snapshot_still_created() {
+        let config = transient_config();
+        let fs = MockFileSystemState::new();
+        // No local snapshots, no drives mounted.
+        // First snapshot should still be created (fail-open for first backup).
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(op, PlannedOperation::CreateSnapshot { .. }))
+            .collect();
+        assert_eq!(creates.len(), 1, "first snapshot should be created even with no drives");
+    }
+
+    #[test]
+    fn transient_absent_drive_pins_not_protected() {
+        // D1 mounted (pin at newest), D2 absent (pin at oldest).
+        // Only D1's pin should be in the mounted set.
+        // Snapshots older than D1's pin should be deleted.
+        let config = transient_multi_drive_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260319-1000-one"),
+                snap("20260320-1000-one"), // D2's pin (absent)
+                snap("20260321-1000-one"),
+                snap("20260322-1400-one"), // D1's pin (mounted)
+            ],
+        );
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap("20260322-1400-one"),
+        );
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D2".to_string()),
+            snap("20260320-1000-one"),
+        );
+        // Only D1 mounted
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![snap("20260322-1400-one")],
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter_map(|op| match op {
+                PlannedOperation::DeleteSnapshot {
+                    subvolume_name,
+                    path,
+                    ..
+                } if subvolume_name == "sv1" => {
+                    Some(path.file_name().unwrap().to_string_lossy().to_string())
+                }
+                _ => None,
+            })
+            .collect();
+
+        // D2's pin is ignored (absent). D1's pin at 20260322-1400 is the only pin.
+        // Everything older than D1's pin is deletable.
+        assert_eq!(deletes.len(), 3, "3 snapshots older than D1's pin should be deleted: {deletes:?}");
+    }
+
+    #[test]
+    fn transient_no_mounted_drives_all_deletable() {
+        let config = transient_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260320-1000-one"),
+                snap("20260321-1000-one"),
+                snap("20260322-1000-one"),
+            ],
+        );
+        // Pin exists but drive is NOT mounted
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap("20260320-1000-one"),
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::DeleteSnapshot {
+                        subvolume_name,
+                        ..
+                    } if subvolume_name == "sv1"
+                )
+            })
+            .collect();
+
+        // No mounted drives → mounted_pins is empty → nothing protected.
+        // The transient skip guard skips snapshot creation but still runs retention.
+        assert_eq!(deletes.len(), 3, "all snapshots deletable when no drives mounted");
+    }
+
+    #[test]
+    fn transient_all_drives_mounted_same_as_before() {
+        // Both drives mounted — behavior should match the existing
+        // transient_multi_drive_pins_at_different_snapshots test.
+        let config = transient_multi_drive_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260319-1000-one"),
+                snap("20260320-1000-one"),
+                snap("20260321-1000-one"),
+                snap("20260322-1000-one"),
+                snap("20260322-1400-one"),
+            ],
+        );
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap("20260322-1400-one"),
+        );
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D2".to_string()),
+            snap("20260320-1000-one"),
+        );
+        fs.mounted_drives.insert("D1".to_string());
+        fs.mounted_drives.insert("D2".to_string());
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![snap("20260322-1400-one")],
+        );
+        fs.external_snapshots.insert(
+            ("D2".to_string(), "sv1".to_string()),
+            vec![snap("20260320-1000-one")],
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter_map(|op| match op {
+                PlannedOperation::DeleteSnapshot {
+                    subvolume_name,
+                    path,
+                    ..
+                } if subvolume_name == "sv1" => {
+                    Some(path.file_name().unwrap().to_string_lossy().to_string())
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Same as transient_multi_drive_pins_at_different_snapshots:
+        // only 20260319 is older than D2's pin (the oldest mounted pin)
+        assert_eq!(deletes.len(), 1, "only pre-oldest-pin snapshot deleted: {deletes:?}");
+        assert!(deletes[0].contains("20260319"));
+    }
+
+    #[test]
+    fn graduated_absent_drive_pins_still_protected() {
+        // Graduated retention must still protect ALL pins, including absent drives.
+        // This is the conservative default — only transient scopes to mounted pins.
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+send_enabled = true
+enabled = true
+
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[drives]]
+label = "D2"
+mount_path = "/mnt/d2"
+snapshot_root = ".snapshots"
+role = "offsite"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "one"
+source = "/data/sv1"
+priority = 1
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260320-1000-one"),
+                snap("20260321-1000-one"),
+                snap("20260322-1400-one"),
+            ],
+        );
+        // D1 mounted, D2 absent. Both have pins.
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap("20260322-1400-one"),
+        );
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D2".to_string()),
+            snap("20260320-1000-one"),
+        );
+        fs.mounted_drives.insert("D1".to_string());
+        // D2 NOT mounted
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::DeleteSnapshot {
+                        subvolume_name,
+                        ..
+                    } if subvolume_name == "sv1"
+                )
+            })
+            .collect();
+
+        // Graduated uses `pinned` (all drives), not `mounted_pins`.
+        // D2's pin at 20260320 is still in the protected set.
+        // All snapshots are protected (pinned or unsent-to-D2).
+        assert_eq!(
+            deletes.len(),
+            0,
+            "graduated retention must protect absent drive pins"
+        );
+    }
+
+    #[test]
+    fn transient_no_pins_no_mounted_drives_deletes_all() {
+        let config = transient_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260321-1000-one"),
+                snap("20260322-1000-one"),
+            ],
+        );
+        // No pin files, no drives mounted
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| {
+                matches!(
+                    op,
+                    PlannedOperation::DeleteSnapshot {
+                        subvolume_name,
+                        ..
+                    } if subvolume_name == "sv1"
+                )
+            })
+            .collect();
+
+        assert_eq!(deletes.len(), 2, "no pins + no drives = all deletable");
+    }
+
+    #[test]
+    fn transient_token_missing_drive_pin_protected() {
+        // TokenMissing drives proceed with sends, so their pins must be protected.
+        let config = transient_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260320-1000-one"),
+                snap("20260321-1000-one"),
+                snap("20260322-1000-one"),
+            ],
+        );
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap("20260321-1000-one"),
+        );
+        // Drive is TokenMissing (first use, no token file yet) — sends proceed
+        fs.drive_availability_overrides.insert(
+            "D1".to_string(),
+            DriveAvailability::TokenMissing,
+        );
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![snap("20260321-1000-one")],
+        );
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let deletes: Vec<_> = result
+            .operations
+            .iter()
+            .filter_map(|op| match op {
+                PlannedOperation::DeleteSnapshot {
+                    subvolume_name,
+                    path,
+                    ..
+                } if subvolume_name == "sv1" => {
+                    Some(path.file_name().unwrap().to_string_lossy().to_string())
+                }
+                _ => None,
+            })
+            .collect();
+
+        // Pin at 20260321 should be protected. 20260322 is unsent-protected.
+        // Only 20260320 (older than pin) should be deleted.
+        assert_eq!(deletes.len(), 1, "only pre-pin snapshot deleted: {deletes:?}");
+        assert!(deletes[0].contains("20260320"), "wrong snapshot deleted: {deletes:?}");
     }
 
     // ── skip_intervals tests ────────────────────────────────────────────

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -741,12 +741,14 @@ pub struct ChainSnapshot {
     pub chain_intact: bool,
 }
 
-/// A drive where all incremental chains broke simultaneously.
+/// A drive where multiple incremental chains broke simultaneously.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriveAnomaly {
     pub drive_label: String,
-    /// Total number of chains on this drive (all of which broke).
+    /// Total number of chains on this drive in the current state.
     pub total_chains: usize,
+    /// Number of chains that broke between the two ticks.
+    pub broken_count: usize,
 }
 
 /// Extract chain snapshots from assessments for mounted drives only.
@@ -775,16 +777,15 @@ pub fn build_chain_snapshots(
     snapshots
 }
 
-/// Detect drives where all incremental chains broke simultaneously.
+/// Detect drives where multiple incremental chains broke simultaneously.
 ///
 /// Compares chain snapshots from two consecutive assessment ticks. Returns
-/// anomalies for drives where:
-/// - The previous tick had >= 2 intact chains on the drive, AND
-/// - The current tick has 0 intact chains on the drive.
+/// anomalies for drives where 2+ chains broke between ticks (computed as
+/// the delta between previous and current intact counts).
 ///
-/// The >= 2 threshold prevents false positives from single-subvolume drives
-/// (a single chain break is a normal operational event). This is the
-/// strongest heuristic signal for a drive swap or mass pin file loss.
+/// The >= 2 threshold prevents false positives from single chain breaks
+/// (normal operational events). This is the strongest heuristic signal
+/// for a drive swap or mass pin file loss.
 #[must_use]
 pub fn detect_simultaneous_chain_breaks(
     previous: &[ChainSnapshot],
@@ -813,13 +814,15 @@ pub fn detect_simultaneous_chain_breaks(
     let mut anomalies = Vec::new();
     for (drive, &prev_count) in &prev_intact {
         let &(intact, total) = curr.get(drive).unwrap_or(&(0, 0));
-        // Drive had >= 2 intact chains before, and now has 0.
+        let broken = prev_count.saturating_sub(intact);
+        // 2+ chains broke simultaneously — suspicious drive-level event.
         // Guard: total > 0 ensures we don't fire when a drive simply disconnected
         // (disconnect removes chains from the current snapshot, leaving total == 0).
-        if prev_count >= 2 && intact == 0 && total > 0 {
+        if broken >= 2 && total > 0 {
             anomalies.push(DriveAnomaly {
                 drive_label: drive.to_string(),
                 total_chains: total,
+                broken_count: broken,
             });
         }
     }
@@ -1611,6 +1614,7 @@ mod tests {
         assert_eq!(anomalies.len(), 1);
         assert_eq!(anomalies[0].drive_label, "D1");
         assert_eq!(anomalies[0].total_chains, 3);
+        assert_eq!(anomalies[0].broken_count, 3);
     }
 
     #[test]
@@ -1658,6 +1662,7 @@ mod tests {
         let anomalies = detect_simultaneous_chain_breaks(&prev, &curr);
         assert_eq!(anomalies.len(), 1);
         assert_eq!(anomalies[0].drive_label, "D1");
+        assert_eq!(anomalies[0].broken_count, 2);
     }
 
     // ── Drive disconnect anomaly guard (021-a) ─────────────────────────
@@ -1694,6 +1699,7 @@ mod tests {
         assert_eq!(anomalies.len(), 1);
         assert_eq!(anomalies[0].drive_label, "D1");
         assert_eq!(anomalies[0].total_chains, 3);
+        assert_eq!(anomalies[0].broken_count, 3);
     }
 
     #[test]
@@ -1717,6 +1723,45 @@ mod tests {
             ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: true },
         ];
         assert!(detect_simultaneous_chain_breaks(&curr_disconnected, &curr_reconnected).is_empty());
+    }
+
+    // ── Partial chain break detection (UPI 022) ────────────────────────
+
+    #[test]
+    fn detect_chain_breaks_partial_break_two_plus_fires() {
+        // 4 intact previously, 2 intact now → broken=2, fires anomaly.
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv4".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+        let curr = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv3".into(), drive_label: "D1".into(), chain_intact: false },
+            ChainSnapshot { subvolume: "sv4".into(), drive_label: "D1".into(), chain_intact: false },
+        ];
+
+        let anomalies = detect_simultaneous_chain_breaks(&prev, &curr);
+        assert_eq!(anomalies.len(), 1);
+        assert_eq!(anomalies[0].broken_count, 2);
+        assert_eq!(anomalies[0].total_chains, 4);
+    }
+
+    #[test]
+    fn detect_chain_breaks_one_of_two_no_anomaly() {
+        // 2 intact previously, 1 intact now → broken=1, below threshold.
+        let prev = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: true },
+        ];
+        let curr = vec![
+            ChainSnapshot { subvolume: "sv1".into(), drive_label: "D1".into(), chain_intact: true },
+            ChainSnapshot { subvolume: "sv2".into(), drive_label: "D1".into(), chain_intact: false },
+        ];
+
+        assert!(detect_simultaneous_chain_breaks(&prev, &curr).is_empty());
     }
 
     // ── Health snapshot tests (VFM-B) ──────────────────────────────────

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -366,7 +366,8 @@ impl SentinelRunner {
             );
             for anomaly in &anomalies {
                 log::warn!(
-                    "Drive anomaly: all {} chains broke on {} simultaneously",
+                    "Drive anomaly: {} of {} chains broke on {} simultaneously",
+                    anomaly.broken_count,
                     anomaly.total_chains,
                     anomaly.drive_label,
                 );
@@ -374,14 +375,15 @@ impl SentinelRunner {
                     event: NotificationEvent::DriveAnomalyDetected {
                         drive_label: anomaly.drive_label.clone(),
                         total_chains: anomaly.total_chains,
+                        broken_count: anomaly.broken_count,
                     },
                     urgency: Urgency::Warning,
                     title: format!("Drive anomaly on {}", anomaly.drive_label),
                     body: format!(
-                        "All {} incremental chains on {} broke simultaneously. \
+                        "{} of {} incremental chains on {} broke simultaneously. \
                          The drive may have been swapped or cloned. \
                          Run `urd status` to inspect chain health.",
-                        anomaly.total_chains, anomaly.drive_label,
+                        anomaly.broken_count, anomaly.total_chains, anomaly.drive_label,
                     ),
                 });
             }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -3936,7 +3936,7 @@ mod tests {
                 },
                 SkippedSubvolume {
                     name: "subvol6-tmp".to_string(),
-                    reason: "send disabled".to_string(),
+                    reason: "local only".to_string(),
                     category: SkipCategory::LocalOnly,
                 },
             ],
@@ -4456,7 +4456,7 @@ mod tests {
             skipped: vec![
                 SkippedSubvolume {
                     name: "subvol4-multimedia".to_string(),
-                    reason: "send disabled".to_string(),
+                    reason: "local only".to_string(),
                     category: SkipCategory::LocalOnly,
                 },
                 SkippedSubvolume {
@@ -4489,7 +4489,7 @@ mod tests {
             operations: vec![],
             skipped: vec![SkippedSubvolume {
                 name: "subvol4-multimedia".to_string(),
-                reason: "send disabled".to_string(),
+                reason: "local only".to_string(),
                 category: SkipCategory::LocalOnly,
             }],
             summary: PlanSummaryOutput {


### PR DESCRIPTION
## Summary

- **Transient retention scoped to mounted drives** — `plan_local_retention()` now uses `mounted_pins` (Available + TokenMissing drives only) for transient subvolumes, preventing indefinite snapshot accumulation for absent drives on space-constrained filesystems
- **Transient snapshot creation skipped** when no drives can receive sends (defense-in-depth)
- **Sentinel chain break detection refined** — delta-based `broken >= 2` replaces `intact == 0`, adds `broken_count` to `DriveAnomaly` and notifications
- **"send disabled" → "local only"** — skip text no longer implies breakage for local-only subvolumes

## Context

First v0.11.0 nightly (run #29) revealed transient snapshots accumulating for absent drives — the exact pattern that caused the catastrophic NVMe exhaustion. Root cause: `plan_local_retention()` protected snapshots as "unsent" for ALL configured drives including absent ones whose sends never complete.

Design: `docs/95-ideas/2026-04-05-design-022-honest-nightly.md`
Review: `docs/99-reports/2026-04-05-design-review-022-honest-nightly.md`

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 931 tests, all passing (10 new)
- Key test coverage: absent-drive pin exclusion, no-mounted-drives deletion, TokenMissing pin protection, graduated retention unchanged, partial chain break detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)