### PR TITLE
feat: structured event log (UPI 036, ADR-114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Structured event log (ADR-114): typed `Event` records of decisions and
+  state transitions persisted to a new `events` SQLite table. Pure modules
+  (planner, retention, awareness, sentinel state machine) emit events as
+  part of their output; impure callers persist them best-effort. Visible
+  via the new `urd events` subcommand with `--since`, `--kind`,
+  `--subvolume`, `--drive`, `--limit`, and `--json` filters. Drive
+  connection records and four Prometheus counter families
+  (circuit-breaker trips, full sends by reason, deferrals by scope,
+  prunes by rule) now derive from the same table.
+
+### Changed
+- Quality gate command updated to `cargo clippy --all-targets` (covers
+  test code, which bare clippy skips). CLAUDE.md adds a
+  `cargo check --all-targets` line specifically for post-mass-edit
+  verification — the bare form misses lints and type errors that live
+  in `mod tests` / `tests/`.
+
 ## [0.13.0] - 2026-04-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-01
+
 ### Added
 - Structured event log (ADR-114): typed `Event` records of decisions and
   state transitions persisted to a new `events` SQLite table. Pure modules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,8 @@ All backup logic flows through: config -> plan -> execute. No exceptions.
 | `drives.rs` | Detect mounted drives, UUID fingerprinting, check space | Mount/unmount drives |
 | `output.rs` | Define structured output types | Render text (voice.rs does that) |
 | `voice.rs` | Render structured output as text (mythic voice) | Perform I/O or compute state |
+| `voice_events.rs` | Per-variant `EventPayload` renderer (columnar + NDJSON) | Perform I/O or query state |
+| `events.rs` | Pure: `Event`, `EventKind`, `EventPayload`, `Severity`, typed payload enums (UPI 036) | Perform I/O |
 | `lock.rs` | Shared advisory lock with metadata (PID, trigger source) | Decide whether to proceed (caller's job) |
 | `sentinel.rs` | Pure state machine for Sentinel daemon (events, actions, circuit breaker) | Perform I/O (sentinel_runner.rs does that) |
 | `error.rs` | Error types, `translate_btrfs_error()` for actionable messages | Recovery logic |
@@ -130,7 +132,7 @@ Dual-parser architecture supporting **legacy** and **v1** schemas. `Config::load
 ## Coding Conventions
 
 - Standard Rust: `snake_case` functions, `CamelCase` types
-- `cargo clippy -- -D warnings` (all warnings are errors)
+- `cargo clippy --all-targets -- -D warnings` (all warnings are errors; `--all-targets` includes test code, which bare clippy skips)
 - `rustfmt` before committing
 - Strong types over primitives: `SnapshotName` not `String`, `Tier` not `u8`
 - `#[must_use]` on functions whose return values matter
@@ -215,7 +217,8 @@ cargo build                          # Debug
 cargo build --release                # Release
 cargo test                           # Unit tests (931+ tests)
 cargo test -- --ignored              # Integration tests (needs drives)
-cargo clippy -- -D warnings          # Lint (all warnings are errors)
+cargo clippy --all-targets -- -D warnings   # Lint (covers test code too)
+cargo check --all-targets            # Fast type-check after mass edits (covers test code; bare `cargo check` does not)
 cargo run -- plan                    # Preview backup plan
 cargo run -- backup --dry-run        # Dry-run
 cargo run -- status                  # Current promise states

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -45,7 +45,10 @@ const DRIVE_AWAY_DEGRADED_DAYS: i64 = 7;
 
 /// Promise status for a subvolume or assessment dimension.
 /// Ordered worst-to-best so `min()` yields the worst status.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
 pub enum PromiseStatus {
     Unprotected,
     AtRisk,
@@ -396,6 +399,47 @@ fn format_age_issue(assessment: &SubvolAssessment, external_only: bool) -> Strin
 }
 
 // ── Core function ──────────────────────────────────────────────────────
+
+/// Diff a previous set of promise snapshots against the current
+/// assessment list and emit one `PromiseTransition` event per subvolume
+/// whose status changed.
+///
+/// Pure function. Empty `previous` returns an empty Vec (suppresses
+/// noise on first run, matching the precedent in
+/// `sentinel::has_changes`). Subvolumes present in `previous` but
+/// missing from `current` are silent (deletion is not a transition we
+/// log). Subvolumes new in `current` (not in `previous`) are also
+/// silent — appearance is not a transition either.
+#[must_use]
+#[allow(dead_code)]
+pub fn diff_promise_states(
+    previous: &[crate::sentinel::PromiseSnapshot],
+    current: &[SubvolAssessment],
+    now: NaiveDateTime,
+    trigger: crate::events::TransitionTrigger,
+) -> Vec<crate::events::Event> {
+    if previous.is_empty() {
+        return Vec::new();
+    }
+    let mut events = Vec::new();
+    for assess in current {
+        if let Some(prev) = previous.iter().find(|p| p.name == assess.name)
+            && prev.status != assess.status
+        {
+            let mut event = crate::events::Event::pure(
+                now,
+                crate::events::EventPayload::PromiseTransition {
+                    from: prev.status,
+                    to: assess.status,
+                    trigger,
+                },
+            );
+            event.subvolume = Some(assess.name.clone());
+            events.push(event);
+        }
+    }
+    events
+}
 
 /// Compute promise states for all enabled subvolumes.
 ///
@@ -4947,5 +4991,146 @@ source = "/data/sv1"
             "fresh age should not emit source-unchanged advisory: {:?}",
             r.advisories
         );
+    }
+
+    // ── diff_promise_states tests ──────────────────────────────────
+
+    fn make_assess(name: &str, status: PromiseStatus) -> SubvolAssessment {
+        SubvolAssessment {
+            name: name.to_string(),
+            status,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
+            local: LocalAssessment {
+                status,
+                snapshot_count: 0,
+                newest_age: None,
+                configured_interval: Interval::hours(1),
+            },
+            external: vec![],
+            chain_health: vec![],
+            advisories: vec![],
+            redundancy_advisories: vec![],
+            errors: vec![],
+        }
+    }
+
+    fn make_promise_snapshot(
+        name: &str,
+        status: PromiseStatus,
+    ) -> crate::sentinel::PromiseSnapshot {
+        crate::sentinel::PromiseSnapshot {
+            name: name.to_string(),
+            status,
+        }
+    }
+
+    fn diff_dt() -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(2026, 4, 30)
+            .unwrap()
+            .and_hms_opt(3, 14, 22)
+            .unwrap()
+    }
+
+    #[test]
+    fn diff_no_change_returns_empty() {
+        let prev = vec![make_promise_snapshot("sv1", PromiseStatus::Protected)];
+        let curr = vec![make_assess("sv1", PromiseStatus::Protected)];
+        let events = diff_promise_states(
+            &prev,
+            &curr,
+            diff_dt(),
+            crate::events::TransitionTrigger::Tick,
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn diff_emits_on_degradation() {
+        let prev = vec![make_promise_snapshot("sv1", PromiseStatus::Protected)];
+        let curr = vec![make_assess("sv1", PromiseStatus::AtRisk)];
+        let events = diff_promise_states(
+            &prev,
+            &curr,
+            diff_dt(),
+            crate::events::TransitionTrigger::Tick,
+        );
+        assert_eq!(events.len(), 1);
+        match &events[0].payload {
+            crate::events::EventPayload::PromiseTransition { from, to, trigger } => {
+                assert_eq!(*from, PromiseStatus::Protected);
+                assert_eq!(*to, PromiseStatus::AtRisk);
+                assert_eq!(*trigger, crate::events::TransitionTrigger::Tick);
+            }
+            other => panic!("expected PromiseTransition, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn diff_emits_on_recovery() {
+        let prev = vec![make_promise_snapshot("sv1", PromiseStatus::Unprotected)];
+        let curr = vec![make_assess("sv1", PromiseStatus::Protected)];
+        let events = diff_promise_states(
+            &prev,
+            &curr,
+            diff_dt(),
+            crate::events::TransitionTrigger::Run,
+        );
+        assert_eq!(events.len(), 1);
+    }
+
+    #[test]
+    fn diff_first_run_returns_empty() {
+        // Empty `previous` → no events, no matter what current looks like.
+        let curr = vec![
+            make_assess("sv1", PromiseStatus::Protected),
+            make_assess("sv2", PromiseStatus::AtRisk),
+        ];
+        let events = diff_promise_states(
+            &[],
+            &curr,
+            diff_dt(),
+            crate::events::TransitionTrigger::Run,
+        );
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn diff_carries_trigger_into_payload() {
+        let prev = vec![make_promise_snapshot("sv1", PromiseStatus::Protected)];
+        let curr = vec![make_assess("sv1", PromiseStatus::AtRisk)];
+        for trigger in [
+            crate::events::TransitionTrigger::Run,
+            crate::events::TransitionTrigger::Tick,
+            crate::events::TransitionTrigger::DriveMounted,
+            crate::events::TransitionTrigger::ConfigChanged,
+        ] {
+            let events = diff_promise_states(&prev, &curr, diff_dt(), trigger);
+            assert_eq!(events.len(), 1);
+            if let crate::events::EventPayload::PromiseTransition { trigger: t, .. } =
+                events[0].payload
+            {
+                assert_eq!(t, trigger);
+            } else {
+                panic!("expected PromiseTransition");
+            }
+        }
+    }
+
+    #[test]
+    fn diff_silent_for_new_subvolume_in_current() {
+        // sv1 in current but not in previous → silent (appearance, not transition).
+        let prev = vec![make_promise_snapshot("sv2", PromiseStatus::Protected)];
+        let curr = vec![
+            make_assess("sv1", PromiseStatus::AtRisk),
+            make_assess("sv2", PromiseStatus::Protected),
+        ];
+        let events = diff_promise_states(
+            &prev,
+            &curr,
+            diff_dt(),
+            crate::events::TransitionTrigger::Tick,
+        );
+        assert!(events.is_empty(), "appearance should not emit a transition");
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,6 +49,8 @@ pub enum Commands {
     Completions(CompletionsArgs),
     /// Migrate config from legacy schema to v1
     Migrate(MigrateArgs),
+    /// View the structured event log
+    Events(EventsArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -83,6 +85,35 @@ pub struct MigrateArgs {
     /// Show what would change without writing files
     #[arg(long)]
     pub dry_run: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct EventsArgs {
+    /// Only events from the last duration (e.g., 7d, 24h, 30m)
+    #[arg(long)]
+    pub since: Option<String>,
+
+    /// Filter by event kind: retention | planner | promise | sentinel | config | drive
+    #[arg(long)]
+    pub kind: Option<String>,
+
+    /// Filter by subvolume name
+    #[arg(long)]
+    pub subvolume: Option<String>,
+
+    /// Filter by drive label
+    #[arg(long)]
+    pub drive: Option<String>,
+
+    /// Maximum number of events to display (1..=1000, default 50)
+    #[arg(long, default_value = "50")]
+    pub limit: usize,
+
+    /// Line-delimited JSON for ad-hoc inspection. Format is
+    /// additive-friendly but not a stable public contract; expect new
+    /// fields and new event variants in future versions.
+    #[arg(long)]
+    pub json: bool,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -95,7 +95,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // Emergency pre-flight: if any snapshot root is critically below threshold
     // (< 50% of min_free_bytes), run emergency retention before planning.
     // Runs under the lock because it performs destructive btrfs deletions.
-    let emergency_ran = run_emergency_preflight(&config)?;
+    let emergency_ran = run_emergency_preflight(&config, state_db.as_ref())?;
 
     // Re-plan if emergency freed space — plan may have different space_pressure decisions
     if emergency_ran {
@@ -320,6 +320,27 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     if !transitions.is_empty() {
         log::debug!("Detected {} transition(s)", transitions.len());
     }
+
+    // Backup is canonical for in-run promise transitions (trigger=Run);
+    // sentinel skips on BackupCompleted to avoid duplicates.
+    if let Some(ref db) = state_db {
+        let prev_snapshots = crate::sentinel::snapshot_promises(&pre_assessments);
+        let promise_events = awareness::diff_promise_states(
+            &prev_snapshots,
+            &assessments,
+            heartbeat_now,
+            crate::events::TransitionTrigger::Run,
+        );
+        if !promise_events.is_empty() {
+            // Stamp run_id from the executor result.
+            let mut stamped = promise_events;
+            for ev in &mut stamped {
+                ev.run_id = result.run_id;
+            }
+            db.record_events_best_effort(&stamped);
+        }
+    }
+
     let summary = build_backup_summary(
         &backup_plan,
         &result,
@@ -740,11 +761,24 @@ fn write_global_metrics(
 ) -> anyhow::Result<()> {
     let (drive_mounted, free_bytes) = drives::first_mounted_drive_status(config);
 
+    // Aggregate counter families from the events table.
+    // Best-effort: a missing or unreadable DB yields zeros, never an error.
+    let event_counters = StateDb::open(&config.general.state_db)
+        .ok()
+        .map(|db| crate::metrics::EventCounters {
+            circuit_breaker_trips: db.count_circuit_breaker_trips().unwrap_or(0),
+            full_sends_by_reason: db.count_full_sends_by_reason().unwrap_or_default(),
+            defers_by_scope: db.count_defers_by_scope().unwrap_or_default(),
+            prunes_by_rule: db.count_prunes_by_rule().unwrap_or_default(),
+        })
+        .unwrap_or_default();
+
     let data = MetricsData {
         subvolumes: subvolume_metrics,
         external_drive_mounted: drive_mounted,
         external_free_bytes: free_bytes,
         script_last_run_timestamp: now_ts,
+        event_counters,
     };
 
     metrics::write_metrics(&config.general.metrics_file, &data)?;
@@ -1085,10 +1119,19 @@ fn dispatch_notifications(
 ///
 /// Runs under the advisory lock. Skips roots without `min_free_bytes`.
 /// Skips transient subvolumes. Isolates per-subvolume failures (ADR-109).
-fn run_emergency_preflight(config: &Config) -> anyhow::Result<bool> {
+///
+/// Emits `RetentionPrune { rule: Emergency }` events for each successful
+/// delete and persists them best-effort to the events log (when
+/// `state_db` is `Some`). Emergency runs before `begin_run`, so these
+/// events have `run_id = None`.
+fn run_emergency_preflight(
+    config: &Config,
+    state_db: Option<&StateDb>,
+) -> anyhow::Result<bool> {
     let resolved = config.resolved_subvolumes();
     let drive_labels = config.drive_labels();
     let mut any_deleted = false;
+    let mut emitted_events: Vec<crate::events::Event> = Vec::new();
 
     // Lazily created btrfs handle — only probe if we need to delete
     let mut btrfs: Option<crate::btrfs::RealBtrfs> = None;
@@ -1151,9 +1194,15 @@ fn run_emergency_preflight(config: &Config) -> anyhow::Result<bool> {
             let pinned =
                 crate::chain::find_pinned_snapshots(&local_dir, &drive_labels);
 
-            let result =
-                crate::retention::emergency_retention(&snaps, &latest, &pinned);
+            let mut result = crate::retention::emergency_retention(
+                &snaps,
+                &latest,
+                &pinned,
+                chrono::Local::now().naive_local(),
+            );
 
+            // Map snap → its emitted event (by snapshot name) so we can
+            // persist only events whose underlying delete succeeded.
             for (snap, _reason) in &result.delete {
                 let snap_path = local_dir.join(snap.as_str());
 
@@ -1174,6 +1223,23 @@ fn run_emergency_preflight(config: &Config) -> anyhow::Result<bool> {
                     Ok(()) => {
                         any_deleted = true;
                         log::info!("Emergency: deleted {}", snap_path.display());
+                        // Stamp the matching emitted event with the
+                        // subvolume name and stash for persistence.
+                        if let Some(idx) =
+                            result.events.iter().position(|ev| match &ev.payload {
+                                crate::events::EventPayload::RetentionPrune {
+                                    snapshot,
+                                    ..
+                                } => snapshot == snap.as_str(),
+                                _ => false,
+                            })
+                        {
+                            let mut ev = result.events.remove(idx);
+                            if ev.subvolume.is_none() {
+                                ev.subvolume = Some(subvol_name.clone());
+                            }
+                            emitted_events.push(ev);
+                        }
                     }
                     Err(e) => {
                         log::error!(
@@ -1198,6 +1264,10 @@ fn run_emergency_preflight(config: &Config) -> anyhow::Result<bool> {
 
     if any_deleted {
         log::warn!("Emergency retention freed space before backup");
+    }
+
+    if let Some(db) = state_db {
+        db.record_events_best_effort(&emitted_events);
     }
 
     Ok(any_deleted)
@@ -1402,6 +1472,7 @@ mod tests {
             operations: vec![],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
+            events: Vec::new(),
         }
     }
 
@@ -1571,6 +1642,7 @@ mod tests {
             ],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = ExecutionResult {
@@ -1620,6 +1692,7 @@ mod tests {
             operations: vec![],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
+            events: Vec::new(),
         };
         let result = ExecutionResult {
             overall: RunResult::Success,
@@ -1674,6 +1747,7 @@ mod tests {
             operations: vec![],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
+            events: Vec::new(),
         };
         let result = ExecutionResult {
             overall: RunResult::Success,
@@ -1703,6 +1777,7 @@ mod tests {
                 ),
                 ("htpc-docs".to_string(), "disabled".to_string()),
             ],
+            events: Vec::new(),
         };
 
         let result = ExecutionResult {
@@ -2026,6 +2101,7 @@ mod tests {
             ],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let mut fs = MockFileSystemState::new();
@@ -2070,6 +2146,7 @@ mod tests {
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let fs = MockFileSystemState::new();
@@ -2097,6 +2174,7 @@ mod tests {
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let mut fs = MockFileSystemState::new();
@@ -2134,6 +2212,7 @@ mod tests {
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
+            events: Vec::new(),
         };
         let est_full = build_size_estimates(&plan_full, &fs);
         assert_eq!(est_full[&("sv1".to_string(), "d1".to_string())], Some(45_000_000_000));
@@ -2150,6 +2229,7 @@ mod tests {
             }],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![],
+            events: Vec::new(),
         };
         let est_inc = build_size_estimates(&plan_inc, &fs);
         assert_eq!(est_inc[&("sv1".to_string(), "d1".to_string())], None);
@@ -2475,6 +2555,7 @@ mod tests {
                 .into_iter()
                 .map(|(n, r)| (n.to_string(), r.to_string()))
                 .collect(),
+            events: Vec::new(),
         }
     }
 

--- a/src/commands/emergency.rs
+++ b/src/commands/emergency.rs
@@ -67,7 +67,12 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
                 };
                 total_unsent += unsent.len();
 
-                let result = retention::emergency_retention(&snaps, &latest, &pinned);
+                let result = retention::emergency_retention(
+                    &snaps,
+                    &latest,
+                    &pinned,
+                    chrono::Local::now().naive_local(),
+                );
 
                 subvol_details.push(EmergencySubvolDetail {
                     name: subvol_name.clone(),
@@ -161,7 +166,12 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
 
             let latest = snaps.iter().max().unwrap().clone();
             let pinned = chain::find_pinned_snapshots(&local_dir, &drive_labels);
-            let result = retention::emergency_retention(&snaps, &latest, &pinned);
+            let result = retention::emergency_retention(
+                &snaps,
+                &latest,
+                &pinned,
+                chrono::Local::now().naive_local(),
+            );
 
             for (snap, _reason) in &result.delete {
                 let snap_path = local_dir.join(snap.as_str());

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -1,0 +1,129 @@
+// `urd events` subcommand — view the structured event log.
+//
+// Filters: --since, --kind, --subvolume, --drive, --limit (clamped 1..=1000).
+// Output: voice-rendered columnar (default) or NDJSON (--json forces JSON
+// regardless of TTY). The JSON format is internal-only — additive but not
+// stable.
+
+use anyhow::Context as _;
+
+use crate::cli::EventsArgs;
+use crate::config::Config;
+use crate::events::EventKind;
+use crate::output::{AppliedEventFilter, EventRow, EventsView, OutputMode};
+use crate::state::{EventQueryFilter, StateDb};
+use crate::voice;
+
+/// Maximum allowed --limit. Defends against accidental full-table dumps.
+const LIMIT_MAX: usize = 1000;
+
+pub fn run(config: Config, args: EventsArgs, output_mode: OutputMode) -> anyhow::Result<()> {
+    let db = StateDb::open(&config.general.state_db).with_context(|| {
+        format!(
+            "failed to open state DB at {}",
+            config.general.state_db.display()
+        )
+    })?;
+
+    let limit = args.limit.clamp(1, LIMIT_MAX);
+
+    let since_dt = match args.since.as_deref() {
+        Some(s) => Some(parse_since(s)?),
+        None => None,
+    };
+
+    let kind = match args.kind.as_deref() {
+        Some(s) => Some(EventKind::from_str(s).with_context(|| {
+            format!(
+                "unknown --kind {s:?}; supported: retention | planner | promise | sentinel | config | drive"
+            )
+        })?),
+        None => None,
+    };
+
+    let filter = EventQueryFilter {
+        since: since_dt,
+        kind,
+        subvolume: args.subvolume.clone(),
+        drive_label: args.drive.clone(),
+        limit,
+    };
+
+    let rows = db.query_events(&filter)?;
+    let events: Vec<EventRow> = rows.into_iter().map(EventRow::from).collect();
+
+    let applied = AppliedEventFilter {
+        since: since_dt.map(|dt| dt.format("%Y-%m-%dT%H:%M:%S").to_string()),
+        kind: kind.map(|k| k.as_str().to_string()),
+        subvolume: args.subvolume,
+        drive: args.drive,
+        limit,
+    };
+
+    let view = EventsView {
+        events,
+        applied_filter: applied,
+    };
+
+    // --json forces NDJSON regardless of TTY.
+    let mode = if args.json {
+        OutputMode::Daemon
+    } else {
+        output_mode
+    };
+    print!("{}", voice::render_events(&view, mode));
+    Ok(())
+}
+
+/// Parse a `--since` argument like "7d" / "24h" / "30m" / "5w" into the
+/// absolute cutoff `now - duration`. Same suffix vocabulary as
+/// `types::Interval::from_str`.
+fn parse_since(s: &str) -> anyhow::Result<chrono::NaiveDateTime> {
+    let interval: crate::types::Interval = s
+        .parse()
+        .with_context(|| format!("invalid --since {s:?} (expected like 7d, 24h, 30m, 5w)"))?;
+    let now = chrono::Local::now().naive_local();
+    Ok(now - interval.as_chrono())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_since_accepts_duration_suffixes() {
+        assert!(parse_since("7d").is_ok());
+        assert!(parse_since("24h").is_ok());
+        assert!(parse_since("30m").is_ok());
+        assert!(parse_since("5w").is_ok());
+    }
+
+    #[test]
+    fn parse_since_rejects_garbage() {
+        assert!(parse_since("garbage").is_err());
+        assert!(parse_since("").is_err());
+        assert!(parse_since("0d").is_err()); // zero is not positive
+    }
+
+    #[test]
+    fn parse_since_subtracts_from_now() {
+        let cutoff = parse_since("1h").unwrap();
+        let now = chrono::Local::now().naive_local();
+        let delta = now.signed_duration_since(cutoff);
+        // ~1h ago ± a few seconds.
+        assert!(delta.num_seconds() >= 3590);
+        assert!(delta.num_seconds() <= 3610);
+    }
+
+    #[test]
+    fn limit_clamp_max() {
+        let n = 99_999_usize.clamp(1, LIMIT_MAX);
+        assert_eq!(n, LIMIT_MAX);
+    }
+
+    #[test]
+    fn limit_clamp_min() {
+        let n = 0_usize.clamp(1, LIMIT_MAX);
+        assert_eq!(n, 1);
+    }
+}

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -1062,7 +1062,7 @@ protection_level = "recorded"
 snapshot_interval = "1w"
 "#;
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let result = build_migration(&legacy);
+        let _result = build_migration(&legacy);
         let v1 = render_v1(&legacy);
 
         // Should NOT have protection = "recorded"
@@ -1166,7 +1166,7 @@ snapshot_interval = "1w"
     fn dry_run_does_not_write_files() {
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let result = build_migration(&legacy);
+        let _result = build_migration(&legacy);
         let v1 = render_v1(&legacy);
 
         assert!(!v1.is_empty());
@@ -1199,12 +1199,10 @@ snapshot_interval = "1w"
     fn migrate_already_v1_is_noop() {
         let dir = tempfile::TempDir::new().unwrap();
         let config_path = dir.path().join("urd.toml");
-        let v1_content = format!(
-            "[general]\nconfig_version = 1\n\n\
+        let v1_content = "[general]\nconfig_version = 1\n\n\
              [[drives]]\nlabel = \"D\"\nmount_path = \"/mnt/d\"\nsnapshot_root = \".snap\"\nrole = \"offsite\"\n\n\
-             [[subvolumes]]\nname = \"test\"\nsource = \"/test\"\nsnapshot_root = \"/snap\"\n"
-        );
-        std::fs::write(&config_path, &v1_content).unwrap();
+             [[subvolumes]]\nname = \"test\"\nsource = \"/test\"\nsnapshot_root = \"/snap\"\n";
+        std::fs::write(&config_path, v1_content).unwrap();
 
         let args = MigrateArgs { dry_run: false };
         let result = run(Some(config_path.as_path()), &args);
@@ -1254,7 +1252,7 @@ protection_level = "sheltered"
 snapshot_interval = "1w"
 "#;
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let result = build_migration(&legacy);
+        let _result = build_migration(&legacy);
         let v1 = render_v1(&legacy);
 
         // Should have baked all operational fields since it's converted to custom
@@ -1405,7 +1403,7 @@ protection_level = "guarded"
 snapshot_interval = "1d"
 "#;
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let result = build_migration(&legacy);
+        let _result = build_migration(&legacy);
         let v1 = render_v1(&legacy);
 
         // Should keep the named level (no conversion) since override matches derived

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod default;
 pub mod doctor;
 pub mod drives;
 pub mod emergency;
+pub mod events;
 pub mod get;
 pub mod history;
 pub mod migrate;

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -113,6 +113,104 @@ pub fn populate_token_warnings(
     }
 }
 
+fn build_operation_entry(
+    op: &PlannedOperation,
+    fs_state: &dyn FileSystemState,
+) -> PlanOperationEntry {
+    match op {
+        PlannedOperation::CreateSnapshot {
+            source,
+            dest,
+            subvolume_name,
+        } => PlanOperationEntry {
+            subvolume: subvolume_name.clone(),
+            operation: "create".to_string(),
+            detail: format!("{} -> {}", source.display(), dest.display()),
+            drive_label: None,
+            estimated_bytes: None,
+            is_full_send: None,
+            full_send_reason: None,
+        },
+        PlannedOperation::SendIncremental {
+            snapshot,
+            drive_label,
+            parent,
+            pin_on_success,
+            subvolume_name,
+            ..
+        } => {
+            let snap_name = snapshot.file_name().unwrap_or_default().to_string_lossy();
+            let parent_name = parent.file_name().unwrap_or_default().to_string_lossy();
+            let pin_suffix = if pin_on_success.is_some() {
+                " + pin"
+            } else {
+                ""
+            };
+
+            let estimated_bytes =
+                plan::estimated_send_size(fs_state, subvolume_name, drive_label, false);
+
+            PlanOperationEntry {
+                subvolume: subvolume_name.clone(),
+                operation: "send".to_string(),
+                detail: format!(
+                    "{snap_name} -> {drive_label} (incremental, parent: {parent_name}){pin_suffix}"
+                ),
+                drive_label: Some(drive_label.clone()),
+                estimated_bytes,
+                is_full_send: Some(false),
+                full_send_reason: None,
+            }
+        }
+        PlannedOperation::SendFull {
+            snapshot,
+            drive_label,
+            pin_on_success,
+            subvolume_name,
+            reason,
+            ..
+        } => {
+            let snap_name = snapshot.file_name().unwrap_or_default().to_string_lossy();
+            let pin_suffix = if pin_on_success.is_some() {
+                " + pin"
+            } else {
+                ""
+            };
+
+            let estimated_bytes =
+                plan::estimated_send_size(fs_state, subvolume_name, drive_label, true);
+
+            PlanOperationEntry {
+                subvolume: subvolume_name.clone(),
+                operation: "send".to_string(),
+                detail: format!(
+                    "{snap_name} -> {drive_label} (full \u{2014} {reason}){pin_suffix}"
+                ),
+                drive_label: Some(drive_label.clone()),
+                estimated_bytes,
+                is_full_send: Some(true),
+                full_send_reason: Some(reason.to_string()),
+            }
+        }
+        PlannedOperation::DeleteSnapshot {
+            path,
+            reason,
+            subvolume_name,
+        } => {
+            let snap_name = path.file_name().unwrap_or_default().to_string_lossy();
+            PlanOperationEntry {
+                subvolume: subvolume_name.clone(),
+                operation: "delete".to_string(),
+                detail: format!("{snap_name} ({reason})"),
+                drive_label: None,
+                estimated_bytes: None,
+                is_full_send: None,
+                full_send_reason: None,
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -278,6 +376,7 @@ mod tests {
                 mock_send_full("htpc-docs", "WD-18TB"),
             ],
             skipped: vec![],
+            events: Vec::new(),
         };
         let output = build_plan_output(&plan, &fs);
         assert_eq!(output.summary.estimated_total_bytes, Some(54_200_000_000));
@@ -297,6 +396,7 @@ mod tests {
                 mock_send_full("htpc-docs", "WD-18TB"), // no estimate
             ],
             skipped: vec![],
+            events: Vec::new(),
         };
         let output = build_plan_output(&plan, &fs);
         assert_eq!(output.summary.estimated_total_bytes, Some(53_000_000_000));
@@ -309,106 +409,9 @@ mod tests {
             timestamp: chrono::NaiveDateTime::default(),
             operations: vec![mock_send_full("htpc-home", "WD-18TB")],
             skipped: vec![],
+            events: Vec::new(),
         };
         let output = build_plan_output(&plan, &fs);
         assert_eq!(output.summary.estimated_total_bytes, None);
-    }
-}
-
-fn build_operation_entry(
-    op: &PlannedOperation,
-    fs_state: &dyn FileSystemState,
-) -> PlanOperationEntry {
-    match op {
-        PlannedOperation::CreateSnapshot {
-            source,
-            dest,
-            subvolume_name,
-        } => PlanOperationEntry {
-            subvolume: subvolume_name.clone(),
-            operation: "create".to_string(),
-            detail: format!("{} -> {}", source.display(), dest.display()),
-            drive_label: None,
-            estimated_bytes: None,
-            is_full_send: None,
-            full_send_reason: None,
-        },
-        PlannedOperation::SendIncremental {
-            snapshot,
-            drive_label,
-            parent,
-            pin_on_success,
-            subvolume_name,
-            ..
-        } => {
-            let snap_name = snapshot.file_name().unwrap_or_default().to_string_lossy();
-            let parent_name = parent.file_name().unwrap_or_default().to_string_lossy();
-            let pin_suffix = if pin_on_success.is_some() {
-                " + pin"
-            } else {
-                ""
-            };
-
-            let estimated_bytes =
-                plan::estimated_send_size(fs_state, subvolume_name, drive_label, false);
-
-            PlanOperationEntry {
-                subvolume: subvolume_name.clone(),
-                operation: "send".to_string(),
-                detail: format!(
-                    "{snap_name} -> {drive_label} (incremental, parent: {parent_name}){pin_suffix}"
-                ),
-                drive_label: Some(drive_label.clone()),
-                estimated_bytes,
-                is_full_send: Some(false),
-                full_send_reason: None,
-            }
-        }
-        PlannedOperation::SendFull {
-            snapshot,
-            drive_label,
-            pin_on_success,
-            subvolume_name,
-            reason,
-            ..
-        } => {
-            let snap_name = snapshot.file_name().unwrap_or_default().to_string_lossy();
-            let pin_suffix = if pin_on_success.is_some() {
-                " + pin"
-            } else {
-                ""
-            };
-
-            let estimated_bytes =
-                plan::estimated_send_size(fs_state, subvolume_name, drive_label, true);
-
-            PlanOperationEntry {
-                subvolume: subvolume_name.clone(),
-                operation: "send".to_string(),
-                detail: format!(
-                    "{snap_name} -> {drive_label} (full \u{2014} {reason}){pin_suffix}"
-                ),
-                drive_label: Some(drive_label.clone()),
-                estimated_bytes,
-                is_full_send: Some(true),
-                full_send_reason: Some(reason.to_string()),
-            }
-        }
-        PlannedOperation::DeleteSnapshot {
-            path,
-            reason,
-            subvolume_name,
-        } => {
-            let snap_name = path.file_name().unwrap_or_default().to_string_lossy();
-            PlanOperationEntry {
-                subvolume: subvolume_name.clone(),
-                operation: "delete".to_string(),
-                detail: format!("{snap_name} ({reason})"),
-                drive_label: None,
-                estimated_bytes: None,
-                is_full_send: None,
-                full_send_reason: None,
-            }
-        }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2013,7 +2013,7 @@ min_free_bytes = "50GB"
             .local_snapshots
             .roots
             .iter()
-            .find(|r| r.path == PathBuf::from("/snap-data"))
+            .find(|r| r.path == Path::new("/snap-data"))
             .unwrap();
         assert_eq!(data_root.min_free_bytes, Some(ByteSize(50_000_000_000)));
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,688 @@
+// Structured event log — typed, append-only records of decisions and state
+// transitions (ADR-114).
+//
+// Pure module: defines the `Event` taxonomy. Pure callers (planner,
+// retention, awareness, sentinel state machine) construct `Event` records
+// as part of their output. Impure callers (executor, sentinel_runner,
+// commands) persist them best-effort via `state::record_events_best_effort`.
+//
+// Wire stability: every `EventPayload` variant uses typed enums with
+// `#[serde(rename_all = "snake_case")]` so JSON encoding stays stable as
+// Rust variants evolve. Adding fields with `#[serde(default)]` is the
+// preferred forward-compatibility lever.
+
+use chrono::NaiveDateTime;
+use serde::{Deserialize, Serialize};
+
+use crate::awareness::PromiseStatus;
+use crate::sentinel::CircuitState;
+use crate::state::DriveEventSource;
+use crate::types::{FullSendReason, SendKind};
+
+// ── Top-level kind ─────────────────────────────────────────────────────
+
+/// Coarse-grained event family. Stored as a SQL column for index-friendly
+/// filtering; derived from the payload variant via `EventPayload::kind()`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum EventKind {
+    Retention,
+    Planner,
+    Promise,
+    Sentinel,
+    Config,
+    Drive,
+}
+
+impl EventKind {
+    /// Lower-case wire form used when writing to SQLite's `kind` column.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Retention => "retention",
+            Self::Planner => "planner",
+            Self::Promise => "promise",
+            Self::Sentinel => "sentinel",
+            Self::Config => "config",
+            Self::Drive => "drive",
+        }
+    }
+
+    /// Parse the wire form back into a kind. Returns `None` for unknown
+    /// strings — callers (e.g., `state::query_events`) log and skip
+    /// unrecognized rows rather than failing the query.
+    #[must_use]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "retention" => Some(Self::Retention),
+            "planner" => Some(Self::Planner),
+            "promise" => Some(Self::Promise),
+            "sentinel" => Some(Self::Sentinel),
+            "config" => Some(Self::Config),
+            "drive" => Some(Self::Drive),
+            _ => None,
+        }
+    }
+}
+
+// ── Severity ───────────────────────────────────────────────────────────
+
+/// Three-level severity derived from the payload variant at render time
+/// rather than stored as a column — derivation is the source of truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Info,
+    Notice,
+    Warn,
+}
+
+// ── Typed enums for payload fields ─────────────────────────────────────
+
+/// What triggered a promise-state transition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransitionTrigger {
+    /// Detected during a backup run by comparing pre/post heartbeat.
+    Run,
+    /// Detected by the sentinel's adaptive assessment tick.
+    Tick,
+    /// Detected by the sentinel after a drive mount event.
+    DriveMounted,
+    /// Detected by the sentinel after a config reload.
+    ConfigChanged,
+}
+
+/// Scope of a planner deferral — which level the skip applied at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DeferScope {
+    /// Skip applies to a single subvolume (most skip messages).
+    Subvolume,
+    /// Skip applies to a specific drive (drive-availability deferrals).
+    Drive,
+    /// Skip applies to the entire run (rare; reserved for future use).
+    Run,
+}
+
+/// Which retention rule fired to produce a prune.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PruneRule {
+    GraduatedHourly,
+    GraduatedDaily,
+    GraduatedWeekly,
+    GraduatedMonthly,
+    BeyondWindow,
+    Emergency,
+    SpacePressure,
+}
+
+/// Why retention took a non-default branch to keep a snapshot. Only fires
+/// on actual override — routine in-window keeps are silent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProtectReason {
+    /// Pinned snapshot would have been deleted by daily/weekly/monthly thinning.
+    PinOverrodeThinning,
+    /// Pinned snapshot would have been deleted as beyond the retention window.
+    PinOverrodeWindow,
+    /// Future-dated snapshot kept by clock-skew guard.
+    ClockSkewFuture,
+}
+
+// ── Event payload ──────────────────────────────────────────────────────
+
+/// Kind-specific event data, serialized as tagged JSON in the `payload`
+/// SQL column.
+///
+/// Wire form uses `#[serde(tag = "type")]` so a payload like
+/// `RetentionPrune { snapshot, rule, tier }` serializes as
+/// `{"type":"RetentionPrune","snapshot":"...","rule":"graduated_daily","tier":null}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub enum EventPayload {
+    RetentionPrune {
+        snapshot: String,
+        rule: PruneRule,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tier: Option<String>,
+    },
+    RetentionProtect {
+        snapshot: String,
+        reason: ProtectReason,
+    },
+    PlannerSendChoice {
+        send_kind: SendKind,
+        reason: FullSendReason,
+        drive_label: String,
+    },
+    PlannerDefer {
+        reason: String,
+        scope: DeferScope,
+    },
+    PromiseTransition {
+        from: PromiseStatus,
+        to: PromiseStatus,
+        trigger: TransitionTrigger,
+    },
+    SentinelCircuitBreak {
+        from: CircuitState,
+        to: CircuitState,
+        reason: String,
+        backoff_secs: u64,
+    },
+    SentinelAnomaly {
+        description: String,
+    },
+    ConfigReloaded {
+        config_version: String,
+        source: String,
+    },
+    ConfigReloadFailed {
+        reason: String,
+    },
+    DriveMounted {
+        detected_by: DriveEventSource,
+    },
+    DriveUnmounted {
+        detected_by: DriveEventSource,
+    },
+}
+
+impl EventPayload {
+    /// Coarse-grained event family for SQL filtering.
+    #[must_use]
+    pub fn kind(&self) -> EventKind {
+        match self {
+            Self::RetentionPrune { .. } | Self::RetentionProtect { .. } => EventKind::Retention,
+            Self::PlannerSendChoice { .. } | Self::PlannerDefer { .. } => EventKind::Planner,
+            Self::PromiseTransition { .. } => EventKind::Promise,
+            Self::SentinelCircuitBreak { .. } | Self::SentinelAnomaly { .. } => EventKind::Sentinel,
+            Self::ConfigReloaded { .. } | Self::ConfigReloadFailed { .. } => EventKind::Config,
+            Self::DriveMounted { .. } | Self::DriveUnmounted { .. } => EventKind::Drive,
+        }
+    }
+
+    /// Severity derived per design table. Computed at render time, not
+    /// stored. Some variants depend on inner fields (e.g.,
+    /// `PlannerSendChoice` is `Notice` only when reason is `ChainBroken`).
+    #[must_use]
+    pub fn severity(&self) -> Severity {
+        match self {
+            Self::RetentionPrune { rule, .. } => match rule {
+                PruneRule::Emergency | PruneRule::SpacePressure => Severity::Notice,
+                _ => Severity::Info,
+            },
+            Self::RetentionProtect { .. } => Severity::Notice,
+            Self::PlannerSendChoice { reason, .. } => match reason {
+                FullSendReason::ChainBroken => Severity::Notice,
+                FullSendReason::FirstSend | FullSendReason::NoPinFile => Severity::Info,
+            },
+            Self::PlannerDefer { .. } => Severity::Info,
+            Self::PromiseTransition { from, to, .. } => {
+                // PromiseStatus is ordered worst-to-best.
+                if to < from {
+                    Severity::Notice // degradation
+                } else {
+                    Severity::Info // recovery (or no-op, but no-ops are filtered upstream)
+                }
+            }
+            Self::SentinelCircuitBreak { .. } | Self::SentinelAnomaly { .. } => Severity::Warn,
+            Self::ConfigReloaded { .. } => Severity::Info,
+            Self::ConfigReloadFailed { .. } => Severity::Warn,
+            Self::DriveMounted { .. } | Self::DriveUnmounted { .. } => Severity::Info,
+        }
+    }
+}
+
+// ── Event record ───────────────────────────────────────────────────────
+
+/// A single event ready for persistence. Constructed by pure modules;
+/// persisted by impure callers via `state::record_events_best_effort`.
+///
+/// Contextual fields (`run_id`, `subvolume`, `drive_label`) are stamped
+/// by the caller — the pure emitter often leaves them as `None` and the
+/// impure layer fills them in before the batch goes to SQLite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Event {
+    pub occurred_at: NaiveDateTime,
+    pub run_id: Option<i64>,
+    pub subvolume: Option<String>,
+    pub drive_label: Option<String>,
+    pub payload: EventPayload,
+}
+
+impl Event {
+    /// Pure-module constructor: leaves `run_id`/`subvolume`/`drive_label`
+    /// unset so the impure caller can stamp them before persistence.
+    #[must_use]
+    pub fn pure(occurred_at: NaiveDateTime, payload: EventPayload) -> Self {
+        Self {
+            occurred_at,
+            run_id: None,
+            subvolume: None,
+            drive_label: None,
+            payload,
+        }
+    }
+
+    /// Convenience: derive kind from the payload.
+    #[must_use]
+    pub fn kind(&self) -> EventKind {
+        self.payload.kind()
+    }
+
+    /// Convenience: derive severity from the payload.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn severity(&self) -> Severity {
+        self.payload.severity()
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now() -> NaiveDateTime {
+        NaiveDateTime::parse_from_str("2026-04-30T03:14:22", "%Y-%m-%dT%H:%M:%S").unwrap()
+    }
+
+    fn event_with(payload: EventPayload) -> Event {
+        Event {
+            occurred_at: now(),
+            run_id: Some(1),
+            subvolume: None,
+            drive_label: None,
+            payload,
+        }
+    }
+
+    // ── Kind derivation ───────────────────────────────────────────────
+
+    #[test]
+    fn kind_derivation_table() {
+        let cases: Vec<(EventPayload, EventKind)> = vec![
+            (
+                EventPayload::RetentionPrune {
+                    snapshot: "s".into(),
+                    rule: PruneRule::GraduatedDaily,
+                    tier: None,
+                },
+                EventKind::Retention,
+            ),
+            (
+                EventPayload::RetentionProtect {
+                    snapshot: "s".into(),
+                    reason: ProtectReason::PinOverrodeThinning,
+                },
+                EventKind::Retention,
+            ),
+            (
+                EventPayload::PlannerSendChoice {
+                    send_kind: SendKind::Full,
+                    reason: FullSendReason::FirstSend,
+                    drive_label: "WD-18TB".into(),
+                },
+                EventKind::Planner,
+            ),
+            (
+                EventPayload::PlannerDefer {
+                    reason: "interval not elapsed".into(),
+                    scope: DeferScope::Subvolume,
+                },
+                EventKind::Planner,
+            ),
+            (
+                EventPayload::PromiseTransition {
+                    from: PromiseStatus::Protected,
+                    to: PromiseStatus::AtRisk,
+                    trigger: TransitionTrigger::Run,
+                },
+                EventKind::Promise,
+            ),
+            (
+                EventPayload::SentinelCircuitBreak {
+                    from: CircuitState::Closed,
+                    to: CircuitState::Open,
+                    reason: "3 consecutive failures".into(),
+                    backoff_secs: 900,
+                },
+                EventKind::Sentinel,
+            ),
+            (
+                EventPayload::SentinelAnomaly {
+                    description: "drive swap".into(),
+                },
+                EventKind::Sentinel,
+            ),
+            (
+                EventPayload::ConfigReloaded {
+                    config_version: "1".into(),
+                    source: "/path/to/urd.toml".into(),
+                },
+                EventKind::Config,
+            ),
+            (
+                EventPayload::ConfigReloadFailed {
+                    reason: "parse error".into(),
+                },
+                EventKind::Config,
+            ),
+            (
+                EventPayload::DriveMounted {
+                    detected_by: DriveEventSource::Sentinel,
+                },
+                EventKind::Drive,
+            ),
+            (
+                EventPayload::DriveUnmounted {
+                    detected_by: DriveEventSource::Sentinel,
+                },
+                EventKind::Drive,
+            ),
+        ];
+        for (payload, expected) in cases {
+            assert_eq!(payload.kind(), expected, "kind mismatch for {payload:?}");
+        }
+    }
+
+    // ── Severity derivation ───────────────────────────────────────────
+
+    #[test]
+    fn severity_retention_prune_by_rule() {
+        let info_rules = [
+            PruneRule::GraduatedHourly,
+            PruneRule::GraduatedDaily,
+            PruneRule::GraduatedWeekly,
+            PruneRule::GraduatedMonthly,
+            PruneRule::BeyondWindow,
+        ];
+        for rule in info_rules {
+            let p = EventPayload::RetentionPrune {
+                snapshot: "s".into(),
+                rule,
+                tier: None,
+            };
+            assert_eq!(p.severity(), Severity::Info, "{rule:?} should be info");
+        }
+        for rule in [PruneRule::Emergency, PruneRule::SpacePressure] {
+            let p = EventPayload::RetentionPrune {
+                snapshot: "s".into(),
+                rule,
+                tier: None,
+            };
+            assert_eq!(p.severity(), Severity::Notice, "{rule:?} should be notice");
+        }
+    }
+
+    #[test]
+    fn severity_planner_send_choice_by_reason() {
+        let chain_broken = EventPayload::PlannerSendChoice {
+            send_kind: SendKind::Full,
+            reason: FullSendReason::ChainBroken,
+            drive_label: "WD-18TB".into(),
+        };
+        assert_eq!(chain_broken.severity(), Severity::Notice);
+
+        for reason in [FullSendReason::FirstSend, FullSendReason::NoPinFile] {
+            let p = EventPayload::PlannerSendChoice {
+                send_kind: SendKind::Full,
+                reason,
+                drive_label: "WD-18TB".into(),
+            };
+            assert_eq!(p.severity(), Severity::Info, "{reason:?} should be info");
+        }
+    }
+
+    #[test]
+    fn severity_promise_transition_direction() {
+        let degradation = EventPayload::PromiseTransition {
+            from: PromiseStatus::Protected,
+            to: PromiseStatus::AtRisk,
+            trigger: TransitionTrigger::Run,
+        };
+        assert_eq!(degradation.severity(), Severity::Notice);
+
+        let recovery = EventPayload::PromiseTransition {
+            from: PromiseStatus::Unprotected,
+            to: PromiseStatus::Protected,
+            trigger: TransitionTrigger::Tick,
+        };
+        assert_eq!(recovery.severity(), Severity::Info);
+    }
+
+    #[test]
+    fn severity_sentinel_and_config() {
+        let cb = EventPayload::SentinelCircuitBreak {
+            from: CircuitState::Closed,
+            to: CircuitState::Open,
+            reason: "x".into(),
+            backoff_secs: 0,
+        };
+        assert_eq!(cb.severity(), Severity::Warn);
+
+        let anomaly = EventPayload::SentinelAnomaly {
+            description: "x".into(),
+        };
+        assert_eq!(anomaly.severity(), Severity::Warn);
+
+        let reload_ok = EventPayload::ConfigReloaded {
+            config_version: "1".into(),
+            source: "x".into(),
+        };
+        assert_eq!(reload_ok.severity(), Severity::Info);
+
+        let reload_fail = EventPayload::ConfigReloadFailed {
+            reason: "x".into(),
+        };
+        assert_eq!(reload_fail.severity(), Severity::Warn);
+    }
+
+    #[test]
+    fn severity_drive_and_defer_are_info() {
+        let mounted = EventPayload::DriveMounted {
+            detected_by: DriveEventSource::Sentinel,
+        };
+        assert_eq!(mounted.severity(), Severity::Info);
+
+        let unmounted = EventPayload::DriveUnmounted {
+            detected_by: DriveEventSource::Sentinel,
+        };
+        assert_eq!(unmounted.severity(), Severity::Info);
+
+        let defer = EventPayload::PlannerDefer {
+            reason: "interval not elapsed".into(),
+            scope: DeferScope::Subvolume,
+        };
+        assert_eq!(defer.severity(), Severity::Info);
+    }
+
+    #[test]
+    fn event_helpers_delegate_to_payload() {
+        let payload = EventPayload::DriveMounted {
+            detected_by: DriveEventSource::Sentinel,
+        };
+        let event = event_with(payload.clone());
+        assert_eq!(event.kind(), payload.kind());
+        assert_eq!(event.severity(), payload.severity());
+    }
+
+    // ── Roundtrip tests (per-variant serde stability) ─────────────────
+
+    fn roundtrip(payload: &EventPayload) {
+        let json = serde_json::to_string(payload).expect("serialize");
+        let back: EventPayload = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(payload, &back, "roundtrip mismatch via {json}");
+    }
+
+    #[test]
+    fn roundtrip_all_payload_variants() {
+        roundtrip(&EventPayload::RetentionPrune {
+            snapshot: "20260423-0400-htpc-home".into(),
+            rule: PruneRule::GraduatedDaily,
+            tier: Some("31d".into()),
+        });
+        roundtrip(&EventPayload::RetentionProtect {
+            snapshot: "20240101-htpc-home".into(),
+            reason: ProtectReason::PinOverrodeWindow,
+        });
+        roundtrip(&EventPayload::PlannerSendChoice {
+            send_kind: SendKind::Full,
+            reason: FullSendReason::ChainBroken,
+            drive_label: "WD-18TB".into(),
+        });
+        roundtrip(&EventPayload::PlannerDefer {
+            reason: "interval not elapsed".into(),
+            scope: DeferScope::Subvolume,
+        });
+        roundtrip(&EventPayload::PromiseTransition {
+            from: PromiseStatus::Protected,
+            to: PromiseStatus::AtRisk,
+            trigger: TransitionTrigger::Tick,
+        });
+        roundtrip(&EventPayload::SentinelCircuitBreak {
+            from: CircuitState::Closed,
+            to: CircuitState::Open,
+            reason: "3 consecutive failures".into(),
+            backoff_secs: 900,
+        });
+        roundtrip(&EventPayload::SentinelAnomaly {
+            description: "drive swap suspected".into(),
+        });
+        roundtrip(&EventPayload::ConfigReloaded {
+            config_version: "1".into(),
+            source: "/home/user/.config/urd/urd.toml".into(),
+        });
+        roundtrip(&EventPayload::ConfigReloadFailed {
+            reason: "parse error: missing field".into(),
+        });
+        roundtrip(&EventPayload::DriveMounted {
+            detected_by: DriveEventSource::Sentinel,
+        });
+        roundtrip(&EventPayload::DriveUnmounted {
+            detected_by: DriveEventSource::Backup,
+        });
+    }
+
+    // ── Wire-form goldens (these are the metric-label contract per R15) ──
+
+    #[test]
+    fn full_send_reason_wire_form_is_snake_case() {
+        let cases = [
+            (FullSendReason::FirstSend, "first_send"),
+            (FullSendReason::ChainBroken, "chain_broken"),
+            (FullSendReason::NoPinFile, "no_pin_file"),
+        ];
+        for (reason, expected) in cases {
+            let payload = EventPayload::PlannerSendChoice {
+                send_kind: SendKind::Full,
+                reason,
+                drive_label: "WD-18TB".into(),
+            };
+            let json = serde_json::to_value(&payload).unwrap();
+            let actual = json.get("reason").and_then(|v| v.as_str()).unwrap();
+            assert_eq!(actual, expected, "wire form for {reason:?} drifted");
+        }
+    }
+
+    #[test]
+    fn prune_rule_wire_form_is_snake_case() {
+        let cases = [
+            (PruneRule::GraduatedHourly, "graduated_hourly"),
+            (PruneRule::GraduatedDaily, "graduated_daily"),
+            (PruneRule::GraduatedWeekly, "graduated_weekly"),
+            (PruneRule::GraduatedMonthly, "graduated_monthly"),
+            (PruneRule::BeyondWindow, "beyond_window"),
+            (PruneRule::Emergency, "emergency"),
+            (PruneRule::SpacePressure, "space_pressure"),
+        ];
+        for (rule, expected) in cases {
+            let payload = EventPayload::RetentionPrune {
+                snapshot: "s".into(),
+                rule,
+                tier: None,
+            };
+            let json = serde_json::to_value(&payload).unwrap();
+            let actual = json.get("rule").and_then(|v| v.as_str()).unwrap();
+            assert_eq!(actual, expected, "wire form for {rule:?} drifted");
+        }
+    }
+
+    #[test]
+    fn defer_scope_wire_form_is_snake_case() {
+        let cases = [
+            (DeferScope::Subvolume, "subvolume"),
+            (DeferScope::Drive, "drive"),
+            (DeferScope::Run, "run"),
+        ];
+        for (scope, expected) in cases {
+            let payload = EventPayload::PlannerDefer {
+                reason: "x".into(),
+                scope,
+            };
+            let json = serde_json::to_value(&payload).unwrap();
+            let actual = json.get("scope").and_then(|v| v.as_str()).unwrap();
+            assert_eq!(actual, expected, "wire form for {scope:?} drifted");
+        }
+    }
+
+    #[test]
+    fn transition_trigger_wire_form_is_snake_case() {
+        let cases = [
+            (TransitionTrigger::Run, "run"),
+            (TransitionTrigger::Tick, "tick"),
+            (TransitionTrigger::DriveMounted, "drive_mounted"),
+            (TransitionTrigger::ConfigChanged, "config_changed"),
+        ];
+        for (trigger, expected) in cases {
+            let payload = EventPayload::PromiseTransition {
+                from: PromiseStatus::Protected,
+                to: PromiseStatus::AtRisk,
+                trigger,
+            };
+            let json = serde_json::to_value(&payload).unwrap();
+            let actual = json.get("trigger").and_then(|v| v.as_str()).unwrap();
+            assert_eq!(actual, expected, "wire form for {trigger:?} drifted");
+        }
+    }
+
+    // ── EventKind string roundtrip ────────────────────────────────────
+
+    #[test]
+    fn event_kind_as_str_roundtrips_via_from_str() {
+        for kind in [
+            EventKind::Retention,
+            EventKind::Planner,
+            EventKind::Promise,
+            EventKind::Sentinel,
+            EventKind::Config,
+            EventKind::Drive,
+        ] {
+            assert_eq!(EventKind::from_str(kind.as_str()), Some(kind));
+        }
+    }
+
+    #[test]
+    fn event_kind_from_str_unknown_is_none() {
+        assert_eq!(EventKind::from_str("unknown"), None);
+        assert_eq!(EventKind::from_str(""), None);
+        assert_eq!(EventKind::from_str("RETENTION"), None); // case-sensitive
+    }
+
+    // ── Optional `tier` field is omitted when None ────────────────────
+
+    #[test]
+    fn retention_prune_omits_tier_when_none() {
+        let payload = EventPayload::RetentionPrune {
+            snapshot: "s".into(),
+            rule: PruneRule::GraduatedDaily,
+            tier: None,
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert!(json.get("tier").is_none(), "tier should be omitted when None");
+    }
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -235,6 +235,19 @@ impl<'a> Executor<'a> {
         // Finish run in SQLite
         self.finish_run(run_id, overall.as_str());
 
+        // Persist plan-level events (planner choices, deferrals, retention
+        // rationale) best-effort. Stamp run_id on a clone so the pure plan
+        // stays unmutated and the &BackupPlan signature is preserved.
+        if let Some(state) = self.state
+            && !plan.events.is_empty()
+        {
+            let mut stamped: Vec<crate::events::Event> = plan.events.clone();
+            for ev in &mut stamped {
+                ev.run_id = run_id;
+            }
+            state.record_events_best_effort(&stamped);
+        }
+
         ExecutionResult {
             overall,
             subvolume_results,
@@ -1081,7 +1094,7 @@ mod tests {
     use crate::btrfs::{MockBtrfs, MockBtrfsCall};
     use crate::types::SnapshotName;
     use chrono::NaiveDate;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
 
     /// Shutdown flag that never triggers — used for all tests that don't test signal handling.
     fn no_shutdown() -> AtomicBool {
@@ -1156,6 +1169,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         }
     }
 
@@ -1213,6 +1227,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1256,6 +1271,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1305,6 +1321,7 @@ source = "/data/b"
             }],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1348,6 +1365,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1369,6 +1387,7 @@ source = "/data/b"
             operations: vec![],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1409,6 +1428,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1467,6 +1487,7 @@ source = "/data/b"
             }],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1504,6 +1525,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1602,6 +1624,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1649,6 +1672,7 @@ source = "/data/b"
             }],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1713,6 +1737,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1749,6 +1774,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         // Set shutdown after sv-a would have executed — but since we can't
@@ -1792,6 +1818,7 @@ source = "/data/b"
             }],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1849,6 +1876,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -1897,6 +1925,7 @@ source = "/data/b"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2026,6 +2055,7 @@ source = "/data/sv1"
             }],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         }
     }
 
@@ -2121,6 +2151,7 @@ source = "/data/sv1"
             }],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         }
     }
 
@@ -2233,6 +2264,7 @@ source = "/data/sv1"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2340,6 +2372,7 @@ local_retention = "transient"
             }],
             timestamp: test_ts(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2420,6 +2453,7 @@ local_retention = "transient"
             ],
             timestamp: test_ts(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2468,6 +2502,7 @@ local_retention = "transient"
             }],
             timestamp: test_ts(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2551,6 +2586,7 @@ local_retention = "transient"
             ],
             timestamp: test_ts(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2604,6 +2640,7 @@ local_retention = "transient"
             }],
             timestamp: test_ts(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2646,6 +2683,7 @@ local_retention = "transient"
             }],
             timestamp: test_ts(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2717,6 +2755,7 @@ local_retention = "transient"
             ],
             timestamp: test_ts(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2780,6 +2819,7 @@ local_retention = "transient"
             }],
             timestamp: test_ts(),
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2825,6 +2865,7 @@ local_retention = "transient"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         executor.execute(&plan, "full");
@@ -2843,19 +2884,19 @@ local_retention = "transient"
         assert_eq!(relevant.len(), 4);
         assert!(matches!(
             relevant[0],
-            MockBtrfsCall::DeleteSubvolume { path } if *path == PathBuf::from("/snap/sv-a/20260301-a")
+            MockBtrfsCall::DeleteSubvolume { path } if path == Path::new("/snap/sv-a/20260301-a")
         ));
         assert!(matches!(
             relevant[1],
-            MockBtrfsCall::SyncSubvolumes { path } if *path == PathBuf::from("/snap/sv-a")
+            MockBtrfsCall::SyncSubvolumes { path } if path == Path::new("/snap/sv-a")
         ));
         assert!(matches!(
             relevant[2],
-            MockBtrfsCall::DeleteSubvolume { path } if *path == PathBuf::from("/snap/sv-a/20260302-a")
+            MockBtrfsCall::DeleteSubvolume { path } if path == Path::new("/snap/sv-a/20260302-a")
         ));
         assert!(matches!(
             relevant[3],
-            MockBtrfsCall::SyncSubvolumes { path } if *path == PathBuf::from("/snap/sv-a")
+            MockBtrfsCall::SyncSubvolumes { path } if path == Path::new("/snap/sv-a")
         ));
     }
 
