### PR TITLE
docs: dependency bumps, UX designs 023/024, source documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,12 +198,19 @@ The send|receive pipeline captures stderr from both sides, checks both exit code
 cleans up partial snapshots on failure. Paths passed as `&Path` to `Command::arg()`, never
 stringified — prevents shell injection and preserves non-UTF-8 paths.
 
+## Dependency Reference
+
+Docs in `docs/00-foundation/source-documentation/` cover current API patterns and migration
+notes for rusqlite 0.39, toml 1.x, nix 0.31, colored 3.x, Rust 2024 edition, and BTRFS.
+Consult when working on code that directly uses these APIs (especially `state.rs`, `config.rs`,
+`lock.rs`). Not needed for domain-level work (retention, awareness, voice, planning).
+
 ## Build & Run
 
 ```bash
 cargo build                          # Debug
 cargo build --release                # Release
-cargo test                           # Unit tests (521+ tests)
+cargo test                           # Unit tests (931+ tests)
 cargo test -- --ignored              # Integration tests (needs drives)
 cargo clippy -- -D warnings          # Lint (all warnings are errors)
 cargo run -- plan                    # Preview backup plan

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,18 +3,6 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,7 +80,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -103,7 +91,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -232,12 +220,11 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "colored"
-version = "2.2.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -253,8 +240,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
- "windows-sys 0.61.2",
+ "nix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -275,7 +262,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -326,7 +313,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -371,6 +358,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,20 +389,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -417,14 +401,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -522,12 +509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -579,18 +560,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
 
 [[package]]
 name = "nix"
@@ -757,10 +726,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
+name = "rsqlite-vfs"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "a8a1f2315036ef6b1fbacd1972e8ee7688030b0a2121edfc2a6550febd41574d"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -768,6 +747,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -780,7 +760,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -840,11 +820,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -858,6 +838,18 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4206ed3a67690b9c29b77d728f6acc3ce78f16bf846d83c94f76400320181b"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "strsim"
@@ -886,7 +878,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -911,44 +903,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
- "serde",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_write",
+ "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 
 [[package]]
-name = "toml_write"
-version = "0.1.2"
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "unicode-ident"
@@ -976,7 +966,7 @@ dependencies = [
  "env_logger",
  "filetime",
  "log",
- "nix 0.29.0",
+ "nix",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1008,12 +998,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"
@@ -1179,15 +1163,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1196,77 +1171,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
@@ -1354,26 +1262,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ clap_complete = "4"
 # Serialization & config
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.8"
+toml = "1"
 
 # Database
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.39", features = ["bundled"] }
 
 # Date/time
 chrono = { version = "0.4", features = ["serde"] }
@@ -30,12 +30,12 @@ anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
 
 # System
-nix = { version = "0.29", features = ["fs"] }
+nix = { version = "0.31", features = ["fs"] }
 dirs = "6"
 ctrlc = "3"
 
 # Output formatting
-colored = "2"
+colored = "3"
 # Logging
 log = "0.4"
 env_logger = "0.11"

--- a/docs/00-foundation/source-documentation/README.md
+++ b/docs/00-foundation/source-documentation/README.md
@@ -1,0 +1,21 @@
+# Source Documentation
+
+Reference documents for Urd's key dependencies and toolchain. Written to help
+Claude Code sessions apply conventions and APIs that are more recent than the
+model's training data.
+
+**Generated:** 2026-04-05
+**Rust toolchain:** 1.94.0, edition 2024
+**Context:** Urd v0.11.1
+
+| Document | Covers |
+|----------|--------|
+| [rust-2024-edition.md](rust-2024-edition.md) | Rust 2024 edition changes, new idioms, lint defaults |
+| [colored-3.md](colored-3.md) | colored 2.x -> 3.x migration, current API |
+| [rusqlite-0.39.md](rusqlite-0.39.md) | rusqlite 0.32 -> 0.39 migration, breaking changes |
+| [toml-1.md](toml-1.md) | toml 0.8 -> 1.x migration, TOML 1.1 support |
+| [nix-0.31.md](nix-0.31.md) | nix 0.29 -> 0.31 migration, I/O safety, file locking |
+| [btrfs-reference.md](btrfs-reference.md) | BTRFS snapshot, send/receive, space management |
+
+These documents are reference material, not prescriptive. Always verify against
+actual crate docs and compiler output when patterns seem uncertain.

--- a/docs/00-foundation/source-documentation/btrfs-reference.md
+++ b/docs/00-foundation/source-documentation/btrfs-reference.md
@@ -1,0 +1,116 @@
+# BTRFS Reference for Backup Tooling
+
+> Based on btrfs-progs documentation through v6.12+ (training data).
+> BTRFS is a stable, slow-moving interface — commands used by Urd have been
+> unchanged for years.
+
+## Snapshot Operations
+
+### Create Read-Only Snapshot
+
+```bash
+sudo btrfs subvolume snapshot -r <source> <dest>
+```
+
+- `-r` creates read-only snapshot (required for send)
+- Snapshot is instantaneous (COW metadata operation)
+- Snapshot appears as a regular directory at `<dest>`
+
+### Delete Snapshot/Subvolume
+
+```bash
+sudo btrfs subvolume delete <path>
+```
+
+- Deletion is asynchronous — space reclamation happens in background
+- `sync` or `btrfs filesystem sync` to force cleanup
+- `btrfs subvolume delete -c` commits after deletion (ensures space is freed)
+
+### Show Subvolume Info
+
+```bash
+sudo btrfs subvolume show <path>
+```
+
+Returns: UUID, parent UUID, creation time, send/receive status, flags.
+
+## Send/Receive Pipeline
+
+### Full Send
+
+```bash
+sudo btrfs send <snapshot> | sudo btrfs receive <dest_dir>
+```
+
+### Incremental Send (with parent)
+
+```bash
+sudo btrfs send -p <parent_snapshot> <snapshot> | sudo btrfs receive <dest_dir>
+```
+
+- Parent must exist at destination (or a clone of it)
+- Incremental sends transfer only the delta — dramatically faster and smaller
+- **The parent snapshot must not be deleted** until the child is successfully received
+
+### Best Practices
+
+- Always use `-p` (parent) for incremental sends when a common parent exists
+- Capture stderr from both `send` and `receive` — either side can fail
+- Check exit codes of both sides of the pipe
+- Clean up partial snapshots on receive failure (incomplete receive leaves a
+  directory that isn't a valid subvolume)
+- Pipe through `pv` for progress monitoring on large sends (optional)
+
+### Common Failure Modes
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| "cannot find parent subvolume" | Parent deleted or not present at dest | Full send required |
+| Partial receive | Interrupted pipe, disk full, I/O error | Delete partial dir, retry |
+| "received UUID already exists" | Duplicate snapshot at destination | Delete existing, re-receive |
+| Permission denied | Missing sudo or capability | Check sudoers configuration |
+
+## Space Management
+
+### Check Filesystem Usage
+
+```bash
+sudo btrfs filesystem usage <mount>
+sudo btrfs filesystem df <mount>
+sudo btrfs filesystem show <mount>
+```
+
+- `usage` gives the most complete picture (data, metadata, system, unallocated)
+- `df` shows allocated/used per profile (single, DUP, RAID1, etc.)
+- `show` lists devices and total/used per device
+
+### Space Considerations for Backup Tools
+
+- Snapshots share data blocks via COW — initial space cost is near zero
+- Space grows as source diverges from snapshot (modified blocks are unique)
+- Many snapshots of a rapidly changing subvolume can consume significant space
+  (each snapshot pins its unique blocks from garbage collection)
+- `btrfs filesystem sync` after deletions to ensure space is reclaimed
+- Monitor unallocated space, not just used space — BTRFS allocates in chunks
+- **Metadata space exhaustion** is harder to recover from than data space exhaustion
+
+### Quota Groups (qgroups)
+
+```bash
+sudo btrfs qgroup show <mount>
+sudo btrfs quota enable <mount>
+```
+
+- Can track per-subvolume space usage
+- Significant performance overhead — not recommended for general use
+- Most backup tools avoid qgroups and estimate sizes via send dry-run or
+  `btrfs filesystem du`
+
+## Urd-Specific Notes
+
+Urd wraps these commands via the `BtrfsOps` trait in `btrfs.rs`. Key conventions:
+- All paths passed as `&Path` to `Command::arg()` — never stringified
+- Stderr captured from both sides of send|receive pipe
+- Both exit codes checked
+- Partial snapshots cleaned up on receive failure
+- Pin files (`.last-external-parent-{DRIVE}`) protect incremental chain parents

--- a/docs/00-foundation/source-documentation/colored-3.md
+++ b/docs/00-foundation/source-documentation/colored-3.md
@@ -1,0 +1,59 @@
+# colored 3.x Reference
+
+> Urd dependency: `colored = "3"` (resolves to 3.1.1)
+> Previous: `colored = "2"`
+
+## Migration from 2.x to 3.x
+
+**The only breaking change is MSRV raised to 1.80.** The API is identical.
+`lazy_static` was replaced with `std::sync::OnceLock` internally.
+
+No code changes needed. Drop-in replacement.
+
+## New in 3.1 (non-breaking)
+
+Hex color support:
+```rust
+"text".color("#efabea");      // 6-digit hex
+"text".on_color("#fd0");      // 3-digit hex
+"text".ansi_color(42u8);      // arbitrary ANSI code
+```
+
+## Current API
+
+```rust
+use colored::Colorize;
+
+// Method chaining
+"bold red".red().bold();
+"green italic".green().italic();
+"on white".blue().on_white();
+
+// Available colors: black, red, green, yellow, blue, magenta (alias: purple),
+// cyan, white — plus bright_* variants for all
+
+// Styles: bold(), dimmed(), italic(), underline(), blink(),
+// reversed(), hidden(), strikethrough(), normal(), clear()
+
+// Dynamic colors
+"text".color("blue");                   // from string
+"text".truecolor(0, 255, 136);          // RGB
+"text".on_truecolor(135, 28, 167);      // RGB background
+"text".custom_color((0, 255, 136));     // via Into<CustomColor>
+```
+
+## Color Control
+
+Environment variables (respected automatically):
+- `NO_COLOR` — disables color output
+- `CLICOLOR` — standard TTY color discovery
+- `CLICOLOR_FORCE` — force color even when not a TTY
+- Priority: `CLICOLOR_FORCE` > `NO_COLOR` > `CLICOLOR`
+- Compile-time disable: `no-color` cargo feature
+
+## Deprecations
+
+- `ColoredString::fgcolor()` getter — use public `fgcolor` field directly
+- `ColoredString::bgcolor()` getter — use public `bgcolor` field directly
+- `ColoredString::style()` getter — use public `style` field directly
+- `Colorize::reverse()` — use `reversed()` instead

--- a/docs/00-foundation/source-documentation/nix-0.31.md
+++ b/docs/00-foundation/source-documentation/nix-0.31.md
@@ -1,0 +1,81 @@
+# nix 0.31 Reference
+
+> Urd dependency: `nix = { version = "0.31", features = ["fs"] }`
+> Previous: `nix = "0.29"`
+
+## Breaking Changes (0.29 -> 0.31)
+
+### 0.30.0 — Major I/O Safety Migration
+
+The biggest change. Public interfaces across nearly every module switched from
+`RawFd` to I/O-safe types (`AsFd`/`OwnedFd`/`BorrowedFd`):
+
+- `fcntl.rs` — all functions now take `AsFd` instead of `RawFd`
+- `dir.rs` — I/O-safe types
+- `sys/signal`, `sys/stat`, `unistd`, `sys/fanotify` — all migrated
+
+**If code passes raw file descriptors to nix functions, wrap them in `OwnedFd`/
+`BorrowedFd` or use types that implement `AsFd` (like `std::fs::File`).**
+
+Other 0.30 breaking changes:
+- `IpTos` renamed to `Ipv4Tos`
+- `EventFlag` renamed to `EvFlags`
+- `MemFdCreateFlag` renamed to `MFdFlags`
+- `recvmsg` takes slice for `cmsg_buffer` instead of `Vec`
+- `Copy` removed from `PollFd`
+- `EventFd::defuse()` removed
+
+### 0.31.0
+
+- `Eq`/`PartialEq` removed from `SigHandler`
+- `EpollEvent` methods are now `const`
+- libc bumped to 0.2.180
+
+## File Locking API (fcntl module)
+
+Urd uses nix for file locking in `lock.rs`. Two mechanisms:
+
+### Flock (RAII — recommended)
+
+```rust
+use nix::fcntl::{Flock, FlockArg};
+use std::fs::File;
+
+let file = File::open("lockfile")?;
+let lock = Flock::lock(file, FlockArg::LockExclusiveNonblock)
+    .map_err(|(_, errno)| errno)?;
+
+// Lock held until dropped
+lock.relock(FlockArg::LockShared)?;   // upgrade/downgrade (since 0.29)
+let file = lock.unlock()?;             // explicit unlock
+```
+
+`Flockable` is implemented for `std::fs::File` and `OwnedFd`.
+
+`FlockArg` variants: `LockShared`, `LockExclusive`, `Unlock`,
+`LockSharedNonblock`, `LockExclusiveNonblock`.
+
+### POSIX Record Locks (fcntl)
+
+```rust
+use nix::fcntl::{fcntl, FcntlArg};
+
+// FcntlArg variants for locking:
+// F_SETLK(&libc::flock)      — set/clear, non-blocking
+// F_SETLKW(&libc::flock)     — set/clear, blocking
+// F_GETLK(&mut libc::flock)  — query locks
+// F_OFD_SETLK, F_OFD_SETLKW, F_OFD_GETLK — open file description locks (Linux)
+```
+
+## Deprecations
+
+- `flock()` function — deprecated since 0.28, use `Flock` struct instead
+- `FlockArg::UnlockNonblock` — deprecated since 0.28, use `FlockArg::Unlock`
+
+## Urd-Specific Notes
+
+Urd uses nix only for file locking (`nix::fcntl` via the `fs` feature).
+The I/O safety migration in 0.30 is the main concern — `std::fs::File`
+implements `AsFd`, so if Urd passes `File` objects to nix functions (which it
+should), the migration is transparent. If any code passes `RawFd` integers,
+those calls need updating to use `AsFd`-implementing types.

--- a/docs/00-foundation/source-documentation/rusqlite-0.39.md
+++ b/docs/00-foundation/source-documentation/rusqlite-0.39.md
@@ -1,0 +1,90 @@
+# rusqlite 0.39 Reference
+
+> Urd dependency: `rusqlite = { version = "0.39", features = ["bundled"] }`
+> Previous: `rusqlite = "0.32"`
+> Bundled SQLite: 3.51.3 (was 3.46.0)
+
+## Breaking Changes (0.32 -> 0.39)
+
+### High Impact for Urd
+
+**`execute()` and `prepare()` reject multi-statement SQL (0.35)**
+If any call passes SQL with multiple statements separated by `;`, it now errors.
+Use `execute_batch()` for multi-statement SQL.
+
+```rust
+// Error in 0.35+:
+conn.execute("INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)", [])?;
+
+// Correct:
+conn.execute_batch("INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)")?;
+```
+
+**u64/usize ToSql/FromSql disabled by default (0.38)**
+Storing or reading `u64`/`usize` values requires explicit casting to `i64` or
+opting in via the `i128_blob` feature. Prevents silent data loss on values
+exceeding i64 range.
+
+**Extended result codes enabled by default (0.32)**
+`SQLITE_OPEN_EXRESCODE` is always active. Error codes are more specific.
+If matching on error codes, values may differ from before.
+
+### Lower Impact
+
+- `FnMut` -> `Fn` in `create_scalar_function` (0.33)
+- `release_memory` feature removed (0.33)
+- Hook ownership checking (0.38, 0.39)
+- Statement cache made optional (0.38)
+
+## Current API Patterns
+
+```rust
+// Connection
+let conn = Connection::open("path.db")?;
+let conn = Connection::open_in_memory()?;
+
+// Execute (single statement only since 0.35)
+conn.execute("INSERT INTO t VALUES (?1, ?2)", params![val1, val2])?;
+conn.execute("INSERT INTO t VALUES (?1, ?2)", (val1, val2))?;  // tuple syntax
+conn.execute_batch("CREATE TABLE ...; INSERT ...")?;  // multi-statement
+
+// Query
+let name: String = conn.query_row(
+    "SELECT name FROM t WHERE id=?1", [id], |row| row.get(0)
+)?;
+
+// Multiple rows
+let mut stmt = conn.prepare("SELECT id, name FROM t")?;
+let rows = stmt.query_map([], |row| {
+    Ok(MyStruct { id: row.get(0)?, name: row.get(1)? })
+})?;
+
+// Transactions
+let tx = conn.transaction()?;
+tx.execute("...", [])?;
+tx.commit()?;
+
+// Parameter binding
+params![val1, val2]             // positional
+named_params!{"@name": val}     // named
+(val1, val2)                    // tuple
+&[&val1 as &dyn ToSql]          // slice
+```
+
+## New Features Since 0.32
+
+| Version | Feature |
+|---------|---------|
+| 0.39 | Unix timestamp support for chrono; `TryFrom` for `Value` |
+| 0.38 | wasm32 support; virtual table transactions; 64-bit length params |
+| 0.37 | `FromSqlError::other` convenience |
+| 0.36 | `query_one` method; column metadata; `Name` trait for `&str`/`&CStr` |
+| 0.35 | Column metadata from prepared statements |
+| 0.34 | `BindIndex` trait; `Deserialize` impls; flexible named params |
+
+## Urd-Specific Concerns
+
+Urd's `state.rs` uses straightforward open/execute/query patterns. Key things:
+- Verify no multi-statement `execute()` calls exist (use `execute_batch()` if so)
+- Verify no `u64`/`usize` values stored without casting to `i64`
+- The `bundled` feature bundles SQLite 3.51.3 — no system SQLite dependency

--- a/docs/00-foundation/source-documentation/rust-2024-edition.md
+++ b/docs/00-foundation/source-documentation/rust-2024-edition.md
@@ -1,0 +1,99 @@
+# Rust 2024 Edition Reference
+
+> Stabilized in Rust 1.85.0 (2025-02-20). Urd uses `edition = "2024"`.
+
+## Key Language Changes
+
+### RPIT Lifetime Capture (RFC 3498, 3617)
+
+All in-scope generic parameters (including lifetimes) are now implicitly captured
+in return-position `impl Trait`. The old `Captures<>` trick and outlives workaround
+(`+ 'a`) are no longer needed.
+
+```rust
+// 2021: lifetime NOT captured — needed workaround
+// 2024: lifetime captured automatically
+fn f(x: &str) -> impl Sized { x.len() }
+
+// Opt out with use<..> syntax (stable since 1.82):
+fn f<'a>(x: &'a ()) -> impl Sized + use<> { }  // capture nothing
+```
+
+### `let` Chains
+
+Chain `let` patterns with `&&` in `if` and `while`:
+
+```rust
+if let Some(first) = iter.next()
+    && let Some(second) = iter.next()
+{
+    // use both
+}
+```
+
+**Urd opportunity:** Useful in pattern-heavy code (config parsing, plan building).
+
+### Tail Expression Temporary Scope
+
+Temporaries in tail expressions drop before local variables. Fixes longstanding
+issues where temporary borrows lived too long.
+
+### `unsafe` Changes
+
+- `unsafe extern "C" { }` required (bare `extern` blocks are errors)
+- `#[unsafe(no_mangle)]`, `#[unsafe(export_name)]`, `#[unsafe(link_section)]`
+- `unsafe_op_in_unsafe_fn` is now warn-by-default
+- `static_mut_refs` is now deny-by-default — use `LazyLock`, `OnceLock`, atomics
+- `std::env::set_var` and `std::env::remove_var` are now `unsafe`
+
+### Match Ergonomics Restrictions
+
+Redundant `ref`/`ref mut` in patterns with default binding mode are now errors.
+Mixing `mut` with inherited binding modes requires fully explicit patterns.
+
+### Reserved Keywords
+
+- `gen` is reserved (future generators)
+- `#"foo"#` guarded string syntax is reserved
+
+## Cargo Changes
+
+### Resolver v3 (automatic with edition 2024)
+
+Rust-version-aware dependency resolution. Dependencies whose `rust-version`
+exceeds yours are deprioritized in favor of older compatible versions.
+
+### Cargo.toml Key Names
+
+Only hyphenated forms are valid:
+- `dev-dependencies` (not `dev_dependencies`)
+- `default-features` (not `default_features`)
+- `build-dependencies` (not `build_dependencies`)
+- `[package]` (not `[project]`)
+
+## Lint Defaults Changed
+
+| Lint | 2021 | 2024 |
+|------|------|------|
+| `unsafe_op_in_unsafe_fn` | allow | warn |
+| `static_mut_refs` | warn | deny |
+| `never_type_fallback_flowing_into_unsafe` | warn | deny |
+| `missing_unsafe_on_extern` | allow | error |
+| `unsafe_attr_outside_unsafe` | allow | error |
+| `deprecated_safe_2024` | allow | error |
+
+## Preferred Patterns
+
+- `let` chains over nested `if let`
+- `use<..>` bounds for precise RPIT lifetime control
+- Interior mutability (`LazyLock`, `OnceLock`, `Mutex`, atomics) over `static mut`
+- `&raw const`/`&raw mut` for raw pointers to statics
+- Explicit `unsafe { }` blocks inside unsafe functions
+
+## Urd-Specific Notes
+
+Urd already compiles clean on edition 2024. Key opportunities:
+- `let` chains can simplify nested option/result matching
+- No `unsafe` code in the project (by convention), so most unsafe changes are irrelevant
+- Resolver v3 is active — explains the "compatible versions" messages during `cargo build`
+- Consider adding `rustfmt.toml` with `style_edition = "2024"` for editor consistency

