### PR TITLE
feat: findings-first verify, doctor trust gap fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Findings-first verify: `urd verify` now shows problems first and collapses OK checks into a summary; `--detail` restores verbose output
+- Doctor trust gap fix: `urd doctor` no longer says "All clear" when degraded subvolumes exist — shows "N subvolumes degraded. Data is safe — drives are absent."
+- Doctor `--thorough` threads section separates findings from expected conditions (absent drives collapsed into summary line)
+- Actionable suggestions on verify chain-break findings (`suggestion` field on verify checks)
+
+### Changed
+- Doctor verdict text uses proper pluralization and removes misleading "Run suggested commands to resolve"
+
 ## [0.11.1] - 2026-04-05
 
 ### Fixed

--- a/docs/95-ideas/2026-04-05-design-023-honest-diagnostic.md
+++ b/docs/95-ideas/2026-04-05-design-023-honest-diagnostic.md
@@ -279,7 +279,8 @@ DoctorVerdictStatus::Warnings => {
 | `cli.rs` | Add `--detail` flag to `VerifyArgs` | Existing clap test patterns |
 | `commands/verify.rs` | Pass `detail` flag through to voice | Minimal — rendering tested via voice |
 | `commands/doctor.rs` | Count degraded subvolumes, new verdict branch | Test verdict computation with various health combinations |
-| `output.rs` | Add `DoctorVerdictStatus::Degraded` variant | Derive coverage (Serialize) |
+| `output.rs` | Add `DoctorVerdictStatus::Degraded` variant, add `suggestion: Option<String>` to `VerifyCheck` | Derive coverage (Serialize) |
+| `commands/verify.rs` | Set `suggestion` on chain-break checks, pass `detail` flag through | Test suggestion text set correctly |
 | `voice.rs` | (1) Findings-first verify, (2) Doctor thorough findings separation, (3) Degraded verdict rendering, (4) Pluralization + verdict text | Bulk of tests — ~15-20 new tests |
 
 ## Effort Estimate
@@ -408,3 +409,40 @@ Option B is more informative but requires the verdict to carry drive-level detai
 currently only in the Data Safety section. Leaning toward **Option A** for the verdict
 line — the Data Safety section already shows the specifics, and the user will see them
 in the output above the verdict.
+
+## Resolved Decisions (grill-me, 2026-04-05)
+
+### R1: Degraded verdict is the anchor
+Add `DoctorVerdictStatus::Degraded` variant. This is the highest-impact change — it
+closes the trust gap where doctor says "All clear" while status says "2 need attention."
+Additive enum change, no ADR needed. Homelab stack consumes Prometheus, not doctor JSON.
+
+### R2: Status advice stays as "urd doctor"
+Do NOT change the advice text to `urd doctor --thorough`. With the degraded verdict (R1),
+plain `urd doctor` now answers the question status raised. Sending every user to
+`--thorough` by default undermines progressive disclosure. Users can discover `--thorough`
+when they want to drill deeper.
+
+### R3: detail as parameter
+`render_verify(data, mode, detail: bool)` — Option A from Q1. Single caller cares about
+the flag (verify command handler). Doctor doesn't call `render_verify` at all (it reads
+`data.verify` directly). Simplest approach, no new public API surface.
+
+### R4: Classification in voice.rs
+Expected-condition classification (`"drive-mounted"` warnings → collapsed summary) stays
+in voice.rs, not output.rs. This is a rendering judgment — which warnings deserve visual
+prominence depends on presentation context. The `"drive-mounted"` string coupling between
+verify.rs and voice.rs is acceptable; both are in-project.
+
+### R5: Generic degraded verdict
+Verdict line: `"2 subvolumes degraded. Data is safe — drives are absent."` — count and
+reassurance only. Drive-specific details are already shown in the Data Safety section
+above the verdict. No drive-level data threaded into verdict computation.
+
+### R6: suggestion field on VerifyCheck
+Add `suggestion: Option<String>` to `VerifyCheck` in output.rs. Verify.rs sets it at the
+source (e.g., chain-break → "Run `urd backup` when ready"). Voice.rs renders if present.
+This replaces the design's original approach of pattern-matching on "Chain broken" in
+detail strings — that was brittle and embedded domain logic in the rendering layer. This
+is a second output.rs change (alongside the Degraded variant), but it's a small additive
+field that respects module boundaries.

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -6,7 +6,7 @@
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
 | 024 | The Warm Details (timestamps, vocabulary, alignment, error guidance) | [design](../95-ideas/2026-04-05-design-024-warm-details.md) | - | - | - | - |
