### PR TITLE
test: voice contract tests (UPI 035)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Voice contract tests (UPI 035): a new `src/voice_contract.rs` test
+  module encodes the seven-rule presentation-layer contract (no
+  falsehoods, no contradictions, acknowledged transitions, first-line
+  answer, gravity calibration) so future voice changes can't silently
+  regress UPI 026's fixes. Surfaces two pre-existing findings as
+  `#[ignore]`d tests: `urd doctor` and `urd plan` emit a process-header
+  first line rather than the verdict/operation count. Lifts shared test
+  fixtures (`test_status_output`, `test_backup_summary`,
+  `test_doctor_output`, `test_verify_output`, `test_plan_output`) into
+  `voice::test_fixtures` for reuse across test modules.
+
+### Changed
+- `colored::control::set_override` calls in `voice.rs` and
+  `voice_events.rs` tests now route through a shared `color_guard()`
+  Mutex-backed helper, eliminating the parallel-test colour-override
+  race that the new contract tests would otherwise hit.
+
 ## [0.14.0] - 2026-05-01
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ mod sentinel_runner;
 mod state;
 mod types;
 mod voice;
+#[cfg(test)]
+mod voice_contract;
 mod voice_events;
 
 use std::io::IsTerminal;

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -3053,20 +3053,40 @@ pub fn format_subvolume_chooser(command: &str, names: &[&str]) -> String {
 // ── Tests ───────────────────────────────────────────────────────────────
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod test_fixtures {
+    //! Shared test fixtures for the voice rendering layer.
+    //!
+    //! Lifted from `mod tests` so sibling test modules such as
+    //! `crate::voice_contract::contract` can share canonical shapes
+    //! without drift. See
+    //! `docs/97-plans/2026-05-01-plan-035-voice-contract-tests.md`.
     use super::*;
-    use crate::awareness::ActionableAdvice;
     use crate::output::{
-        BackupSummary, CalibrateEntry, CalibrateOutput, CalibrateResult, ChainHealth,
-        ChainHealthEntry, DeferredInfo, DisconnectedDrive, DriveInfo, EmergencyRootAssessment,
-        EmergencySubvolDetail, HistoryOutput, HistoryRun, InitCheck, InitDriveStatus, InitOutput,
-        InitPinFile, InitSnapshotCount, InitStatus, LastRunInfo, PlanOperationEntry, PlanOutput,
-        PlanSummaryOutput, SendSummary, SkipCategory, SkippedSubvolume, StatusAssessment,
-        StatusDriveAssessment, SubvolumeSummary, TransitionEvent, VerifyCheck, VerifyDrive,
-        VerifyOutput, VerifySubvolume,
+        ChainHealthEntry, DoctorDataSafety, DoctorSentinelStatus, DoctorVerdict, DriveInfo,
+        LastRunInfo, PlanOperationEntry, PlanSummaryOutput, SendSummary, StatusDriveAssessment,
+        SubvolumeSummary,
     };
+    use std::sync::{Mutex, MutexGuard, PoisonError};
 
-    fn test_status_output() -> StatusOutput {
+    /// Global mutex serializing every test that touches the colored
+    /// crate's global override. `colored::control::set_override` writes
+    /// to a process-wide static, so any two tests that disagree about
+    /// the desired color state will race under cargo test's default
+    /// parallelism. Every voice test (and every voice_contract test)
+    /// must acquire this guard via `color_guard(...)` instead of calling
+    /// `colored::control::set_override` directly.
+    static COLOR_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Acquire the global color lock and apply the requested override.
+    /// Hold the returned guard for the duration of the test by binding
+    /// it to a `let _color = color_guard(...);` variable.
+    pub(crate) fn color_guard(color_on: bool) -> MutexGuard<'static, ()> {
+        let g = COLOR_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        colored::control::set_override(color_on);
+        g
+    }
+
+    pub(crate) fn test_status_output() -> StatusOutput {
         StatusOutput {
             assessments: vec![
                 StatusAssessment {
@@ -3159,412 +3179,7 @@ mod tests {
         }
     }
 
-    #[test]
-    fn interactive_contains_subvolume_names() {
-        colored::control::set_override(false);
-        let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("htpc-home"), "missing htpc-home");
-        assert!(output.contains("htpc-docs"), "missing htpc-docs");
-    }
-
-    #[test]
-    fn interactive_contains_safety_vocabulary() {
-        colored::control::set_override(false);
-        let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("sealed"), "missing sealed exposure label");
-        assert!(output.contains("waning"), "missing waning exposure label");
-    }
-
-    #[test]
-    fn interactive_promise_column_shown_when_exposure_conflicts() {
-        colored::control::set_override(false);
-        let mut data = test_status_output();
-        // Set a promise level on a non-PROTECTED assessment — triggers PROTECTION column
-        data.assessments[1].promise_level = Some("protected".to_string());
-        // assessments[1] has status "AT RISK" — conflict with promise
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(output.contains("PROTECTION"), "missing PROTECTION header");
-        assert!(output.contains("protected"), "missing promise level value");
-    }
-
-    #[test]
-    fn interactive_promise_column_hidden_when_all_sealed() {
-        colored::control::set_override(false);
-        let mut data = test_status_output();
-        // Set a promise level but all statuses are PROTECTED — no conflict
-        data.assessments[0].promise_level = Some("sheltered".to_string());
-        data.assessments[1].status = "PROTECTED".to_string();
-        data.assessments[1].promise_level = Some("fortified".to_string());
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            !output.contains("PROTECTION"),
-            "PROTECTION column should be hidden when all sealed"
-        );
-    }
-
-    #[test]
-    fn interactive_no_promise_column_when_none_set() {
-        colored::control::set_override(false);
-        let data = test_status_output(); // all promise_level are None
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            !output.contains("PROTECTION"),
-            "PROTECTION column should be hidden when no protection levels set"
-        );
-    }
-
-    #[test]
-    fn interactive_contains_drive_info() {
-        colored::control::set_override(false);
-        let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("WD-18TB"), "missing drive label");
-        assert!(output.contains("connected"), "missing connected status");
-        assert!(output.contains("Offsite-4TB"), "missing unmounted drive");
-        // With no absent_duration_secs and no last_activity_age_secs, the
-        // cascade stays silent — "disconnected" rather than a fabricated
-        // "away" label driven by role alone.
-        assert!(
-            output.contains("disconnected"),
-            "expected silent fallback: {output}"
-        );
-    }
-
-    #[test]
-    fn drive_summary_escalated_at_risk() {
-        colored::control::set_override(false);
-        // Build a status with an unmounted drive that has AT RISK assessment data
-        let mut data = test_status_output();
-        data.drives.push(DriveInfo {
-            label: "Backup-2TB".to_string(),
-            mounted: false,
-            free_bytes: None,
-            role: DriveRole::Primary,
-        });
-        data.assessments[0].external.push(StatusDriveAssessment {
-            drive_label: "Backup-2TB".to_string(),
-            status: "AT RISK".to_string(),
-            mounted: false,
-            snapshot_count: None,
-            last_send_age_secs: Some(604800), // 7 days
-            role: DriveRole::Primary,
-            absent_duration_secs: Some(604800), // 7 days — drives the "away" label
-            last_activity_age_secs: None,
-        });
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            output.contains("consider connecting"),
-            "missing escalated text for AT RISK drive: {output}"
-        );
-        assert!(
-            output.contains("Backup-2TB"),
-            "missing drive label: {output}"
-        );
-    }
-
-    #[test]
-    fn interactive_contains_last_run_relative_time() {
-        colored::control::set_override(false);
-        let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("#42"), "missing run ID");
-        assert!(output.contains("success"), "missing run result");
-        assert!(output.contains("1m 30s"), "missing duration");
-        assert!(output.contains("10h ago"), "should show relative time, got: {output}");
-    }
-
-    #[test]
-    fn interactive_last_run_falls_back_to_timestamp_without_age() {
-        colored::control::set_override(false);
-        let mut data = test_status_output();
-        data.last_run_age_secs = None;
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            output.contains("2026-03-24T02:00:00"),
-            "should fall back to ISO timestamp when age is None"
-        );
-    }
-
-    #[test]
-    fn interactive_contains_thread_health() {
-        colored::control::set_override(false);
-        let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("unbroken"), "missing unbroken thread");
-        assert!(
-            output.contains("broken"),
-            "missing broken thread"
-        );
-    }
-
-    #[test]
-    fn interactive_contains_pin_count() {
-        colored::control::set_override(false);
-        let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("3"), "missing pin count");
-    }
-
-    #[test]
-    fn interactive_no_subvolumes() {
-        colored::control::set_override(false);
-        let data = StatusOutput {
-            assessments: vec![],
-            chain_health: vec![],
-            drives: vec![],
-            last_run: None,
-            last_run_age_secs: None,
-            total_pins: 0,
-            redundancy_advisories: vec![],
-            advice: vec![],
-        };
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            output.contains("No subvolumes configured"),
-            "missing empty message"
-        );
-    }
-
-    #[test]
-    fn daemon_produces_valid_json() {
-        let output = render_status(&test_status_output(), OutputMode::Daemon);
-        let parsed: serde_json::Value =
-            serde_json::from_str(&output).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{output}"));
-        assert!(
-            parsed.get("assessments").is_some(),
-            "missing assessments key"
-        );
-        assert!(parsed.get("drives").is_some(), "missing drives key");
-        assert!(parsed.get("last_run").is_some(), "missing last_run key");
-        assert!(
-            parsed.get("chain_health").is_some(),
-            "missing chain_health key"
-        );
-        assert!(
-            parsed.get("last_run_age_secs").is_some(),
-            "missing last_run_age_secs key"
-        );
-    }
-
-    #[test]
-    fn daemon_contains_subvolume_data() {
-        let output = render_status(&test_status_output(), OutputMode::Daemon);
-        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-        let assessments = parsed["assessments"].as_array().unwrap();
-        assert_eq!(assessments.len(), 2);
-        assert_eq!(assessments[0]["name"], "htpc-home");
-        assert_eq!(assessments[0]["status"], "PROTECTED");
-        assert_eq!(assessments[1]["name"], "htpc-docs");
-        assert_eq!(assessments[1]["status"], "AT RISK");
-    }
-
-    #[test]
-    fn interactive_renders_advisories_and_errors() {
-        colored::control::set_override(false);
-        let mut data = test_status_output();
-        data.assessments[0]
-            .errors
-            .push("can't read snapshot directory".to_string());
-        data.assessments[1]
-            .advisories
-            .push("offsite drive not connected in 14 days".to_string());
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            output.contains("can't read snapshot directory"),
-            "missing error"
-        );
-        assert!(
-            output.contains("offsite drive not connected"),
-            "missing advisory"
-        );
-    }
-
-    #[test]
-    fn interactive_no_last_run() {
-        colored::control::set_override(false);
-        let data = StatusOutput {
-            assessments: vec![],
-            chain_health: vec![],
-            drives: vec![],
-            last_run: None,
-            last_run_age_secs: None,
-            total_pins: 0,
-            redundancy_advisories: vec![],
-            advice: vec![],
-        };
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            output.contains("no runs recorded"),
-            "missing no-runs message"
-        );
-    }
-
-    // ── External-only status table tests (UPI 018) ─────────────────
-
-    #[test]
-    fn status_table_external_only_shows_em_dash_local() {
-        colored::control::set_override(false);
-        let mut data = test_status_output();
-        // Make first subvol external-only
-        data.assessments[0].external_only = true;
-        data.assessments[0].local_snapshot_count = 0;
-        data.assessments[0].local_newest_age_secs = None;
-        let output = render_status(&data, OutputMode::Interactive);
-        // The LOCAL column for htpc-home should show em-dash, not "0"
-        // Split into lines and find the htpc-home row
-        let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
-        assert!(
-            home_line.contains('\u{2014}'),
-            "external_only LOCAL should show em-dash, got: {home_line}"
-        );
-        assert!(
-            !home_line.contains(" 0 "),
-            "external_only LOCAL should not show '0', got: {home_line}"
-        );
-    }
-
-    #[test]
-    fn status_table_external_only_shows_ext_only_thread() {
-        colored::control::set_override(false);
-        let mut data = test_status_output();
-        data.assessments[0].external_only = true;
-        let output = render_status(&data, OutputMode::Interactive);
-        let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
-        assert!(
-            home_line.contains("drive-only"),
-            "external_only THREAD should show 'drive-only', got: {home_line}"
-        );
-    }
-
-    #[test]
-    fn status_table_normal_subvol_unchanged() {
-        colored::control::set_override(false);
-        let data = test_status_output();
-        let output = render_status(&data, OutputMode::Interactive);
-        let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
-        // Normal subvol should show count (47) not em-dash for LOCAL
-        assert!(
-            home_line.contains("47"),
-            "normal subvol LOCAL should show count, got: {home_line}"
-        );
-        // Should show chain health, not ext-only
-        assert!(
-            home_line.contains("unbroken"),
-            "normal subvol THREAD should show chain health, got: {home_line}"
-        );
-    }
-
-    // ── Status advice rendering tests ────────────────────────────────
-
-    #[test]
-    fn status_single_issue_shows_inline_fix() {
-        colored::control::set_override(false);
-        let mut data = test_status_output();
-        data.advice = vec![ActionableAdvice {
-            subvolume: "htpc-docs".to_string(),
-            issue: "waning — last backup 3 hours ago".to_string(),
-            command: Some("urd backup --subvolume htpc-docs".to_string()),
-            reason: None,
-        }];
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            output.contains("htpc-docs"),
-            "missing subvolume name in advice: {output}"
-        );
-        assert!(
-            output.contains("urd backup --subvolume htpc-docs"),
-            "missing inline fix command: {output}"
-        );
-    }
-
-    #[test]
-    fn status_multiple_issues_shows_doctor() {
-        colored::control::set_override(false);
-        let mut data = test_status_output();
-        data.advice = vec![
-            ActionableAdvice {
-                subvolume: "htpc-docs".to_string(),
-                issue: "waning".to_string(),
-                command: Some("urd backup --subvolume htpc-docs".to_string()),
-                reason: None,
-            },
-            ActionableAdvice {
-                subvolume: "htpc-home".to_string(),
-                issue: "exposed".to_string(),
-                command: None,
-                reason: Some("Connect WD-18TB".to_string()),
-            },
-        ];
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            output.contains("2 subvolumes need attention"),
-            "missing doctor redirect: {output}"
-        );
-        assert!(
-            output.contains("urd doctor"),
-            "missing doctor command: {output}"
-        );
-    }
-
-    #[test]
-    fn status_no_issues_no_suggestion() {
-        colored::control::set_override(false);
-        let data = test_status_output();
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            !output.contains("need attention"),
-            "healthy state should not have attention message: {output}"
-        );
-        assert!(
-            !output.contains("to fix"),
-            "healthy state should not have fix message: {output}"
-        );
-    }
-
-    // ── Redundancy advisory rendering tests ─────────────────────────
-
-    #[test]
-    fn render_redundancy_section_with_advisories() {
-        use crate::output::{RedundancyAdvisory, RedundancyAdvisoryKind};
-
-        colored::control::set_override(false);
-        let mut data = test_status_output();
-        data.redundancy_advisories = vec![
-            RedundancyAdvisory {
-                kind: RedundancyAdvisoryKind::NoOffsiteProtection,
-                subvolume: "htpc-home".to_string(),
-                drive: None,
-                detail: "test".to_string(),
-            },
-            RedundancyAdvisory {
-                kind: RedundancyAdvisoryKind::TransientNoLocalRecovery,
-                subvolume: "htpc-tmp".to_string(),
-                drive: None,
-                detail: "test".to_string(),
-            },
-        ];
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(output.contains("REDUNDANCY"), "missing REDUNDANCY section header");
-        assert!(
-            output.contains("all drives share the same fate"),
-            "missing NoOffsiteProtection text"
-        );
-        assert!(
-            output.contains("Recovery requires a connected drive"),
-            "missing TransientNoLocalRecovery text"
-        );
-    }
-
-    #[test]
-    fn render_no_redundancy_section_when_empty() {
-        colored::control::set_override(false);
-        let data = test_status_output(); // has empty redundancy_advisories
-        let output = render_status(&data, OutputMode::Interactive);
-        assert!(
-            !output.contains("REDUNDANCY"),
-            "REDUNDANCY section should be absent when no advisories"
-        );
-    }
-
-    // ── Backup summary tests ────────────────────────────────────────
-
-    fn test_backup_summary() -> BackupSummary {
+    pub(crate) fn test_backup_summary() -> BackupSummary {
         BackupSummary {
             result: "success".to_string(),
             run_id: Some(47),
@@ -3627,9 +3242,546 @@ mod tests {
         }
     }
 
+    pub(crate) fn test_doctor_output() -> DoctorOutput {
+        DoctorOutput {
+            config_checks: vec![DoctorCheck {
+                name: "9 subvolumes, 3 drives".to_string(),
+                status: DoctorCheckStatus::Ok,
+                detail: None,
+                suggestion: None,
+            }],
+            infra_checks: vec![
+                DoctorCheck {
+                    name: "Verifying state database".to_string(),
+                    status: DoctorCheckStatus::Ok,
+                    detail: Some("already exists".to_string()),
+                    suggestion: None,
+                },
+                DoctorCheck {
+                    name: "sudo btrfs".to_string(),
+                    status: DoctorCheckStatus::Ok,
+                    detail: None,
+                    suggestion: None,
+                },
+            ],
+            data_safety: vec![
+                DoctorDataSafety {
+                    name: "htpc-home".to_string(),
+                    status: "PROTECTED".to_string(),
+                    health: "healthy".to_string(),
+                    issue: None,
+                    suggestion: None,
+                    reason: None,
+                },
+                DoctorDataSafety {
+                    name: "htpc-docs".to_string(),
+                    status: "PROTECTED".to_string(),
+                    health: "healthy".to_string(),
+                    issue: None,
+                    suggestion: None,
+                    reason: None,
+                },
+            ],
+            sentinel: DoctorSentinelStatus {
+                running: true,
+                pid: Some(12345),
+                uptime: Some("3h 12m".to_string()),
+            },
+            verify: None,
+            verdict: DoctorVerdict::healthy(),
+        }
+    }
+
+    pub(crate) fn test_default_status_output() -> DefaultStatusOutput {
+        DefaultStatusOutput {
+            total: 4,
+            waning_names: vec![],
+            exposed_names: vec![],
+            degraded_count: 0,
+            blocked_count: 0,
+            last_run: Some(LastRunInfo {
+                id: 42,
+                started_at: "2026-03-31T21:00:00".to_string(),
+                result: "success".to_string(),
+                duration: Some("1m 30s".to_string()),
+            }),
+            last_run_age_secs: Some(25200), // 7 hours
+            best_advice: None,
+            total_needing_attention: 0,
+        }
+    }
+
+    pub(crate) fn test_verify_output() -> VerifyOutput {
+        VerifyOutput {
+            subvolumes: vec![],
+            preflight_warnings: vec![],
+            ok_count: 5,
+            warn_count: 0,
+            fail_count: 0,
+        }
+    }
+
+    pub(crate) fn test_plan_output() -> PlanOutput {
+        PlanOutput {
+            timestamp: "2026-03-26 04:00".to_string(),
+            operations: vec![
+                PlanOperationEntry {
+                    subvolume: "htpc-home".to_string(),
+                    operation: "create".to_string(),
+                    detail: "/home -> /snapshots/htpc-home/20260326-0400-home".to_string(),
+                    drive_label: None,
+                    estimated_bytes: None,
+                    is_full_send: None,
+                    full_send_reason: None,
+                },
+                PlanOperationEntry {
+                    subvolume: "htpc-home".to_string(),
+                    operation: "send".to_string(),
+                    detail:
+                        "20260326-0400-home -> WD-18TB (incremental, parent: 20260325-0400-home) + pin"
+                            .to_string(),
+                    drive_label: Some("WD-18TB".to_string()),
+                    estimated_bytes: None,
+                    is_full_send: None,
+                    full_send_reason: None,
+                },
+            ],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 1,
+                sends: 1,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: None,
+            },
+            warnings: vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use super::test_fixtures::*;
+    use crate::awareness::ActionableAdvice;
+    use crate::output::{
+        BackupSummary, CalibrateEntry, CalibrateOutput, CalibrateResult, ChainHealth,
+        DeferredInfo, DisconnectedDrive, DriveInfo, EmergencyRootAssessment,
+        EmergencySubvolDetail, HistoryOutput, HistoryRun, InitCheck, InitDriveStatus, InitOutput,
+        InitPinFile, InitSnapshotCount, InitStatus, PlanOperationEntry, PlanOutput,
+        PlanSummaryOutput, SendSummary, SkipCategory, SkippedSubvolume, StatusAssessment,
+        StatusDriveAssessment, TransitionEvent, VerifyCheck, VerifyDrive,
+        VerifyOutput, VerifySubvolume,
+    };
+
+    #[test]
+    fn interactive_contains_subvolume_names() {
+        let _color = color_guard(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("htpc-home"), "missing htpc-home");
+        assert!(output.contains("htpc-docs"), "missing htpc-docs");
+    }
+
+    #[test]
+    fn interactive_contains_safety_vocabulary() {
+        let _color = color_guard(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("sealed"), "missing sealed exposure label");
+        assert!(output.contains("waning"), "missing waning exposure label");
+    }
+
+    #[test]
+    fn interactive_promise_column_shown_when_exposure_conflicts() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        // Set a promise level on a non-PROTECTED assessment — triggers PROTECTION column
+        data.assessments[1].promise_level = Some("protected".to_string());
+        // assessments[1] has status "AT RISK" — conflict with promise
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(output.contains("PROTECTION"), "missing PROTECTION header");
+        assert!(output.contains("protected"), "missing promise level value");
+    }
+
+    #[test]
+    fn interactive_promise_column_hidden_when_all_sealed() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        // Set a promise level but all statuses are PROTECTED — no conflict
+        data.assessments[0].promise_level = Some("sheltered".to_string());
+        data.assessments[1].status = "PROTECTED".to_string();
+        data.assessments[1].promise_level = Some("fortified".to_string());
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("PROTECTION"),
+            "PROTECTION column should be hidden when all sealed"
+        );
+    }
+
+    #[test]
+    fn interactive_no_promise_column_when_none_set() {
+        let _color = color_guard(false);
+        let data = test_status_output(); // all promise_level are None
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("PROTECTION"),
+            "PROTECTION column should be hidden when no protection levels set"
+        );
+    }
+
+    #[test]
+    fn interactive_contains_drive_info() {
+        let _color = color_guard(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("WD-18TB"), "missing drive label");
+        assert!(output.contains("connected"), "missing connected status");
+        assert!(output.contains("Offsite-4TB"), "missing unmounted drive");
+        // With no absent_duration_secs and no last_activity_age_secs, the
+        // cascade stays silent — "disconnected" rather than a fabricated
+        // "away" label driven by role alone.
+        assert!(
+            output.contains("disconnected"),
+            "expected silent fallback: {output}"
+        );
+    }
+
+    #[test]
+    fn drive_summary_escalated_at_risk() {
+        let _color = color_guard(false);
+        // Build a status with an unmounted drive that has AT RISK assessment data
+        let mut data = test_status_output();
+        data.drives.push(DriveInfo {
+            label: "Backup-2TB".to_string(),
+            mounted: false,
+            free_bytes: None,
+            role: DriveRole::Primary,
+        });
+        data.assessments[0].external.push(StatusDriveAssessment {
+            drive_label: "Backup-2TB".to_string(),
+            status: "AT RISK".to_string(),
+            mounted: false,
+            snapshot_count: None,
+            last_send_age_secs: Some(604800), // 7 days
+            role: DriveRole::Primary,
+            absent_duration_secs: Some(604800), // 7 days — drives the "away" label
+            last_activity_age_secs: None,
+        });
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("consider connecting"),
+            "missing escalated text for AT RISK drive: {output}"
+        );
+        assert!(
+            output.contains("Backup-2TB"),
+            "missing drive label: {output}"
+        );
+    }
+
+    #[test]
+    fn interactive_contains_last_run_relative_time() {
+        let _color = color_guard(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("#42"), "missing run ID");
+        assert!(output.contains("success"), "missing run result");
+        assert!(output.contains("1m 30s"), "missing duration");
+        assert!(output.contains("10h ago"), "should show relative time, got: {output}");
+    }
+
+    #[test]
+    fn interactive_last_run_falls_back_to_timestamp_without_age() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.last_run_age_secs = None;
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("2026-03-24T02:00:00"),
+            "should fall back to ISO timestamp when age is None"
+        );
+    }
+
+    #[test]
+    fn interactive_contains_thread_health() {
+        let _color = color_guard(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("unbroken"), "missing unbroken thread");
+        assert!(
+            output.contains("broken"),
+            "missing broken thread"
+        );
+    }
+
+    #[test]
+    fn interactive_contains_pin_count() {
+        let _color = color_guard(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(output.contains("3"), "missing pin count");
+    }
+
+    #[test]
+    fn interactive_no_subvolumes() {
+        let _color = color_guard(false);
+        let data = StatusOutput {
+            assessments: vec![],
+            chain_health: vec![],
+            drives: vec![],
+            last_run: None,
+            last_run_age_secs: None,
+            total_pins: 0,
+            redundancy_advisories: vec![],
+            advice: vec![],
+        };
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("No subvolumes configured"),
+            "missing empty message"
+        );
+    }
+
+    #[test]
+    fn daemon_produces_valid_json() {
+        let output = render_status(&test_status_output(), OutputMode::Daemon);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&output).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{output}"));
+        assert!(
+            parsed.get("assessments").is_some(),
+            "missing assessments key"
+        );
+        assert!(parsed.get("drives").is_some(), "missing drives key");
+        assert!(parsed.get("last_run").is_some(), "missing last_run key");
+        assert!(
+            parsed.get("chain_health").is_some(),
+            "missing chain_health key"
+        );
+        assert!(
+            parsed.get("last_run_age_secs").is_some(),
+            "missing last_run_age_secs key"
+        );
+    }
+
+    #[test]
+    fn daemon_contains_subvolume_data() {
+        let output = render_status(&test_status_output(), OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let assessments = parsed["assessments"].as_array().unwrap();
+        assert_eq!(assessments.len(), 2);
+        assert_eq!(assessments[0]["name"], "htpc-home");
+        assert_eq!(assessments[0]["status"], "PROTECTED");
+        assert_eq!(assessments[1]["name"], "htpc-docs");
+        assert_eq!(assessments[1]["status"], "AT RISK");
+    }
+
+    #[test]
+    fn interactive_renders_advisories_and_errors() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.assessments[0]
+            .errors
+            .push("can't read snapshot directory".to_string());
+        data.assessments[1]
+            .advisories
+            .push("offsite drive not connected in 14 days".to_string());
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("can't read snapshot directory"),
+            "missing error"
+        );
+        assert!(
+            output.contains("offsite drive not connected"),
+            "missing advisory"
+        );
+    }
+
+    #[test]
+    fn interactive_no_last_run() {
+        let _color = color_guard(false);
+        let data = StatusOutput {
+            assessments: vec![],
+            chain_health: vec![],
+            drives: vec![],
+            last_run: None,
+            last_run_age_secs: None,
+            total_pins: 0,
+            redundancy_advisories: vec![],
+            advice: vec![],
+        };
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("no runs recorded"),
+            "missing no-runs message"
+        );
+    }
+
+    // ── External-only status table tests (UPI 018) ─────────────────
+
+    #[test]
+    fn status_table_external_only_shows_em_dash_local() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        // Make first subvol external-only
+        data.assessments[0].external_only = true;
+        data.assessments[0].local_snapshot_count = 0;
+        data.assessments[0].local_newest_age_secs = None;
+        let output = render_status(&data, OutputMode::Interactive);
+        // The LOCAL column for htpc-home should show em-dash, not "0"
+        // Split into lines and find the htpc-home row
+        let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
+        assert!(
+            home_line.contains('\u{2014}'),
+            "external_only LOCAL should show em-dash, got: {home_line}"
+        );
+        assert!(
+            !home_line.contains(" 0 "),
+            "external_only LOCAL should not show '0', got: {home_line}"
+        );
+    }
+
+    #[test]
+    fn status_table_external_only_shows_ext_only_thread() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.assessments[0].external_only = true;
+        let output = render_status(&data, OutputMode::Interactive);
+        let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
+        assert!(
+            home_line.contains("drive-only"),
+            "external_only THREAD should show 'drive-only', got: {home_line}"
+        );
+    }
+
+    #[test]
+    fn status_table_normal_subvol_unchanged() {
+        let _color = color_guard(false);
+        let data = test_status_output();
+        let output = render_status(&data, OutputMode::Interactive);
+        let home_line = output.lines().find(|l| l.contains("htpc-home")).unwrap();
+        // Normal subvol should show count (47) not em-dash for LOCAL
+        assert!(
+            home_line.contains("47"),
+            "normal subvol LOCAL should show count, got: {home_line}"
+        );
+        // Should show chain health, not ext-only
+        assert!(
+            home_line.contains("unbroken"),
+            "normal subvol THREAD should show chain health, got: {home_line}"
+        );
+    }
+
+    // ── Status advice rendering tests ────────────────────────────────
+
+    #[test]
+    fn status_single_issue_shows_inline_fix() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.advice = vec![ActionableAdvice {
+            subvolume: "htpc-docs".to_string(),
+            issue: "waning — last backup 3 hours ago".to_string(),
+            command: Some("urd backup --subvolume htpc-docs".to_string()),
+            reason: None,
+        }];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("htpc-docs"),
+            "missing subvolume name in advice: {output}"
+        );
+        assert!(
+            output.contains("urd backup --subvolume htpc-docs"),
+            "missing inline fix command: {output}"
+        );
+    }
+
+    #[test]
+    fn status_multiple_issues_shows_doctor() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.advice = vec![
+            ActionableAdvice {
+                subvolume: "htpc-docs".to_string(),
+                issue: "waning".to_string(),
+                command: Some("urd backup --subvolume htpc-docs".to_string()),
+                reason: None,
+            },
+            ActionableAdvice {
+                subvolume: "htpc-home".to_string(),
+                issue: "exposed".to_string(),
+                command: None,
+                reason: Some("Connect WD-18TB".to_string()),
+            },
+        ];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("2 subvolumes need attention"),
+            "missing doctor redirect: {output}"
+        );
+        assert!(
+            output.contains("urd doctor"),
+            "missing doctor command: {output}"
+        );
+    }
+
+    #[test]
+    fn status_no_issues_no_suggestion() {
+        let _color = color_guard(false);
+        let data = test_status_output();
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("need attention"),
+            "healthy state should not have attention message: {output}"
+        );
+        assert!(
+            !output.contains("to fix"),
+            "healthy state should not have fix message: {output}"
+        );
+    }
+
+    // ── Redundancy advisory rendering tests ─────────────────────────
+
+    #[test]
+    fn render_redundancy_section_with_advisories() {
+        use crate::output::{RedundancyAdvisory, RedundancyAdvisoryKind};
+
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.redundancy_advisories = vec![
+            RedundancyAdvisory {
+                kind: RedundancyAdvisoryKind::NoOffsiteProtection,
+                subvolume: "htpc-home".to_string(),
+                drive: None,
+                detail: "test".to_string(),
+            },
+            RedundancyAdvisory {
+                kind: RedundancyAdvisoryKind::TransientNoLocalRecovery,
+                subvolume: "htpc-tmp".to_string(),
+                drive: None,
+                detail: "test".to_string(),
+            },
+        ];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(output.contains("REDUNDANCY"), "missing REDUNDANCY section header");
+        assert!(
+            output.contains("all drives share the same fate"),
+            "missing NoOffsiteProtection text"
+        );
+        assert!(
+            output.contains("Recovery requires a connected drive"),
+            "missing TransientNoLocalRecovery text"
+        );
+    }
+
+    #[test]
+    fn render_no_redundancy_section_when_empty() {
+        let _color = color_guard(false);
+        let data = test_status_output(); // has empty redundancy_advisories
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("REDUNDANCY"),
+            "REDUNDANCY section should be absent when no advisories"
+        );
+    }
+
+    // ── Backup summary tests ────────────────────────────────────────
+
     #[test]
     fn backup_interactive_contains_header() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
         assert!(output.contains("success"), "missing result in header");
         assert!(output.contains("#47"), "missing run ID");