--- a/docs/00-foundation/source-documentation/toml-1.md
+++ b/docs/00-foundation/source-documentation/toml-1.md
@@ -1,0 +1,71 @@
+# toml 1.x Reference
+
+> Urd dependency: `toml = "1"` (resolves to 1.1.2)
+> Previous: `toml = "0.8"`
+> MSRV: 1.85
+
+## Breaking Changes (0.8 -> 1.x)
+
+### 0.8 -> 0.9 (the big jump)
+
+- `from_str`, `Deserializer` no longer preserve order by default
+  (use `preserve_order` feature if needed)
+- `impl FromStr for Value` now parses TOML *values*, not documents.
+  Use `toml::from_str` or `Table::from_str` for documents.
+- `Deserializer::new` deprecated -> use `Deserializer::parse`
+- `Serializer::new` takes `&mut Buffer` not `&mut String`
+  (invisible if using `to_string`/`to_string_pretty` convenience functions)
+- Serde support requires `serde` feature (default, so no change for most users)
+
+### 0.9 -> 1.0
+
+- `Time::second` and `Time::nanosecond` are now `Option`
+  (only relevant if manipulating TOML datetime types directly)
+- Borrowed `&str` deserialization now supported
+
+### 1.0 -> 1.1
+
+- MSRV bumped to 1.85
+- No API changes
+
+## Current API
+
+```rust
+// Deserialization (unchanged from 0.8 for common usage)
+let config: Config = toml::from_str(&contents)?;
+
+// Serialization
+let s = toml::to_string(&config)?;
+let s = toml::to_string_pretty(&config)?;
+
+// Direct value access
+let value: toml::Value = toml::from_str(&contents)?;
+let name = value["section"]["key"].as_str();
+```
+
+## TOML 1.1 Support (since 0.9.10)
+
+The parser now supports TOML 1.1 features:
+- Multi-line inline tables
+- Trailing commas in inline tables
+- `\e` and `\xHH` string escape sequences
+- Optional seconds in time values
+
+## Feature Flags
+
+| Feature | Default | Purpose |
+|---------|---------|---------|
+| `serde` | yes | Serialize/Deserialize support |
+| `std` | yes | Standard library support |
+| `preserve_order` | no | Insertion-order maps |
+| `fast_hash` | no | Performance optimization |
+| `debug` | no | Debug output |
+
+## Urd-Specific Notes
+
+Urd uses `toml::from_str` for config parsing and `toml::to_string_pretty` for
+migration output. These convenience functions are unchanged across the 0.8 -> 1.x
+boundary. No code changes were needed for the bump.
+
+The TOML 1.1 multi-line inline tables and trailing commas could improve config
+readability if adopted in future config schema iterations.

