### PR TITLE
feat: drift telemetry (UPI 030, ADR-113 Layer 0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Drift telemetry (UPI 030, ADR-113 Layer 0): a new `src/drift.rs` pure
+  module aggregates per-send wire bytes into a rolling time-windowed
+  churn rate, persisted in a new `drift_samples` SQLite table populated
+  by a one-shot idempotent backfill from `operations` history on first
+  open. Each backup run writes one drift sample per `(run_id, subvolume)`
+  derived from the first successful send in plan order. Heartbeat schema
+  bumps 2 → 3 with two additive `Option` fields
+  (`churn_bytes_per_second`, `last_full_send_bytes`); two new Prometheus
+  gauges (`backup_subvolume_churn_bytes_per_second`,
+  `backup_subvolume_last_full_send_bytes`) expose the same signal in
+  base units. `urd doctor --thorough` gains a Churn section with a
+  five-state ladder (cold-start, first measurement, incremental,
+  full-send-only first, full-send-only) and a bursty-churn disclaimer.
 - Voice contract tests (UPI 035): a new `src/voice_contract.rs` test
   module encodes the seven-rule presentation-layer contract (no
   falsehoods, no contradictions, acknowledged transitions, first-line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-05-01
+
 ### Added
 - Drift telemetry (UPI 030, ADR-113 Layer 0): a new `src/drift.rs` pure
   module aggregates per-send wire bytes into a rolling time-windowed
@@ -391,7 +393,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/vonrobak/urd/compare/v0.14.0...v0.15.0
+[0.14.0]: https://github.com/vonrobak/urd/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/vonrobak/urd/compare/v0.12.2...v0.13.0
 [0.12.2]: https://github.com/vonrobak/urd/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/vonrobak/urd/compare/v0.12.0...v0.12.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ All backup logic flows through: config -> plan -> execute. No exceptions.
 | `heartbeat.rs` | Write JSON health signal after each run | Block backups on failure |
 | `metrics.rs` | Write Prometheus `.prom` files | Read metrics |
 | `notify.rs` | Compute and dispatch notifications | Decide promise states (uses awareness) |
+| `drift.rs` | Pure: rolling time-windowed churn aggregation from `drift_samples` (UPI 030) | Perform I/O or persist |
 | `drives.rs` | Detect mounted drives, UUID fingerprinting, check space | Mount/unmount drives |
 | `output.rs` | Define structured output types | Render text (voice.rs does that) |
 | `voice.rs` | Render structured output as text (mythic voice) | Perform I/O or compute state |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -19,8 +19,9 @@ use crate::heartbeat;
 use crate::lock;
 use crate::metrics::{self, MetricsData, SubvolumeMetrics};
 use crate::output::{
-    BackupSummary, DeferredInfo, EmptyPlanExplanation, OutputMode, SendSummary, SkipCategory,
-    SkippedSubvolume, StatusAssessment, StructuredError, SubvolumeSummary, TransitionEvent,
+    BackupSummary, ChurnHeartbeatFields, ChurnRender, DeferredInfo, EmptyPlanExplanation,
+    OutputMode, SendSummary, SkipCategory, SkippedSubvolume, StatusAssessment, StructuredError,
+    SubvolumeSummary, TransitionEvent,
 };
 use crate::notify;
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
@@ -116,12 +117,13 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         } else {
             println!("{}", "Nothing to do.".dimmed());
         }
-        write_metrics_for_skipped(&config, &backup_plan, now, &fs_state)?;
         let heartbeat_now = chrono::Local::now().naive_local();
+        let churn_views = build_churn_views(&config, state_db.as_ref(), heartbeat_now);
+        write_metrics_for_skipped(&config, &backup_plan, now, &fs_state, &churn_views)?;
         let previous_hb = heartbeat::read(&config.general.heartbeat_file);
         let mut assessments = awareness::assess(&config, heartbeat_now, &fs_state);
         awareness::overlay_offsite_freshness(&mut assessments, &config);
-        let hb = heartbeat::build_empty(&config, heartbeat_now, &assessments);
+        let hb = heartbeat::build_empty(&config, heartbeat_now, &assessments, &churn_views);
         if let Err(e) = heartbeat::write(&config.general.heartbeat_file, &hb) {
             log::warn!("Failed to write heartbeat: {e}");
         }
@@ -290,17 +292,21 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         h.join().ok();
     }
 
-    // Write metrics
-    write_metrics_after_execution(&config, &result, &backup_plan, now, &fs_state)?;
-
     // Read previous heartbeat BEFORE writing the new one (notification comparison).
     let previous_hb = heartbeat::read(&config.general.heartbeat_file);
 
-    // Write heartbeat (fresh timestamp — `now` is from before execution)
+    // Compute churn views from the just-recorded drift samples, then thread
+    // the same projection into both metrics and heartbeat (UPI 030).
     let heartbeat_now = chrono::Local::now().naive_local();
+    let churn_views = build_churn_views(&config, state_db.as_ref(), heartbeat_now);
+
+    // Write metrics
+    write_metrics_after_execution(&config, &result, &backup_plan, now, &fs_state, &churn_views)?;
+
+    // Write heartbeat (fresh timestamp — `now` is from before execution)
     let mut assessments = awareness::assess(&config, heartbeat_now, &fs_state);
     awareness::overlay_offsite_freshness(&mut assessments, &config);
-    let hb = heartbeat::build_from_run(&config, heartbeat_now, &result, &assessments);
+    let hb = heartbeat::build_from_run(&config, heartbeat_now, &result, &assessments, &churn_views);
     if let Err(e) = heartbeat::write(&config.general.heartbeat_file, &hb) {
         log::warn!("Failed to write heartbeat: {e}");
     }
