### PR TITLE
feat: trust-repair (UPI 026) — awareness correctness + voice cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-04-21
+
 ### Added
 - `BackupSummary.notes` — separate output channel for by-design informational
   outcomes (not warnings). Currently carries the space-guard message; future
@@ -338,7 +340,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.12.2...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/vonrobak/urd/compare/v0.12.2...v0.13.0
 [0.12.2]: https://github.com/vonrobak/urd/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/vonrobak/urd/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/vonrobak/urd/compare/v0.11.1...v0.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `BackupSummary.notes` — separate output channel for by-design informational
+  outcomes (not warnings). Currently carries the space-guard message; future
+  similar advisory outputs will land here.
+- One-time post-upgrade acknowledgment shown to returning users whose
+  previously-reported `blocked` states become `healthy`. Appears above
+  `urd status` / `urd backup` / `urd` output once, then never again. Fresh
+  installs see nothing.
+
+### Fixed
+- Incremental space estimates no longer use the full subvolume's calibrated
+  size — fixes false `blocked` health reports on healthy incremental chains
+  where the actual delta fits comfortably.
+- Drive operation-type queries now use the correct schema strings; previously
+  dead size-estimate fallback tiers now activate.
+- Drive `away` duration now sources from drive connection events rather than
+  last send age — a freshly unplugged drive no longer reports `away 3d`
+  based on the last successful backup timestamp. When no connection event
+  is available, the status line shows `last backup Nd ago` instead.
+- Informational cleanup outcomes no longer render as warnings. "Space
+  recovered — N skipped deletion(s)" is replaced with a dimmed note
+  "space guard held — N snapshot(s) retained."
+
+### Changed
+- Homelab monitoring consumers: the `warnings` bucket semantically narrowed
+  (the cleanup `space recovered` string moves to `notes`). No currently
+  shipped homelab alert is affected; see the homelab ADR-021 update for
+  future JSON-consumer precedent.
+- Unmounted drive labels use the word `away` uniformly; the severity
+  escalation (yellow, `protection aging`) is carried by color and suffix,
+  not by a separate word.
+
 ## [0.12.2] - 2026-04-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.12.2"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.12.2"
+version = "0.13.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -15,8 +15,10 @@ use serde::Serialize;
 
 use crate::config::{Config, DriveConfig};
 use crate::output::{RedundancyAdvisory, RedundancyAdvisoryKind};
-use crate::plan::FileSystemState;
-use crate::types::{DriveRole, Interval, LocalRetentionPolicy, ProtectionLevel, SnapshotName};
+use crate::plan::{self, FileSystemState};
+use crate::types::{
+    DriveEventKind, DriveRole, Interval, LocalRetentionPolicy, ProtectionLevel, SnapshotName,
+};
 
 // ── Thresholds ─────────────────────────────────────────────────────────
 
@@ -175,6 +177,20 @@ pub struct DriveAssessment {
     #[allow(dead_code)] // consumed by verbose status display (future)
     pub configured_interval: Interval,
     pub role: DriveRole,
+    /// Seconds since the drive's last `Unmount` event in `drive_connections`,
+    /// populated only when the drive is currently unmounted AND the most
+    /// recent physical event is an Unmount. Rule 1 of the voice contract:
+    /// stay silent when the sentinel missed the disconnect (last event is
+    /// Mount but drive is unmounted) — fall through to activity or silence.
+    #[allow(dead_code)] // consumed via StatusDriveAssessment by voice.rs
+    pub absent_duration_secs: Option<i64>,
+    /// Seconds since the most recent successful operation targeting this
+    /// drive in the operations log. Populated only when the drive is
+    /// unmounted AND `drive_connections` holds *no* events for this drive
+    /// at all — the drive predates sentinel observation. Never mixed with
+    /// `absent_duration_secs`.
+    #[allow(dead_code)] // consumed via StatusDriveAssessment by voice.rs
+    pub last_activity_age_secs: Option<i64>,
 }
 
 // ── Actionable Advice ─────────────────────────────────────────────────
@@ -394,6 +410,32 @@ pub fn assess(
     let resolved = config.resolved_subvolumes();
     let mut assessments = Vec::new();
 
+    // Per-drive cascade lookup computed once (identical for all subvols).
+    // Avoids N*M SQLite round-trips on every render.
+    let drive_absence: std::collections::HashMap<String, (Option<i64>, Option<i64>)> = config
+        .drives
+        .iter()
+        .map(|d| {
+            let signal = if fs.is_drive_mounted(d) {
+                (None, None)
+            } else {
+                match fs.last_drive_event(&d.label) {
+                    Some(event) => match event.kind {
+                        DriveEventKind::Unmount => {
+                            (Some((now - event.at).num_seconds()), None)
+                        }
+                        DriveEventKind::Mount => (None, None),
+                    },
+                    None => match fs.last_successful_operation_at(&d.label) {
+                        Some(op_time) => (None, Some((now - op_time).num_seconds())),
+                        None => (None, None),
+                    },
+                }
+            };
+            (d.label.clone(), signal)
+        })
+        .collect();
+
     for subvol in &resolved {
         if !subvol.enabled {
             continue;
@@ -545,6 +587,9 @@ pub fn assess(
                     ));
                 }
 
+                let (absent_duration_secs, last_activity_age_secs) =
+                    drive_absence.get(&drive.label).copied().unwrap_or((None, None));
+
                 drive_assessments.push(DriveAssessment {
                     drive_label: drive.label.clone(),
                     status,
@@ -553,6 +598,8 @@ pub fn assess(
                     last_send_age,
                     configured_interval: subvol.send_interval,
                     role: drive.role,
+                    absent_duration_secs,
+                    last_activity_age_secs,
                 });
             }
         }
@@ -943,13 +990,6 @@ fn compute_health(
             let free = fs.filesystem_free_bytes(&cfg.mount_path).unwrap_or(u64::MAX);
             let min_free = cfg.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
 
-            // Estimate next send size: calibrated > last send > skip
-            let est_size = fs
-                .calibrated_size(subvol_name)
-                .map(|(bytes, _)| bytes)
-                .or_else(|| fs.last_send_size(subvol_name, &da.drive_label, "incremental"))
-                .or_else(|| fs.last_send_size(subvol_name, &da.drive_label, "full"));
-
             // Check if chain is broken on this drive (full send will be needed)
             let chain_broken = chain_health.iter().any(|ch| {
                 ch.drive_label == da.drive_label
@@ -957,6 +997,10 @@ fn compute_health(
                         if *reason != ChainBreakReason::NoDriveData
                             && !is_expected_chain_break(is_transient, reason))
             });
+
+            // Calibrated size is the full-subvolume footprint; estimated_send_size
+            // only returns it when a full send is needed (chain broken).
+            let est_size = plan::estimated_send_size(fs, subvol_name, &da.drive_label, chain_broken);
 
             match est_size {
                 Some(size) if free.saturating_sub(min_free) < size => {
@@ -993,10 +1037,8 @@ fn compute_health(
             worst = worst.min(OperationalHealth::Degraded);
 
             // Surface uncertainty: chain broken means full send, but no size estimate
-            let has_estimate = fs
-                .calibrated_size(subvol_name)
-                .is_some()
-                || fs.last_send_size(subvol_name, &ch.drive_label, "full").is_some();
+            let has_estimate =
+                plan::estimated_send_size(fs, subvol_name, &ch.drive_label, true).is_some();
             if !has_estimate {
                 reasons.push(format!(
                     "full send size unknown for {} \u{2014} space check unavailable",
@@ -2689,21 +2731,23 @@ send_enabled = false
         let now = dt(2026, 3, 23, 14, 0);
         let mut fs = MockFileSystemState::new();
 
+        // Pin snap present both locally and on drive → chain Intact → incremental path.
+        let pin_snap = snap(dt(2026, 3, 23, 12, 0), "sv1");
         fs.local_snapshots.insert(
             "sv1".to_string(),
-            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+            vec![pin_snap.clone(), snap(dt(2026, 3, 23, 13, 30), "sv1")],
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
         fs.external_snapshots.insert(
             ("WD-18TB".to_string(), "sv1".to_string()),
-            vec![snap(dt(2026, 3, 23, 12, 0), "sv1")],
+            vec![pin_snap.clone()],
         );
         fs.pin_files.insert(
             (
                 std::path::PathBuf::from("/snap/sv1"),
                 "WD-18TB".to_string(),
             ),
-            snap(dt(2026, 3, 23, 12, 0), "sv1"),
+            pin_snap,
         );
         fs.send_times.insert(
             ("sv1".to_string(), "WD-18TB".to_string()),
@@ -2713,13 +2757,285 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 150_000_000_000);
         fs.send_sizes.insert(
-            ("sv1".to_string(), "WD-18TB".to_string(), "incremental".to_string()),
+            ("sv1".to_string(), "WD-18TB".to_string(), crate::types::SendKind::Incremental),
             60_000_000_000,
         );
 
         let results = assess(&config, now, &fs);
         assert_eq!(results[0].health, OperationalHealth::Blocked);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("insufficient space")));
+    }
+
+    // ── compute_health regression: estimator must not use calibrated size for incrementals ──
+
+    #[test]
+    fn health_intact_chain_large_calibrated_small_incremental_not_blocked() {
+        // Regression: before the fix, awareness consulted calibrated (full subvolume
+        // footprint) even for incrementals with intact chains, triggering false
+        // Blocked states on healthy subvolumes.
+        let config = test_config_with_min_free();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        let pin_snap = snap(dt(2026, 3, 23, 12, 0), "sv1");
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![pin_snap.clone(), snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots
+            .insert(("WD-18TB".to_string(), "sv1".to_string()), vec![pin_snap.clone()]);
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "WD-18TB".to_string()),
+            pin_snap,
+        );
+        // 6GB free (above min_free=100GB would block, but we set available=6GB here)
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 106_000_000_000);
+        // Calibrated = 10TB, but incremental history says 5GB — incremental fits easily.
+        fs.calibrated_sizes
+            .insert("sv1".to_string(), (10_000_000_000_000, "2026-04-01".to_string()));
+        fs.send_sizes.insert(
+            ("sv1".to_string(), "WD-18TB".to_string(), crate::types::SendKind::Incremental),
+            5_000_000_000,
+        );
+
+        let results = assess(&config, now, &fs);
+        assert_ne!(
+            results[0].health,
+            OperationalHealth::Blocked,
+            "intact chain with small incremental must not be Blocked by large calibrated size"
+        );
+    }
+
+    #[test]
+    fn health_broken_chain_no_history_fails_open() {
+        // Chain broken (PinMissingOnDrive, not NoDriveData), no size data at all →
+        // fail open (not Blocked) and surface uncertainty.
+        let config = test_config_with_min_free();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        // External has snapshots but not the pin → PinMissingOnDrive (a real break).
+        let pin_snap = snap(dt(2026, 3, 23, 12, 0), "sv1");
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![pin_snap.clone(), snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv1".to_string()),
+            vec![snap(dt(2026, 3, 22, 10, 0), "sv1")], // different snap, not the pin
+        );
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "WD-18TB".to_string()),
+            pin_snap,
+        );
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 200_000_000_000);
+
+        let results = assess(&config, now, &fs);
+        assert_ne!(
+            results[0].health,
+            OperationalHealth::Blocked,
+            "broken chain with no size data must fail open, not block"
+        );
+        assert!(
+            results[0].health_reasons.iter().any(|r| r.contains("full send size unknown")),
+            "should surface uncertainty: {:?}",
+            results[0].health_reasons
+        );
+    }
+
+    #[test]
+    fn health_regression_false_blocked_on_healthy_incremental() {
+        // Reproduces the original subvol3-opptak report:
+        // intact chain, calibrated=large, incremental history=small, free >> incremental.
+        // Pre-fix: Blocked. Post-fix: not Blocked.
+        let config = test_config_with_min_free();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        let pin_snap = snap(dt(2026, 3, 23, 12, 0), "sv1");
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![pin_snap.clone(), snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots
+            .insert(("WD-18TB".to_string(), "sv1".to_string()), vec![pin_snap.clone()]);
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "WD-18TB".to_string()),
+            pin_snap,
+        );
+        // 2.7TB free, min_free 100GB → 2.6TB available
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/wd"), 2_700_000_000_000);
+        fs.calibrated_sizes
+            .insert("sv1".to_string(), (10_000_000_000_000, "2026-04-01".to_string()));
+        fs.send_sizes.insert(
+            ("sv1".to_string(), "WD-18TB".to_string(), crate::types::SendKind::Incremental),
+            50_000_000_000,
+        );
+
+        let results = assess(&config, now, &fs);
+        assert_ne!(
+            results[0].health,
+            OperationalHealth::Blocked,
+            "subvol3-opptak regression: must not be Blocked when incremental fits"
+        );
+    }
+
+    // ── Drive-absence + last-activity cascade ──
+
+    #[test]
+    fn drive_assessment_absent_duration_populated_when_unmounted_and_last_event_is_unmount() {
+        use crate::types::{DriveEvent, DriveEventKind};
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        // Drive is NOT mounted. Last event is Unmount 6 hours ago.
+        fs.drive_events.insert(
+            "WD-18TB".to_string(),
+            DriveEvent {
+                kind: DriveEventKind::Unmount,
+                at: dt(2026, 3, 23, 8, 0),
+            },
+        );
+
+        let results = assess(&config, now, &fs);
+        let drive = &results[0].external[0];
+        assert_eq!(
+            drive.absent_duration_secs,
+            Some(6 * 3600),
+            "expected 6h since Unmount event"
+        );
+        assert_eq!(drive.last_activity_age_secs, None);
+    }
+
+    #[test]
+    fn drive_assessment_absent_duration_none_when_mounted() {
+        use crate::types::{DriveEvent, DriveEventKind};
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        fs.external_snapshots.insert(
+            ("WD-18TB".to_string(), "sv1".to_string()),
+            vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        // Event data present but drive is mounted → cascade must yield (None, None).
+        fs.drive_events.insert(
+            "WD-18TB".to_string(),
+            DriveEvent {
+                kind: DriveEventKind::Mount,
+                at: dt(2026, 3, 23, 12, 0),
+            },
+        );
+        fs.last_successful_ops
+            .insert("WD-18TB".to_string(), dt(2026, 3, 22, 12, 0));
+
+        let results = assess(&config, now, &fs);
+        let drive = &results[0].external[0];
+        assert_eq!(drive.absent_duration_secs, None);
+        assert_eq!(drive.last_activity_age_secs, None);
+    }
+
+    #[test]
+    fn drive_assessment_absent_duration_none_when_last_event_is_mount_but_drive_unmounted() {
+        // Sentinel missed the disconnect. Rule 1: stay silent rather than
+        // emit a confident falsehood. Must NOT fall through to ops-log.
+        use crate::types::{DriveEvent, DriveEventKind};
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        // Drive unmounted, last event is Mount (stale — the Unmount was missed).
+        fs.drive_events.insert(
+            "WD-18TB".to_string(),
+            DriveEvent {
+                kind: DriveEventKind::Mount,
+                at: dt(2026, 3, 22, 8, 0),
+            },
+        );
+        // Ops log has data, but cascade must not consult it (an event exists).
+        fs.last_successful_ops
+            .insert("WD-18TB".to_string(), dt(2026, 3, 22, 10, 0));
+
+        let results = assess(&config, now, &fs);
+        let drive = &results[0].external[0];
+        assert_eq!(drive.absent_duration_secs, None);
+        assert_eq!(
+            drive.last_activity_age_secs, None,
+            "must not fall through to ops-log when any drive event exists"
+        );
+    }
+
+    #[test]
+    fn drive_assessment_last_activity_from_ops_log_when_no_event() {
+        // drive_connections empty for this drive → fall through to operations log.
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        // Drive unmounted, zero drive_events → ops-log fallback.
+        fs.last_successful_ops
+            .insert("WD-18TB".to_string(), dt(2026, 3, 20, 14, 0));
+
+        let results = assess(&config, now, &fs);
+        let drive = &results[0].external[0];
+        assert_eq!(drive.absent_duration_secs, None);
+        assert_eq!(
+            drive.last_activity_age_secs,
+            Some(3 * 86400),
+            "expected 3 days since last successful op"
+        );
+    }
+
+    #[test]
+    fn drive_assessment_last_activity_none_when_any_drive_event_exists() {
+        // Even with ops-log data present, a single Unmount event takes precedence:
+        // absent_duration_secs populated, last_activity_age_secs silent.
+        use crate::types::{DriveEvent, DriveEventKind};
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        fs.drive_events.insert(
+            "WD-18TB".to_string(),
+            DriveEvent {
+                kind: DriveEventKind::Unmount,
+                at: dt(2026, 3, 23, 10, 0),
+            },
+        );
+        fs.last_successful_ops
+            .insert("WD-18TB".to_string(), dt(2026, 3, 20, 10, 0));
+
+        let results = assess(&config, now, &fs);
+        let drive = &results[0].external[0];
+        assert_eq!(drive.absent_duration_secs, Some(4 * 3600));
+        assert_eq!(
+            drive.last_activity_age_secs, None,
+            "cascade must not mix sources"
+        );
+    }
+
+    #[test]
+    fn drive_assessment_both_none_when_no_data() {
+        // Unmounted drive, zero drive_events, zero ops-log entries → both None.
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+
+        let results = assess(&config, now, &fs);
+        let drive = &results[0].external[0];
+        assert_eq!(drive.absent_duration_secs, None);
+        assert_eq!(drive.last_activity_age_secs, None);
     }
 
     #[test]
@@ -3372,6 +3688,8 @@ drives = ["primary-drive", "offsite-drive"]
             last_send_age: age_days.map(Duration::days),
             configured_interval: Interval::hours(24),
             role: DriveRole::Offsite,
+            absent_duration_secs: None,
+            last_activity_age_secs: None,
         }
     }
 