-| 023 | The Honest Diagnostic (findings-first verify + doctor trust coherence) | [design](../95-ideas/2026-04-05-design-023-honest-diagnostic.md) | - | - | - | - |
+| 023 | The Honest Diagnostic (findings-first verify + doctor trust coherence) | [design](../95-ideas/2026-04-05-design-023-honest-diagnostic.md) | - | [adversary](../99-reports/2026-04-05-review-adversary-023-honest-diagnostic.md) | - | - |
 | 022 | The Honest Nightly (transient fix + sentinel guard + text fix + config scope) | [design](../95-ideas/2026-04-05-design-022-honest-nightly.md) | [review](../99-reports/2026-04-05-design-review-022-honest-nightly.md) | - | merged | [#91](https://github.com/vonrobak/urd/pull/91) |
 | 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | merged | [#84](https://github.com/vonrobak/urd/pull/84) |
 | 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | merged | [#85](https://github.com/vonrobak/urd/pull/85) |

--- a/docs/96-project-supervisor/roadmap.md
+++ b/docs/96-project-supervisor/roadmap.md
@@ -23,25 +23,38 @@ Phase E delivered: sentinel config reload (021), compressed sends + post-delete 
 external-only runtime (018), context-aware suggestions (020), skip unchanged subvolumes (014),
 emergency space response with both automatic pre-flight and interactive `urd emergency` (016).
 
-## Active Arc: Deploy → The Encounter → v1.0
+## Active Arc: Deploy → Polish → The Encounter → v1.0
 
-**Goal:** Deploy v0.11.0, validate in production, then build the first-encounter experience.
-Two phases remain before v1.0.
+**Goal:** Deploy v0.11.1, polish the invoked surfaces based on production experience,
+then build the first-encounter experience. Three phases remain before v1.0.
 
-### Deploy v0.11.0
+### Deploy v0.11.1 ✓
 
-v0.10.0 was tagged but never deployed. v0.11.0 includes all Phase E features on top.
-Deploy directly to v0.11.0 — the config migration path is the same.
+v0.11.1 deployed and running. Includes all Phase E features plus production fixes
+from the first v0.11.0 nightly (run #29).
 
-**Pre-deploy checklist:**
-- Hand-edit config: `local_retention = "transient"` → `local_snapshots = false`
-- Verify: `btrfs send --help` as unprivileged user (compressed-data probe, 013)
-- Install: `cargo install --path .`
-- First nightly: watch for skip-unchanged `[SAME]` tags, emergency pre-flight (if space low)
-- First sentinel tick: expect one-time HealthRecovered for htpc-root
+**Gate:** Live with v0.11.1 for several days before building polish or designing
+The Encounter. The designs must be informed by real nightly logs, real doctor output,
+real sentinel behavior.
 
-**Gate:** Live with v0.11.0 for several days before designing The Encounter. The design
-must be informed by real nightly logs, real doctor output, real sentinel behavior.
+### Phase D-0: Presentation Polish (023, 024)
+
+```
+023 — The Honest Diagnostic            (~1-2 sessions)
+    Findings-first verify, doctor trust coherence, collapsed noise
+    Design: docs/95-ideas/2026-04-05-design-023-honest-diagnostic.md
+
+024 — The Warm Details                  (~1-2 sessions)
+    Relative timestamps, vocabulary, alignment, error guidance
+    Design: docs/95-ideas/2026-04-05-design-024-warm-details.md
+```
+
+**Rationale:** The Encounter is the first-run experience — if `urd status` shows cold
+timestamps and `urd doctor` contradicts `urd status`, trust breaks in the first five
+minutes. Polish the invoked surfaces before building onboarding on top of them.
+
+**Gate:** After D-0, every invoked surface (status, verify, doctor, history) should feel
+crafted. Then The Encounter builds on surfaces the team trusts.
 
 ### Phase D: Progressive Disclosure + The Encounter
 

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -11,19 +11,12 @@
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
 931 tests, all passing, clippy clean. Current version: v0.11.1.
 
-**v0.11.1 fixes production issues from the first v0.11.0 nightly (run #29):**
+**v0.11.1 deployed and running.** Fixes production issues from the first v0.11.0 nightly:
 - Transient retention now scoped to mounted drives — absent drives' pins no longer block
   cleanup, preventing the NVMe space exhaustion pattern
 - Sentinel chain break detection refined (delta-based, reports actual broken count)
 - "local only" skip text replaces misleading "send disabled"
 - Transient snapshot creation skipped when no drives available (defense-in-depth)
-
-**Deployment status:**
-- v0.11.1 tagged and merged — ready to deploy
-- Pre-deploy: hand-edit config `local_retention = "transient"` → `local_snapshots = false`
-- Pre-deploy: add `drives = ["WD-18TB"]` to htpc-root section (scopes to primary drive)
-- Pre-deploy: run `btrfs send --help` as unprivileged user to verify no-sudo probe (013)
-- Install: `cargo install --path .`
 
 ## In Progress
 
@@ -31,9 +24,12 @@ Nothing active.
 
 ## Next Up
 
-1. **Deploy v0.11.1** — install, edit config, watch next nightly for correct behavior
-2. **6-O: Progressive disclosure** (~2 sessions) — framework for The Encounter
-3. **6-H: The Encounter** (~4-6 sessions) — auto-trigger onboarding, Fate Conversation,
+1. **023: The Honest Diagnostic** (~1-2 sessions) — findings-first verify, doctor trust
+   coherence, collapsed noise. Pure presentation changes.
+2. **024: The Warm Details** (~1-2 sessions) — relative timestamps, vocabulary, alignment,
+   error guidance. Pure voice.rs/output.rs changes.
+3. **6-O: Progressive disclosure** (~2 sessions) — framework for The Encounter
+4. **6-H: The Encounter** (~4-6 sessions) — auto-trigger onboarding, Fate Conversation,
    config generation. Targets v1.0.
 
 ## Key Links

--- a/docs/99-reports/2026-04-05-review-adversary-023-honest-diagnostic.md
+++ b/docs/99-reports/2026-04-05-review-adversary-023-honest-diagnostic.md
@@ -1,0 +1,184 @@
+---
+upi: "023"
+date: 2026-04-05
+---
+
+# Adversary Review: UPI 023 — The Honest Diagnostic
+
+**Project:** Urd  
+**Date:** 2026-04-05  
+**Scope:** Implementation plan at `.claude/plans/compiled-dazzling-flute.md`, design doc at
+`docs/95-ideas/2026-04-05-design-023-honest-diagnostic.md`  
+**Mode:** Design review (plan, pre-implementation)  
+**Commit:** b1db859 (master)
+
+---
+
+## Executive Summary
+
+A well-scoped presentation-layer fix with one subtle verdict-interaction bug that needs
+resolving before implementation. The trust gap fix (Degraded verdict) is the right call
+and the highest-value change. The findings-first verify and doctor threads rewrite are
+clean presentation work that respects module boundaries. One finding (Significant) about
+the `--thorough` interaction with `degraded_count` needs a design decision.
+
+## What Kills You
+
+**Catastrophic failure mode for Urd:** Silent data loss — deleting snapshots that shouldn't
+be deleted.
+
+**Distance from this plan:** Very far. This is purely presentation-layer work. No code in
+this plan touches retention, pin files, btrfs commands, or the executor. The plan explicitly
+changes no behavior — only how existing data is rendered. The closest proximity is indirect:
+if the degraded verdict gave false reassurance ("Data is safe") when data *isn't* safe, a
+user might not act. But the plan only applies "Data is safe" to Protected subvolumes, which
+by definition have data on at least one external drive. The promise model is correct here.
+
+## Scorecard
+
+| # | Dimension | Score | Rationale |
+|---|-----------|-------|-----------|
+| 1 | Correctness | 4 | One verdict-interaction edge case (F1); otherwise solid |
+| 2 | Security | 5 | No security surface — presentation only, no sudo, no paths |
+| 3 | Architectural Excellence | 4 | Respects module boundaries (R4, R6); clean output.rs/voice.rs separation |
+| 4 | Systems Design | 4 | Handles daemon mode correctly; JSON backward-compatible |
+
+## Design Tensions
+
+### T1: Verdict precedence hierarchy (errors > warnings > degraded > healthy)
+
+The plan places `Degraded` below `Warnings` in the verdict hierarchy. This means that
+when `--thorough` is used and verify finds any warnings (including `drive-mounted` warnings),
+those warnings mask the degraded verdict. This is a conscious trade-off: warnings and errors
+represent actionable problems, while degraded is informational. The hierarchy is correct in
+principle — but the interaction with `drive-mounted` warnings specifically is problematic
+(see F1).
+
+### T2: Classification in voice.rs vs. output.rs (R4 vs. R6)
+
+The plan correctly puts expected-condition classification in voice.rs (rendering judgment)
+while putting suggestions in output.rs (domain knowledge). This is the right split — the
+same check might be an expected condition in one context but not another, while the
+suggestion for a chain break is always "run backup."
+
+## Findings
+
+### F1: `--thorough` drive-mounted warnings mask degraded verdict [Significant]
+
+**What:** When `urd doctor --thorough` runs, verify's `warn_count` (which includes
+`drive-mounted` warnings for absent drives) gets added to doctor's `warn_count` at
+line 238. The verdict cascade is `errors > warnings > degraded > healthy`. So with
+2 absent drives and 2 degraded subvolumes, the user gets `"14 warnings."` instead of
+`"2 subvolumes degraded."` The warnings are the *same absent drives* causing the
+degradation — the verdict double-counts the condition.
+
+**Consequence:** The exact scenario that motivated this design (user runs doctor,
+gets a non-answer) partially recurs with `--thorough`. Plain `urd doctor` works
+correctly (no verify, no drive-mounted warnings). But `--thorough` users get a
+warning count that obscures the degraded message.
+
+**Suggested fix:** Two options:
+
+**Option A (simple):** When computing the verdict, subtract verify's drive-mounted
+warning count from `warn_count` before the cascade. This prevents expected conditions
+from masking degraded status:
+```rust
+// After verify count accumulation
+let verify_expected_warns = verify_output.as_ref().map_or(0, |v| {
+    v.subvolumes.iter().flat_map(|sv| &sv.drives)
+        .flat_map(|d| &d.checks)
+        .filter(|c| c.name == "drive-mounted" && c.status == "warn")
+        .count()
+});
+let effective_warn_count = warn_count - verify_expected_warns;
+```
+Then use `effective_warn_count` in the verdict cascade.
+
+**Option B (defer):** Accept this as a known limitation. Plain `urd doctor` (which R2
+directs users toward) works correctly. Document that `--thorough` may show a higher
+warning count that includes expected conditions from verify.
+
+**Recommendation:** Option B for this implementation. The fix in Option A puts
+classification logic in doctor.rs (the same `drive-mounted` string matching), which
+muddies the module boundary. The `--thorough` interaction is a real but secondary issue
+— the primary trust gap (plain doctor) is fully resolved. Revisit if users report
+confusion.
+
+### F2: Verify summary line counts could drift from VerifyOutput totals [Moderate]
+
+**What:** The findings-first renderer in Step 3e computes its own counts by iterating
+checks (findings vs. expected conditions), then renders `"N subvolumes verified, M
+checks OK."` using `data.ok_count`. But `data.ok_count` was computed in verify.rs and
+includes all OK checks regardless of classification. The summary line uses this total
+alongside a separately-computed absent-drive count.
+
+**Consequence:** No actual bug — `ok_count` is correct regardless of classification.
+But the two counting paths (verify.rs totals vs. voice.rs classification) create a
+maintenance coupling. If a new expected-condition type is added (not just drive-mounted),
+the summary's arithmetic could become confusing: "34 checks OK, 2 drives skipped" when
+the total checks were 37 (34 OK + 2 drive-mounted + 1 fail) — the user might wonder
+where the missing check went.
+
+**Suggested fix:** Note this in a code comment where the summary line is rendered:
+`// ok_count is the verify.rs total; it doesn't include drive-mounted warnings.`
+No code change needed — just documentation of the relationship.
+
+### F3: Commendation — R6 (suggestion field on VerifyCheck)
+
+The grill-me session's pivot from string-matching ("Chain broken" in detail text) to a
+structured `suggestion` field is the right call. It respects the module boundary table:
+verify.rs knows the domain (what's broken, what fixes it), voice.rs knows the
+presentation (how to render it). This is exactly how output.rs is supposed to work —
+structured data in, rendering decisions out. The original design's approach would have
+embedded verify's domain vocabulary into voice.rs as a stringly-typed contract.
+
+### F4: Commendation — Sequencing
+
+Shipping the trust gap fix (Step 1) first means the highest-value change lands with the
+smallest diff. If implementation runs long or gets interrupted, the most important fix
+is already in. The dependency ordering (Step 2 needs Step 1's Degraded variant, Step 4
+reuses Step 3's classification pattern) is correct and well-reasoned.
+
+### F5: Commendation — "What NOT to Change" section
+
+Explicitly listing what stays unchanged (R2: status advice text, daemon paths, no new
+modules) prevents scope creep during implementation. This is particularly valuable for
+a presentation-layer change where it's tempting to "fix one more thing while we're here."
+
+## The Simplicity Question
+
+**What could be removed?** Nothing. The plan is already lean — four focused changes in
+five files, no new modules, no new abstractions beyond a `pluralize()` helper. The
+rejected alternatives (interactive doctor, generic compression utility, streaming output)
+were all correctly rejected for adding machinery this doesn't need.
+
+**What's earning its keep?** The `suggestion` field on VerifyCheck (R6) earns its keep
+immediately — it eliminates string matching and enables the doctor Threads section to
+render suggestions without domain knowledge. The `--detail` flag earns its keep by
+preserving the current verbose output for debugging without cluttering the default view.
+
+## For the Dev Team
+
+Priority-ordered action items:
+
+1. **Decide on F1 (--thorough masking).** Before implementing Step 1, decide whether to
+   accept Option B (document the limitation) or implement Option A (subtract expected
+   warnings). Recommendation: Option B — ship the primary fix, revisit if it matters in
+   practice. Add a code comment at the verdict block noting the known interaction.
+
+2. **Implement as sequenced.** Steps 1→2→3→4. No reordering needed. Each step has a
+   clean checkpoint.
+
+3. **Step 3 mechanical updates.** The `suggestion: None` addition to ~16 VerifyCheck sites
+   is tedious but the compiler catches all of them. Don't try to be clever — just add the
+   field and move on.
+
+4. **Step 3f test decision.** The existing `verify_interactive_shows_checks` test asserts
+   on `"OK"` text which won't appear in findings-first mode. The plan offers two options
+   (switch to `detail: true` or rewrite assertions). Recommend: switch to `detail: true` —
+   the test's intent is "all check statuses render," which is what detail mode tests.
+
+## Open Questions
+
+1. **F1 decision:** Accept the `--thorough` masking as a known limitation (Option B), or
+   fix it now (Option A)? This is the only finding that needs a decision before implementation.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -231,6 +231,10 @@ pub struct VerifyArgs {
     /// Only verify against this drive
     #[arg(long)]
     pub drive: Option<String>,
+
+    /// Show every check, not just findings
+    #[arg(long)]
+    pub detail: bool,
 }
 
 #[cfg(test)]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -228,6 +228,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         let verify_args = VerifyArgs {
             subvolume: None,
             drive: None,
+            detail: false,
         };
         Some(verify::collect_verify_output(&config, &verify_args))
     } else {
@@ -240,10 +241,21 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     }
 
     // ── 6. Verdict ────────────────────────────────────────────────
+    let degraded_count = data_safety
+        .iter()
+        .filter(|d| d.status == "PROTECTED" && d.health != "healthy")
+        .count();
+
+    // NOTE: When --thorough is used, verify's drive-mounted warnings inflate warn_count.
+    // This can mask the Degraded verdict when absent drives are the only issue.
+    // Accepted trade-off: plain `urd doctor` (where status directs users) works correctly.
+    // The --thorough path may show Warnings instead of Degraded in this scenario.
     let verdict = if error_count > 0 {
         DoctorVerdict::issues(error_count)
     } else if warn_count > 0 {
         DoctorVerdict::warnings(warn_count)
+    } else if degraded_count > 0 {
+        DoctorVerdict::degraded(degraded_count)
     } else {
         DoctorVerdict::healthy()
     };

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -11,7 +11,7 @@ use crate::voice;
 pub fn run(config: Config, args: VerifyArgs, mode: OutputMode) -> anyhow::Result<()> {
     let data = collect_verify_output(&config, &args);
 
-    print!("{}", voice::render_verify(&data, mode));
+    print!("{}", voice::render_verify(&data, mode, args.detail));
 
     if data.fail_count > 0 {
         std::process::exit(1);
@@ -58,6 +58,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                                      Unsent snapshot protection is disabled \u{2014} retention may delete snapshots not yet on all drives",
                                     pinned.len(),
                                 )),
+                                suggestion: None,
                             }],
                         }],
                     });