@@ -583,6 +589,7 @@ fn write_metrics_after_execution(
     plan: &crate::types::BackupPlan,
     now: chrono::NaiveDateTime,
     fs_state: &dyn FileSystemState,
+    churn_views: &HashMap<String, ChurnHeartbeatFields>,
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
     let mut subvolume_metrics = Vec::new();
@@ -598,6 +605,7 @@ fn write_metrics_after_execution(
 
         let local_count = count_local_snapshots(config, &sv_result.name, fs_state);
         let external_count = count_external_snapshots(config, &sv_result.name, fs_state);
+        let churn = churn_views.get(&sv_result.name).copied().unwrap_or_default();
 
         subvolume_metrics.push(SubvolumeMetrics {
             name: sv_result.name.clone(),
@@ -607,6 +615,8 @@ fn write_metrics_after_execution(
             local_snapshot_count: local_count,
             external_snapshot_count: external_count,
             send_type: sv_result.send_type.metric_value(),
+            churn_bytes_per_second: churn.churn_bytes_per_second,
+            last_full_send_bytes: churn.last_full_send_bytes,
         });
     }
 
@@ -622,6 +632,7 @@ fn write_metrics_after_execution(
         fs_state,
         &mut subvolume_metrics,
         &already_emitted,
+        churn_views,
     );
 
     // Carry forward last_success_timestamp from previous .prom file
@@ -636,6 +647,7 @@ fn write_metrics_for_skipped(
     plan: &crate::types::BackupPlan,
     now: chrono::NaiveDateTime,
     fs_state: &dyn FileSystemState,
+    churn_views: &HashMap<String, ChurnHeartbeatFields>,
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
     let mut subvolume_metrics = Vec::new();
@@ -646,6 +658,7 @@ fn write_metrics_for_skipped(
         fs_state,
         &mut subvolume_metrics,
         &HashSet::new(),
+        churn_views,
     );
 
     // Carry forward last_success_timestamp from previous .prom file
@@ -653,6 +666,54 @@ fn write_metrics_for_skipped(
     metrics::apply_carried_forward_timestamps(&mut subvolume_metrics, &carried);
 
     write_global_metrics(config, now_ts, subvolume_metrics)
+}
+
+/// Compute heartbeat / metrics churn projections for every configured
+/// subvolume. UPI 030: queries `drift_samples` for each subvolume, runs the
+/// pure aggregator, and projects the render to two flat fields.
+///
+/// Returns an empty map when `state_db` is `None` (no churn data available).
+/// Errors querying drift samples for any one subvolume produce `Default`
+/// (both fields `None`) for that subvolume — best-effort, never fatal.
+fn build_churn_views(
+    config: &Config,
+    state_db: Option<&StateDb>,
+    now: chrono::NaiveDateTime,
+) -> HashMap<String, ChurnHeartbeatFields> {
+    let mut out: HashMap<String, ChurnHeartbeatFields> = HashMap::new();
+    let Some(db) = state_db else { return out };
+    let since = now - crate::drift::default_window();
+    for sv in config.subvolumes.iter() {
+        let rows = match db.drift_samples_for_subvolume(&sv.name, since) {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("drift query failed for {}: {e}", sv.name);
+                continue;
+            }
+        };
+        let samples: Vec<crate::drift::DriftSample> =
+            rows.into_iter().map(StateDb::drift_row_to_sample).collect();
+        let estimate =
+            crate::drift::compute_rolling_churn(&samples, crate::drift::default_window(), now);
+        let fields = match crate::output::render_churn(&estimate) {
+            ChurnRender::NotMeasured => ChurnHeartbeatFields::default(),
+            ChurnRender::FirstMeasurement { bytes_per_second }
+            | ChurnRender::Incremental { bytes_per_second } => ChurnHeartbeatFields {
+                churn_bytes_per_second: Some(bytes_per_second),
+                last_full_send_bytes: None,
+            },
+            ChurnRender::FullSendOnly { .. } => ChurnHeartbeatFields {
+                churn_bytes_per_second: None,
+                last_full_send_bytes: estimate.latest_full_bytes,
+            },
+            ChurnRender::FullSendOnlyFirst { bytes } => ChurnHeartbeatFields {
+                churn_bytes_per_second: None,
+                last_full_send_bytes: Some(bytes),
+            },
+        };
+        out.insert(sv.name.clone(), fields);
+    }
+    out
 }
 
 fn build_empty_plan_explanation(
@@ -731,6 +792,7 @@ fn append_skipped_metrics(
     fs_state: &dyn FileSystemState,
     subvolume_metrics: &mut Vec<SubvolumeMetrics>,
     already_emitted: &HashSet<String>,
+    churn_views: &HashMap<String, ChurnHeartbeatFields>,
 ) {
     let mut seen = already_emitted.clone();
 
@@ -741,6 +803,7 @@ fn append_skipped_metrics(
 
         let local_count = count_local_snapshots(config, name, fs_state);
         let external_count = count_external_snapshots(config, name, fs_state);
+        let churn = churn_views.get(name).copied().unwrap_or_default();
 
         subvolume_metrics.push(SubvolumeMetrics {
             name: name.clone(),
@@ -750,6 +813,8 @@ fn append_skipped_metrics(
             local_snapshot_count: local_count,
             external_snapshot_count: external_count,
             send_type: 2,
+            churn_bytes_per_second: churn.churn_bytes_per_second,
+            last_full_send_bytes: churn.last_full_send_bytes,
         });
     }
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -240,6 +240,13 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         error_count += v.fail_count as usize;
     }
 
+    // ── 5.5 Churn (UPI 030 — only with --thorough) ────────────────
+    let churn_view = if args.thorough {
+        Some(build_doctor_churn_view(&config))
+    } else {
+        None
+    };
+
     // ── 6. Verdict ────────────────────────────────────────────────
     let degraded_count = data_safety
         .iter()
@@ -266,10 +273,151 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         data_safety,
         sentinel,
         verify: verify_output,
+        churn: churn_view,
         verdict,
     };
 
     print!("{}", voice::render_doctor(&output, output_mode));
 
     Ok(())
+}
+
+/// Build the `--thorough` Churn-section view from `drift_samples` history.
+///
+/// Opens the state DB once; falls back to all-NotMeasured when unavailable.
+/// Best-effort per-subvolume: a query failure renders as `NotMeasured`.
+fn build_doctor_churn_view(config: &Config) -> crate::output::DoctorChurnView {
+    let state_db = StateDb::open(&config.general.state_db).ok();
+    let now = chrono::Local::now().naive_local();
+    build_doctor_churn_view_inner(config, state_db.as_ref(), now)
+}
+
+/// Pure-ish core (still does DB I/O via `state_db`) — extracted so unit tests
+/// can pass an in-memory `StateDb` and a fixed `now`.
+fn build_doctor_churn_view_inner(
+    config: &Config,
+    state_db: Option<&StateDb>,
+    now: chrono::NaiveDateTime,
+) -> crate::output::DoctorChurnView {
+    use crate::output::{DoctorChurnRow, DoctorChurnView};
+
+    let since = now - crate::drift::default_window();
+    let rows: Vec<DoctorChurnRow> = config
+        .subvolumes
+        .iter()
+        .map(|sv| {
+            let state = state_db
+                .and_then(|db| db.drift_samples_for_subvolume(&sv.name, since).ok())
+                .map(|rows| {
+                    let samples: Vec<crate::drift::DriftSample> =
+                        rows.into_iter().map(StateDb::drift_row_to_sample).collect();
+                    let estimate = crate::drift::compute_rolling_churn(
+                        &samples,
+                        crate::drift::default_window(),
+                        now,
+                    );
+                    crate::output::render_churn(&estimate)
+                })
+                .unwrap_or(crate::output::ChurnRender::NotMeasured);
+            DoctorChurnRow {
+                name: sv.name.clone(),
+                state,
+            }
+        })
+        .collect();
+
+    DoctorChurnView {
+        window_label: "rolling 7 days, time-weighted; bursty subvolumes may differ".to_string(),
+        rows,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> Config {
+        let toml_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-doctor-test/urd.db"
+metrics_file = "/tmp/urd-doctor-test/backup.prom"
+log_dir = "/tmp/urd-doctor-test"
+heartbeat_file = "/tmp/urd-doctor-test/heartbeat.json"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["alpha", "beta", "gamma"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[subvolumes]]
+name = "alpha"
+short_name = "alpha"
+source = "/data/alpha"
+
+[[subvolumes]]
+name = "beta"
+short_name = "beta"
+source = "/data/beta"
+
+[[subvolumes]]
+name = "gamma"
+short_name = "gamma"
+source = "/data/gamma"
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn doctor_thorough_populates_churn_view_for_all_subvolumes() {
+        let config = cfg();
+        let db = StateDb::open_memory().unwrap();
+        let now = chrono::NaiveDateTime::parse_from_str(
+            "2026-05-01T12:00:00",
+            "%Y-%m-%dT%H:%M:%S",
+        )
+        .unwrap();
+
+        // Seed alpha + beta with a successful incremental sample each.
+        // Leave gamma without any samples so it renders as NotMeasured.
+        for name in &["alpha", "beta"] {
+            db.record_drift_sample_best_effort(&crate::state::DriftSampleRow {
+                run_id: None,
+                subvolume: (*name).to_string(),
+                sampled_at: now - chrono::Duration::days(1),
+                seconds_since_prev_send: Some(86_400),
+                bytes_transferred: 1_000_000,
+                source_free_bytes: None,
+                send_kind: crate::types::SendKind::Incremental,
+            });
+        }
+
+        let view = build_doctor_churn_view_inner(&config, Some(&db), now);
+        assert_eq!(view.rows.len(), 3);
+        assert_eq!(view.rows[0].name, "alpha");
+        assert_eq!(view.rows[1].name, "beta");
+        assert_eq!(view.rows[2].name, "gamma");
+        assert!(matches!(
+            view.rows[2].state,
+            crate::output::ChurnRender::NotMeasured
+        ));
+        // alpha and beta each have one incremental → FirstMeasurement.
+        assert!(matches!(
+            view.rows[0].state,
+            crate::output::ChurnRender::FirstMeasurement { .. }
+        ));
+        assert!(matches!(
+            view.rows[1].state,
+            crate::output::ChurnRender::FirstMeasurement { .. }
+        ));
+    }
 }

--- a/src/drift.rs
+++ b/src/drift.rs
@@ -1,0 +1,383 @@
+// Drift telemetry — pure module that aggregates per-send drift samples into
+// a rolling time-windowed churn estimate.
+//
+// This is the foundation of the Do-No-Harm arc (ADR-113, UPI 030): pure
+// observability with no behavior change. The executor records a sample per
+// (run_id, subvolume) after a successful send; this module aggregates those
+// samples over a `Duration`-shaped window to answer "how much is this
+// subvolume churning?" The presentation layer (`output::render_churn`) maps
+// the raw aggregates here onto a `ChurnRender` enum.
+//
+// Design: ADR-108 (pure functions). Time-windowed (not sample-count-windowed)
+// so the same code holds when Urd moves beyond nightly cadence.
+// See `docs/95-ideas/2026-04-18-design-030-drift-telemetry.md`.
+//
+// Cadence-agnostic obligation (RD-2): the time-weighted mean is computed as
+// `sum(bytes) / sum(intervals)`. This is correct only after F1 dedup
+// (one row per `(run_id, subvolume)`) — see executor.rs.
+
+use chrono::{Duration, NaiveDateTime};
+
+use crate::types::SendKind;
+
+/// One persisted drift sample, projected from the `drift_samples` table for
+/// consumption by `compute_rolling_churn`. The `run_id` and `subvolume`
+/// fields used for storage are dropped here — the domain function does not
+/// need them.
+#[derive(Debug, Clone, PartialEq)]
+pub struct DriftSample {
+    pub sampled_at: NaiveDateTime,
+    /// Seconds elapsed since the previous successful send for this subvolume
+    /// on the canonical drive chain. `None` for the very first send (no prior
+    /// reference) or when the prior reference was lost.
+    pub seconds_since_prev_send: Option<i64>,
+    /// Wire bytes transferred for this send. Source: `bytes_transferred`
+    /// counter from `BtrfsOps::send`.
+    pub bytes_transferred: u64,
+    /// Free bytes on the source filesystem at run start. `None` when statvfs
+    /// failed; backfilled rows always carry `None`.
+    pub source_free_bytes: Option<u64>,
+    pub send_kind: SendKind,
+}
+
+/// Raw aggregates over an in-window slice of drift samples.
+/// No presentation labels — `output::render_churn` maps this to `ChurnRender`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChurnEstimate {
+    /// Time-weighted mean over in-window incrementals: `sum(bytes) / sum(intervals)`.
+    /// `None` when no in-window incremental has a usable interval
+    /// (`incremental_count == 0`).
+    pub mean_bytes_per_second: Option<f64>,
+    /// Count of in-window samples whose `send_kind` is `Incremental` and that
+    /// have a usable (non-zero, non-None) `seconds_since_prev_send`.
+    pub incremental_count: usize,
+    /// Count of in-window samples whose `send_kind` is `Full`.
+    pub full_count: usize,
+    /// Median of `bytes_transferred` across in-window full sends.
+    /// `None` when `full_count == 0`.
+    pub median_full_bytes: Option<u64>,
+    /// `bytes_transferred` of the most recent in-window full send.
+    /// `None` when `full_count == 0`.
+    pub latest_full_bytes: Option<u64>,
+    /// `seconds_since_prev_send` of the most recent in-window full send.
+    /// `None` when `full_count == 0` or that sample's interval is `None`.
+    pub latest_full_interval_secs: Option<i64>,
+}
+
+/// The default rolling window for churn aggregation: seven days.
+///
+/// Returned as a function (not a `pub const`) because `chrono::Duration::days`
+/// is not a `const fn` in chrono 0.4 (post-F4 from the adversary review).
+#[must_use]
+pub fn default_window() -> Duration {
+    Duration::days(7)
+}
+
+/// Aggregate drift samples over the rolling window ending at `now`.
+///
+/// Inclusive at both window boundaries: a sample with
+/// `sampled_at == now - window` is in-window.
+///
+/// Pure function: no I/O, no side effects.
+#[must_use]
+pub fn compute_rolling_churn(
+    samples: &[DriftSample],
+    window: Duration,
+    now: NaiveDateTime,
+) -> ChurnEstimate {
+    let window_start = now - window;
+
+    // Step 1: window filter (inclusive at both ends).
+    let in_window: Vec<&DriftSample> = samples
+        .iter()
+        .filter(|s| s.sampled_at >= window_start && s.sampled_at <= now)
+        .collect();
+
+    // Step 2: partition by send_kind.
+    let (incrementals, fulls): (Vec<&DriftSample>, Vec<&DriftSample>) = in_window
+        .iter()
+        .copied()
+        .partition(|s| s.send_kind == SendKind::Incremental);
+
+    // Step 3: incremental aggregation — only samples with a usable positive interval.
+    let usable_incrementals: Vec<&DriftSample> = incrementals
+        .iter()
+        .copied()
+        .filter(|s| s.seconds_since_prev_send.is_some_and(|secs| secs > 0))
+        .collect();
+
+    let incremental_count = usable_incrementals.len();
+    let mean_bytes_per_second = if usable_incrementals.is_empty() {
+        None
+    } else {
+        let total_bytes: u64 = usable_incrementals.iter().map(|s| s.bytes_transferred).sum();
+        let total_seconds: i64 = usable_incrementals
+            .iter()
+            .map(|s| s.seconds_since_prev_send.unwrap_or(0))
+            .sum();
+        if total_seconds > 0 {
+            #[allow(clippy::cast_precision_loss)]
+            let mean = total_bytes as f64 / total_seconds as f64;
+            Some(mean)
+        } else {
+            None
+        }
+    };
+
+    // Step 4: full aggregation.
+    let full_count = fulls.len();
+    let (median_full_bytes, latest_full_bytes, latest_full_interval_secs) = match fulls.split_first() {
+        None => (None, None, None),
+        Some((first, rest)) => {
+            let mut bytes: Vec<u64> = fulls.iter().map(|s| s.bytes_transferred).collect();
+            bytes.sort_unstable();
+            let median = bytes[bytes.len() / 2];
+
+            // Latest by sampled_at — fold across the rest to keep the running max.
+            let latest = rest.iter().copied().fold(*first, |acc, s| {
+                if s.sampled_at > acc.sampled_at { s } else { acc }
+            });
+            (
+                Some(median),
+                Some(latest.bytes_transferred),
+                latest.seconds_since_prev_send,
+            )
+        }
+    };
+
+    ChurnEstimate {
+        mean_bytes_per_second,
+        incremental_count,
+        full_count,
+        median_full_bytes,
+        latest_full_bytes,
+        latest_full_interval_secs,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn dt(y: i32, m: u32, d: u32, h: u32, min: u32) -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(y, m, d)
+            .unwrap()
+            .and_hms_opt(h, min, 0)
+            .unwrap()
+    }
+
+    fn sample(
+        sampled_at: NaiveDateTime,
+        secs: Option<i64>,
+        bytes: u64,
+        kind: SendKind,
+    ) -> DriftSample {
+        DriftSample {
+            sampled_at,
+            seconds_since_prev_send: secs,
+            bytes_transferred: bytes,
+            source_free_bytes: None,
+            send_kind: kind,
+        }
+    }
+
+    #[test]
+    fn empty_samples_returns_zero_counts() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let est = compute_rolling_churn(&[], default_window(), now);
+        assert_eq!(est.incremental_count, 0);
+        assert_eq!(est.full_count, 0);
+        assert_eq!(est.mean_bytes_per_second, None);
+        assert_eq!(est.median_full_bytes, None);
+        assert_eq!(est.latest_full_bytes, None);
+        assert_eq!(est.latest_full_interval_secs, None);
+    }
+
+    #[test]
+    fn all_samples_outside_window_returns_zero_counts() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let old = dt(2026, 4, 1, 12, 0);
+        let samples = vec![
+            sample(old, Some(86_400), 1_000_000, SendKind::Incremental),
+            sample(old, Some(86_400), 5_000_000_000, SendKind::Full),
+        ];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 0);
+        assert_eq!(est.full_count, 0);
+        assert_eq!(est.mean_bytes_per_second, None);
+    }
+
+    #[test]
+    fn single_incremental_sample_sets_incremental_count_1_and_mean() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s = dt(2026, 4, 30, 12, 0);
+        let samples = vec![sample(s, Some(86_400), 86_400_000, SendKind::Incremental)];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 1);
+        assert_eq!(est.full_count, 0);
+        // 86_400_000 bytes / 86_400 seconds = 1000.0 B/s
+        assert_eq!(est.mean_bytes_per_second, Some(1000.0));
+    }
+
+    #[test]
+    fn single_incremental_sample_with_none_prev_send_excluded_from_count() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s = dt(2026, 4, 30, 12, 0);
+        let samples = vec![sample(s, None, 86_400_000, SendKind::Incremental)];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 0);
+        assert_eq!(est.mean_bytes_per_second, None);
+    }
+
+    #[test]
+    fn two_incrementals_time_weighted_mean() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s1 = dt(2026, 4, 29, 12, 0);
+        let s2 = dt(2026, 4, 30, 12, 0);
+        let samples = vec![
+            sample(s1, Some(86_400), 100_000_000, SendKind::Incremental),
+            sample(s2, Some(86_400), 200_000_000, SendKind::Incremental),
+        ];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 2);
+        // (100M + 200M) / (86_400 + 86_400) = 300M / 172_800 = ~1736.11 B/s
+        let expected = 300_000_000.0_f64 / 172_800.0_f64;
+        assert!((est.mean_bytes_per_second.unwrap() - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn heterogeneous_cadence_within_window() {
+        let now = dt(2026, 5, 1, 12, 0);
+        // Five samples with uneven intervals (3h, 26h, 24h, 48h, 6h).
+        // Total interval = (3 + 26 + 24 + 48 + 6) * 3600 = 380_400 secs
+        // Total bytes = 1G + 2G + 1G + 4G + 500M = 8.5G
+        let s1 = dt(2026, 4, 28, 9, 0);
+        let s2 = dt(2026, 4, 29, 11, 0);
+        let s3 = dt(2026, 4, 30, 11, 0);
+        let s4 = dt(2026, 5, 2, 11, 0); // future-relative-to-others, but still within "now"
+        let s5 = dt(2026, 4, 30, 17, 0);
+        // Use values such that all are within 7 days of now=2026-05-01 12:00
+        let samples = vec![
+            sample(s1, Some(3 * 3600), 1_000_000_000, SendKind::Incremental),
+            sample(s2, Some(26 * 3600), 2_000_000_000, SendKind::Incremental),
+            sample(s3, Some(24 * 3600), 1_000_000_000, SendKind::Incremental),
+            sample(s4, Some(48 * 3600), 4_000_000_000, SendKind::Incremental),
+            sample(s5, Some(6 * 3600), 500_000_000, SendKind::Incremental),
+        ];
+        // Filter: now=2026-05-01 12:00, window 7d → window_start=2026-04-24 12:00.
+        // s4=2026-05-02 11:00 is AFTER now, so it should be excluded.
+        // Effective: s1, s2, s3, s5 — 4 samples in window.
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 4);
+        let total_bytes = 1_000_000_000_u64 + 2_000_000_000 + 1_000_000_000 + 500_000_000;
+        let total_secs = (3 + 26 + 24 + 6) * 3600;
+        let expected = total_bytes as f64 / total_secs as f64;
+        assert!((est.mean_bytes_per_second.unwrap() - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mixed_full_and_incremental_partition_by_kind() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s1 = dt(2026, 4, 29, 12, 0);
+        let s2 = dt(2026, 4, 30, 12, 0);
+        let s3 = dt(2026, 4, 28, 12, 0);
+        let samples = vec![
+            sample(s1, Some(86_400), 100_000_000, SendKind::Incremental),
+            sample(s2, Some(86_400), 200_000_000, SendKind::Incremental),
+            sample(s3, Some(86_400), 5_000_000_000, SendKind::Full),
+        ];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 2);
+        assert_eq!(est.full_count, 1);
+        let expected_mean = 300_000_000.0_f64 / 172_800.0_f64;
+        assert!((est.mean_bytes_per_second.unwrap() - expected_mean).abs() < 1e-6);
+        assert_eq!(est.median_full_bytes, Some(5_000_000_000));
+        assert_eq!(est.latest_full_bytes, Some(5_000_000_000));
+    }
+
+    #[test]
+    fn single_full_send_sets_full_count_1_with_latest_full_bytes_some() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s = dt(2026, 4, 30, 12, 0);
+        let samples = vec![sample(s, Some(86_400), 12_000_000_000, SendKind::Full)];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 0);
+        assert_eq!(est.full_count, 1);
+        assert_eq!(est.latest_full_bytes, Some(12_000_000_000));
+        assert_eq!(est.median_full_bytes, Some(12_000_000_000));
+        assert_eq!(est.latest_full_interval_secs, Some(86_400));
+    }
+
+    #[test]
+    fn two_full_sends_median_and_latest() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s_old = dt(2026, 4, 29, 12, 0);
+        let s_new = dt(2026, 4, 30, 12, 0);
+        let samples = vec![
+            sample(s_old, Some(24 * 3600), 10_000_000_000, SendKind::Full),
+            sample(s_new, Some(26 * 3600), 14_000_000_000, SendKind::Full),
+        ];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.full_count, 2);
+        // sort_unstable [10G, 14G]; median = bytes[1] = 14G (median of even count
+        // taken as upper-mid, which is what bytes[len/2] yields).
+        assert_eq!(est.median_full_bytes, Some(14_000_000_000));
+        assert_eq!(est.latest_full_bytes, Some(14_000_000_000));
+        assert_eq!(est.latest_full_interval_secs, Some(26 * 3600));
+    }
+
+    #[test]
+    fn stale_window_returns_zero_counts() {
+        let now = dt(2026, 5, 1, 12, 0);
+        // Last sample 30 days ago — well outside 7-day window.
+        let s = dt(2026, 4, 1, 12, 0);
+        let samples = vec![sample(s, Some(86_400), 1_000_000, SendKind::Incremental)];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 0);
+        assert_eq!(est.full_count, 0);
+    }
+
+    #[test]
+    fn samples_at_window_boundary_are_inclusive() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let exactly_at_boundary = now - default_window();
+        let samples = vec![sample(
+            exactly_at_boundary,
+            Some(86_400),
+            86_400_000,
+            SendKind::Incremental,
+        )];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 1);
+    }
+
+    #[test]
+    fn default_window_is_seven_days() {
+        assert_eq!(default_window(), Duration::days(7));
+    }
+
+    #[test]
+    fn numerical_stability_with_terabyte_samples() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s = dt(2026, 4, 24, 12, 0); // exactly 7 days back, inclusive boundary
+        let total_secs = 7 * 86_400_i64;
+        let bytes: u64 = 10_000_000_000_000; // 10 TB
+        let samples = vec![sample(s, Some(total_secs), bytes, SendKind::Incremental)];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        let expected = bytes as f64 / total_secs as f64;
+        let actual = est.mean_bytes_per_second.unwrap();
+        let rel_err = ((actual - expected) / expected).abs();
+        assert!(rel_err < 1e-5, "relative error {rel_err} too large");
+    }
+
+    #[test]
+    fn seconds_since_prev_send_zero_is_excluded_from_incremental_count() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s = dt(2026, 4, 30, 12, 0);
+        let samples = vec![sample(s, Some(0), 86_400_000, SendKind::Incremental)];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 0);
+        assert_eq!(est.mean_bytes_per_second, None);
+    }
+}

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -12,7 +12,7 @@ use crate::commands::backup::{format_completion_line, ProgressContext, SizeEstim
 use crate::config::Config;
 use crate::drives;
 use crate::error::BtrfsOperation;
-use crate::state::{OperationRecord, StateDb};
+use crate::state::{DriftSampleRow, OperationRecord, StateDb};
 use crate::types::{BackupPlan, FullSendReason, PlannedOperation, SendKind};
 
 // ── Types ───────────────────────────────────────────────────────────────
@@ -187,6 +187,29 @@ impl<'a> Executor<'a> {
         // Begin run in SQLite (optional)
         let run_id = self.begin_run(mode);
 
+        // Snapshot source-FS free bytes once at run start (UPI 030 drift telemetry).
+        // Walk the union of legacy `local_snapshots.roots` AND v1 inline
+        // `snapshot_root` per subvolume so both schemas are covered. Statvfs
+        // failure → None for that path; the drift sample still writes.
+        let mut roots: HashSet<PathBuf> = HashSet::new();
+        for root in &self.config.local_snapshots.roots {
+            roots.insert(root.path.clone());
+        }
+        let mut subvol_to_root: HashMap<String, PathBuf> = HashMap::new();
+        for sv in self.config.resolved_subvolumes() {
+            if let Some(p) = sv.snapshot_root.clone() {
+                subvol_to_root.insert(sv.name.clone(), p.clone());
+                roots.insert(p);
+            }
+        }
+        let source_free: HashMap<PathBuf, Option<u64>> = roots
+            .into_iter()
+            .map(|p| {
+                let v = drives::filesystem_free_bytes(&p).ok();
+                (p, v)
+            })
+            .collect();
+
         // Group operations by subvolume, preserving order
         let groups = group_by_subvolume(&plan.operations);
 
@@ -218,7 +241,14 @@ impl<'a> Executor<'a> {
                 name: subvol_name.clone(),
                 is_transient,
             };
-            let result = self.execute_subvolume(&context, ops, run_id, &mut space_recovered);
+            let result = self.execute_subvolume(
+                &context,
+                ops,
+                run_id,
+                &mut space_recovered,
+                &source_free,
+                &subvol_to_root,
+            );
             subvolume_results.push(result);
         }
 
@@ -261,6 +291,8 @@ impl<'a> Executor<'a> {
         ops: &[&PlannedOperation],
         run_id: Option<i64>,
         space_recovered: &mut HashMap<String, bool>,
+        source_free: &HashMap<PathBuf, Option<u64>>,
+        subvol_to_root: &HashMap<String, PathBuf>,
     ) -> SubvolumeResult {
         let subvol_name = &context.name;
         let subvol_start = Instant::now();
@@ -274,6 +306,46 @@ impl<'a> Executor<'a> {
         let mut old_pin_parents: HashMap<String, std::path::PathBuf> = HashMap::new();
         let mut sends_succeeded: HashSet<String> = HashSet::new();
         let mut planned_send_drives: HashSet<String> = HashSet::new();
+
+        // UPI 030 drift telemetry: capture the prior successful send time per
+        // drive BEFORE this run records any operation, so seconds_since_prev_send
+        // reflects the gap relative to history (not the row we're about to write).
+        // post-F1: one drift sample per (run_id, subvolume), derived from the first
+        // successful send in plan-iteration order. Track that send's drive label so
+        // we can compute the interval from the right chain after the loop.
+        let prior_send_time_by_drive: HashMap<String, chrono::NaiveDateTime> = self
+            .state
+            .map(|s| {
+                let mut map: HashMap<String, chrono::NaiveDateTime> = HashMap::new();
+                for op in ops {
+                    let drive = match op {
+                        PlannedOperation::SendIncremental { drive_label, .. }
+                        | PlannedOperation::SendFull { drive_label, .. } => Some(drive_label),
+                        _ => None,
+                    };
+                    if let Some(d) = drive
+                        && !map.contains_key(d)
+                        && let Ok(Some(t)) = s.last_successful_send_time(subvol_name, d)
+                    {
+                        map.insert(d.clone(), t);
+                    }
+                }
+                map
+            })
+            .unwrap_or_default();
+        // Order in which sends are planned, used to find the FIRST successful send.
+        let mut send_plan_order: Vec<(String, SendKind)> = Vec::new();
+        for op in ops {
+            match op {
+                PlannedOperation::SendIncremental { drive_label, .. } => {
+                    send_plan_order.push((drive_label.clone(), SendKind::Incremental));
+                }
+                PlannedOperation::SendFull { drive_label, .. } => {
+                    send_plan_order.push((drive_label.clone(), SendKind::Full));
+                }
+                _ => {}
+            }
+        }
 
         for op in ops {
             if self.shutdown.load(Ordering::SeqCst) {
@@ -405,6 +477,21 @@ impl<'a> Executor<'a> {
             pin_failures,
         );
 
+        // post-F1: write at most ONE drift sample per (run_id, subvolume),
+        // derived from the FIRST successful send in plan-iteration order.
+        // Statvfs failure → source_free_bytes is None; sample still writes.
+        // Failed-only runs write no sample; the time-weighted mean naturally
+        // excludes the run from the rolling window.
+        self.maybe_record_drift_sample(
+            run_id,
+            subvol_name,
+            &operations,
+            &send_plan_order,
+            &prior_send_time_by_drive,
+            source_free,
+            subvol_to_root,
+        );
+
         SubvolumeResult {
             name: subvol_name.to_string(),
             success: subvol_success,
@@ -414,6 +501,67 @@ impl<'a> Executor<'a> {
             pin_failures,
             transient_cleanup,
         }
+    }
+
+    /// Build and persist a drift sample for the subvolume's run, if at least
+    /// one send succeeded. Picks the first successful send in plan-iteration
+    /// order — deterministic, reproducible, and surprises the least.
+    #[allow(clippy::too_many_arguments)]
+    fn maybe_record_drift_sample(
+        &self,
+        run_id: Option<i64>,
+        subvol_name: &str,
+        operations: &[OperationOutcome],
+        send_plan_order: &[(String, SendKind)],
+        prior_send_time_by_drive: &HashMap<String, chrono::NaiveDateTime>,
+        source_free: &HashMap<PathBuf, Option<u64>>,
+        subvol_to_root: &HashMap<String, PathBuf>,
+    ) {
+        let Some(state) = self.state else { return };
+
+        // Find the first successful send outcome in plan-iteration order.
+        // The outer order of `operations` mirrors `ops` (same source); within
+        // it, sends are emitted in plan order, so the FIRST OperationOutcome
+        // whose `result == Success` and whose `operation` parses as a SendKind
+        // is the right pick.
+        let chosen = operations.iter().find(|o| {
+            o.result == OpResult::Success
+                && SendKind::from_db_str(&o.operation).is_some()
+                && o.bytes_transferred.is_some()
+        });
+        let Some(chosen) = chosen else { return };
+        let Some(bytes) = chosen.bytes_transferred else { return };
+        let Some(drive_label) = chosen.drive_label.as_ref() else {
+            return;
+        };
+        let Some(send_kind) = SendKind::from_db_str(&chosen.operation) else {
+            return;
+        };
+        // Sanity: the chosen send must appear in the plan order with the same
+        // (drive_label, kind). Defensive — should always hold.
+        let _matches_plan = send_plan_order
+            .iter()
+            .any(|(d, k)| d == drive_label && *k == send_kind);
+
+        let sampled_at = chrono::Local::now().naive_local();
+        let seconds_since_prev_send = prior_send_time_by_drive
+            .get(drive_label)
+            .map(|prev| (sampled_at - *prev).num_seconds());
+        let source_free_bytes = subvol_to_root
+            .get(subvol_name)
+            .and_then(|p| source_free.get(p).copied())
+            .flatten();
+
+        let row = DriftSampleRow {
+            run_id,
+            subvolume: subvol_name.to_string(),
+            sampled_at,
+            seconds_since_prev_send,
+            bytes_transferred: bytes,
+            source_free_bytes,
+            send_kind,
+        };
+        state.record_drift_sample_best_effort(&row);
     }
 
     fn execute_create<'b>(
@@ -3067,5 +3215,252 @@ local_retention = "transient"
             })
             .unwrap();
         assert!(rows.is_empty());
+    }
+
+    // ── Drift sample emission (UPI 030) ────────────────────────────
+
+    fn drift_count(db: &crate::state::StateDb) -> i64 {
+        db.conn
+            .query_row("SELECT COUNT(*) FROM drift_samples", [], |r| r.get(0))
+            .unwrap()
+    }
+
+    #[test]
+    fn execute_records_drift_sample_after_successful_send() {
+        use crate::state::StateDb;
+
+        let mock = MockBtrfs::new();
+        *mock.mock_bytes_transferred.borrow_mut() = Some(1_000_000);
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let db = StateDb::open_memory().unwrap();
+        let executor = Executor::new(&mock, Some(&db), &config, &shutdown);
+
+        let result = executor.execute(&simple_plan(), "full");
+        assert_eq!(result.overall, RunResult::Success);
+        assert_eq!(drift_count(&db), 1);
+
+        let row: (String, i64, String) = db
+            .conn
+            .query_row(
+                "SELECT subvolume, bytes_transferred, send_type FROM drift_samples LIMIT 1",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(row.0, "sv-a");
+        assert_eq!(row.1, 1_000_000);
+        assert_eq!(row.2, "send_incremental");
+    }
+
+    #[test]
+    fn execute_records_drift_sample_with_null_free_bytes_when_statvfs_fails() {
+        use crate::state::StateDb;
+
+        let mock = MockBtrfs::new();
+        *mock.mock_bytes_transferred.borrow_mut() = Some(1_000_000);
+        // test_config() uses /snap which doesn't exist on the test runner —
+        // statvfs returns Err, source_free_bytes becomes None.
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let db = StateDb::open_memory().unwrap();
+        let executor = Executor::new(&mock, Some(&db), &config, &shutdown);
+
+        let _ = executor.execute(&simple_plan(), "full");
+
+        let free: Option<i64> = db
+            .conn
+            .query_row(
+                "SELECT source_free_bytes FROM drift_samples LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(free, None);
+    }
+
+    #[test]
+    fn execute_does_not_record_drift_sample_when_all_sends_failed() {
+        use crate::state::StateDb;
+
+        let mock = MockBtrfs::new();
+        *mock.mock_bytes_transferred.borrow_mut() = Some(1_000_000);
+        // Fail the only send in simple_plan.
+        mock.fail_sends
+            .borrow_mut()
+            .insert(PathBuf::from("/snap/sv-a/20260322-1430-a"));
+
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let db = StateDb::open_memory().unwrap();
+        let executor = Executor::new(&mock, Some(&db), &config, &shutdown);
+
+        let _ = executor.execute(&simple_plan(), "full");
+        assert_eq!(drift_count(&db), 0);
+    }
+
+    #[test]
+    fn execute_records_first_send_with_null_seconds_since_prev_send() {
+        use crate::state::StateDb;
+
+        let mock = MockBtrfs::new();
+        *mock.mock_bytes_transferred.borrow_mut() = Some(1_000_000);
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let db = StateDb::open_memory().unwrap(); // fresh state, no prior sends
+        let executor = Executor::new(&mock, Some(&db), &config, &shutdown);
+
+        let _ = executor.execute(&simple_plan(), "full");
+
+        let secs: Option<i64> = db
+            .conn
+            .query_row(
+                "SELECT seconds_since_prev_send FROM drift_samples LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(secs, None);
+    }
+
+    #[test]
+    fn two_drives_same_subvolume_same_run_records_one_drift_row() {
+        use crate::state::StateDb;
+
+        let mock = MockBtrfs::new();
+        *mock.mock_bytes_transferred.borrow_mut() = Some(1_000_000);
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let db = StateDb::open_memory().unwrap();
+        let executor = Executor::new(&mock, Some(&db), &config, &shutdown);
+
+        // One subvolume, two SendIncrementals to two drive labels in one plan.
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/a"),
+                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::SendIncremental {
+                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
+                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest_dir: PathBuf::from("/mnt/drive-a/.snapshots/sv-a"),
+                    drive_label: "DRIVE-A".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    pin_on_success: None,
+                },
+                PlannedOperation::SendIncremental {
+                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
+                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest_dir: PathBuf::from("/mnt/drive-b/.snapshots/sv-a"),
+                    drive_label: "DRIVE-B".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    pin_on_success: None,
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let _ = executor.execute(&plan, "full");
+        // F1 dedup: exactly one row regardless of two-drive fan-out.
+        assert_eq!(drift_count(&db), 1);
+    }
+
+    #[test]
+    fn execute_records_drift_sample_using_first_successful_send_when_first_failed_then_succeeded() {
+        use crate::state::StateDb;
+
+        let mock = MockBtrfs::new();
+        *mock.mock_bytes_transferred.borrow_mut() = Some(2_000_000);
+        // Fail the first send; second succeeds. Both are to the same snapshot
+        // path so we use a different mock approach: set fail_sends on one
+        // dest_dir... but fail_sends matches snapshot, not dest. So instead,
+        // use distinct snapshots — give each drive a different planned
+        // SendIncremental whose `snapshot` field is unique enough that
+        // fail_sends can distinguish them. The simpler approach: make the
+        // first send fail by failing the snapshot itself (a common scenario
+        // would be two distinct sends with distinct snapshots). For the
+        // executor's "first successful" picker, two distinct snapshots in one
+        // plan with different SendKinds is enough.
+
+        // Plan: snapshot create, then SendIncremental drive A (fail),
+        // SendIncremental drive B (succeed). Both target the same snapshot
+        // because in real life multi-drive sends share the local snapshot —
+        // so the fail_sends set will fail BOTH. Use two distinct snapshots
+        // instead by having two CreateSnapshot ops.
+
+        let snap_a = PathBuf::from("/snap/sv-a/20260322-1430-a");
+        let snap_b = PathBuf::from("/snap/sv-b/20260322-1430-b");
+        // Fail sv-a's send only.
+        mock.fail_sends.borrow_mut().insert(snap_a.clone());
+
+        // We use the same subvolume name so the F1 dedup considers both as
+        // candidates. But our setup uses different subvolume_name per op,
+        // which would split into two execute_subvolume invocations. To keep
+        // the "first successful in plan order for THIS subvolume" semantics
+        // honest, both sends must be within the same subvolume.
+        // Workaround: rename the snapshots to distinct paths but keep
+        // subvolume_name = "sv-a" on both ops.
+        let snap_b_for_sv_a = PathBuf::from("/snap/sv-a/20260322-1430-b-second");
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let db = StateDb::open_memory().unwrap();
+        let executor = Executor::new(&mock, Some(&db), &config, &shutdown);
+
+        let _ = snap_b; // unused now
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::CreateSnapshot {
+                    source: PathBuf::from("/data/a"),
+                    dest: snap_a.clone(),
+                    subvolume_name: "sv-a".to_string(),
+                },
+                PlannedOperation::SendIncremental {
+                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
+                    snapshot: snap_a.clone(),
+                    dest_dir: PathBuf::from("/mnt/drive-a/.snapshots/sv-a"),
+                    drive_label: "DRIVE-A".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    pin_on_success: None,
+                },
+                PlannedOperation::SendIncremental {
+                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
+                    snapshot: snap_b_for_sv_a.clone(),
+                    dest_dir: PathBuf::from("/mnt/drive-b/.snapshots/sv-a"),
+                    drive_label: "DRIVE-B".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    pin_on_success: None,
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let _ = executor.execute(&plan, "full");
+
+        // Exactly one drift row. The chosen drive_label should be DRIVE-B
+        // (the first SUCCESSFUL send in plan order).
+        assert_eq!(drift_count(&db), 1);
+        let bytes: i64 = db
+            .conn
+            .query_row(
+                "SELECT bytes_transferred FROM drift_samples LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(bytes, 2_000_000);
     }
 }

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -8,6 +8,7 @@
 // fields from a higher version. The writer MUST NOT remove fields between
 // versions — only add. Additive changes bump the version.
 
+use std::collections::HashMap;
 use std::path::Path;
 
 use chrono::NaiveDateTime;
@@ -17,9 +18,10 @@ use crate::awareness::SubvolAssessment;
 use crate::config::Config;
 use crate::error::UrdError;
 use crate::executor::{ExecutionResult, SendType};
+use crate::output::ChurnHeartbeatFields;
 
 /// Current schema version. Bump when adding fields (never remove fields).
-const SCHEMA_VERSION: u32 = 2;
+const SCHEMA_VERSION: u32 = 3;
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -60,6 +62,16 @@ pub struct SubvolumeHeartbeat {
     /// Defaults to `true` for backward compat (schema v1 heartbeats without this field).
     #[serde(default = "default_true")]
     pub send_completed: bool,
+    /// Rolling time-windowed churn rate in bytes per second (UPI 030, schema v3).
+    /// `None` for cold-start subvolumes and for subvolumes whose latest in-window
+    /// send was a full send (use `last_full_send_bytes` for those).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub churn_bytes_per_second: Option<f64>,
+    /// Bytes of the most recent in-window full send (UPI 030, schema v3).
+    /// `None` for subvolumes with no in-window full send (incremental-only or
+    /// cold-start subvolumes).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_full_send_bytes: Option<u64>,
 }
 
 // ── Builder ─────────────────────────────────────────────────────────────
@@ -71,8 +83,9 @@ pub fn build_from_run(
     now: NaiveDateTime,
     result: &ExecutionResult,
     assessments: &[SubvolAssessment],
+    churn_views: &HashMap<String, ChurnHeartbeatFields>,
 ) -> Heartbeat {
-    let subvolumes = build_subvolume_entries(Some(result), assessments);
+    let subvolumes = build_subvolume_entries(Some(result), assessments, churn_views);
 
     Heartbeat {
         schema_version: SCHEMA_VERSION,
@@ -93,8 +106,9 @@ pub fn build_empty(
     config: &Config,
     now: NaiveDateTime,
     assessments: &[SubvolAssessment],
+    churn_views: &HashMap<String, ChurnHeartbeatFields>,
 ) -> Heartbeat {
-    let subvolumes = build_subvolume_entries(None, assessments);
+    let subvolumes = build_subvolume_entries(None, assessments, churn_views);
 
     Heartbeat {
         schema_version: SCHEMA_VERSION,
@@ -112,6 +126,7 @@ pub fn build_empty(
 fn build_subvolume_entries(
     result: Option<&ExecutionResult>,
     assessments: &[SubvolAssessment],
+    churn_views: &HashMap<String, ChurnHeartbeatFields>,
 ) -> Vec<SubvolumeHeartbeat> {
     assessments
         .iter()
@@ -124,12 +139,16 @@ fn build_subvolume_entries(
                 matches!(sv.send_type, SendType::Full | SendType::Incremental)
             });
 
+            let churn = churn_views.get(&a.name).copied().unwrap_or_default();
+
             SubvolumeHeartbeat {
                 name: a.name.clone(),
                 backup_success: sv_result.map(|sv| sv.success),
                 promise_status: a.status.to_string(),
                 pin_failures: sv_result.map(|sv| sv.pin_failures).unwrap_or(0),
                 send_completed,
+                churn_bytes_per_second: churn.churn_bytes_per_second,
+                last_full_send_bytes: churn.last_full_send_bytes,
             }
         })
         .collect()
@@ -370,11 +389,11 @@ mod tests {
         let assessments = test_assessments();
         let result = test_execution_result();
 
-        let heartbeat = build_from_run(&config, now, &result, &assessments);
+        let heartbeat = build_from_run(&config, now, &result, &assessments, &HashMap::new());
         let json = serde_json::to_string_pretty(&heartbeat).unwrap();
         let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed.schema_version, 2);
+        assert_eq!(parsed.schema_version, 3);
         assert_eq!(parsed.timestamp, "2026-03-24T02:05:00");
         assert_eq!(parsed.run_result, "partial");
         assert_eq!(parsed.run_id, Some(42));
@@ -427,7 +446,7 @@ mod tests {
             NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let assessments = test_assessments();
 
-        let heartbeat = build_empty(&config, now, &assessments);
+        let heartbeat = build_empty(&config, now, &assessments, &HashMap::new());
 
         assert_eq!(heartbeat.run_result, "empty");
         assert_eq!(heartbeat.run_id, None);
@@ -452,14 +471,14 @@ mod tests {
             NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let assessments = test_assessments();
 
-        let heartbeat = build_empty(&config, now, &assessments);
+        let heartbeat = build_empty(&config, now, &assessments, &HashMap::new());
         write(&path, &heartbeat).unwrap();
 
         // Temp file cleaned up
         assert!(!dir.path().join("heartbeat.json.tmp").exists());
         // File exists and is valid
         let read_back = read(&path).unwrap();
-        assert_eq!(read_back.schema_version, 2);
+        assert_eq!(read_back.schema_version, 3);
         assert_eq!(read_back.timestamp, "2026-03-24T02:00:00");
     }
 
@@ -471,10 +490,117 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let heartbeat = build_empty(&config, now, &test_assessments());
+        let heartbeat = build_empty(&config, now, &test_assessments(), &HashMap::new());
         write(&path, &heartbeat).unwrap();
 
         assert!(path.exists());
+    }
+
+    // ── UPI 030: schema v3 + churn / last-full-send fields ──────────────
+
+    #[test]
+    fn heartbeat_serializes_at_schema_version_3() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let heartbeat = build_empty(&config, now, &test_assessments(), &HashMap::new());
+        assert_eq!(heartbeat.schema_version, 3);
+    }
+
+    #[test]
+    fn heartbeat_roundtrip_with_churn_field_present() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let mut churn = HashMap::new();
+        churn.insert(
+            "home".to_string(),
+            ChurnHeartbeatFields {
+                churn_bytes_per_second: Some(1234.5),
+                last_full_send_bytes: None,
+            },
+        );
+
+        let hb = build_empty(&config, now, &test_assessments(), &churn);
+        let json = serde_json::to_string(&hb).unwrap();
+        let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
+        let home = parsed.subvolumes.iter().find(|s| s.name == "home").unwrap();
+        assert_eq!(home.churn_bytes_per_second, Some(1234.5));
+        assert_eq!(home.last_full_send_bytes, None);
+    }
+
+    #[test]
+    fn heartbeat_roundtrip_with_last_full_send_bytes_field_present() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let mut churn = HashMap::new();
+        churn.insert(
+            "home".to_string(),
+            ChurnHeartbeatFields {
+                churn_bytes_per_second: None,
+                last_full_send_bytes: Some(12_000_000_000),
+            },
+        );
+
+        let hb = build_empty(&config, now, &test_assessments(), &churn);
+        let json = serde_json::to_string(&hb).unwrap();
+        let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
+        let home = parsed.subvolumes.iter().find(|s| s.name == "home").unwrap();
+        assert_eq!(home.last_full_send_bytes, Some(12_000_000_000));
+        assert_eq!(home.churn_bytes_per_second, None);
+    }
+
+    #[test]
+    fn heartbeat_roundtrip_v2_file_without_new_fields_defaults_to_none() {
+        // A v2-on-disk JSON file (no churn / last_full_send_bytes fields)
+        // must deserialize cleanly with both new fields = None.
+        let json = r#"{
+            "schema_version": 2,
+            "timestamp": "2026-03-24T02:00:00",
+            "stale_after": "2026-03-24T04:00:00",
+            "run_result": "success",
+            "run_id": 1,
+            "subvolumes": [
+                {
+                    "name": "home",
+                    "backup_success": true,
+                    "promise_status": "PROTECTED",
+                    "pin_failures": 0,
+                    "send_completed": true
+                }
+            ],
+            "notifications_dispatched": true
+        }"#;
+        let parsed: Heartbeat = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.subvolumes[0].churn_bytes_per_second, None);
+        assert_eq!(parsed.subvolumes[0].last_full_send_bytes, None);
+    }
+
+    #[test]
+    fn heartbeat_omits_churn_field_when_none() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let hb = build_empty(&config, now, &test_assessments(), &HashMap::new());
+        let json = serde_json::to_string(&hb).unwrap();
+        assert!(
+            !json.contains("churn_bytes_per_second"),
+            "field should be omitted when None: {json}"
+        );
+    }
+
+    #[test]
+    fn heartbeat_omits_last_full_send_bytes_when_none() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let hb = build_empty(&config, now, &test_assessments(), &HashMap::new());
+        let json = serde_json::to_string(&hb).unwrap();
+        assert!(
+            !json.contains("last_full_send_bytes"),
+            "field should be omitted when None: {json}"
+        );
     }
 
     #[test]
@@ -521,7 +647,7 @@ mod tests {
             run_id: Some(1),
         };
 
-        let hb = build_from_run(&config, now, &result, &assessments);
+        let hb = build_from_run(&config, now, &result, &assessments, &HashMap::new());
         assert!(hb.subvolumes[0].send_completed);
     }
 
@@ -549,7 +675,7 @@ mod tests {
             run_id: Some(1),
         };
 
-        let hb = build_from_run(&config, now, &result, &assessments);
+        let hb = build_from_run(&config, now, &result, &assessments, &HashMap::new());
         assert!(!hb.subvolumes[0].send_completed);
     }
 
@@ -577,7 +703,7 @@ mod tests {
             run_id: Some(1),
         };
 
-        let hb = build_from_run(&config, now, &result, &assessments);
+        let hb = build_from_run(&config, now, &result, &assessments, &HashMap::new());
         assert!(!hb.subvolumes[0].send_completed);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod chain;
 mod cli;
 mod commands;
 mod config;
+mod drift;
 mod drives;
 mod error;
 mod events;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -40,6 +40,13 @@ pub struct SubvolumeMetrics {
     pub external_snapshot_count: usize,
     /// 0 = full, 1 = incremental, 2 = no send
     pub send_type: u8,
+    /// Rolling time-windowed churn rate (UPI 030). Emitted only when `Some`.
+    /// Absent for cold-start subvolumes and for subvolumes whose latest
+    /// in-window send was a full send (use `last_full_send_bytes` instead).
+    pub churn_bytes_per_second: Option<f64>,
+    /// Bytes of the most recent in-window full send (UPI 030). Emitted only
+    /// when `Some`. Absent for incremental-only and cold-start subvolumes.
+    pub last_full_send_bytes: Option<u64>,
 }
 
 // ── Writer ──────────────────────────────────────────────────────────────
@@ -251,6 +258,52 @@ fn format_metrics(data: &MetricsData) -> String {
     )
     .unwrap();
 
+    // ── Drift telemetry (UPI 030) ─────────────────────────────────
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP backup_subvolume_churn_bytes_per_second Rolling time-windowed churn rate per subvolume (bytes/second). Absent for cold-start subvolumes and for subvolumes whose latest in-window send was a full send."
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "# TYPE backup_subvolume_churn_bytes_per_second gauge"
+    )
+    .unwrap();
+    for sv in &data.subvolumes {
+        if let Some(churn) = sv.churn_bytes_per_second {
+            writeln!(
+                out,
+                "backup_subvolume_churn_bytes_per_second{{subvolume=\"{}\"}} {}",
+                sv.name, churn
+            )
+            .unwrap();
+        }
+    }
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP backup_subvolume_last_full_send_bytes Bytes of the most recent in-window full send for subvolumes whose latest send was a full send (e.g., transient/storage_critical subvolumes). Absent for incremental-only and cold-start subvolumes."
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "# TYPE backup_subvolume_last_full_send_bytes gauge"
+    )
+    .unwrap();
+    for sv in &data.subvolumes {
+        if let Some(bytes) = sv.last_full_send_bytes {
+            writeln!(
+                out,
+                "backup_subvolume_last_full_send_bytes{{subvolume=\"{}\"}} {}",
+                sv.name, bytes
+            )
+            .unwrap();
+        }
+    }
+
     // ── Structured event counters ─────────────────────────────────
 
     let counters = &data.event_counters;