@@ -3384,6 +3702,8 @@ drives = ["primary-drive", "offsite-drive"]
             last_send_age: Some(Duration::hours(2)),
             configured_interval: Interval::hours(24),
             role: DriveRole::Primary,
+            absent_duration_secs: None,
+            last_activity_age_secs: None,
         }
     }
 
@@ -3445,6 +3765,8 @@ drives = ["primary-drive", "offsite-drive"]
             last_send_age: Some(Duration::days(60)),
             configured_interval: Interval::hours(24),
             role: DriveRole::Offsite,
+            absent_duration_secs: None,
+            last_activity_age_secs: None,
         }];
         let mut assessments = vec![make_assessment("sv1", PromiseStatus::Protected, drives)];
 
@@ -3483,6 +3805,8 @@ drives = ["primary-drive", "offsite-drive"]
             last_send_age: Some(Duration::days(60)),
             configured_interval: Interval::hours(24),
             role: DriveRole::Offsite,
+            absent_duration_secs: None,
+            last_activity_age_secs: None,
         };
         let fresh_offsite = offsite_drive_assessment(Some(10));
         let drives = vec![primary_drive_assessment(), stale_offsite, fresh_offsite];
@@ -4157,6 +4481,8 @@ drives = ["D1"]
             last_send_age: send_age_hours.map(Duration::hours),
             configured_interval: Interval::hours(24),
             role: DriveRole::Primary,
+            absent_duration_secs: None,
+            last_activity_age_secs: None,
         }
     }
 

--- a/src/commands/acknowledgment.rs
+++ b/src/commands/acknowledgment.rs
@@ -1,0 +1,120 @@
+use crate::state::StateDb;
+use colored::Colorize;
+use std::path::Path;
+
+const MARKER_NAME: &str = "trust-repair-v0_13_0";
+const MESSAGE: &str = "Urd's self-check is now more accurate. Some subvolumes previously reported as blocked are now reported as healthy — their drives always had space.";
+
+/// Returns a one-shot dimmed line acknowledging the v0.13.0 awareness
+/// correctness improvement, if this is the user's first invocation after
+/// upgrade AND they have completed at least one backup (so they're a
+/// returning user, not a fresh install).
+///
+/// Side effect on success: creates the marker file so the line does not
+/// repeat. If marker creation fails, still returns the line (fail-open)
+/// and logs a warning — the line may repeat once.
+///
+/// `data_dir` is the XDG data directory (typically `~/.local/share/urd/`).
+/// `db` is an already-open `StateDb` handle.
+/// Convenience wrapper: resolves the data directory from the configured
+/// `state_db` path and returns the preamble string (empty if not applicable).
+/// Call sites that already hold a `StateDb` and the `Config` use this to
+/// avoid duplicating the `state_db.parent()` plumbing.
+pub fn preamble_for(state_db_path: &Path, db: Option<&StateDb>) -> String {
+    db.and_then(|db| state_db_path.parent().and_then(|dir| take_post_upgrade_preamble(dir, db)))
+        .unwrap_or_default()
+}
+
+pub fn take_post_upgrade_preamble(data_dir: &Path, db: &StateDb) -> Option<String> {
+    let marker_dir = data_dir.join(".acknowledgments");
+    let marker = marker_dir.join(MARKER_NAME);
+    if marker.exists() {
+        return None;
+    }
+    match db.has_any_completed_runs() {
+        Ok(true) => {}
+        Ok(false) | Err(_) => return None,
+    }
+    if let Err(e) = std::fs::create_dir_all(&marker_dir) {
+        log::warn!("failed to create acknowledgment dir: {e}");
+    }
+    if let Err(e) = std::fs::File::create(&marker) {
+        log::warn!("failed to create acknowledgment marker: {e}");
+    }
+    Some(format!("{}\n", MESSAGE.dimmed()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn open_db(tmp: &TempDir) -> StateDb {
+        let db_path = tmp.path().join("urd.db");
+        StateDb::open(&db_path).unwrap()
+    }
+
+    fn record_completed_run(db: &StateDb) {
+        db.begin_run("full").unwrap();
+    }
+
+    #[test]
+    fn no_completed_runs_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let db = open_db(&tmp);
+        assert!(take_post_upgrade_preamble(tmp.path(), &db).is_none());
+    }
+
+    #[test]
+    fn marker_present_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let db = open_db(&tmp);
+        record_completed_run(&db);
+        let marker_dir = tmp.path().join(".acknowledgments");
+        std::fs::create_dir_all(&marker_dir).unwrap();
+        std::fs::File::create(marker_dir.join(MARKER_NAME)).unwrap();
+
+        assert!(take_post_upgrade_preamble(tmp.path(), &db).is_none());
+    }
+
+    #[test]
+    fn has_runs_and_no_marker_returns_line_and_creates_marker() {
+        let tmp = TempDir::new().unwrap();
+        let db = open_db(&tmp);
+        record_completed_run(&db);
+
+        let preamble = take_post_upgrade_preamble(tmp.path(), &db);
+        assert!(preamble.is_some());
+        let line = preamble.unwrap();
+        assert!(line.contains("self-check is now more accurate"));
+        assert!(line.ends_with('\n'));
+
+        let marker = tmp.path().join(".acknowledgments").join(MARKER_NAME);
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn second_call_after_first_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let db = open_db(&tmp);
+        record_completed_run(&db);
+
+        let first = take_post_upgrade_preamble(tmp.path(), &db);
+        assert!(first.is_some());
+
+        let second = take_post_upgrade_preamble(tmp.path(), &db);
+        assert!(second.is_none());
+    }
+
+    #[test]
+    fn fresh_install_twice_silent() {
+        let tmp = TempDir::new().unwrap();
+        let db = open_db(&tmp);
+
+        assert!(take_post_upgrade_preamble(tmp.path(), &db).is_none());
+        assert!(take_post_upgrade_preamble(tmp.path(), &db).is_none());
+
+        let marker = tmp.path().join(".acknowledgments").join(MARKER_NAME);
+        assert!(!marker.exists());
+    }
+}

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -27,7 +27,7 @@ use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
 use crate::sentinel_runner;
 use crate::preflight;
 use crate::state::StateDb;