@@ -86,9 +87,10 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
 
             if !drives::is_drive_mounted(drive) {
                 checks.push(VerifyCheck {
-                    name: "drive-mounted".to_string(),
+                    name: VerifyCheck::DRIVE_MOUNTED.to_string(),
                     status: "warn".to_string(),
                     detail: Some("Drive not mounted \u{2014} skipping".to_string()),
+                    suggestion: None,
                 });
                 total_warn += 1;
                 sv_drives.push(VerifyDrive {
@@ -112,6 +114,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                         name: "pin-file".to_string(),
                         status: "ok".to_string(),
                         detail: Some(format!("Pin: {pin_label}")),
+                        suggestion: None,
                     });
                     total_ok += 1;
 
@@ -122,6 +125,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                             name: "pin-exists-local".to_string(),
                             status: "ok".to_string(),
                             detail: Some("Exists locally".to_string()),
+                            suggestion: None,
                         });
                         total_ok += 1;
                     } else if is_legacy {
@@ -131,6 +135,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                             detail: Some(format!(
                                 "Pinned snapshot missing locally: {pin} (legacy pin \u{2014} may not apply to this drive)"
                             )),
+                            suggestion: None,
                         });
                         total_warn += 1;
                     } else {
@@ -140,6 +145,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                             detail: Some(format!(
                                 "Pinned snapshot missing locally: {pin} \u{2014} Chain broken \u{2014} next send will be full"
                             )),
+                            suggestion: Some("Run `urd backup` when drive is connected.".to_string()),
                         });
                         total_fail += 1;
                     }