@@ -347,6 +400,8 @@ mod tests {
                     local_snapshot_count: 15,
                     external_snapshot_count: 14,
                     send_type: 1,
+                    churn_bytes_per_second: None,
+                    last_full_send_bytes: None,
                 },
                 SubvolumeMetrics {
                     name: "htpc-home".to_string(),
@@ -356,6 +411,8 @@ mod tests {
                     local_snapshot_count: 20,
                     external_snapshot_count: 18,
                     send_type: 2,
+                    churn_bytes_per_second: None,
+                    last_full_send_bytes: None,
                 },
             ],
             external_drive_mounted: true,
@@ -501,6 +558,8 @@ mod tests {
                 local_snapshot_count: 5,
                 external_snapshot_count: 3,
                 send_type: 1,
+                churn_bytes_per_second: None,
+                last_full_send_bytes: None,
             },
             SubvolumeMetrics {
                 name: "sv-b".to_string(),
@@ -510,6 +569,8 @@ mod tests {
                 local_snapshot_count: 5,
                 external_snapshot_count: 3,
                 send_type: 2,
+                churn_bytes_per_second: None,
+                last_full_send_bytes: None,
             },
             SubvolumeMetrics {
                 name: "sv-c".to_string(),
@@ -519,6 +580,8 @@ mod tests {
                 local_snapshot_count: 5,
                 external_snapshot_count: 3,
                 send_type: 2,
+                churn_bytes_per_second: None,
+                last_full_send_bytes: None,
             },
         ];
 
@@ -548,6 +611,8 @@ mod tests {
                 local_snapshot_count: 5,
                 external_snapshot_count: 3,
                 send_type: 1,
+                churn_bytes_per_second: None,
+                last_full_send_bytes: None,
             }],
             external_drive_mounted: true,
             external_free_bytes: 1_000_000,
