### PR TITLE
feat: warm details — relative timestamps, vocabulary, alignment, guided errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Doctor trust gap fix: `urd doctor` no longer says "All clear" when degraded subvolumes exist — shows "N subvolumes degraded. Data is safe — drives are absent."
 - Doctor `--thorough` threads section separates findings from expected conditions (absent drives collapsed into summary line)
 - Actionable suggestions on verify chain-break findings (`suggestion` field on verify checks)
+- Relative timestamps in `urd status` — "10h ago" instead of raw ISO 8601
+- Status summary line now names all absent drives (up to 3, then "and N more")
+- Guided subvolume chooser for `urd retention-preview` — sorted list with usage hint instead of comma-separated error dump
 
 ### Changed
 - Doctor verdict text uses proper pluralization and removes misleading "Run suggested commands to resolve"
+- "ext-only" thread label renamed to "drive-only" for clarity
+- "protection degrading" vocabulary replaced with "protection aging" for absent drives
+- Zero-duration history runs show "<1s" instead of "0s"
+- Drives table TOKEN column uses ASCII text (ok/MISMATCH/MISSING) instead of Unicode symbols for portable alignment
 
 ## [0.11.1] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-04-05
+
 ### Added
 - Findings-first verify: `urd verify` now shows problems first and collapses OK checks into a summary; `--detail` restores verbose output
 - Doctor trust gap fix: `urd doctor` no longer says "All clear" when degraded subvolumes exist — shows "N subvolumes degraded. Data is safe — drives are absent."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "MIT"

--- a/docs/95-ideas/2026-04-05-design-024-warm-details.md
+++ b/docs/95-ideas/2026-04-05-design-024-warm-details.md
@@ -200,7 +200,7 @@ produce negative durations.
 **New:**
 ```rust
 "UNPROTECTED" => format!(
-    "{} absent {} — copies aging",
+    "{} absent {} — protection aging",
     label.bold(), age_str
 ),
 ```
@@ -214,11 +214,11 @@ change needed there.
 
 The `"AT RISK"` case says "consider connecting" which is already appropriate.
 
-"Copies aging" conveys drift without urgency. "Degrading" implies active damage.
+"Protection aging" conveys drift without urgency. "Degrading" implies active damage.
 The user can't act on an absent drive — the vocabulary should match the action space.
 
 **Test strategy:**
-- Test escalated text for UNPROTECTED → contains "copies aging"
+- Test escalated text for UNPROTECTED → contains "protection aging"
 - Test escalated text for AT RISK → "consider connecting" (unchanged)
 - Test PROTECTED fallback → just age shown (unchanged)
 
@@ -440,3 +440,49 @@ already generic enough.
 Leaning toward **Option A (`ok`)** — the TOKEN column already has `recorded`, `new`,
 `MISMATCH`, `MISSING` as descriptive states. The verified state just means "nothing wrong"
 which `ok` conveys. Plus it aligns with the `ok`/`warn`/`fail` vocabulary used elsewhere.