-use crate::types::{BackupPlan, ByteSize, PlannedOperation, ProtectionLevel};
+use crate::types::{BackupPlan, ByteSize, PlannedOperation, ProtectionLevel, SendKind};
 
 pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let now = chrono::Local::now().naive_local();
@@ -330,7 +330,11 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     );
     let output_mode = OutputMode::detect();
     let rendered = crate::voice::render_backup_summary(&summary, output_mode);
-    println!("{rendered}");
+    let preamble = crate::commands::acknowledgment::preamble_for(
+        &config.general.state_db,
+        state_db.as_ref(),
+    );
+    println!("{preamble}{rendered}");
 
     // Exit with appropriate code
     if result.overall != RunResult::Success {
@@ -341,6 +345,18 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 }
 
 // ── Summary builder ─────────────────────────────────────────────────────
+
+/// Maps an `OperationOutcome.operation` string back to the short user-facing
+/// label ("full" / "incremental"). Returns `None` for non-send operations.
+fn send_kind_display(op_name: &str) -> Option<&'static str> {
+    if op_name == SendKind::Full.as_db_str() {
+        Some("full")
+    } else if op_name == SendKind::Incremental.as_db_str() {
+        Some("incremental")
+    } else {
+        None
+    }
+}
 
 /// Build a structured backup summary from plan, execution results, and awareness assessments.
 /// Pure function — no I/O.