@@ -566,6 +631,8 @@ mod tests {
             local_snapshot_count: 5,
             external_snapshot_count: 3,
             send_type: 2,
+            churn_bytes_per_second: None,
+            last_full_send_bytes: None,
         }];
         apply_carried_forward_timestamps(&mut svs, &carried);
 
@@ -610,6 +677,60 @@ mod tests {
         let output = format_metrics(&data);
         assert!(output.contains("urd_planner_full_sends_total{reason=\"first_send\"} 3"));
         assert!(output.contains("urd_planner_full_sends_total{reason=\"chain_broken\"} 1"));
+    }
+
+    // ── UPI 030: churn / last-full-send gauges ─────────────────────
+
+    #[test]
+    fn format_metrics_emits_churn_help_and_type_lines_unconditionally() {
+        let data = sample_data(); // both subvols have None
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_subvolume_churn_bytes_per_second"));
+        assert!(output.contains("# TYPE backup_subvolume_churn_bytes_per_second gauge"));
+    }
+
+    #[test]
+    fn format_metrics_emits_churn_value_when_some() {
+        let mut data = sample_data();
+        data.subvolumes[0].churn_bytes_per_second = Some(1234.5);
+        let output = format_metrics(&data);
+        assert!(output.contains(
+            "backup_subvolume_churn_bytes_per_second{subvolume=\"subvol3-opptak\"} 1234.5"
+        ));
+    }
+
+    #[test]
+    fn format_metrics_omits_churn_value_line_when_none_but_keeps_help_type() {
+        let data = sample_data(); // all None
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_subvolume_churn_bytes_per_second"));
+        assert!(!output.contains("backup_subvolume_churn_bytes_per_second{"));
+    }
+
+    #[test]
+    fn format_metrics_emits_last_full_send_bytes_help_and_type_lines_unconditionally() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_subvolume_last_full_send_bytes"));
+        assert!(output.contains("# TYPE backup_subvolume_last_full_send_bytes gauge"));
+    }
+
+    #[test]
+    fn format_metrics_emits_last_full_send_bytes_value_when_some() {
+        let mut data = sample_data();
+        data.subvolumes[0].last_full_send_bytes = Some(12_000_000_000);
+        let output = format_metrics(&data);
+        assert!(output.contains(
+            "backup_subvolume_last_full_send_bytes{subvolume=\"subvol3-opptak\"} 12000000000"
+        ));
+    }
+
+    #[test]
+    fn format_metrics_omits_last_full_send_bytes_value_line_when_none_but_keeps_help_type() {
+        let data = sample_data(); // all None
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_subvolume_last_full_send_bytes"));
+        assert!(!output.contains("backup_subvolume_last_full_send_bytes{"));
     }
 
     #[test]

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -599,6 +599,8 @@ mod tests {
                     backup_success: *success,
                     pin_failures,
                     send_completed: true,
+                    churn_bytes_per_second: None,
+                    last_full_send_bytes: None,
                 })
                 .collect(),
         }