@@ -2890,6 +2931,7 @@ local_retention = "transient"
             ],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         let result = executor.execute(&plan, "full");
@@ -2919,6 +2961,7 @@ local_retention = "transient"
             }],
             timestamp: ts,
             skipped: vec![],
+            events: Vec::new(),
         };
 
         executor.execute(&plan, "full");
@@ -2927,7 +2970,102 @@ local_retention = "transient"
         let calls = mock.calls();
         assert!(calls.iter().any(|c| matches!(
             c,
-            MockBtrfsCall::SyncSubvolumes { path } if *path == PathBuf::from("/mnt/test/.snapshots/sv-a")
+            MockBtrfsCall::SyncSubvolumes { path } if path == Path::new("/mnt/test/.snapshots/sv-a")
         )));
+    }
+
+    // ── BackupPlan.events persistence ──────────────────────────────
+
+    #[test]
+    fn execute_persists_plan_events_with_run_id_stamped() {
+        use crate::events::{DeferScope, Event, EventPayload};
+        use crate::state::{EventQueryFilter, StateDb};
+
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let db = StateDb::open_memory().unwrap();
+        let executor = Executor::new(&mock, Some(&db), &config, &shutdown);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 4, 30)
+            .unwrap()
+            .and_hms_opt(3, 14, 22)
+            .unwrap();
+        let mut plan = simple_plan();
+        let mut event = Event::pure(
+            ts,
+            EventPayload::PlannerDefer {
+                reason: "interval not elapsed".to_string(),
+                scope: DeferScope::Subvolume,
+            },
+        );
+        event.subvolume = Some("sv-a".to_string());
+        plan.events.push(event);
+
+        let result = executor.execute(&plan, "full");
+        assert_eq!(result.overall, RunResult::Success);
+
+        let rows = db
+            .query_events(&EventQueryFilter {
+                limit: 10,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].run_id, result.run_id);
+        assert!(matches!(
+            rows[0].payload,
+            EventPayload::PlannerDefer { .. }
+        ));
+    }
+
+    #[test]
+    fn execute_with_no_state_drops_events_without_panic() {
+        use crate::events::{DeferScope, Event, EventPayload};
+
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 4, 30)
+            .unwrap()
+            .and_hms_opt(3, 14, 22)
+            .unwrap();
+        let mut plan = simple_plan();
+        let mut event = Event::pure(
+            ts,
+            EventPayload::PlannerDefer {
+                reason: "x".to_string(),
+                scope: DeferScope::Subvolume,
+            },
+        );
+        event.subvolume = Some("sv-a".to_string());
+        plan.events.push(event);
+
+        // No state DB, no panic — events are silently dropped.
+        let result = executor.execute(&plan, "full");
+        assert_eq!(result.overall, RunResult::Success);
+    }
+
+    #[test]
+    fn execute_persists_empty_events_as_noop() {
+        use crate::state::{EventQueryFilter, StateDb};
+
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let db = StateDb::open_memory().unwrap();
+        let executor = Executor::new(&mock, Some(&db), &config, &shutdown);
+        let plan = simple_plan(); // events is empty
+
+        let _ = executor.execute(&plan, "full");
+        let rows = db
+            .query_events(&EventQueryFilter {
+                limit: 10,
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(rows.is_empty());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod commands;
 mod config;
 mod drives;
 mod error;
+mod events;
 mod executor;
 mod heartbeat;
 mod lock;
@@ -20,6 +21,7 @@ mod sentinel_runner;
 mod state;
 mod types;
 mod voice;
+mod voice_events;
 
 use std::io::IsTerminal;
 
@@ -95,6 +97,7 @@ fn main() -> anyhow::Result<()> {
         Commands::RetentionPreview(args) => {
             commands::retention_preview::run(config, args, output_mode)
         }
+        Commands::Events(args) => commands::events::run(config, args, output_mode),
         Commands::Completions(_) | Commands::Migrate(_) => unreachable!("handled above"),
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,6 +12,19 @@ pub struct MetricsData {
     pub external_drive_mounted: bool,
     pub external_free_bytes: u64,
     pub script_last_run_timestamp: i64,
+    /// Counters derived from the events table at write time.
+    /// Empty/zero when no state DB is available.
+    pub event_counters: EventCounters,
+}
+
+/// Prometheus counter family derived from the events table by
+/// `state.rs::count_*` helpers.
+#[derive(Debug, Default, Clone)]
+pub struct EventCounters {
+    pub circuit_breaker_trips: u64,
+    pub full_sends_by_reason: Vec<(String, u64)>,
+    pub defers_by_scope: Vec<(String, u64)>,
+    pub prunes_by_rule: Vec<(String, u64)>,
 }
 
 /// Per-subvolume metrics for a backup run.
@@ -238,6 +251,82 @@ fn format_metrics(data: &MetricsData) -> String {
     )
     .unwrap();
 
+    // ── Structured event counters ─────────────────────────────────
+
+    let counters = &data.event_counters;
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP urd_circuit_breaker_trips_total Sentinel circuit-breaker open transitions."
+    )
+    .unwrap();
+    writeln!(out, "# TYPE urd_circuit_breaker_trips_total counter").unwrap();
+    writeln!(
+        out,
+        "urd_circuit_breaker_trips_total {}",
+        counters.circuit_breaker_trips
+    )
+    .unwrap();
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP urd_planner_full_sends_total Full-send choices, by reason."
+    )
+    .unwrap();
+    writeln!(out, "# TYPE urd_planner_full_sends_total counter").unwrap();
+    if counters.full_sends_by_reason.is_empty() {
+        // Emit a zero so consumers can detect the metric exists.
+        writeln!(out, "urd_planner_full_sends_total{{reason=\"none\"}} 0").unwrap();
+    } else {
+        for (reason, count) in &counters.full_sends_by_reason {
+            writeln!(
+                out,
+                "urd_planner_full_sends_total{{reason=\"{reason}\"}} {count}"
+            )
+            .unwrap();
+        }
+    }
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP urd_planner_defers_total Planner deferrals, by scope."
+    )
+    .unwrap();
+    writeln!(out, "# TYPE urd_planner_defers_total counter").unwrap();
+    if counters.defers_by_scope.is_empty() {
+        writeln!(out, "urd_planner_defers_total{{scope=\"none\"}} 0").unwrap();
+    } else {
+        for (scope, count) in &counters.defers_by_scope {
+            writeln!(
+                out,
+                "urd_planner_defers_total{{scope=\"{scope}\"}} {count}"
+            )
+            .unwrap();
+        }
+    }
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP urd_retention_prunes_total Snapshots pruned by retention, by rule."
+    )
+    .unwrap();
+    writeln!(out, "# TYPE urd_retention_prunes_total counter").unwrap();
+    if counters.prunes_by_rule.is_empty() {
+        writeln!(out, "urd_retention_prunes_total{{rule=\"none\"}} 0").unwrap();
+    } else {
+        for (rule, count) in &counters.prunes_by_rule {
+            writeln!(
+                out,
+                "urd_retention_prunes_total{{rule=\"{rule}\"}} {count}"
+            )
+            .unwrap();
+        }
+    }
+
     out
 }
 