--- a/docs/95-ideas/2026-04-05-brainstorm-presentation-layer-polish.md
+++ b/docs/95-ideas/2026-04-05-brainstorm-presentation-layer-polish.md
@@ -1,0 +1,439 @@
+---
+status: raw
+date: 2026-04-05
+source: Steve Jobs product review of v0.11.1 test session
+---
+
+# Brainstorm: Presentation Layer Polish
+
+Divergent ideas for solving the UX issues identified in the
+[Steve Jobs v0.11.1 test session review](../99-reports/2026-04-05-steve-jobs-000-v0111-test-session.md).
+
+The review praised the bare invocation, vocabulary, and TTY/pipe split. It flagged
+information hierarchy problems in verify/doctor, trust gaps between commands, opaque
+table numbers, verbose error messages, and several small paper cuts.
+
+These ideas explore solutions — some surgical, some ambitious.
+
+---
+
+## Theme A: Information Hierarchy ("Lead with what matters")
+
+Steve's core critique: verify and doctor bury findings under noise. The user ran these
+commands to learn if something is wrong, not to read 34 lines of "OK."
+
+### A1. Verify: findings-first default
+
+Invert the verify output. Default mode shows only findings (warn + fail), with a
+one-line summary of what passed. Current verbose output becomes `--detail`.
+
+Default:
+```
+htpc-root/WD-18TB: Chain broken — pinned snapshot missing locally.
+  Next send will be full.
+
+6 subvolumes verified clean. 2 drives not mounted (WD-18TB1, 2TB-backup).
+```
+
+`--detail` gives current behavior (every check for every subvolume).
+
+Touches: `voice.rs` (render_verify_interactive), `cli.rs` (VerifyArgs gets `--detail`
+flag). Pure presentation change — `output.rs` data model unchanged.
+
+### A2. Verify: progressive reveal with streaming output
+
+Instead of buffering everything and printing at once, verify streams output as it checks.
+Clean subvolumes get a single-line "✓ subvol1-docs" that stays on screen briefly, then
+findings get full detail. Creates a sense of progress and naturally foregrounds problems.
+
+More complex: requires changing from `String` buffering to streaming `Write`. May not
+compose well with daemon/JSON mode. Ambitious but would feel alive.
+
+### A3. Doctor --thorough: separate findings from expected conditions
+
+When doctor runs thread verification, group output into two tiers:
+1. **Findings** (fail + unexpected warn) — shown first, with full detail
+2. **Expected conditions** (absent drives, known states) — collapsed into a summary line
+
+```
+  Threads
+    ✗ htpc-root/WD-18TB: Chain broken — next send will be full
+      → Run `urd backup` when ready (will do a full send)
+
+    14 checks OK. 2 drives absent (WD-18TB1, 2TB-backup) — skipped as expected.
+```
+
+The key insight: an absent drive is not a *finding* — it's a *known state* that the user
+already sees in `urd status` and `urd drives`. Repeating it 12 times is noise.
+
+Touches: `voice.rs` (render_doctor_interactive, the verify-inside-doctor section).
+Could filter on `check.status == "warn"` where the check name is `drive-mounted` to
+identify "expected" vs "unexpected" warnings.
+
+### A4. Doctor --thorough: fold identical warnings
+
+Instead of listing each subvolume/drive combination separately, group identical messages:
+
+```
+  Threads
+    ✗ htpc-root/WD-18TB: Chain broken — next send will be full
+    ⚠ 6 subvolumes × WD-18TB1: Drive not mounted
+    ⚠ 6 subvolumes × 2TB-backup: Drive not mounted
+```
+
+Compresses 14 warning lines into 2. Information preserved, noise eliminated.
+
+### A5. All commands: "nothing to report" compression
+
+Generalize the principle: when a section has all-OK results, compress to one summary line.
+This could be a voice.rs utility function used by verify, doctor, and future commands.
+
+```rust
+fn compress_homogeneous_results(items: &[CheckResult]) -> CompressedOutput {
+    // If all same status, return summary line
+    // If mixed, return the exceptions + summary of the rest
+}
+```
+
+---
+
+## Theme B: Trust Coherence ("Commands should agree")
+
+Steve's finding: status says "2 need attention, run doctor" but doctor says "All clear."
+The breadcrumb leads to a dead end.
+
+### B1. Doctor acknowledges what status surfaced
+
+When doctor's data safety section shows degraded subvolumes, the verdict should reflect
+this. "All clear" should mean *everything* is fine, not just infrastructure.
+
+Option: change verdict logic to include health degradation as a warning-level concern.
+"All clear" becomes "Infrastructure healthy. 2 subvolumes degraded — absent drives."
+
+Touches: `commands/doctor.rs` (verdict computation), `voice.rs` (verdict rendering).
+
+### B2. Status advice points to doctor --thorough, not doctor
+
+When status generates the "run doctor for details" advice, it should point to
+`urd doctor --thorough` when the issues are thread/drive-related (not infrastructure).
+This ensures the user lands on the view that actually shows their problem.
+
+Simpler: always recommend `urd doctor --thorough` in advice text. The base doctor is
+fast enough that the difference doesn't matter for UX.
+
+### B3. Doctor: tiered verdicts
+
+Replace the binary healthy/issues verdict with a three-tier assessment:
+
+```
+Infrastructure: all clear
+Protection: 2 subvolumes degraded (WD-18TB1 away 8d)
+Threads: 1 broken chain (htpc-root)
+```
+
+Each tier gets its own one-line verdict. The user sees exactly what's fine and what isn't.
+The combined "All clear" only appears when all three tiers are clear.
+
+### B4. Doctor inherits the status summary line
+
+Start doctor output with the same safety summary that status uses: "All sealed.
+2 degraded." This frames the diagnostic run in the context of what the user already
+knows, and makes it obvious if doctor sees the same state status reported.
+
+---
+
+## Theme C: Self-Documenting Output ("Don't make me guess")
+
+### C1. Status table: count+age column headers
+
+Change `LOCAL` → `LOCAL #` or `LOCAL (n/age)`. Change drive columns similarly:
+`WD-18TB` → `WD-18TB #`. The `#` suffix is compact and conventional for "count."
+
+Alternatively, add a footnote line below the table:
+```
+# = snapshot count, (age) = newest snapshot age
+```
+
+### C2. Status table: use words for small counts
+
+Instead of `31 (10h)`, use `31 snapshots (10h)` for the first row only, then just
+numbers. The first row teaches the format, the rest are compact.
+
+Too clever? Maybe. But the first-row-as-legend pattern works in dense tables.
+
+### C3. Status summary line: match bare invocation quality
+
+Change "All sealed. 2 degraded — WD-18TB1 away for 8 days." to include context like
+the bare invocation does. And mention *all* absent drives in the summary, not just one.
+
+```
+All sealed. 2 degraded — WD-18TB1 away 8d, 2TB-backup away 2d.
+```
+
+### C4. Relative timestamps in status
+
+The bare invocation says "10h ago" (warm, immediate). The status command says
+"2026-04-05T04:01:11" (cold, precise). Steve's suggestion: lead with relative, append
+precise.
+
+```
+Last backup: 10h ago (04:01, success) [#29]
+```
+
+The `humanize_duration()` function already exists in voice.rs. The status output already
+has `last_run_age_secs` computed. This is a rendering-only change.
+
+### C5. Thread column: rename ext-only to drive-only
+
+"ext-only" is internal vocabulary. "drive-only" maps to the user's mental model (their
+data lives on the drive, not locally). Or use `—` in the thread column with a note in
+the drive summary that htpc-root has no local snapshots.
+
+### C6. History: humanize zero-duration runs
+
+When a backup completes in 0 seconds (nothing to do), show `<1s` or `(no-op)` instead
+of `0s`. The current `0s` reads as broken or erroneous.
+
+```
+20   2026-04-01T20:56:05  full  success  <1s
+```
+
+---
+
+## Theme D: Error Messages as Guidance ("Guide, don't dump")
+
+### D1. Retention-preview: columnar subvolume list
+
+Replace the comma-separated dump with a structured error:
+
+```
+Usage: urd retention-preview <subvolume> [--all]
+
+Available subvolumes:
+  subvol1-docs        subvol3-opptak      subvol5-music
+  subvol2-pics        subvol4-multimedia  subvol6-tmp
+  subvol7-containers  htpc-home           htpc-root
+```
+
+Touches: `commands/retention_preview.rs` (the `anyhow::bail!` call). Could move to
+voice.rs as a reusable `format_subvolume_chooser()` for any command that needs a
+subvolume argument.
+
+### D2. Subvolume chooser pattern
+
+Multiple commands need a subvolume argument (retention-preview, history <subvolume>,
+potentially verify). A shared `format_subvolume_list()` in voice.rs would ensure
+consistent, scannable presentation across all of them.
+
+### D3. Graceful --verbose handling
+
+The global `--verbose` flag exists in `Cli` but clap requires it *before* the subcommand.
+`urd status --verbose` fails because clap interprets `--verbose` as an argument to the
+`Status` subcommand, which has no args.
+
+Options:
+- **a)** Add `#[arg(long, short)]` verbose flag to every subcommand struct. Slightly
+  redundant but clap-idiomatic.
+- **b)** Use clap's `#[command(args_conflicts_with_subcommands = false)]` or
+  `#[command(propagate_version = true)]` — need to check if global arg propagation
+  works.
+- **c)** Catch the clap error in main.rs and suggest `urd -v status` — cheapest fix
+  but teaches the user a workaround, not the right way.
+
+The real question: what does `--verbose` *do* for each command? Status already shows
+the full view. Plan could show more reasoning. Verify could show all checks (Theme A
+makes this `--detail`). Define the semantics before adding the flag.
+
+### D4. Friendly typo recovery
+
+Clap's built-in "tip: a similar subcommand exists" is functional but impersonal. Since
+Urd has a voice, consider intercepting unrecognized subcommands:
+
+```
+Did you mean `urd drives`?
+```
+
+Touches: `main.rs` error handling. Clap may expose the suggestion programmatically.
+
+---
+
+## Theme E: Paper Cuts ("The details that signal care")
+
+### E1. Fix `issue(s)` pluralization
+
+In `render_doctor_interactive`, replace `format!("{} issue(s).", count)` with proper
+pluralization:
+
+```rust
+let word = if count == 1 { "issue" } else { "issues" };
+format!("{count} {word}.")
+```
+
+Same for `warning(s)`. Five-minute fix. Apply everywhere this pattern appears.
+
+### E2. Doctor: fulfill the "suggested commands" promise
+
+The verdict says "Run suggested commands to resolve" but the chain-break finding doesn't
+include a command suggestion. Either:
+- Add a suggestion: `→ Run 'urd backup' to trigger a full send`
+- Change the verdict text: `1 issue found.` without the promise
+
+### E3. Drives table: fix Unicode width alignment
+
+The `✓` (U+2713) and `—` (U+2014) have different display widths in many terminal fonts.
+Use fixed-width representations or pad explicitly to account for this. The `strip_ansi_len`
+function exists but doesn't account for Unicode display width. Consider the `unicode-width`
+crate, or use ASCII alternatives (`OK` / `-`).
+
+### E4. Protection aging vocabulary
+
+Status says "protection degrading" for absent drives. Steve suggests "protection aging" or
+"stale" — less urgent, more accurate. The user can't act on this (the drive is physically
+elsewhere), so the vocabulary should convey drift, not emergency.
+
+Options:
+- `WD-18TB1 absent 8d — copies aging`
+- `WD-18TB1 absent 8d — stale`
+- `WD-18TB1 absent 8d — last sync aging`
+
+### E5. History: relative timestamps option
+
+Currently history shows ISO timestamps only. A `--relative` flag (or default behavior)
+could show relative times alongside:
+
+```
+RUN  STARTED          AGE     MODE  RESULT   DURATION
+29   04:01 today      10h     full  success  9m 31s
+28   04:00 yesterday  1d      full  success  31s
+```
+
+Ambitious but natural extension of the "humanize timestamps" principle.
+
+---
+
+## Theme F: Ambitious ("What if we could?")
+
+### F1. Verify as a quiet guardian
+
+What if `urd verify` was designed like a linter? Default output: one line per finding,
+nothing for clean. A return code tells scripts whether everything passed. The user gets
+signal, not ceremony.
+
+```
+$ urd verify
+htpc-root/WD-18TB: chain broken — next send will be full
+$ echo $?
+1
+```
+
+Clean run:
+```
+$ urd verify
+All threads intact.
+$ echo $?
+0
+```
+
+The detailed per-check view becomes `urd verify --detail` for debugging. This is the
+`cargo clippy` model — you want to know what's wrong, not that 200 things are right.
+
+### F2. Command output that teaches
+
+What if every command could optionally explain itself? Not `--verbose` (more data) but
+`--explain` (why this data):
+
+```
+$ urd status --explain
+All sealed. 2 degraded — WD-18TB1 away for 8 days.
+
+  "sealed" means every subvolume has at least one copy on an external drive,
+  matching its configured protection level.
+
+  "degraded" means a drive that's expected to have copies hasn't been seen
+  recently. Your data is safe, but redundancy is reduced.
+```
+
+This is progressive disclosure at the command level. Useful for onboarding without
+cluttering the default experience. Could be powered by a `voice::explain()` module.
+
+### F3. The diagnostic journey
+
+What if doctor wasn't a static report but a guided diagnostic? Instead of showing
+everything and hoping the user finds the problem, doctor asks questions:
+
+```
+$ urd doctor
+Your data is safe. One thread is broken.
+
+  htpc-root last sent to WD-18TB 1 day ago.
+  The local copy was deleted, so the next send will be a full transfer.
+
+  This is expected after manual cleanup. No action needed —
+  the next nightly will handle it.
+
+Want to see infrastructure checks? [y/N]
+```
+
+Interactive when TTY, static report when piped. The key insight: most of the time,
+the user just wants to know "should I worry?" Doctor should answer that first, then
+offer depth.
+
+### F4. Unified health score
+
+What if Urd had a single number — a health score from 0-100? Not as the primary
+interface, but as a quick-glance metric for monitoring dashboards and bare invocation:
+
+```
+Urd health: 94/100. All sealed, 2 drives aging.
+```
+
+Dangerous territory — reductive metrics can mislead. But if the scoring is transparent
+(deductions for: broken chain -3, absent drive -2/drive, degraded subvol -1/subvol),
+it could serve the "is my data safe?" question at a glance.
+
+Probably a bad idea for the CLI. Maybe good for Prometheus metrics. Park this.
+
+### F5. The voice module as a personality layer
+
+Currently `voice.rs` is a rendering engine — it formats structured data into text. But
+the mythic voice aspiration in CLAUDE.md suggests something more: a personality layer
+that makes the same data feel different depending on context.
+
+What if the same data — "htpc-root chain broken" — could be presented differently
+based on context?
+
+- Interactive (invoked by user): "htpc-root's thread to WD-18TB is broken. The next
+  send will retrace the full path."
+- Notification (sentinel alert): "A thread has broken. htpc-root will need a full send."
+- Bare invocation (glance): "1 thread needs mending."
+
+Same data, different register. The structured output types already support this — the
+rendering layer just needs to be context-aware. This is the mythic voice done right:
+not dramatic prose, but contextual communication that matches the user's current
+attention level.
+
+---
+
+## Handoff to Architecture
+
+The five most promising ideas for deeper analysis:
+
+1. **A1 + A3: Findings-first verify and doctor** — The single highest-impact UX change.
+   Both commands need the same inversion: lead with problems, summarize what's fine.
+   Pure voice.rs changes with no data model impact. Should be a single design.
+
+2. **B1 + B2: Trust coherence between status and doctor** — The "All clear" / "2 need
+   attention" gap is a trust-eroding bug. Doctor's verdict needs to account for degraded
+   health, and status's advice should point to `--thorough`.
+
+3. **C4: Relative timestamps in status** — Quick win. The function exists, the data
+   exists, it's just a rendering change. Brings status in line with the bare invocation's
+   warmth.
+
+4. **D3: Graceful --verbose handling** — The global `-v` flag exists but doesn't
+   propagate to subcommands. Solving this requires deciding what verbose *means* per
+   command, which is a design question worth getting right.
+
+5. **D1 + D2: Subvolume chooser pattern** — The retention-preview error is the worst
+   error message in the tool. A shared columnar subvolume list would fix it and
+   establish a pattern for future commands.