--- a/src/output.rs
+++ b/src/output.rs
@@ -470,7 +470,83 @@ pub struct DoctorOutput {
     pub sentinel: DoctorSentinelStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verify: Option<VerifyOutput>,
+    /// Per-subvolume churn aggregates rendered under `urd doctor --thorough`.
+    /// `None` for default `urd doctor` (no Churn section). UPI 030.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub churn: Option<DoctorChurnView>,
     pub verdict: DoctorVerdict,
+}
+
+// ── Churn (UPI 030) ────────────────────────────────────────────────────
+
+/// `urd doctor --thorough` Churn-section view: a header label and one row per
+/// configured subvolume. The header carries a one-line disclaimer about
+/// time-weighted aggregation hiding bursty churn (post-F9).
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorChurnView {
+    pub window_label: String,
+    pub rows: Vec<DoctorChurnRow>,
+}
+
+/// One row of the Churn section.
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorChurnRow {
+    pub name: String,
+    pub state: ChurnRender,
+}
+
+/// Presentation enum mapped from `drift::ChurnEstimate`. Mapping rules
+/// (post-F8 adds the n=1 full-send variant):
+/// - 0 samples         → `NotMeasured`
+/// - 1 incremental     → `FirstMeasurement`
+/// - ≥2 incrementals   → `Incremental`
+/// - 0 incr & 1 full   → `FullSendOnlyFirst`
+/// - 0 incr & ≥2 full  → `FullSendOnly`
+///
+/// (Mixed: incrementals win — full counts are silent in the render.)
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ChurnRender {
+    NotMeasured,
+    FirstMeasurement { bytes_per_second: f64 },
+    Incremental { bytes_per_second: f64 },
+    FullSendOnly { bytes_per_send: u64, seconds_between: i64 },
+    FullSendOnlyFirst { bytes: u64 },
+}
+
+/// Pure mapping from raw aggregates (`drift::ChurnEstimate`) to the
+/// presentation enum (`ChurnRender`). No I/O.
+#[must_use]
+pub fn render_churn(estimate: &crate::drift::ChurnEstimate) -> ChurnRender {
+    use ChurnRender::*;
+    match (estimate.incremental_count, estimate.full_count) {
+        (0, 0) => NotMeasured,
+        (0, 1) => FullSendOnlyFirst {
+            bytes: estimate.latest_full_bytes.unwrap_or(0),
+        },
+        (0, _) => FullSendOnly {
+            bytes_per_send: estimate.median_full_bytes.unwrap_or(0),
+            seconds_between: estimate.latest_full_interval_secs.unwrap_or(0),
+        },
+        (1, _) => FirstMeasurement {
+            bytes_per_second: estimate.mean_bytes_per_second.unwrap_or(0.0),
+        },
+        (_, _) => Incremental {
+            bytes_per_second: estimate.mean_bytes_per_second.unwrap_or(0.0),
+        },
+    }
+}
+
+/// Heartbeat / metrics projection of a single subvolume's churn state.
+/// `commands/backup.rs` builds a `HashMap<String, ChurnHeartbeatFields>` and
+/// passes it to both `heartbeat::build_from_run` and
+/// `metrics::write_metrics_after_execution` so both surfaces share the same
+/// policy: incremental → `churn_bytes_per_second`; full-only →
+/// `last_full_send_bytes`. Cold-start subvolumes have both `None`.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ChurnHeartbeatFields {
+    pub churn_bytes_per_second: Option<f64>,
+    pub last_full_send_bytes: Option<u64>,
 }
 
 /// A single diagnostic check result.