@@ -272,6 +361,7 @@ mod tests {
             external_drive_mounted: true,
             external_free_bytes: 4_400_000_000_000,
             script_last_run_timestamp: 1_711_100_120,
+            event_counters: EventCounters::default(),
         }
     }
 
@@ -354,6 +444,7 @@ mod tests {
             external_drive_mounted: false,
             external_free_bytes: 0,
             script_last_run_timestamp: 1_711_100_000,
+            event_counters: EventCounters::default(),
         };
         let output = format_metrics(&data);
         assert!(output.contains("backup_external_drive_mounted 0"));
@@ -371,7 +462,7 @@ mod tests {
 
         let ts = read_existing_timestamps(&path);
         assert_eq!(ts.get("subvol3-opptak"), Some(&1_711_100_000));
-        assert!(ts.get("htpc-home").is_none()); // was not emitted (no success)
+        assert!(!ts.contains_key("htpc-home")); // was not emitted (no success)
     }
 
     #[test]
@@ -396,7 +487,7 @@ mod tests {
         let ts = read_existing_timestamps(&path);
         assert_eq!(ts.get("good"), Some(&12345));
         assert_eq!(ts.get("also-good"), Some(&67890));
-        assert!(ts.get("bad").is_none());
+        assert!(!ts.contains_key("bad"));
     }
 
     #[test]
@@ -461,6 +552,7 @@ mod tests {
             external_drive_mounted: true,
             external_free_bytes: 1_000_000,
             script_last_run_timestamp: 12345,
+            event_counters: EventCounters::default(),
         };
         write_metrics(&path, &data).unwrap();
 