+
+## Resolved Decisions
+
+Resolved during `/grill-me` session (2026-04-05). These decisions are authoritative for
+`/prepare`.
+
+### R1: `last_run_age_secs` placement → `StatusOutput`
+
+Add `last_run_age_secs: Option<i64>` to `StatusOutput`, computed by the status command
+handler. Mirrors the existing pattern in `DefaultStatusOutput`. Additive JSON field —
+backward-compatible. The stable `started_at` field remains for consumers who want absolute
+time; the age field is convenience.
+
+### R2: Health reason dedup → string-based `BTreeSet`
+
+String-based dedup on raw reason strings is correct and sufficient. `awareness.rs` computes
+all assessments from the same `now` timestamp, so identical drives produce identical age
+strings across assessments. No need for a more complex dedup key.
+
+### R3: Vocabulary → "protection aging"
+
+Replace "protection degrading" with "protection aging" for UNPROTECTED absent drives.
+Stays in the same semantic domain as the current text, swaps the alarming verb for one
+that conveys drift without urgency. "Copies aging" was rejected — "copies" is not part of
+Urd's established vocabulary.
+
+### R4: TOKEN column → `ok` / `MISMATCH` / `MISSING` / `-`
+
+Replace Unicode symbols with ASCII: `✓` → `ok`, `✗ mismatch` → `MISMATCH`,
+`✗ missing` → `MISSING`, `—` → `-`. Lowercase for normal states, UPPERCASE for anomalies
+— the case contrast provides strong visual anomaly detection. `ok` is preferred over
+`verified` (shorter, doesn't widen every row for the normal case).
+
+### R5: Summary truncation threshold → 3 named drives
+
+Name up to 3 absent drives in the summary line, then "and N more". Threshold of 3 fits
+~80 columns. Urd should scale to diverse drive setups (network mounts, cloud targets,
+many drives) — building for this future is intentional. The important characteristic is
+identifying primary external and offsite targets per subvolume.
+
+### R6: Open questions Q1–Q3 resolved
+
+- **Q1 (summary line names vs counts):** Option A with truncation — name drives, cap at 3.
+- **Q2 (format_subvolume_chooser genericity):** Option A — specific signature
+  `(command: &str, names: &[&str])` is already generic enough for reuse.
+- **Q3 (TOKEN column text):** Option A — `ok`.

--- a/docs/96-project-supervisor/registry.md
+++ b/docs/96-project-supervisor/registry.md
@@ -5,8 +5,8 @@
 
 | UPI | Title | Design | Design Review | Adversary Review | PR | GH# |
 |-----|-------|--------|---------------|------------------|----|-----|
-| 024 | The Warm Details (timestamps, vocabulary, alignment, error guidance) | [design](../95-ideas/2026-04-05-design-024-warm-details.md) | - | - | - | - |
-| 023 | The Honest Diagnostic (findings-first verify + doctor trust coherence) | [design](../95-ideas/2026-04-05-design-023-honest-diagnostic.md) | - | [adversary](../99-reports/2026-04-05-review-adversary-023-honest-diagnostic.md) | - | - |
+| 024 | The Warm Details (timestamps, vocabulary, alignment, error guidance) | [design](../95-ideas/2026-04-05-design-024-warm-details.md) | - | [adversary](../99-reports/2026-04-05-design-review-024-warm-details.md) | - | - |
+| 023 | The Honest Diagnostic (findings-first verify + doctor trust coherence) | [design](../95-ideas/2026-04-05-design-023-honest-diagnostic.md) | - | [adversary](../99-reports/2026-04-05-review-adversary-023-honest-diagnostic.md) | merged | [#93](https://github.com/vonrobak/urd/pull/93) |
 | 022 | The Honest Nightly (transient fix + sentinel guard + text fix + config scope) | [design](../95-ideas/2026-04-05-design-022-honest-nightly.md) | [review](../99-reports/2026-04-05-design-review-022-honest-nightly.md) | - | merged | [#91](https://github.com/vonrobak/urd/pull/91) |
 | 021 | The Living Daemon (sentinel config reload + anomaly fix) | [design](../95-ideas/2026-04-04-design-021-living-daemon.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-021-living-daemon.md) | merged | [#84](https://github.com/vonrobak/urd/pull/84) |
 | 020 | The Doctor Knows (context-aware suggestions) | [design](../95-ideas/2026-04-04-design-020-doctor-knows.md) | - | [adversary](../99-reports/2026-04-04-review-adversary-020-doctor-knows.md) | merged | [#85](https://github.com/vonrobak/urd/pull/85) |

--- a/docs/96-project-supervisor/roadmap.md
+++ b/docs/96-project-supervisor/roadmap.md
@@ -37,12 +37,11 @@ from the first v0.11.0 nightly (run #29).
 The Encounter. The designs must be informed by real nightly logs, real doctor output,
 real sentinel behavior.
 
-### Phase D-0: Presentation Polish (023, 024)
+### Phase D-0: Presentation Polish (023 ✓, 024)
 
 ```
-023 — The Honest Diagnostic            (~1-2 sessions)
+023 — The Honest Diagnostic  ✓         (1 session, PR #93)
     Findings-first verify, doctor trust coherence, collapsed noise
-    Design: docs/95-ideas/2026-04-05-design-023-honest-diagnostic.md
 
 024 — The Warm Details                  (~1-2 sessions)
     Relative timestamps, vocabulary, alignment, error guidance

--- a/docs/96-project-supervisor/status.md
+++ b/docs/96-project-supervisor/status.md
@@ -9,14 +9,13 @@
 
 **Urd is the sole backup system.** Systemd timer running nightly at 04:00 since 2026-03-25.
 Sentinel daemon deployed (passive monitoring, drive detection, backup overdue alerts).
-931 tests, all passing, clippy clean. Current version: v0.11.1.
+948 tests, all passing, clippy clean. Current version: v0.11.1.
 
-**v0.11.1 deployed and running.** Fixes production issues from the first v0.11.0 nightly:
-- Transient retention now scoped to mounted drives — absent drives' pins no longer block
-  cleanup, preventing the NVMe space exhaustion pattern
-- Sentinel chain break detection refined (delta-based, reports actual broken count)
-- "local only" skip text replaces misleading "send disabled"
-- Transient snapshot creation skipped when no drives available (defense-in-depth)
+**UPI 023 complete.** Findings-first verify, doctor trust gap fix (Degraded verdict),
+doctor --thorough findings separation, proper pluralization, suggestion field on VerifyCheck.
+12 new tests. Full standard workflow completed. PR #93 merged.
+
+**5 unreleased changes in CHANGELOG.md** — ready for `/release` when appropriate.
 
 ## In Progress
 
@@ -24,12 +23,10 @@ Nothing active.
 
 ## Next Up
 
-1. **023: The Honest Diagnostic** (~1-2 sessions) — findings-first verify, doctor trust
-   coherence, collapsed noise. Pure presentation changes.
-2. **024: The Warm Details** (~1-2 sessions) — relative timestamps, vocabulary, alignment,
-   error guidance. Pure voice.rs/output.rs changes.
-3. **6-O: Progressive disclosure** (~2 sessions) — framework for The Encounter
-4. **6-H: The Encounter** (~4-6 sessions) — auto-trigger onboarding, Fate Conversation,
+1. **024: The Warm Details** (~1-2 sessions) — relative timestamps, vocabulary, alignment,
+   error guidance. Pure voice.rs/output.rs changes. Completes Phase D-0 polish.
+2. **6-O: Progressive disclosure** (~2 sessions) — framework for The Encounter
+3. **6-H: The Encounter** (~4-6 sessions) — auto-trigger onboarding, Fate Conversation,
    config generation. Targets v1.0.
 
 ## Key Links
@@ -41,7 +38,7 @@ Nothing active.
 | Architecture and code conventions | [CLAUDE.md](../../CLAUDE.md) |
 | Documentation standards | [CONTRIBUTING.md](../../CONTRIBUTING.md) |
 | ADRs (100-112) | [decisions/](../00-foundation/decisions/) |
-| Latest review | [022 design review](../99-reports/2026-04-05-design-review-022-honest-nightly.md) |
+| Latest review | [023 adversary review](../99-reports/2026-04-05-review-adversary-023-honest-diagnostic.md) |
 
 ## Known Issues
 
@@ -49,3 +46,4 @@ Nothing active.
 - UPI 011 Change 3 (pin self-healing) deferred — orthogonal to 022, still valuable
 - Status string fragility: "UNPROTECTED"/"AT RISK"/"PROTECTED" matched as raw strings
 - `compute_health` at 8 params — consider struct grouping in next awareness.rs change
+- Doctor --thorough verdict: drive-mounted warnings can mask Degraded verdict (documented trade-off, F1 in 023 adversary review)

--- a/docs/99-reports/2026-04-05-design-review-024-warm-details.md
+++ b/docs/99-reports/2026-04-05-design-review-024-warm-details.md
@@ -1,0 +1,281 @@
+---
+upi: "024"
+date: 2026-04-05
+type: arch-adversary
+scope: design-review
+verdict: proceed-with-fixes
+---
+
+# Architectural Adversary Review: UPI 024 -- The Warm Details
+
+## 1. Executive Summary
+
+Seven independent presentation-layer changes. No behavioral code, no data model
+mutations, no new modules. The plan is competent and well-structured. The changes
+are correctly scoped to voice.rs, types.rs, output.rs, and two command handlers.
+
+Distance from catastrophic failure (silent data loss) is large. None of these
+changes touch retention, planning, execution, or btrfs operations.
+
+Three findings need attention before building. The most important: the plan's
+`bail!` multiline message (Change 6) will produce ugly output because anyhow
+prefixes "Error: " to the first line but not subsequent lines, creating a
+misaligned block. The second: the `{:<12}` padding constant for the TOKEN column
+needs adjustment now that the longest token string changes from 10 chars
+(`✗ mismatch`) to 8 chars (`MISMATCH`). The third: `humanize_duration(0)` returns
+`"0s"` -- the plan should apply the same `<1s` treatment there or accept the
+inconsistency.
+
+## 2. What Kills You
+
+Nothing in this changeset can kill you. This is purely presentation-layer work.
+Verified by tracing every modified function:
+
+- `render_last_run` -- reads `StatusOutput`, writes to string. No side effects.
+- `render_summary_line` -- reads `StatusOutput`, writes to string. No side effects.
+- `format_token_state` -- pure match on enum, returns string.
+- `escalated_staleness_text` -- pure function, returns formatted string.
+- `format_duration_secs` -- pure arithmetic, returns string.
+- `format_subvolume_chooser` -- new pure function, returns string.
+
+The only structural change (adding `last_run_age_secs` to `StatusOutput`) adds a
+field to a `#[derive(Serialize)]` struct. This means JSON output from
+`OutputMode::Daemon` will gain a new key. This is additive and backward-compatible
+-- existing consumers ignore unknown keys. The `daemon_produces_valid_json` test
+(voice.rs:3210) will continue to pass.
+
+## 3. Scorecard
+
+| Dimension | Score | Notes |
+|-----------|-------|-------|
+| Correctness | 8/10 | Two edge cases missed (humanize_duration(0), anyhow multiline formatting) |
+| Security | 10/10 | No attack surface. Presentation only. |
+| Architecture | 9/10 | Clean separation maintained. No purity violations. One naming convention question. |
+| Systems Design | 8/10 | Column width constant needs recalculation. Serialization impact correctly identified. |
+
+**Overall: 8.75/10** -- Solid plan. Fix the three findings and build.
+
+## 4. Design Tensions
+
+**Consistency vs. independence.** Two duration formatters exist in the hot path:
+`format_duration_secs` (types.rs) and `humanize_duration` (voice.rs). Change 4
+modifies the former but not the latter. If `humanize_duration(0)` produces `"0s"`
+while `format_duration_secs(0)` produces `"<1s"`, users see inconsistent behavior
+for the same edge case depending on which surface they're looking at. The plan
+should acknowledge this and either (a) apply the same treatment to both, or
+(b) document why the inconsistency is acceptable.
+
+**Error channel vs. help channel.** Change 6 routes a help message through
+`anyhow::bail!`. This is ergonomically wrong -- `bail!` is the error channel, but
+the subvolume chooser is help/guidance. The output has "Error: " prefixed by
+anyhow's display, which looks odd before "Usage: urd retention-preview". The plan
+acknowledges this implicitly in its expected output but doesn't address whether a
+non-error exit (printing to stdout and returning `Ok(())`) would be more
+appropriate.
+
+## 5. Findings
+
+### Severity: Must Fix
+
+**F1. anyhow::bail! multiline formatting produces ugly output.**
+
+The plan proposes:
+```rust
+let message = voice::format_subvolume_chooser("urd retention-preview", &names);
+anyhow::bail!("{message}");
+```
+
+When anyhow displays this, it prefixes "Error: " to the first line only. The
+output becomes:
+```
+Error: Usage: urd retention-preview <subvolume> or urd retention-preview --all
+
+Available subvolumes:
+  htpc-home
+  ...
+```
+
+The "Error: " prefix before "Usage:" reads poorly. This is a help message, not an
+error. Two options:
+
+(a) Print the message to stdout and return `Ok(())` -- this is the correct channel
+for guidance. The command didn't fail; the user just didn't provide enough
+information. This matches the UX principle "guide through affordances, not error
+messages."
+
+(b) If error exit code is required, use `eprintln!` + `std::process::exit(1)` --
+but this bypasses anyhow's error chain, which is worse.
+
+Recommendation: option (a). Print to stdout, exit cleanly.
+
+**F2. TOKEN column `{:<12}` padding constant needs recalculation.**
+
+The header and row formatting both use `{:<12}` for the TOKEN column
+(voice.rs:2833, 2850). With the current Unicode symbols, the longest formatted
+token is `"✗ mismatch"` (10 visible chars, but 12 bytes because of the Unicode
+character). With the ASCII replacements, the longest token is `"MISMATCH"` (8
+chars) or `"recorded"` (8 chars).
+
+The `{:<12}` pads to 12 chars. With ASCII, this means 4 chars of trailing
+whitespace after "MISMATCH". This still works for alignment -- it just wastes
+horizontal space. The plan should either:
+
+(a) Reduce to `{:<10}` to tighten the table, or
+(b) Leave `{:<12}` and note that it's intentionally generous for future token
+states.
+
+Either is fine, but the plan should make the choice explicit rather than
+accidentally inheriting a width that was sized for different content.
+
+### Severity: Should Fix
+
+**F3. `humanize_duration(0)` still returns `"0s"` -- inconsistent with Change 4.**
+
+Change 4 modifies `format_duration_secs(0)` to return `"<1s"`. But Change 1 uses
+`humanize_duration()` for relative timestamps in status. If a backup just
+completed, `last_run_age_secs` could be 0, and `humanize_duration(0)` returns
+`"0s"` -- producing "Last backup: 0s ago". This is the same class of problem
+Change 4 fixes.
+
+The fix is trivial: add the same `<= 0` guard to `humanize_duration`:
+```rust
+if secs <= 0 {
+    "<1s".to_string()
+} else if secs < 60 {
+    ...
+```
+
+Or, since `humanize_duration` is used in `escalated_staleness_text` too, consider
+whether `"<1s ago"` or `"just now"` is the better phrase for age display.
+
+**F4. Summary enrichment (Change 2) silently produces empty health part for
+degraded assessments with no reasons.**
+
+The plan collects `health_reasons` from non-healthy assessments and joins them.
+If `unique_reasons` is empty, it produces an empty string. This means a degraded
+assessment with no reasons would show `"1 degraded."` with no explanation.
+
+Verified in `awareness.rs`: `compute_health` always pushes a reason before
+setting degraded/blocked. However, `StatusAssessment` is a plain struct with
+public string fields -- nothing prevents a test helper or future code from
+constructing `health: "degraded"` with `health_reasons: vec![]`. The plan's
+`unwrap_or_default()` fallback (producing empty string) is safe but uninformative.
+
+This is low risk because the awareness module currently guarantees reasons, but
+the plan should add a defensive comment noting the invariant it depends on.
+
+**F5. Plan references wrong line numbers for several changes.**
+
+The plan says `escalated_staleness_text` is at line 2723 (voice.rs). The actual
+function starts at line 2713, and the "protection degrading" text is at line 2723.
+Similarly, `render_summary_line` is cited as line 141 but starts at line 91.
+These are minor but could slow down implementation if taken literally.
+
+The plan should reference function names as the primary anchor and line numbers as
+approximate hints -- which it mostly does, but the file-to-modify table at the top
+uses line numbers as if they're precise coordinates.
+
+### Severity: Consider
+
+**F6. `format_subvolume_chooser` naming convention.**
+
+Voice.rs uses `render_*` for all public functions (30+ of them). Adding a `format_*`
+public function breaks the naming pattern. The distinction seems to be that
+`render_*` functions take an output struct and a mode, while this function takes
+raw data.
+
+Options: (a) Keep `format_subvolume_chooser` since it doesn't follow the
+render pattern (no OutputMode, no struct). (b) Name it
+`render_subvolume_chooser` for consistency, accepting that the signature differs.
+
+This is a judgment call. The plan's choice is defensible -- the function is
+genuinely different from the render family. But it should be noted as a
+conscious decision, not an accident.
+
+**F7. The `sorted` variable in `format_subvolume_chooser` mutates a cloned vec.**
+
+The plan proposes:
+```rust
+let mut sorted = names.to_vec();
+sorted.sort();
+```
+
+This is fine for 9 items but the function signature takes `&[&str]`. If the
+caller already has a sorted list, this re-sorts unnecessarily. Not worth fixing
+for this use case, but if the function is reused elsewhere, the caller should
+sort instead (or the function should document that it sorts).
+
+**F8. No test for the JSON serialization of the new `last_run_age_secs` field.**
+
+The `daemon_produces_valid_json` test (voice.rs:3210) checks for key presence
+but doesn't verify `last_run_age_secs`. The `daemon_contains_subvolume_data`
+test checks assessment fields. Neither will verify the new field appears in JSON
+output. The plan should add a test assertion:
+
+```rust
+assert!(parsed.get("last_run_age_secs").is_some(), "missing last_run_age_secs key");
+```
+
+This catches serialization regressions (e.g., if someone adds
+`skip_serializing_if` later).
+
+## 6. The Simplicity Question
+
+*Is there a simpler version of this plan that achieves 80% of the value?*
+
+Yes: Changes 1, 3, 4, and 5 are each 1-5 lines of code with no structural
+impact. They deliver the majority of the "crafted" feeling. Changes 2, 6, and 7
+are higher effort.
+
+However, the plan already sequences by impact and each change is independent. The
+implementor can stop at any point. The plan doesn't over-engineer -- it's already
+at the simplicity floor for its stated goals.
+
+## 7. For the Dev Team
+
+### Build in this order
+
+The plan's suggested order is good. One refinement: do Change 4 (format_duration_secs)
+before Change 1 (relative timestamps) because Change 4 is a one-line change that
+also highlights the `humanize_duration` inconsistency (F3), which should be resolved
+before Change 1 uses it.
+
+### Watch for
+
+- **Test helper updates.** There are 4 `StatusOutput` construction sites in voice.rs
+  tests (lines 2982, 3193, 3262, and around line 3262 again for interactive_no_last_run).
+  The plan correctly identifies this but doesn't enumerate them. Grep for `StatusOutput {`
+  in voice.rs before building.
+
+- **The `serde(skip_serializing_if)` question.** Should `last_run_age_secs` use
+  `skip_serializing_if = "Option::is_none"` like other optional fields in StatusOutput?
+  The plan doesn't specify. Current fields like `local_newest_age_secs` use
+  `skip_serializing_if` on StatusAssessment. Decide and be consistent.
+
+### What's safe to parallelize
+
+All 7 changes can be built in any order. No dependencies between them. Each can
+be tested independently. The only shared concern is the `test_status_output()`
+helper which Change 1 modifies -- other changes that add tests using this helper
+should be aware of the new field.
+
+## 8. Open Questions
+
+**OQ1. Should the subvolume chooser exit 0 or exit 1?**
+
+The plan uses `bail!` (exit 1). But "you didn't specify which subvolume" is
+guidance, not an error. `git branch` with no arguments exits 0 and shows the
+list. `git checkout` with no arguments exits 1. The UX principle "guide through
+affordances" suggests exit 0 with helpful output. This is a UX decision for the
+maintainer.
+
+**OQ2. Should `humanize_duration` and `format_duration_secs` be unified?**
+
+A previous review (2026-03-29) noted three duration formatters exist. This plan
+adds a fourth inconsistency vector. Low priority but worth tracking.
+
+**OQ3. Should the `{:<12}` be computed dynamically like `label_w` and `status_w`?**
+
+The drives table already computes dynamic widths for DRIVE and STATUS columns.
+TOKEN is the only hardcoded width. Making it dynamic would future-proof against
+token state changes. Low effort, high consistency.

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -36,13 +36,7 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
 
     let last_run = state_db.as_ref().and_then(|db| db.last_run_info());
 
-    // Pre-compute age for voice rendering (voice.rs must stay pure — no I/O)
-    let last_run_age_secs = last_run.as_ref().and_then(|run| {
-        let dt = chrono::NaiveDateTime::parse_from_str(&run.started_at, "%Y-%m-%dT%H:%M:%S")
-            .ok()?;
-        let age = now.signed_duration_since(dt).num_seconds();
-        if age >= 0 { Some(age) } else { None }
-    });
+    let last_run_age_secs = last_run.as_ref().and_then(|run| run.age_secs(now));
 
     // Build output — single pass over assessments
     let total = assessments.len();

--- a/src/commands/retention_preview.rs
+++ b/src/commands/retention_preview.rs
@@ -26,10 +26,9 @@ pub fn run(config: Config, args: RetentionPreviewArgs, mode: OutputMode) -> anyh
             .filter(|sv| sv.enabled)
             .map(|sv| sv.name.as_str())
             .collect();
-        anyhow::bail!(
-            "specify a subvolume or use --all. Configured subvolumes: {}",
-            names.join(", ")
-        );
+        let message = voice::format_subvolume_chooser("urd retention-preview", &names);
+        println!("{message}");
+        return Ok(());
     };
 
     // Optionally load calibrated sizes from state DB

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -73,6 +73,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
 
     // ── Last run ────────────────────────────────────────────────────
     let last_run = state_db.as_ref().and_then(|db| db.last_run_info());
+    let last_run_age_secs = last_run.as_ref().and_then(|run| run.age_secs(now));
 
     // ── Pin count ───────────────────────────────────────────────────
     let total_pins: usize = config
@@ -122,6 +123,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         chain_health: chain_health_entries,
         drives: drive_infos,
         last_run,
+        last_run_age_secs,
         total_pins,
         redundancy_advisories,
         advice,

--- a/src/output.rs
+++ b/src/output.rs
@@ -146,6 +146,9 @@ pub struct StatusOutput {
     pub drives: Vec<DriveInfo>,
     /// Last backup run info (if any).
     pub last_run: Option<LastRunInfo>,
+    /// Seconds since last backup started, pre-computed by the command handler.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_run_age_secs: Option<i64>,
     /// Total pinned snapshot count across all subvolumes.
     pub total_pins: usize,
     /// Structured redundancy advisories (omitted from JSON when empty).
@@ -264,6 +267,18 @@ pub struct LastRunInfo {
     pub started_at: String,
     pub result: String,
     pub duration: Option<String>,
+}
+
+impl LastRunInfo {
+    /// Compute seconds since this run started. Returns `None` if the timestamp
+    /// cannot be parsed or the result would be negative (clock skew).
+    #[must_use]
+    pub fn age_secs(&self, now: chrono::NaiveDateTime) -> Option<i64> {
+        let dt = chrono::NaiveDateTime::parse_from_str(&self.started_at, "%Y-%m-%dT%H:%M:%S")
+            .ok()?;
+        let age = now.signed_duration_since(dt).num_seconds();
+        if age >= 0 { Some(age) } else { None }
+    }
 }
 
 // ── DefaultStatusOutput ────────────────────────────────────────────────

--- a/src/types.rs
+++ b/src/types.rs
@@ -888,7 +888,9 @@ impl Serialize for ByteSize {
 /// Format a number of seconds as a human-readable duration string (e.g., "2m 15s", "45s").
 #[must_use]
 pub fn format_duration_secs(secs: i64) -> String {
-    if secs < 60 {
+    if secs <= 0 {
+        "<1s".to_string()
+    } else if secs < 60 {
         format!("{secs}s")
     } else {
         format!("{}m {}s", secs / 60, secs % 60)
@@ -1388,6 +1390,28 @@ weekly = 4
         let toml_str = toml::to_string(&graduated).unwrap();
         let parsed: Wrapper = toml::from_str(&toml_str).unwrap();
         assert_eq!(parsed, graduated);
+    }
+
+    #[test]
+    fn format_duration_secs_zero_returns_less_than_one() {
+        assert_eq!(format_duration_secs(0), "<1s");
+    }
+
+    #[test]
+    fn format_duration_secs_negative_returns_less_than_one() {
+        assert_eq!(format_duration_secs(-1), "<1s");
+    }
+
+    #[test]
+    fn format_duration_secs_seconds() {
+        assert_eq!(format_duration_secs(1), "1s");
+        assert_eq!(format_duration_secs(59), "59s");
+    }
+
+    #[test]
+    fn format_duration_secs_minutes() {
+        assert_eq!(format_duration_secs(60), "1m 0s");
+        assert_eq!(format_duration_secs(135), "2m 15s");
     }
 
     #[test]

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -137,14 +137,26 @@ fn render_summary_line(data: &StatusOutput, out: &mut String) {
             .iter()
             .filter(|a| a.health == "degraded")
             .count();
-        // Pick the first reason from the worst non-healthy subvolume
-        let first_reason = data
+        // Collect all unique health reasons across degraded/blocked assessments.
+        // awareness.rs guarantees health_reasons is non-empty for non-healthy
+        // assessments; if violated, reasons_part is safely empty.
+        let unique_reasons: Vec<&str> = data
             .assessments
             .iter()
-            .find(|a| a.health != "healthy")
-            .and_then(|a| a.health_reasons.first())
-            .map(|r| format!(" \u{2014} {r}"))
-            .unwrap_or_default();
+            .filter(|a| a.health != "healthy")
+            .flat_map(|a| a.health_reasons.iter().map(String::as_str))
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let reasons_part = if unique_reasons.is_empty() {
+            String::new()
+        } else if unique_reasons.len() <= 3 {
+            format!(" \u{2014} {}", unique_reasons.join(", "))
+        } else {
+            let shown = &unique_reasons[..3];
+            let remaining = unique_reasons.len() - 3;
+            format!(" \u{2014} {}, and {remaining} more", shown.join(", "))
+        };
         let mut parts = Vec::new();
         if blocked_count > 0 {
             parts.push(format!("{blocked_count} blocked"));
@@ -152,7 +164,7 @@ fn render_summary_line(data: &StatusOutput, out: &mut String) {
         if degraded_count > 0 {
             parts.push(format!("{degraded_count} degraded"));
         }
-        format!(" {}{first_reason}.", parts.join(", "))
+        format!(" {}{reasons_part}.", parts.join(", "))
     } else {
         String::new()
     };
@@ -258,7 +270,7 @@ fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
 
         // Thread health (interactive rendering — Display impl feeds daemon JSON, do not change it)
         let thread = if assessment.external_only {
-            "ext-only".dimmed().to_string()
+            "drive-only".dimmed().to_string()
         } else {
             data.chain_health
                 .iter()
@@ -304,7 +316,9 @@ fn format_count_with_age(count: usize, age_secs: Option<i64>) -> String {
 
 /// Humanize seconds into a compact duration string.
 fn humanize_duration(secs: i64) -> String {
-    if secs < 60 {
+    if secs <= 0 {
+        "<1s".to_string()
+    } else if secs < 60 {
         format!("{secs}s")
     } else if secs < 3600 {
         format!("{}m", secs / 60)
@@ -440,10 +454,14 @@ fn render_last_run(data: &StatusOutput, out: &mut String) {
                 .as_ref()
                 .map(|d| format!(", {d}"))
                 .unwrap_or_default();
+            let time_str = data
+                .last_run_age_secs
+                .map(|secs| format!("{} ago", humanize_duration(secs)))
+                .unwrap_or_else(|| run.started_at.clone());
             writeln!(
                 out,
                 "Last backup: {} ({}{}) [#{}]",
-                run.started_at, result_colored, duration_str, run.id,
+                time_str, result_colored, duration_str, run.id,
             )
             .ok();
         }
@@ -2720,7 +2738,7 @@ fn escalated_staleness_text(
 
     Some(match worst_status {
         "UNPROTECTED" => format!(
-            "{} absent {} — protection degrading",
+            "{} absent {} — protection aging",
             label.bold(),
             age_str
         ),
@@ -2830,7 +2848,7 @@ fn render_drives_list_interactive(data: &DrivesListOutput) -> String {
     // Header.
     writeln!(
         out,
-        "{:<label_w$}   {:<status_w$}   {:<12}   {:>8}   ROLE",
+        "{:<label_w$}   {:<status_w$}   {:<10}   {:>8}   ROLE",
         "DRIVE", "STATUS", "TOKEN", "FREE",
     )
     .ok();
@@ -2847,7 +2865,7 @@ fn render_drives_list_interactive(data: &DrivesListOutput) -> String {
 
         writeln!(
             out,
-            "{:<label_w$}   {:<status_w$}   {:<12}   {:>8}   {}",
+            "{:<label_w$}   {:<status_w$}   {:<10}   {:>8}   {}",
             entry.label, status_colored, token_colored, free_str, role_str,
         )
         .ok();
@@ -2886,12 +2904,12 @@ fn color_drive_status(status: &DriveStatus, text: &str) -> String {
 
 fn format_token_state(state: &TokenState) -> String {
     match state {
-        TokenState::Verified => "\u{2713}".to_string(),
+        TokenState::Verified => "ok".to_string(),
         TokenState::New => "new".to_string(),
-        TokenState::Mismatch => "\u{2717} mismatch".to_string(),
-        TokenState::ExpectedButMissing => "\u{2717} missing".to_string(),
+        TokenState::Mismatch => "MISMATCH".to_string(),
+        TokenState::ExpectedButMissing => "MISSING".to_string(),
         TokenState::Recorded => "recorded".to_string(),
-        TokenState::Unknown => "\u{2014}".to_string(),
+        TokenState::Unknown => "-".to_string(),
     }
 }
 
@@ -2958,6 +2976,23 @@ fn render_drives_adopt_interactive(data: &DriveAdoptOutput) -> String {
             )
             .ok();
         }
+    }
+    out
+}
+
+// ── Guided error messages ───────────────────────────────────────────────
+
+/// Format a subvolume chooser message for commands that require a subvolume argument.
+/// Names are sorted alphabetically for easy scanning.
+#[must_use]
+pub fn format_subvolume_chooser(command: &str, names: &[&str]) -> String {
+    let mut out = format!(
+        "Usage: {command} <subvolume> or {command} --all\n\nAvailable subvolumes:\n"
+    );
+    let mut sorted = names.to_vec();
+    sorted.sort();
+    for name in &sorted {
+        writeln!(out, "  {name}").ok();
     }
     out
 }
@@ -3060,6 +3095,7 @@ mod tests {
                 result: "success".to_string(),
                 duration: Some("1m 30s".to_string()),
             }),
+            last_run_age_secs: Some(36000), // 10h
             total_pins: 3,
             redundancy_advisories: vec![],
             advice: vec![],
@@ -3161,12 +3197,25 @@ mod tests {
     }
 
     #[test]
-    fn interactive_contains_last_run() {
+    fn interactive_contains_last_run_relative_time() {
         colored::control::set_override(false);
         let output = render_status(&test_status_output(), OutputMode::Interactive);
         assert!(output.contains("#42"), "missing run ID");
         assert!(output.contains("success"), "missing run result");
         assert!(output.contains("1m 30s"), "missing duration");
+        assert!(output.contains("10h ago"), "should show relative time, got: {output}");
+    }
+
+    #[test]
+    fn interactive_last_run_falls_back_to_timestamp_without_age() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        data.last_run_age_secs = None;
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("2026-03-24T02:00:00"),
+            "should fall back to ISO timestamp when age is None"
+        );
     }
 
     #[test]
@@ -3195,6 +3244,7 @@ mod tests {
             chain_health: vec![],
             drives: vec![],
             last_run: None,
+            last_run_age_secs: None,
             total_pins: 0,
             redundancy_advisories: vec![],
             advice: vec![],
@@ -3220,6 +3270,10 @@ mod tests {
         assert!(
             parsed.get("chain_health").is_some(),
             "missing chain_health key"
+        );
+        assert!(
+            parsed.get("last_run_age_secs").is_some(),
+            "missing last_run_age_secs key"
         );
     }
 
@@ -3264,6 +3318,7 @@ mod tests {
             chain_health: vec![],
             drives: vec![],
             last_run: None,
+            last_run_age_secs: None,
             total_pins: 0,
             redundancy_advisories: vec![],
             advice: vec![],
@@ -3307,8 +3362,8 @@ mod tests {
         let output = render_status(&data, OutputMode::Interactive);
         let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
         assert!(
-            home_line.contains("ext-only"),
-            "external_only THREAD should show 'ext-only', got: {home_line}"
+            home_line.contains("drive-only"),
+            "external_only THREAD should show 'drive-only', got: {home_line}"
         );
     }
 
@@ -5136,6 +5191,46 @@ mod tests {
     }
 
     #[test]
+    fn summary_line_shows_all_health_reasons() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        data.assessments[0].health = "degraded".to_string();
+        data.assessments[0].health_reasons = vec!["WD-18TB away 8d".to_string()];
+        data.assessments[1].health = "degraded".to_string();
+        data.assessments[1].health_reasons = vec!["2TB-backup away 2d".to_string()];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("WD-18TB away 8d"),
+            "missing first drive reason in summary"
+        );
+        assert!(
+            output.contains("2TB-backup away 2d"),
+            "missing second drive reason in summary"
+        );
+    }
+
+    #[test]
+    fn summary_line_truncates_at_three_reasons() {
+        colored::control::set_override(false);
+        let mut data = test_status_output();
+        // Clear second assessment's health to isolate the test
+        data.assessments[1].health = "healthy".to_string();
+        data.assessments[1].health_reasons = vec![];
+        data.assessments[0].health = "degraded".to_string();
+        data.assessments[0].health_reasons = vec![
+            "drive-A away 1d".to_string(),
+            "drive-B away 2d".to_string(),
+            "drive-C away 3d".to_string(),
+            "drive-D away 4d".to_string(),
+        ];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("and 1 more"),
+            "should truncate at 3 reasons, got: {output}"
+        );
+    }
+
+    #[test]
     fn summary_line_differentiates_exposed_and_waning() {
         colored::control::set_override(false);
         let mut data = test_status_output();
@@ -6414,7 +6509,7 @@ mod tests {
         assert!(text.contains("WD-18TB1"), "missing label: {text}");
         assert!(text.contains("absent"), "should use 'absent': {text}");
         assert!(
-            text.contains("protection degrading"),
+            text.contains("protection aging"),
             "missing escalation: {text}"
         );
         assert!(text.contains("30d"), "missing age: {text}");
@@ -6960,6 +7055,18 @@ mod tests {
     }
 
     #[test]
+    fn drives_list_token_column_uses_ascii() {
+        colored::control::set_override(false);
+        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive);
+        assert!(output.contains("ok"), "Verified token should show 'ok': {output}");
+        // Token column should not contain Unicode check/cross marks
+        assert!(
+            !output.contains('\u{2713}') && !output.contains('\u{2717}'),
+            "token column should not contain Unicode check/cross marks: {output}"
+        );
+    }
+
+    #[test]
     fn drives_list_daemon_valid_json() {
         let output = render_drives_list(&test_drives_list(), OutputMode::Daemon);
         let parsed: serde_json::Value =
@@ -7163,5 +7270,35 @@ mod tests {
             output.contains("Still below threshold"),
             "should show still critical: {output}"
         );
+    }
+
+    // ── Subvolume chooser tests ────────────────────────────────────────
+
+    #[test]
+    fn subvolume_chooser_contains_usage_and_names() {
+        let output = format_subvolume_chooser("urd retention-preview", &["docs", "pics", "home"]);
+        assert!(output.contains("Usage: urd retention-preview <subvolume>"));
+        assert!(output.contains("--all"));
+        assert!(output.contains("Available subvolumes:"));
+        // Should be sorted alphabetically
+        let docs_pos = output.find("docs").unwrap();
+        let home_pos = output.find("home").unwrap();
+        let pics_pos = output.find("pics").unwrap();
+        assert!(docs_pos < home_pos && home_pos < pics_pos, "names should be sorted");
+    }
+
+    #[test]
+    fn subvolume_chooser_single_name() {
+        let output = format_subvolume_chooser("urd history", &["only-one"]);
+        assert!(output.contains("only-one"));
+        assert!(output.contains("Usage: urd history"));
+    }
+
+    // ── humanize_duration tests ────────────────────────────────────────
+
+    #[test]
+    fn humanize_duration_zero_returns_less_than_one() {
+        assert_eq!(humanize_duration(0), "<1s");
+        assert_eq!(humanize_duration(-1), "<1s");
     }
 }


### PR DESCRIPTION
## Summary

- **Relative timestamps** in `urd status` — "10h ago" instead of raw ISO 8601, matching the bare `urd` invocation style
- **Summary line enrichment** — names all absent drives (truncated at 3) instead of picking only the first reason
- **Vocabulary refinements** — "ext-only" → "drive-only", "protection degrading" → "protection aging", "0s" → "<1s"
- **Guided subvolume chooser** — `urd retention-preview` with no args shows sorted list with usage hint (exit 0) instead of a comma-separated error dump
- **Drives table ASCII tokens** — Unicode symbols replaced with portable ASCII (ok/MISMATCH/MISSING/-) for consistent column alignment across terminals
- **Extracted `LastRunInfo::age_secs()`** — deduplicates age computation between status and default commands

UPI 024 — The Warm Details. Completes Phase D-0 presentation polish.

## Testing

- cargo clippy: pass (0 warnings)
- cargo test: 959 tests, all passing
- Integration tests: not applicable (presentation-layer only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)