@@ -152,6 +158,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                             name: "pin-exists-drive".to_string(),
                             status: "ok".to_string(),
                             detail: Some("Exists on drive".to_string()),
+                            suggestion: None,
                         });
                         total_ok += 1;
                     } else if is_legacy {
@@ -161,6 +168,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                             detail: Some(format!(
                                 "Pinned snapshot not on this drive: {pin} (legacy pin \u{2014} run urd backup to establish drive-specific chain)"
                             )),
+                            suggestion: None,
                         });
                         total_warn += 1;
                     } else {
@@ -170,6 +178,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                             detail: Some(format!(
                                 "Pinned snapshot missing from drive: {pin} \u{2014} Chain broken \u{2014} next send will be full"
                             )),
+                            suggestion: Some("Run `urd backup` when drive is connected.".to_string()),
                         });
                         total_fail += 1;
                     }
@@ -210,6 +219,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                                 "No pin file, but {ext_count} snapshot(s) on drive \u{2014} \
                                  Next send will be full \u{2014} consider running urd backup to establish chain"
                             )),
+                            suggestion: None,
                         });
                         total_warn += 1;
                     } else {
@@ -217,6 +227,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                             name: "pin-file".to_string(),
                             status: "ok".to_string(),
                             detail: Some("No pin file (no snapshots on drive)".to_string()),
+                            suggestion: None,
                         });
                         total_ok += 1;
                     }
@@ -226,6 +237,7 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                         name: "pin-file".to_string(),
                         status: "fail".to_string(),
                         detail: Some(format!("Pin file error: {e}")),
+                        suggestion: None,
                     });
                     total_fail += 1;
                 }
@@ -281,6 +293,7 @@ fn collect_orphan_checks(
             name: "orphans".to_string(),
             status: "ok".to_string(),
             detail: Some("No orphaned snapshots on drive".to_string()),
+            suggestion: None,
         });
         *total_ok += 1;
     } else {
@@ -291,6 +304,7 @@ fn collect_orphan_checks(
                 detail: Some(format!(
                     "Orphaned snapshot on drive: {orphan} (newer than pin, possibly from interrupted send)"
                 )),
+                suggestion: None,
             });
         }
         *total_warn += orphans.len() as u32;