@@ -478,5 +570,65 @@ mod tests {
         apply_carried_forward_timestamps(&mut svs, &carried);
 
         assert_eq!(svs[0].last_success_timestamp, Some(12345));
+    }
+
+    // ── Event-counter family tests ────────────────────────────────
+
+    #[test]
+    fn format_includes_event_counter_help_lines() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP urd_circuit_breaker_trips_total"));
+        assert!(output.contains("# TYPE urd_circuit_breaker_trips_total counter"));
+        assert!(output.contains("# HELP urd_planner_full_sends_total"));
+        assert!(output.contains("# TYPE urd_planner_full_sends_total counter"));
+        assert!(output.contains("# HELP urd_planner_defers_total"));
+        assert!(output.contains("# TYPE urd_planner_defers_total counter"));
+        assert!(output.contains("# HELP urd_retention_prunes_total"));
+        assert!(output.contains("# TYPE urd_retention_prunes_total counter"));
+    }
+
+    #[test]
+    fn format_emits_zero_counters_when_empty() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+        // Trips: bare counter, no labels.
+        assert!(output.contains("urd_circuit_breaker_trips_total 0"));
+        // Family counters: emit a sentinel zero with reason="none" / scope="none".
+        assert!(output.contains("urd_planner_full_sends_total{reason=\"none\"} 0"));
+        assert!(output.contains("urd_planner_defers_total{scope=\"none\"} 0"));
+        assert!(output.contains("urd_retention_prunes_total{rule=\"none\"} 0"));
+    }
+
+    #[test]
+    fn format_renders_full_send_reasons_as_labels() {
+        let mut data = sample_data();
+        data.event_counters.full_sends_by_reason = vec![
+            ("first_send".to_string(), 3),
+            ("chain_broken".to_string(), 1),
+        ];
+        let output = format_metrics(&data);
+        assert!(output.contains("urd_planner_full_sends_total{reason=\"first_send\"} 3"));
+        assert!(output.contains("urd_planner_full_sends_total{reason=\"chain_broken\"} 1"));
+    }
+
+    #[test]
+    fn format_renders_prune_rules_and_defer_scopes() {
+        let mut data = sample_data();
+        data.event_counters.prunes_by_rule = vec![
+            ("graduated_daily".to_string(), 14),
+            ("emergency".to_string(), 2),
+        ];
+        data.event_counters.defers_by_scope = vec![
+            ("subvolume".to_string(), 7),
+            ("drive".to_string(), 3),
+        ];
+        data.event_counters.circuit_breaker_trips = 5;
+        let output = format_metrics(&data);
+        assert!(output.contains("urd_retention_prunes_total{rule=\"graduated_daily\"} 14"));
+        assert!(output.contains("urd_retention_prunes_total{rule=\"emergency\"} 2"));
+        assert!(output.contains("urd_planner_defers_total{scope=\"subvolume\"} 7"));
+        assert!(output.contains("urd_planner_defers_total{scope=\"drive\"} 3"));
+        assert!(output.contains("urd_circuit_breaker_trips_total 5"));
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -570,6 +570,60 @@ pub struct GetOutput {
     pub file_size: u64,
 }
 
+// ── EventsView ────────────────────────────────────────────────────────
+
+/// Presentation projection of one event log row, ready for rendering.
+/// Wraps `state::EventQueryRow` for serde + voice consumption.
+#[derive(Debug, Clone, Serialize)]
+pub struct EventRow {
+    pub id: i64,
+    pub kind: crate::events::EventKind,
+    pub occurred_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subvolume: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drive_label: Option<String>,
+    pub payload: crate::events::EventPayload,
+}
+
+impl From<crate::state::EventQueryRow> for EventRow {
+    fn from(row: crate::state::EventQueryRow) -> Self {
+        Self {
+            id: row.id,
+            kind: row.kind,
+            occurred_at: row.occurred_at,
+            run_id: row.run_id,
+            subvolume: row.subvolume,
+            drive_label: row.drive_label,
+            payload: row.payload,
+        }
+    }
+}
+
+/// Top-level output for `urd events`. Holds the rows plus an echo of
+/// the applied filter (handy for daemon consumers).
+#[derive(Debug, Serialize)]
+pub struct EventsView {
+    pub events: Vec<EventRow>,
+    pub applied_filter: AppliedEventFilter,
+}
+
+/// Echo of the filter actually applied, after parsing and clamping.
+#[derive(Debug, Serialize)]
+pub struct AppliedEventFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub since: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subvolume: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drive: Option<String>,
+    pub limit: usize,
+}
+
 // ── BackupSummary ──────────────────────────────────────────────────────
 
 /// Structured output for the post-backup summary.

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -8,11 +8,52 @@ use chrono::NaiveDateTime;
 use crate::config::{Config, DriveConfig, ResolvedSubvolume};
 use crate::drives::DriveAvailability;
 use crate::error::UrdError;
+use crate::events::{DeferScope, Event, EventPayload};
 use crate::retention;
 use crate::types::{
     BackupPlan, DriveEvent, DriveEventKind, FullSendReason, LocalRetentionPolicy, PlannedOperation,
     SendKind, SnapshotName,
 };
+
+// ── Audit helpers ──────────────────────────────────────────────────────
+
+/// Push a `(subvol, reason)` skip onto `skipped` and emit a matching
+/// `PlannerDefer` event. `drive_label` is `Some` when the deferral is
+/// drive-specific (e.g., "send to {drive} not due"), `None` for
+/// subvolume-wide deferrals.
+fn record_defer(
+    skipped: &mut Vec<(String, String)>,
+    events: &mut Vec<Event>,
+    subvol_name: &str,
+    drive_label: Option<&str>,
+    reason: String,
+    scope: DeferScope,
+    now: NaiveDateTime,
+) {
+    skipped.push((subvol_name.to_string(), reason.clone()));
+    let mut event = Event::pure(now, EventPayload::PlannerDefer { reason, scope });
+    event.subvolume = Some(subvol_name.to_string());
+    event.drive_label = drive_label.map(str::to_string);
+    events.push(event);
+}
+
+/// Stamp `subvolume` and/or `drive_label` onto events that don't already
+/// carry one. Used after a pure helper returns so the run-level accumulator
+/// has full context before persistence.
+fn stamp_context(events: &mut [Event], subvolume: Option<&str>, drive_label: Option<&str>) {
+    for ev in events.iter_mut() {
+        if let Some(sv) = subvolume
+            && ev.subvolume.is_none()
+        {
+            ev.subvolume = Some(sv.to_string());
+        }
+        if let Some(d) = drive_label
+            && ev.drive_label.is_none()
+        {
+            ev.drive_label = Some(d.to_string());
+        }
+    }
+}
 
 // ── FileSystemState trait ───────────────────────────────────────────────
 