--- a/docs/95-ideas/2026-04-05-design-023-honest-diagnostic.md
+++ b/docs/95-ideas/2026-04-05-design-023-honest-diagnostic.md
@@ -1,0 +1,410 @@
+---
+upi: "023"
+status: proposed
+date: 2026-04-05
+---
+
+# Design: The Honest Diagnostic (UPI 023)
+
+> **TL;DR:** Fix the information hierarchy in verify and doctor so findings lead,
+> noise collapses, and commands agree with each other. When status says "run doctor,"
+> doctor must answer the question status raised. Pure presentation changes — no new
+> modules, no data model changes, no behavioral changes.
+
+## Problem
+
+The v0.11.1 test session (Steve Jobs review, 2026-04-05) identified three UX failures
+in the diagnostic path:
+
+### 1. Verify buries findings under noise
+
+`urd verify` with 7 subvolumes × 3 drives produces 60+ lines. One actual finding
+(htpc-root chain break) appears on line ~50, preceded by 34 "OK" lines and 12 "Drive
+not mounted" warnings. The user ran verify to learn if something is wrong — the answer
+is buried.
+
+### 2. Doctor --thorough buries findings identically
+
+The Threads section of `urd doctor --thorough` lists every non-OK check individually.
+With 2 absent drives × 6 subvolumes = 12 "Drive not mounted — skipping" warnings before
+the one actual chain-break failure. The finding appears on line 13 of 15.
+
+### 3. Trust gap between status and doctor
+
+`urd status` says "2 subvolumes need attention — run `urd doctor` for details." The user
+runs `urd doctor`. Doctor says "All clear." This happens because:
+
+- Status's "need attention" is driven by `advice` (which includes degraded health from
+  absent drives).
+- Doctor's verdict is driven by `warn_count` + `error_count`, which only increment for
+  Unprotected/AtRisk promise states, infrastructure issues, and verify failures.
+- **Degraded-but-Protected subvolumes produce advice/issue text but don't increment
+  the verdict counters** (doctor.rs line 157: the `Protected` non-healthy branch sets
+  `issue` and `suggestion` via advice but has no `warn_count += 1`).
+
+The result: doctor renders degraded subvolumes in its Data Safety section (the JSON shows
+`"health": "degraded"` and `"issue": "degraded — WD-18TB1 away"`), but the verdict says
+"All clear" because the counters are zero.
+
+### 4. Paper cuts in verdict text
+
+- `"{} issue(s)"` / `"{} warning(s)"` — lazy pluralization
+- `"Run suggested commands to resolve."` — but the chain-break finding in doctor
+  --thorough doesn't include a command suggestion. The promise is unfulfilled.
+
+## Proposed Design
+
+Four changes, all in `voice.rs` and `commands/doctor.rs`. No new types, no new modules,
+no output.rs changes (the data model already carries everything needed).
+
+### Change 1: Findings-first verify (voice.rs)
+
+**Current:** `render_verify_interactive` iterates all subvolumes × drives × checks
+sequentially, printing every result.
+
+**New:** Two rendering modes controlled by a `--detail` flag on `VerifyArgs`.
+
+**Default mode (findings-first):**
+1. Collect all non-OK checks into a findings list
+2. Render findings first, grouped by subvolume/drive
+3. Render a one-line summary of clean results and expected conditions
+4. If no findings: render a clean "All threads intact" message
+
+Example (current state with htpc-root chain break, 2 absent drives):
+```
+htpc-root/WD-18TB:
+  FAIL  Pinned snapshot missing locally: 20260404-0400-htpc-root
+        Chain broken — next send will be full
+
+7 subvolumes verified, 34 checks OK.
+2 drives not mounted (WD-18TB1, 2TB-backup) — skipped.
+```
+
+Example (all clean):
+```
+All threads intact. 7 subvolumes verified, 35 checks OK.
+```
+
+**Detail mode (`--detail`):** Current behavior — every check printed for every
+subvolume/drive combination. For debugging and audit.
+
+**Implementation approach in `render_verify_interactive`:**
+
+```
+fn render_verify_interactive(data: &VerifyOutput, detail: bool) -> String {
+    if detail {
+        return render_verify_detail(data);  // current implementation, extracted
+    }
+    // findings-first rendering
+    ...
+}
+```
+
+The `render_verify` public function gains a `detail: bool` parameter. The `VerifyArgs`
+struct gains a `--detail` flag. The command handler passes it through.
+
+**Absent drive handling:** "Drive not mounted — skipping" warnings (check name
+`"drive-mounted"`) are *expected conditions*, not findings. In findings-first mode,
+they're collapsed into the summary line: `"2 drives not mounted (WD-18TB1, 2TB-backup)
+— skipped."` In detail mode, they render as today.
+
+The key classification: a check with `status == "warn"` and `name == "drive-mounted"` is
+an expected condition. All other non-OK checks are findings.
+
+**Test strategy:**
+- Test findings-first with 0 findings (all clean) → "All threads intact" message
+- Test findings-first with 1 failure → failure shown, clean summary follows
+- Test findings-first with mixed warnings and failures → grouped correctly
+- Test absent drive collapsing → drive names collected, summary line correct
+- Test detail mode → identical to current output
+- Test JSON/daemon mode → unchanged (no detail parameter in daemon mode)
+
+### Change 2: Doctor --thorough findings separation (voice.rs)
+
+**Current:** The Threads section in `render_doctor_interactive` iterates all non-OK checks
+from the embedded VerifyOutput, printing each one. When there are issues, it shows every
+warn + fail check in order.
+
+**New:** Apply the same findings/expected-conditions split as verify, but in the compact
+doctor format.
+
+When there are findings:
+```
+  Threads
+    ✗ htpc-root/WD-18TB: Pinned snapshot missing locally — chain broken, next send will be full
+      → Run `urd backup` when ready
+
+    34 checks OK. 2 drives not mounted (WD-18TB1, 2TB-backup) — skipped.
+```
+
+When all clean (current behavior, unchanged):
+```
+  Threads
+    ✓ All threads intact (35 checks OK)
+```
+
+**Implementation:** The existing code at voice.rs:2249-2271 already filters `check.status
+!= "ok"`. The change adds a second pass that classifies non-OK checks:
+- `drive-mounted` warnings → expected conditions (collapsed to summary)
+- Everything else → findings (rendered with icons)
+
+After findings, render a one-line summary: `"{ok_count} checks OK. {absent_count} drives
+not mounted ({drive_names}) — skipped."`
+
+**Suggestion for chain-break finding:** Currently the chain-break check in verify produces
+a detail string but no actionable command. Add a suggestion line below the finding:
+`"→ Run 'urd backup' when ready"`. This is rendered in the doctor context only (verify
+already has its own suggestion system via `append_suggestion`). Implementation: voice.rs
+can detect the chain-break pattern by checking for "Chain broken" in the detail string
+and append a suggestion line.
+
+**Test strategy:**
+- Test doctor --thorough with only absent-drive warnings → summary line only, no
+  individual warnings listed
+- Test doctor --thorough with one failure + absent-drive warnings → failure shown first,
+  summary after
+- Test doctor --thorough all clean → unchanged "All threads intact" message
+- Test chain-break suggestion line appears when "Chain broken" detected
+
+### Change 3: Doctor verdict includes health degradation (commands/doctor.rs)
+
+**Current:** `Protected` subvolumes with non-healthy status set `issue` text but don't
+increment `warn_count`. The verdict is "All clear" even when degraded subvolumes are
+present and surfaced in the Data Safety section.
+
+**New:** Degraded-but-Protected subvolumes increment a separate `degraded_count`. The
+verdict computation uses it:
+
+```rust
+// doctor.rs, after building data_safety
+let degraded_count = data_safety.iter()
+    .filter(|d| d.status == "PROTECTED" && d.health != "healthy")
+    .count();
+
+let verdict = if error_count > 0 {
+    DoctorVerdict::issues(error_count)
+} else if warn_count > 0 {
+    DoctorVerdict::warnings(warn_count)
+} else if degraded_count > 0 {
+    DoctorVerdict::degraded(degraded_count)
+} else {
+    DoctorVerdict::healthy()
+};
+```
+
+This requires a new `DoctorVerdictStatus::Degraded` variant in output.rs — the one
+output.rs change in this design. The rendering in voice.rs:
+
+```
+DoctorVerdictStatus::Degraded => {
+    let word = if count == 1 { "subvolume" } else { "subvolumes" };
+    writeln!(out, "{}",
+        format!("{count} {word} degraded. Data is safe — drives are absent.").yellow()
+    ).ok();
+}
+```
+
+This directly addresses the trust gap: "All clear" now only appears when everything is
+genuinely clear. When status says "2 need attention" and the user runs doctor, doctor says
+"2 subvolumes degraded. Data is safe — drives are absent." The user's breadcrumb leads
+to an answer, not a dead end.
+
+**Status advice update (voice.rs):** Change line 84 from `urd doctor` to
+`urd doctor --thorough` so the user lands on the view that shows thread and drive detail:
+
+```rust
+// voice.rs line 84, current:
+format!("{} subvolumes need attention — run `urd doctor` for details.", ...)
+// new:
+format!("{} subvolumes need attention — run `urd doctor --thorough` for details.", ...)
+```
+
+**Test strategy:**
+- Test verdict with 0 errors, 0 warnings, 2 degraded → `Degraded` status
+- Test verdict with 1 error + 2 degraded → `Issues` (errors take precedence)
+- Test verdict with 0 errors, 1 warning, 2 degraded → `Warnings` (warnings take
+  precedence)
+- Test verdict with all healthy → `Healthy` (unchanged)
+- Test rendering of degraded verdict → correct message text, yellow color
+- Test status advice text → contains `urd doctor --thorough`
+
+### Change 4: Verdict text polish (voice.rs)
+
+**Pluralization:** Replace `format!("{} issue(s).", count)` and `"{} warning(s)."` with
+proper pluralization:
+
+```rust
+fn pluralize(count: usize, singular: &str, plural: &str) -> String {
+    if count == 1 { format!("{count} {singular}") } else { format!("{count} {plural}") }
+}
+```
+
+Apply to: `DoctorVerdictStatus::Warnings` rendering, `DoctorVerdictStatus::Issues`
+rendering, and the new `Degraded` rendering.
+
+**Verdict guidance:** Replace `"Run suggested commands to resolve."` with context-aware
+text:
+- When all findings have suggestions: `"Run suggested commands to resolve."` (current,
+  now accurate because chain-break gets a suggestion in Change 2)
+- When some findings lack suggestions: just state the count without the promise.
+  `"1 issue found."` or `"2 warnings."` — the individual findings already include their
+  own suggestions where applicable.
+
+Implementation: voice.rs can check `data.verify` for whether all non-OK checks have
+suggestions, but this is over-engineering. Simpler approach: always use the count-only
+format for the verdict line, and let individual findings carry their own suggestions.
+Change verdict text from `"{count} issue(s). Run suggested commands to resolve."` to
+just `"{count} {word} found."`:
+
+```
+DoctorVerdictStatus::Issues => {
+    let word = pluralize(count, "issue", "issues");
+    writeln!(out, "{}", format!("{word} found.").red()).ok();
+}
+DoctorVerdictStatus::Warnings => {
+    let word = pluralize(count, "warning", "warnings");
+    writeln!(out, "{}", format!("{word}.").yellow()).ok();
+}
+```
+
+**Test strategy:**
+- Test singular: 1 issue → "1 issue found."
+- Test plural: 3 warnings → "3 warnings."
+- Test no `"issue(s)"` or `"warning(s)"` appears anywhere in rendered output
+
+## Module Map
+
+| Module | Changes | Test Strategy |
+|--------|---------|---------------|
+| `cli.rs` | Add `--detail` flag to `VerifyArgs` | Existing clap test patterns |
+| `commands/verify.rs` | Pass `detail` flag through to voice | Minimal — rendering tested via voice |
+| `commands/doctor.rs` | Count degraded subvolumes, new verdict branch | Test verdict computation with various health combinations |
+| `output.rs` | Add `DoctorVerdictStatus::Degraded` variant | Derive coverage (Serialize) |
+| `voice.rs` | (1) Findings-first verify, (2) Doctor thorough findings separation, (3) Degraded verdict rendering, (4) Pluralization + verdict text | Bulk of tests — ~15-20 new tests |
+
+## Effort Estimate
+
+~1 session. Comparable to UPI 020 (context-aware suggestions): primarily voice.rs rendering
+changes with one small output.rs addition and one logic change in doctor.rs. No new modules,
+no new traits, no filesystem interaction.
+
+## Sequencing
+
+1. **Change 3 first (doctor verdict)** — This is the trust gap fix. Smallest change,
+   highest impact. If this shipped alone, the worst UX problem would be solved.
+2. **Change 4 (verdict polish)** — Depends on Change 3 (new Degraded variant needs
+   pluralization). Quick follow-on.
+3. **Change 1 (findings-first verify)** — Largest change, most new code. Benefits from
+   the classification logic being thought through in Change 2.
+4. **Change 2 (doctor thorough separation)** — Reuses the classification approach from
+   Change 1. Natural last step.
+
+## Architectural Gates
+
+**One minor output.rs change:** Adding `DoctorVerdictStatus::Degraded`. This is an enum
+variant addition, not a contract change — existing JSON consumers will see a new possible
+value `"degraded"` in the `verdict.status` field. Since the homelab monitoring stack
+consumes Prometheus metrics and heartbeat, not doctor JSON output, this is safe. The
+Prometheus metrics are unchanged.
+
+No ADR needed. The change is additive and backward-compatible for JSON consumers
+(new enum variant, not a removed or renamed one).
+
+## Rejected Alternatives
+
+### Interactive doctor (F3 from brainstorm)
+
+A guided diagnostic that asks "Want to see infrastructure checks? [y/N]" was proposed.
+Rejected because: (1) it requires stdin interaction which doesn't compose with piped
+output or scripts, (2) doctor's current structure (Config → Infrastructure → Data Safety
+→ Sentinel → Threads) is already good progressive disclosure via `--thorough`, (3) the
+real problem isn't structure, it's that the verdict doesn't reflect what the sections show.
+Fix the verdict, not the structure.
+
+### Generic compression utility (A5)
+
+A reusable `compress_homogeneous_results()` function was proposed. Rejected because: the
+classification logic is specific to each context. Verify's "expected condition" is
+`drive-mounted` warnings. Doctor's is the same but rendered differently (icons vs. status
+tags). Premature abstraction — if a third command needs this pattern, extract then.
+
+### Streaming verify output (A2)
+
+Progressive reveal with streaming writes. Rejected because: (1) requires changing from
+`String` return to `Write` trait, which breaks the daemon/JSON rendering model, (2) the
+findings-first approach achieves the same UX goal (problems visible immediately) without
+architectural change, (3) the verify operation is fast enough that streaming adds no
+perceptible benefit.
+
+### Warning folding in doctor (A4)
+
+`"6 subvolumes × WD-18TB1: Drive not mounted"` format. Rejected in favor of the simpler
+summary line approach: `"2 drives not mounted (WD-18TB1, 2TB-backup) — skipped."` The
+folding format looks like multiplication, which is visual noise. The summary is cleaner
+and conveys the same information.
+
+## Assumptions
+
+1. **`drive-mounted` is a stable check name.** The verify system uses string-based check
+   names. This design relies on `"drive-mounted"` to classify expected conditions. If the
+   check name changes, the classification breaks silently (shows absent-drive warnings as
+   findings instead of collapsing them). Mitigation: the check name is set in verify.rs
+   and consumed in voice.rs — both in this project's control.
+
+2. **Degraded-but-Protected is not an error.** The design renders degraded status as
+   yellow (warning level), not red. This assumes that Protection is the primary safety
+   guarantee and health degradation is an operational concern, not a safety concern. This
+   matches CLAUDE.md's promise model: Protected means the data is safe, degraded means
+   redundancy is reduced.
+
+3. **No JSON schema consumers depend on verdict shape.** Adding `Degraded` as a new
+   verdict status value is backward-compatible if consumers handle unknown values
+   gracefully. The homelab monitoring stack uses Prometheus metrics, not doctor JSON.
+
+4. **The `render_verify` public function can accept a `detail` parameter.** This changes
+   the function signature. All callers (verify command handler, doctor command handler via
+   embedded verify) must be updated. There are exactly two call sites: `commands/verify.rs`
+   and `commands/doctor.rs`.
+
+## Open Questions
+
+### Q1: Should `render_verify` gain a `detail` parameter, or should detail mode be a separate function?
+
+**Option A (parameter):** `render_verify(data, mode, detail)` — clean, but changes the
+public API and requires updating both call sites. Doctor always passes `detail: false`
+(it has its own rendering for the Threads section).
+
+**Option B (separate function):** `render_verify(data, mode)` stays as-is (becomes
+findings-first), add `render_verify_detail(data, mode)` for the `--detail` flag. Verify
+command calls the appropriate one based on the flag. Doctor never calls render_verify at
+all (it uses the data directly).
+
+Leaning toward **Option A** — the parameter is the simplest approach and doctor already
+doesn't call `render_verify` (it reads `data.verify` and renders inline). The parameter
+only affects the verify command handler.
+
+### Q2: Should verify's "expected conditions" classification be in voice.rs or in output.rs?
+
+**Option A (voice.rs):** The classification happens during rendering. The VerifyCheck type
+stays unchanged. Voice.rs checks `check.name == "drive-mounted"` to decide presentation.
+Simple, no data model change, but embeds knowledge of check names in the rendering layer.
+
+**Option B (output.rs):** Add a `category` field to VerifyCheck: `Finding` or
+`ExpectedCondition`. Verify.rs sets it when building checks. Voice.rs renders based on
+category. Cleaner separation but changes the data model and adds a field to JSON output.
+
+Leaning toward **Option A** — the classification is purely a presentation concern. Which
+checks are "expected" depends on context (absent drives are expected; a UUID mismatch
+warning is not). The rendering layer is the right place to make this judgment. Adding a
+field to the data model for a presentation concern violates the output.rs/voice.rs
+separation.
+
+### Q3: Should the degraded verdict include specific drive names?
+
+**Option A (generic):** `"2 subvolumes degraded. Data is safe — drives are absent."`
+**Option B (specific):** `"2 subvolumes degraded — WD-18TB1 away 8d, 2TB-backup away 2d."`
+
+Option B is more informative but requires the verdict to carry drive-level detail that's
+currently only in the Data Safety section. Leaning toward **Option A** for the verdict
+line — the Data Safety section already shows the specifics, and the user will see them
+in the output above the verdict.