@@ -364,14 +380,10 @@ fn build_backup_summary(
             for op in &sv.operations {
                 match op.result {
                     OpResult::Success => {
-                        if op.operation == "send_incremental" || op.operation == "send_full" {
+                        if let Some(send_type) = send_kind_display(&op.operation) {
                             sends.push(SendSummary {
                                 drive: op.drive_label.clone().unwrap_or_default(),
-                                send_type: if op.operation == "send_full" {
-                                    "full".to_string()
-                                } else {
-                                    "incremental".to_string()
-                                },
+                                send_type: send_type.to_string(),
                                 bytes_transferred: op.bytes_transferred,
                             });
                         }
@@ -504,12 +516,10 @@ fn build_backup_summary(
         }
     }
 
-    // Skipped deletions (space recovery)
-    let planned_deletes = plan
-        .operations
-        .iter()
-        .filter(|op| matches!(op, crate::types::PlannedOperation::DeleteSnapshot { .. }))
-        .count();
+    // Skipped deletions (space guard held — ADR-113 do-no-harm behavior).
+    // This is an informational note, not a warning — the user did not ask
+    // for the cleanup, the space guard protected them from a tight margin.
+    let mut notes: Vec<String> = Vec::new();
     let skipped_deletes: usize = result
         .subvolume_results
         .iter()
@@ -524,8 +534,9 @@ fn build_backup_summary(
         })
         .count();
     if skipped_deletes > 0 {
-        warnings.push(format!(
-            "{skipped_deletes} of {planned_deletes} planned deletion(s) skipped (space recovered)"
+        let noun = if skipped_deletes == 1 { "snapshot" } else { "snapshots" };
+        notes.push(format!(
+            "space guard held — {skipped_deletes} {noun} retained."
         ));
     }
 
@@ -541,6 +552,7 @@ fn build_backup_summary(
             .collect(),
         transitions,
         warnings,
+        notes,
     }
 }
 
@@ -809,14 +821,7 @@ fn build_size_estimates(
                 drive_label,
                 ..
             } => {
-                let est = fs_state
-                    .last_send_size(subvolume_name, drive_label, "send_full")
-                    .or_else(|| fs_state.last_send_size_any_drive(subvolume_name, "send_full"))
-                    .or_else(|| {
-                        fs_state
-                            .calibrated_size(subvolume_name)
-                            .map(|(bytes, _)| bytes)
-                    });
+                let est = crate::plan::estimated_send_size(fs_state, subvolume_name, drive_label, true);
                 estimates.insert((subvolume_name.clone(), drive_label.clone()), est);
             }
             PlannedOperation::SendIncremental {
@@ -824,11 +829,7 @@ fn build_size_estimates(
                 drive_label,
                 ..
             } => {
-                let est = fs_state
-                    .last_send_size(subvolume_name, drive_label, "send_incremental")
-                    .or_else(|| {
-                        fs_state.last_send_size_any_drive(subvolume_name, "send_incremental")
-                    });
+                let est = crate::plan::estimated_send_size(fs_state, subvolume_name, drive_label, false);
                 estimates.insert((subvolume_name.clone(), drive_label.clone()), est);
             }
             _ => {}
@@ -1326,7 +1327,7 @@ mod tests {
         ChainBreakReason, ChainStatus, DriveAssessment, DriveChainHealth, LocalAssessment,
         OperationalHealth, PromiseStatus, SubvolAssessment,
     };
-    use crate::types::DriveRole;
+    use crate::types::{DriveRole, SendKind};
     use crate::executor::{
         ExecutionResult, OpResult, OperationOutcome, RunResult, SendType, SubvolumeResult,
         TransientCleanupOutcome,
@@ -1599,8 +1600,95 @@ mod tests {
             &[],
         );
 
-        assert_eq!(summary.warnings.len(), 1);
-        assert!(summary.warnings[0].contains("1 of 2 planned deletion(s) skipped"));
+        assert_eq!(
+            summary.notes,
+            vec!["space guard held — 1 snapshot retained.".to_string()]
+        );
+        assert!(
+            !summary.warnings.iter().any(|w| w.contains("space recovered")),
+            "must not appear as a warning"
+        );
+        assert!(
+            !summary.warnings.iter().any(|w| w.contains("skipped")),
+            "must not appear as a warning"
+        );
+    }
+
+    #[test]
+    fn build_summary_space_guard_plural_snapshots() {
+        let plan = BackupPlan {
+            operations: vec![],
+            timestamp: chrono::NaiveDateTime::default(),
+            skipped: vec![],
+        };
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![make_subvol_result(
+                "sv1",
+                true,
+                vec![
+                    make_outcome(
+                        "delete",
+                        None,
+                        OpResult::Skipped,
+                        Some("space recovered by prior deletes"),
+                        None,
+                    ),
+                    make_outcome(
+                        "delete",
+                        None,
+                        OpResult::Skipped,
+                        Some("space recovered by prior deletes"),
+                        None,
+                    ),
+                    make_outcome(
+                        "delete",
+                        None,
+                        OpResult::Skipped,
+                        Some("space recovered by prior deletes"),
+                        None,
+                    ),
+                ],
+                SendType::NoSend,
+                0,
+            )],
+            run_id: Some(15),
+        };
+        let summary = build_backup_summary(
+            &plan,
+            &result,
+            &empty_assessments(),
+            vec![],
+            Duration::from_secs(1),
+            &[],
+        );
+        assert_eq!(
+            summary.notes,
+            vec!["space guard held — 3 snapshots retained.".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_summary_no_notes_when_no_skips() {
+        let plan = BackupPlan {
+            operations: vec![],
+            timestamp: chrono::NaiveDateTime::default(),
+            skipped: vec![],
+        };
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![],
+            run_id: Some(16),
+        };
+        let summary = build_backup_summary(
+            &plan,
+            &result,
+            &empty_assessments(),
+            vec![],
+            Duration::from_secs(1),
+            &[],
+        );
+        assert!(summary.notes.is_empty());
     }
 
     #[test]
@@ -1942,11 +2030,11 @@ mod tests {
 
         let mut fs = MockFileSystemState::new();
         fs.send_sizes.insert(
-            ("sv1".to_string(), "WD-18TB".to_string(), "send_full".to_string()),
+            ("sv1".to_string(), "WD-18TB".to_string(), SendKind::Full),
             53_000_000_000,
         );
         fs.send_sizes.insert(
-            ("sv2".to_string(), "WD-18TB".to_string(), "send_incremental".to_string()),
+            ("sv2".to_string(), "WD-18TB".to_string(), SendKind::Incremental),
             5_500_000,
         );
 
@@ -2015,7 +2103,7 @@ mod tests {
         // No same-drive ("new-drive") history, but history from "old-drive" exists.
         // last_send_size_any_drive picks this up.
         fs.send_sizes.insert(
-            ("sv1".to_string(), "old-drive".to_string(), "send_full".to_string()),
+            ("sv1".to_string(), "old-drive".to_string(), SendKind::Full),
             50_000_000_000,
         );
 
@@ -2147,6 +2235,8 @@ mod tests {
             last_send_age: None,
             configured_interval: Interval::hours(4),
             role: DriveRole::Primary,
+            absent_duration_secs: None,
+            last_activity_age_secs: None,
         }
     }
 

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -82,7 +82,12 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         total_needing_attention,
     };
 
-    print!("{}", voice::render_default_status(&output, output_mode));
+    let rendered = voice::render_default_status(&output, output_mode);
+    let preamble = crate::commands::acknowledgment::preamble_for(
+        &config.general.state_db,
+        state_db.as_ref(),
+    );
+    print!("{preamble}{rendered}");
     Ok(())
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod acknowledgment;
 pub mod backup;
 pub mod calibrate;
 pub mod completions;

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -117,7 +117,7 @@ pub fn populate_token_warnings(
 mod tests {
     use super::*;
     use crate::plan::MockFileSystemState;
-    use crate::types::SnapshotName;
+    use crate::types::{SendKind, SnapshotName};
     use std::path::PathBuf;
 
     fn dummy_snap(subvol: &str) -> SnapshotName {
@@ -159,7 +159,7 @@ mod tests {
     fn full_send_same_drive_history() {
         let mut fs = MockFileSystemState::new();
         fs.send_sizes.insert(
-            ("htpc-home".into(), "WD-18TB".into(), "send_full".into()),
+            ("htpc-home".into(), "WD-18TB".into(), SendKind::Full),
             53_000_000_000,
         );
         let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
@@ -175,7 +175,7 @@ mod tests {
         let mut fs = MockFileSystemState::new();
         // History on different drive, not on target drive
         fs.send_sizes.insert(
-            ("htpc-home".into(), "OTHER-DRIVE".into(), "send_full".into()),
+            ("htpc-home".into(), "OTHER-DRIVE".into(), SendKind::Full),
             50_000_000_000,
         );
         let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
@@ -197,11 +197,11 @@ mod tests {
     fn full_send_same_drive_wins_over_cross_drive() {
         let mut fs = MockFileSystemState::new();
         fs.send_sizes.insert(
-            ("htpc-home".into(), "WD-18TB".into(), "send_full".into()),
+            ("htpc-home".into(), "WD-18TB".into(), SendKind::Full),
             53_000_000_000,
         );
         fs.send_sizes.insert(
-            ("htpc-home".into(), "OTHER".into(), "send_full".into()),
+            ("htpc-home".into(), "OTHER".into(), SendKind::Full),
             50_000_000_000,
         );
         fs.calibrated_sizes.insert(
@@ -225,7 +225,7 @@ mod tests {
     fn incremental_send_same_drive_history() {
         let mut fs = MockFileSystemState::new();
         fs.send_sizes.insert(
-            ("htpc-home".into(), "WD-18TB".into(), "send_incremental".into()),
+            ("htpc-home".into(), "WD-18TB".into(), SendKind::Incremental),
             5_500_000,
         );
         let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs);
@@ -239,7 +239,7 @@ mod tests {
     fn incremental_send_cross_drive_fallback() {
         let mut fs = MockFileSystemState::new();
         fs.send_sizes.insert(
-            ("htpc-home".into(), "OTHER".into(), "send_incremental".into()),
+            ("htpc-home".into(), "OTHER".into(), SendKind::Incremental),
             3_000_000,
         );
         let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs);
@@ -264,11 +264,11 @@ mod tests {
     fn summary_aggregates_all_estimates() {
         let mut fs = MockFileSystemState::new();
         fs.send_sizes.insert(
-            ("htpc-home".into(), "WD-18TB".into(), "send_full".into()),
+            ("htpc-home".into(), "WD-18TB".into(), SendKind::Full),
             53_000_000_000,
         );
         fs.send_sizes.insert(
-            ("htpc-docs".into(), "WD-18TB".into(), "send_full".into()),
+            ("htpc-docs".into(), "WD-18TB".into(), SendKind::Full),
             1_200_000_000,
         );
         let plan = crate::types::BackupPlan {
@@ -287,7 +287,7 @@ mod tests {
     fn summary_partial_estimates() {
         let mut fs = MockFileSystemState::new();
         fs.send_sizes.insert(
-            ("htpc-home".into(), "WD-18TB".into(), "send_full".into()),
+            ("htpc-home".into(), "WD-18TB".into(), SendKind::Full),
             53_000_000_000,
         );
         let plan = crate::types::BackupPlan {
@@ -349,13 +349,8 @@ fn build_operation_entry(
                 ""
             };
 
-            // Two-tier fallback: same-drive history, then cross-drive.
-            // No calibrated fallback for incrementals (calibration measures full subvolume).
-            let estimated_bytes = fs_state
-                .last_send_size(subvolume_name, drive_label, "send_incremental")
-                .or_else(|| {
-                    fs_state.last_send_size_any_drive(subvolume_name, "send_incremental")
-                });
+            let estimated_bytes =
+                plan::estimated_send_size(fs_state, subvolume_name, drive_label, false);
 
             PlanOperationEntry {
                 subvolume: subvolume_name.clone(),
@@ -384,11 +379,8 @@ fn build_operation_entry(
                 ""
             };
 
-            // Three-tier fallback: same-drive, cross-drive, calibrated.
-            let estimated_bytes = fs_state
-                .last_send_size(subvolume_name, drive_label, "send_full")
-                .or_else(|| fs_state.last_send_size_any_drive(subvolume_name, "send_full"))
-                .or_else(|| fs_state.calibrated_size(subvolume_name).map(|(bytes, _)| bytes));
+            let estimated_bytes =
+                plan::estimated_send_size(fs_state, subvolume_name, drive_label, true);
 
             PlanOperationEntry {
                 subvolume: subvolume_name.clone(),

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -130,7 +130,11 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     };
 
     let rendered = voice::render_status(&status_output, output_mode);
-    print!("{rendered}");
+    let preamble = crate::commands::acknowledgment::preamble_for(
+        &config.general.state_db,
+        state_db.as_ref(),
+    );
+    print!("{preamble}{rendered}");
 
     Ok(())
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -13,7 +13,7 @@ use crate::config::Config;
 use crate::drives;
 use crate::error::BtrfsOperation;
 use crate::state::{OperationRecord, StateDb};
-use crate::types::{BackupPlan, FullSendReason, PlannedOperation};
+use crate::types::{BackupPlan, FullSendReason, PlannedOperation, SendKind};
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -325,7 +325,7 @@ impl<'a> Executor<'a> {
                         );
                         send_type = SendType::Deferred;
                         OperationOutcome {
-                            operation: "send_full".to_string(),
+                            operation: SendKind::Full.as_db_str().to_string(),
                             drive_label: Some(drive_label.clone()),
                             result: OpResult::Deferred,
                             duration: std::time::Duration::ZERO,
@@ -460,11 +460,12 @@ impl<'a> Executor<'a> {
         subvol_name: &str,
     ) -> (OperationOutcome, bool) {
         let start = Instant::now();
-        let op_name = if parent.is_some() {
-            "send_incremental"
+        let send_kind = if parent.is_some() {
+            SendKind::Incremental
         } else {
-            "send_full"
+            SendKind::Full
         };
+        let op_name = send_kind.as_db_str();
 
         // Cascading failure check: if the snapshot was not created, skip
         if failed_creates.contains(snapshot) {

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -219,7 +219,7 @@ mod tests {
     use crate::executor::{
         ExecutionResult, RunResult, SendType, SubvolumeResult, TransientCleanupOutcome,
     };
-    use crate::types::{DriveRole, GraduatedRetention, Interval, RunFrequency};
+    use crate::types::{DriveRole, GraduatedRetention, Interval, RunFrequency, SendKind};
     use std::path::PathBuf;
 
     fn test_config(intervals: &[(&str, &str)]) -> Config {
@@ -305,6 +305,8 @@ mod tests {
                     last_send_age: Some(chrono::Duration::hours(2)),
                     configured_interval: Interval::hours(4),
                     role: DriveRole::Primary,
+                    absent_duration_secs: None,
+                    last_activity_age_secs: None,
                 }],
                 chain_health: vec![],
                 advisories: vec![],
@@ -508,7 +510,7 @@ mod tests {
                 name: "home".to_string(),
                 success: true,
                 operations: vec![make_operation(
-                    "send_incremental",
+                    SendKind::Incremental.as_db_str(),
                     crate::executor::OpResult::Success,
                 )],
                 duration: std::time::Duration::from_secs(5),
@@ -536,7 +538,7 @@ mod tests {
                 name: "home".to_string(),
                 success: true,
                 operations: vec![make_operation(
-                    "send_full",
+                    SendKind::Full.as_db_str(),
                     crate::executor::OpResult::Deferred,
                 )],
                 duration: std::time::Duration::from_secs(0),

--- a/src/output.rs
+++ b/src/output.rs
@@ -228,6 +228,16 @@ pub struct StatusDriveAssessment {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_send_age_secs: Option<i64>,
     pub role: DriveRole,
+    /// Seconds since the drive's last recorded Unmount event. Populated only
+    /// when drive is currently unmounted AND the most recent physical event
+    /// is an Unmount. See awareness::DriveAssessment for cascade rules.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub absent_duration_secs: Option<i64>,
+    /// Seconds since the most recent successful operation targeting this
+    /// drive. Populated only when drive is unmounted and no physical events
+    /// exist for this drive at all (ops-log fallback).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_activity_age_secs: Option<i64>,
 }
 
 impl StatusDriveAssessment {
@@ -240,6 +250,8 @@ impl StatusDriveAssessment {
             snapshot_count: a.snapshot_count,
             last_send_age_secs: a.last_send_age.map(|d| d.num_seconds()),
             role: a.role,
+            absent_duration_secs: a.absent_duration_secs,
+            last_activity_age_secs: a.last_activity_age_secs,
         }
     }
 }
@@ -584,6 +596,12 @@ pub struct BackupSummary {
 
     /// Summary warnings (pin failures, skipped deletions, etc.)
     pub warnings: Vec<String>,
+
+    /// Informational outcomes that are not warnings: conservative-cleanup
+    /// completion, by-design skips, reassurance about safety behaviors the
+    /// user did not explicitly request. See ADR-113 (do-no-harm) — when the
+    /// storage guard retains snapshots, that's a success, not a warning.
+    pub notes: Vec<String>,
 }
 
 /// A meaningful state change detected by comparing pre-backup and post-backup

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -10,7 +10,8 @@ use crate::drives::DriveAvailability;
 use crate::error::UrdError;
 use crate::retention;
 use crate::types::{
-    BackupPlan, FullSendReason, LocalRetentionPolicy, PlannedOperation, SnapshotName,
+    BackupPlan, DriveEvent, DriveEventKind, FullSendReason, LocalRetentionPolicy, PlannedOperation,
+    SendKind, SnapshotName,
 };
 
 // ── FileSystemState trait ───────────────────────────────────────────────
@@ -52,13 +53,18 @@ pub trait FileSystemState {
     /// Collect all pinned snapshot names for a subvolume across all drives.
     fn pinned_snapshots(&self, local_dir: &Path, drive_labels: &[String]) -> HashSet<SnapshotName>;
 
-    /// Get the bytes_transferred from the most recent successful send of a given type.
+    /// Get the bytes_transferred from the most recent successful send of a given kind.
     /// Returns None if no history exists (e.g., first-ever send).
-    fn last_send_size(&self, subvol_name: &str, drive_label: &str, send_type: &str) -> Option<u64>;
+    fn last_send_size(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+        send_kind: SendKind,
+    ) -> Option<u64>;
 
-    /// Get the bytes_transferred from the most recent successful send of a given type
+    /// Get the bytes_transferred from the most recent successful send of a given kind
     /// across **all** drives. Cross-drive fallback for drive swap scenarios.
-    fn last_send_size_any_drive(&self, subvol_name: &str, send_type: &str) -> Option<u64>;
+    fn last_send_size_any_drive(&self, subvol_name: &str, send_kind: SendKind) -> Option<u64>;
 
     /// Get a calibrated size estimate for a subvolume (from `urd calibrate`).
     /// Returns `(estimated_bytes, measured_at)` or None if not calibrated.
@@ -74,6 +80,47 @@ pub trait FileSystemState {
         subvol_name: &str,
         drive_label: &str,
     ) -> Option<NaiveDateTime>;
+
+    /// Most recent mount/unmount event for a drive from `drive_connections`.
+    /// None if no event recorded (drive never seen by sentinel).
+    fn last_drive_event(&self, drive_label: &str) -> Option<DriveEvent>;
+
+    /// Most recent successful send timestamp for this drive (any subvolume).
+    /// None when no successful send has ever completed for this drive.
+    fn last_successful_operation_at(&self, drive_label: &str) -> Option<NaiveDateTime>;
+}
+
+// ── Size estimation helper ──────────────────────────────────────────────
+
+/// Best available estimate of the bytes a next send will transfer.
+/// Strategy: same-drive history > cross-drive history > calibrated
+/// size (full sends only). Returns None when no data is available.
+///
+/// Note: calibrated size is the full subvolume footprint, so it is
+/// only a valid estimate when a full send is needed. For incremental
+/// sends, returning None is correct — callers must treat "unknown"
+/// as not-a-constraint rather than substituting calibrated.
+#[must_use]
+pub fn estimated_send_size(
+    fs: &dyn FileSystemState,
+    subvol_name: &str,
+    drive_label: &str,
+    needs_full: bool,
+) -> Option<u64> {
+    let send_kind = if needs_full {
+        SendKind::Full
+    } else {
+        SendKind::Incremental
+    };
+    fs.last_send_size(subvol_name, drive_label, send_kind)
+        .or_else(|| fs.last_send_size_any_drive(subvol_name, send_kind))
+        .or_else(|| {
+            if needs_full {
+                fs.calibrated_size(subvol_name).map(|(bytes, _)| bytes)
+            } else {
+                None
+            }
+        })
 }
 
 // ── PlanFilters ─────────────────────────────────────────────────────────
@@ -838,14 +885,14 @@ fn plan_external_send(
 
     // Space estimation: skip if estimated send size exceeds available space.
     // Three-tier fallback: same-drive history > cross-drive history > calibrated (full only).
-    let send_type_str = if is_incremental {
-        "send_incremental"
+    let send_kind = if is_incremental {
+        SendKind::Incremental
     } else {
-        "send_full"
+        SendKind::Full
     };
     if let Some(last_size) = fs
-        .last_send_size(&subvol.name, &drive.label, send_type_str)
-        .or_else(|| fs.last_send_size_any_drive(&subvol.name, send_type_str))
+        .last_send_size(&subvol.name, &drive.label, send_kind)
+        .or_else(|| fs.last_send_size_any_drive(&subvol.name, send_kind))
     {
         // Tier 1/2: historical data from same drive or cross-drive fallback
         if let Some((estimated, available, free, min_free)) =
@@ -1065,8 +1112,14 @@ impl FileSystemState for RealFileSystemState<'_> {
         crate::chain::find_pinned_snapshots(local_dir, drive_labels)
     }
 
-    fn last_send_size(&self, subvol_name: &str, drive_label: &str, send_type: &str) -> Option<u64> {
+    fn last_send_size(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+        send_kind: SendKind,
+    ) -> Option<u64> {
         self.state.and_then(|db| {
+            let send_type = send_kind.as_db_str();
             let successful = db
                 .last_successful_send_size(subvol_name, drive_label, send_type)
                 .ok()
@@ -1082,8 +1135,9 @@ impl FileSystemState for RealFileSystemState<'_> {
         })
     }
 
-    fn last_send_size_any_drive(&self, subvol_name: &str, send_type: &str) -> Option<u64> {
+    fn last_send_size_any_drive(&self, subvol_name: &str, send_kind: SendKind) -> Option<u64> {
         self.state.and_then(|db| {
+            let send_type = send_kind.as_db_str();
             let successful = db
                 .last_successful_send_size_any_drive(subvol_name, send_type)
                 .ok()
@@ -1115,6 +1169,37 @@ impl FileSystemState for RealFileSystemState<'_> {
     ) -> Option<NaiveDateTime> {
         self.state.and_then(|db| {
             db.last_successful_send_time(subvol_name, drive_label)
+                .ok()
+                .flatten()
+        })
+    }
+
+    fn last_drive_event(&self, drive_label: &str) -> Option<DriveEvent> {
+        let record = self
+            .state
+            .and_then(|db| db.last_drive_connection(drive_label).ok().flatten())?;
+        let kind = match record.event_type.as_str() {
+            "mounted" => DriveEventKind::Mount,
+            "unmounted" => DriveEventKind::Unmount,
+            other => {
+                log::warn!("unknown drive_connections.event_type {other:?} — ignoring");
+                return None;
+            }
+        };
+        let at = chrono::NaiveDateTime::parse_from_str(&record.timestamp, "%Y-%m-%dT%H:%M:%S")
+            .inspect_err(|e| {
+                log::warn!(
+                    "failed to parse drive_connections.timestamp {:?}: {e}",
+                    record.timestamp
+                );
+            })
+            .ok()?;
+        Some(DriveEvent { kind, at })
+    }
+
+    fn last_successful_operation_at(&self, drive_label: &str) -> Option<NaiveDateTime> {
+        self.state.and_then(|db| {
+            db.last_successful_operation_at(drive_label)
                 .ok()
                 .flatten()
         })
@@ -1165,9 +1250,11 @@ pub struct MockFileSystemState {
         std::collections::HashMap<String, crate::drives::DriveAvailability>,
     pub free_bytes: std::collections::HashMap<PathBuf, u64>,
     pub pin_files: std::collections::HashMap<(PathBuf, String), SnapshotName>,
-    pub send_sizes: std::collections::HashMap<(String, String, String), u64>,
+    pub send_sizes: std::collections::HashMap<(String, String, SendKind), u64>,
     pub calibrated_sizes: std::collections::HashMap<String, (u64, String)>,
     pub send_times: std::collections::HashMap<(String, String), NaiveDateTime>,
+    pub drive_events: std::collections::HashMap<String, DriveEvent>,
+    pub last_successful_ops: std::collections::HashMap<String, NaiveDateTime>,
     /// Subvolume names for which local_snapshots() should return an error.
     pub fail_local_snapshots: HashSet<String>,
     /// (local_dir, drive_label) pairs for which read_pin_file() should return an error.
@@ -1191,6 +1278,8 @@ impl MockFileSystemState {
             send_sizes: std::collections::HashMap::new(),
             calibrated_sizes: std::collections::HashMap::new(),
             send_times: std::collections::HashMap::new(),
+            drive_events: std::collections::HashMap::new(),
+            last_successful_ops: std::collections::HashMap::new(),
             fail_local_snapshots: HashSet::new(),
             fail_pin_reads: HashSet::new(),
             generations: std::collections::HashMap::new(),
@@ -1282,23 +1371,28 @@ impl FileSystemState for MockFileSystemState {
         pinned
     }
 
-    fn last_send_size(&self, subvol_name: &str, drive_label: &str, send_type: &str) -> Option<u64> {
+    fn last_send_size(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+        send_kind: SendKind,
+    ) -> Option<u64> {
         self.send_sizes
             .get(&(
                 subvol_name.to_string(),
                 drive_label.to_string(),
-                send_type.to_string(),
+                send_kind,
             ))
             .copied()
     }
 
-    fn last_send_size_any_drive(&self, subvol_name: &str, send_type: &str) -> Option<u64> {
+    fn last_send_size_any_drive(&self, subvol_name: &str, send_kind: SendKind) -> Option<u64> {
         // Note: returns max by value, not most-recent-by-time.
         // Real impl uses recency (ORDER BY id DESC). The mock has no
         // insertion ordering, so max-by-value is the best approximation.
         self.send_sizes
             .iter()
-            .filter(|((sv, _, st), _)| sv == subvol_name && st == send_type)
+            .filter(|((sv, _, st), _)| sv == subvol_name && *st == send_kind)
             .map(|(_, &bytes)| bytes)
             .max()
     }
@@ -1337,6 +1431,14 @@ impl FileSystemState for MockFileSystemState {
         self.send_times
             .get(&(subvol_name.to_string(), drive_label.to_string()))
             .copied()
+    }
+
+    fn last_drive_event(&self, drive_label: &str) -> Option<DriveEvent> {
+        self.drive_events.get(drive_label).cloned()
+    }
+
+    fn last_successful_operation_at(&self, drive_label: &str) -> Option<NaiveDateTime> {
+        self.last_successful_ops.get(drive_label).copied()
     }
 }
 
@@ -1410,6 +1512,71 @@ priority = 2
 
     fn snap(s: &str) -> SnapshotName {
         SnapshotName::parse(s).unwrap()
+    }
+
+    // ── estimated_send_size tests ──────────────────────────────────────
+
+    #[test]
+    fn est_full_needed_uses_same_drive_history_first() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes
+            .insert(("sv1".into(), "D1".into(), SendKind::Full), 50_000_000_000);
+        fs.send_sizes
+            .insert(("sv1".into(), "OTHER".into(), SendKind::Full), 10_000_000_000);
+        fs.calibrated_sizes
+            .insert("sv1".into(), (999_999_999_999, "2026-04-01".into()));
+        assert_eq!(estimated_send_size(&fs, "sv1", "D1", true), Some(50_000_000_000));
+    }
+
+    #[test]
+    fn est_full_needed_falls_back_cross_drive() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes
+            .insert(("sv1".into(), "OTHER".into(), SendKind::Full), 10_000_000_000);
+        assert_eq!(estimated_send_size(&fs, "sv1", "D1", true), Some(10_000_000_000));
+    }
+
+    #[test]
+    fn est_full_needed_falls_back_calibrated_when_no_history() {
+        let mut fs = MockFileSystemState::new();
+        fs.calibrated_sizes
+            .insert("sv1".into(), (42_000_000_000, "2026-04-01".into()));
+        assert_eq!(estimated_send_size(&fs, "sv1", "D1", true), Some(42_000_000_000));
+    }
+
+    #[test]
+    fn est_incremental_uses_same_drive_history() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes.insert(
+            ("sv1".into(), "D1".into(), SendKind::Incremental),
+            5_000_000,
+        );
+        assert_eq!(estimated_send_size(&fs, "sv1", "D1", false), Some(5_000_000));
+    }
+
+    #[test]
+    fn est_incremental_falls_back_cross_drive() {
+        let mut fs = MockFileSystemState::new();
+        fs.send_sizes.insert(
+            ("sv1".into(), "OTHER".into(), SendKind::Incremental),
+            3_000_000,
+        );
+        assert_eq!(estimated_send_size(&fs, "sv1", "D1", false), Some(3_000_000));
+    }
+
+    #[test]
+    fn est_incremental_never_uses_calibrated() {
+        let mut fs = MockFileSystemState::new();
+        fs.calibrated_sizes
+            .insert("sv1".into(), (999_999_999_999, "2026-04-01".into()));
+        assert_eq!(estimated_send_size(&fs, "sv1", "D1", false), None);
+    }
+
+    #[test]
+    fn est_returns_none_when_no_data() {
+        let fs = MockFileSystemState::new();
+        assert_eq!(estimated_send_size(&fs, "sv1", "D1", true), None);
+        assert_eq!(estimated_send_size(&fs, "sv1", "D1", false), None);
     }
 
     #[test]
@@ -1999,7 +2166,7 @@ send_enabled = false
         fs.mounted_drives.insert("D1".to_string());
         // Historical full send was 200GB
         fs.send_sizes.insert(
-            ("sv1".to_string(), "D1".to_string(), "send_full".to_string()),
+            ("sv1".to_string(), "D1".to_string(), SendKind::Full),
             200_000_000_000,
         );
         // Only 150GB free on external drive (min_free=100GB, so available=50GB)
@@ -2035,7 +2202,7 @@ send_enabled = false
         fs.mounted_drives.insert("D1".to_string());
         // Historical full send was 50GB
         fs.send_sizes.insert(
-            ("sv1".to_string(), "D1".to_string(), "send_full".to_string()),
+            ("sv1".to_string(), "D1".to_string(), SendKind::Full),
             50_000_000_000,
         );
         // 500GB free on external drive (min_free=100GB, available=400GB, estimated=60GB)
@@ -2124,7 +2291,7 @@ send_enabled = false
         fs.mounted_drives.insert("D1".to_string());
         // Tier 1 says 100KB (small send)
         fs.send_sizes.insert(
-            ("sv1".to_string(), "D1".to_string(), "send_full".to_string()),
+            ("sv1".to_string(), "D1".to_string(), SendKind::Full),
             100_000,
         );
         // Calibrated says 1TB (would block if used)
@@ -2181,7 +2348,7 @@ send_enabled = false
         fs.mounted_drives.insert("D1".to_string());
         // No same-drive history, but cross-drive history says 1TB
         fs.send_sizes.insert(
-            ("sv1".to_string(), "OTHER-DRIVE".to_string(), "send_full".to_string()),
+            ("sv1".to_string(), "OTHER-DRIVE".to_string(), SendKind::Full),
             1_000_000_000_000,
         );
         // Drive has only 500GB free
@@ -4106,5 +4273,24 @@ local_retention = "transient"
             skip.is_some() && skip.unwrap().1.starts_with("unchanged"),
             "should report unchanged reason"
         );
+    }
+
+    #[test]
+    fn real_file_system_state_round_trips_drive_events() {
+        use crate::state::{DriveEventSource, DriveEventType, StateDb};
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let db = StateDb::open(&dir.path().join("urd.db")).unwrap();
+        db.record_drive_event("D1", DriveEventType::Mounted, DriveEventSource::Sentinel)
+            .unwrap();
+        db.record_drive_event("D1", DriveEventType::Unmounted, DriveEventSource::Sentinel)
+            .unwrap();
+
+        let fs = RealFileSystemState { state: Some(&db) };
+        let event = fs
+            .last_drive_event("D1")
+            .expect("round-trip must yield an event — guards schema/parser drift");
+        assert!(matches!(event.kind, DriveEventKind::Unmount));
     }
 }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -893,6 +893,8 @@ mod tests {
                 last_send_age: None,
                 configured_interval: Interval::hours(24),
                 role: DriveRole::Primary,
+                absent_duration_secs: None,
+                last_activity_age_secs: None,
             }],
             chain_health: vec![],
             advisories: vec![],

--- a/src/state.rs
+++ b/src/state.rs
@@ -461,6 +461,63 @@ impl StateDb {
         }
     }
 
+    /// Get the timestamp of the most recent successful send (any subvolume) for a
+    /// given drive. Used by the D-1 drive-absence cascade to estimate when a
+    /// drive was last actively written to, when `drive_connections` is empty.
+    pub fn last_successful_operation_at(
+        &self,
+        drive_label: &str,
+    ) -> crate::error::Result<Option<chrono::NaiveDateTime>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT MAX(r.started_at) FROM operations o
+                 JOIN runs r ON o.run_id = r.id
+                 WHERE o.drive_label = ?1
+                   AND o.operation IN ('send_full', 'send_incremental')
+                   AND o.result = 'success'",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut rows = stmt
+            .query_map(rusqlite::params![drive_label], |row| {
+                let ts: Option<String> = row.get(0)?;
+                Ok(ts)
+            })
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        match rows.next() {
+            Some(Ok(Some(ts))) => {
+                let parsed = chrono::NaiveDateTime::parse_from_str(&ts, "%Y-%m-%dT%H:%M:%S")
+                    .map_err(|e| {
+                        UrdError::State(format!("failed to parse operation timestamp {ts:?}: {e}"))
+                    })?;
+                Ok(Some(parsed))
+            }
+            Some(Ok(None)) => Ok(None),
+            Some(Err(e)) => Err(UrdError::State(format!(
+                "failed to read operation time: {e}"
+            ))),
+            None => Ok(None),
+        }
+    }
+
+    /// Whether any run has been recorded. Used to gate first-run-only output
+    /// (e.g., the post-upgrade acknowledgment) behind actual usage.
+    pub fn has_any_completed_runs(&self) -> crate::error::Result<bool> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT 1 FROM runs LIMIT 1")
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+        let mut rows = stmt
+            .query(rusqlite::params![])
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+        Ok(rows
+            .next()
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?
+            .is_some())
+    }
+
     // ── Calibration methods ─────────────────────────────────────────
 
     /// Store (or update) a calibrated size for a subvolume.
@@ -677,7 +734,6 @@ impl StateDb {
     }
 
     /// Get the most recent connection event for a drive, if any.
-    #[allow(dead_code)] // consumed by urd sentinel status (future) and tests
     pub fn last_drive_connection(
         &self,
         drive_label: &str,
@@ -1462,5 +1518,129 @@ mod tests {
             .drive_connection_count("other", "2000-01-01T00:00:00")
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    // ── Drive activity + first-run gating ─────────
+
+    #[test]
+    fn last_successful_operation_at_returns_none_when_empty() {
+        let db = StateDb::open_memory().unwrap();
+        assert_eq!(db.last_successful_operation_at("WD-18TB").unwrap(), None);
+    }
+
+    #[test]
+    fn last_successful_operation_at_returns_none_when_only_failed() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("WD-18TB".to_string()),
+            duration_secs: Some(1.0),
+            result: "failed".to_string(),
+            error_message: Some("boom".to_string()),
+            bytes_transferred: None,
+        })
+        .unwrap();
+        assert_eq!(db.last_successful_operation_at("WD-18TB").unwrap(), None);
+    }
+
+    #[test]
+    fn last_successful_operation_at_returns_most_recent_success() {
+        let db = StateDb::open_memory().unwrap();
+        let run1 = db.begin_run("full").unwrap();
+        db.record_operation(&OperationRecord {
+            run_id: run1,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("WD-18TB".to_string()),
+            duration_secs: Some(2.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(100),
+        })
+        .unwrap();
+        // Second, later run — MAX(started_at) should pick this one.
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        let run2 = db.begin_run("incremental").unwrap();
+        db.record_operation(&OperationRecord {
+            run_id: run2,
+            subvolume: "sv1".to_string(),
+            operation: "send_incremental".to_string(),
+            drive_label: Some("WD-18TB".to_string()),
+            duration_secs: Some(1.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(50),
+        })
+        .unwrap();
+
+        let t1: String = db
+            .conn
+            .query_row("SELECT started_at FROM runs WHERE id = ?1", [run1], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        let t2: String = db
+            .conn
+            .query_row("SELECT started_at FROM runs WHERE id = ?1", [run2], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert!(t2 > t1, "run2 should have later started_at than run1");
+
+        let got = db.last_successful_operation_at("WD-18TB").unwrap().unwrap();
+        let expected = chrono::NaiveDateTime::parse_from_str(&t2, "%Y-%m-%dT%H:%M:%S").unwrap();
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn last_successful_operation_at_filtered_by_drive_label() {
+        let db = StateDb::open_memory().unwrap();
+        let run = db.begin_run("full").unwrap();
+        db.record_operation(&OperationRecord {
+            run_id: run,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("OTHER-DRIVE".to_string()),
+            duration_secs: Some(1.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(10),
+        })
+        .unwrap();
+        assert_eq!(db.last_successful_operation_at("WD-18TB").unwrap(), None);
+    }
+
+    #[test]
+    fn last_successful_operation_at_ignores_non_send_operations() {
+        let db = StateDb::open_memory().unwrap();
+        let run = db.begin_run("full").unwrap();
+        db.record_operation(&OperationRecord {
+            run_id: run,
+            subvolume: "sv1".to_string(),
+            operation: "snapshot".to_string(),
+            drive_label: Some("WD-18TB".to_string()),
+            duration_secs: Some(0.5),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: None,
+        })
+        .unwrap();
+        assert_eq!(db.last_successful_operation_at("WD-18TB").unwrap(), None);
+    }
+
+    #[test]
+    fn has_any_completed_runs_false_for_fresh_db() {
+        let db = StateDb::open_memory().unwrap();
+        assert!(!db.has_any_completed_runs().unwrap());
+    }
+
+    #[test]
+    fn has_any_completed_runs_true_after_begin_run() {
+        let db = StateDb::open_memory().unwrap();
+        let _ = db.begin_run("full").unwrap();
+        assert!(db.has_any_completed_runs().unwrap());
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -103,6 +103,47 @@ impl Serialize for Interval {
     }
 }
 
+// ── SendKind ────────────────────────────────────────────────────────────
+
+/// Whether a btrfs send is full (no parent snapshot) or incremental
+/// (parent snapshot already on destination). Used in size estimation,
+/// operations-log filtering, and health assessment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SendKind {
+    /// No parent snapshot on the destination — sends the entire subvolume.
+    Full,
+    /// Parent snapshot present — sends only the delta since the parent.
+    Incremental,
+}
+
+impl SendKind {
+    /// Canonical string form used in `OperationRecord.operation` and
+    /// SQL queries against `operations.operation`.
+    #[must_use]
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            SendKind::Full => "send_full",
+            SendKind::Incremental => "send_incremental",
+        }
+    }
+}
+
+// ── DriveEvent ──────────────────────────────────────────────────────────
+
+/// A drive mount or unmount event recorded by the sentinel daemon.
+/// Sourced from the `drive_connections` table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriveEvent {
+    pub kind: DriveEventKind,
+    pub at: NaiveDateTime,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DriveEventKind {
+    Mount,
+    Unmount,
+}
+
 // ── SnapshotName ────────────────────────────────────────────────────────
 
 /// A snapshot name in the format `YYYYMMDD-HHMM-shortname`.
@@ -950,6 +991,18 @@ mod tests {
         assert!("5x".parse::<Interval>().is_err());
         assert!("h".parse::<Interval>().is_err());
         assert!("".parse::<Interval>().is_err());
+    }
+
+    // ── SendKind tests ──────────────────────────────────────────────
+
+    #[test]
+    fn send_kind_db_str_full() {
+        assert_eq!(SendKind::Full.as_db_str(), "send_full");
+    }
+
+    #[test]
+    fn send_kind_db_str_incremental() {
+        assert_eq!(SendKind::Incremental.as_db_str(), "send_incremental");
     }
 
     // ── SnapshotName tests ──────────────────────────────────────────

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -427,20 +427,14 @@ fn render_drive_summary(data: &StatusOutput, out: &mut String) {
             )
             .ok();
         } else {
-            let (worst_status, max_age) =
-                aggregate_drive_staleness(&data.assessments, &drive.label);
-            if let Some(escalated) =
-                escalated_staleness_text(&drive.label, worst_status, max_age)
-            {
-                writeln!(out, "Drives: {escalated}").ok();
-            } else {
-                let status = if drive.role == DriveRole::Offsite {
-                    "away".dimmed()
-                } else {
-                    "disconnected".dimmed()
-                };
-                writeln!(out, "Drives: {} {}", drive.label.bold(), status).ok();
-            }
+            let agg = aggregate_drive_info(&data.assessments, &drive.label);
+            let line = unmounted_drive_label(
+                &drive.label,
+                agg.absent_duration_secs,
+                agg.last_activity_age_secs,
+                agg.worst_status,
+            );
+            writeln!(out, "Drives: {line}").ok();
         }
     }
 }
@@ -709,6 +703,16 @@ fn render_backup_interactive(data: &BackupSummary) -> String {
         writeln!(out).ok();
         for warning in &data.warnings {
             writeln!(out, "{} {}", "WARNING:".yellow().bold(), warning).ok();
+        }
+    }
+
+    // ── Notes (informational, not warnings) ──────────────────────────
+    // Middle-dot glyph, dimmed, two-space indent. No "NOTE:" label —
+    // the dim rendering signals informational tone without yellow gravity.
+    if !data.notes.is_empty() {
+        writeln!(out).ok();
+        for note in &data.notes {
+            writeln!(out, "  {} {}", "·".dimmed(), note.dimmed()).ok();
         }
     }
 
@@ -2696,16 +2700,24 @@ fn status_severity(status: &str) -> u8 {
     }
 }
 
-/// Aggregate worst promise status and maximum send age for a drive label
-/// across all subvolume assessments.
-///
-/// Returns `("PROTECTED", None)` when no assessments reference the drive.
-fn aggregate_drive_staleness<'a>(
+/// Single-pass aggregation of per-drive presentation fields. The drive-level
+/// fields (`absent_duration_secs`, `last_activity_age_secs`) co-travel across
+/// all subvolume `DriveAssessment` entries on the same drive, so we take the
+/// first populated value we see; they are invariant per drive. The worst
+/// promise status across subvolumes drives the gravity escalation.
+struct DriveAggregate<'a> {
+    worst_status: &'a str,
+    absent_duration_secs: Option<i64>,
+    last_activity_age_secs: Option<i64>,
+}
+
+fn aggregate_drive_info<'a>(
     assessments: &'a [StatusAssessment],
     drive_label: &str,
-) -> (&'a str, Option<i64>) {
+) -> DriveAggregate<'a> {
     let mut worst: &str = "PROTECTED";
-    let mut max_age: Option<i64> = None;
+    let mut absent_duration_secs: Option<i64> = None;
+    let mut last_activity_age_secs: Option<i64> = None;
 
     for assessment in assessments {
         for ext in &assessment.external {
@@ -2713,42 +2725,71 @@ fn aggregate_drive_staleness<'a>(
                 if status_severity(&ext.status) > status_severity(worst) {
                     worst = &ext.status;
                 }
-                if let Some(age) = ext.last_send_age_secs {
-                    max_age = Some(max_age.map_or(age, |current| current.max(age)));
+                if absent_duration_secs.is_none() {
+                    absent_duration_secs = ext.absent_duration_secs;
+                }
+                if last_activity_age_secs.is_none() {
+                    last_activity_age_secs = ext.last_activity_age_secs;
                 }
             }
         }
     }
 
-    (worst, max_age)
+    DriveAggregate {
+        worst_status: worst,
+        absent_duration_secs,
+        last_activity_age_secs,
+    }
 }
 
-/// Graduated text for disconnected drives, calibrated by awareness status.
+/// Label for an unmounted drive. Cascade:
+/// - physical Unmount event → "away" + age (gravity-calibrated)
+/// - ops-log fallback → "last backup" + age (same gravity escalation)
+/// - neither → "disconnected" (silent — prefer no claim over a wrong one).
 ///
-/// Returns `None` when no age data is available (caller uses existing fallback).
-/// Text is calibrated to the awareness model's promise status — voice never
-/// claims urgency that awareness doesn't support.
-fn escalated_staleness_text(
-    label: &str,
+/// Never mix sources for a single drive — mixing produces confidently-wrong
+/// labels (e.g. "away 30d" when the drive was only just unplugged but
+/// hadn't backed up recently).
+fn unmounted_drive_label(
+    drive_label: &str,
+    absent_duration_secs: Option<i64>,
+    last_activity_age_secs: Option<i64>,
     worst_status: &str,
-    max_age_secs: Option<i64>,
-) -> Option<String> {
-    let age_secs = max_age_secs?;
-    let age_str = humanize_duration(age_secs);
+) -> String {
+    match (absent_duration_secs, last_activity_age_secs) {
+        (Some(d), _) => format_drive_age_label(drive_label, d, worst_status, "away"),
+        (None, Some(a)) => format_drive_age_label(drive_label, a, worst_status, "last backup"),
+        (None, None) => format!("{} {}", drive_label.bold(), "disconnected".dimmed()),
+    }
+}
 
-    Some(match worst_status {
+/// Shared formatter for "{drive} {phrase} {age}" labels with gravity
+/// escalation. `phrase` is "away" (physical Unmount event) or "last backup"
+/// (ops-log fallback). The word "absent" is reserved — PROTECTED states
+/// should not feel alarming.
+///
+///   UNPROTECTED → bold + "protection aging"
+///   AT RISK     → yellow age + "consider connecting"
+///   PROTECTED   → dimmed age
+fn format_drive_age_label(
+    drive_label: &str,
+    age_secs: i64,
+    worst_status: &str,
+    phrase: &str,
+) -> String {
+    let age_str = humanize_duration(age_secs);
+    match worst_status {
         "UNPROTECTED" => format!(
-            "{} absent {} — protection aging",
-            label.bold(),
-            age_str
+            "{} {phrase} {age_str} — protection aging",
+            drive_label.bold(),
         ),
         "AT RISK" => format!(
-            "{} away {} — consider connecting",
-            label.bold(),
-            age_str.yellow()
+            "{} {phrase} {} — consider connecting",
+            drive_label.bold(),
+            age_str.yellow(),
         ),
-        _ => format!("{} away — {}", label.bold(), age_str.dimmed()),
-    })
+        _ => format!("{} {phrase} — {}", drive_label.bold(), age_str.dimmed()),
+    }
 }
 
 // ── Next-Action Suggestions (4b) ──────────────────────────────────────
@@ -3032,6 +3073,8 @@ mod tests {
                         snapshot_count: Some(12),
                         last_send_age_secs: Some(7200),
                         role: DriveRole::Primary,
+                        absent_duration_secs: None,
+                        last_activity_age_secs: None,
                     }],
                     advisories: vec![],
                     redundancy_advisories: vec![],
@@ -3057,6 +3100,8 @@ mod tests {
                         snapshot_count: Some(0),
                         last_send_age_secs: None,
                         role: DriveRole::Primary,
+                        absent_duration_secs: None,
+                        last_activity_age_secs: None,
                     }],
                     advisories: vec![],
                     redundancy_advisories: vec![],
@@ -3163,7 +3208,13 @@ mod tests {
         assert!(output.contains("WD-18TB"), "missing drive label");
         assert!(output.contains("connected"), "missing connected status");
         assert!(output.contains("Offsite-4TB"), "missing unmounted drive");
-        assert!(output.contains("away"), "missing away status for offsite drive");
+        // With no absent_duration_secs and no last_activity_age_secs, the
+        // cascade stays silent — "disconnected" rather than a fabricated
+        // "away" label driven by role alone.
+        assert!(
+            output.contains("disconnected"),
+            "expected silent fallback: {output}"
+        );
     }
 
     #[test]
@@ -3184,6 +3235,8 @@ mod tests {
             snapshot_count: None,
             last_send_age_secs: Some(604800), // 7 days
             role: DriveRole::Primary,
+            absent_duration_secs: Some(604800), // 7 days — drives the "away" label
+            last_activity_age_secs: None,
         });
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
@@ -3558,6 +3611,7 @@ mod tests {
             }],
             transitions: vec![],
             warnings: vec![],
+            notes: vec![],
         }
     }
 
@@ -3668,6 +3722,70 @@ mod tests {
         let output = render_backup_summary(&data, OutputMode::Interactive);
         assert!(output.contains("pin file write"), "missing warning");
         assert!(output.contains("WARNING"), "missing WARNING label");
+    }
+
+    #[test]
+    fn backup_summary_notes_rendered_dim_no_label() {
+        // Notes render with a middle-dot glyph and no "NOTE:" label — the
+        // dim rendering signals informational tone.
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.notes = vec!["space guard held — 1 snapshot retained.".to_string()];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(output.contains("·"), "missing middle-dot glyph: {output}");
+        assert!(
+            output.contains("space guard held"),
+            "missing note text: {output}"
+        );
+        assert!(
+            !output.contains("NOTE:"),
+            "notes must not render with 'NOTE:' prefix: {output}"
+        );
+    }
+
+    #[test]
+    fn backup_summary_notes_below_warnings() {
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.warnings = vec!["something worth noting loudly".to_string()];
+        data.notes = vec!["space guard held — 2 snapshots retained.".to_string()];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        let warning_pos = output
+            .find("something worth noting loudly")
+            .expect("warning line missing");
+        let note_pos = output
+            .find("space guard held")
+            .expect("note line missing");
+        assert!(
+            note_pos > warning_pos,
+            "note should render after warnings: {output}"
+        );
+    }
+
+    #[test]
+    fn backup_summary_empty_notes_not_rendered() {
+        colored::control::set_override(false);
+        let data = test_backup_summary(); // notes default to empty
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("·"),
+            "middle-dot glyph must not appear when notes is empty: {output}"
+        );
+    }
+
+    #[test]
+    fn backup_summary_notes_do_not_render_yellow_warning_prefix() {
+        // A note must never pick up the yellow WARNING gravity indicator.
+        // Under Interactive + forced colors, render_backup_summary must
+        // still not emit "WARNING" for a note.
+        colored::control::set_override(false);
+        let mut data = test_backup_summary();
+        data.notes = vec!["space guard held — 1 snapshot retained.".to_string()];
+        let output = render_backup_summary(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("WARNING"),
+            "notes must never surface with WARNING gravity: {output}"
+        );
     }
 
     #[test]
@@ -3811,6 +3929,7 @@ mod tests {
             assessments: vec![],
             transitions: vec![],
             warnings: vec![],
+            notes: vec![],
         };
         let output = render_backup_summary(&data, OutputMode::Interactive);
         assert!(
@@ -4647,6 +4766,7 @@ mod tests {
             assessments: vec![],
             transitions: vec![],
             warnings: vec![],
+            notes: vec![],
         };
         let output = render_backup_summary(&data, OutputMode::Interactive);
         // Local-only should NOT appear in the skip section
@@ -5254,6 +5374,8 @@ mod tests {
             snapshot_count: None,
             last_send_age_secs: Some(86400),
             role: DriveRole::Primary,
+            absent_duration_secs: Some(86400),
+            last_activity_age_secs: None,
         });
         data.drives.push(DriveInfo {
             label: "Test-Drive".to_string(),
@@ -5321,6 +5443,8 @@ mod tests {
             snapshot_count: None,
             last_send_age_secs: Some(172800), // 2 days
             role: DriveRole::Offsite,
+            absent_duration_secs: Some(172800),
+            last_activity_age_secs: None,
         });
         let output = render_status(&data, OutputMode::Interactive);
         assert!(output.contains("away"), "unmounted drive with history should show 'away': {output}");
@@ -6301,11 +6425,17 @@ mod tests {
         assert_eq!(status_severity("unknown"), 0);
     }
 
-    #[test]
-    fn aggregate_staleness_single_subvol() {
-        let assessments = vec![StatusAssessment {
-            name: "data".to_string(),
-            status: "AT RISK".to_string(),
+    // ── Unmounted-drive cascade: unmounted_drive_label + aggregate_drive_info ───
+
+    fn drive_aggregate_assessment(
+        drive_label: &str,
+        status: &str,
+        absent: Option<i64>,
+        last_activity: Option<i64>,
+    ) -> StatusAssessment {
+        StatusAssessment {
+            name: "sv1".to_string(),
+            status: status.to_string(),
             health: "healthy".to_string(),
             health_reasons: vec![],
             promise_level: None,
@@ -6313,212 +6443,176 @@ mod tests {
             local_newest_age_secs: Some(3600),
             local_status: "PROTECTED".to_string(),
             external: vec![StatusDriveAssessment {
-                drive_label: "WD-18TB".to_string(),
-                status: "AT RISK".to_string(),
+                drive_label: drive_label.to_string(),
+                status: status.to_string(),
                 mounted: false,
                 snapshot_count: None,
-                last_send_age_secs: Some(604800),
+                last_send_age_secs: None,
                 role: DriveRole::Primary,
+                absent_duration_secs: absent,
+                last_activity_age_secs: last_activity,
             }],
             advisories: vec![],
             redundancy_advisories: vec![],
             retention_summary: None,
             external_only: false,
             errors: vec![],
-        }];
-
-        let (status, age) = aggregate_drive_staleness(&assessments, "WD-18TB");
-        assert_eq!(status, "AT RISK");
-        assert_eq!(age, Some(604800));
+        }
     }
 
     #[test]
-    fn aggregate_staleness_worst_across_subvols() {
+    fn aggregate_drive_info_picks_worst_status() {
         let assessments = vec![
-            StatusAssessment {
-                name: "home".to_string(),
-                status: "PROTECTED".to_string(),
-                health: "healthy".to_string(),
-                health_reasons: vec![],
-                promise_level: None,
-                local_snapshot_count: 10,
-                local_newest_age_secs: Some(1800),
-                local_status: "PROTECTED".to_string(),
-                external: vec![StatusDriveAssessment {
-                    drive_label: "WD-18TB".to_string(),
-                    status: "PROTECTED".to_string(),
-                    mounted: false,
-                    snapshot_count: None,
-                    last_send_age_secs: Some(86400),
-                    role: DriveRole::Primary,
-                }],
-                advisories: vec![],
-                redundancy_advisories: vec![],
-                retention_summary: None,
-                external_only: false,
-                errors: vec![],
-            },
-            StatusAssessment {
-                name: "docs".to_string(),
-                status: "UNPROTECTED".to_string(),
-                health: "healthy".to_string(),
-                health_reasons: vec![],
-                promise_level: None,
-                local_snapshot_count: 5,
-                local_newest_age_secs: Some(3600),
-                local_status: "PROTECTED".to_string(),
-                external: vec![StatusDriveAssessment {
-                    drive_label: "WD-18TB".to_string(),
-                    status: "UNPROTECTED".to_string(),
-                    mounted: false,
-                    snapshot_count: None,
-                    last_send_age_secs: Some(2592000),
-                    role: DriveRole::Primary,
-                }],
-                advisories: vec![],
-                redundancy_advisories: vec![],
-                retention_summary: None,
-                external_only: false,
-                errors: vec![],
-            },
+            drive_aggregate_assessment("WD-18TB", "PROTECTED", Some(86400), None),
+            drive_aggregate_assessment("WD-18TB", "UNPROTECTED", Some(86400), None),
         ];
-
-        let (status, _) = aggregate_drive_staleness(&assessments, "WD-18TB");
-        assert_eq!(status, "UNPROTECTED");
+        let agg = aggregate_drive_info(&assessments, "WD-18TB");
+        assert_eq!(agg.worst_status, "UNPROTECTED");
     }
 
     #[test]
-    fn aggregate_staleness_max_age() {
-        let assessments = vec![
-            StatusAssessment {
-                name: "home".to_string(),
-                status: "AT RISK".to_string(),
-                health: "healthy".to_string(),
-                health_reasons: vec![],
-                promise_level: None,
-                local_snapshot_count: 10,
-                local_newest_age_secs: Some(1800),
-                local_status: "PROTECTED".to_string(),
-                external: vec![StatusDriveAssessment {
-                    drive_label: "WD-18TB".to_string(),
-                    status: "AT RISK".to_string(),
-                    mounted: false,
-                    snapshot_count: None,
-                    last_send_age_secs: Some(86400),
-                    role: DriveRole::Primary,
-                }],
-                advisories: vec![],
-                redundancy_advisories: vec![],
-                retention_summary: None,
-                external_only: false,
-                errors: vec![],
-            },
-            StatusAssessment {
-                name: "docs".to_string(),
-                status: "AT RISK".to_string(),
-                health: "healthy".to_string(),
-                health_reasons: vec![],
-                promise_level: None,
-                local_snapshot_count: 5,
-                local_newest_age_secs: Some(3600),
-                local_status: "PROTECTED".to_string(),
-                external: vec![StatusDriveAssessment {
-                    drive_label: "WD-18TB".to_string(),
-                    status: "PROTECTED".to_string(),
-                    mounted: false,
-                    snapshot_count: None,
-                    last_send_age_secs: Some(604800),
-                    role: DriveRole::Primary,
-                }],
-                advisories: vec![],
-                redundancy_advisories: vec![],
-                retention_summary: None,
-                external_only: false,
-                errors: vec![],
-            },
-        ];
-
-        let (_, age) = aggregate_drive_staleness(&assessments, "WD-18TB");
-        assert_eq!(age, Some(604800));
+    fn aggregate_drive_info_propagates_absent_duration() {
+        let assessments =
+            vec![drive_aggregate_assessment("WD-18TB", "AT RISK", Some(604800), None)];
+        let agg = aggregate_drive_info(&assessments, "WD-18TB");
+        assert_eq!(agg.absent_duration_secs, Some(604800));
+        assert_eq!(agg.last_activity_age_secs, None);
     }
 
     #[test]
-    fn aggregate_staleness_no_match() {
-        let assessments = vec![StatusAssessment {
-            name: "data".to_string(),
-            status: "PROTECTED".to_string(),
-            health: "healthy".to_string(),
-            health_reasons: vec![],
-            promise_level: None,
-            local_snapshot_count: 10,
-            local_newest_age_secs: Some(1800),
-            local_status: "PROTECTED".to_string(),
-            external: vec![StatusDriveAssessment {
-                drive_label: "WD-18TB".to_string(),
-                status: "PROTECTED".to_string(),
-                mounted: true,
-                snapshot_count: Some(5),
-                last_send_age_secs: Some(3600),
-                role: DriveRole::Primary,
-            }],
-            advisories: vec![],
-            redundancy_advisories: vec![],
-            retention_summary: None,
-            external_only: false,
-            errors: vec![],
-        }];
-
-        let (status, age) = aggregate_drive_staleness(&assessments, "NONEXISTENT");
-        assert_eq!(status, "PROTECTED");
-        assert_eq!(age, None);
+    fn aggregate_drive_info_propagates_last_activity() {
+        let assessments =
+            vec![drive_aggregate_assessment("WD-18TB", "AT RISK", None, Some(86400))];
+        let agg = aggregate_drive_info(&assessments, "WD-18TB");
+        assert_eq!(agg.absent_duration_secs, None);
+        assert_eq!(agg.last_activity_age_secs, Some(86400));
     }
 
     #[test]
-    fn staleness_text_protected_minimal() {
+    fn aggregate_drive_info_no_match_defaults_protected_and_none() {
+        let assessments =
+            vec![drive_aggregate_assessment("WD-18TB", "UNPROTECTED", Some(86400), None)];
+        let agg = aggregate_drive_info(&assessments, "MISSING-DRIVE");
+        assert_eq!(agg.worst_status, "PROTECTED");
+        assert_eq!(agg.absent_duration_secs, None);
+        assert_eq!(agg.last_activity_age_secs, None);
+    }
+
+    #[test]
+    fn unmounted_with_physical_event_renders_away() {
         colored::control::set_override(false);
-        let result =
-            escalated_staleness_text("WD-18TB", "PROTECTED", Some(259200));
-        let text = result.unwrap();
-        assert!(text.contains("WD-18TB"), "missing label: {text}");
-        assert!(text.contains("away"), "missing 'away': {text}");
-        assert!(text.contains("3d"), "missing age: {text}");
-        assert!(!text.contains("consider"), "should not have urgency: {text}");
-        assert!(!text.contains("degrading"), "should not have urgency: {text}");
+        let label = unmounted_drive_label("WD-18TB", Some(259200), None, "PROTECTED");
+        assert!(label.contains("WD-18TB"), "missing label: {label}");
+        assert!(label.contains("away"), "missing 'away': {label}");
+        assert!(label.contains("3d"), "missing age: {label}");
     }
 
     #[test]
-    fn staleness_text_at_risk_consider() {
+    fn unmounted_without_event_with_ops_renders_last_backup() {
         colored::control::set_override(false);
-        let result =
-            escalated_staleness_text("WD-18TB", "AT RISK", Some(604800));
-        let text = result.unwrap();
-        assert!(text.contains("WD-18TB"), "missing label: {text}");
+        let label = unmounted_drive_label("WD-18TB", None, Some(259200), "PROTECTED");
+        assert!(label.contains("WD-18TB"), "missing label: {label}");
+        assert!(label.contains("last backup"), "missing 'last backup': {label}");
+        assert!(label.contains("3d"), "missing age: {label}");
+    }
+
+    #[test]
+    fn unmounted_no_data_renders_disconnected_silent() {
+        colored::control::set_override(false);
+        let label = unmounted_drive_label("WD-18TB", None, None, "PROTECTED");
+        assert!(label.contains("WD-18TB"), "missing label: {label}");
         assert!(
-            text.contains("consider connecting"),
-            "missing suggestion: {text}"
+            label.contains("disconnected"),
+            "expected 'disconnected': {label}"
         );
-        assert!(text.contains("7d"), "missing age: {text}");
-    }
-
-    #[test]
-    fn staleness_text_unprotected_degrading() {
-        colored::control::set_override(false);
-        let result =
-            escalated_staleness_text("WD-18TB1", "UNPROTECTED", Some(2592000));
-        let text = result.unwrap();
-        assert!(text.contains("WD-18TB1"), "missing label: {text}");
-        assert!(text.contains("absent"), "should use 'absent': {text}");
+        assert!(!label.contains("away"), "no age should leak 'away': {label}");
         assert!(
-            text.contains("protection aging"),
-            "missing escalation: {text}"
+            !label.contains("last backup"),
+            "must not surface fictional activity: {label}"
         );
-        assert!(text.contains("30d"), "missing age: {text}");
     }
 
     #[test]
-    fn staleness_text_no_age_returns_none() {
-        let result = escalated_staleness_text("WD-18TB", "AT RISK", None);
-        assert!(result.is_none());
+    fn unmounted_last_event_mount_renders_disconnected_silent() {
+        // Rule 1 seed at render layer: if the cascade populated neither field
+        // (sentinel-missed-unmount case, verified by awareness tests), voice
+        // must stay silent — no "away" or "last backup".
+        colored::control::set_override(false);
+        let label = unmounted_drive_label("WD-18TB", None, None, "AT RISK");
+        assert!(label.contains("disconnected"), "must be silent: {label}");
+        assert!(!label.contains("away"));
+        assert!(!label.contains("last backup"));
+    }
+
+    #[test]
+    fn at_risk_escalation_away() {
+        colored::control::set_override(false);
+        let label = unmounted_drive_label("WD-18TB", Some(604800), None, "AT RISK");
+        assert!(label.contains("away"), "missing 'away': {label}");
+        assert!(label.contains("7d"), "missing age: {label}");
+        assert!(
+            label.contains("consider connecting"),
+            "missing suggestion: {label}"
+        );
+    }
+
+    #[test]
+    fn at_risk_escalation_last_backup() {
+        colored::control::set_override(false);
+        let label = unmounted_drive_label("WD-18TB", None, Some(604800), "AT RISK");
+        assert!(label.contains("last backup"), "missing 'last backup': {label}");
+        assert!(label.contains("7d"), "missing age: {label}");
+        assert!(
+            label.contains("consider connecting"),
+            "missing suggestion: {label}"
+        );
+    }
+
+    #[test]
+    fn unprotected_escalation_away() {
+        colored::control::set_override(false);
+        let label = unmounted_drive_label("WD-18TB1", Some(2592000), None, "UNPROTECTED");
+        assert!(label.contains("WD-18TB1"), "missing label: {label}");
+        assert!(label.contains("away"), "missing 'away': {label}");
+        assert!(label.contains("30d"), "missing age: {label}");
+        assert!(
+            label.contains("protection aging"),
+            "missing escalation: {label}"
+        );
+        // The word "absent" must never render on PROTECTED drives.
+        assert!(
+            !label.contains("absent"),
+            "the word 'absent' must not appear: {label}"
+        );
+    }
+
+    #[test]
+    fn unprotected_escalation_last_backup() {
+        colored::control::set_override(false);
+        let label = unmounted_drive_label("WD-18TB", None, Some(2592000), "UNPROTECTED");
+        assert!(label.contains("last backup"), "missing 'last backup': {label}");
+        assert!(label.contains("30d"), "missing age: {label}");
+        assert!(
+            label.contains("protection aging"),
+            "missing escalation: {label}"
+        );
+    }
+
+    #[test]
+    fn unmounted_away_uses_absent_duration_not_activity() {
+        // Voice-Contract-Rule-1 seed test: absent_duration_secs wins over
+        // last_activity_age_secs; the right field drives the right label.
+        colored::control::set_override(false);
+        let label = unmounted_drive_label("WD-18TB", Some(15 * 60), Some(7 * 86400), "PROTECTED");
+        assert!(label.contains("15m"), "should render 15m: {label}");
+        assert!(
+            !label.contains("7d"),
+            "must not leak ops-log age when event exists: {label}"
+        );
+        assert!(
+            !label.contains("last backup"),
+            "must not use ops-log label when event exists: {label}"
+        );
     }
 
     // ── 4b: Next-Action Suggestion Tests ──────────────────────────────


### PR DESCRIPTION
## Summary

Restores trust in Urd's self-reporting after the v0.12.x awareness/voice regressions. Fixes planner chain-awareness, the drive-absence voice cascade, and a silent production bug where the `last_drive_event` parser matched non-existent strings.

- **Awareness correctness:** planner now considers chain state when estimating incremental send sizes, so drive-space assessment stops over-reporting risk on healthy chains
- **Voice cascade (PD-2):** unmounted drives render by cascade — Unmount event → "away (N ago)", ops-log → "last backup (N ago)", neither → "disconnected". Silence beats a confident-but-wrong role-based fallback.
- **Production bug:** `RealFileSystemState::last_drive_event` matched `"mount"`/`"unmount"` but the DB contract writes `"mounted"`/`"unmounted"` — the entire cascade was dead. Match arms corrected; regression test exercises a real `StateDb` round-trip.
- **Informational channel (PD-3):** space-recovered outcomes reclassified as `notes`, not warnings; ADR-021 updated so the homelab's Prometheus `backup_warnings_total` stays surgical
- **Post-upgrade acknowledgment (PD-4):** first invocation after upgrade that has at least one completed run shows a one-shot dimmed preamble; marker file guards against repeat
- **Simplifications:** `format_drive_age_label` merged two near-duplicates behind a phrase parameter; `drive_absence` hoisted out of `assess()`'s nested loop (N×M → 2×M SQLite queries); `SendKind::as_db_str()` replaces stringly-typed comparisons at call sites

## Testing

- cargo clippy: pre-existing lints unchanged (23 → 22 on this branch)
- cargo test: 1024 passed, 0 failed
- Regression test for drive-event round-trip added (`real_file_system_state_round_trips_drive_events`)
- Voice-contract tests formalized (12+ new tests covering cascade + notes rendering)

## Related

- UPI 026 trust-repair plan: `docs/97-plans/2026-04-20-plan-026-trust-repair.md`
- Pre-committed decisions PD-1 through PD-6 resolved
- Follow-up: UPI 035 (Voice Contract Tests) tracked in registry.md
- Homelab ADR-021 companion branch: `docs/adr-021-urd-v0.13.0-notes-contract` (not yet pushed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)