@@ -155,51 +196,78 @@ fn check_drive_availability(
     drive: &DriveConfig,
     fs: &dyn FileSystemState,
     skipped: &mut Vec<(String, String)>,
+    events: &mut Vec<Event>,
+    now: NaiveDateTime,
 ) -> bool {
     match fs.drive_availability(drive) {
         DriveAvailability::Available => true,
         DriveAvailability::NotMounted => {
-            skipped.push((
-                subvol_name.to_string(),
+            record_defer(
+                skipped,
+                events,
+                subvol_name,
+                Some(&drive.label),
                 format!("drive {} not mounted", drive.label),
-            ));
+                DeferScope::Drive,
+                now,
+            );
             false
         }
         DriveAvailability::UuidMismatch { expected, found } => {
-            skipped.push((
-                subvol_name.to_string(),
+            record_defer(
+                skipped,
+                events,
+                subvol_name,
+                Some(&drive.label),
                 format!(
                     "drive {} UUID mismatch (expected {}, found {})",
                     drive.label, expected, found
                 ),
-            ));
+                DeferScope::Drive,
+                now,
+            );
             false
         }
         DriveAvailability::UuidCheckFailed(reason) => {
-            skipped.push((
-                subvol_name.to_string(),
+            record_defer(
+                skipped,
+                events,
+                subvol_name,
+                Some(&drive.label),
                 format!("drive {} UUID check failed: {}", drive.label, reason),
-            ));
+                DeferScope::Drive,
+                now,
+            );
             false
         }
         DriveAvailability::TokenMismatch { expected, found } => {
-            skipped.push((
-                subvol_name.to_string(),
+            record_defer(
+                skipped,
+                events,
+                subvol_name,
+                Some(&drive.label),
                 format!(
                     "drive {} token mismatch (expected {}, found {}) — possible drive swap",
                     drive.label, expected, found
                 ),
-            ));
+                DeferScope::Drive,
+                now,
+            );
             false
         }
         DriveAvailability::TokenExpectedButMissing => {
-            skipped.push((
-                subvol_name.to_string(),
+            record_defer(
+                skipped,
+                events,
+                subvol_name,
+                Some(&drive.label),
                 format!(
                     "drive {} token expected but missing \u{2014} run `urd drives adopt {}`",
                     drive.label, drive.label
                 ),
-            ));
+                DeferScope::Drive,
+                now,
+            );
             false
         }
         DriveAvailability::TokenMissing => {
@@ -242,6 +310,7 @@ pub fn plan(
     // Skip reason strings are classified by output::SkipCategory::from_reason().
     // When adding new patterns, update output::tests::classify_all_18_patterns.
     let mut skipped = Vec::new();
+    let mut events: Vec<Event> = Vec::new();
 
     let resolved = config.resolved_subvolumes();
     let drive_labels: Vec<String> = config.drives.iter().map(|d| d.label.clone()).collect();
@@ -249,7 +318,15 @@ pub fn plan(
     for subvol in &resolved {
         // Filter: enabled
         if !subvol.enabled {
-            skipped.push((subvol.name.clone(), "disabled".to_string()));
+            record_defer(
+                &mut skipped,
+                &mut events,
+                &subvol.name,
+                None,
+                "disabled".to_string(),
+                DeferScope::Subvolume,
+                now,
+            );
             continue;
         }
 
@@ -271,10 +348,15 @@ pub fn plan(
 
         // Resolve local snapshot directory
         let Some(ref snapshot_root) = subvol.snapshot_root else {
-            skipped.push((
-                subvol.name.clone(),
+            record_defer(
+                &mut skipped,
+                &mut events,
+                &subvol.name,
+                None,
                 "no snapshot root configured".to_string(),
-            ));
+                DeferScope::Subvolume,
+                now,
+            );
             continue;
         };
         let local_dir = snapshot_root.join(&subvol.name);
@@ -323,7 +405,7 @@ pub fn plan(
         if subvol.local_retention.is_transient() && subvol.send_enabled {
             plan_transient_lifecycle(
                 subvol, config, &local_dir, &local_snaps, now, force, filters,
-                &pinned, &mounted_pins, fs, &mut operations, &mut skipped,
+                &pinned, &mounted_pins, fs, &mut operations, &mut skipped, &mut events,
             );
             continue; // skip the normal two-phase flow
         }
@@ -345,6 +427,7 @@ pub fn plan(
                 fs,
                 &mut operations,
                 &mut skipped,
+                &mut events,
             );
             plan_local_retention(
                 subvol,
@@ -355,6 +438,7 @@ pub fn plan(
                 &mounted_pins,
                 fs,
                 &mut operations,
+                &mut events,
             );
         }
 
@@ -365,7 +449,14 @@ pub fn plan(
                     continue;
                 }
 
-                if !check_drive_availability(&subvol.name, drive, fs, &mut skipped) {
+                if !check_drive_availability(
+                    &subvol.name,
+                    drive,
+                    fs,
+                    &mut skipped,
+                    &mut events,
+                    now,
+                ) {
                     continue;
                 }
 
@@ -380,12 +471,29 @@ pub fn plan(
                     fs,
                     &mut operations,
                     &mut skipped,
+                    &mut events,
                 );
 
-                plan_external_retention(subvol, drive, now, fs, &pinned, &mut operations);
+                plan_external_retention(
+                    subvol,
+                    drive,
+                    now,
+                    fs,
+                    &pinned,
+                    &mut operations,
+                    &mut events,
+                );
             }
         } else if !filters.local_only && !subvol.send_enabled {
-            skipped.push((subvol.name.clone(), "local only".to_string()));
+            record_defer(
+                &mut skipped,
+                &mut events,
+                &subvol.name,
+                None,
+                "local only".to_string(),
+                DeferScope::Subvolume,
+                now,
+            );
         }
     }
 
@@ -427,6 +535,7 @@ pub fn plan(
         operations,
         timestamp: now,
         skipped,
+        events,
     })
 }
 
@@ -442,6 +551,7 @@ fn plan_local_snapshot(
     fs: &dyn FileSystemState,
     operations: &mut Vec<PlannedOperation>,
     skipped: &mut Vec<(String, String)>,
+    events: &mut Vec<Event>,
 ) -> Option<SnapshotName> {
     // Space guard: refuse to create if local filesystem is below min_free_bytes threshold.
     // This prevents the catastrophic failure mode where snapshot creation fills the source
@@ -451,14 +561,19 @@ fn plan_local_snapshot(
         let free = fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
         if free < min_free {
             use crate::types::ByteSize;
-            skipped.push((
-                subvol.name.clone(),
+            record_defer(
+                skipped,
+                events,
+                &subvol.name,
+                None,
                 format!(
                     "local filesystem low on space ({} free, {} required)",
                     ByteSize(free),
                     ByteSize(min_free),
                 ),
-            ));
+                DeferScope::Subvolume,
+                now,
+            );
             return None;
         }
     }
@@ -502,13 +617,18 @@ fn plan_local_snapshot(
                 (Ok(sg), Ok(ng)) if sg == ng => {
                     let elapsed = now.signed_duration_since(newest.datetime());
                     let mins = elapsed.num_minutes();
-                    skipped.push((
-                        subvol.name.clone(),
+                    record_defer(
+                        skipped,
+                        events,
+                        &subvol.name,
+                        None,
                         format!(
                             "unchanged \u{2014} no changes since last snapshot ({} ago)",
                             format_duration_short(mins)
                         ),
-                    ));
+                        DeferScope::Subvolume,
+                        now,
+                    );
                     return None;
                 }
                 (Err(e1), Err(e2)) => {
@@ -540,7 +660,15 @@ fn plan_local_snapshot(
         let snap_name = SnapshotName::new(now, &subvol.short_name);
         // Check if this exact snapshot already exists
         if local_snaps.iter().any(|s| s.as_str() == snap_name.as_str()) {
-            skipped.push((subvol.name.clone(), "snapshot already exists".to_string()));
+            record_defer(
+                skipped,
+                events,
+                &subvol.name,
+                None,
+                "snapshot already exists".to_string(),
+                DeferScope::Subvolume,
+                now,
+            );
             return None;
         }
         operations.push(PlannedOperation::CreateSnapshot {
@@ -554,13 +682,18 @@ fn plan_local_snapshot(
         let next_in = subvol.snapshot_interval.as_chrono()
             - now.signed_duration_since(newest.unwrap().datetime());
         let mins = next_in.num_minutes();
-        skipped.push((
-            subvol.name.clone(),
+        record_defer(
+            skipped,
+            events,
+            &subvol.name,
+            None,
             format!(
                 "interval not elapsed (next in ~{})",
                 format_duration_short(mins)
             ),
-        ));
+            DeferScope::Subvolume,
+            now,
+        );
         None
     }
 }
@@ -575,6 +708,7 @@ fn plan_local_retention(
     mounted_pins: &HashSet<SnapshotName>,
     fs: &dyn FileSystemState,
     operations: &mut Vec<PlannedOperation>,
+    events: &mut Vec<Event>,
 ) {
     if local_snaps.is_empty() {
         return;
@@ -637,7 +771,7 @@ fn plan_local_retention(
             let free_bytes = fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
             let space_pressure = min_free > 0 && free_bytes < min_free;
 
-            let result = retention::graduated_retention(
+            let mut result = retention::graduated_retention(
                 local_snaps,
                 now,
                 retention_config,
@@ -652,6 +786,9 @@ fn plan_local_retention(
                     subvolume_name: subvol.name.clone(),
                 });
             }
+
+            stamp_context(&mut result.events, Some(&subvol.name), None);
+            events.extend(result.events);
         }
     }
 }
@@ -682,6 +819,7 @@ fn plan_transient_lifecycle(
     fs: &dyn FileSystemState,
     operations: &mut Vec<PlannedOperation>,
     skipped: &mut Vec<(String, String)>,
+    events: &mut Vec<Event>,
 ) {
     // ── Phase 1: Determine if any send will actually happen ────────
     // Cache newest external snapshot time per drive for skip message formatting.
@@ -692,7 +830,7 @@ fn plan_transient_lifecycle(
         if !is_drive_in_scope(subvol, &drive.label) {
             continue;
         }
-        if !check_drive_availability(&subvol.name, drive, fs, skipped) {
+        if !check_drive_availability(&subvol.name, drive, fs, skipped, events, now) {
             continue; // skip reason already emitted
         }
 
@@ -720,13 +858,28 @@ fn plan_transient_lifecycle(
     // Decision gate
     if sendable_drives.is_empty() {
         if !filters.external_only {
-            skipped.push((
-                subvol.name.clone(),
+            record_defer(
+                skipped,
+                events,
+                &subvol.name,
+                None,
                 "transient \u{2014} no drives available for send".to_string(),
-            ));
+                DeferScope::Subvolume,
+                now,
+            );
         }
         // Phase 4 only: retention on leftovers
-        plan_local_retention(subvol, local_dir, local_snaps, now, pinned, mounted_pins, fs, operations);
+        plan_local_retention(
+            subvol,
+            local_dir,
+            local_snaps,
+            now,
+            pinned,
+            mounted_pins,
+            fs,
+            operations,
+            events,
+        );
         return;
     }
 
@@ -746,10 +899,30 @@ fn plan_transient_lifecycle(
             .collect::<Vec<_>>()
             .join("; ");
         if !skip_msg.is_empty() {
-            skipped.push((subvol.name.clone(), skip_msg));
+            // Subvolume-scope: applies to the whole subvolume across the
+            // batch of sendable drives, not a single drive.
+            record_defer(
+                skipped,
+                events,
+                &subvol.name,
+                None,
+                skip_msg,
+                DeferScope::Subvolume,
+                now,
+            );
         }
         // Phase 4 only: retention on leftovers
-        plan_local_retention(subvol, local_dir, local_snaps, now, pinned, mounted_pins, fs, operations);
+        plan_local_retention(
+            subvol,
+            local_dir,
+            local_snaps,
+            now,
+            pinned,
+            mounted_pins,
+            fs,
+            operations,
+            events,
+        );
         return;
     }
 
@@ -758,7 +931,7 @@ fn plan_transient_lifecycle(
         let min_free = subvol.min_free_bytes.unwrap_or(0);
         plan_local_snapshot(
             subvol, local_dir, local_snaps, now, force, filters,
-            min_free, fs, operations, skipped,
+            min_free, fs, operations, skipped, events,
         )
     } else {
         None
@@ -766,7 +939,17 @@ fn plan_transient_lifecycle(
 
     if planned_snap.is_none() && local_snaps.iter().max().is_none() {
         // No planned snapshot and no existing snapshots — nothing to send.
-        plan_local_retention(subvol, local_dir, local_snaps, now, pinned, mounted_pins, fs, operations);
+        plan_local_retention(
+            subvol,
+            local_dir,
+            local_snaps,
+            now,
+            pinned,
+            mounted_pins,
+            fs,
+            operations,
+            events,
+        );
         return;
     }
 
@@ -792,14 +975,24 @@ fn plan_transient_lifecycle(
     for (drive, _) in &sendable_drives {
         plan_external_send(
             subvol, drive, local_dir, effective_local_snaps, now, force,
-            filters.skip_intervals, fs, operations, skipped,
+            filters.skip_intervals, fs, operations, skipped, events,
         );
-        plan_external_retention(subvol, drive, now, fs, pinned, operations);
+        plan_external_retention(subvol, drive, now, fs, pinned, operations, events);
     }
 
     // ── Phase 4: Plan transient retention ─────────────────────────
     // Use original local_snaps — retention only operates on existing-on-disk snapshots.
-    plan_local_retention(subvol, local_dir, local_snaps, now, pinned, mounted_pins, fs, operations);
+    plan_local_retention(
+        subvol,
+        local_dir,
+        local_snaps,
+        now,
+        pinned,
+        mounted_pins,
+        fs,
+        operations,
+        events,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -814,6 +1007,7 @@ fn plan_external_send(
     fs: &dyn FileSystemState,
     operations: &mut Vec<PlannedOperation>,
     skipped: &mut Vec<(String, String)>,
+    events: &mut Vec<Event>,
 ) {
     let ext_dir = crate::drives::external_snapshot_dir(drive, &subvol.name);
     let ext_snaps = fs
@@ -834,14 +1028,19 @@ fn plan_external_send(
     if !should_send {
         let next_in = subvol.send_interval.as_chrono()
             - now.signed_duration_since(newest_ext.unwrap().datetime());
-        skipped.push((
-            subvol.name.clone(),
+        record_defer(
+            skipped,
+            events,
+            &subvol.name,
+            Some(&drive.label),
             format!(
                 "send to {} not due (next in ~{})",
                 drive.label,
                 format_duration_short(next_in.num_minutes())
             ),
-        ));
+            DeferScope::Drive,
+            now,
+        );
         return;
     }
 
@@ -852,7 +1051,15 @@ fn plan_external_send(
         } else {
             "no local snapshots to send".to_string()
         };
-        skipped.push((subvol.name.clone(), reason));
+        record_defer(
+            skipped,
+            events,
+            &subvol.name,
+            None,
+            reason,
+            DeferScope::Subvolume,
+            now,
+        );
         return;
     };
 
@@ -861,10 +1068,15 @@ fn plan_external_send(
         .iter()
         .any(|s| s.as_str() == snap_to_send.as_str())
     {
-        skipped.push((
-            subvol.name.clone(),
+        record_defer(
+            skipped,
+            events,
+            &subvol.name,
+            Some(&drive.label),
             format!("{} already on {}", snap_to_send, drive.label),
-        ));
+            DeferScope::Drive,
+            now,
+        );
         return;
     }
 
@@ -899,8 +1111,11 @@ fn plan_external_send(
             exceeds_available_space(last_size, &ext_dir, drive, fs)
         {
             use crate::types::ByteSize;
-            skipped.push((
-                subvol.name.clone(),
+            record_defer(
+                skipped,
+                events,
+                &subvol.name,
+                Some(&drive.label),
                 format!(
                     "send to {} skipped: estimated ~{} exceeds {} available (free: {}, min_free: {})",
                     drive.label,
@@ -909,7 +1124,9 @@ fn plan_external_send(
                     ByteSize(free),
                     ByteSize(min_free),
                 ),
-            ));
+                DeferScope::Drive,
+                now,
+            );
             return;
         }
     } else if !is_incremental {
@@ -929,8 +1146,11 @@ fn plan_external_send(
                 exceeds_available_space(cal_bytes, &ext_dir, drive, fs)
             {
                 use crate::types::ByteSize;
-                skipped.push((
-                    subvol.name.clone(),
+                record_defer(
+                    skipped,
+                    events,
+                    &subvol.name,
+                    Some(&drive.label),
                     format!(
                         "send to {} skipped: calibrated size ~{} exceeds {} available{}",
                         drive.label,
@@ -938,7 +1158,9 @@ fn plan_external_send(
                         ByteSize(available),
                         staleness,
                     ),
-                ));
+                    DeferScope::Drive,
+                    now,
+                );
                 return;
             }
         }
@@ -978,6 +1200,19 @@ fn plan_external_send(
             reason,
             token_verified: false, // stamped by backup.rs after plan creation
         });
+        // PlannerSendChoice only on full sends — incrementals are routine
+        // and covered by the operations log.
+        let mut event = Event::pure(
+            now,
+            EventPayload::PlannerSendChoice {
+                send_kind: SendKind::Full,
+                reason,
+                drive_label: drive.label.clone(),
+            },
+        );
+        event.subvolume = Some(subvol.name.clone());
+        event.drive_label = Some(drive.label.clone());
+        events.push(event);
     }
 }
 
@@ -988,6 +1223,7 @@ fn plan_external_retention(
     fs: &dyn FileSystemState,
     pinned: &HashSet<SnapshotName>,
     operations: &mut Vec<PlannedOperation>,
+    events: &mut Vec<Event>,
 ) {
     let ext_dir = crate::drives::external_snapshot_dir(drive, &subvol.name);
     let ext_snaps = fs
@@ -1001,7 +1237,7 @@ fn plan_external_retention(
     let free_bytes = fs.filesystem_free_bytes(&ext_dir).unwrap_or(u64::MAX);
     let min_free = drive.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
 
-    let result = retention::space_governed_retention(
+    let mut result = retention::space_governed_retention(
         &ext_snaps,
         now,
         &subvol.external_retention,
@@ -1017,6 +1253,9 @@ fn plan_external_retention(
             subvolume_name: subvol.name.clone(),
         });
     }
+
+    stamp_context(&mut result.events, Some(&subvol.name), Some(&drive.label));
+    events.extend(result.events);
 }
 
 /// Format a duration in minutes to a short human-readable string.
@@ -1401,10 +1640,7 @@ impl FileSystemState for MockFileSystemState {
         if self.fail_generations.contains(path) {
             return Err(crate::error::UrdError::Io {
                 path: path.to_path_buf(),
-                source: std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "mock: generation query failed",
-                ),
+                source: std::io::Error::other("mock: generation query failed"),
             });
         }
         self.generations
@@ -4292,5 +4528,145 @@ local_retention = "transient"
             .last_drive_event("D1")
             .expect("round-trip must yield an event — guards schema/parser drift");
         assert!(matches!(event.kind, DriveEventKind::Unmount));
+    }
+
+    // ── Planner event-emission tests ───────────────────────────────────
+
+    fn count_planner_send_choices_for(
+        events: &[Event],
+        drive: &str,
+    ) -> usize {
+        events
+            .iter()
+            .filter(|e| match &e.payload {
+                EventPayload::PlannerSendChoice { drive_label, .. } => drive_label == drive,
+                _ => false,
+            })
+            .count()
+    }
+
+    #[test]
+    fn plan_emits_full_send_choice_with_first_send_reason() {
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.mounted_drives.insert("D1".to_string());
+        // sv1 has a local snapshot but no external — first send to D1.
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1455-one")]);
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![]);
+
+        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let saw_first_send = plan.events.iter().any(|e| {
+            matches!(
+                &e.payload,
+                EventPayload::PlannerSendChoice {
+                    reason: FullSendReason::FirstSend,
+                    drive_label,
+                    ..
+                } if drive_label == "D1"
+            )
+        });
+        assert!(saw_first_send, "should emit FirstSend PlannerSendChoice");
+    }
+
+    #[test]
+    fn plan_does_not_emit_send_choice_for_routine_incremental() {
+        // Note: plan() in this test returns full incremental_or_full ops based
+        // on pin presence. Without a pin file we get a SendFull (NoPinFile),
+        // not an incremental. Mock out a pin so we get an incremental.
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        fs.mounted_drives.insert("D1".to_string());
+        let local_snap = snap("20260322-1455-one");
+        let parent = snap("20260322-1300-one");
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![parent.clone(), local_snap.clone()]);
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![parent.clone()],
+        );
+        // Set pin file to parent so incremental is chosen.
+        fs.pin_files
+            .insert((PathBuf::from("/snap/sv1"), "D1".to_string()), parent.clone());
+
+        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        // Sanity: ensure an incremental was actually chosen (else the test is moot).
+        let any_incremental = plan
+            .operations
+            .iter()
+            .any(|op| matches!(op, PlannedOperation::SendIncremental { .. }));
+        assert!(any_incremental, "test setup should result in incremental");
+        // Incrementals should NOT emit PlannerSendChoice.
+        assert_eq!(count_planner_send_choices_for(&plan.events, "D1"), 0);
+    }
+
+    #[test]
+    fn plan_emits_planner_defer_for_disabled_subvolume() {
+        let mut config = test_config();
+        // Disable sv1.
+        for sv in &mut config.subvolumes {
+            if sv.name == "sv1" {
+                sv.enabled = Some(false);
+            }
+        }
+        let fs = MockFileSystemState::new();
+        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let saw_disabled_defer = plan.events.iter().any(|e| match &e.payload {
+            EventPayload::PlannerDefer { reason, scope } => {
+                reason == "disabled" && *scope == DeferScope::Subvolume
+            }
+            _ => false,
+        });
+        assert!(
+            saw_disabled_defer,
+            "disabled subvolume should emit PlannerDefer with subvolume scope"
+        );
+    }
+
+    #[test]
+    fn plan_emits_planner_defer_with_drive_scope_for_unavailable_drive() {
+        // No drives mounted → NotMounted defer for sv2 (sv1 mounted check
+        // is also affected; both produce drive-scoped defers).
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+        // Give sv1 something to send so we get past the local-snapshot phase.
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1455-one")]);
+        // Drive D1 not mounted.
+
+        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let saw_drive_defer = plan.events.iter().any(|e| match &e.payload {
+            EventPayload::PlannerDefer { reason, scope } => {
+                reason.contains("not mounted") && *scope == DeferScope::Drive
+            }
+            _ => false,
+        });
+        assert!(
+            saw_drive_defer,
+            "unmounted drive should emit PlannerDefer with drive scope"
+        );
+    }
+
+    #[test]
+    fn plan_events_carry_subvol_for_planner_defers() {
+        let mut config = test_config();
+        for sv in &mut config.subvolumes {
+            if sv.name == "sv2" {
+                sv.enabled = Some(false);
+            }
+        }
+        let fs = MockFileSystemState::new();
+        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let sv2_defers: Vec<_> = plan
+            .events
+            .iter()
+            .filter(|e| matches!(e.payload, EventPayload::PlannerDefer { .. }))
+            .filter(|e| e.subvolume.as_deref() == Some("sv2"))
+            .collect();
+        assert!(
+            !sv2_defers.is_empty(),
+            "PlannerDefer for sv2 should carry subvolume='sv2'"
+        );
     }
 }

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -2,16 +2,44 @@ use std::collections::HashSet;
 
 use chrono::{Datelike, Months, NaiveDateTime, Timelike};
 
+use crate::events::{Event, EventPayload, ProtectReason, PruneRule};
 use crate::output::{
     DiskEstimate, EstimateMethod, RecoveryWindow, RetentionPreview, TransientComparison,
 };
 use crate::types::{Interval, LocalRetentionPolicy, ResolvedGraduatedRetention, SnapshotName};
 
 /// The result of a retention computation.
-#[derive(Debug, Clone)]
+///
+/// `events` carries rationale for the planner's audit log. Pure modules
+/// emit; impure callers (executor) persist via
+/// `state::record_events_best_effort`. Contextual fields
+/// (`run_id`, `subvolume`, `drive_label`) are stamped by the caller.
+#[derive(Debug, Clone, Default)]
 pub struct RetentionResult {
     pub keep: Vec<SnapshotName>,
     pub delete: Vec<(SnapshotName, String)>,
+    pub events: Vec<Event>,
+}
+
+fn prune_event(snap: &SnapshotName, rule: PruneRule, now: NaiveDateTime) -> Event {
+    Event::pure(
+        now,
+        EventPayload::RetentionPrune {
+            snapshot: snap.as_str().to_string(),
+            rule,
+            tier: None,
+        },
+    )
+}
+
+fn protect_event(snap: &SnapshotName, reason: ProtectReason, now: NaiveDateTime) -> Event {
+    Event::pure(
+        now,
+        EventPayload::RetentionProtect {
+            snapshot: snap.as_str().to_string(),
+            reason,
+        },
+    )
 }
 
 /// Apply graduated retention to a list of snapshots.
@@ -33,10 +61,7 @@ pub fn graduated_retention(
     space_pressure: bool,
 ) -> RetentionResult {
     if snapshots.is_empty() {
-        return RetentionResult {
-            keep: Vec::new(),
-            delete: Vec::new(),
-        };
+        return RetentionResult::default();
     }
 
     let mut sorted: Vec<SnapshotName> = snapshots.to_vec();
@@ -45,6 +70,7 @@ pub fn graduated_retention(
 
     let mut keep = Vec::new();
     let mut delete = Vec::new();
+    let mut events = Vec::new();
 
     // Compute window boundaries as timestamps
     let hourly_cutoff = now - chrono::Duration::hours(i64::from(config.hourly));
@@ -72,15 +98,35 @@ pub fn graduated_retention(
     // For space pressure: track hourly slots
     let mut hourly_slots: HashSet<(i32, u32, u32, u32)> = HashSet::new(); // (y, m, d, hour)
 
+    let apply_slot_thinning =
+        |snap: &SnapshotName,
+         slot_was_empty: bool,
+         is_pinned: bool,
+         rule: PruneRule,
+         delete_reason: &str,
+         keep: &mut Vec<SnapshotName>,
+         delete: &mut Vec<(SnapshotName, String)>,
+         events: &mut Vec<Event>| {
+            if slot_was_empty {
+                keep.push(snap.clone());
+            } else if is_pinned {
+                keep.push(snap.clone());
+                events.push(protect_event(snap, ProtectReason::PinOverrodeThinning, now));
+            } else {
+                delete.push((snap.clone(), delete_reason.to_string()));
+                events.push(prune_event(snap, rule, now));
+            }
+        };
+
     for snap in &sorted {
         let dt = snap.datetime();
         let is_pinned = pinned.contains(snap);
 
         if dt > now {
-            // Future snapshot — keep it (clock skew protection)
+            // Clock-skew guard: future-dated snapshots are kept regardless.
             keep.push(snap.clone());
+            events.push(protect_event(snap, ProtectReason::ClockSkewFuture, now));
         } else if dt >= hourly_cutoff {
-            // Hourly window
             if space_pressure {
                 let slot = (
                     dt.date().year(),
@@ -88,50 +134,77 @@ pub fn graduated_retention(
                     dt.date().day(),
                     dt.time().hour(),
                 );
-                if hourly_slots.insert(slot) || is_pinned {
-                    keep.push(snap.clone());
-                } else {
-                    delete.push((snap.clone(), "space pressure: hourly thinning".to_string()));
-                }
+                let slot_was_empty = hourly_slots.insert(slot);
+                apply_slot_thinning(
+                    snap,
+                    slot_was_empty,
+                    is_pinned,
+                    PruneRule::SpacePressure,
+                    "space pressure: hourly thinning",
+                    &mut keep,
+                    &mut delete,
+                    &mut events,
+                );
             } else {
                 keep.push(snap.clone());
             }
         } else if dt >= daily_cutoff {
-            // Daily window: keep newest per calendar day
             let day_key = dt.date().and_hms_opt(0, 0, 0).unwrap_or(dt);
-            if daily_slots.insert(day_key) || is_pinned {
-                keep.push(snap.clone());
-            } else {
-                delete.push((snap.clone(), "graduated: daily thinning".to_string()));
-            }
+            let slot_was_empty = daily_slots.insert(day_key);
+            apply_slot_thinning(
+                snap,
+                slot_was_empty,
+                is_pinned,
+                PruneRule::GraduatedDaily,
+                "graduated: daily thinning",
+                &mut keep,
+                &mut delete,
+                &mut events,
+            );
         } else if dt >= weekly_cutoff {
-            // Weekly window: keep newest per ISO week
             let iso = dt.date().iso_week();
             let week_key = (iso.year(), iso.week());
-            if weekly_slots.insert(week_key) || is_pinned {
-                keep.push(snap.clone());
-            } else {
-                delete.push((snap.clone(), "graduated: weekly thinning".to_string()));
-            }
+            let slot_was_empty = weekly_slots.insert(week_key);
+            apply_slot_thinning(
+                snap,
+                slot_was_empty,
+                is_pinned,
+                PruneRule::GraduatedWeekly,
+                "graduated: weekly thinning",
+                &mut keep,
+                &mut delete,
+                &mut events,
+            );
         } else if monthly_cutoff.is_none() || dt >= monthly_cutoff.unwrap() {
-            // Monthly window: keep newest per year-month
             let month_key = (dt.date().year(), dt.date().month());
-            if monthly_slots.insert(month_key) || is_pinned {
-                keep.push(snap.clone());
-            } else {
-                delete.push((snap.clone(), "graduated: monthly thinning".to_string()));
-            }
+            let slot_was_empty = monthly_slots.insert(month_key);
+            apply_slot_thinning(
+                snap,
+                slot_was_empty,
+                is_pinned,
+                PruneRule::GraduatedMonthly,
+                "graduated: monthly thinning",
+                &mut keep,
+                &mut delete,
+                &mut events,
+            );
         } else if is_pinned {
             keep.push(snap.clone());
+            events.push(protect_event(snap, ProtectReason::PinOverrodeWindow, now));
         } else {
             delete.push((
                 snap.clone(),
                 "graduated: beyond retention window".to_string(),
             ));
+            events.push(prune_event(snap, PruneRule::BeyondWindow, now));
         }
     }
 
-    RetentionResult { keep, delete }
+    RetentionResult {
+        keep,
+        delete,
+        events,
+    }
 }
 
 /// Compute the minimal keep set for emergency space recovery.
@@ -154,26 +227,30 @@ pub fn emergency_retention(
     snapshots: &[SnapshotName],
     latest: &SnapshotName,
     pinned: &HashSet<SnapshotName>,
+    now: NaiveDateTime,
 ) -> RetentionResult {
     if snapshots.is_empty() {
-        return RetentionResult {
-            keep: Vec::new(),
-            delete: Vec::new(),
-        };
+        return RetentionResult::default();
     }
 
     let mut keep = Vec::new();
     let mut delete = Vec::new();
+    let mut events = Vec::new();
 
     for snap in snapshots {
         if snap == latest || pinned.contains(snap) {
             keep.push(snap.clone());
         } else {
             delete.push((snap.clone(), "emergency: aggressive thinning".to_string()));
+            events.push(prune_event(snap, PruneRule::Emergency, now));
         }
     }
 
-    RetentionResult { keep, delete }
+    RetentionResult {
+        keep,
+        delete,
+        events,
+    }
 }
 
 /// Space-governed retention with graduated thinning.
@@ -202,6 +279,7 @@ pub fn space_governed_retention(
         keep_sorted.sort(); // oldest first
 
         let mut additional_deletes = Vec::new();
+        let mut additional_events = Vec::new();
         for snap in &keep_sorted {
             if pinned.contains(snap) {
                 continue;
@@ -211,12 +289,14 @@ pub fn space_governed_retention(
                 break;
             }
             additional_deletes.push((snap.clone(), "space pressure: freeing space".to_string()));
+            additional_events.push(prune_event(snap, PruneRule::SpacePressure, now));
         }
 
         // Remove additional deletes from keep, add to delete
         let delete_set: HashSet<_> = additional_deletes.iter().map(|(s, _)| s.clone()).collect();
         result.keep.retain(|s| !delete_set.contains(s));
         result.delete.extend(additional_deletes);
+        result.events.extend(additional_events);
     }
 
     result
@@ -1057,7 +1137,7 @@ mod tests {
     #[test]
     fn emergency_empty() {
         let latest = make_snap("20260322", "1400", "home");
-        let result = emergency_retention(&[], &latest, &HashSet::new());
+        let result = emergency_retention(&[], &latest, &HashSet::new(), now());
         assert!(result.keep.is_empty());
         assert!(result.delete.is_empty());
     }
@@ -1066,7 +1146,7 @@ mod tests {
     fn emergency_single_snapshot() {
         let latest = make_snap("20260322", "1400", "home");
         let snaps = vec![latest.clone()];
-        let result = emergency_retention(&snaps, &latest, &HashSet::new());
+        let result = emergency_retention(&snaps, &latest, &HashSet::new(), now());
         assert_eq!(result.keep.len(), 1);
         assert_eq!(result.keep[0].as_str(), "20260322-1400-home");
         assert!(result.delete.is_empty());
@@ -1082,7 +1162,7 @@ mod tests {
         let pinned: HashSet<SnapshotName> =
             [snaps[2].clone(), snaps[6].clone()].into_iter().collect();
 
-        let result = emergency_retention(&snaps, &latest, &pinned);
+        let result = emergency_retention(&snaps, &latest, &pinned, now());
         assert_eq!(result.keep.len(), 3, "keep latest + 2 pinned");
         assert_eq!(result.delete.len(), 7);
         assert!(result.keep.contains(&latest));
@@ -1103,7 +1183,7 @@ mod tests {
         let latest = snaps[2].clone();
         let pinned: HashSet<SnapshotName> = [snaps[2].clone()].into_iter().collect();
 
-        let result = emergency_retention(&snaps, &latest, &pinned);
+        let result = emergency_retention(&snaps, &latest, &pinned, now());
         // latest is also pinned — no double-counting
         assert_eq!(result.keep.len(), 1, "latest=pinned should not duplicate");
         assert_eq!(result.delete.len(), 2);
@@ -1119,7 +1199,7 @@ mod tests {
         let latest = snaps[2].clone();
         let pinned: HashSet<SnapshotName> = snaps.iter().cloned().collect();
 
-        let result = emergency_retention(&snaps, &latest, &pinned);
+        let result = emergency_retention(&snaps, &latest, &pinned, now());
         assert_eq!(result.keep.len(), 3, "all pinned → keep all");
         assert!(result.delete.is_empty());
     }
@@ -1135,9 +1215,228 @@ mod tests {
         ];
         let latest = snaps[4].clone();
 
-        let result = emergency_retention(&snaps, &latest, &HashSet::new());
+        let result = emergency_retention(&snaps, &latest, &HashSet::new(), now());
         assert_eq!(result.keep.len(), 1, "no pins → keep latest only");
         assert_eq!(result.keep[0].as_str(), "20260322-1200-home");
         assert_eq!(result.delete.len(), 4);
+    }
+
+    // ── Event emission tests ───────────────────────────────────────────
+
+    #[test]
+    fn graduated_emits_one_prune_event_per_delete() {
+        let snaps = vec![
+            make_snap("20260320", "1400", "home"),
+            make_snap("20260320", "1000", "home"),
+            make_snap("20260320", "0800", "home"),
+        ];
+        let result =
+            graduated_retention(&snaps, now(), &default_config(), &HashSet::new(), false);
+        assert_eq!(result.delete.len(), 2);
+        let prune_count = result
+            .events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e.payload,
+                    crate::events::EventPayload::RetentionPrune { .. }
+                )
+            })
+            .count();
+        assert_eq!(prune_count, result.delete.len());
+    }
+
+    #[test]
+    fn graduated_emits_correct_prune_rule_per_branch() {
+        // Daily window: 3 same-day snapshots → 2 deletes with GraduatedDaily
+        let snaps = vec![
+            make_snap("20260320", "1400", "home"),
+            make_snap("20260320", "1000", "home"),
+            make_snap("20260320", "0800", "home"),
+        ];
+        let result =
+            graduated_retention(&snaps, now(), &default_config(), &HashSet::new(), false);
+        for ev in &result.events {
+            if let crate::events::EventPayload::RetentionPrune { rule, .. } = ev.payload {
+                assert_eq!(rule, crate::events::PruneRule::GraduatedDaily);
+            }
+        }
+    }
+
+    #[test]
+    fn graduated_emits_beyond_window_for_old_snapshot() {
+        // Config keeps only hourly+daily+weekly; nothing monthly. Snapshot
+        // older than weekly_cutoff with no monthly slot → BeyondWindow.
+        let config = ResolvedGraduatedRetention {
+            hourly: 1,
+            daily: 1,
+            weekly: 1,
+            monthly: 1, // very narrow monthly so older snap falls beyond
+        };
+        let very_old = make_daily_snap("20240101", "home"); // way past all windows
+        let snaps = vec![make_snap("20260322", "1400", "home"), very_old.clone()];
+        let result = graduated_retention(&snaps, now(), &config, &HashSet::new(), false);
+        let saw = result.events.iter().any(|e| {
+            matches!(
+                e.payload,
+                crate::events::EventPayload::RetentionPrune {
+                    rule: crate::events::PruneRule::BeyondWindow,
+                    ..
+                }
+            )
+        });
+        assert!(saw, "should emit BeyondWindow prune event for 2024-01-01");
+    }
+
+    #[test]
+    fn graduated_emits_protect_clock_skew_for_future_snapshot() {
+        // Snapshot in the future (clock skew protection branch).
+        let future = make_snap("20260401", "1200", "home"); // 10 days after now()
+        let snaps = vec![future.clone()];
+        let result =
+            graduated_retention(&snaps, now(), &default_config(), &HashSet::new(), false);
+        assert!(result.keep.contains(&future));
+        let saw = result.events.iter().any(|e| {
+            matches!(
+                e.payload,
+                crate::events::EventPayload::RetentionProtect {
+                    reason: crate::events::ProtectReason::ClockSkewFuture,
+                    ..
+                }
+            )
+        });
+        assert!(saw, "future snapshot should emit ClockSkewFuture protect event");
+    }
+
+    #[test]
+    fn graduated_emits_protect_pin_overrode_thinning_for_pinned_in_filled_slot() {
+        // Two snapshots same day; the older one is pinned. Without the pin
+        // the older would be thinned; with the pin it is kept and we emit
+        // PinOverrodeThinning.
+        let newer = make_snap("20260320", "1400", "home");
+        let older = make_snap("20260320", "1000", "home");
+        let pinned: HashSet<SnapshotName> = [older.clone()].into_iter().collect();
+        let snaps = vec![newer.clone(), older.clone()];
+        let result = graduated_retention(&snaps, now(), &default_config(), &pinned, false);
+        assert!(result.keep.contains(&older));
+        let saw = result.events.iter().any(|e| {
+            matches!(
+                e.payload,
+                crate::events::EventPayload::RetentionProtect {
+                    reason: crate::events::ProtectReason::PinOverrodeThinning,
+                    ..
+                }
+            )
+        });
+        assert!(saw, "pinned same-day snapshot should emit PinOverrodeThinning");
+    }
+
+    #[test]
+    fn graduated_emits_protect_pin_overrode_window_for_pinned_old_snapshot() {
+        // Snapshot beyond all windows but pinned → PinOverrodeWindow.
+        let very_old = make_daily_snap("20240101", "home");
+        let snaps = vec![make_snap("20260322", "1400", "home"), very_old.clone()];
+        let pinned: HashSet<SnapshotName> = [very_old.clone()].into_iter().collect();
+        let result = graduated_retention(&snaps, now(), &default_config(), &pinned, false);
+        assert!(result.keep.contains(&very_old));
+        let saw = result.events.iter().any(|e| {
+            matches!(
+                e.payload,
+                crate::events::EventPayload::RetentionProtect {
+                    reason: crate::events::ProtectReason::PinOverrodeWindow,
+                    ..
+                }
+            )
+        });
+        assert!(saw, "old pinned snapshot should emit PinOverrodeWindow");
+    }
+
+    #[test]
+    fn graduated_silent_on_routine_in_window_keeps() {
+        // All within hourly window, no thinning; no protect events should
+        // fire for routine keeps.
+        let snaps = vec![
+            make_snap("20260322", "1400", "home"),
+            make_snap("20260322", "1300", "home"),
+        ];
+        let result =
+            graduated_retention(&snaps, now(), &default_config(), &HashSet::new(), false);
+        let protect_count = result
+            .events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e.payload,
+                    crate::events::EventPayload::RetentionProtect { .. }
+                )
+            })
+            .count();
+        assert_eq!(protect_count, 0);
+    }
+
+    #[test]
+    fn space_governed_propagates_events_from_graduated() {
+        let snaps = vec![
+            make_snap("20260320", "1400", "home"),
+            make_snap("20260320", "1000", "home"),
+        ];
+        let result = space_governed_retention(
+            &snaps,
+            now(),
+            &default_config(),
+            &HashSet::new(),
+            500_000_000_000, // plenty of free space
+            10_000_000_000,
+        );
+        // Should still surface events from the graduated step.
+        assert!(!result.events.is_empty());
+    }
+
+    #[test]
+    fn space_governed_emits_space_pressure_for_additional_deletes() {
+        let snaps = vec![
+            make_daily_snap("20260322", "home"),
+            make_daily_snap("20260321", "home"),
+            make_daily_snap("20260320", "home"),
+            make_daily_snap("20260319", "home"),
+        ];
+        let result = space_governed_retention(
+            &snaps,
+            now(),
+            &default_config(),
+            &HashSet::new(),
+            1_000_000_000,  // 1GB free
+            10_000_000_000, // 10GB min
+        );
+        let saw = result.events.iter().any(|e| {
+            matches!(
+                e.payload,
+                crate::events::EventPayload::RetentionPrune {
+                    rule: crate::events::PruneRule::SpacePressure,
+                    ..
+                }
+            )
+        });
+        assert!(saw, "additional deletes should emit SpacePressure events");
+    }
+
+    #[test]
+    fn emergency_emits_one_prune_emergency_per_delete() {
+        let snaps: Vec<SnapshotName> = (1..=5)
+            .map(|d| make_snap(&format!("202603{d:02}"), "1200", "home"))
+            .collect();
+        let latest = snaps[4].clone();
+        let result = emergency_retention(&snaps, &latest, &HashSet::new(), now());
+        assert_eq!(result.delete.len(), 4);
+        for ev in &result.events {
+            assert!(matches!(
+                ev.payload,
+                crate::events::EventPayload::RetentionPrune {
+                    rule: crate::events::PruneRule::Emergency,
+                    ..
+                }
+            ));
+        }
+        assert_eq!(result.events.len(), result.delete.len());
     }
 }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -330,16 +330,27 @@ pub fn compute_next_tick(assessments: &[SubvolAssessment]) -> Duration {
 
 // ── State machine transition ────────────────────────────────────────────
 
+/// What `sentinel_transition` returns: new state and actions for the
+/// runner to execute. Named struct (not a tuple) so future additions stay
+/// stable across destructures.
+#[derive(Debug, Clone)]
+pub struct TransitionResult {
+    pub state: SentinelState,
+    pub actions: Vec<SentinelAction>,
+}
+
 /// Pure state machine: given current state and an event, compute the new
-/// state and the actions the runner should execute.
+/// state and the actions the runner should execute. Never performs I/O.
 ///
-/// The runner calls this, executes the actions, then stores the new state.
-/// This function never performs I/O.
+/// Audit events for sentinel transitions are emitted by the runner, not
+/// here — drive mount/unmount via `record_drive_event`, promise transitions
+/// via `awareness::diff_promise_states`, anomalies from the chain-break
+/// detector. Circuit-breaker events are deferred to active mode.
 #[must_use]
 pub fn sentinel_transition(
     state: &SentinelState,
     event: &SentinelEvent,
-) -> (SentinelState, Vec<SentinelAction>) {
+) -> TransitionResult {
     let mut new_state = state.clone();
     let mut actions = Vec::new();
 
@@ -395,7 +406,10 @@ pub fn sentinel_transition(
         }
     }
 
-    (new_state, actions)
+    TransitionResult {
+        state: new_state,
+        actions,
+    }
 }
 
 // ── Trigger decision (runner-level) ─────────────────────────────────────
@@ -912,7 +926,7 @@ mod tests {
             label: "WD-18TB".to_string(),
         };
 
-        let (new_state, actions) = sentinel_transition(&state, &event);
+        let TransitionResult { state: new_state, actions, .. } = sentinel_transition(&state, &event);
 
         assert!(new_state.mounted_drives.contains("WD-18TB"));
         assert_eq!(actions.len(), 2);
@@ -934,7 +948,7 @@ mod tests {
         let event = SentinelEvent::DriveUnmounted {
             label: "WD-18TB".to_string(),
         };
-        let (new_state, actions) = sentinel_transition(&state, &event);
+        let TransitionResult { state: new_state, actions, .. } = sentinel_transition(&state, &event);
 
         assert!(!new_state.mounted_drives.contains("WD-18TB"));
         assert_eq!(actions.len(), 2);
@@ -951,7 +965,7 @@ mod tests {
     #[test]
     fn transition_assessment_tick_triggers_assess() {
         let state = fresh_state();
-        let (_, actions) = sentinel_transition(&state, &SentinelEvent::AssessmentTick);
+        let TransitionResult { actions, .. } = sentinel_transition(&state, &SentinelEvent::AssessmentTick);
 
         assert_eq!(actions, vec![SentinelAction::Assess]);
     }
@@ -959,7 +973,7 @@ mod tests {
     #[test]
     fn transition_backup_completed_triggers_assess() {
         let state = fresh_state();
-        let (_, actions) = sentinel_transition(&state, &SentinelEvent::BackupCompleted);
+        let TransitionResult { actions, .. } = sentinel_transition(&state, &SentinelEvent::BackupCompleted);
 
         assert_eq!(actions, vec![SentinelAction::Assess]);
     }
@@ -967,7 +981,7 @@ mod tests {
     #[test]
     fn transition_shutdown_triggers_exit() {
         let state = fresh_state();
-        let (_, actions) = sentinel_transition(&state, &SentinelEvent::Shutdown);
+        let TransitionResult { actions, .. } = sentinel_transition(&state, &SentinelEvent::Shutdown);
 
         assert_eq!(actions, vec![SentinelAction::Exit]);
     }
@@ -975,7 +989,7 @@ mod tests {
     #[test]
     fn transition_config_changed_triggers_assess() {
         let state = fresh_state();
-        let (_, actions) = sentinel_transition(&state, &SentinelEvent::ConfigChanged);
+        let TransitionResult { actions, .. } = sentinel_transition(&state, &SentinelEvent::ConfigChanged);
 
         assert_eq!(actions, vec![SentinelAction::Assess]);
     }
@@ -990,7 +1004,7 @@ mod tests {
         let event = SentinelEvent::DriveMounted {
             label: "WD-18TB".to_string(),
         };
-        let (new_state, actions) = sentinel_transition(&state, &event);
+        let TransitionResult { state: new_state, actions, .. } = sentinel_transition(&state, &event);
 
         assert_eq!(new_state.mounted_drives.len(), 1);
         assert!(actions.is_empty(), "duplicate mount should produce no actions");
@@ -1002,7 +1016,7 @@ mod tests {
         let event = SentinelEvent::DriveUnmounted {
             label: "unknown".to_string(),
         };
-        let (_, actions) = sentinel_transition(&state, &event);
+        let TransitionResult { actions, .. } = sentinel_transition(&state, &event);
 
         assert!(actions.is_empty());
     }
@@ -1011,13 +1025,13 @@ mod tests {
     fn multiple_drives_tracked_independently() {
         let state = fresh_state();
 
-        let (state, _) = sentinel_transition(
+        let TransitionResult { state, .. } = sentinel_transition(
             &state,
             &SentinelEvent::DriveMounted {
                 label: "WD-18TB".to_string(),
             },
         );
-        let (state, _) = sentinel_transition(
+        let TransitionResult { state, .. } = sentinel_transition(
             &state,
             &SentinelEvent::DriveMounted {
                 label: "2TB-backup".to_string(),
@@ -1028,7 +1042,7 @@ mod tests {
         assert!(state.mounted_drives.contains("WD-18TB"));
         assert!(state.mounted_drives.contains("2TB-backup"));
 
-        let (state, actions) = sentinel_transition(
+        let TransitionResult { state, actions, .. } = sentinel_transition(
             &state,
             &SentinelEvent::DriveUnmounted {
                 label: "WD-18TB".to_string(),
@@ -1928,7 +1942,7 @@ mod tests {
         let mut state = fresh_state();
         state.has_initial_assessment = true;
 
-        let (new_state, actions) = sentinel_transition(
+        let TransitionResult { state: new_state, actions, .. } = sentinel_transition(
             &state,
             &SentinelEvent::DriveMounted {
                 label: "WD-18TB".to_string(),
@@ -1952,7 +1966,7 @@ mod tests {
     fn drive_mount_without_initial_assessment_no_reconnection() {
         let state = fresh_state(); // has_initial_assessment = false
 
-        let (_new_state, actions) = sentinel_transition(
+        let TransitionResult { state: _new_state, actions, .. } = sentinel_transition(
             &state,
             &SentinelEvent::DriveMounted {
                 label: "WD-18TB".to_string(),
@@ -1974,7 +1988,7 @@ mod tests {
         state.has_initial_assessment = true;
         state.mounted_drives.insert("WD-18TB".to_string());
 
-        let (_new_state, actions) = sentinel_transition(
+        let TransitionResult { state: _new_state, actions, .. } = sentinel_transition(
             &state,
             &SentinelEvent::DriveMounted {
                 label: "WD-18TB".to_string(),
@@ -1994,7 +2008,7 @@ mod tests {
         state.mounted_drives.insert("WD-18TB".to_string());
 
         // Unmount
-        let (state_after_unmount, _) = sentinel_transition(
+        let TransitionResult { state: state_after_unmount, .. } = sentinel_transition(
             &state,
             &SentinelEvent::DriveUnmounted {
                 label: "WD-18TB".to_string(),
@@ -2003,7 +2017,7 @@ mod tests {
         assert!(!state_after_unmount.mounted_drives.contains("WD-18TB"));
 
         // Remount
-        let (state_after_remount, actions) = sentinel_transition(
+        let TransitionResult { state: state_after_remount, actions, .. } = sentinel_transition(
             &state_after_unmount,
             &SentinelEvent::DriveMounted {
                 label: "WD-18TB".to_string(),

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -24,7 +24,8 @@ use crate::notify::{self, Notification, NotificationEvent, Urgency};
 use crate::output::{SentinelCircuitState, SentinelPromiseState, SentinelStateFile};
 use crate::plan::RealFileSystemState;
 use crate::sentinel::{
-    self, SentinelAction, SentinelEvent, SentinelState, CircuitBreakerConfig, PromiseSnapshot,
+    self, CircuitBreakerConfig, PromiseSnapshot, SentinelAction, SentinelEvent, SentinelState,
+    TransitionResult,
 };
 use crate::state::StateDb;
 
@@ -107,10 +108,14 @@ impl SentinelRunner {
         // Main poll loop.
         loop {
             if self.shutdown.load(Ordering::SeqCst) {
-                let (new_state, actions) =
-                    sentinel::sentinel_transition(&self.state, &SentinelEvent::Shutdown);
+                let TransitionResult {
+                    state: new_state,
+                    actions,
+                } = sentinel::sentinel_transition(&self.state, &SentinelEvent::Shutdown);
                 self.state = new_state;
-                self.execute_actions(&actions);
+                // Shutdown path: no audit events to collect, no trigger.
+                let mut audit_events = Vec::new();
+                self.execute_actions(&actions, None, &mut audit_events);
                 break;
             }
 
@@ -145,29 +150,60 @@ impl SentinelRunner {
     }
 
     /// Process events through the state machine, coalescing Assess actions (M1 fix).
+    ///
+    /// Collects audit-log events from each transition and from
+    /// config-reload outcomes, then persists them best-effort after all
+    /// actions have run. The originating triggers are passed to
+    /// `execute_assess` so it can emit promise-transition events with the
+    /// correct `TransitionTrigger`.
     fn process_events(&mut self, events: Vec<SentinelEvent>) {
+        let mut all_audit_events: Vec<crate::events::Event> = Vec::new();
+
         // Pre-pass: reload config before state machine processes ConfigChanged.
         // This ensures the Assess action (emitted by the transition) uses the new config.
         for event in &events {
             if matches!(event, SentinelEvent::ConfigChanged) {
-                self.try_reload_config();
+                self.try_reload_config(&mut all_audit_events);
             }
         }
 
         let mut all_actions = Vec::new();
 
         for event in &events {
-            let (new_state, actions) = sentinel::sentinel_transition(&self.state, event);
+            let TransitionResult { state: new_state, actions } =
+                sentinel::sentinel_transition(&self.state, event);
             self.state = new_state;
             all_actions.extend(actions);
         }
 
-        self.execute_actions(&all_actions);
+        // Skip the diff on BackupCompleted — the backup already emitted
+        // promise transitions with trigger=Run, so the sentinel must not
+        // duplicate them. DriveMounted/ConfigChanged take precedence over
+        // a routine Tick when both fire in the same cycle.
+        let trigger = pick_transition_trigger(&events);
+
+        self.execute_actions(&all_actions, trigger, &mut all_audit_events);
+
+        // Persist all collected audit events best-effort.
+        if !all_audit_events.is_empty()
+            && let Ok(db) = StateDb::open(&self.config.general.state_db)
+        {
+            db.record_events_best_effort(&all_audit_events);
+        }
     }
 
     /// Execute actions with Assess coalescing (M1 fix): if multiple Assess actions
     /// are queued, execute only one. LogDriveChange and Exit run individually.
-    fn execute_actions(&mut self, actions: &[SentinelAction]) {
+    ///
+    /// `trigger` is `Some(t)` when one of the originating events should
+    /// produce promise-transition audit events; `None` on
+    /// `BackupCompleted`-only cycles.
+    fn execute_actions(
+        &mut self,
+        actions: &[SentinelAction],
+        trigger: Option<crate::events::TransitionTrigger>,
+        audit_events: &mut Vec<crate::events::Event>,
+    ) {
         let mut need_assess = false;
 
         for action in actions {
@@ -186,7 +222,7 @@ impl SentinelRunner {
         }
 
         if need_assess
-            && let Err(e) = self.execute_assess()
+            && let Err(e) = self.execute_assess(trigger, audit_events)
         {
             log::error!("Assessment failed: {e}");
         }
@@ -264,7 +300,12 @@ impl SentinelRunner {
 
     /// Attempt to reload config from disk. On success, swap config and update
     /// cached paths. On failure, log and keep old config.
-    fn try_reload_config(&mut self) {
+    ///
+    /// Emits `ConfigReloaded` on success or `ConfigReloadFailed` on
+    /// parse error. Initial loads (sentinel startup) do **not** call this
+    /// — only sentinel-detected reloads do.
+    fn try_reload_config(&mut self, audit_events: &mut Vec<crate::events::Event>) {
+        let now = chrono::Local::now().naive_local();
         match Config::load(Some(&self.config_path)) {
             Ok(new_config) => {
                 log::warn!("Config reloaded — reassessing");
@@ -279,10 +320,24 @@ impl SentinelRunner {
                     .and_then(|m| m.modified().ok());
                 }
 
+                let version = new_config
+                    .general
+                    .config_version
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "legacy".to_string());
+
                 // F1 fix: update cached paths derived from config.
                 self.config = new_config;
                 self.heartbeat_path = self.config.general.heartbeat_file.clone();
                 self.state_file_path = sentinel_state_path(&self.config);
+
+                audit_events.push(crate::events::Event::pure(
+                    now,
+                    crate::events::EventPayload::ConfigReloaded {
+                        config_version: version,
+                        source: self.config_path.display().to_string(),
+                    },
+                ));
 
                 // F2 note: stale drives in self.state.mounted_drives (from old
                 // config) will be cleaned up by the next detect_drive_events()
@@ -294,13 +349,23 @@ impl SentinelRunner {
                 log::error!(
                     "Config file changed but reload failed: {e}. Keeping previous config."
                 );
+                audit_events.push(crate::events::Event::pure(
+                    now,
+                    crate::events::EventPayload::ConfigReloadFailed {
+                        reason: e.to_string(),
+                    },
+                ));
             }
         }
     }
 
     // ── Action execution ────────────────────────────────────────────────
 
-    fn execute_assess(&mut self) -> anyhow::Result<()> {
+    fn execute_assess(
+        &mut self,
+        trigger: Option<crate::events::TransitionTrigger>,
+        audit_events: &mut Vec<crate::events::Event>,
+    ) -> anyhow::Result<()> {
         let now = chrono::Local::now().naive_local();
         let state_db = if self.config.general.state_db.exists() {
             StateDb::open(&self.config.general.state_db).ok()
@@ -313,6 +378,21 @@ impl SentinelRunner {
 
         let mut assessments = awareness::assess(&self.config, now, &fs);
         awareness::overlay_offsite_freshness(&mut assessments, &self.config);
+
+        // Emit promise-transition events when the originating event was
+        // Tick/DriveMounted/ConfigChanged. On BackupCompleted the backup
+        // itself emitted these with trigger=Run; sentinel just refreshes
+        // its baseline.
+        if self.state.has_initial_assessment
+            && let Some(t) = trigger
+        {
+            audit_events.extend(awareness::diff_promise_states(
+                &self.state.last_promise_states,
+                &assessments,
+                now,
+                t,
+            ));
+        }
 
         // Collect notifications from two independent sources.
         let mut notifications = Vec::new();
@@ -386,6 +466,19 @@ impl SentinelRunner {
                         anomaly.broken_count, anomaly.total_chains, anomaly.drive_label,
                     ),
                 });
+                let mut event = crate::events::Event::pure(
+                    now,
+                    crate::events::EventPayload::SentinelAnomaly {
+                        description: format!(
+                            "{} of {} incremental chains on {} broke simultaneously",
+                            anomaly.broken_count,
+                            anomaly.total_chains,
+                            anomaly.drive_label,
+                        ),
+                    },
+                );
+                event.drive_label = Some(anomaly.drive_label.clone());
+                audit_events.push(event);
             }
             self.state.last_chain_health = current_chains;
         }
@@ -601,6 +694,35 @@ impl SentinelRunner {
 ///
 /// This is a separate path from `notify::compute_notifications()`, which operates
 /// on heartbeat data. The two paths converge at `notify::dispatch()`.
+/// Pick the originating `TransitionTrigger` for promise-transition events
+/// emitted during this cycle. Returns `None` when only `BackupCompleted`
+/// fired — in that case the backup itself emitted promise transitions
+/// with `trigger=Run` and the sentinel must not duplicate them.
+///
+/// Precedence (when multiple events fire in the same cycle): an explicit
+/// trigger event (DriveMounted, ConfigChanged) wins over a routine Tick.
+fn pick_transition_trigger(
+    events: &[SentinelEvent],
+) -> Option<crate::events::TransitionTrigger> {
+    let mut chosen = None;
+    for event in events {
+        match event {
+            SentinelEvent::DriveMounted { .. } => {
+                return Some(crate::events::TransitionTrigger::DriveMounted);
+            }
+            SentinelEvent::ConfigChanged => {
+                return Some(crate::events::TransitionTrigger::ConfigChanged);
+            }
+            SentinelEvent::AssessmentTick => {
+                chosen.get_or_insert(crate::events::TransitionTrigger::Tick);
+            }
+            // BackupCompleted, DriveUnmounted, Shutdown — no diff trigger.
+            _ => {}
+        }
+    }
+    chosen
+}
+
 pub fn build_notifications(
     previous: &[PromiseSnapshot],
     current: &[SubvolAssessment],
@@ -1392,10 +1514,15 @@ protection = "recorded"
 
         // Overwrite with invalid TOML.
         std::fs::write(&config_path, "this is not valid toml [[[").unwrap();
-        runner.try_reload_config();
+        let mut events = Vec::new();
+        runner.try_reload_config(&mut events);
 
         // Config should be unchanged.
         assert_eq!(runner.config.general.state_db, original_state_db);
+        assert!(events.iter().any(|e| matches!(
+            e.payload,
+            crate::events::EventPayload::ConfigReloadFailed { .. }
+        )));
     }
 
     #[test]
@@ -1411,7 +1538,13 @@ protection = "recorded"
         std::fs::create_dir_all(&new_dir).unwrap();
         write_test_config(&config_path, &new_dir);
 
-        runner.try_reload_config();
+        let mut events = Vec::new();
+        runner.try_reload_config(&mut events);
+
+        assert!(events.iter().any(|e| matches!(
+            e.payload,
+            crate::events::EventPayload::ConfigReloaded { .. }
+        )));
 
         // Config should reflect new values.
         let expected_db = new_dir.join("urd.db");
@@ -1421,5 +1554,58 @@ protection = "recorded"
             runner.state_file_path,
             sentinel_state_path(&runner.config),
         );
+    }
+
+    // ── pick_transition_trigger tests ──────────────────────────────
+
+    #[test]
+    fn trigger_drive_mounted_wins_over_tick() {
+        let events = vec![
+            SentinelEvent::AssessmentTick,
+            SentinelEvent::DriveMounted {
+                label: "WD-18TB".into(),
+            },
+        ];
+        assert_eq!(
+            pick_transition_trigger(&events),
+            Some(crate::events::TransitionTrigger::DriveMounted)
+        );
+    }
+
+    #[test]
+    fn trigger_config_changed_wins_over_tick() {
+        let events = vec![
+            SentinelEvent::AssessmentTick,
+            SentinelEvent::ConfigChanged,
+        ];
+        assert_eq!(
+            pick_transition_trigger(&events),
+            Some(crate::events::TransitionTrigger::ConfigChanged)
+        );
+    }
+
+    #[test]
+    fn trigger_tick_when_alone() {
+        let events = vec![SentinelEvent::AssessmentTick];
+        assert_eq!(
+            pick_transition_trigger(&events),
+            Some(crate::events::TransitionTrigger::Tick)
+        );
+    }
+
+    #[test]
+    fn trigger_none_for_backup_completed_only() {
+        // BackupCompleted by itself does not yield a trigger — the backup
+        // itself emitted the promise transitions with Run.
+        let events = vec![SentinelEvent::BackupCompleted];
+        assert_eq!(pick_transition_trigger(&events), None);
+    }
+
+    #[test]
+    fn trigger_none_for_drive_unmounted_alone() {
+        let events = vec![SentinelEvent::DriveUnmounted {
+            label: "WD-18TB".into(),
+        }];
+        assert_eq!(pick_transition_trigger(&events), None);
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use rusqlite::Connection;
 
 use crate::error::UrdError;
+use crate::events::{Event, EventKind, EventPayload};
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -39,17 +40,11 @@ pub enum DriveEventType {
     Unmounted,
 }
 
-impl DriveEventType {
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Mounted => "mounted",
-            Self::Unmounted => "unmounted",
-        }
-    }
-}
-
 /// What detected the drive event.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
 #[allow(dead_code)] // Backup variant wired when backup records drive events
 pub enum DriveEventSource {
     Sentinel,
@@ -57,7 +52,11 @@ pub enum DriveEventSource {
 }
 
 impl DriveEventSource {
-    fn as_str(self) -> &'static str {
+    /// Wire form for the legacy `DriveConnectionRecord.detected_by`
+    /// projection — preserved post-UPI-036 so consumers (notably
+    /// `RealFileSystemState::last_drive_event`) keep matching against
+    /// the "sentinel" / "backup" strings.
+    pub(crate) fn as_str(self) -> &'static str {
         match self {
             Self::Sentinel => "sentinel",
             Self::Backup => "backup",
@@ -163,15 +162,88 @@ impl StateDb {
                     last_verified TEXT NOT NULL
                 );
 
-                CREATE TABLE IF NOT EXISTS drive_connections (
+                CREATE TABLE IF NOT EXISTS events (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    drive_label TEXT NOT NULL,
-                    event_type TEXT NOT NULL,
-                    timestamp TEXT NOT NULL,
-                    detected_by TEXT NOT NULL
-                );",
+                    kind TEXT NOT NULL,
+                    occurred_at TEXT NOT NULL,
+                    run_id INTEGER REFERENCES runs(id),
+                    subvolume TEXT,
+                    drive_label TEXT,
+                    payload TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS events_by_run
+                    ON events(run_id);
+                CREATE INDEX IF NOT EXISTS events_by_kind_time
+                    ON events(kind, occurred_at DESC);
+                CREATE INDEX IF NOT EXISTS events_by_subvolume_time
+                    ON events(subvolume, occurred_at DESC) WHERE subvolume IS NOT NULL;
+                CREATE INDEX IF NOT EXISTS events_by_drive_time
+                    ON events(drive_label, occurred_at DESC) WHERE drive_label IS NOT NULL;",
             )
             .map_err(|e| UrdError::State(format!("failed to create schema: {e}")))?;
+
+        // Migration: subsume drive_connections into events.
+        // Best-effort — logs and continues on failure (next run retries).
+        // Idempotent — skips when drive_connections is absent (fresh DB or
+        // already migrated).
+        if let Err(e) = self.subsume_drive_connections() {
+            log::warn!(
+                "drive_connections → events migration failed (best-effort, continuing): {e}"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Idempotent migration: copy `drive_connections` rows into `events`
+    /// with `kind='drive'` and the appropriate JSON payload, then drop the
+    /// old table. Wrapped in a transaction so failure leaves both tables
+    /// intact and the next run retries.
+    fn subsume_drive_connections(&self) -> crate::error::Result<()> {
+        // Skip if already migrated or never existed.
+        let exists: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type='table' AND name='drive_connections'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(|e| UrdError::State(format!("migration probe failed: {e}")))?;
+        if exists == 0 {
+            return Ok(());
+        }
+
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| UrdError::State(format!("migration tx: {e}")))?;
+
+        // Copy rows into events. The CASE turns the legacy `event_type`
+        // string into the EventPayload variant tag.
+        tx.execute(
+            "INSERT INTO events (kind, occurred_at, drive_label, payload)
+             SELECT 'drive', timestamp, drive_label,
+                    json_object(
+                        'type',
+                        CASE event_type
+                            WHEN 'mounted' THEN 'DriveMounted'
+                            ELSE 'DriveUnmounted'
+                        END,
+                        'detected_by', detected_by
+                    )
+             FROM drive_connections",
+            [],
+        )
+        .map_err(|e| UrdError::State(format!("migration insert: {e}")))?;
+
+        tx.execute("DROP TABLE drive_connections", [])
+            .map_err(|e| UrdError::State(format!("migration drop: {e}")))?;
+
+        tx.commit()
+            .map_err(|e| UrdError::State(format!("migration commit: {e}")))?;
+
         Ok(())
     }
 
@@ -715,25 +787,29 @@ impl StateDb {
 
     // ── Drive connection methods ─────────────────────────────────────
 
-    /// Record a drive mount or unmount event.
+    /// Record a drive mount or unmount event. Post-UPI-036, drive events
+    /// are written to the `events` table; the public signature is
+    /// preserved so callers (executor, sentinel_runner) need no change.
     pub fn record_drive_event(
         &self,
         drive_label: &str,
         event_type: DriveEventType,
         detected_by: DriveEventSource,
     ) -> crate::error::Result<()> {
-        let now = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
-        self.conn
-            .execute(
-                "INSERT INTO drive_connections (drive_label, event_type, timestamp, detected_by)
-                 VALUES (?1, ?2, ?3, ?4)",
-                rusqlite::params![drive_label, event_type.as_str(), now, detected_by.as_str()],
-            )
-            .map_err(|e| UrdError::State(format!("failed to record drive event: {e}")))?;
-        Ok(())
+        let payload = match event_type {
+            DriveEventType::Mounted => EventPayload::DriveMounted { detected_by },
+            DriveEventType::Unmounted => EventPayload::DriveUnmounted { detected_by },
+        };
+        let mut event = Event::pure(chrono::Local::now().naive_local(), payload);
+        event.drive_label = Some(drive_label.to_string());
+        self.record_events_inner(&[event])
+            .map_err(|e| UrdError::State(format!("failed to record drive event: {e}")))
     }
 
-    /// Get the most recent connection event for a drive, if any.
+    /// Get the most recent drive event for a drive, if any. Reads from
+    /// the `events` table post-UPI-036; reconstructs the legacy
+    /// `DriveConnectionRecord` shape from the JSON payload so existing
+    /// callers (`RealFileSystemState::last_drive_event`) keep working.
     pub fn last_drive_connection(
         &self,
         drive_label: &str,
@@ -741,50 +817,57 @@ impl StateDb {
         let mut stmt = self
             .conn
             .prepare(
-                "SELECT id, drive_label, event_type, timestamp, detected_by
-                 FROM drive_connections WHERE drive_label = ?1
+                "SELECT id, occurred_at, payload
+                 FROM events
+                 WHERE kind = 'drive' AND drive_label = ?1
                  ORDER BY id DESC LIMIT 1",
             )
             .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
 
         let mut rows = stmt
-            .query_map(rusqlite::params![drive_label], |row| {
-                Ok(DriveConnectionRecord {
-                    id: row.get(0)?,
-                    drive_label: row.get(1)?,
-                    event_type: row.get(2)?,
-                    timestamp: row.get(3)?,
-                    detected_by: row.get(4)?,
-                })
-            })
+            .query(rusqlite::params![drive_label])
             .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
 
-        match rows.next() {
-            Some(Ok(record)) => Ok(Some(record)),
-            Some(Err(e)) => Err(UrdError::State(format!(
-                "failed to read drive connection: {e}"
-            ))),
+        match rows
+            .next()
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?
+        {
+            Some(row) => {
+                let id: i64 = row
+                    .get(0)
+                    .map_err(|e| UrdError::State(format!("read id: {e}")))?;
+                let timestamp: String = row
+                    .get(1)
+                    .map_err(|e| UrdError::State(format!("read occurred_at: {e}")))?;
+                let payload_json: String = row
+                    .get(2)
+                    .map_err(|e| UrdError::State(format!("read payload: {e}")))?;
+                let payload: EventPayload = serde_json::from_str(&payload_json).map_err(|e| {
+                    UrdError::State(format!("decode drive event payload: {e}"))
+                })?;
+                let (event_type, detected_by) = match payload {
+                    EventPayload::DriveMounted { detected_by } => {
+                        ("mounted".to_string(), detected_by.as_str().to_string())
+                    }
+                    EventPayload::DriveUnmounted { detected_by } => {
+                        ("unmounted".to_string(), detected_by.as_str().to_string())
+                    }
+                    other => {
+                        return Err(UrdError::State(format!(
+                            "drive event row #{id} has non-drive payload: {other:?}"
+                        )));
+                    }
+                };
+                Ok(Some(DriveConnectionRecord {
+                    id,
+                    drive_label: drive_label.to_string(),
+                    event_type,
+                    timestamp,
+                    detected_by,
+                }))
+            }
             None => Ok(None),
         }
-    }
-
-    /// Count drive connection events for a drive since a given ISO 8601 timestamp.
-    #[allow(dead_code)] // consumed by urd sentinel status (future) and tests
-    pub fn drive_connection_count(
-        &self,
-        drive_label: &str,
-        since: &str,
-    ) -> crate::error::Result<u64> {
-        let count: i64 = self
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM drive_connections
-                 WHERE drive_label = ?1 AND timestamp >= ?2",
-                rusqlite::params![drive_label, since],
-                |row| row.get(0),
-            )
-            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
-        Ok(count as u64)
     }
 
     fn map_operation_row(row: &rusqlite::Row) -> rusqlite::Result<OperationRow> {
@@ -800,6 +883,223 @@ impl StateDb {
             bytes_transferred: row.get(8)?,
         })
     }
+
+    // ── Event log methods ───────────────────────────────────────────
+
+    /// Persist a batch of events. Best-effort per ADR-102: failures are
+    /// logged and swallowed so the audit log never blocks a backup.
+    /// The naming carries the contract — there is no `Result`-returning
+    /// public variant.
+    pub fn record_events_best_effort(&self, events: &[Event]) {
+        if events.is_empty() {
+            return;
+        }
+        if let Err(e) = self.record_events_inner(events) {
+            log::warn!(
+                "event log write failed (best-effort, continuing): {e} ({} event(s) lost)",
+                events.len()
+            );
+        }
+    }
+
+    /// Inner persistence used by the best-effort wrapper and by
+    /// `record_drive_event`. One transaction per batch keeps multi-event
+    /// emit-points (e.g., a retention sweep) atomic.
+    fn record_events_inner(&self, events: &[Event]) -> crate::error::Result<()> {
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| UrdError::State(format!("events tx: {e}")))?;
+        for ev in events {
+            let payload = serde_json::to_string(&ev.payload)
+                .map_err(|e| UrdError::State(format!("events serialize: {e}")))?;
+            tx.execute(
+                "INSERT INTO events (kind, occurred_at, run_id, subvolume, drive_label, payload)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                rusqlite::params![
+                    ev.kind().as_str(),
+                    ev.occurred_at.format("%Y-%m-%dT%H:%M:%S").to_string(),
+                    ev.run_id,
+                    ev.subvolume,
+                    ev.drive_label,
+                    payload,
+                ],
+            )
+            .map_err(|e| UrdError::State(format!("events insert: {e}")))?;
+        }
+        tx.commit()
+            .map_err(|e| UrdError::State(format!("events commit: {e}")))?;
+        Ok(())
+    }
+
+    /// Query events with optional filters, newest first.
+    #[allow(dead_code)]
+    pub fn query_events(
+        &self,
+        filter: &EventQueryFilter,
+    ) -> crate::error::Result<Vec<EventQueryRow>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, kind, occurred_at, run_id, subvolume, drive_label, payload
+                 FROM events
+                 WHERE (?1 IS NULL OR occurred_at >= ?1)
+                   AND (?2 IS NULL OR kind = ?2)
+                   AND (?3 IS NULL OR subvolume = ?3)
+                   AND (?4 IS NULL OR drive_label = ?4)
+                 ORDER BY occurred_at DESC, id DESC
+                 LIMIT ?5",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let since = filter.since.as_ref().map(|dt| dt.format("%Y-%m-%dT%H:%M:%S").to_string());
+        let kind_str = filter.kind.map(|k| k.as_str().to_string());
+
+        let rows = stmt
+            .query_map(
+                rusqlite::params![
+                    since,
+                    kind_str,
+                    filter.subvolume,
+                    filter.drive_label,
+                    filter.limit as i64,
+                ],
+                |row| {
+                    Ok((
+                        row.get::<_, i64>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                        row.get::<_, Option<i64>>(3)?,
+                        row.get::<_, Option<String>>(4)?,
+                        row.get::<_, Option<String>>(5)?,
+                        row.get::<_, String>(6)?,
+                    ))
+                },
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            let (id, kind_s, occurred_at, run_id, subvolume, drive_label, payload_json) =
+                row.map_err(|e| UrdError::State(format!("read event row: {e}")))?;
+            let Some(kind) = EventKind::from_str(&kind_s) else {
+                log::warn!("skipping event id={id} with unknown kind {kind_s:?}");
+                continue;
+            };
+            let payload: EventPayload = match serde_json::from_str(&payload_json) {
+                Ok(p) => p,
+                Err(e) => {
+                    log::warn!("skipping event id={id} with undecodable payload: {e}");
+                    continue;
+                }
+            };
+            out.push(EventQueryRow {
+                id,
+                kind,
+                occurred_at,
+                run_id,
+                subvolume,
+                drive_label,
+                payload,
+            });
+        }
+        Ok(out)
+    }
+
+    // ── Counter helpers for Prometheus metrics ──────────────────────
+
+    /// Total number of `SentinelCircuitBreak` events whose `to` is `open`.
+    #[allow(dead_code)]
+    pub fn count_circuit_breaker_trips(&self) -> crate::error::Result<u64> {
+        let n: i64 = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM events
+                 WHERE kind = 'sentinel'
+                   AND json_extract(payload, '$.type') = 'SentinelCircuitBreak'
+                   AND json_extract(payload, '$.to') = 'open'",
+                [],
+                |r| r.get(0),
+            )
+            .map_err(|e| UrdError::State(format!("counter query failed: {e}")))?;
+        Ok(n as u64)
+    }
+
+    /// `PlannerSendChoice` counts grouped by `reason` (full-send reason).
+    #[allow(dead_code)]
+    pub fn count_full_sends_by_reason(
+        &self,
+    ) -> crate::error::Result<Vec<(String, u64)>> {
+        self.count_grouped("planner", "PlannerSendChoice", "reason")
+    }
+
+    /// `PlannerDefer` counts grouped by `scope`.
+    #[allow(dead_code)]
+    pub fn count_defers_by_scope(&self) -> crate::error::Result<Vec<(String, u64)>> {
+        self.count_grouped("planner", "PlannerDefer", "scope")
+    }
+
+    /// `RetentionPrune` counts grouped by `rule`.
+    #[allow(dead_code)]
+    pub fn count_prunes_by_rule(&self) -> crate::error::Result<Vec<(String, u64)>> {
+        self.count_grouped("retention", "RetentionPrune", "rule")
+    }
+
+    fn count_grouped(
+        &self,
+        kind: &str,
+        payload_type: &str,
+        field: &str,
+    ) -> crate::error::Result<Vec<(String, u64)>> {
+        let sql = format!(
+            "SELECT json_extract(payload, '$.{field}') as g, COUNT(*)
+             FROM events
+             WHERE kind = ?1
+               AND json_extract(payload, '$.type') = ?2
+             GROUP BY g",
+        );
+        let mut stmt = self
+            .conn
+            .prepare(&sql)
+            .map_err(|e| UrdError::State(format!("counter query failed: {e}")))?;
+        let rows = stmt
+            .query_map(rusqlite::params![kind, payload_type], |r| {
+                let label: Option<String> = r.get(0)?;
+                let count: i64 = r.get(1)?;
+                Ok((label.unwrap_or_default(), count as u64))
+            })
+            .map_err(|e| UrdError::State(format!("counter query failed: {e}")))?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|e| UrdError::State(format!("read counter rows: {e}")))
+    }
+}
+
+// ── Event query types ──────────────────────────────────────────────────
+
+/// Filter parameters for `StateDb::query_events`.
+#[derive(Debug, Clone, Default)]
+#[allow(dead_code)]
+pub struct EventQueryFilter {
+    pub since: Option<chrono::NaiveDateTime>,
+    pub kind: Option<EventKind>,
+    pub subvolume: Option<String>,
+    pub drive_label: Option<String>,
+    pub limit: usize,
+}
+
+/// One row returned from `StateDb::query_events` with the payload
+/// already deserialized. Presentation projection (`output::EventRow`)
+/// wraps this for the `urd events` subcommand.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
+pub struct EventQueryRow {
+    pub id: i64,
+    pub kind: EventKind,
+    pub occurred_at: String,
+    pub run_id: Option<i64>,
+    pub subvolume: Option<String>,
+    pub drive_label: Option<String>,
+    pub payload: EventPayload,
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -1498,27 +1798,9 @@ mod tests {
         assert!(db.last_drive_connection("nonexistent").unwrap().is_none());
     }
 
-    #[test]
-    fn drive_connection_count() {
-        let db = StateDb::open_memory().unwrap();
-        db.record_drive_event("WD-18TB", DriveEventType::Mounted, DriveEventSource::Sentinel)
-            .unwrap();
-        db.record_drive_event("WD-18TB", DriveEventType::Unmounted, DriveEventSource::Sentinel)
-            .unwrap();
-        db.record_drive_event("WD-18TB", DriveEventType::Mounted, DriveEventSource::Backup)
-            .unwrap();
-
-        let count = db
-            .drive_connection_count("WD-18TB", "2000-01-01T00:00:00")
-            .unwrap();
-        assert_eq!(count, 3);
-
-        // Different drive has zero events.
-        let count = db
-            .drive_connection_count("other", "2000-01-01T00:00:00")
-            .unwrap();
-        assert_eq!(count, 0);
-    }
+    // (test `drive_connection_count` removed — function deleted in
+    // UPI 036 since callers were dead code; counts now derive from
+    // the `events` table via dedicated counter helpers.)
 
     // ── Drive activity + first-run gating ─────────
 
@@ -1642,5 +1924,440 @@ mod tests {
         let db = StateDb::open_memory().unwrap();
         let _ = db.begin_run("full").unwrap();
         assert!(db.has_any_completed_runs().unwrap());
+    }
+
+    // ── Event log tests ─────────────────────────────────────────────
+
+    use crate::events::{
+        DeferScope, Event, EventKind, EventPayload, PruneRule, TransitionTrigger,
+    };
+    use chrono::NaiveDateTime;
+
+    fn ev(payload: EventPayload, dt: &str) -> Event {
+        Event {
+            occurred_at: NaiveDateTime::parse_from_str(dt, "%Y-%m-%dT%H:%M:%S").unwrap(),
+            run_id: None,
+            subvolume: None,
+            drive_label: None,
+            payload,
+        }
+    }
+
+    #[test]
+    fn events_table_created_on_open() {
+        let db = StateDb::open_memory().unwrap();
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn events_indexes_created() {
+        let db = StateDb::open_memory().unwrap();
+        let names: Vec<String> = db
+            .conn
+            .prepare(
+                "SELECT name FROM sqlite_master
+                 WHERE type='index' AND tbl_name='events'",
+            )
+            .unwrap()
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+        for expected in [
+            "events_by_run",
+            "events_by_kind_time",
+            "events_by_subvolume_time",
+        ] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "missing index {expected}; got {names:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn record_events_best_effort_empty_is_noop() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_events_best_effort(&[]); // does not panic
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn record_events_best_effort_persists_one() {
+        let db = StateDb::open_memory().unwrap();
+        let event = ev(
+            EventPayload::PlannerDefer {
+                reason: "interval not elapsed".into(),
+                scope: DeferScope::Subvolume,
+            },
+            "2026-04-30T03:14:22",
+        );
+        db.record_events_best_effort(&[event]);
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn record_events_best_effort_atomic_batch() {
+        let db = StateDb::open_memory().unwrap();
+        let batch = vec![
+            ev(
+                EventPayload::RetentionPrune {
+                    snapshot: "a".into(),
+                    rule: PruneRule::GraduatedDaily,
+                    tier: None,
+                },
+                "2026-04-30T03:00:00",
+            ),
+            ev(
+                EventPayload::RetentionPrune {
+                    snapshot: "b".into(),
+                    rule: PruneRule::GraduatedDaily,
+                    tier: None,
+                },
+                "2026-04-30T03:00:01",
+            ),
+            ev(
+                EventPayload::RetentionPrune {
+                    snapshot: "c".into(),
+                    rule: PruneRule::GraduatedDaily,
+                    tier: None,
+                },
+                "2026-04-30T03:00:02",
+            ),
+        ];
+        db.record_events_best_effort(&batch);
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn query_events_returns_newest_first() {
+        let db = StateDb::open_memory().unwrap();
+        let events = vec![
+            ev(
+                EventPayload::PlannerDefer {
+                    reason: "older".into(),
+                    scope: DeferScope::Subvolume,
+                },
+                "2026-04-29T03:00:00",
+            ),
+            ev(
+                EventPayload::PlannerDefer {
+                    reason: "newer".into(),
+                    scope: DeferScope::Subvolume,
+                },
+                "2026-04-30T03:00:00",
+            ),
+        ];
+        db.record_events_best_effort(&events);
+        let rows = db
+            .query_events(&EventQueryFilter {
+                limit: 10,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].occurred_at, "2026-04-30T03:00:00");
+        assert_eq!(rows[1].occurred_at, "2026-04-29T03:00:00");
+    }
+
+    #[test]
+    fn query_events_filters_by_kind() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_events_best_effort(&[
+            ev(
+                EventPayload::PlannerDefer {
+                    reason: "x".into(),
+                    scope: DeferScope::Subvolume,
+                },
+                "2026-04-30T03:00:00",
+            ),
+            ev(
+                EventPayload::RetentionPrune {
+                    snapshot: "a".into(),
+                    rule: PruneRule::GraduatedDaily,
+                    tier: None,
+                },
+                "2026-04-30T03:00:01",
+            ),
+        ]);
+        let rows = db
+            .query_events(&EventQueryFilter {
+                kind: Some(EventKind::Retention),
+                limit: 10,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].kind, EventKind::Retention);
+    }
+
+    #[test]
+    fn query_events_filters_by_since() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_events_best_effort(&[
+            ev(
+                EventPayload::PlannerDefer {
+                    reason: "old".into(),
+                    scope: DeferScope::Subvolume,
+                },
+                "2026-04-29T03:00:00",
+            ),
+            ev(
+                EventPayload::PlannerDefer {
+                    reason: "new".into(),
+                    scope: DeferScope::Subvolume,
+                },
+                "2026-04-30T03:00:00",
+            ),
+        ]);
+        let cutoff =
+            NaiveDateTime::parse_from_str("2026-04-30T00:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let rows = db
+            .query_events(&EventQueryFilter {
+                since: Some(cutoff),
+                limit: 10,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].occurred_at, "2026-04-30T03:00:00");
+    }
+
+    #[test]
+    fn query_events_filters_by_subvolume_and_drive() {
+        let db = StateDb::open_memory().unwrap();
+        let mut e1 = ev(
+            EventPayload::PlannerDefer {
+                reason: "x".into(),
+                scope: DeferScope::Subvolume,
+            },
+            "2026-04-30T03:00:00",
+        );
+        e1.subvolume = Some("htpc-home".into());
+        let mut e2 = ev(
+            EventPayload::PlannerDefer {
+                reason: "x".into(),
+                scope: DeferScope::Subvolume,
+            },
+            "2026-04-30T03:00:00",
+        );
+        e2.subvolume = Some("htpc-root".into());
+        e2.drive_label = Some("WD-18TB".into());
+        db.record_events_best_effort(&[e1, e2]);
+
+        let by_sv = db
+            .query_events(&EventQueryFilter {
+                subvolume: Some("htpc-home".into()),
+                limit: 10,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(by_sv.len(), 1);
+        assert_eq!(by_sv[0].subvolume.as_deref(), Some("htpc-home"));
+
+        let by_drive = db
+            .query_events(&EventQueryFilter {
+                drive_label: Some("WD-18TB".into()),
+                limit: 10,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(by_drive.len(), 1);
+        assert_eq!(by_drive[0].drive_label.as_deref(), Some("WD-18TB"));
+    }
+
+    #[test]
+    fn query_events_respects_limit() {
+        let db = StateDb::open_memory().unwrap();
+        let mut events = Vec::new();
+        for i in 0..5 {
+            events.push(ev(
+                EventPayload::PlannerDefer {
+                    reason: format!("e{i}"),
+                    scope: DeferScope::Subvolume,
+                },
+                &format!("2026-04-30T03:00:{i:02}"),
+            ));
+        }
+        db.record_events_best_effort(&events);
+        let rows = db
+            .query_events(&EventQueryFilter {
+                limit: 2,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn record_drive_event_writes_to_events_table() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_drive_event(
+            "WD-18TB",
+            DriveEventType::Mounted,
+            DriveEventSource::Sentinel,
+        )
+        .unwrap();
+
+        // Direct check: row in events table.
+        let kind: String = db
+            .conn
+            .query_row(
+                "SELECT kind FROM events WHERE drive_label = 'WD-18TB' ORDER BY id DESC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(kind, "drive");
+
+        // Backward-compat read API still works.
+        let record = db.last_drive_connection("WD-18TB").unwrap().unwrap();
+        assert_eq!(record.event_type, "mounted");
+        assert_eq!(record.detected_by, "sentinel");
+    }
+
+    #[test]
+    fn record_drive_event_unmount_payload_decoded_correctly() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_drive_event(
+            "WD-18TB",
+            DriveEventType::Unmounted,
+            DriveEventSource::Backup,
+        )
+        .unwrap();
+        let record = db.last_drive_connection("WD-18TB").unwrap().unwrap();
+        assert_eq!(record.event_type, "unmounted");
+        assert_eq!(record.detected_by, "backup");
+    }
+
+    #[test]
+    fn last_drive_connection_returns_most_recent_via_events() {
+        let db = StateDb::open_memory().unwrap();
+        db.record_drive_event(
+            "WD-18TB",
+            DriveEventType::Mounted,
+            DriveEventSource::Sentinel,
+        )
+        .unwrap();
+        db.record_drive_event(
+            "WD-18TB",
+            DriveEventType::Unmounted,
+            DriveEventSource::Sentinel,
+        )
+        .unwrap();
+        let record = db.last_drive_connection("WD-18TB").unwrap().unwrap();
+        assert_eq!(record.event_type, "unmounted"); // most recent wins
+    }
+
+    #[test]
+    fn migration_subsumes_legacy_drive_connections() {
+        // Build a pre-UPI-036 DB by hand, then open it and verify the
+        // legacy rows landed in events and the old table is gone.
+        use rusqlite::Connection;
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE drive_connections (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                drive_label TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                detected_by TEXT NOT NULL
+            );
+            INSERT INTO drive_connections (drive_label, event_type, timestamp, detected_by)
+            VALUES ('WD-18TB', 'mounted',  '2026-03-01T08:00:00', 'sentinel'),
+                   ('WD-18TB', 'unmounted','2026-03-01T18:00:00', 'sentinel');",
+        )
+        .unwrap();
+        let db = StateDb { conn };
+        db.init_schema().unwrap();
+
+        // Old table is gone.
+        let exists: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type='table' AND name='drive_connections'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(exists, 0);
+
+        // Two events copied.
+        let rows = db
+            .query_events(&EventQueryFilter {
+                kind: Some(EventKind::Drive),
+                limit: 10,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 2);
+        // Most-recent first.
+        assert!(matches!(
+            rows[0].payload,
+            EventPayload::DriveUnmounted { .. }
+        ));
+        assert!(matches!(
+            rows[1].payload,
+            EventPayload::DriveMounted { .. }
+        ));
+    }
+
+    #[test]
+    fn migration_is_idempotent_on_fresh_db() {
+        // Brand-new DB has no drive_connections table — migration is a no-op.
+        let db = StateDb::open_memory().unwrap();
+        db.init_schema().unwrap(); // second call must not error
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM events", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn promise_transition_trigger_value_persists() {
+        // Smoke test that the new TransitionTrigger enum survives a roundtrip
+        // through SQLite, since TransitionTrigger is the only payload field
+        // exercised purely via this path post-Step-7.
+        let db = StateDb::open_memory().unwrap();
+        db.record_events_best_effort(&[ev(
+            EventPayload::PromiseTransition {
+                from: crate::awareness::PromiseStatus::Protected,
+                to: crate::awareness::PromiseStatus::AtRisk,
+                trigger: TransitionTrigger::DriveMounted,
+            },
+            "2026-04-30T03:00:00",
+        )]);
+        let rows = db
+            .query_events(&EventQueryFilter {
+                kind: Some(EventKind::Promise),
+                limit: 1,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        match &rows[0].payload {
+            EventPayload::PromiseTransition { trigger, .. } => {
+                assert_eq!(*trigger, TransitionTrigger::DriveMounted);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -108,7 +108,8 @@ impl Serialize for Interval {
 /// Whether a btrfs send is full (no parent snapshot) or incremental
 /// (parent snapshot already on destination). Used in size estimation,
 /// operations-log filtering, and health assessment.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SendKind {
     /// No parent snapshot on the destination — sends the entire subvolume.
     Full,
@@ -641,7 +642,8 @@ impl LocalRetentionPolicy {
 // ── PlannedOperation ────────────────────────────────────────────────────
 
 /// Why a full send was planned instead of an incremental send.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum FullSendReason {
     /// First send to this drive for this subvolume (no external snapshots). Normal.
     FirstSend,
@@ -761,12 +763,18 @@ impl fmt::Display for PlannedOperation {
 // ── BackupPlan ──────────────────────────────────────────────────────────
 
 /// The complete output of the backup planner.
+///
+/// `events` carries the planner's audit-log emissions: full-send choices
+/// with reason, deferrals with scope, and retention rationale flowed up
+/// from `RetentionResult.events`. The executor persists them at run end
+/// via `state::record_events_best_effort`.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct BackupPlan {
     pub operations: Vec<PlannedOperation>,
     pub timestamp: NaiveDateTime,
     pub skipped: Vec<(String, String)>, // (subvolume_name, reason)
+    pub events: Vec<crate::events::Event>,
 }
 
 #[allow(dead_code)]
@@ -1162,6 +1170,7 @@ mod tests {
                 "subvol6-tmp".to_string(),
                 "interval not elapsed".to_string(),
             )],
+            events: Vec::new(),
         };
         let s = plan.summary();
         assert_eq!(s.snapshots, 1);
@@ -1407,6 +1416,7 @@ weekly = 4
 
         #[derive(Debug, Deserialize)]
         struct Wrapper {
+            #[allow(dead_code)] // deserialize-only validation; field is read by serde
             local_retention: LocalRetentionConfig,
         }
 

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1333,6 +1333,18 @@ fn render_individual_skips(
     }
 }
 
+// ── Events ──────────────────────────────────────────────────────────────
+
+/// Render the `urd events` view. Delegates to `voice_events` for the
+/// per-variant columnar / NDJSON formatting.
+#[must_use]
+pub fn render_events(view: &crate::output::EventsView, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => crate::voice_events::render_interactive(view),
+        OutputMode::Daemon => crate::voice_events::render_ndjson(view),
+    }
+}
+
 // ── History ─────────────────────────────────────────────────────────────
 
 /// Render history (recent runs) output.
@@ -6072,21 +6084,21 @@ mod tests {
 
     #[test]
     fn doctor_verdict_healthy() {
-        let v = serde_json::to_value(&DoctorVerdict::healthy()).unwrap();
+        let v = serde_json::to_value(DoctorVerdict::healthy()).unwrap();
         assert_eq!(v["status"], "healthy");
         assert_eq!(v["count"], 0);
     }
 
     #[test]
     fn doctor_verdict_warnings() {
-        let v = serde_json::to_value(&DoctorVerdict::warnings(3)).unwrap();
+        let v = serde_json::to_value(DoctorVerdict::warnings(3)).unwrap();
         assert_eq!(v["status"], "warnings");
         assert_eq!(v["count"], 3);
     }
 
     #[test]
     fn doctor_verdict_issues() {
-        let v = serde_json::to_value(&DoctorVerdict::issues(2)).unwrap();
+        let v = serde_json::to_value(DoctorVerdict::issues(2)).unwrap();
         assert_eq!(v["status"], "issues");
         assert_eq!(v["count"], 2);
     }
@@ -6128,19 +6140,19 @@ mod tests {
 
     #[test]
     fn doctor_verdict_errors_override_degraded() {
-        let v = serde_json::to_value(&DoctorVerdict::issues(1)).unwrap();
+        let v = serde_json::to_value(DoctorVerdict::issues(1)).unwrap();
         assert_eq!(v["status"], "issues", "errors should take precedence over degraded");
     }
 
     #[test]
     fn doctor_verdict_warnings_override_degraded() {
-        let v = serde_json::to_value(&DoctorVerdict::warnings(1)).unwrap();
+        let v = serde_json::to_value(DoctorVerdict::warnings(1)).unwrap();
         assert_eq!(v["status"], "warnings", "warnings should take precedence over degraded");
     }
 
     #[test]
     fn doctor_verdict_degraded_json() {
-        let v = serde_json::to_value(&DoctorVerdict::degraded(2)).unwrap();
+        let v = serde_json::to_value(DoctorVerdict::degraded(2)).unwrap();
         assert_eq!(v["status"], "degraded");
         assert_eq!(v["count"], 2);
     }

--- a/src/voice_events.rs
+++ b/src/voice_events.rs
@@ -1,0 +1,470 @@
+// Voice rendering for the structured event log.
+//
+// Per-variant one-line columnar renderer. Density beats ornamentation —
+// users will read pages of these when investigating. Mythic verbs apply
+// to verbs/framings; identifiers (timestamps, snapshot names, drive
+// labels, rules) stay literal.
+
+use std::fmt::Write as _;
+
+use colored::Colorize;
+
+use crate::events::{EventPayload, Severity};
+use crate::output::{EventRow, EventsView};
+
+/// Render the events view as a columnar listing for interactive use.
+#[must_use]
+pub fn render_interactive(view: &EventsView) -> String {
+    let mut out = String::new();
+
+    if view.events.is_empty() {
+        writeln!(out, "{}", "No events recorded for the given filter.".dimmed()).ok();
+        return out;
+    }
+
+    // Header row.
+    writeln!(
+        out,
+        "{}",
+        format!(
+            "{:<19}  {:<9}  {:<14}  {}",
+            "WHEN", "KIND", "SCOPE", "DETAIL",
+        )
+        .bold()
+    )
+    .ok();
+
+    for row in &view.events {
+        let line = format_row(row);
+        writeln!(out, "{line}").ok();
+    }
+
+    out
+}
+
+/// Render the events view as line-delimited JSON (NDJSON). One object
+/// per event row. Documented as internal-only — additive but not
+/// stable (R12).
+#[must_use]
+pub fn render_ndjson(view: &EventsView) -> String {
+    let mut out = String::new();
+    for row in &view.events {
+        match serde_json::to_string(row) {
+            Ok(json) => {
+                out.push_str(&json);
+                out.push('\n');
+            }
+            Err(e) => {
+                // Should be unreachable — payload roundtrips by construction.
+                log::warn!("failed to serialize event id={}: {e}", row.id);
+            }
+        }
+    }
+    out
+}
+
+fn format_row(row: &EventRow) -> String {
+    let scope = scope_label(row);
+    let summary = summary_for(&row.payload);
+    let painted = colorize_severity(&row.payload, &summary);
+    format!(
+        "{:<19}  {:<9}  {:<14}  {painted}",
+        truncate(&row.occurred_at, 19),
+        row.kind.as_str(),
+        truncate(&scope, 14),
+    )
+}
+
+fn scope_label(row: &EventRow) -> String {
+    match (&row.subvolume, &row.drive_label) {
+        (Some(sv), Some(d)) => format!("{sv}/{d}"),
+        (Some(sv), None) => sv.clone(),
+        (None, Some(d)) => d.clone(),
+        (None, None) => "-".to_string(),
+    }
+}
+
+fn summary_for(payload: &EventPayload) -> String {
+    match payload {
+        EventPayload::RetentionPrune { snapshot, rule, tier } => {
+            let tier_suffix = tier
+                .as_ref()
+                .map(|t| format!(" [{t}]"))
+                .unwrap_or_default();
+            format!("pruned {snapshot}  ({})", prune_rule_phrase(*rule)) + &tier_suffix
+        }
+        EventPayload::RetentionProtect { snapshot, reason } => {
+            format!("stayed her hand on {snapshot}  ({})", protect_phrase(*reason))
+        }
+        EventPayload::PlannerSendChoice {
+            send_kind: _,
+            reason,
+            drive_label,
+        } => {
+            format!("full send chosen → {drive_label}  ({reason})")
+        }
+        EventPayload::PlannerDefer { reason, scope: _ } => {
+            format!("deferred — {reason}")
+        }
+        EventPayload::PromiseTransition { from, to, trigger } => {
+            let arrow = if to < from { "←" } else { "→" };
+            format!(
+                "the thread of this subvolume {} ({} {arrow} {})  [{}]",
+                if to < from {
+                    "frayed"
+                } else {
+                    "is mended"
+                },
+                from,
+                to,
+                trigger_phrase(*trigger)
+            )
+        }
+        EventPayload::SentinelCircuitBreak {
+            from,
+            to,
+            reason,
+            backoff_secs,
+        } => {
+            format!(
+                "circuit-break {from}→{to}  ({reason}, backoff {}s)",
+                backoff_secs
+            )
+        }
+        EventPayload::SentinelAnomaly { description } => {
+            format!("anomaly: {description}")
+        }
+        EventPayload::ConfigReloaded {
+            config_version,
+            source,
+        } => {
+            format!("config reloaded (version {config_version}) from {source}")
+        }
+        EventPayload::ConfigReloadFailed { reason } => {
+            format!("config reload failed: {reason}")
+        }
+        EventPayload::DriveMounted { detected_by } => {
+            format!("drive mounted  ({})", detected_by.as_str())
+        }
+        EventPayload::DriveUnmounted { detected_by } => {
+            format!("drive unmounted  ({})", detected_by.as_str())
+        }
+    }
+}
+
+fn prune_rule_phrase(rule: crate::events::PruneRule) -> &'static str {
+    use crate::events::PruneRule::*;
+    match rule {
+        GraduatedHourly => "graduated: hourly thinning",
+        GraduatedDaily => "graduated: daily thinning",
+        GraduatedWeekly => "graduated: weekly thinning",
+        GraduatedMonthly => "graduated: monthly thinning",
+        BeyondWindow => "beyond retention window",
+        Emergency => "emergency: aggressive thinning",
+        SpacePressure => "space pressure",
+    }
+}
+
+fn protect_phrase(reason: crate::events::ProtectReason) -> &'static str {
+    use crate::events::ProtectReason::*;
+    match reason {
+        PinOverrodeThinning => "pin overrode thinning",
+        PinOverrodeWindow => "pin overrode window",
+        ClockSkewFuture => "clock-skew guard",
+    }
+}
+
+fn trigger_phrase(trigger: crate::events::TransitionTrigger) -> &'static str {
+    use crate::events::TransitionTrigger::*;
+    match trigger {
+        Run => "run",
+        Tick => "tick",
+        DriveMounted => "drive mounted",
+        ConfigChanged => "config changed",
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let mut end = max.saturating_sub(1);
+        while !s.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        format!("{}…", &s[..end])
+    }
+}
+
+fn colorize_severity(payload: &EventPayload, text: &str) -> String {
+    match payload.severity() {
+        Severity::Warn => text.red().to_string(),
+        Severity::Notice => text.yellow().to_string(),
+        Severity::Info => text.normal().to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::{
+        DeferScope, Event, EventPayload, ProtectReason, PruneRule, TransitionTrigger,
+    };
+    use crate::output::{AppliedEventFilter, EventRow, EventsView};
+    use crate::state::DriveEventSource;
+    use chrono::NaiveDateTime;
+
+    fn make_row(payload: EventPayload, sv: Option<&str>, drive: Option<&str>) -> EventRow {
+        EventRow {
+            id: 1,
+            kind: payload.kind(),
+            occurred_at: "2026-04-30T03:14:22".to_string(),
+            run_id: Some(42),
+            subvolume: sv.map(str::to_string),
+            drive_label: drive.map(str::to_string),
+            payload,
+        }
+    }
+
+    fn empty_filter() -> AppliedEventFilter {
+        AppliedEventFilter {
+            since: None,
+            kind: None,
+            subvolume: None,
+            drive: None,
+            limit: 50,
+        }
+    }
+
+    fn setup() {
+        colored::control::set_override(false);
+    }
+
+    #[test]
+    fn render_empty_shows_dimmed_message() {
+        setup();
+        let view = EventsView {
+            events: vec![],
+            applied_filter: empty_filter(),
+        };
+        let out = render_interactive(&view);
+        assert!(out.contains("No events recorded"));
+    }
+
+    #[test]
+    fn render_retention_prune() {
+        setup();
+        let row = make_row(
+            EventPayload::RetentionPrune {
+                snapshot: "20260423-0400-htpc-home".into(),
+                rule: PruneRule::GraduatedDaily,
+                tier: None,
+            },
+            Some("htpc-home"),
+            None,
+        );
+        let line = format_row(&row);
+        assert!(line.contains("retention"));
+        assert!(line.contains("htpc-home"));
+        assert!(line.contains("pruned 20260423-0400-htpc-home"));
+        assert!(line.contains("daily thinning"));
+    }
+
+    #[test]
+    fn render_retention_protect_uses_mythic_verb() {
+        setup();
+        let row = make_row(
+            EventPayload::RetentionProtect {
+                snapshot: "20240101-htpc-home".into(),
+                reason: ProtectReason::PinOverrodeWindow,
+            },
+            Some("htpc-home"),
+            None,
+        );
+        let line = format_row(&row);
+        assert!(line.contains("stayed her hand"));
+        assert!(line.contains("pin overrode window"));
+    }
+
+    #[test]
+    fn render_planner_send_choice_shows_drive_and_reason() {
+        setup();
+        let row = make_row(
+            EventPayload::PlannerSendChoice {
+                send_kind: crate::types::SendKind::Full,
+                reason: crate::types::FullSendReason::ChainBroken,
+                drive_label: "WD-18TB".into(),
+            },
+            Some("htpc-home"),
+            Some("WD-18TB"),
+        );
+        let line = format_row(&row);
+        assert!(line.contains("full send chosen"));
+        assert!(line.contains("chain broken"));
+        assert!(line.contains("WD-18TB"));
+    }
+
+    #[test]
+    fn render_planner_defer_shows_reason() {
+        setup();
+        let row = make_row(
+            EventPayload::PlannerDefer {
+                reason: "interval not elapsed (next in ~30m)".into(),
+                scope: DeferScope::Subvolume,
+            },
+            Some("htpc-home"),
+            None,
+        );
+        let line = format_row(&row);
+        assert!(line.contains("deferred"));
+        assert!(line.contains("interval not elapsed"));
+    }
+
+    #[test]
+    fn render_promise_transition_degradation_uses_frayed_verb() {
+        setup();
+        let row = make_row(
+            EventPayload::PromiseTransition {
+                from: crate::awareness::PromiseStatus::Protected,
+                to: crate::awareness::PromiseStatus::AtRisk,
+                trigger: TransitionTrigger::Run,
+            },
+            Some("htpc-home"),
+            None,
+        );
+        let line = format_row(&row);
+        assert!(line.contains("frayed"));
+        assert!(line.contains("run"));
+    }
+
+    #[test]
+    fn render_promise_transition_recovery_uses_mended_verb() {
+        setup();
+        let row = make_row(
+            EventPayload::PromiseTransition {
+                from: crate::awareness::PromiseStatus::Unprotected,
+                to: crate::awareness::PromiseStatus::Protected,
+                trigger: TransitionTrigger::Tick,
+            },
+            Some("htpc-home"),
+            None,
+        );
+        let line = format_row(&row);
+        assert!(line.contains("mended"));
+        assert!(line.contains("tick"));
+    }
+
+    #[test]
+    fn render_sentinel_circuit_break() {
+        setup();
+        let row = make_row(
+            EventPayload::SentinelCircuitBreak {
+                from: crate::sentinel::CircuitState::Closed,
+                to: crate::sentinel::CircuitState::Open,
+                reason: "3 consecutive failures".into(),
+                backoff_secs: 900,
+            },
+            None,
+            None,
+        );
+        let line = format_row(&row);
+        assert!(line.contains("circuit-break"));
+        assert!(line.contains("900s"));
+    }
+
+    #[test]
+    fn render_drive_mount_unmount() {
+        setup();
+        let mounted = make_row(
+            EventPayload::DriveMounted {
+                detected_by: DriveEventSource::Sentinel,
+            },
+            None,
+            Some("WD-18TB"),
+        );
+        assert!(format_row(&mounted).contains("drive mounted"));
+
+        let unmounted = make_row(
+            EventPayload::DriveUnmounted {
+                detected_by: DriveEventSource::Sentinel,
+            },
+            None,
+            Some("WD-18TB"),
+        );
+        assert!(format_row(&unmounted).contains("drive unmounted"));
+    }
+
+    #[test]
+    fn render_config_reload_success_and_fail() {
+        setup();
+        let ok = make_row(
+            EventPayload::ConfigReloaded {
+                config_version: "1".into(),
+                source: "/etc/urd.toml".into(),
+            },
+            None,
+            None,
+        );
+        assert!(format_row(&ok).contains("config reloaded"));
+        assert!(format_row(&ok).contains("/etc/urd.toml"));
+
+        let fail = make_row(
+            EventPayload::ConfigReloadFailed {
+                reason: "missing field".into(),
+            },
+            None,
+            None,
+        );
+        assert!(format_row(&fail).contains("config reload failed"));
+    }
+
+    #[test]
+    fn ndjson_one_line_per_event_round_trips() {
+        let row = make_row(
+            EventPayload::PlannerDefer {
+                reason: "interval not elapsed".into(),
+                scope: DeferScope::Subvolume,
+            },
+            Some("htpc-home"),
+            None,
+        );
+        let view = EventsView {
+            events: vec![row.clone(), row.clone()],
+            applied_filter: empty_filter(),
+        };
+        let ndjson = render_ndjson(&view);
+        let lines: Vec<_> = ndjson.lines().collect();
+        assert_eq!(lines.len(), 2);
+        let parsed: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(
+            parsed.get("kind").and_then(|v| v.as_str()),
+            Some("planner")
+        );
+        assert!(parsed.get("payload").is_some());
+    }
+
+    #[test]
+    fn truncate_is_char_boundary_safe() {
+        // Multibyte char near the boundary should not panic.
+        let s = "café-café-café";
+        let _ = truncate(s, 6);
+    }
+
+    fn _unused_event() -> Event {
+        // Suppress dead-code warning if module-level Event re-export is unused.
+        Event {
+            occurred_at: NaiveDateTime::parse_from_str(
+                "2026-04-30T03:14:22",
+                "%Y-%m-%dT%H:%M:%S",
+            )
+            .unwrap(),
+            run_id: None,
+            subvolume: None,
+            drive_label: None,
+            payload: EventPayload::SentinelAnomaly {
+                description: "x".into(),
+            },
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

- New `events` SQLite table holds typed `Event` records of decisions and state transitions. Pure modules (planner, retention, awareness, sentinel state machine) emit events as part of their output; impure callers persist them best-effort. Drive connection records and four Prometheus counter families now derive from the same table.
- New `urd events` subcommand renders the log: voice-rendered columnar by default, NDJSON via `--json`. Filters: `--since`, `--kind`, `--subvolume`, `--drive`, `--limit` (clamped 1..=1000).
- Quality gate updated to `cargo clippy --all-targets` and CLAUDE.md adds a `cargo check --all-targets` line for post-mass-edit verification — bare forms skip test code, which is exactly where mass-edit breakage tends to land.

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: 1104 passed, 0 failed
- `cargo build --release`: pass
- Integration tests: not run (no drive available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)