--- a/docs/95-ideas/2026-04-05-design-024-warm-details.md
+++ b/docs/95-ideas/2026-04-05-design-024-warm-details.md
@@ -1,0 +1,442 @@
+---
+upi: "024"
+status: proposed
+date: 2026-04-05
+---
+
+# Design: The Warm Details (UPI 024)
+
+> **TL;DR:** Eight small rendering changes that transform Urd's CLI from "engineered
+> correctly" to "crafted with care." Relative timestamps, better vocabulary, fixed
+> alignment, humanized edge cases, and a guided error message. All changes are in
+> voice.rs, types.rs, and one command handler. No new modules, no data model changes.
+
+## Problem
+
+The v0.11.1 test session (Steve Jobs review, 2026-04-05) identified a pattern: Urd's
+major surfaces (bare invocation, status table, vocabulary) are excellent, but scattered
+details break the impression. Each is small alone; together they create a gap between
+the crafted feeling of `urd` (bare invocation) and the uncrafted feeling of some
+secondary surfaces.
+
+These are the details that signal whether a tool was made with care.
+
+### Inventory of problems
+
+1. **Cold timestamps in status.** Bare `urd` says "Last backup 10h ago" (warm).
+   `urd status` says "Last backup: 2026-04-05T04:01:11" (cold ISO 8601). The same
+   tool speaks two different languages.
+
+2. **Summary line drops context.** Bare `urd`: "All connected drives are sealed."
+   `urd status`: "All sealed." — drops "connected drives" framing. Also, the health
+   part says "2 degraded — WD-18TB1 away for 8 days" but only names one drive while
+   two are absent.
+
+3. **`ext-only` is internal jargon.** The thread column shows "ext-only" for htpc-root
+   (no local snapshots, drive-only). A user seeing this next to "sealed / healthy"
+   can't tell if it's good, bad, or neutral.
+
+4. **`0s` duration in history.** Run #20 shows `0s` which reads as broken. It means
+   nothing needed doing (all subvolumes skipped).
+
+5. **`protection degrading` is urgent-sounding.** Absent drives show "protection
+   degrading" which implies an active emergency. The user can't act on it (the drive
+   is physically elsewhere). The vocabulary should convey drift, not crisis.
+
+6. **Retention-preview error dumps subvolume names.** A comma-separated wall of nine
+   names on one line. No usage hint, no scannable format.
+
+7. **Drives table Unicode alignment.** The TOKEN column uses `✓`, `—`, and `recorded`
+   — characters with different display widths. The `{:<12}` format padding counts bytes
+   or chars, not display width, causing visual misalignment.
+
+8. **Pluralization `issue(s)`/`warning(s)`.** Addressed in UPI 023 (Change 4) so not
+   duplicated here. Included in the inventory for completeness.
+
+## Proposed Design
+
+Seven changes (item 8 is in UPI 023). Each is independent — they can be implemented
+and tested individually in any order.
+
+### Change 1: Relative timestamps in status (voice.rs)
+
+**Current** (`render_last_run`):
+```
+Last backup: 2026-04-05T04:01:11 (success, 9m 31s) [#29]
+```
+
+**New:**
+```
+Last backup: 10h ago (success, 9m 31s) [#29]
+```
+
+**Implementation:** `StatusOutput` already has `last_run: Option<LastRunInfo>` with
+`started_at` as a string timestamp. Add `last_run_age_secs: Option<i64>` to
+`StatusOutput` (matching `DefaultStatusOutput` which already has it). The status command
+handler computes it the same way the default command handler does. Then `render_last_run`
+uses `humanize_duration()` (already exists in voice.rs) when the age is available.
+
+The precise timestamp is still useful for scripts and logs — it remains in the JSON/daemon
+output. Interactive mode shows relative time.
+
+**Fallback:** If `last_run_age_secs` is `None` (shouldn't happen in practice), fall back
+to the ISO timestamp.
+
+**Test strategy:**
+- Test render with age present → "Xh ago (result, duration) [#N]"
+- Test render with age absent → falls back to ISO timestamp
+- Test various age ranges: seconds, minutes, hours, days
+- Test daemon mode → unchanged JSON with `started_at` string
+
+### Change 2: Status summary line enrichment (voice.rs)
+
+Two sub-changes to `render_summary_line`:
+
+**2a. Health part names all absent drives.**
+
+Current: `"2 degraded — WD-18TB1 away for 8 days."` (names one drive)
+
+The `first_reason` variable picks the first health reason from the first non-healthy
+assessment. But multiple drives may be absent. Instead, collect unique drive-related
+reasons and show them all.
+
+New: `"2 degraded — WD-18TB1 away 8d, 2TB-backup away 2d."`
+
+**Implementation:** Replace the `first_reason` single-pick with collecting all unique
+`health_reasons` from degraded assessments, deduplicating (the same drive appears in
+multiple assessments), and joining them.
+
+```rust
+let unique_reasons: Vec<&str> = data.assessments.iter()
+    .filter(|a| a.health != "healthy")
+    .flat_map(|a| a.health_reasons.iter().map(String::as_str))
+    .collect::<std::collections::BTreeSet<_>>()  // dedup + sort
+    .into_iter()
+    .collect();
+```
+
+If there are more than 3 unique reasons, truncate: `"WD-18TB1 away 8d, 2TB-backup
+away 2d, and 1 more"`. This prevents the summary line from growing unbounded.
+
+**2b. Omitted: "All connected drives are sealed" framing.** After re-reading the code,
+the status summary uses "All sealed" deliberately — it's the concise form appropriate
+for the detailed view (the table below provides full context). The bare invocation uses
+the longer form because it's the only text shown. Keeping them different is actually
+correct progressive disclosure: the bare invocation is self-contained, the status summary
+is a table header. No change needed.
+
+**Test strategy:**
+- Test with 2 degraded subvolumes, 2 different drive reasons → both drives named
+- Test with >3 reasons → truncation with "and N more"
+- Test with 1 degraded → single reason shown (current behavior preserved)
+- Test with all healthy → no health part (current behavior preserved)
+
+### Change 3: Rename ext-only to drive-only (voice.rs)
+
+**Current** (voice.rs:261):
+```rust
+"ext-only".dimmed().to_string()
+```
+
+**New:**
+```rust
+"drive-only".dimmed().to_string()
+```
+
+"drive-only" maps to the user's mental model: their data lives on drives, not locally.
+"ext-only" is an internal abbreviation for "external-only" which means nothing to a user
+who thinks in terms of drives, not external/local storage tiers.
+
+The daemon/JSON output uses `ChainHealth` display impl, not this interactive rendering
+path, so JSON output is unchanged.
+
+**Test strategy:**
+- Test status output for external-only subvolume → "drive-only" appears
+- Test no regression for non-external-only subvolumes → "unbroken" / "broken" unchanged
+
+### Change 4: Humanize zero-duration history runs (types.rs)
+
+**Current** (`format_duration_secs`):
+```rust
+if secs < 60 {
+    format!("{secs}s")
+}
+```
+`format_duration_secs(0)` returns `"0s"`.
+
+**New:**
+```rust
+if secs <= 0 {
+    "<1s".to_string()
+} else if secs < 60 {
+    format!("{secs}s")
+}
+```
+
+A 0-second backup means all subvolumes were skipped (nothing to do). `<1s` communicates
+"it ran but there was nothing to do" without looking broken. The `<` prefix is a
+convention users understand from other tools.
+
+Note: `secs <= 0` handles both actual zero and any rounding/clock-skew edge cases that
+produce negative durations.
+
+**Test strategy:**
+- Test `format_duration_secs(0)` → `"<1s"`
+- Test `format_duration_secs(-1)` → `"<1s"` (defensive)
+- Test `format_duration_secs(1)` → `"1s"` (unchanged)
+- Test `format_duration_secs(59)` → `"59s"` (unchanged)
+- Test `format_duration_secs(60)` → `"1m 0s"` (unchanged)
+
+### Change 5: Protection vocabulary — "aging" not "degrading" (voice.rs)
+
+**Current** (`escalated_staleness_text`, line 2599):
+```rust
+"UNPROTECTED" => format!(
+    "{} absent {} — protection degrading",
+    label.bold(), age_str
+),
+```
+
+**New:**
+```rust
+"UNPROTECTED" => format!(
+    "{} absent {} — copies aging",
+    label.bold(), age_str
+),
+```
+
+And the `"PROTECTED"` fallback case (line 2608):
+```rust
+_ => format!("{} away — {}", label.bold(), age_str.dimmed()),
+```
+Currently the `PROTECTED` case just shows duration, which is fine — no vocabulary
+change needed there.
+
+The `"AT RISK"` case says "consider connecting" which is already appropriate.
+
+"Copies aging" conveys drift without urgency. "Degrading" implies active damage.
+The user can't act on an absent drive — the vocabulary should match the action space.
+
+**Test strategy:**
+- Test escalated text for UNPROTECTED → contains "copies aging"
+- Test escalated text for AT RISK → "consider connecting" (unchanged)
+- Test PROTECTED fallback → just age shown (unchanged)
+
+### Change 6: Retention-preview subvolume chooser (commands/retention_preview.rs, voice.rs)
+
+**Current** (retention_preview.rs:29-32):
+```rust
+anyhow::bail!(
+    "specify a subvolume or use --all. Configured subvolumes: {}",
+    names.join(", ")
+);
+```
+
+Produces: `Error: specify a subvolume or use --all. Configured subvolumes: subvol3-opptak, htpc-home, ...`
+
+**New:** Replace the `anyhow::bail!` with a structured error rendered by a new voice
+function:
+
+```rust
+// retention_preview.rs
+let message = voice::format_subvolume_chooser(
+    "urd retention-preview",
+    &names,
+);
+anyhow::bail!("{message}");
+```
+
+```rust
+// voice.rs
+pub fn format_subvolume_chooser(command: &str, names: &[&str]) -> String {
+    let mut out = format!("Usage: {command} <subvolume> or {command} --all\n\n");
+    out.push_str("Available subvolumes:\n");
+    // Render in columns (2-3 columns depending on terminal width,
+    // or just sorted single-column for simplicity)
+    for name in names {
+        writeln!(out, "  {name}").ok();
+    }
+    out
+}
+```
+
+Output:
+```
+Error: Usage: urd retention-preview <subvolume> or urd retention-preview --all
+
+Available subvolumes:
+  htpc-home
+  htpc-root
+  subvol1-docs
+  subvol2-pics
+  subvol3-opptak
+  subvol4-multimedia
+  subvol5-music
+  subvol6-tmp
+  subvol7-containers
+```
+
+Sorted alphabetically. Single-column for simplicity — multi-column adds complexity for
+marginal benefit with 9 items. The function lives in voice.rs because it's presentation,
+and it's reusable by any command that needs a subvolume argument (history --subvolume
+could use it later).
+
+**Test strategy:**
+- Test format output → contains "Usage:", "Available subvolumes:", sorted names
+- Test with single subvolume → still shows list format (consistent)
+- Test that anyhow::bail wraps the message correctly
+
+### Change 7: Drives table Unicode width (voice.rs)
+
+**Current:** The TOKEN column uses `{:<12}` format padding which counts char length,
+not display width. `✓` (U+2713) and `—` (U+2014) are each 1 char but have ambiguous
+display width in many terminal fonts (some render them as 1 cell, some as 2).
+
+**Approach:** Replace Unicode symbols in the TOKEN column with ASCII equivalents that
+have predictable display width:
+
+| Current | New | Reason |
+|---------|-----|--------|
+| `✓` (U+2713) | `ok` | Predictable 2-char width, matches green coloring for context |
+| `✗ mismatch` | `MISMATCH` | Clearer signal |
+| `✗ missing` | `MISSING` | Clearer signal |
+| `—` (U+2014) | `-` | Standard ASCII dash |
+
+This sidesteps the Unicode display width problem entirely. The `unicode-width` crate
+would be a more general solution but adds a dependency for a narrow problem. ASCII
+equivalents are simpler and more portable across terminal emulators.
+
+The status column (`connected`, `absent`, etc.) already uses ASCII words and aligns fine.
+The TOKEN column is the only one with Unicode symbol alignment issues.
+
+**Alternative considered:** Use the `unicode-width` crate. Rejected because: (1) adds a
+dependency, (2) `unicode-width` reports `UnicodeWidthChar` for U+2713 as 1, but some
+CJK-aware terminals render it as 2 — the crate doesn't solve the ambiguous-width problem
+for all terminals. ASCII is the only universally predictable option.
+
+**Test strategy:**
+- Test drives list rendering → TOKEN column uses ASCII text
+- Test alignment with mixed token states → columns align correctly
+- Visual inspection of output with multiple drives
+
+## Module Map
+
+| Module | Changes | Test Strategy |
+|--------|---------|---------------|
+| `voice.rs` | (1) Relative timestamps in render_last_run, (2) Summary enrichment, (3) ext-only → drive-only, (5) Vocabulary, (6) format_subvolume_chooser, (7) Drives ASCII tokens | ~12-15 new tests |
+| `output.rs` | Add `last_run_age_secs: Option<i64>` to `StatusOutput` | Covered by voice tests |
+| `types.rs` | (4) Zero-duration humanization | 3-4 new tests |
+| `commands/status.rs` | Compute `last_run_age_secs` for StatusOutput | Existing command patterns |
+| `commands/retention_preview.rs` | (6) Use format_subvolume_chooser | Existing error test patterns |
+
+## Effort Estimate
+
+~0.5–1 session. Each change is 5-20 lines. No architectural complexity. Comparable to
+UPI 007 (safety gate communication): scattered small changes across voice.rs with
+straightforward test coverage.
+
+## Sequencing
+
+No dependencies between changes — they can be implemented in any order. Suggested order
+by impact:
+
+1. **Change 1 (relative timestamps)** — Most visible improvement, touches the status
+   command output every user sees
+2. **Change 5 (vocabulary)** — One-line change, high polish signal
+3. **Change 4 (zero duration)** — One-line change, removes a confusing edge case
+4. **Change 3 (ext-only rename)** — One-line change, clearer vocabulary
+5. **Change 2 (summary enrichment)** — Medium complexity, improves summary accuracy
+6. **Change 6 (subvolume chooser)** — New function, fixes the worst error message
+7. **Change 7 (drives ASCII tokens)** — Alignment fix, some test adjustment
+
+## Architectural Gates
+
+None. All changes are presentation-layer. No new contracts, no behavioral changes.
+
+The `last_run_age_secs` addition to `StatusOutput` adds a field to the JSON output,
+which is additive and backward-compatible. The existing `started_at` field is unchanged.
+
+## Rejected Alternatives
+
+### Multi-column subvolume list (D1 from brainstorm)
+
+The brainstorm proposed a 3-column layout for the subvolume chooser. Rejected because:
+(1) calculating column widths for terminal width adds complexity, (2) 9 items in a single
+column is perfectly scannable, (3) multi-column layout is harder to parse visually when
+names have variable lengths. Single-column sorted list is cleaner.
+
+### First-row legend (C2 from brainstorm)
+
+Using the first table row to teach the column format ("31 snapshots (10h)") was proposed.
+Rejected because: if the header needs a legend, fix the header. The simpler approach is
+Change 1's model — use language that doesn't need explaining. The `LOCAL` column header
+is fine because the number + age format is self-evident once you see it in context with
+the table structure. Adding `#` to column headers was considered but rejected — it looks
+like a comment marker, not a count indicator.
+
+### History relative timestamps (E5 from brainstorm)
+
+Adding an `AGE` column or relative timestamps to history was proposed. Rejected because:
+(1) history is a log — precise timestamps are appropriate for logs, (2) relative
+timestamps in a list of 10 entries create confusion ("10h" next to "1d" next to "2d" is
+harder to scan than ISO timestamps), (3) the status command already shows last backup age.
+History and status serve different purposes.
+
+### unicode-width crate for drives table (E3 alternative)
+
+Adding the `unicode-width` dependency for proper Unicode width calculation. Rejected
+because: the crate doesn't solve the ambiguous-width problem (U+2713 is width 1 in
+Unicode but width 2 in some terminal fonts). ASCII is the only universally predictable
+solution, and it's simpler.
+
+## Assumptions
+
+1. **`last_run_age_secs` can be computed the same way in status and default commands.**
+   The default status command (`commands/default.rs` or equivalent) already computes this.
+   The status command handler needs to do the same computation. Both use
+   `chrono::Local::now()` and the timestamp from the state DB.
+
+2. **Alphabetical sorting is the right order for the subvolume chooser.** The current
+   comma-separated list uses config order. Alphabetical is more scannable for lookup.
+   If config order is semantically meaningful, this assumption is wrong — but config
+   order is arbitrary (order of `[[subvolumes]]` sections in TOML).
+
+3. **ASCII token symbols won't confuse users expecting Unicode.** The current `✓` for
+   verified tokens is visually distinctive. Replacing with `ok` is less eye-catching but
+   more predictable. The green coloring still provides visual distinction.
+
+4. **"copies aging" is better than "protection degrading."** This is a vocabulary judgment.
+   "Aging" conveys drift; "degrading" conveys damage. Both are accurate. Steve's review
+   specifically flagged "degrading" as too urgent. If users later report that "aging" is
+   too passive, it's a one-line change back.
+
+## Open Questions
+
+### Q1: Should the status summary line name all absent drives, or just count them?
+
+**Option A (names):** `"2 degraded — WD-18TB1 away 8d, 2TB-backup away 2d."`
+**Option B (count):** `"2 degraded — 2 drives absent."`
+
+Option A is more informative but gets long with many drives. Option B is compact but
+loses the drive identity. Leaning toward **Option A with truncation** at 3 drives —
+the summary line should fit on one terminal line (~80 chars).
+
+### Q2: Should `format_subvolume_chooser` be generic enough for other commands?
+
+**Option A (specific):** Function takes a command name and names list. Simple.
+**Option B (generic):** Function takes a template with placeholders for command-specific
+text. Over-engineered for one caller.
+
+Leaning toward **Option A** — `history --subvolume` could call it later with a different
+command name. The function signature `(command: &str, names: &[&str]) -> String` is
+already generic enough.
+
+### Q3: Should the TOKEN column use "ok" or "verified"?
+
+**Option A:** `ok` — short, standard, aligns well
+**Option B:** `verified` — matches the `TokenState::Verified` meaning, more descriptive
+**Option C:** `valid` — shorter than "verified", conveys the same idea
+
+Leaning toward **Option A (`ok`)** — the TOKEN column already has `recorded`, `new`,
+`MISMATCH`, `MISSING` as descriptive states. The verified state just means "nothing wrong"
+which `ok` conveys. Plus it aligns with the `ok`/`warn`/`fail` vocabulary used elsewhere.

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,7 +5,9 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
-| 022 | The Honest Nightly (transient fix + sentinel guard + text fix + config scope) | [design](../95-ideas/2026-04-05-design-022-honest-nightly.md) | [review](../99-reports/2026-04-05-design-review-022-honest-nightly.md) | - | - | - |
+| 024 | The Warm Details (timestamps, vocabulary, alignment, error guidance) | [design](../95-ideas/2026-04-05-design-024-warm-details.md) | - | - | - | - |
+| 023 | The Honest Diagnostic (findings-first verify + doctor trust coherence) | [design](../95-ideas/2026-04-05-design-023-honest-diagnostic.md) | - | - | - | - |
+| 022 | The Honest Nightly (transient fix + sentinel guard + text fix + config scope) | [design](../95-ideas/2026-04-05-design-022-honest-nightly.md) | [review](../99-reports/2026-04-05-design-review-022-honest-nightly.md) | - | merged | [#91](https://github.com/vonrobak/urd/pull/91) |
 | 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | merged | [#84](https://github.com/vonrobak/urd/pull/84) |
 | 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | merged | [#85](https://github.com/vonrobak/urd/pull/85) |
 | 019 | The Honest Worker (token-aware gate + honest results) | [design](../95-ideas/2026-04-04-design-019-honest-worker.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-019-honest-worker.md) | merged | [#83](https://github.com/vonrobak/urd/pull/83) |

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -9,20 +9,21 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-921 tests, all passing, clippy clean. Current version: v0.11.0.
+931 tests, all passing, clippy clean. Current version: v0.11.1.
 
-**Phase E complete.** All six items shipped: sentinel fixes (021), btrfs pipeline (013),
-external-only runtime (018), context-aware suggestions (020), skip unchanged subvolumes (014),
-emergency space response (016). The invisible worker is now smart: compressed sends,
-post-delete sync, generation-based skip, emergency thinning, correct external-only
-presentation, and context-aware suggestions at every invoked surface.
+**v0.11.1 fixes production issues from the first v0.11.0 nightly (run #29):**
+- Transient retention now scoped to mounted drives — absent drives' pins no longer block
+  cleanup, preventing the NVMe space exhaustion pattern
+- Sentinel chain break detection refined (delta-based, reports actual broken count)
+- "local only" skip text replaces misleading "send disabled"
+- Transient snapshot creation skipped when no drives available (defense-in-depth)
 
-**Deployment notes:**
-- v0.10.0 tagged but never deployed — config migration (`local_snapshots = false`) pending
-- v0.11.0 tagged — includes all Phase E features on top of v0.10.0
-- Decision needed: deploy v0.10.0 first (validate migration) or jump to v0.11.0 directly
+**Deployment status:**
+- v0.11.1 tagged and merged — ready to deploy
 - Pre-deploy: hand-edit config `local_retention = "transient"` → `local_snapshots = false`
+- Pre-deploy: add `drives = ["WD-18TB"]` to htpc-root section (scopes to primary drive)
 - Pre-deploy: run `btrfs send --help` as unprivileged user to verify no-sudo probe (013)
+- Install: `cargo install --path .`
 
 ## In Progress
 
@@ -30,9 +31,7 @@ Nothing active.
 
 ## Next Up
 
-**Phase D: Progressive Disclosure + The Encounter** (~6-8 sessions)
-
-1. **Deploy v0.11.0** — validate production, verify emergency and skip-unchanged in live nightly
+1. **Deploy v0.11.1** — install, edit config, watch next nightly for correct behavior
 2. **6-O: Progressive disclosure** (~2 sessions) — framework for The Encounter
 3. **6-H: The Encounter** (~4-6 sessions) — auto-trigger onboarding, Fate Conversation,
    config generation. Targets v1.0.
@@ -46,10 +45,11 @@ Nothing active.
 | Architecture and code conventions | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
+| Latest review | [022 design review](../99-reports/2026-04-05-design-review-022-honest-nightly.md) |
 
 ## Known Issues
 
 - WD-18TB and WD-18TB1 share BTRFS UUID from cloning — needs `btrfstune -u` when offsite drive returns
-- Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" matched as raw strings — consider constants
+- UPI 011 Change 3 (pin self-healing) deferred — orthogonal to 022, still valuable
+- Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" matched as raw strings
 - `compute_health` at 8 params — consider struct grouping in next awareness.rs change
-- Roadmap lists 016-interactive as Phase F — now complete, roadmap should be updated

--- a/docs/99-reports/2026-04-05-steve-jobs-000-polish-before-encounter.md
+++ b/docs/99-reports/2026-04-05-steve-jobs-000-polish-before-encounter.md
@@ -1,0 +1,176 @@
+---
+upi: "000"
+date: 2026-04-05
+mode: vision-filter
+---
+
+# Steve Jobs Review: Presentation Polish and Roadmap Fit
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-05
+**Scope:** Brainstorm (presentation layer polish) + roadmap integration
+**Mode:** Vision Filter
+
+## The Verdict
+
+This brainstorm found the right problems and the right moment to solve them. Urd is
+about to build The Encounter — the first thing a new user sees. Shipping that on top
+of an interface with trust gaps and buried findings would be building a beautiful front
+door on a house with crooked hallways. Polish the hallways first.
+
+## What's Insanely Great
+
+**The brainstorm correctly identified information hierarchy as the core problem.** Not
+styling, not features, not vocabulary — *hierarchy*. The verify and doctor commands have
+the right information; they present it in the wrong order. That's the kind of problem
+that sounds small and is actually fundamental. When you get information hierarchy right,
+everything else clicks. When you get it wrong, no amount of polish on individual elements
+helps.
+
+**The trust coherence theme (B) is the most important insight in the document.** When
+`urd status` says "2 need attention — run `urd doctor`" and doctor says "All clear,"
+that's not a UX annoyance. That's a breach of the tool's implicit promise: "I will tell
+you the truth, and my surfaces will agree." For a backup tool — a tool people trust with
+their data — command coherence isn't nice to have. It's the foundation.
+
+**The brainstorm stays grounded in real architecture.** Every idea names the actual modules
+and functions it touches. That's discipline. Ideas that name `voice.rs` and
+`render_verify_interactive` are ideas that can be designed, reviewed, and built. Ideas
+that say "improve the output" are wishes.
+
+## What's Not Good Enough
+
+**The brainstorm doesn't prioritize ruthlessly enough.** Twenty-five ideas across six
+themes. Half of them are worth doing. Maybe five of them are worth doing *now*. The
+brainstorm should have been harder on itself about what matters before The Encounter and
+what can wait.
+
+Here's the filter I'd apply:
+
+**Must ship before The Encounter (Phase D):**
+- Trust coherence (B1+B2) — a new user who follows breadcrumbs to dead ends will not
+  trust the tool
+- Findings-first hierarchy (A1+A3) — a new user running `urd verify` should see problems
+  first, not 60 lines of "OK"
+- Paper cuts that signal low care (E1, E2) — pluralization bugs and unfulfilled promises
+  are the kind of thing that makes a user question everything else
+
+**Should ship alongside or shortly after The Encounter:**
+- Relative timestamps (C4) — warm, quick, polishes the status command
+- Subvolume chooser (D1) — better error for the one surface that currently dumps on users
+- Status summary enrichment (C3) — all absent drives named, not just the first
+- Protection vocabulary tuning (E4) — "aging" not "degrading"
+
+**Park until after v1.0:**
+- --verbose propagation (D3) — needs semantic design per command, not worth the
+  distraction now
+- Streaming verify (A2) — cool but architecturally expensive for marginal UX gain
+- Health score (F4) — rightfully identified as probably bad for CLI
+- Diagnostic journey (F3) — beautiful vision but belongs in a future where Urd is
+  interactive, not now
+- --explain mode (F2) — belongs with progressive disclosure (6-O), not here
+- History relative timestamps (E5) — nice but low-impact
+
+**Kill:**
+- F4 (health score) — reductive numbers betray the promise model. "Sealed" is better
+  than "94/100" because sealed is a *state*, not a *grade*. Don't grade the user's
+  backup setup.
+- C2 (first-row legend) — too clever. If the column header needs a legend, fix the
+  header. Don't make the first row magic.
+- A5 (generic compression utility) — premature abstraction. Fix verify and doctor
+  specifically. If a pattern emerges, extract it then.
+
+## The Vision
+
+Here's how this fits into the roadmap. The roadmap says:
+
+> **Gate:** Live with v0.11.0 for several days before designing The Encounter.
+
+You've lived with it. You ran the test session. You found the problems. The gate is
+passed — not because everything is perfect, but because you know exactly what isn't.
+
+The question isn't whether to fix these things. It's *when*. And the answer is: before
+The Encounter, not after.
+
+Think about it this way. The Encounter is the moment a new user meets Urd for the first
+time. They run `urd init`, they go through the Fate Conversation, Urd generates their
+config. Then what? They run `urd status`. They run `urd doctor`. They run `urd verify`.
+And if those commands have trust gaps and buried findings and `issue(s)` pluralization,
+the carefully crafted first encounter leads into an uncrafted second encounter.
+
+The original Mac team obsessed over the out-of-box experience. But they *also* obsessed
+over what happened five minutes after the out-of-box experience. The transition from
+"welcome" to "daily use" is where most products lose people. Urd's transition from
+"The Encounter" to "the invoked norn" needs to be seamless.
+
+So here's the sequencing I'd propose:
+
+```
+Current: v0.11.1 deployed, test session complete
+
+Phase D-prep: Presentation Polish              (~1-2 sessions)
+    UPI 023 — Information hierarchy + trust coherence
+    UPI 024 — Paper cuts and warmth
+
+Phase D: Progressive Disclosure + The Encounter (~6-8 sessions)
+    6-O — Progressive disclosure
+    6-H — The Encounter
+```
+
+Phase D-prep is small. It's voice.rs changes, doctor verdict logic, a few rendering
+tweaks. No new modules, no new architecture. But it ensures that when The Encounter
+hands off to the daily-use commands, those commands are worthy of the handoff.
+
+## The Details
+
+**The roadmap needs one line added.** Between "Deploy v0.11.0" (done) and "Phase D:
+Progressive Disclosure + The Encounter," insert a polish phase. Call it what you want —
+"Phase D-prep," "Presentation polish," "The Second Encounter" — but make it explicit
+that the test session findings get addressed before the first-run experience is built.
+
+**F5 (voice as personality layer) is the most interesting parked idea.** Not for now. But
+when The Encounter is built and Urd has contextual communication from progressive
+disclosure (6-O), the idea that the same data renders differently based on context —
+invoked vs. notification vs. glance — is the natural next step for voice.rs. Note it in
+the Horizon section of the roadmap.
+
+**D3 (--verbose) has a hidden dependency on A1.** If verify becomes findings-first with
+`--detail` for the full view, then `--verbose` for verify becomes unnecessary — `--detail`
+*is* verbose. And if status already shows everything, `--verbose` for status is meaningless.
+The semantic question "what does verbose mean per command?" is mostly answered by fixing
+the default hierarchy first. Then you see what's left.
+
+## The Ask
+
+Two design specs. Both are pre-Encounter work. Both are voice.rs-centric.
+
+**Design 1: UPI 023 — "The Honest Diagnostic"**
+
+Scope: A1 (findings-first verify) + A3/A4 (doctor findings separation) + B1/B2 (trust
+coherence) + E2 (fulfill command suggestions).
+
+This is one coherent design because the principle is one: *every diagnostic command leads
+with what matters and agrees with every other command.* The implementation touches
+verify rendering, doctor verdict logic, doctor thread rendering, and status advice text.
+
+Why before The Encounter: A new user running `urd verify` after setup must see "all
+threads intact" or "1 problem found," not 60 lines of per-check output.
+
+**Design 2: UPI 024 — "The Warm Details"**
+
+Scope: C3 (status summary enrichment) + C4 (relative timestamps) + C5 (ext-only rename)
++ C6 (zero-duration humanization) + D1 (subvolume chooser) + E1 (pluralization) + E3
+(Unicode width) + E4 (protection vocabulary).
+
+This is the paper-cuts-and-warmth pass. Each item is small. Together they transform the
+feeling of the tool from "engineered correctly" to "crafted with care." None require
+architectural decisions — they're all rendering changes in voice.rs.
+
+Why before The Encounter: The Encounter will generate a config and then invite the user
+to explore. If `urd status` shows ISO timestamps, `urd retention-preview` dumps subvolume
+names, and `urd drives` has misaligned columns, the crafted welcome dissolves into an
+uncrafted daily experience.
+
+**Order: 023 first, then 024.** The hierarchy and trust fixes are structural — they change
+what users see when they follow the status → doctor → verify diagnostic path. The warmth
+fixes are textural — they polish what's already there. Structure before texture.

--- a/docs/99-reports/2026-04-05-steve-jobs-000-v0111-test-session.md
+++ b/docs/99-reports/2026-04-05-steve-jobs-000-v0111-test-session.md
@@ -1,0 +1,241 @@
+---
+upi: "000"
+date: 2026-04-05
+mode: product-review
+---
+
+# Steve Jobs Review: v0.11.1 Test Session
+
+**Project:** Urd — BTRFS Time Machine for Linux
+**Date:** 2026-04-05
+**Scope:** All human-facing CLI outputs from a live test session of urd v0.11.1
+**Mode:** Product Review
+**Commands reviewed:** bare invocation, status, verify, doctor, doctor --thorough, drives, history, retention-preview (error), drive (typo)
+
+## The Verdict
+
+Urd is a backup tool that genuinely respects the person using it. The bare invocation
+alone — three lines that tell you whether your data is safe — is better than anything
+I've seen from any backup tool on any platform. But it's not done. Several surfaces still
+speak engineer, not user. And the tool has a habit that will hurt it: it answers questions
+the user didn't ask while making them work to get the answer they wanted.
+
+## What's Insanely Great
+
+**The bare invocation is a masterpiece of information hierarchy.**
+
+```
+All connected drives are sealed. 2 degraded. Last backup 10h ago.
+2 subvolumes need attention — run `urd status` for details.
+```
+
+Three lines. In those three lines, I know: my data is safe, two things need attention but
+aren't urgent, and my last backup was recent. Then it tells me exactly what to do next.
+This is what every backup tool should do and none of them do. Time Machine buries this
+behind a GUI. Restic doesn't even have a concept of "are you safe." Borg makes you ask
+five different questions to get one answer. Urd gives you the answer before you ask.
+
+**The vocabulary is exactly right.** "Sealed," "degraded," "exposed," "waning," "unbroken" —
+these words carry weight without being theatrical. They don't explain, they *communicate*.
+When I read "sealed," I feel something that "PROTECTED" never gave me. When I see "waning,"
+I understand the trajectory without needing a number. This is the mythic voice working
+exactly as intended — in the vocabulary choices, not in dramatic prose.
+
+**The status table is dense and honest.** Nine subvolumes, their snapshot counts, ages,
+thread health — all in a compact table that doesn't waste a character. The `(10h)` and
+`(1d)` age markers are perfect: they tell you the age of the *newest* snapshot without
+cluttering the view. The thread column — `unbroken`, `ext-only` — is the kind of detail
+that rewards the user who looks closer.
+
+**The TTY/pipe split is good design instinct.** Interactive gets the human voice, pipes get
+JSON. This is the correct separation. Most tools get this wrong — they either pipe ANSI
+codes into files or dumb down the TTY output. Urd respects both audiences.
+
+**`urd doctor` is calm and comprehensive.** The checklist format — Config, Infrastructure,
+Data Safety, Sentinel — tells you what was checked, not just what failed. "All clear" at
+the end is reassuring in a way that no output at all never is. The `--thorough` flag is
+progressive disclosure done right: the casual check gives you the summary, the deep check
+gives you everything.
+
+## What's Not Good Enough
+
+**The `urd status` summary line drops the "drives are sealed" framing.**
+
+The bare invocation says: `All connected drives are sealed.`
+The status command says: `All sealed. 2 degraded — WD-18TB1 away for 8 days.`
+
+"All sealed" without context is weaker than "All connected drives are sealed." The status
+command is the one place where the user deliberately asked "how am I doing?" — give them
+the full sentence. Moreover, "2 degraded — WD-18TB1 away for 8 days" is good, but it only
+names one drive while two are absent (WD-18TB1 and 2TB-backup). The drive summary below
+covers both, but the summary line creates an incomplete first impression.
+
+**The status table numbers are opaque.**
+
+```
+sealed    degraded  subvol3-opptak      31 (10h)  7 (1d)   unbroken
+```
+
+What does 31 mean? Snapshot count. What does 7 mean? Snapshot count on the drive. But
+nowhere does the table say this. A new user sees `31 (10h)` under `LOCAL` and has to
+*guess* that 31 is a count and 10h is an age. The column headers should be enough to decode
+any row. `LOCAL` is not enough. `SNAPSHOTS` or even `LOCAL (count/age)` would make this
+self-documenting. The numbers are useful — the framing makes them mysterious.
+
+**`urd verify` is too verbose for the common case.**
+
+When 6 of 7 subvolumes have identical results (all OK on WD-18TB, two drives not mounted),
+the output is 60+ lines of repetition to surface one actual finding (htpc-root's broken
+chain). The verify command should lead with what matters:
+
+```
+htpc-root/WD-18TB: Chain broken — pinned snapshot missing locally.
+  Next send will be full.
+
+6 subvolumes verified clean. 2 drives not mounted (WD-18TB1, 2TB-backup).
+```
+
+The detailed per-subvolume output should be behind a `--verbose` or `--detail` flag. The
+user ran verify because they want to know if something is wrong, not to read 34 lines of
+"OK."
+
+**`doctor --thorough` buries its one real finding.**
+
+```
+    ✗ htpc-root/WD-18TB: Pinned snapshot missing locally...
+```
+
+This line — the only actual problem — appears on line 13 of 15, buried under 12 identical
+"Drive not mounted — skipping" warnings. The user already knows those drives aren't mounted.
+The thorough check should separate *findings* from *expected conditions*. A drive being
+absent is a known state, not a finding. The broken chain is a finding. Don't make me read
+past 12 non-events to find the one event that matters.
+
+**`retention-preview` error is a wall of text.**
+
+```
+Error: specify a subvolume or use --all. Configured subvolumes: subvol3-opptak,
+htpc-home, subvol2-pics, subvol1-docs, subvol7-containers, subvol5-music,
+subvol4-multimedia, subvol6-tmp, htpc-root
+```
+
+This is a dump, not guidance. Nine subvolume names in a comma-separated list on one line.
+The error should show the right usage pattern first, then list the names in a scannable
+format:
+
+```
+Usage: urd retention-preview <subvolume> or urd retention-preview --all
+
+Available subvolumes:
+  subvol1-docs        subvol3-opptak      subvol5-music
+  subvol2-pics        subvol4-multimedia  subvol6-tmp
+  subvol7-containers  htpc-home           htpc-root
+```
+
+**`--verbose` doesn't exist, but users expect it.** Both `urd status --verbose` and
+`urd plan --verbose` failed with clap's generic "unexpected argument" error. A tool this
+thoughtful about UX should either support `--verbose` (even as an alias for existing detail
+flags) or give a helpful error: "Try `urd status` — it already shows the detail view."
+
+**`doctor` says "All clear" but `status` says "2 subvolumes need attention."** These are
+not contradictory if you understand that "All clear" means infrastructure is fine and
+"need attention" means degraded drive state. But the user doesn't know that. They ran
+`doctor` because `status` told them to, and `doctor` said everything is fine. This is a
+trust gap. Either `doctor` should acknowledge the degradation that `status` surfaced, or
+the status advice text should say `urd doctor --thorough` instead of just `urd doctor`.
+
+**`1 issue(s).` in doctor --thorough.** Don't pluralize with parenthetical `(s)`. Either
+write `1 issue` or `3 issues`. This is a small thing that signals low attention to detail
+in a tool that otherwise demonstrates exceptionally high attention to detail. The contrast
+makes it worse, not better.
+
+## The Vision
+
+Here's what Urd is becoming, and it's rare: a tool that makes invisible infrastructure
+feel *known*. Not monitored — known. The difference is the same as the difference between
+a security camera and a trusted friend watching your house. Both detect problems. One makes
+you feel surveilled, the other makes you feel safe.
+
+The bare invocation is the proof of concept for this vision. In three lines, it transforms
+"do I need to worry about backups?" from a question that requires expertise into one that
+requires reading a sentence. That's the transformation.
+
+Where it needs to go next: that same clarity needs to flow through every surface.
+`verify` should be as scannable as `status`. `doctor` should answer the question `status`
+raised, not a different question. The error messages should guide with the same confidence
+that the success messages inform.
+
+And the vocabulary — sealed, waning, exposed, unbroken — this is genuinely distinctive.
+No other backup tool has a vocabulary that carries emotional weight while remaining
+technically precise. Protect this. Don't let it get diluted by falling back to generic
+terms in new features.
+
+## The Details
+
+1. **"Last backup 10h ago" vs "Last backup: 2026-04-05T04:01:11"** — The bare invocation
+   uses the relative "10h ago" (perfect). The status command uses an ISO timestamp
+   (functional but cold). Status should lead with the relative time and append the
+   timestamp: `Last backup: 10h ago (04:01, success) [#29]`. Nobody's first question is
+   "what ISO 8601 timestamp was my last backup?"
+
+2. **`sealed_count()` says "9 of 9 sealed"** but it renders as "All sealed" — good. But if
+   it were 8 of 9, it would say "8 of 9 sealed" which sounds like a test score, not a
+   warning. Consider: "8 sealed. 1 exposed." — lead with the good news, name the problem.
+
+3. **`ext-only` in the thread column** — what does this mean? It's technically accurate
+   (htpc-root has no local snapshots, only external). But a user seeing `ext-only` next to
+   a `sealed / healthy` row has no idea if this is good, bad, or neutral. Consider
+   `drive-only` or even `—` with the explanation in the drive summary section.
+
+4. **Drives table alignment** — `TOKEN` column has `✓` for WD-18TB but `—` and
+   `recorded` for the others. The visual alignment breaks slightly because the checkmark
+   character and the em-dash have different widths. This is the kind of detail that
+   matters at 2am.
+
+5. **History table: `0s` duration for run #20** — what does a 0-second backup mean? It
+   probably means nothing needed doing (all skipped). But "0s" reads as "broken." Consider
+   `<1s` or `—` with a tooltip concept, or append `(no-op)` when duration rounds to zero.
+
+6. **"Run suggested commands to resolve"** at the end of `doctor --thorough` — but it
+   didn't suggest any commands. The chain break message says what's wrong but not what to
+   do. Either suggest the command (`urd backup` to trigger a full send) or don't promise
+   suggested commands.
+
+7. **The `urd drive` typo recovery** is clap's built-in "tip: a similar subcommand exists:
+   'drives'" — functional but impersonal. Since Urd has a voice, consider intercepting
+   this: `Did you mean 'urd drives'?` — one line, no boilerplate.
+
+8. **"protection degrading"** in the drives section of status — degrading implies an
+   active process, which is accurate (copies are getting staler). But "protection
+   degrading" reads like something is *happening right now* that the user should stop.
+   Consider "protection aging" or simply "stale" — conveys drift without urgency that
+   can't be acted on (the user can't teleport the drive home).
+
+## The Ask
+
+1. **Fix the verify/doctor information hierarchy.** This is the most impactful change.
+   Both commands bury findings under noise. Lead with what's wrong. Summarize what's fine.
+   Put the detail behind a flag. This is the `urd status` principle applied to diagnostics.
+
+2. **Reconcile doctor and status.** When status says "run doctor for details," doctor must
+   surface those details. The trust gap between "2 need attention" → "All clear" will
+   erode user confidence.
+
+3. **Add `--verbose` as an alias** for whatever the existing detail flag is, or give a
+   helpful redirect. Users will try it — don't punish them with a generic clap error.
+
+4. **Fix the `1 issue(s)` pluralization** and the "Run suggested commands" promise that
+   isn't fulfilled. These are 10-minute fixes that remove paper cuts.
+
+5. **Humanize the status timestamp.** Lead with relative time, append the exact time.
+   The bare invocation already knows the right format — extend that instinct to status.
+
+6. **Improve the retention-preview error.** Format the subvolume list as a scannable
+   column layout with a usage example above it.
+
+7. **Consider a `--quiet` mode for verify** (or make the current output the `--verbose`
+   mode and the summary the default). Nine subvolumes × three drives × five checks is a
+   lot of output for "one thing is wrong."
+
+8. **Add column hints to the status table** so the numbers are self-documenting. This
+   doesn't need to be verbose — `LOCAL` → `LOCAL #` or a footnote line below the table.


### PR DESCRIPTION
## Summary

- Bump four dependencies to current versions: rusqlite 0.32→0.39, toml 0.8→1.x, nix 0.29→0.31, colored 2→3
- Add source documentation (`docs/00-foundation/source-documentation/`) covering API migration notes for each dependency and Rust 2024 edition
- Add UPI 023 (honest diagnostic) and UPI 024 (warm details) designs from presentation layer polish session
- Add brainstorm and Steve reviews for presentation layer polish
- Update status.md to v0.11.1 state, registry.md with new UPIs and 022 completion

## Testing

- Documentation and dependency lock changes only — no Rust source modified
- cargo clippy: not applicable
- cargo test: not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)