### PR TITLE
fix: non-transient planner strands new snapshot when local matches external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Non-transient planner now augments `local_snaps` with the just-planned
+  snapshot before computing sends, so a freshly-created snapshot ships in
+  the same run when latest local already equals latest external (the
+  "caught up" state). Mirrors the transient-lifecycle fix from 0f52555.
+  Previously, after emergency retention or a generation-equality skip
+  caught local and external up, the next run would create a new local
+  snapshot and silently defer its send as "already on <drive>", stranding
+  the snapshot until the following night's run.
+
 ## [0.15.0] - 2026-05-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-05-02
+
 ### Fixed
 - Non-transient planner now augments `local_snaps` with the just-planned
   snapshot before computing sends, so a freshly-created snapshot ships in
@@ -403,7 +405,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/vonrobak/urd/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/vonrobak/urd/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/vonrobak/urd/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/vonrobak/urd/compare/v0.12.2...v0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -414,9 +414,9 @@ pub fn plan(
         // LOAD-BEARING ORDER: Operations are emitted as create → send → delete.
         // The executor relies on this ordering within each subvolume.
         // Do not reorder without updating the executor contract in PLAN.md.
-        if !filters.external_only {
+        let planned_snap = if !filters.external_only {
             let min_free = subvol.min_free_bytes.unwrap_or(0);
-            let _ = plan_local_snapshot(
+            let planned = plan_local_snapshot(
                 subvol,
                 &local_dir,
                 &local_snaps,
@@ -440,7 +440,31 @@ pub fn plan(
                 &mut operations,
                 &mut events,
             );
-        }
+            planned
+        } else {
+            None
+        };
+
+        // Send planning must consider the just-planned snapshot. Without
+        // this augmentation, a "caught up" state (latest local already on
+        // drive) defers the send and strands tonight's snapshot until the
+        // next run. Mirrors plan_transient_lifecycle's effective_local_snaps
+        // (Bug B fixed for transient in 0f52555 — same shape applies here).
+        let augmented;
+        let effective_local_snaps: &[SnapshotName] = if let Some(ref snap) = planned_snap {
+            if !local_snaps.iter().any(|s| s.as_str() == snap.as_str()) {
+                augmented = {
+                    let mut v = local_snaps.clone();
+                    v.push(snap.clone());
+                    v
+                };
+                &augmented
+            } else {
+                &local_snaps
+            }
+        } else {
+            &local_snaps
+        };
 
         // ── External operations ─────────────────────────────────────
         if !filters.local_only && subvol.send_enabled {
@@ -464,7 +488,7 @@ pub fn plan(
                     subvol,
                     drive,
                     &local_dir,
-                    &local_snaps,
+                    effective_local_snaps,
                     now,
                     force,
                     filters.skip_intervals,
@@ -2965,6 +2989,73 @@ send_enabled = false
     }
 
     #[test]
+    fn non_transient_sends_when_local_caught_up_to_external() {
+        // Regression: same class of bug fixed for transient in commit 0f52555
+        // ("Bug B: phase 2 sends used a stale local_snaps list that didn't
+        //  include the snapshot planned in phase 1").
+        // The non-transient code path was unpatched until this fix.
+        //
+        // Trigger: latest local == latest external (caught-up state). This is
+        // reached after any prior run that deferred snapshot creation but
+        // successfully sent the existing latest. In the wild this happened for
+        // htpc-home on 2026-05-02 after emergency retention freed space.
+        let config = test_config();
+        let mut fs = MockFileSystemState::new();
+
+        // Caught-up: same single snapshot S1 exists locally and on D1.
+        let s1 = snap("20260322-1330-one"); // 1.5h before now() — past 15m and 1h intervals
+        fs.local_snapshots.insert("sv1".to_string(), vec![s1.clone()]);
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![s1.clone()]);
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            s1.clone(),
+        );
+
+        // Plenty of local space (above the 10GB min_free threshold).
+        fs.free_bytes
+            .insert(PathBuf::from("/snap/sv1"), 50_000_000_000);
+
+        // Source generation differs from the snapshot's, so the
+        // "unchanged" generation check at plan_local_snapshot does NOT fire.
+        fs.generations.insert(PathBuf::from("/data/sv1"), 100);
+        fs.generations
+            .insert(PathBuf::from("/snap/sv1").join(s1.as_str()), 50);
+
+        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+
+        let creates: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(
+                op,
+                PlannedOperation::CreateSnapshot { subvolume_name, .. }
+                if subvolume_name == "sv1"
+            ))
+            .collect();
+        let sends: Vec<_> = result
+            .operations
+            .iter()
+            .filter(|op| matches!(
+                op,
+                PlannedOperation::SendIncremental { subvolume_name, .. }
+                | PlannedOperation::SendFull { subvolume_name, .. }
+                if subvolume_name == "sv1"
+            ))
+            .collect();
+
+        assert_eq!(creates.len(), 1, "should create new snapshot");
+        assert_eq!(
+            sends.len(),
+            1,
+            "should plan send of newly-created snapshot when caught up; \
+             skipped: {:?}",
+            result.skipped
+        );
+    }
+
+    #[test]
     fn space_guard_fails_open_when_free_bytes_unreadable() {
         let config = test_config(); // min_free_bytes = 10GB
         let mut fs = MockFileSystemState::new();
@@ -4575,7 +4666,15 @@ local_retention = "transient"
         // Note: plan() in this test returns full incremental_or_full ops based
         // on pin presence. Without a pin file we get a SendFull (NoPinFile),
         // not an incremental. Mock out a pin so we get an incremental.
-        let config = test_config();
+        // sv2 is disabled to keep the test focused on sv1's incremental —
+        // otherwise sv2 plans its own first send (SendFull) which emits a
+        // PlannerSendChoice and pollutes the count.
+        let mut config = test_config();
+        for sv in &mut config.subvolumes {
+            if sv.name == "sv2" {
+                sv.enabled = Some(false);
+            }
+        }
         let mut fs = MockFileSystemState::new();
         fs.mounted_drives.insert("D1".to_string());
         let local_snap = snap("20260322-1455-one");


### PR DESCRIPTION
## Summary

- Non-transient code path in `plan()` was passing un-augmented `local_snaps` to `plan_external_send`, so when latest local already equalled latest external (the "caught-up" state), the planner deferred the send as `<snap> already on <drive>` and the freshly-planned snapshot was stranded until the next nightly run.
- Same root cause as Bug B that commit `0f52555` fixed for transient subvolumes; the non-transient sibling was never patched.
- Surfaced in the wild for the first time on 2026-05-02 when `htpc-home` triggered emergency retention (the new event that creates the caught-up precondition by deferring snapshot creation while still sending the existing latest). Three subvolumes affected: `htpc-home`, `subvol2-pics`, `subvol1-docs`.
- Fix mirrors the existing transient code path: capture `plan_local_snapshot`'s `Option<SnapshotName>` return, build `effective_local_snaps` augmented with the planned snapshot, pass to `plan_external_send`.

## Testing

- cargo clippy: pass (clean, no warnings)
- cargo test: 1187 passed, 0 failed (was 1186, +1 regression test `non_transient_sends_when_local_caught_up_to_external`)
- cargo build --release: pass
- Existing test `plan_does_not_emit_send_choice_for_routine_incremental` updated to disable sv2 — the test had been incidentally passing because sv2 was being silently orphaned by the same bug.
- Integration tests: not run (no behavior change in execution path; this is planner-only).

## Recovery for the live system

Three snapshots from the 2026-05-02 nightly are stranded on the source filesystem and not yet on WD-18TB. Running `urd backup --force` before the next nightly will plan and ship them — the latest local is genuinely not on the drive regardless of augmentation logic, so the send plans correctly. Otherwise the next nightly self-heals (local moves ahead of external again, normal flow).

## Follow-ups (out of scope)

- The post-plan orphan invariant at `plan.rs:524-555` only checks transient subvolumes. Extending it to non-transient would catch any future planner regression that reintroduces this bug. Needs careful gating because legitimate "no drives in scope" cases produce non-orphan local-only snapshots.
- `htpc-home` retention profile (14d/8w/0m on a 118GB NVMe at 89% baseline) is still tight enough to trigger emergency retention. Worth revisiting independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)