@@ -1886,5 +1962,130 @@ source = "/data/sv2"
         assert!(json.contains("last_seen"));
         let json = serde_json::to_string(&absent_no_history).unwrap();
         assert!(!json.contains("last_seen"));
+    }
+
+    // ── UPI 030: render_churn mapping table + JSON omission ────────
+
+    fn drift_estimate(
+        incr: usize,
+        full: usize,
+        mean: Option<f64>,
+        median_full: Option<u64>,
+        latest_full: Option<u64>,
+        latest_full_secs: Option<i64>,
+    ) -> crate::drift::ChurnEstimate {
+        crate::drift::ChurnEstimate {
+            mean_bytes_per_second: mean,
+            incremental_count: incr,
+            full_count: full,
+            median_full_bytes: median_full,
+            latest_full_bytes: latest_full,
+            latest_full_interval_secs: latest_full_secs,
+        }
+    }
+
+    #[test]
+    fn render_churn_table() {
+        // Cold start: all zero.
+        assert_eq!(
+            render_churn(&drift_estimate(0, 0, None, None, None, None)),
+            ChurnRender::NotMeasured
+        );
+
+        // Single incremental: FirstMeasurement.
+        assert_eq!(
+            render_churn(&drift_estimate(1, 0, Some(100.0), None, None, None)),
+            ChurnRender::FirstMeasurement {
+                bytes_per_second: 100.0
+            }
+        );
+
+        // Two incrementals: Incremental.
+        assert_eq!(
+            render_churn(&drift_estimate(2, 0, Some(123.4), None, None, None)),
+            ChurnRender::Incremental {
+                bytes_per_second: 123.4
+            }
+        );
+
+        // Single full: FullSendOnlyFirst.
+        assert_eq!(
+            render_churn(&drift_estimate(
+                0,
+                1,
+                None,
+                Some(12_000_000_000),
+                Some(12_000_000_000),
+                Some(86_400),
+            )),
+            ChurnRender::FullSendOnlyFirst {
+                bytes: 12_000_000_000
+            }
+        );
+
+        // Two fulls: FullSendOnly with median + latest interval.
+        assert_eq!(
+            render_churn(&drift_estimate(
+                0,
+                2,
+                None,
+                Some(14_000_000_000),
+                Some(14_000_000_000),
+                Some(93_600),
+            )),
+            ChurnRender::FullSendOnly {
+                bytes_per_send: 14_000_000_000,
+                seconds_between: 93_600
+            }
+        );
+
+        // Mixed (1 incr, 1 full): incrementals win → FirstMeasurement.
+        assert_eq!(
+            render_churn(&drift_estimate(
+                1,
+                1,
+                Some(50.0),
+                Some(10_000_000_000),
+                Some(10_000_000_000),
+                Some(86_400),
+            )),
+            ChurnRender::FirstMeasurement {
+                bytes_per_second: 50.0
+            }
+        );
+
+        // Mixed (2 incr, 1 full): incrementals win → Incremental.
+        assert_eq!(
+            render_churn(&drift_estimate(
+                2,
+                1,
+                Some(75.0),
+                Some(10_000_000_000),
+                Some(10_000_000_000),
+                Some(86_400),
+            )),
+            ChurnRender::Incremental {
+                bytes_per_second: 75.0
+            }
+        );
+    }
+
+    #[test]
+    fn doctor_output_serializes_with_omitted_churn_when_none() {
+        let output = DoctorOutput {
+            config_checks: vec![],
+            infra_checks: vec![],
+            data_safety: vec![],
+            sentinel: DoctorSentinelStatus {
+                running: false,
+                pid: None,
+                uptime: None,
+            },
+            verify: None,
+            churn: None,
+            verdict: DoctorVerdict::healthy(),
+        };
+        let json = serde_json::to_string(&output).unwrap();
+        assert!(!json.contains("\"churn\""), "churn should be omitted when None: {json}");
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -8,7 +8,7 @@ use crate::events::{Event, EventKind, EventPayload};
 // ── Types ───────────────────────────────────────────────────────────────
 
 pub struct StateDb {
-    conn: Connection,
+    pub(crate) conn: Connection,
 }
 
 /// Input record for writing a single operation to the database.
@@ -88,6 +88,22 @@ pub struct OperationRow {
     pub result: String,
     pub error_message: Option<String>,
     pub bytes_transferred: Option<i64>,
+}
+
+/// Persisted shape of a `drift_samples` row.
+/// `run_id` is `Option` so future test fixtures can construct rows without
+/// a run; production writes always have one. The send_kind serializes via
+/// `SendKind::as_db_str()` (`"send_full"` / `"send_incremental"`) — same
+/// strings as `operations.operation` for join compatibility (post-F7).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DriftSampleRow {
+    pub run_id: Option<i64>,
+    pub subvolume: String,
+    pub sampled_at: chrono::NaiveDateTime,
+    pub seconds_since_prev_send: Option<i64>,
+    pub bytes_transferred: u64,
+    pub source_free_bytes: Option<u64>,
+    pub send_kind: crate::types::SendKind,
 }
 
 // ── StateDb ─────────────────────────────────────────────────────────────
@@ -179,7 +195,21 @@ impl StateDb {
                 CREATE INDEX IF NOT EXISTS events_by_subvolume_time
                     ON events(subvolume, occurred_at DESC) WHERE subvolume IS NOT NULL;
                 CREATE INDEX IF NOT EXISTS events_by_drive_time
-                    ON events(drive_label, occurred_at DESC) WHERE drive_label IS NOT NULL;",
+                    ON events(drive_label, occurred_at DESC) WHERE drive_label IS NOT NULL;
+
+                CREATE TABLE IF NOT EXISTS drift_samples (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    run_id INTEGER REFERENCES runs(id),
+                    subvolume TEXT NOT NULL,
+                    sampled_at TEXT NOT NULL,
+                    seconds_since_prev_send INTEGER,
+                    bytes_transferred INTEGER NOT NULL,
+                    source_free_bytes INTEGER,
+                    send_type TEXT NOT NULL
+                );
+
+                CREATE INDEX IF NOT EXISTS drift_samples_by_subvolume_time
+                    ON drift_samples(subvolume, sampled_at DESC);",
             )
             .map_err(|e| UrdError::State(format!("failed to create schema: {e}")))?;
 
@@ -193,6 +223,70 @@ impl StateDb {
             );
         }
 
+        // One-shot drift_samples backfill from operations history.
+        // Best-effort and idempotent: a non-empty drift_samples table skips
+        // the work. Failures (e.g., older SQLite without window functions)
+        // log and continue — users without backfill simply see empty churn
+        // until one nightly run accumulates a fresh sample.
+        if let Err(e) = self.backfill_drift_samples_from_operations() {
+            log::warn!(
+                "drift_samples backfill failed (best-effort, continuing): {e}"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Idempotent one-shot: project history rows from `operations` JOIN
+    /// `runs` into `drift_samples`. Skipped when `drift_samples` is already
+    /// non-empty. Backfilled rows carry `source_free_bytes = NULL` (no
+    /// historical statvfs data) and `send_type` carrying the canonical DB
+    /// strings (`send_full` / `send_incremental`) directly from
+    /// `operations.operation`. The window-function-derived
+    /// `seconds_since_prev_send` chain partitions on `(subvolume, drive_label)`,
+    /// so historical multi-drive runs may produce one row per drive — the
+    /// time-weighted mean handles this. Going-forward writes are deduped
+    /// at the executor layer (one row per `(run_id, subvolume)`).
+    fn backfill_drift_samples_from_operations(&self) -> crate::error::Result<()> {
+        let any: i64 = self
+            .conn
+            .query_row("SELECT COUNT(*) FROM drift_samples LIMIT 1", [], |row| {
+                row.get(0)
+            })
+            .map_err(|e| UrdError::State(format!("backfill probe: {e}")))?;
+        if any > 0 {
+            return Ok(());
+        }
+
+        let tx = self
+            .conn
+            .unchecked_transaction()
+            .map_err(|e| UrdError::State(format!("backfill tx: {e}")))?;
+        tx.execute(
+            "INSERT INTO drift_samples (run_id, subvolume, sampled_at,
+                 seconds_since_prev_send, bytes_transferred,
+                 source_free_bytes, send_type)
+             SELECT
+                 o.run_id,
+                 o.subvolume,
+                 r.started_at,
+                 CAST((julianday(r.started_at) -
+                       julianday(LAG(r.started_at) OVER w)) * 86400 AS INTEGER),
+                 o.bytes_transferred,
+                 NULL,
+                 o.operation
+             FROM operations o
+             JOIN runs r ON o.run_id = r.id
+             WHERE o.operation IN ('send_full', 'send_incremental')
+               AND o.result = 'success'
+               AND o.bytes_transferred IS NOT NULL
+             WINDOW w AS (PARTITION BY o.subvolume, o.drive_label
+                          ORDER BY r.started_at)",
+            [],
+        )
+        .map_err(|e| UrdError::State(format!("backfill insert: {e}")))?;
+        tx.commit()
+            .map_err(|e| UrdError::State(format!("backfill commit: {e}")))?;
         Ok(())
     }
 
@@ -867,6 +961,126 @@ impl StateDb {
                 }))
             }
             None => Ok(None),