@@ -326,6 +340,7 @@ fn collect_stale_pin_check(
             detail: Some(format!(
                 "Pin file is {days} day(s) old (threshold: {threshold_str}) \u{2014} last successful send was {days} day(s) ago"
             )),
+            suggestion: None,
         });
         *total_warn += 1;
     } else {
@@ -333,6 +348,7 @@ fn collect_stale_pin_check(
             name: "stale-pin".to_string(),
             status: "ok".to_string(),
             detail: Some("Pin file age OK".to_string()),
+            suggestion: None,
         });
         *total_ok += 1;
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -506,6 +506,7 @@ pub enum DoctorVerdictStatus {
     Healthy,
     Warnings,
     Issues,
+    Degraded,
 }
 
 impl DoctorVerdict {
@@ -522,6 +523,11 @@ impl DoctorVerdict {
     #[must_use]
     pub fn issues(count: usize) -> Self {
         Self { status: DoctorVerdictStatus::Issues, count }
+    }
+
+    #[must_use]
+    pub fn degraded(count: usize) -> Self {
+        Self { status: DoctorVerdictStatus::Degraded, count }
     }
 }
 
@@ -1005,6 +1011,19 @@ pub struct VerifyCheck {
     pub name: String,
     pub status: String,
     pub detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggestion: Option<String>,
+}
+
+impl VerifyCheck {
+    /// Check name for absent-drive warnings — used by voice.rs to classify expected conditions.
+    pub const DRIVE_MOUNTED: &str = "drive-mounted";
+
+    /// Returns true if this check is an expected condition (absent drive), not a real finding.
+    #[must_use]
+    pub fn is_expected_condition(&self) -> bool {
+        self.name == Self::DRIVE_MOUNTED && self.status == "warn"
+    }
 }
 
 // ── Init output ─────────────────────────────────────────────────────────

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -18,7 +18,7 @@ use crate::output::{
     FailuresOutput, GetOutput, HistoryOutput, InitOutput, InitStatus, OutputMode, PlanOutput,
     PreActionSummary, RecoveryWindow, RedundancyAdvisoryKind, RetentionPreviewOutput,
     SentinelStatusOutput, SkipCategory, SkippedSubvolume, StatusAssessment, StatusOutput,
-    SubvolumeHistoryOutput, TokenState, VerifyOutput, parse_duration_to_minutes,
+    SubvolumeHistoryOutput, TokenState, VerifyCheck, VerifyOutput, parse_duration_to_minutes,
 };
 use crate::plan::format_duration_short;
 use crate::types::{ByteSize, DriveRole};
@@ -1594,16 +1594,24 @@ fn render_calibrate_interactive(data: &CalibrateOutput) -> String {
 
 /// Render verify output according to the given mode.
 #[must_use]
-pub fn render_verify(data: &VerifyOutput, mode: OutputMode) -> String {
+pub fn render_verify(data: &VerifyOutput, mode: OutputMode, detail: bool) -> String {
     match mode {
-        OutputMode::Interactive => render_verify_interactive(data),
+        OutputMode::Interactive => render_verify_interactive(data, detail),
         OutputMode::Daemon => {
             serde_json::to_string_pretty(data).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
         }
     }
 }
 
-fn render_verify_interactive(data: &VerifyOutput) -> String {
+fn render_verify_interactive(data: &VerifyOutput, detail: bool) -> String {
+    if detail {
+        return render_verify_detail(data);
+    }
+    render_verify_findings_first(data)
+}
+
+/// Detail mode: every check for every subvolume/drive (original verbose output).
+fn render_verify_detail(data: &VerifyOutput) -> String {
     let mut out = String::new();
 
     for sv in &data.subvolumes {
@@ -1627,35 +1635,96 @@ fn render_verify_interactive(data: &VerifyOutput) -> String {
         writeln!(out).ok();
     }
 
+    render_verify_tail(data, &mut out);
+    out
+}
+
+/// Findings-first mode: problems first, noise collapsed.
+fn render_verify_findings_first(data: &VerifyOutput) -> String {
+    let mut out = String::new();
+
+    let (findings, absent_drives) = classify_verify_checks(data);
+
+    // Render findings grouped by subvolume/drive
+    if findings.is_empty() {
+        writeln!(
+            out,
+            "{}",
+            format!(
+                "All threads intact. {} verified, {} OK.",
+                pluralize(data.subvolumes.len(), "subvolume", "subvolumes"),
+                pluralize(data.ok_count as usize, "check", "checks")
+            )
+            .green()
+            .bold()
+        )
+        .ok();
+    } else {
+        for (sv_name, drive_label, check) in &findings {
+            let status_str = match check.status.as_str() {
+                "warn" => format!("{}  ", "WARN".yellow()),
+                "fail" => format!("{}  ", "FAIL".red()),
+                other => format!("{other:<6}"),
+            };
+            let detail = check.detail.as_deref().unwrap_or(&check.name);
+            writeln!(out, "{sv_name}/{drive_label}:").ok();
+            writeln!(out, "  {status_str}{detail}").ok();
+            if let Some(ref suggestion) = check.suggestion {
+                writeln!(out, "  \u{2192} {suggestion}").ok();
+            }
+            writeln!(out).ok();
+        }
+
+        // ok_count from verify.rs includes all OK checks; drive-mounted
+        // warnings are counted separately in the absent-drives line below.
+        writeln!(
+            out,
+            "{}",
+            format!(
+                "{} verified, {} OK.",
+                pluralize(data.subvolumes.len(), "subvolume", "subvolumes"),
+                pluralize(data.ok_count as usize, "check", "checks")
+            )
+            .dimmed()
+        )
+        .ok();
+    }
+
+    // Absent drives summary
+    if !absent_drives.is_empty() {
+        writeln!(
+            out,
+            "{}",
+            format!(
+                "{} not mounted ({}) \u{2014} skipped.",
+                pluralize(absent_drives.len(), "drive", "drives"),
+                absent_drives.join(", ")
+            )
+            .dimmed()
+        )
+        .ok();
+    }
+
+    render_verify_tail(data, &mut out);
+    out
+}
+
+/// Shared tail: preflight warnings + next-action suggestion.
+fn render_verify_tail(data: &VerifyOutput, out: &mut String) {
     // Preflight warnings
     if !data.preflight_warnings.is_empty() {
+        writeln!(out).ok();
         writeln!(out, "{}", "Config consistency:".bold()).ok();
         for warning in &data.preflight_warnings {
             writeln!(out, "  {} {}", "WARN".yellow(), warning).ok();
         }
-        writeln!(out).ok();
     }
 
-    // Summary
-    let summary = format!(
-        "Verify complete: {} OK, {} warnings, {} failures",
-        data.ok_count, data.warn_count, data.fail_count
-    );
-    if data.fail_count > 0 {
-        writeln!(out, "{}", summary.red().bold()).ok();
-    } else if data.warn_count > 0 {
-        writeln!(out, "{}", summary.yellow().bold()).ok();
-    } else {
-        writeln!(out, "{}", summary.green().bold()).ok();
-    }
-
-    // ── Next-action suggestion ──────────────────────────────────────
+    // Next-action suggestion
     append_suggestion(
         &SuggestionContext::Verify { has_broken: data.fail_count > 0 },
-        &mut out,
+        out,
     );
-
-    out
 }
 
 // ── Init ────────────────────────────────────────────────────────────────
@@ -2246,28 +2315,38 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
             )
             .ok();
         } else {
-            for sv in &verify.subvolumes {
-                for drive in &sv.drives {
-                    for check in &drive.checks {
-                        let icon = match check.status.as_str() {
-                            "ok" => "\u{2713}".green().to_string(),
-                            "warn" => "\u{26a0}".yellow().to_string(),
-                            _ => "\u{2717}".red().to_string(),
-                        };
-                        let detail = check
-                            .detail
-                            .as_deref()
-                            .unwrap_or(&check.name);
-                        if check.status != "ok" {
-                            writeln!(
-                                out,
-                                "    {icon} {}/{}: {detail}",
-                                sv.name, drive.label
-                            )
-                            .ok();
-                        }
-                    }
+            let (findings, absent_drives) = classify_verify_checks(verify);
+
+            // Render findings
+            for (sv_name, drive_label, check) in &findings {
+                let icon = match check.status.as_str() {
+                    "warn" => "\u{26a0}".yellow().to_string(),
+                    _ => "\u{2717}".red().to_string(),
+                };
+                let detail = check.detail.as_deref().unwrap_or(&check.name);
+                writeln!(out, "    {icon} {sv_name}/{drive_label}: {detail}").ok();
+                if let Some(ref suggestion) = check.suggestion {
+                    writeln!(out, "      \u{2192} {suggestion}").ok();
                 }
+            }
+
+            // Summary line
+            let mut summary_parts = Vec::new();
+            if verify.ok_count > 0 {
+                summary_parts.push(format!(
+                    "{} OK",
+                    pluralize(verify.ok_count as usize, "check", "checks")
+                ));
+            }
+            if !absent_drives.is_empty() {
+                summary_parts.push(format!(
+                    "{} not mounted ({}) \u{2014} skipped",
+                    pluralize(absent_drives.len(), "drive", "drives"),
+                    absent_drives.join(", ")
+                ));
+            }
+            if !summary_parts.is_empty() {
+                writeln!(out, "    {}", summary_parts.join(". ").dimmed()).ok();
             }
         }
     } else {
@@ -2289,8 +2368,7 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
             writeln!(
                 out,
                 "{}",
-                format!("{} warning(s). Run suggested commands to resolve.", data.verdict.count)
-                    .yellow()
+                format!("{}.", pluralize(data.verdict.count, "warning", "warnings")).yellow()
             )
             .ok();
         }
@@ -2298,8 +2376,19 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
             writeln!(
                 out,
                 "{}",
-                format!("{} issue(s). Run suggested commands to resolve.", data.verdict.count)
-                    .red()
+                format!("{} found.", pluralize(data.verdict.count, "issue", "issues")).red()
+            )
+            .ok();
+        }
+        DoctorVerdictStatus::Degraded => {
+            writeln!(
+                out,
+                "{}",
+                format!(
+                    "{} degraded. Data is safe \u{2014} drives are absent.",
+                    pluralize(data.verdict.count, "subvolume", "subvolumes")
+                )
+                .yellow()
             )
             .ok();
         }
@@ -2309,6 +2398,41 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
     append_suggestion(&SuggestionContext::Doctor, &mut out);
 
     out
+}
+
+/// Classify verify checks into findings (real problems) and expected conditions (absent drives).
+fn classify_verify_checks(
+    verify: &VerifyOutput,
+) -> (Vec<(&str, &str, &VerifyCheck)>, Vec<&str>) {
+    let mut findings: Vec<(&str, &str, &VerifyCheck)> = Vec::new();
+    let mut absent_drives: Vec<&str> = Vec::new();
+
+    for sv in &verify.subvolumes {
+        for drive in &sv.drives {
+            for check in &drive.checks {
+                if check.status == "ok" {
+                    continue;
+                }
+                if check.is_expected_condition() {
+                    if !absent_drives.contains(&drive.label.as_str()) {
+                        absent_drives.push(&drive.label);
+                    }
+                } else {
+                    findings.push((&sv.name, &drive.label, check));
+                }
+            }
+        }
+    }
+
+    (findings, absent_drives)
+}
+
+fn pluralize(count: usize, singular: &str, plural: &str) -> String {
+    if count == 1 {
+        format!("{count} {singular}")
+    } else {
+        format!("{count} {plural}")
+    }
 }
 
 fn render_doctor_check_section(out: &mut String, title: &str, checks: &[DoctorCheck]) {
@@ -4578,7 +4702,7 @@ mod tests {
     // ── Verify tests ────────────────────────────────────────────────────
 
     #[test]
-    fn verify_interactive_shows_checks() {
+    fn verify_detail_shows_all_checks() {
         let data = VerifyOutput {
             subvolumes: vec![VerifySubvolume {
                 name: "htpc-home".to_string(),
@@ -4589,11 +4713,13 @@ mod tests {
                             name: "pin-file".to_string(),
                             status: "ok".to_string(),
                             detail: Some("Pin: 20260325-0400-home".to_string()),
+                            suggestion: None,
                         },
                         VerifyCheck {
                             name: "pin-exists-local".to_string(),
                             status: "fail".to_string(),
                             detail: Some("Pinned snapshot missing locally".to_string()),
+                            suggestion: None,
                         },
                     ],
                 }],
@@ -4603,11 +4729,10 @@ mod tests {
             warn_count: 0,
             fail_count: 1,
         };
-        let output = render_verify(&data, OutputMode::Interactive);
+        let output = render_verify(&data, OutputMode::Interactive, true);
         assert!(output.contains("htpc-home"), "missing subvolume");
         assert!(output.contains("OK"), "missing ok check");
         assert!(output.contains("FAIL"), "missing fail check");
-        assert!(output.contains("1 failures"), "missing failure count");
     }
 
     #[test]
@@ -4619,8 +4744,177 @@ mod tests {
             warn_count: 0,
             fail_count: 0,
         };
-        let output = render_verify(&data, OutputMode::Daemon);
+        let output = render_verify(&data, OutputMode::Daemon, false);
         let _: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+    }
+
+    #[test]
+    fn verify_findings_first_all_clean() {
+        colored::control::set_override(false);
+        let data = VerifyOutput {
+            subvolumes: vec![VerifySubvolume {
+                name: "htpc-home".to_string(),
+                drives: vec![VerifyDrive {
+                    label: "WD-18TB".to_string(),
+                    checks: vec![VerifyCheck {
+                        name: "pin-file".to_string(),
+                        status: "ok".to_string(),
+                        detail: Some("Pin: 20260325-0400-home".to_string()),
+                        suggestion: None,
+                    }],
+                }],
+            }],
+            preflight_warnings: vec![],
+            ok_count: 1,
+            warn_count: 0,
+            fail_count: 0,
+        };
+        let output = render_verify(&data, OutputMode::Interactive, false);
+        assert!(
+            output.contains("All threads intact"),
+            "missing all-clean message: {output}"
+        );
+    }
+
+    #[test]
+    fn verify_findings_first_one_failure() {
+        colored::control::set_override(false);
+        let data = VerifyOutput {
+            subvolumes: vec![VerifySubvolume {
+                name: "htpc-home".to_string(),
+                drives: vec![VerifyDrive {
+                    label: "WD-18TB".to_string(),
+                    checks: vec![
+                        VerifyCheck {
+                            name: "pin-file".to_string(),
+                            status: "ok".to_string(),
+                            detail: Some("Pin: 20260325-0400-home".to_string()),
+                            suggestion: None,
+                        },
+                        VerifyCheck {
+                            name: "pin-exists-local".to_string(),
+                            status: "fail".to_string(),
+                            detail: Some("Pinned snapshot missing locally".to_string()),
+                            suggestion: Some("Run `urd backup` when drive is connected.".to_string()),
+                        },
+                    ],
+                }],
+            }],
+            preflight_warnings: vec![],
+            ok_count: 1,
+            warn_count: 0,
+            fail_count: 1,
+        };
+        let output = render_verify(&data, OutputMode::Interactive, false);
+        assert!(
+            output.contains("htpc-home/WD-18TB"),
+            "missing subvol/drive grouping: {output}"
+        );
+        assert!(
+            output.contains("FAIL"),
+            "missing failure indicator: {output}"
+        );
+        assert!(
+            output.contains("1 check OK"),
+            "missing OK summary: {output}"
+        );
+        assert!(
+            !output.contains("All threads intact"),
+            "should not show all-clean: {output}"
+        );
+    }
+
+    #[test]
+    fn verify_findings_first_absent_drives_collapsed() {
+        colored::control::set_override(false);
+        let data = VerifyOutput {
+            subvolumes: vec![VerifySubvolume {
+                name: "htpc-home".to_string(),
+                drives: vec![
+                    VerifyDrive {
+                        label: "WD-18TB1".to_string(),
+                        checks: vec![VerifyCheck {
+                            name: "drive-mounted".to_string(),
+                            status: "warn".to_string(),
+                            detail: Some("Drive not mounted".to_string()),
+                            suggestion: None,
+                        }],
+                    },
+                    VerifyDrive {
+                        label: "2TB-backup".to_string(),
+                        checks: vec![VerifyCheck {
+                            name: "drive-mounted".to_string(),
+                            status: "warn".to_string(),
+                            detail: Some("Drive not mounted".to_string()),
+                            suggestion: None,
+                        }],
+                    },
+                ],
+            }],
+            preflight_warnings: vec![],
+            ok_count: 0,
+            warn_count: 2,
+            fail_count: 0,
+        };
+        let output = render_verify(&data, OutputMode::Interactive, false);
+        assert!(
+            output.contains("2 drives not mounted"),
+            "missing absent drives summary: {output}"
+        );
+        assert!(
+            output.contains("WD-18TB1"),
+            "missing drive label: {output}"
+        );
+        assert!(
+            output.contains("2TB-backup"),
+            "missing drive label: {output}"
+        );
+        assert!(
+            !output.contains("WARN"),
+            "should not show individual warnings: {output}"
+        );
+    }
+
+    #[test]
+    fn verify_findings_first_suggestion_rendered() {
+        colored::control::set_override(false);
+        let data = VerifyOutput {
+            subvolumes: vec![VerifySubvolume {
+                name: "htpc-root".to_string(),
+                drives: vec![VerifyDrive {
+                    label: "WD-18TB".to_string(),
+                    checks: vec![VerifyCheck {
+                        name: "pin-exists-local".to_string(),
+                        status: "fail".to_string(),
+                        detail: Some("Chain broken".to_string()),
+                        suggestion: Some("Run `urd backup` when drive is connected.".to_string()),
+                    }],
+                }],
+            }],
+            preflight_warnings: vec![],
+            ok_count: 0,
+            warn_count: 0,
+            fail_count: 1,
+        };
+        let output = render_verify(&data, OutputMode::Interactive, false);
+        assert!(
+            output.contains("\u{2192} Run `urd backup`"),
+            "missing suggestion: {output}"
+        );
+    }
+
+    #[test]
+    fn verify_daemon_ignores_detail() {
+        let data = VerifyOutput {
+            subvolumes: vec![],
+            preflight_warnings: vec![],
+            ok_count: 0,
+            warn_count: 0,
+            fail_count: 0,
+        };
+        let output_false = render_verify(&data, OutputMode::Daemon, false);
+        let output_true = render_verify(&data, OutputMode::Daemon, true);
+        assert_eq!(output_false, output_true, "daemon mode should ignore detail flag");
     }
 
     // ── Init tests ─────────────────────────────────────────────────────
@@ -5387,6 +5681,177 @@ mod tests {
     }
 
     #[test]
+    fn doctor_thorough_findings_separated() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.verify = Some(VerifyOutput {
+            subvolumes: vec![VerifySubvolume {
+                name: "htpc-root".to_string(),
+                drives: vec![
+                    VerifyDrive {
+                        label: "WD-18TB".to_string(),
+                        checks: vec![VerifyCheck {
+                            name: "pin-exists-local".to_string(),
+                            status: "fail".to_string(),
+                            detail: Some("Chain broken".to_string()),
+                            suggestion: Some(
+                                "Run `urd backup` when drive is connected.".to_string(),
+                            ),
+                        }],
+                    },
+                    VerifyDrive {
+                        label: "WD-18TB1".to_string(),
+                        checks: vec![VerifyCheck {
+                            name: "drive-mounted".to_string(),
+                            status: "warn".to_string(),
+                            detail: Some("Drive not mounted".to_string()),
+                            suggestion: None,
+                        }],
+                    },
+                ],
+            }],
+            preflight_warnings: vec![],
+            ok_count: 3,
+            warn_count: 1,
+            fail_count: 1,
+        });
+        data.verdict = DoctorVerdict::issues(1);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        // Finding should be shown
+        assert!(
+            output.contains("htpc-root/WD-18TB"),
+            "missing finding: {output}"
+        );
+        assert!(
+            output.contains("Chain broken"),
+            "missing detail: {output}"
+        );
+        // Suggestion should be shown
+        assert!(
+            output.contains("\u{2192} Run `urd backup`"),
+            "missing suggestion: {output}"
+        );
+        // Absent drive should be in summary, not as individual warning
+        assert!(
+            output.contains("1 drive not mounted (WD-18TB1)"),
+            "missing absent drives summary: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_only_absent_drives() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.verify = Some(VerifyOutput {
+            subvolumes: vec![VerifySubvolume {
+                name: "htpc-home".to_string(),
+                drives: vec![
+                    VerifyDrive {
+                        label: "WD-18TB1".to_string(),
+                        checks: vec![VerifyCheck {
+                            name: "drive-mounted".to_string(),
+                            status: "warn".to_string(),
+                            detail: Some("Drive not mounted".to_string()),
+                            suggestion: None,
+                        }],
+                    },
+                    VerifyDrive {
+                        label: "2TB-backup".to_string(),
+                        checks: vec![VerifyCheck {
+                            name: "drive-mounted".to_string(),
+                            status: "warn".to_string(),
+                            detail: Some("Drive not mounted".to_string()),
+                            suggestion: None,
+                        }],
+                    },
+                ],
+            }],
+            preflight_warnings: vec![],
+            ok_count: 5,
+            warn_count: 2,
+            fail_count: 0,
+        });
+        data.verdict = DoctorVerdict::warnings(2);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        // Should show summary line with drive names, not individual warnings with icons
+        assert!(
+            output.contains("2 drives not mounted"),
+            "missing absent drives summary: {output}"
+        );
+        assert!(
+            output.contains("5 checks OK"),
+            "missing OK count: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_all_clean_unchanged() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.verify = Some(VerifyOutput {
+            subvolumes: vec![],
+            preflight_warnings: vec![],
+            ok_count: 35,
+            warn_count: 0,
+            fail_count: 0,
+        });
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("All threads intact"),
+            "missing all-clean message: {output}"
+        );
+        assert!(
+            output.contains("35 checks OK"),
+            "missing check count: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_absent_drives_deduped() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.verify = Some(VerifyOutput {
+            subvolumes: vec![
+                VerifySubvolume {
+                    name: "htpc-home".to_string(),
+                    drives: vec![VerifyDrive {
+                        label: "WD-18TB1".to_string(),
+                        checks: vec![VerifyCheck {
+                            name: "drive-mounted".to_string(),
+                            status: "warn".to_string(),
+                            detail: Some("Drive not mounted".to_string()),
+                            suggestion: None,
+                        }],
+                    }],
+                },
+                VerifySubvolume {
+                    name: "htpc-docs".to_string(),
+                    drives: vec![VerifyDrive {
+                        label: "WD-18TB1".to_string(),
+                        checks: vec![VerifyCheck {
+                            name: "drive-mounted".to_string(),
+                            status: "warn".to_string(),
+                            detail: Some("Drive not mounted".to_string()),
+                            suggestion: None,
+                        }],
+                    }],
+                },
+            ],
+            preflight_warnings: vec![],
+            ok_count: 0,
+            warn_count: 2,
+            fail_count: 0,
+        });
+        data.verdict = DoctorVerdict::warnings(2);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        // Same drive across two subvolumes should appear once
+        assert!(
+            output.contains("1 drive not mounted (WD-18TB1)"),
+            "drive should be deduped: {output}"
+        );
+    }
+
+    #[test]
     fn doctor_verdict_healthy() {
         let v = serde_json::to_value(&DoctorVerdict::healthy()).unwrap();
         assert_eq!(v["status"], "healthy");
@@ -5405,6 +5870,105 @@ mod tests {
         let v = serde_json::to_value(&DoctorVerdict::issues(2)).unwrap();
         assert_eq!(v["status"], "issues");
         assert_eq!(v["count"], 2);
+    }
+
+    #[test]
+    fn doctor_verdict_degraded() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.data_safety[0].health = "degraded".to_string();
+        data.data_safety[1].health = "degraded".to_string();
+        data.verdict = DoctorVerdict::degraded(2);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("2 subvolumes degraded"),
+            "missing degraded verdict: {output}"
+        );
+        assert!(
+            output.contains("Data is safe"),
+            "missing reassurance: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_verdict_degraded_singular() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.data_safety[0].health = "degraded".to_string();
+        data.verdict = DoctorVerdict::degraded(1);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("1 subvolume degraded"),
+            "should use singular: {output}"
+        );
+        assert!(
+            !output.contains("subvolumes degraded"),
+            "should not use plural form in verdict: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_verdict_errors_override_degraded() {
+        let v = serde_json::to_value(&DoctorVerdict::issues(1)).unwrap();
+        assert_eq!(v["status"], "issues", "errors should take precedence over degraded");
+    }
+
+    #[test]
+    fn doctor_verdict_warnings_override_degraded() {
+        let v = serde_json::to_value(&DoctorVerdict::warnings(1)).unwrap();
+        assert_eq!(v["status"], "warnings", "warnings should take precedence over degraded");
+    }
+
+    #[test]
+    fn doctor_verdict_degraded_json() {
+        let v = serde_json::to_value(&DoctorVerdict::degraded(2)).unwrap();
+        assert_eq!(v["status"], "degraded");
+        assert_eq!(v["count"], 2);
+    }
+
+    #[test]
+    fn doctor_verdict_singular_issue() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.data_safety[0].status = "UNPROTECTED".to_string();
+        data.data_safety[0].health = "blocked".to_string();
+        data.data_safety[0].issue = Some("exposed".to_string());
+        data.verdict = DoctorVerdict::issues(1);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("1 issue found."),
+            "should use singular: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_verdict_plural_warnings() {
+        colored::control::set_override(false);
+        let mut data = test_doctor_healthy();
+        data.verdict = DoctorVerdict::warnings(2);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("2 warnings."),
+            "should use plural: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_verdict_no_run_suggested_text() {
+        colored::control::set_override(false);
+        for verdict in [
+            DoctorVerdict::warnings(1),
+            DoctorVerdict::issues(1),
+            DoctorVerdict::degraded(1),
+        ] {
+            let mut data = test_doctor_healthy();
+            data.verdict = verdict;
+            let output = render_doctor(&data, OutputMode::Interactive);
+            assert!(
+                !output.contains("Run suggested commands"),
+                "verdict should not contain 'Run suggested commands': {output}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Findings-first verify**: `urd verify` now shows problems first, collapses OK checks into a summary line, and folds absent-drive warnings into a compact footer. `--detail` flag restores the original verbose output.
- **Doctor trust gap fix**: New `DoctorVerdictStatus::Degraded` variant — doctor no longer says "All clear" when degraded subvolumes are present. Verdict now shows "N subvolumes degraded. Data is safe — drives are absent."
- **Doctor --thorough threads separation**: Threads section separates real findings from expected conditions (absent drives), with suggestion lines and a collapsed summary.
- **Verdict polish**: Proper pluralization, removed misleading "Run suggested commands to resolve" text, `suggestion` field on `VerifyCheck` set at source.

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 948 tests, all passing (+12 new)
- Integration tests: not applicable (presentation-layer changes only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)