@@ -3638,7 +3790,7 @@ mod tests {
 
     #[test]
     fn backup_interactive_contains_subvolumes() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
         assert!(output.contains("htpc-home"), "missing subvolume name");
         assert!(output.contains("htpc-docs"), "missing subvolume name");
@@ -3647,7 +3799,7 @@ mod tests {
 
     #[test]
     fn backup_interactive_contains_send_info() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
         assert!(
             output.contains("incremental") && output.contains("WD-18TB"),
@@ -3657,7 +3809,7 @@ mod tests {
 
     #[test]
     fn backup_interactive_groups_not_mounted_skips() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
         assert!(
             output.contains("Drives disconnected"),
@@ -3672,7 +3824,7 @@ mod tests {
 
     #[test]
     fn backup_interactive_uuid_mismatch_not_grouped() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.skipped = vec![
             SkippedSubvolume {
@@ -3699,7 +3851,7 @@ mod tests {
 
     #[test]
     fn backup_interactive_all_protected_one_line() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
         assert!(
             output.contains("All subvolumes sealed"),
@@ -3714,7 +3866,7 @@ mod tests {
 
     #[test]
     fn backup_interactive_shows_table_when_at_risk() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.assessments[0].status = "AT RISK".to_string();
         let output = render_backup_summary(&data, OutputMode::Interactive);
@@ -3727,7 +3879,7 @@ mod tests {
 
     #[test]
     fn backup_interactive_shows_warnings() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.warnings =
             vec!["2 pin file write(s) failed. Run `urd verify` to diagnose.".to_string()];
@@ -3740,7 +3892,7 @@ mod tests {
     fn backup_summary_notes_rendered_dim_no_label() {
         // Notes render with a middle-dot glyph and no "NOTE:" label — the
         // dim rendering signals informational tone.
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.notes = vec!["space guard held — 1 snapshot retained.".to_string()];
         let output = render_backup_summary(&data, OutputMode::Interactive);
@@ -3757,7 +3909,7 @@ mod tests {
 
     #[test]
     fn backup_summary_notes_below_warnings() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.warnings = vec!["something worth noting loudly".to_string()];
         data.notes = vec!["space guard held — 2 snapshots retained.".to_string()];
@@ -3776,7 +3928,7 @@ mod tests {
 
     #[test]
     fn backup_summary_empty_notes_not_rendered() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = test_backup_summary(); // notes default to empty
         let output = render_backup_summary(&data, OutputMode::Interactive);
         assert!(
@@ -3790,7 +3942,7 @@ mod tests {
         // A note must never pick up the yellow WARNING gravity indicator.
         // Under Interactive + forced colors, render_backup_summary must
         // still not emit "WARNING" for a note.
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.notes = vec!["space guard held — 1 snapshot retained.".to_string()];
         let output = render_backup_summary(&data, OutputMode::Interactive);
@@ -3802,7 +3954,7 @@ mod tests {
 
     #[test]
     fn backup_interactive_shows_errors() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.subvolumes[1].success = false;
         data.subvolumes[1].errors = vec!["send_full: btrfs send failed".to_string()];
@@ -3814,7 +3966,7 @@ mod tests {
 
     #[test]
     fn backup_deferred_only_renders_deferred_status() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         // htpc-home: deferred-only (no sends)
         data.subvolumes[0].deferred = vec![DeferredInfo {
@@ -3829,7 +3981,7 @@ mod tests {
 
     #[test]
     fn backup_mixed_success_and_deferred_renders_ok() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         // htpc-docs: has a successful send AND a deferred op
         data.subvolumes[1].deferred = vec![DeferredInfo {
@@ -3844,7 +3996,7 @@ mod tests {
 
     #[test]
     fn backup_header_shows_deferred_count() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.subvolumes[0].deferred = vec![DeferredInfo {
             reason: "full send gated".to_string(),
@@ -3856,7 +4008,7 @@ mod tests {
 
     #[test]
     fn backup_header_shows_failed_and_deferred_counts() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.result = "partial".to_string();
         data.subvolumes[0].success = false;
@@ -3872,7 +4024,7 @@ mod tests {
 
     #[test]
     fn backup_interactive_multi_drive_sends() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.subvolumes[1].sends = vec![
             SendSummary {
@@ -3910,7 +4062,7 @@ mod tests {
 
     #[test]
     fn backup_all_skips_run() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = BackupSummary {
             result: "success".to_string(),
             run_id: Some(48),
@@ -4025,7 +4177,7 @@ mod tests {
 
     #[test]
     fn plan_structural_headings_present() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![PlanOperationEntry {
@@ -4061,7 +4213,7 @@ mod tests {
 
     #[test]
     fn plan_no_operations_shows_message() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
@@ -4092,7 +4244,7 @@ mod tests {
 
     #[test]
     fn plan_grouped_drive_not_mounted() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
@@ -4146,7 +4298,7 @@ mod tests {
 
     #[test]
     fn plan_grouped_interval_shows_shortest() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
@@ -4194,7 +4346,7 @@ mod tests {
 
     #[test]
     fn plan_grouped_interval_days_vs_hours() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
@@ -4229,7 +4381,7 @@ mod tests {
 
     #[test]
     fn plan_grouped_disabled_comma_list() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
@@ -4284,7 +4436,7 @@ mod tests {
 
     #[test]
     fn plan_space_exceeded_individual_lines() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
@@ -4316,7 +4468,7 @@ mod tests {
 
     #[test]
     fn plan_skip_external_only_renders_grouped() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
@@ -4351,7 +4503,7 @@ mod tests {
 
     #[test]
     fn backup_skipped_block_hides_external_only() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_backup_summary();
         data.skipped = vec![SkippedSubvolume {
             name: "htpc-root".to_string(),
@@ -4371,7 +4523,7 @@ mod tests {
 
     #[test]
     fn plan_mixed_categories_render_order() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![],
@@ -4446,7 +4598,7 @@ mod tests {
 
     #[test]
     fn plan_summary_with_total_estimate() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![
@@ -4493,7 +4645,7 @@ mod tests {
 
     #[test]
     fn plan_incremental_send_size_annotation() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![PlanOperationEntry {
@@ -4524,7 +4676,7 @@ mod tests {
 
     #[test]
     fn plan_summary_partial_estimates_qualified() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![
@@ -4566,7 +4718,7 @@ mod tests {
 
     #[test]
     fn plan_summary_no_estimates_no_size() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
             operations: vec![PlanOperationEntry {
@@ -4757,7 +4909,7 @@ mod tests {
 
     #[test]
     fn local_only_suppressed_in_backup_summary() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = BackupSummary {
             result: "success".to_string(),
             run_id: Some(1),
@@ -4937,7 +5089,7 @@ mod tests {
 
     #[test]
     fn verify_findings_first_all_clean() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = VerifyOutput {
             subvolumes: vec![VerifySubvolume {
                 name: "htpc-home".to_string(),
@@ -4965,7 +5117,7 @@ mod tests {
 
     #[test]
     fn verify_findings_first_one_failure() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = VerifyOutput {
             subvolumes: vec![VerifySubvolume {
                 name: "htpc-home".to_string(),
@@ -5013,7 +5165,7 @@ mod tests {
 
     #[test]
     fn verify_findings_first_absent_drives_collapsed() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = VerifyOutput {
             subvolumes: vec![VerifySubvolume {
                 name: "htpc-home".to_string(),
@@ -5064,7 +5216,7 @@ mod tests {
 
     #[test]
     fn verify_findings_first_suggestion_rendered() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = VerifyOutput {
             subvolumes: vec![VerifySubvolume {
                 name: "htpc-root".to_string(),
@@ -5207,21 +5359,21 @@ mod tests {
 
     #[test]
     fn sentinel_running_contains_watching() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
         assert!(output.contains("watching"), "missing 'watching'");
     }
 
     #[test]
     fn sentinel_running_contains_pid() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
         assert!(output.contains("12345"), "missing PID");
     }
 
     #[test]
     fn sentinel_running_contains_tick() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
         assert!(output.contains("15m"), "missing tick interval");
         assert!(output.contains("all promises held"), "missing promise summary");
@@ -5229,14 +5381,14 @@ mod tests {
 
     #[test]
     fn sentinel_running_contains_drive() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
         assert!(output.contains("WD-18TB"), "missing drive label");
     }
 
     #[test]
     fn sentinel_not_running_shows_message() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = SentinelStatusOutput::NotRunning { last_seen: None };
         let output = render_sentinel_status(&data, OutputMode::Interactive);
         assert!(output.contains("not running"), "missing 'not running'");
@@ -5245,7 +5397,7 @@ mod tests {
 
     #[test]
     fn sentinel_not_running_with_last_seen() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = SentinelStatusOutput::NotRunning {
             last_seen: Some("2026-03-27T10:00:00".to_string()),
         };
@@ -5267,7 +5419,7 @@ mod tests {
 
     #[test]
     fn summary_line_all_safe_all_healthy() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         // Make all assessments safe and healthy
         for a in &mut data.assessments {
@@ -5281,7 +5433,7 @@ mod tests {
 
     #[test]
     fn summary_line_all_safe_degraded() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = test_status_output(); // htpc-docs is degraded
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
@@ -5292,7 +5444,7 @@ mod tests {
 
     #[test]
     fn safety_column_uses_new_vocabulary() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = test_status_output();
         let output = render_status(&data, OutputMode::Interactive);
         assert!(output.contains("sealed"), "missing sealed label");
@@ -5324,7 +5476,7 @@ mod tests {
 
     #[test]
     fn summary_line_shows_all_health_reasons() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         data.assessments[0].health = "degraded".to_string();
         data.assessments[0].health_reasons = vec!["WD-18TB away 8d".to_string()];
@@ -5343,7 +5495,7 @@ mod tests {
 
     #[test]
     fn summary_line_truncates_at_three_reasons() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         // Clear second assessment's health to isolate the test
         data.assessments[1].health = "healthy".to_string();
@@ -5364,7 +5516,7 @@ mod tests {
 
     #[test]
     fn summary_line_differentiates_exposed_and_waning() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         data.assessments[0].status = "UNPROTECTED".to_string();
         data.assessments[1].status = "AT RISK".to_string();
@@ -5376,7 +5528,7 @@ mod tests {
 
     #[test]
     fn primary_drive_unmounted_shows_dash_not_away() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         // Add an unmounted Primary drive with send history
         data.assessments[0].external.push(StatusDriveAssessment {
@@ -5415,7 +5567,7 @@ mod tests {
 
     #[test]
     fn health_column_hidden_when_all_healthy() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         for a in &mut data.assessments {
             a.health = "healthy".to_string();
@@ -5427,7 +5579,7 @@ mod tests {
 
     #[test]
     fn health_column_shown_when_degraded() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = test_status_output(); // htpc-docs is degraded
         let output = render_status(&data, OutputMode::Interactive);
         assert!(output.contains("HEALTH"), "HEALTH column should be visible");
@@ -5436,7 +5588,7 @@ mod tests {
 
     #[test]
     fn temporal_context_in_local_column() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = test_status_output();
         let output = render_status(&data, OutputMode::Interactive);
         // htpc-home has local_newest_age_secs = 1800 (30m)
@@ -5445,7 +5597,7 @@ mod tests {
 
     #[test]
     fn unmounted_drive_shows_away() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         // Add an unmounted drive with send history to one assessment
         data.assessments[0].external.push(StatusDriveAssessment {
@@ -5479,7 +5631,7 @@ mod tests {
 
     #[test]
     fn disconnected_drive_column_collapsed() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = test_status_output();
         // Offsite-4TB is unmounted in the test fixture — should NOT appear as table column
         let output = render_status(&data, OutputMode::Interactive);
@@ -5491,7 +5643,7 @@ mod tests {
 
     #[test]
     fn mounted_offsite_drive_shows_role_annotation() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         // Mount the offsite drive
         data.drives[1].mounted = true;
@@ -5505,7 +5657,7 @@ mod tests {
 
     #[test]
     fn offsite_degradation_advisory_rendered() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         data.assessments[0]
             .advisories
@@ -5519,7 +5671,7 @@ mod tests {
 
     #[test]
     fn advisory_transient_no_recovery_uses_disabled_vocabulary() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         data.redundancy_advisories
             .push(crate::output::RedundancyAdvisory {
@@ -5542,29 +5694,10 @@ mod tests {
 
     // ── Default status tests ───────────────────────────────────────────
 
-    fn test_default_all_sealed() -> DefaultStatusOutput {
-        DefaultStatusOutput {
-            total: 4,
-            waning_names: vec![],
-            exposed_names: vec![],
-            degraded_count: 0,
-            blocked_count: 0,
-            last_run: Some(LastRunInfo {
-                id: 42,
-                started_at: "2026-03-31T21:00:00".to_string(),
-                result: "success".to_string(),
-                duration: Some("1m 30s".to_string()),
-            }),
-            last_run_age_secs: Some(25200), // 7 hours
-            best_advice: None,
-            total_needing_attention: 0,
-        }
-    }
-
     #[test]
     fn default_all_sealed() {
-        colored::control::set_override(false);
-        let output = render_default_status(&test_default_all_sealed(), OutputMode::Interactive);
+        let _color = color_guard(false);
+        let output = render_default_status(&test_default_status_output(), OutputMode::Interactive);
         assert!(output.contains("All connected drives are sealed."), "missing sealed message in: {output}");
         assert!(
             output.contains("urd status"),
@@ -5578,7 +5711,7 @@ mod tests {
 
     #[test]
     fn default_some_exposed() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = DefaultStatusOutput {
             total: 9,
             waning_names: vec![],
@@ -5611,7 +5744,7 @@ mod tests {
 
     #[test]
     fn default_some_waning() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = DefaultStatusOutput {
             total: 5,
             waning_names: vec!["htpc-config".to_string()],
@@ -5640,8 +5773,8 @@ mod tests {
 
     #[test]
     fn default_health_degradation_surfaced() {
-        colored::control::set_override(false);
-        let mut data = test_default_all_sealed();
+        let _color = color_guard(false);
+        let mut data = test_default_status_output();
         data.degraded_count = 1;
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
@@ -5656,8 +5789,8 @@ mod tests {
 
     #[test]
     fn default_with_last_backup() {
-        colored::control::set_override(false);
-        let output = render_default_status(&test_default_all_sealed(), OutputMode::Interactive);
+        let _color = color_guard(false);
+        let output = render_default_status(&test_default_status_output(), OutputMode::Interactive);
         assert!(
             output.contains("Last backup 7h ago."),
             "missing deterministic 'Last backup 7h ago.' in: {output}"
@@ -5666,7 +5799,7 @@ mod tests {
 
     #[test]
     fn default_no_last_backup() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let data = DefaultStatusOutput {
             total: 2,
             waning_names: vec![],
@@ -5730,8 +5863,8 @@ mod tests {
 
     #[test]
     fn default_single_issue_shows_command() {
-        colored::control::set_override(false);
-        let mut data = test_default_all_sealed();
+        let _color = color_guard(false);
+        let mut data = test_default_status_output();
         data.waning_names = vec!["htpc-docs".to_string()];
         data.best_advice = Some(ActionableAdvice {
             subvolume: "htpc-docs".to_string(),
@@ -5749,8 +5882,8 @@ mod tests {
 
     #[test]
     fn default_multiple_issues_shows_count() {
-        colored::control::set_override(false);
-        let mut data = test_default_all_sealed();
+        let _color = color_guard(false);
+        let mut data = test_default_status_output();
         data.waning_names = vec!["htpc-docs".to_string()];
         data.exposed_names = vec!["htpc-home".to_string()];
         data.best_advice = Some(ActionableAdvice {
@@ -5774,64 +5907,14 @@ mod tests {
     // ── Doctor tests ──────────────────────────────────────────────────
 
     use crate::output::{
-        DiskEstimate, DoctorCheck, DoctorDataSafety, DoctorOutput, DoctorSentinelStatus,
-        DoctorVerdict, EstimateMethod, RetentionPreview, TransientComparison,
+        DiskEstimate, DoctorCheck, DoctorDataSafety, DoctorVerdict, EstimateMethod,
+        RetentionPreview, TransientComparison,
     };
-
-    fn test_doctor_healthy() -> DoctorOutput {
-        DoctorOutput {
-            config_checks: vec![DoctorCheck {
-                name: "9 subvolumes, 3 drives".to_string(),
-                status: DoctorCheckStatus::Ok,
-                detail: None,
-                suggestion: None,
-            }],
-            infra_checks: vec![
-                DoctorCheck {
-                    name: "Verifying state database".to_string(),
-                    status: DoctorCheckStatus::Ok,
-                    detail: Some("already exists".to_string()),
-                    suggestion: None,
-                },
-                DoctorCheck {
-                    name: "sudo btrfs".to_string(),
-                    status: DoctorCheckStatus::Ok,
-                    detail: None,
-                    suggestion: None,
-                },
-            ],
-            data_safety: vec![
-                DoctorDataSafety {
-                    name: "htpc-home".to_string(),
-                    status: "PROTECTED".to_string(),
-                    health: "healthy".to_string(),
-                    issue: None,
-                    suggestion: None,
-                    reason: None,
-                },
-                DoctorDataSafety {
-                    name: "htpc-docs".to_string(),
-                    status: "PROTECTED".to_string(),
-                    health: "healthy".to_string(),
-                    issue: None,
-                    suggestion: None,
-                    reason: None,
-                },
-            ],
-            sentinel: DoctorSentinelStatus {
-                running: true,
-                pid: Some(12345),
-                uptime: Some("3h 12m".to_string()),
-            },
-            verify: None,
-            verdict: DoctorVerdict::healthy(),
-        }
-    }
 
     #[test]
     fn doctor_all_healthy() {
-        colored::control::set_override(false);
-        let output = render_doctor(&test_doctor_healthy(), OutputMode::Interactive);
+        let _color = color_guard(false);
+        let output = render_doctor(&test_doctor_output(), OutputMode::Interactive);
         assert!(output.contains("All clear."), "missing verdict: {output}");
         assert!(output.contains("2 of 2 sealed"), "missing sealed count: {output}");
         assert!(output.contains("Sentinel running"), "missing sentinel: {output}");
@@ -5839,8 +5922,8 @@ mod tests {
 
     #[test]
     fn doctor_config_warnings() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.config_checks = vec![DoctorCheck {
             name: "retention window shorter than send interval for htpc-root".to_string(),
             status: DoctorCheckStatus::Warn,
@@ -5861,8 +5944,8 @@ mod tests {
 
     #[test]
     fn doctor_promise_issues() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.data_safety[1] = DoctorDataSafety {
             name: "htpc-docs".to_string(),
             status: "UNPROTECTED".to_string(),
@@ -5883,8 +5966,8 @@ mod tests {
 
     #[test]
     fn doctor_with_thorough() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.verify = Some(crate::output::VerifyOutput {
             subvolumes: vec![],
             preflight_warnings: vec![],
@@ -5902,8 +5985,8 @@ mod tests {
 
     #[test]
     fn doctor_without_thorough() {
-        colored::control::set_override(false);
-        let data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let data = test_doctor_output();
         let output = render_doctor(&data, OutputMode::Interactive);
         assert!(
             output.contains("--thorough"),
@@ -5913,8 +5996,8 @@ mod tests {
 
     #[test]
     fn doctor_thorough_findings_separated() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.verify = Some(VerifyOutput {
             subvolumes: vec![VerifySubvolume {
                 name: "htpc-root".to_string(),
@@ -5971,8 +6054,8 @@ mod tests {
 
     #[test]
     fn doctor_thorough_only_absent_drives() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.verify = Some(VerifyOutput {
             subvolumes: vec![VerifySubvolume {
                 name: "htpc-home".to_string(),
@@ -6017,8 +6100,8 @@ mod tests {
 
     #[test]
     fn doctor_thorough_all_clean_unchanged() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.verify = Some(VerifyOutput {
             subvolumes: vec![],
             preflight_warnings: vec![],
@@ -6039,8 +6122,8 @@ mod tests {
 
     #[test]
     fn doctor_thorough_absent_drives_deduped() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.verify = Some(VerifyOutput {
             subvolumes: vec![
                 VerifySubvolume {
@@ -6105,8 +6188,8 @@ mod tests {
 
     #[test]
     fn doctor_verdict_degraded() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.data_safety[0].health = "degraded".to_string();
         data.data_safety[1].health = "degraded".to_string();
         data.verdict = DoctorVerdict::degraded(2);
@@ -6123,8 +6206,8 @@ mod tests {
 
     #[test]
     fn doctor_verdict_degraded_singular() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.data_safety[0].health = "degraded".to_string();
         data.verdict = DoctorVerdict::degraded(1);
         let output = render_doctor(&data, OutputMode::Interactive);
@@ -6159,8 +6242,8 @@ mod tests {
 
     #[test]
     fn doctor_verdict_singular_issue() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.data_safety[0].status = "UNPROTECTED".to_string();
         data.data_safety[0].health = "blocked".to_string();
         data.data_safety[0].issue = Some("exposed".to_string());
@@ -6174,8 +6257,8 @@ mod tests {
 
     #[test]
     fn doctor_verdict_plural_warnings() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.verdict = DoctorVerdict::warnings(2);
         let output = render_doctor(&data, OutputMode::Interactive);
         assert!(
@@ -6186,13 +6269,13 @@ mod tests {
 
     #[test]
     fn doctor_verdict_no_run_suggested_text() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         for verdict in [
             DoctorVerdict::warnings(1),
             DoctorVerdict::issues(1),
             DoctorVerdict::degraded(1),
         ] {
-            let mut data = test_doctor_healthy();
+            let mut data = test_doctor_output();
             data.verdict = verdict;
             let output = render_doctor(&data, OutputMode::Interactive);
             assert!(
@@ -6204,8 +6287,8 @@ mod tests {
 
     #[test]
     fn doctor_sentinel_running() {
-        colored::control::set_override(false);
-        let data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let data = test_doctor_output();
         let output = render_doctor(&data, OutputMode::Interactive);
         assert!(
             output.contains("PID 12345"),
@@ -6219,7 +6302,7 @@ mod tests {
 
     #[test]
     fn doctor_daemon_json() {
-        let data = test_doctor_healthy();
+        let data = test_doctor_output();
         let output = render_doctor(&data, OutputMode::Daemon);
         let parsed: serde_json::Value =
             serde_json::from_str(&output).expect("doctor daemon output should be valid JSON");
@@ -6233,8 +6316,8 @@ mod tests {
 
     #[test]
     fn doctor_chain_broken_shows_force_full() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.data_safety[0] = DoctorDataSafety {
             name: "htpc-home".to_string(),
             status: "AT RISK".to_string(),
@@ -6257,8 +6340,8 @@ mod tests {
 
     #[test]
     fn doctor_absent_drive_shows_connect() {
-        colored::control::set_override(false);
-        let mut data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
         data.data_safety[0] = DoctorDataSafety {
             name: "htpc-home".to_string(),
             status: "UNPROTECTED".to_string(),
@@ -6277,8 +6360,8 @@ mod tests {
 
     #[test]
     fn doctor_protected_healthy_no_suggestion() {
-        colored::control::set_override(false);
-        let data = test_doctor_healthy();
+        let _color = color_guard(false);
+        let data = test_doctor_output();
         let output = render_doctor(&data, OutputMode::Interactive);
         assert!(
             !output.contains("Run `urd backup"),
@@ -6328,7 +6411,7 @@ mod tests {
 
     #[test]
     fn retention_preview_interactive() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_retention_preview(&test_graduated_preview(), OutputMode::Interactive);
         assert!(
             output.contains("htpc-root"),
@@ -6371,7 +6454,7 @@ mod tests {
 
     #[test]
     fn retention_preview_transient() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_retention_preview(
             &RetentionPreviewOutput {
                 previews: vec![RetentionPreview {
@@ -6394,7 +6477,7 @@ mod tests {
 
     #[test]
     fn retention_preview_with_comparison() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_retention_preview(
             &RetentionPreviewOutput {
                 previews: vec![RetentionPreview {
@@ -6512,7 +6595,7 @@ mod tests {
 
     #[test]
     fn unmounted_with_physical_event_renders_away() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let label = unmounted_drive_label("WD-18TB", Some(259200), None, "PROTECTED");
         assert!(label.contains("WD-18TB"), "missing label: {label}");
         assert!(label.contains("away"), "missing 'away': {label}");
@@ -6521,7 +6604,7 @@ mod tests {
 
     #[test]
     fn unmounted_without_event_with_ops_renders_last_backup() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let label = unmounted_drive_label("WD-18TB", None, Some(259200), "PROTECTED");
         assert!(label.contains("WD-18TB"), "missing label: {label}");
         assert!(label.contains("last backup"), "missing 'last backup': {label}");
@@ -6530,7 +6613,7 @@ mod tests {
 
     #[test]
     fn unmounted_no_data_renders_disconnected_silent() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let label = unmounted_drive_label("WD-18TB", None, None, "PROTECTED");
         assert!(label.contains("WD-18TB"), "missing label: {label}");
         assert!(
@@ -6549,7 +6632,7 @@ mod tests {
         // Rule 1 seed at render layer: if the cascade populated neither field
         // (sentinel-missed-unmount case, verified by awareness tests), voice
         // must stay silent — no "away" or "last backup".
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let label = unmounted_drive_label("WD-18TB", None, None, "AT RISK");
         assert!(label.contains("disconnected"), "must be silent: {label}");
         assert!(!label.contains("away"));
@@ -6558,7 +6641,7 @@ mod tests {
 
     #[test]
     fn at_risk_escalation_away() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let label = unmounted_drive_label("WD-18TB", Some(604800), None, "AT RISK");
         assert!(label.contains("away"), "missing 'away': {label}");
         assert!(label.contains("7d"), "missing age: {label}");
@@ -6570,7 +6653,7 @@ mod tests {
 
     #[test]
     fn at_risk_escalation_last_backup() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let label = unmounted_drive_label("WD-18TB", None, Some(604800), "AT RISK");
         assert!(label.contains("last backup"), "missing 'last backup': {label}");
         assert!(label.contains("7d"), "missing age: {label}");
@@ -6582,7 +6665,7 @@ mod tests {
 
     #[test]
     fn unprotected_escalation_away() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let label = unmounted_drive_label("WD-18TB1", Some(2592000), None, "UNPROTECTED");
         assert!(label.contains("WD-18TB1"), "missing label: {label}");
         assert!(label.contains("away"), "missing 'away': {label}");
@@ -6600,7 +6683,7 @@ mod tests {
 
     #[test]
     fn unprotected_escalation_last_backup() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let label = unmounted_drive_label("WD-18TB", None, Some(2592000), "UNPROTECTED");
         assert!(label.contains("last backup"), "missing 'last backup': {label}");
         assert!(label.contains("30d"), "missing age: {label}");
@@ -6614,7 +6697,7 @@ mod tests {
     fn unmounted_away_uses_absent_duration_not_activity() {
         // Voice-Contract-Rule-1 seed test: absent_duration_secs wins over
         // last_activity_age_secs; the right field drives the right label.
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let label = unmounted_drive_label("WD-18TB", Some(15 * 60), Some(7 * 86400), "PROTECTED");
         assert!(label.contains("15m"), "should render 15m: {label}");
         assert!(
@@ -6708,7 +6791,7 @@ mod tests {
 
     #[test]
     fn status_interactive_exposed_has_suggestion_line() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut data = test_status_output();
         // Provide advice so the suggestion line renders
         data.advice = vec![ActionableAdvice {
@@ -6726,8 +6809,8 @@ mod tests {
 
     #[test]
     fn default_status_healthy_has_help_hint() {
-        colored::control::set_override(false);
-        let data = test_default_all_sealed();
+        let _color = color_guard(false);
+        let data = test_default_status_output();
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
             output.contains("urd --help"),
@@ -6741,8 +6824,8 @@ mod tests {
 
     #[test]
     fn default_status_issues_suggests_status() {
-        colored::control::set_override(false);
-        let mut data = test_default_all_sealed();
+        let _color = color_guard(false);
+        let mut data = test_default_status_output();
         data.exposed_names = vec!["htpc-docs".to_string()];
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
@@ -6753,8 +6836,8 @@ mod tests {
 
     #[test]
     fn doctor_interactive_healthy_no_suggestion() {
-        colored::control::set_override(false);
-        let output = render_doctor(&test_doctor_healthy(), OutputMode::Interactive);
+        let _color = color_guard(false);
+        let output = render_doctor(&test_doctor_output(), OutputMode::Interactive);
         // Should have verdict "All clear." but no extra suggestion line
         assert!(output.contains("All clear."), "missing verdict: {output}");
         // The suggestion system returns None for doctor, so no "urd" command in suggestion
@@ -6765,7 +6848,7 @@ mod tests {
 
     #[test]
     fn render_transitions_interactive() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let mut summary = test_backup_summary();
         summary.transitions = vec![
             TransitionEvent::ThreadRestored {
@@ -6805,7 +6888,7 @@ mod tests {
 
     #[test]
     fn no_transitions_no_output() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let summary = test_backup_summary();
         assert!(summary.transitions.is_empty());
         let output = render_backup_summary(&summary, OutputMode::Interactive);
@@ -7122,7 +7205,7 @@ mod tests {
 
     #[test]
     fn drives_list_interactive_columns() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_drives_list(&test_drives_list(), OutputMode::Interactive);
         assert!(output.contains("DRIVE"), "should have header: {output}");
         assert!(output.contains("STATUS"), "should have header: {output}");
@@ -7141,7 +7224,7 @@ mod tests {
 
     #[test]
     fn drives_list_absent_shows_duration() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_drives_list(&test_drives_list(), OutputMode::Interactive);
         // The absent drive's last_seen is 2026-03-24, so "absent Nd" should appear
         assert!(
@@ -7152,7 +7235,7 @@ mod tests {
 
     #[test]
     fn drives_list_uuid_mismatch_shows_status() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_drives_list(&test_drives_list(), OutputMode::Interactive);
         assert!(
             output.contains("uuid mismatch"),
@@ -7162,7 +7245,7 @@ mod tests {
 
     #[test]
     fn drives_list_token_column_uses_ascii() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
         let output = render_drives_list(&test_drives_list(), OutputMode::Interactive);
         assert!(output.contains("ok"), "Verified token should show 'ok': {output}");
         // Token column should not contain Unicode check/cross marks
@@ -7183,7 +7266,7 @@ mod tests {
 
     #[test]
     fn drives_adopt_messages() {
-        colored::control::set_override(false);
+        let _color = color_guard(false);
 
         let adopted = DriveAdoptOutput {
             label: "WD-18TB".to_string(),

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -1,0 +1,887 @@
+// ── Voice contract tests ────────────────────────────────────────────────
+//
+// Encodes the seven-rule voice contract from the presentation-layer
+// manifesto as in-tree tests. Future voice changes can't silently regress
+// the falsehood/gravity fixes from UPI 026.
+//
+// Manifesto: docs/95-ideas/2026-04-06-presentation-layer-manifesto.md
+// If that path moves, grep the repo for "voice contract" or
+// "presentation-layer manifesto".
+//
+// Plan: docs/97-plans/2026-05-01-plan-035-voice-contract-tests.md
+//
+// All bodies in this file are `#[cfg(test)]`. Nothing here is compiled
+// into the production binary.
+//
+// Rules tested today (primitive ships):
+//   Rule 1 — No falsehoods (durations match labels)
+//   Rule 2 — No contradictions (no red on a sealed row)
+//   Rule 4 (partial) — Acknowledged transitions (TransitionEvent rendering)
+//   Rule 5 — First-line answer
+//   Rule 6 — Gravity calibration (red is earned)
+//
+// Rules deferred to UPI 024+ Voice Evolution (`#[ignore]` stubs at the
+// bottom of `mod contract`):
+//   Rule 3 — Time-aware messaging
+//   Rule 4 (drive-event part) — sentinel→awareness→voice ack of reconnection
+//   Rule 7 — Repeated-advisory suppression
+//
+// Color-override convention:
+//   Every contract test MUST call `helpers::set_color(true|false)` as its
+//   first statement. This is not optional — see PD-11 / R3 in the plan.
+//   Even tests that don't strictly need the override call it so whichever
+//   test runs second always sets its required state before reading
+//   colored output. If flakiness ever emerges,
+//   `cargo test -- --test-threads=1` is the documented escape hatch.
+
+#[cfg(test)]
+mod contract {
+    use crate::output::{BackupSummary, OutputMode, TransitionEvent};
+    use crate::voice::test_fixtures::{
+        color_guard, test_backup_summary, test_default_status_output, test_doctor_output,
+        test_plan_output, test_status_output, test_verify_output,
+    };
+    use crate::voice::{
+        render_backup_summary, render_default_status, render_doctor, render_first_time,
+        render_plan, render_status, render_verify,
+    };
+
+    mod helpers {
+        /// Strip ANSI escape sequences (CSI ... m form) from a string.
+        ///
+        /// Mirrors `voice::strip_ansi_len` but returns the stripped string
+        /// instead of just the length. Handles bare `\x1b[31m`,
+        /// compound `\x1b[1;31m` / `\x1b[31;1m`, and reset `\x1b[0m`.
+        pub(super) fn strip_ansi(s: &str) -> String {
+            let mut out = String::with_capacity(s.len());
+            let mut chars = s.chars().peekable();
+            while let Some(c) = chars.next() {
+                if c == '\u{1b}' && chars.peek() == Some(&'[') {
+                    chars.next(); // consume '['
+                    // Skip until we find the terminator (any final byte 0x40..=0x7e).
+                    for term in chars.by_ref() {
+                        if ('@'..='~').contains(&term) {
+                            break;
+                        }
+                    }
+                } else {
+                    out.push(c);
+                }
+            }
+            out
+        }
+
+        /// ANSI-stripped non-blank lines.
+        pub(super) fn non_blank_lines(s: &str) -> Vec<String> {
+            strip_ansi(s)
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| l.to_string())
+                .collect()
+        }
+
+        /// Find every (label, duration) pair in the ANSI-stripped output.
+        ///
+        /// Matches the case-sensitive shapes
+        ///   "away <N><unit>"
+        ///   "last backup <N><unit>"
+        ///   "Last backup <N><unit>"
+        /// where `<unit>` is one of `s m h d w y`. A trailing " ago" is
+        /// permitted but not required. Does NOT handle compound durations
+        /// like "1y6m" — those don't appear in voice.rs's current rendering.
+        pub(super) fn extract_label_age_pairs(s: &str) -> Vec<(String, String)> {
+            let stripped = strip_ansi(s);
+            let mut pairs = Vec::new();
+            for label in &["away", "last backup", "Last backup"] {
+                let mut search_from = 0;
+                while let Some(pos) = stripped[search_from..].find(label) {
+                    let abs = search_from + pos;
+                    // Boundary before label: start-of-string or non-alpha.
+                    let before_ok = abs == 0
+                        || !stripped[..abs]
+                            .chars()
+                            .next_back()
+                            .is_some_and(|c| c.is_ascii_alphabetic());
+                    let after_label = abs + label.len();
+                    if !before_ok {
+                        search_from = abs + label.len();
+                        continue;
+                    }
+                    // Skip exactly one whitespace run between label and duration.
+                    let rest = &stripped[after_label..];
+                    let trim_lead = rest.trim_start_matches([' ', '\t']);
+                    if trim_lead.len() == rest.len() {
+                        // No whitespace separator: not a label/age pair.
+                        search_from = after_label;
+                        continue;
+                    }
+                    // Capture digits, then exactly one unit char from [smhdwy].
+                    let digits: String =
+                        trim_lead.chars().take_while(|c| c.is_ascii_digit()).collect();
+                    if digits.is_empty() {
+                        search_from = after_label;
+                        continue;
+                    }
+                    let after_digits = &trim_lead[digits.len()..];
+                    let Some(unit) = after_digits.chars().next() else {
+                        search_from = after_label;
+                        continue;
+                    };
+                    if !matches!(unit, 's' | 'm' | 'h' | 'd' | 'w' | 'y') {
+                        search_from = after_label;
+                        continue;
+                    }
+                    pairs.push(((*label).to_string(), format!("{digits}{unit}")));
+                    // Advance past the consumed label + spaces + digits + unit
+                    // so adjacent matches don't double-count.
+                    let consumed = label.len() + (rest.len() - trim_lead.len()) + digits.len() + 1;
+                    search_from = abs + consumed;
+                }
+            }
+            pairs
+        }
+
+        /// Count ANSI escape sequences whose SGR parameter list contains
+        /// the target color code. Parses CSI ... m sequences and splits
+        /// the parameter list on `;`. Catches both bare `\x1b[31m` and
+        /// compound `\x1b[1;31m` / `\x1b[31;1m`.
+        fn count_sgr_color(s: &str, target: u8) -> usize {
+            let target_s = target.to_string();
+            let mut count = 0;
+            let bytes = s.as_bytes();
+            let mut i = 0;
+            while i < bytes.len() {
+                if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+                    let start = i + 2;
+                    let mut end = start;
+                    while end < bytes.len() {
+                        let b = bytes[end];
+                        if (0x40..=0x7e).contains(&b) {
+                            break;
+                        }
+                        end += 1;
+                    }
+                    if end < bytes.len() && bytes[end] == b'm' {
+                        let params = &s[start..end];
+                        if params.split(';').any(|p| p == target_s) {
+                            count += 1;
+                        }
+                    }
+                    i = end + 1;
+                } else {
+                    i += 1;
+                }
+            }
+            count
+        }
+
+        pub(super) fn count_red(s: &str) -> usize {
+            count_sgr_color(s, 31)
+        }
+
+        pub(super) fn count_yellow(s: &str) -> usize {
+            count_sgr_color(s, 33)
+        }
+
+        /// Identify "data rows" in a rendered status table.
+        ///
+        /// `format_status_table` emits rows whose cells are separated by
+        /// two spaces. A "data row" is a line whose first cell (after
+        /// ANSI strip and trim) equals one of the exposure-label tokens
+        /// `sealed`, `waning`, or `exposed`. Header rows (cell 0 =
+        /// `EXPOSURE`), summary lines (cell 0 is prose like
+        /// `All sealed.`), and advisory lines are excluded.
+        ///
+        /// Returns `Vec<(exposure_label, original_line_with_ansi)>`.
+        pub(super) fn data_rows_by_exposure(s: &str) -> Vec<(String, String)> {
+            let mut rows = Vec::new();
+            for line in s.lines() {
+                let stripped = strip_ansi(line);
+                let first_cell = stripped.split("  ").next().unwrap_or("").trim().to_string();
+                if matches!(first_cell.as_str(), "sealed" | "waning" | "exposed") {
+                    rows.push((first_cell, line.to_string()));
+                }
+            }
+            rows
+        }
+    }
+
+    // ── Helper unit tests ───────────────────────────────────────────────
+
+    #[test]
+    fn helper_strip_ansi_removes_compound_color_escapes() {
+        let _color = color_guard(false);
+        assert_eq!(helpers::strip_ansi("\x1b[31mX\x1b[0m"), "X");
+        assert_eq!(helpers::strip_ansi("\x1b[1;31mX\x1b[0m"), "X");
+        assert_eq!(helpers::strip_ansi("\x1b[31;1mX\x1b[0m"), "X");
+        assert_eq!(helpers::strip_ansi("plain text"), "plain text");
+    }
+
+    #[test]
+    fn helper_non_blank_lines_skips_blank_and_whitespace_only_lines() {
+        let _color = color_guard(false);
+        let input = "first\n\n   \nsecond\n\t\nthird\n";
+        let lines = helpers::non_blank_lines(input);
+        assert_eq!(lines, vec!["first", "second", "third"]);
+    }
+
+    #[test]
+    fn helper_extract_label_age_pairs_finds_known_label_shapes() {
+        let _color = color_guard(false);
+        // Positive cases.
+        let p = helpers::extract_label_age_pairs("away 3d");
+        assert_eq!(p, vec![("away".to_string(), "3d".to_string())]);
+
+        let p = helpers::extract_label_age_pairs("last backup 7d");
+        assert_eq!(p, vec![("last backup".to_string(), "7d".to_string())]);
+
+        let p = helpers::extract_label_age_pairs("Last backup 1h ago");
+        assert_eq!(p, vec![("Last backup".to_string(), "1h".to_string())]);
+
+        // Mixed line with both labels.
+        let p = helpers::extract_label_age_pairs("away 2d   last backup 5h ago");
+        assert!(p.contains(&("away".to_string(), "2d".to_string())));
+        assert!(p.contains(&("last backup".to_string(), "5h".to_string())));
+
+        // Negative cases — none should match.
+        assert!(helpers::extract_label_age_pairs("awayfar").is_empty());
+        assert!(helpers::extract_label_age_pairs("last backup soon").is_empty());
+        assert!(helpers::extract_label_age_pairs("Last backup —").is_empty());
+        assert!(helpers::extract_label_age_pairs("relayed 3d").is_empty());
+    }
+
+    #[test]
+    fn helper_count_red_matches_bare_and_compound_red() {
+        let _color = color_guard(false);
+        assert_eq!(helpers::count_red("\x1b[31mX\x1b[0m"), 1);
+        assert_eq!(helpers::count_red("\x1b[1;31mX\x1b[0m"), 1);
+        assert_eq!(helpers::count_red("\x1b[31;1mX\x1b[0m"), 1);
+        assert_eq!(helpers::count_red("\x1b[33mX\x1b[0m"), 0);
+        assert_eq!(helpers::count_red("plain text"), 0);
+        // Two distinct red sequences.
+        assert_eq!(helpers::count_red("\x1b[31mA\x1b[0m \x1b[1;31mB\x1b[0m"), 2);
+    }
+
+    #[test]
+    fn helper_color_guard_round_trip() {
+        use colored::Colorize;
+        {
+            let _color = color_guard(true);
+            let on = "X".red().to_string();
+            assert!(
+                on.contains('\u{1b}'),
+                "expected ANSI escape after color_guard(true), got {on:?}"
+            );
+        }
+        let _color = color_guard(false);
+        let off = "X".red().to_string();
+        assert_eq!(off, "X", "expected plain text after color_guard(false)");
+    }
+
+    // ── Rule 1 — No falsehoods (durations match labels) ─────────────────
+
+    /// Set the WD-18TB drive to unmounted across the canonical fixture so
+    /// the drive-summary line renders the unmounted_drive_label cascade.
+    /// Mutates both the data.drives entry and the per-assessment external
+    /// entries (which the aggregator reads for `absent_duration_secs` and
+    /// `last_activity_age_secs`).
+    fn unmount_wd18tb(
+        data: &mut crate::output::StatusOutput,
+        absent_secs: Option<i64>,
+        last_activity_secs: Option<i64>,
+    ) {
+        if let Some(d) = data.drives.iter_mut().find(|d| d.label == "WD-18TB") {
+            d.mounted = false;
+        }
+        for a in &mut data.assessments {
+            for e in a.external.iter_mut() {
+                if e.drive_label == "WD-18TB" {
+                    e.mounted = false;
+                    e.absent_duration_secs = absent_secs;
+                    e.last_activity_age_secs = last_activity_secs;
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rule1_status_unmounted_drive_no_event_uses_last_backup_not_away() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        unmount_wd18tb(&mut data, None, Some(259200)); // 3d
+        let output = render_status(&data, OutputMode::Interactive);
+        let stripped = helpers::strip_ansi(&output);
+        let drives_line = stripped
+            .lines()
+            .find(|l| l.contains("WD-18TB") && l.starts_with("Drives:"))
+            .unwrap_or_else(|| panic!("no Drives: line for WD-18TB in:\n{stripped}"));
+        assert!(
+            drives_line.contains("last backup"),
+            "expected 'last backup' on drive line, got: {drives_line}"
+        );
+        assert!(
+            !drives_line.contains("away"),
+            "must not synthesize 'away' when no Unmount event was recorded: {drives_line}"
+        );
+    }
+
+    #[test]
+    fn rule1_status_unmounted_drive_with_event_uses_away_not_last_backup() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        unmount_wd18tb(&mut data, Some(259200), None); // 3d Unmount event
+        let output = render_status(&data, OutputMode::Interactive);
+        let stripped = helpers::strip_ansi(&output);
+        let drives_line = stripped
+            .lines()
+            .find(|l| l.contains("WD-18TB") && l.starts_with("Drives:"))
+            .unwrap_or_else(|| panic!("no Drives: line for WD-18TB in:\n{stripped}"));
+        assert!(
+            drives_line.contains("away"),
+            "expected 'away' on drive line, got: {drives_line}"
+        );
+        assert!(
+            !drives_line.contains("last backup"),
+            "must not synthesize 'last backup' when an Unmount event drives the label: {drives_line}"
+        );
+    }
+
+    #[test]
+    fn rule1_status_no_data_renders_silent() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        unmount_wd18tb(&mut data, None, None);
+        let output = render_status(&data, OutputMode::Interactive);
+        let stripped = helpers::strip_ansi(&output);
+        let drives_line = stripped
+            .lines()
+            .find(|l| l.contains("WD-18TB") && l.starts_with("Drives:"))
+            .unwrap_or_else(|| panic!("no Drives: line for WD-18TB in:\n{stripped}"));
+        assert!(
+            !drives_line.contains("away"),
+            "must not invent 'away' with no data: {drives_line}"
+        );
+        assert!(
+            !drives_line.contains("last backup"),
+            "must not invent 'last backup' with no data: {drives_line}"
+        );
+        assert!(
+            drives_line.contains("disconnected"),
+            "expected 'disconnected' silent label, got: {drives_line}"
+        );
+    }
+
+    #[test]
+    fn rule1_default_status_last_backup_age_uses_last_run_age_secs() {
+        let _color = color_guard(false);
+        let mut data = test_default_status_output();
+        data.last_run_age_secs = Some(36000); // 10h
+        let output = render_default_status(&data, OutputMode::Interactive);
+        let pairs = helpers::extract_label_age_pairs(&output);
+        let last_backup = pairs.iter().find(|(l, _)| l == "Last backup");
+        let (_, dur) = last_backup
+            .unwrap_or_else(|| panic!("expected 'Last backup <age>' pair in:\n{output}"));
+        assert_eq!(
+            dur, "10h",
+            "10h derived from 36000s; got {dur} in:\n{output}"
+        );
+    }
+
+    #[test]
+    fn rule1_backup_summary_does_not_invent_age_information() {
+        let _color = color_guard(false);
+        let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
+        let pairs = helpers::extract_label_age_pairs(&output);
+        assert!(
+            pairs.is_empty(),
+            "backup summary fixture has no age fields populated; \
+             render must not synthesize any 'away'/'last backup' duration claims, \
+             got pairs={pairs:?} in:\n{output}"
+        );
+    }
+
+    // ── Rule 2 — No contradictions (no red on a sealed row) ────────────
+
+    /// Split a rendered status-table row into its non-empty cells. ANSI
+    /// codes (if any) are preserved on each cell. Cells in
+    /// `format_status_table` are "  "-separated, but per-cell padding
+    /// inserts additional spaces, so we drop empty splits.
+    fn split_row_cells(row: &str) -> Vec<&str> {
+        row.split("  ").filter(|c| !c.trim().is_empty()).collect()
+    }
+
+    #[test]
+    fn rule2_sealed_row_blocked_health_no_red_outside_health_cell() {
+        let _color = color_guard(true);
+        let mut data = test_status_output();
+        // Sealed assessment with blocked operational health — Rule 2's
+        // contradiction territory.
+        data.assessments[0].health = "blocked".to_string();
+        data.assessments[0].health_reasons = vec!["chain broken on WD-18TB".to_string()];
+        let output = render_status(&data, OutputMode::Interactive);
+        let rows = helpers::data_rows_by_exposure(&output);
+        let sealed = rows
+            .iter()
+            .find(|(label, _)| label == "sealed")
+            .unwrap_or_else(|| panic!("no sealed row in:\n{output}"));
+        let cells = split_row_cells(&sealed.1);
+        assert_eq!(
+            helpers::count_red(cells[0]),
+            0,
+            "EXPOSURE cell must not be red on a sealed row, cell={:?}",
+            cells[0]
+        );
+        // HEALTH cell red is the contradiction itself — permitted here.
+        // We do, however, sanity-check that the colorist did emit red
+        // somewhere on the row (otherwise the test wouldn't catch a
+        // future regression that turns the EXPOSURE cell red too).
+        assert!(
+            helpers::count_red(&sealed.1) >= 1,
+            "expected red somewhere on the row (HEALTH cell), got: {}",
+            sealed.1
+        );
+    }
+
+    #[test]
+    fn rule2_sealed_row_degraded_health_yellow_only_in_health_cell() {
+        let _color = color_guard(true);
+        let mut data = test_status_output();
+        data.assessments[0].health = "degraded".to_string();
+        data.assessments[0].health_reasons = vec!["one drive lagging".to_string()];
+        let output = render_status(&data, OutputMode::Interactive);
+        let rows = helpers::data_rows_by_exposure(&output);
+        let sealed = rows
+            .iter()
+            .find(|(label, _)| label == "sealed")
+            .unwrap_or_else(|| panic!("no sealed row in:\n{output}"));
+        assert_eq!(
+            helpers::count_red(&sealed.1),
+            0,
+            "no red anywhere on a sealed row even with degraded health, got: {}",
+            sealed.1
+        );
+        assert!(
+            helpers::count_yellow(&sealed.1) >= 1,
+            "expected yellow on HEALTH cell for degraded health, got: {}",
+            sealed.1
+        );
+    }
+
+    // ── Rule 4 (partial) — Acknowledged transitions ────────────────────
+
+    fn backup_with_transitions(transitions: Vec<TransitionEvent>) -> BackupSummary {
+        let mut s = test_backup_summary();
+        s.transitions = transitions;
+        s
+    }
+
+    #[test]
+    fn rule4_thread_restored_renders_thread_to_drive_mended() {
+        let _color = color_guard(false);
+        let s = backup_with_transitions(vec![TransitionEvent::ThreadRestored {
+            subvolume: "htpc-home".to_string(),
+            drive: "WD-18TB".to_string(),
+        }]);
+        let output = render_backup_summary(&s, OutputMode::Interactive);
+        assert!(
+            output.contains("thread to WD-18TB mended"),
+            "expected 'thread to WD-18TB mended' in:\n{output}"
+        );
+    }
+
+    #[test]
+    fn rule4_first_send_to_drive_renders_first_thread_established() {
+        let _color = color_guard(false);
+        let s = backup_with_transitions(vec![TransitionEvent::FirstSendToDrive {
+            subvolume: "htpc-home".to_string(),
+            drive: "Offsite-4TB".to_string(),
+        }]);
+        let output = render_backup_summary(&s, OutputMode::Interactive);
+        assert!(
+            output.contains("first thread to Offsite-4TB established"),
+            "expected 'first thread to Offsite-4TB established' in:\n{output}"
+        );
+    }
+
+    #[test]
+    fn rule4_all_sealed_renders_all_threads_hold() {
+        let _color = color_guard(false);
+        let s = backup_with_transitions(vec![TransitionEvent::AllSealed]);
+        let output = render_backup_summary(&s, OutputMode::Interactive);
+        assert!(
+            output.contains("All threads hold"),
+            "expected 'All threads hold' in:\n{output}"
+        );
+    }
+
+    #[test]
+    fn rule4_promise_recovered_renders_arrow_with_exposure_labels() {
+        let _color = color_guard(false);
+        let s = backup_with_transitions(vec![TransitionEvent::PromiseRecovered {
+            subvolume: "htpc-home".to_string(),
+            from: "UNPROTECTED".to_string(),
+            to: "PROTECTED".to_string(),
+        }]);
+        let output = render_backup_summary(&s, OutputMode::Interactive);
+        // The recovered transition uses exposure vocabulary, not raw promise strings.
+        assert!(
+            output.contains("exposed \u{2192} sealed"),
+            "expected 'exposed → sealed' (exposure vocabulary, not raw status), in:\n{output}"
+        );
+        assert!(
+            !output.contains("UNPROTECTED \u{2192}") && !output.contains("\u{2192} PROTECTED"),
+            "must not render raw promise status strings on the arrow line: {output}"
+        );
+    }
+
+    #[test]
+    fn rule4_empty_transitions_vec_silent() {
+        let _color = color_guard(false);
+        let s = backup_with_transitions(vec![]);
+        let output = render_backup_summary(&s, OutputMode::Interactive);
+        // None of the four mythic markers may appear.
+        assert!(
+            !output.contains("thread to "),
+            "must not render 'thread to <drive>' with empty transitions: {output}"
+        );
+        assert!(
+            !output.contains("All threads hold"),
+            "must not render 'All threads hold' with empty transitions: {output}"
+        );
+        assert!(
+            !output.contains("first thread to"),
+            "must not render 'first thread' with empty transitions: {output}"
+        );
+        assert!(
+            !output.contains("\u{2192} sealed"),
+            "must not render '→ sealed' with empty transitions: {output}"
+        );
+    }
+
+    // ── Rule 5 — First-line answer ─────────────────────────────────────
+
+    #[test]
+    fn rule5_bare_urd_first_line_contains_sealed_token() {
+        let _color = color_guard(false);
+        let output = render_default_status(&test_default_status_output(), OutputMode::Interactive);
+        let first = helpers::non_blank_lines(&output)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("empty output for bare urd:\n{output}"));
+        assert!(
+            first.contains("sealed"),
+            "first non-blank line of bare `urd` must contain 'sealed', got: {first}"
+        );
+    }
+
+    #[test]
+    fn rule5_status_first_line_contains_sealed_token() {
+        let _color = color_guard(false);
+        let output = render_status(&test_status_output(), OutputMode::Interactive);
+        let first = helpers::non_blank_lines(&output)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("empty status output:\n{output}"));
+        assert!(
+            first.contains("sealed"),
+            "first non-blank line of `urd status` must contain 'sealed', got: {first}"
+        );
+    }
+
+    /// FINDING (Rule 5 violation in current rendering): `render_plan`
+    /// emits "Urd backup plan for {timestamp}" as its first non-blank
+    /// line. The list of operations (or "Nothing to do.") only appears
+    /// after the header. Rule 5 demands the first non-blank line answer
+    /// the question. File as a fast-follow under the "Voice gravity
+    /// audit" UPI alongside the doctor finding (PD-3 / R4). Marked
+    /// `#[ignore]` so the contract is documented without breaking the
+    /// suite.
+    #[test]
+    #[ignore = "finding: plan first non-blank line is 'Urd backup plan for {ts}' rather than the operation count or 'Nothing to do.'; fix in voice gravity audit UPI"]
+    fn rule5_plan_first_line_contains_operations_or_sealed_or_no_backups() {
+        let _color = color_guard(false);
+        // Non-empty plan: lifted fixture has 2 operations, 1 send.
+        let non_empty = test_plan_output();
+        let output = render_plan(&non_empty, OutputMode::Interactive);
+        let first = helpers::non_blank_lines(&output)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("empty plan output:\n{output}"));
+        assert!(
+            first.contains("operations") || first.contains("All sealed") || first.contains("No backups planned"),
+            "first non-blank line of `urd plan` must answer the question \
+             ('operations'/'All sealed'/'No backups planned'), got: {first}"
+        );
+        // Empty plan branch.
+        let mut empty = test_plan_output();
+        empty.operations.clear();
+        empty.summary = crate::output::PlanSummaryOutput {
+            snapshots: 0,
+            sends: 0,
+            deletions: 0,
+            skipped: 0,
+            estimated_total_bytes: None,
+        };
+        let output = render_plan(&empty, OutputMode::Interactive);
+        let first = helpers::non_blank_lines(&output)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("empty plan output:\n{output}"));
+        assert!(
+            first.contains("operations") || first.contains("All sealed") || first.contains("No backups planned"),
+            "first non-blank line of empty `urd plan` must answer the question, got: {first}"
+        );
+    }
+
+    #[test]
+    fn rule5_backup_first_line_contains_urd_backup_header() {
+        let _color = color_guard(false);
+        let output = render_backup_summary(&test_backup_summary(), OutputMode::Interactive);
+        let first = helpers::non_blank_lines(&output)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("empty backup output:\n{output}"));
+        assert!(
+            first.contains("Urd backup"),
+            "first non-blank line of `urd backup` must contain 'Urd backup', got: {first}"
+        );
+    }
+
+    /// FINDING (Rule 5 violation in current rendering): `render_doctor`
+    /// emits "Checking Urd health..." as its first non-blank line, then
+    /// the verdict line ("All clear." / "N warnings." / "N issues found.")
+    /// only at the END of the output. Rule 5 demands the first non-blank
+    /// line answer the question. File as a fast-follow under the
+    /// "Voice gravity audit" UPI (PD-3 / R4). Marked `#[ignore]` so the
+    /// contract is documented but the suite is green; remove the
+    /// `#[ignore]` once doctor's verdict is hoisted to the first line.
+    #[test]
+    #[ignore = "finding: doctor first non-blank line is 'Checking Urd health...' rather than the verdict; fix in voice gravity audit UPI"]
+    fn rule5_doctor_first_line_is_verdict_or_check_count() {
+        let _color = color_guard(false);
+        let output = render_doctor(&test_doctor_output(), OutputMode::Interactive);
+        let first = helpers::non_blank_lines(&output)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("empty doctor output:\n{output}"));
+        assert!(
+            first.contains("warnings")
+                || first.contains("checks")
+                || first.contains("All clear"),
+            "first non-blank line of `urd doctor` must answer the question \
+             ('warnings'/'checks'/'All clear'), got: {first}"
+        );
+    }
+
+    #[test]
+    fn rule5_verify_first_line_contains_verified_or_ok_or_broken() {
+        let _color = color_guard(false);
+        let output = render_verify(&test_verify_output(), OutputMode::Interactive, false);
+        let first = helpers::non_blank_lines(&output)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("empty verify output:\n{output}"));
+        assert!(
+            first.contains("verified") || first.contains("OK") || first.contains("broken"),
+            "first non-blank line of `urd verify` must answer the question \
+             ('verified'/'OK'/'broken'), got: {first}"
+        );
+    }
+
+    // ── Rule 6 — Gravity calibration (red is earned) ──────────────────
+
+    /// Build a fully-sealed StatusOutput by promoting the canonical
+    /// fixture's AT-RISK assessment to PROTECTED and clearing all
+    /// degraded/blocked health on both subvolumes.
+    fn all_sealed_status() -> crate::output::StatusOutput {
+        let mut data = test_status_output();
+        for a in &mut data.assessments {
+            a.status = "PROTECTED".to_string();
+            a.health = "healthy".to_string();
+            a.health_reasons.clear();
+            a.local_status = "PROTECTED".to_string();
+            for e in a.external.iter_mut() {
+                e.status = "PROTECTED".to_string();
+                e.mounted = true;
+                if e.snapshot_count.is_none() {
+                    e.snapshot_count = Some(12);
+                }
+                if e.last_send_age_secs.is_none() {
+                    e.last_send_age_secs = Some(7200);
+                }
+            }
+        }
+        // Mark all drives mounted with ample free space — the canonical
+        // fixture has Offsite-4TB unmounted, which is acceptable since
+        // unmounted offsite drives don't trigger red.
+        for d in data.drives.iter_mut() {
+            if d.label == "WD-18TB" {
+                d.mounted = true;
+                d.free_bytes = Some(5_000_000_000_000);
+            }
+        }
+        data
+    }
+
+    #[test]
+    fn rule6_all_sealed_status_renders_zero_red_sgr_escapes() {
+        let _color = color_guard(true);
+        let data = all_sealed_status();
+        let output = render_status(&data, OutputMode::Interactive);
+        assert_eq!(
+            helpers::count_red(&output),
+            0,
+            "fully-sealed status output must have zero red SGR escapes \
+             (regression-prevention for UPI 026's false 'blocked' red on a \
+             healthy drive); count_red parses both bare \\x1b[31m and \
+             compound \\x1b[1;31m / \\x1b[31;1m. Got output:\n{output}"
+        );
+    }
+
+    #[test]
+    fn rule6_unprotected_row_emits_red_on_exposure_cell() {
+        let _color = color_guard(true);
+        let mut data = test_status_output();
+        data.assessments[1].status = "UNPROTECTED".to_string();
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            helpers::count_red(&output) >= 1,
+            "exposed status row must emit at least one earned red \
+             (negative control: confirms the colorist is on); got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn rule6_backup_failure_result_emits_red() {
+        let _color = color_guard(true);
+        let mut s = test_backup_summary();
+        s.result = "failure".to_string();
+        s.subvolumes[0].success = false;
+        let output = render_backup_summary(&s, OutputMode::Interactive);
+        assert!(
+            helpers::count_red(&output) >= 1,
+            "backup summary with result='failure' must emit at least one \
+             earned red (negative control); got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn rule6_blocked_health_emits_red_only_on_health_cell() {
+        let _color = color_guard(true);
+        let mut data = test_status_output();
+        data.assessments[0].status = "PROTECTED".to_string();
+        data.assessments[0].health = "blocked".to_string();
+        data.assessments[0].health_reasons = vec!["chain broken on WD-18TB".to_string()];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            helpers::count_red(&output) >= 1,
+            "PROTECTED + blocked must emit earned red on the HEALTH cell \
+             (paired with Rule 2's no-red-outside-HEALTH check); got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn rule5_first_time_renders_not_configured_yet() {
+        let _color = color_guard(false);
+        let output = render_first_time(OutputMode::Interactive);
+        assert!(
+            output.starts_with("Urd is not configured yet."),
+            "first-time output must literally start with \
+             'Urd is not configured yet.', got: {output}"
+        );
+    }
+
+    #[test]
+    fn rule2_negative_control_unprotected_row_red_allowed() {
+        let _color = color_guard(true);
+        let mut data = test_status_output();
+        // Promote the AT RISK assessment to UNPROTECTED so the exposure
+        // label becomes "exposed" — earned-red territory.
+        data.assessments[1].status = "UNPROTECTED".to_string();
+        let output = render_status(&data, OutputMode::Interactive);
+        let rows = helpers::data_rows_by_exposure(&output);
+        let exposed = rows
+            .iter()
+            .find(|(label, _)| label == "exposed")
+            .unwrap_or_else(|| panic!("no exposed row in:\n{output}"));
+        assert!(
+            helpers::count_red(&exposed.1) >= 1,
+            "exposed row must have at least one earned red (negative control), got: {}",
+            exposed.1
+        );
+    }
+
+    #[test]
+    fn rule1_status_external_only_no_local_age_emitted() {
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        // external_only subvolume with a deliberately stale local age — table must ignore it.
+        data.assessments[0].external_only = true;
+        data.assessments[0].local_snapshot_count = 3;
+        data.assessments[0].local_newest_age_secs = Some(1_800_000); // ~21d — stale
+        let output = render_status(&data, OutputMode::Interactive);
+        let stripped = helpers::strip_ansi(&output);
+        // Find the htpc-home row and inspect its LOCAL cell.
+        let row = stripped
+            .lines()
+            .find(|l| l.contains("htpc-home") && l.contains("sealed"))
+            .unwrap_or_else(|| panic!("no sealed htpc-home row in:\n{stripped}"));
+        let cells: Vec<&str> = split_row_cells(row).iter().map(|c| c.trim()).collect();
+        // Columns: EXPOSURE HEALTH SUBVOLUME LOCAL WD-18TB THREAD.
+        let local_idx = cells
+            .iter()
+            .position(|c| *c == "htpc-home")
+            .map(|i| i + 1)
+            .unwrap_or_else(|| panic!("htpc-home not found in cells={cells:?}"));
+        assert_eq!(
+            cells.get(local_idx).copied(),
+            Some("\u{2014}"),
+            "external_only LOCAL cell must be em-dash (—), not a count/age; cells={cells:?}"
+        );
+        // And the stale 1_800_000-derived duration (e.g. "21d", "3w") must not appear at all on this row.
+        assert!(
+            !row.contains("21d") && !row.contains("3w"),
+            "external_only row must not surface the suppressed local age, got: {row}"
+        );
+    }
+
+    // ── Deferred — Rules 3, 4-drive, 7 (UPI 024+ Voice Evolution) ─────
+    //
+    // These rules require primitives that don't ship yet (per-status
+    // time-aware label tiers, sentinel→awareness→voice drive-event ack,
+    // last-shown-N-runs-ago state). The stubs document the intended
+    // assertions so future-us can fill them in once UPI 024+ lands.
+    //
+    // `unimplemented!()` is used over `todo!()` per F7 — same panic
+    // semantics, but signals "this isn't on the current TODO list" more
+    // precisely. Running `cargo test -- --ignored` will panic on these
+    // by design.
+
+    #[test]
+    #[ignore = "Unblocked by UPI 024+ Voice Evolution (Phase 2: time-aware messaging)"]
+    fn rule3_repeated_advisory_must_change_language_or_position() {
+        // When 024+ ships per-status time-aware label tiers, render two
+        // consecutive status outputs with the same advisory and assert
+        // the second's wording differs from the first.
+        unimplemented!("UPI 024+ Voice Evolution — see voice_contract.rs header");
+    }
+
+    #[test]
+    #[ignore = "Unblocked by UPI 024+ Voice Evolution (sentinel→awareness→voice path)"]
+    fn rule4_drive_reconnect_after_absence_acks_the_event() {
+        // When 024+ wires drive-event acknowledgement through awareness,
+        // simulate a drive reconnect after absence and assert the next
+        // backup summary calls out the reconnection (e.g. "WD-18TB
+        // returned").
+        unimplemented!("UPI 024+ Voice Evolution — see voice_contract.rs header");
+    }
+
+    #[test]
+    #[ignore = "Unblocked by UPI 024+ or beyond (last-shown N runs ago state)"]
+    fn rule7_repeated_advisory_must_be_suppressed_when_unchanged() {
+        // When the last-shown-N-runs-ago state ships, render the same
+        // advisory across multiple consecutive runs and assert it
+        // appears in run 1 and run K but is suppressed in runs 2..K-1.
+        unimplemented!("UPI 024+ Voice Evolution — see voice_contract.rs header");
+    }
+}

--- a/src/voice_events.rs
+++ b/src/voice_events.rs
@@ -236,13 +236,13 @@ mod tests {
         }
     }
 
-    fn setup() {
-        colored::control::set_override(false);
+    fn setup() -> std::sync::MutexGuard<'static, ()> {
+        crate::voice::test_fixtures::color_guard(false)
     }
 
     #[test]
     fn render_empty_shows_dimmed_message() {
-        setup();
+        let _color = setup();
         let view = EventsView {
             events: vec![],
             applied_filter: empty_filter(),
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn render_retention_prune() {
-        setup();
+        let _color = setup();
         let row = make_row(
             EventPayload::RetentionPrune {
                 snapshot: "20260423-0400-htpc-home".into(),
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn render_retention_protect_uses_mythic_verb() {
-        setup();
+        let _color = setup();
         let row = make_row(
             EventPayload::RetentionProtect {
                 snapshot: "20240101-htpc-home".into(),
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn render_planner_send_choice_shows_drive_and_reason() {
-        setup();
+        let _color = setup();
         let row = make_row(
             EventPayload::PlannerSendChoice {
                 send_kind: crate::types::SendKind::Full,
@@ -306,7 +306,7 @@ mod tests {
 
     #[test]
     fn render_planner_defer_shows_reason() {
-        setup();
+        let _color = setup();
         let row = make_row(
             EventPayload::PlannerDefer {
                 reason: "interval not elapsed (next in ~30m)".into(),
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn render_promise_transition_degradation_uses_frayed_verb() {
-        setup();
+        let _color = setup();
         let row = make_row(
             EventPayload::PromiseTransition {
                 from: crate::awareness::PromiseStatus::Protected,
@@ -339,7 +339,7 @@ mod tests {
 
     #[test]
     fn render_promise_transition_recovery_uses_mended_verb() {
-        setup();
+        let _color = setup();
         let row = make_row(
             EventPayload::PromiseTransition {
                 from: crate::awareness::PromiseStatus::Unprotected,
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn render_sentinel_circuit_break() {
-        setup();
+        let _color = setup();
         let row = make_row(
             EventPayload::SentinelCircuitBreak {
                 from: crate::sentinel::CircuitState::Closed,
@@ -374,7 +374,7 @@ mod tests {
 
     #[test]
     fn render_drive_mount_unmount() {
-        setup();
+        let _color = setup();
         let mounted = make_row(
             EventPayload::DriveMounted {
                 detected_by: DriveEventSource::Sentinel,
@@ -396,7 +396,7 @@ mod tests {
 
     #[test]
     fn render_config_reload_success_and_fail() {
-        setup();
+        let _color = setup();
         let ok = make_row(
             EventPayload::ConfigReloaded {
                 config_version: "1".into(),
@@ -420,6 +420,7 @@ mod tests {
 
     #[test]
     fn ndjson_one_line_per_event_round_trips() {
+        let _color = setup();
         let row = make_row(
             EventPayload::PlannerDefer {
                 reason: "interval not elapsed".into(),
@@ -445,6 +446,7 @@ mod tests {
 
     #[test]
     fn truncate_is_char_boundary_safe() {
+        let _color = setup();
         // Multibyte char near the boundary should not panic.
         let s = "café-café-café";
         let _ = truncate(s, 6);


### PR DESCRIPTION
## Summary

- Encodes the seven-rule presentation-layer voice contract as in-tree tests so future voice changes can't silently regress UPI 026's falsehood/gravity fixes. 28 active tests cover Rules 1, 2, 4-partial, 5, 6 plus 5 helper unit tests; 3 `#[ignore]`'d stubs cover Rules 3, 4-drive, 7 (deferred to UPI 024+).
- Lifts shared fixtures (`test_status_output`, `test_backup_summary`, `test_default_status_output`, `test_doctor_output`, `test_verify_output`, `test_plan_output`) into a sibling `voice::test_fixtures` module so contract and unit tests share canonical shapes.
- Adds a `color_guard()` Mutex-backed helper that all 130+ voice / voice_events / voice_contract tests now route through, eliminating the parallel-test race on the `colored` crate's global override that Rule 6's `set_override(true)` tests would otherwise hit.
- Surfaces two findings as `#[ignore]`'d tests: `render_doctor` and `render_plan` both emit a process-header first non-blank line rather than the verdict / operation count Rule 5 demands. Per the plan's R4, marked `#[ignore]` with a `finding:` prefix rather than relaxed; fix belongs in the upcoming Voice gravity audit UPI.
- Zero production-code changes — voice.rs's 7,400+ rendering lines are untouched. Voice rendering is exercised through its existing public API.

## Testing

- `cargo clippy --all-targets -- -D warnings`: PASS
- `cargo test`: PASS — 1132 passed, 0 failed, 5 ignored (3 deferred-rule stubs + 2 documented findings)
- `cargo build --release`: PASS
- `cargo test -- --ignored`: 5 panics by design (deferred stubs use `unimplemented!()`; finding stubs surface their assertion message)
- Stability: ran `cargo test` 5+ times after switching to `color_guard()` — no flakes; wall-time ~1.05s
- Integration tests: not applicable (tests-only patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)