+        }
+    }
+
+    // ── Drift-sample methods ────────────────────────────────────────
+
+    /// Persist a drift sample. Best-effort per ADR-102 (telemetry must
+    /// never block backups): failures are logged and swallowed.
+    pub fn record_drift_sample_best_effort(&self, sample: &DriftSampleRow) {
+        if let Err(e) = self.record_drift_sample_inner(sample) {
+            log::warn!(
+                "drift sample write failed (best-effort, continuing): {e}"
+            );
+        }
+    }
+
+    fn record_drift_sample_inner(&self, sample: &DriftSampleRow) -> crate::error::Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO drift_samples (run_id, subvolume, sampled_at,
+                     seconds_since_prev_send, bytes_transferred,
+                     source_free_bytes, send_type)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params![
+                    sample.run_id,
+                    sample.subvolume,
+                    sample.sampled_at.format("%Y-%m-%dT%H:%M:%S").to_string(),
+                    sample.seconds_since_prev_send,
+                    sample.bytes_transferred as i64,
+                    sample.source_free_bytes.map(|b| b as i64),
+                    sample.send_kind.as_db_str(),
+                ],
+            )
+            .map_err(|e| UrdError::State(format!("failed to record drift sample: {e}")))?;
+        Ok(())
+    }
+
+    /// Query drift samples for a subvolume since the given timestamp,
+    /// newest first. The `since` lower bound is inclusive so callers can
+    /// pass `now - default_window()` to walk the rolling window without
+    /// off-by-one fudging.
+    pub fn drift_samples_for_subvolume(
+        &self,
+        subvolume: &str,
+        since: chrono::NaiveDateTime,
+    ) -> crate::error::Result<Vec<DriftSampleRow>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT run_id, subvolume, sampled_at, seconds_since_prev_send,
+                        bytes_transferred, source_free_bytes, send_type
+                 FROM drift_samples
+                 WHERE subvolume = ?1 AND sampled_at >= ?2
+                 ORDER BY sampled_at DESC",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let since_str = since.format("%Y-%m-%dT%H:%M:%S").to_string();
+        let rows = stmt
+            .query_map(
+                rusqlite::params![subvolume, since_str],
+                Self::map_drift_sample_row,
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut out = Vec::new();
+        for row in rows {
+            match row {
+                Ok(Some(r)) => out.push(r),
+                Ok(None) => continue, // unparseable send_type, already logged
+                Err(e) => return Err(UrdError::State(format!("read drift row: {e}"))),
+            }
+        }
+        Ok(out)
+    }
+
+    fn map_drift_sample_row(row: &rusqlite::Row) -> rusqlite::Result<Option<DriftSampleRow>> {
+        let run_id: Option<i64> = row.get(0)?;
+        let subvolume: String = row.get(1)?;
+        let sampled_at_s: String = row.get(2)?;
+        let seconds_since_prev_send: Option<i64> = row.get(3)?;
+        let bytes_transferred: i64 = row.get(4)?;
+        let source_free_bytes: Option<i64> = row.get(5)?;
+        let send_type_s: String = row.get(6)?;
+
+        let sampled_at = match chrono::NaiveDateTime::parse_from_str(
+            &sampled_at_s,
+            "%Y-%m-%dT%H:%M:%S",
+        ) {
+            Ok(dt) => dt,
+            Err(e) => {
+                log::warn!("skipping drift row with unparseable sampled_at {sampled_at_s:?}: {e}");
+                return Ok(None);
+            }
+        };
+        let Some(send_kind) = crate::types::SendKind::from_db_str(&send_type_s) else {
+            log::warn!("skipping drift row with unknown send_type {send_type_s:?}");
+            return Ok(None);
+        };
+
+        Ok(Some(DriftSampleRow {
+            run_id,
+            subvolume,
+            sampled_at,
+            seconds_since_prev_send,
+            bytes_transferred: bytes_transferred.max(0) as u64,
+            source_free_bytes: source_free_bytes.map(|b| b.max(0) as u64),
+            send_kind,
+        }))
+    }
+
+    /// Convert a persisted row into the domain shape used by `drift::compute_rolling_churn`.
+    /// Drops the `run_id` and `subvolume` fields (the domain function does not use them).
+    #[must_use]
+    pub fn drift_row_to_sample(row: DriftSampleRow) -> crate::drift::DriftSample {
+        crate::drift::DriftSample {
+            sampled_at: row.sampled_at,
+            seconds_since_prev_send: row.seconds_since_prev_send,
+            bytes_transferred: row.bytes_transferred,
+            source_free_bytes: row.source_free_bytes,
+            send_kind: row.send_kind,
         }
     }
 
@@ -2359,5 +2573,408 @@ mod tests {
             }
             other => panic!("unexpected payload: {other:?}"),
         }
+    }
+
+    // ── Drift sample tests (UPI 030) ─────────────────────────────────
+
+    fn drift_dt(s: &str) -> chrono::NaiveDateTime {
+        chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").unwrap()
+    }
+
+    fn make_drift_row(
+        run_id: Option<i64>,
+        subvol: &str,
+        sampled_at: &str,
+        secs_prev: Option<i64>,
+        bytes: u64,
+        free: Option<u64>,
+        kind: crate::types::SendKind,
+    ) -> DriftSampleRow {
+        DriftSampleRow {
+            run_id,
+            subvolume: subvol.to_string(),
+            sampled_at: drift_dt(sampled_at),
+            seconds_since_prev_send: secs_prev,
+            bytes_transferred: bytes,
+            source_free_bytes: free,
+            send_kind: kind,
+        }
+    }
+
+    #[test]
+    fn drift_samples_table_created_on_open() {
+        let db = StateDb::open_memory().unwrap();
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM drift_samples", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn drift_samples_index_created() {
+        let db = StateDb::open_memory().unwrap();
+        let n: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master
+                 WHERE type='index' AND name='drift_samples_by_subvolume_time'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(n, 1);
+    }
+
+    #[test]
+    fn record_drift_sample_persists_one() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+        let row = make_drift_row(
+            Some(run_id),
+            "home",
+            "2026-04-30T04:00:00",
+            Some(86_400),
+            123_456_789,
+            Some(1_000_000_000),
+            crate::types::SendKind::Incremental,
+        );
+        db.record_drift_sample_best_effort(&row);
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM drift_samples", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let stored: (i64, String, i64, i64, i64, String) = db
+            .conn
+            .query_row(
+                "SELECT run_id, subvolume, seconds_since_prev_send,
+                        bytes_transferred, source_free_bytes, send_type
+                 FROM drift_samples LIMIT 1",
+                [],
+                |r| {
+                    Ok((
+                        r.get(0)?,
+                        r.get(1)?,
+                        r.get(2)?,
+                        r.get(3)?,
+                        r.get(4)?,
+                        r.get(5)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(stored.0, run_id);
+        assert_eq!(stored.1, "home");
+        assert_eq!(stored.2, 86_400);
+        assert_eq!(stored.3, 123_456_789);
+        assert_eq!(stored.4, 1_000_000_000);
+        assert_eq!(stored.5, "send_incremental");
+    }
+
+    #[test]
+    fn record_drift_sample_with_null_free_bytes_persists() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+        let row = make_drift_row(
+            Some(run_id),
+            "home",
+            "2026-04-30T04:00:00",
+            Some(86_400),
+            1_000_000,
+            None,
+            crate::types::SendKind::Incremental,
+        );
+        db.record_drift_sample_best_effort(&row);
+
+        let free: Option<i64> = db
+            .conn
+            .query_row(
+                "SELECT source_free_bytes FROM drift_samples LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(free, None);
+    }
+
+    #[test]
+    fn record_drift_sample_with_null_seconds_since_prev_send_persists() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+        let row = make_drift_row(
+            Some(run_id),
+            "home",
+            "2026-04-30T04:00:00",
+            None,
+            1_000_000,
+            None,
+            crate::types::SendKind::Full,
+        );
+        db.record_drift_sample_best_effort(&row);
+
+        let secs: Option<i64> = db
+            .conn
+            .query_row(
+                "SELECT seconds_since_prev_send FROM drift_samples LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(secs, None);
+    }
+
+    #[test]
+    fn record_drift_sample_best_effort_swallows_errors_on_closed_db() {
+        // Force a write failure by passing a foreign-run-id that violates
+        // the FK reference once a CHECK is added — for now, simulate via
+        // dropping the table first.
+        let db = StateDb::open_memory().unwrap();
+        db.conn.execute("DROP TABLE drift_samples", []).unwrap();
+        let row = make_drift_row(
+            None,
+            "home",
+            "2026-04-30T04:00:00",
+            Some(86_400),
+            1_000_000,
+            None,
+            crate::types::SendKind::Incremental,
+        );
+        // Must not panic.
+        db.record_drift_sample_best_effort(&row);
+    }
+
+    #[test]
+    fn drift_samples_for_subvolume_filters_by_name_and_since() {
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+        // Three subvolumes, several time-points.
+        let rows = vec![
+            make_drift_row(
+                Some(run_id),
+                "home",
+                "2026-04-30T04:00:00",
+                Some(86_400),
+                100,
+                None,
+                crate::types::SendKind::Incremental,
+            ),
+            make_drift_row(
+                Some(run_id),
+                "home",
+                "2026-04-25T04:00:00",
+                Some(86_400),
+                200,
+                None,
+                crate::types::SendKind::Incremental,
+            ),
+            make_drift_row(
+                Some(run_id),
+                "home",
+                "2026-04-15T04:00:00", // older than since
+                Some(86_400),
+                300,
+                None,
+                crate::types::SendKind::Incremental,
+            ),
+            make_drift_row(
+                Some(run_id),
+                "photos",
+                "2026-04-30T04:00:00",
+                Some(86_400),
+                400,
+                None,
+                crate::types::SendKind::Incremental,
+            ),
+        ];
+        for r in &rows {
+            db.record_drift_sample_best_effort(r);
+        }
+
+        let since = drift_dt("2026-04-20T00:00:00");
+        let result = db.drift_samples_for_subvolume("home", since).unwrap();
+        assert_eq!(result.len(), 2);
+        // Newest first.
+        assert_eq!(result[0].sampled_at, drift_dt("2026-04-30T04:00:00"));
+        assert_eq!(result[1].sampled_at, drift_dt("2026-04-25T04:00:00"));
+    }
+
+    #[test]
+    fn drift_samples_for_subvolume_returns_empty_vec_when_none() {
+        let db = StateDb::open_memory().unwrap();
+        let result = db
+            .drift_samples_for_subvolume("nope", drift_dt("2026-01-01T00:00:00"))
+            .unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn drift_sample_send_type_string_matches_operations_operation_string() {
+        // Round-trip a drift sample with SendKind::Full and an operation row
+        // with operation="send_full" — the persisted strings must be byte-equal
+        // (post-F7: drift_samples.send_type joins operations.operation).
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "home".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: Some("WD-18TB".to_string()),
+            duration_secs: Some(10.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(1_000_000),
+        })
+        .unwrap();
+        db.record_drift_sample_best_effort(&make_drift_row(
+            Some(run_id),
+            "home",
+            "2026-04-30T04:00:00",
+            Some(86_400),
+            1_000_000,
+            None,
+            crate::types::SendKind::Full,
+        ));
+        let op_str: String = db
+            .conn
+            .query_row("SELECT operation FROM operations LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        let drift_str: String = db
+            .conn
+            .query_row("SELECT send_type FROM drift_samples LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(op_str, drift_str);
+        assert_eq!(op_str, "send_full");
+    }
+
+    #[test]
+    fn backfill_populates_drift_samples_from_operations_history() {
+        // Open one DB to seed runs + operations.
+        let db = StateDb::open_memory().unwrap();
+
+        // Seed three runs with operations on a single drive chain so the
+        // window-function-derived seconds_since_prev_send is meaningful.
+        db.conn
+            .execute(
+                "INSERT INTO runs (id, started_at, mode, result)
+                 VALUES (1, '2026-04-15T04:00:00', 'full', 'success'),
+                        (2, '2026-04-22T04:00:00', 'full', 'success'),
+                        (3, '2026-04-29T04:00:00', 'full', 'success')",
+                [],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO operations (run_id, subvolume, operation, drive_label,
+                                         result, bytes_transferred)
+                 VALUES (1, 'home', 'send_full', 'WD-18TB', 'success', 1000000),
+                        (2, 'home', 'send_incremental', 'WD-18TB', 'success', 200000),
+                        (3, 'home', 'send_incremental', 'WD-18TB', 'success', 300000),
+                        (1, 'home', 'snapshot', 'WD-18TB', 'success', NULL),
+                        (2, 'home', 'send_incremental', 'WD-18TB', 'failure', NULL)",
+                [],
+            )
+            .unwrap();
+
+        // Drop drift_samples so backfill runs fresh on next init_schema call.
+        db.conn.execute("DELETE FROM drift_samples", []).unwrap();
+
+        // Re-trigger backfill (idempotent guard sees empty table → runs).
+        db.backfill_drift_samples_from_operations().unwrap();
+
+        // Three successful sends → three rows.
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM drift_samples", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 3);
+
+        // All backfilled rows have NULL source_free_bytes.
+        let null_free: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM drift_samples WHERE source_free_bytes IS NULL",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(null_free, 3);
+
+        // First in chain has NULL seconds_since_prev_send (no prior).
+        let first_secs: Option<i64> = db
+            .conn
+            .query_row(
+                "SELECT seconds_since_prev_send FROM drift_samples
+                 ORDER BY sampled_at ASC LIMIT 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(first_secs, None);
+
+        // Second has 7-day interval = 604_800.
+        let second_secs: Option<i64> = db
+            .conn
+            .query_row(
+                "SELECT seconds_since_prev_send FROM drift_samples
+                 ORDER BY sampled_at ASC LIMIT 1 OFFSET 1",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(second_secs, Some(604_800));
+
+        // send_type strings match operations.operation directly.
+        let kinds: Vec<String> = db
+            .conn
+            .prepare("SELECT send_type FROM drift_samples ORDER BY sampled_at ASC")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(
+            kinds,
+            vec!["send_full", "send_incremental", "send_incremental"]
+        );
+    }
+
+    #[test]
+    fn backfill_idempotent_when_drift_samples_already_populated() {
+        let db = StateDb::open_memory().unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO runs (id, started_at, mode, result)
+                 VALUES (1, '2026-04-15T04:00:00', 'full', 'success')",
+                [],
+            )
+            .unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO operations (run_id, subvolume, operation, drive_label,
+                                         result, bytes_transferred)
+                 VALUES (1, 'home', 'send_full', 'WD-18TB', 'success', 1000000)",
+                [],
+            )
+            .unwrap();
+
+        // First backfill: writes one row.
+        db.backfill_drift_samples_from_operations().unwrap();
+        let count_after_first: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM drift_samples", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count_after_first, 1);
+
+        // Second backfill: must be a no-op.
+        db.backfill_drift_samples_from_operations().unwrap();
+        let count_after_second: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM drift_samples", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count_after_second, 1);
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -127,6 +127,19 @@ impl SendKind {
             SendKind::Incremental => "send_incremental",
         }
     }
+
+    /// Parse the canonical DB form back into a `SendKind`. Returns `None`
+    /// for any string that does not match `as_db_str()` exactly. Used by
+    /// readers of the `drift_samples.send_type` column and for cross-table
+    /// joins against `operations.operation`.
+    #[must_use]
+    pub fn from_db_str(s: &str) -> Option<Self> {
+        match s {
+            "send_full" => Some(SendKind::Full),
+            "send_incremental" => Some(SendKind::Incremental),
+            _ => None,
+        }
+    }
 }
 
 // ── DriveEvent ──────────────────────────────────────────────────────────

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -2392,6 +2392,28 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
         .ok();
     }
 
+    // Churn section (--thorough only). UPI 030.
+    if let Some(ref churn) = data.churn {
+        writeln!(out).ok();
+        let header = format!("Churn ({})", churn.window_label);
+        writeln!(out, "  {}", header.bold()).ok();
+
+        if churn.rows.is_empty() {
+            writeln!(out, "    {}", "(no subvolumes)".dimmed()).ok();
+        } else {
+            let name_width = churn
+                .rows
+                .iter()
+                .map(|r| r.name.len())
+                .max()
+                .unwrap_or(8)
+                .max(8);
+            for row in &churn.rows {
+                writeln!(out, "    {}", format_churn_row(&row.name, &row.state, name_width)).ok();
+            }
+        }
+    }
+
     // Verdict
     writeln!(out).ok();
     match data.verdict.status {
@@ -2468,6 +2490,53 @@ fn pluralize(count: usize, singular: &str, plural: &str) -> String {
         format!("{count} {plural}")
     }
 }
+
+/// Render one Churn-section row: padded name + per-state body.
+/// Helper for `render_doctor_interactive`'s --thorough Churn block (UPI 030).
+fn format_churn_row(
+    name: &str,
+    state: &crate::output::ChurnRender,
+    name_width: usize,
+) -> String {
+    use crate::output::ChurnRender::*;
+    use crate::types::ByteSize;
+    let pad = format!("{:width$}", name, width = name_width);
+    match state {
+        NotMeasured => format!("{pad}    {}", "not yet measured".dimmed()),
+        FirstMeasurement { bytes_per_second } => {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let per_day = (*bytes_per_second * 86_400.0) as u64;
+            format!(
+                "{pad}    ~{}/day        {}",
+                ByteSize(per_day),
+                "(first measurement, no trend yet)".dimmed()
+            )
+        }
+        Incremental { bytes_per_second } => {
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let per_day = (*bytes_per_second * 86_400.0) as u64;
+            format!(
+                "{pad}    ~{}/day        {}",
+                ByteSize(per_day),
+                "(incremental)".dimmed()
+            )
+        }
+        FullSendOnly {
+            bytes_per_send,
+            seconds_between,
+        } => format!(
+            "{pad}    ~{}/full-send   {}",
+            ByteSize(*bytes_per_send),
+            format!("(every ~{})", format_duration_short(*seconds_between / 60)).dimmed()
+        ),
+        FullSendOnlyFirst { bytes } => format!(
+            "{pad}    ~{} recorded     {}",
+            ByteSize(*bytes),
+            "(one full send so far, no trend yet)".dimmed()
+        ),
+    }
+}
+
 
 fn render_doctor_check_section(out: &mut String, title: &str, checks: &[DoctorCheck]) {
     writeln!(out, "  {}", title.bold()).ok();
@@ -3288,6 +3357,7 @@ pub(crate) mod test_fixtures {
                 uptime: Some("3h 12m".to_string()),
             },
             verify: None,
+            churn: None,
             verdict: DoctorVerdict::healthy(),
         }
     }
@@ -7489,5 +7559,190 @@ mod tests {
     fn humanize_duration_zero_returns_less_than_one() {
         assert_eq!(humanize_duration(0), "<1s");
         assert_eq!(humanize_duration(-1), "<1s");
+    }
+
+    // ── UPI 030 Churn section ──────────────────────────────────────
+
+    fn churn_doctor_output(view: crate::output::DoctorChurnView) -> DoctorOutput {
+        let mut data = test_doctor_output();
+        data.churn = Some(view);
+        data
+    }
+
+    #[test]
+    fn doctor_thorough_renders_churn_section_with_header_and_disclaimer() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorChurnView {
+            window_label: "rolling 7 days, time-weighted; bursty subvolumes may differ"
+                .to_string(),
+            rows: vec![crate::output::DoctorChurnRow {
+                name: "home".to_string(),
+                state: crate::output::ChurnRender::NotMeasured,
+            }],
+        };
+        let output = render_doctor(&churn_doctor_output(view), OutputMode::Interactive);
+        assert!(
+            output.contains(
+                "Churn (rolling 7 days, time-weighted; bursty subvolumes may differ)"
+            ),
+            "missing header + disclaimer: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_churn_renders_first_measurement_label() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorChurnView {
+            window_label: "rolling 7 days".to_string(),
+            rows: vec![crate::output::DoctorChurnRow {
+                name: "home".to_string(),
+                state: crate::output::ChurnRender::FirstMeasurement {
+                    bytes_per_second: 1000.0,
+                },
+            }],
+        };
+        let output = render_doctor(&churn_doctor_output(view), OutputMode::Interactive);
+        assert!(
+            output.contains("(first measurement, no trend yet)"),
+            "missing first-measurement label: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_churn_renders_incremental_label() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorChurnView {
+            window_label: "rolling 7 days".to_string(),
+            rows: vec![crate::output::DoctorChurnRow {
+                name: "home".to_string(),
+                state: crate::output::ChurnRender::Incremental {
+                    bytes_per_second: 4_745.37, // ~410 MB/day
+                },
+            }],
+        };
+        let output = render_doctor(&churn_doctor_output(view), OutputMode::Interactive);
+        assert!(
+            output.contains("(incremental)"),
+            "missing incremental label: {output}"
+        );
+        assert!(output.contains("/day"), "missing /day suffix: {output}");
+    }
+
+    #[test]
+    fn doctor_thorough_churn_renders_full_send_only_label() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorChurnView {
+            window_label: "rolling 7 days".to_string(),
+            rows: vec![crate::output::DoctorChurnRow {
+                name: "htpc-root".to_string(),
+                state: crate::output::ChurnRender::FullSendOnly {
+                    bytes_per_send: 12_000_000_000,
+                    seconds_between: 86_400,
+                },
+            }],
+        };
+        let output = render_doctor(&churn_doctor_output(view), OutputMode::Interactive);
+        assert!(
+            output.contains("/full-send"),
+            "missing /full-send suffix: {output}"
+        );
+        assert!(output.contains("(every ~"), "missing every-~ label: {output}");
+    }
+
+    #[test]
+    fn doctor_thorough_churn_renders_full_send_only_first_label() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorChurnView {
+            window_label: "rolling 7 days".to_string(),
+            rows: vec![crate::output::DoctorChurnRow {
+                name: "transient".to_string(),
+                state: crate::output::ChurnRender::FullSendOnlyFirst {
+                    bytes: 12_000_000_000,
+                },
+            }],
+        };
+        let output = render_doctor(&churn_doctor_output(view), OutputMode::Interactive);
+        assert!(
+            output.contains("recorded"),
+            "missing recorded label: {output}"
+        );
+        assert!(
+            output.contains("(one full send so far, no trend yet)"),
+            "missing first-full-send disclaimer: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_churn_renders_not_measured_label() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorChurnView {
+            window_label: "rolling 7 days".to_string(),
+            rows: vec![crate::output::DoctorChurnRow {
+                name: "fresh".to_string(),
+                state: crate::output::ChurnRender::NotMeasured,
+            }],
+        };
+        let output = render_doctor(&churn_doctor_output(view), OutputMode::Interactive);
+        assert!(
+            output.contains("not yet measured"),
+            "missing not-yet-measured label: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_churn_renders_five_state_ladder_full_fixture() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorChurnView {
+            window_label: "rolling 7 days, time-weighted; bursty subvolumes may differ"
+                .to_string(),
+            rows: vec![
+                crate::output::DoctorChurnRow {
+                    name: "home".to_string(),
+                    state: crate::output::ChurnRender::Incremental {
+                        bytes_per_second: 4_745.37,
+                    },
+                },
+                crate::output::DoctorChurnRow {
+                    name: "rootbackup".to_string(),
+                    state: crate::output::ChurnRender::FirstMeasurement {
+                        bytes_per_second: 37_037.04,
+                    },
+                },
+                crate::output::DoctorChurnRow {
+                    name: "htpc-root".to_string(),
+                    state: crate::output::ChurnRender::FullSendOnly {
+                        bytes_per_send: 12_000_000_000,
+                        seconds_between: 86_400,
+                    },
+                },
+                crate::output::DoctorChurnRow {
+                    name: "transient".to_string(),
+                    state: crate::output::ChurnRender::FullSendOnlyFirst {
+                        bytes: 8_000_000_000,
+                    },
+                },
+                crate::output::DoctorChurnRow {
+                    name: "other".to_string(),
+                    state: crate::output::ChurnRender::NotMeasured,
+                },
+            ],
+        };
+        let output = render_doctor(&churn_doctor_output(view), OutputMode::Interactive);
+        assert!(output.contains("(incremental)"));
+        assert!(output.contains("(first measurement, no trend yet)"));
+        assert!(output.contains("/full-send"));
+        assert!(output.contains("(one full send so far, no trend yet)"));
+        assert!(output.contains("not yet measured"));
+    }
+
+    #[test]
+    fn doctor_without_thorough_omits_churn_section() {
+        let _color = color_guard(false);
+        // Default test_doctor_output has churn=None.
+        let output = render_doctor(&test_doctor_output(), OutputMode::Interactive);
+        assert!(
+            !output.contains("Churn ("),
+            "Churn section should not render when churn=None: {output}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- **Drift telemetry, the foundation of the Do-No-Harm arc.** New pure `drift.rs` module aggregates per-send wire bytes into a rolling 7-day, time-weighted churn rate, persisted in a new `drift_samples` SQLite table. One-shot idempotent backfill from `operations` history means day-one delivers actual numbers, not "wait a week."
- **One sample per run per subvolume (post-F1 dedup).** Multi-drive fan-out no longer double-counts: the executor writes a single drift row at the end of `execute_subvolume`, derived from the first successful send in plan-iteration order. Statvfs failure is non-fatal — `source_free_bytes` becomes `None` and the sample still writes.
- **Heartbeat schema v3 + two new Prometheus gauges.** Additive fields `churn_bytes_per_second` and `last_full_send_bytes` round-trip cleanly through v2-on-disk files via `serde(default)`. Two distinct gauges (`backup_subvolume_churn_bytes_per_second` for incremental subvolumes, `backup_subvolume_last_full_send_bytes` for full-send-only subvolumes) with unconditional `# HELP` / `# TYPE` lines so dashboards find them on a fresh install.
- **`urd doctor --thorough` Churn section.** Five-state ladder (cold-start, first measurement, incremental, full-send-only first, full-send-only) with a bursty-churn disclaimer. Pure domain → presentation mapping in `output::render_churn` keeps `drift.rs` presentation-free.

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: **1186 passed, 0 failed, 5 ignored** (54 new — 14 drift, 11 state, 6 executor, 6 heartbeat, 6 metrics, 11 voice/output/doctor)
- `cargo build --release`: pass
- Manual pressure-test (Step 8 of plan) **still required** before merge: install with `cargo install --path .`, verify `sqlite3 ~/.local/share/urd/urd.db 'SELECT COUNT(*) FROM drift_samples'` is non-zero after first open (backfill), confirm `urd doctor --thorough` numbers match intuition.

## Pre-merge follow-ups (cross-repo)

- [ ] **Homelab ADR-021 update.** Add the two new heartbeat fields (`churn_bytes_per_second`, `last_full_send_bytes`) and two new Prometheus metrics (`backup_subvolume_churn_bytes_per_second`, `backup_subvolume_last_full_send_bytes`) to the consumer-side ADR.
- [ ] **Homelab parser tolerance for v3.** Grep the homelab repo for the heartbeat parser; confirm it tolerates unknown fields (`serde(default)` or equivalent). Block merge if v3 rejects.
- [ ] Pressure-test the numbers on real production data (Step 8 of the plan).

## Architecture notes

- ADR-100 (planner/executor): planner unchanged.
- ADR-101 (BtrfsOps): statvfs is not btrfs.
- ADR-102 (filesystem truth, SQLite history): `record_drift_sample_best_effort` log-and-continues so telemetry never blocks backups.
- ADR-105 (backward compat): additive heartbeat fields, additive metric names (no renames), `CREATE TABLE IF NOT EXISTS`, idempotent backfill.
- ADR-108 (pure-function modules): `drift.rs` is pure (no I/O, no `unwrap`/`expect` in production).
- ADR-113 (Do-No-Harm): this is Layer 0 — observability only. Future UPIs 031–034 act on the data.
- ADR-114 (event log): no drift events in 030. Anomaly thresholds deferred until 4–8 weeks of baseline data exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)