### PR TITLE
docs: track 00-foundation source-documentation and bash-era ADR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,13 @@ Thumbs.db
 # Claude Code (CLAUDE.md stays tracked — commands and settings are local)
 .claude/
 
-# Internal project documentation (kept locally, not published)
-# ADRs and guides remain tracked — they signal engineering rigor
-docs/00-foundation/source-documentation/
-docs/00-foundation/decisions/ADR-relating-to-bash-script/
+# Project-management documentation (kept locally, not published)
+# Everything in the 9*-* range is internal: ideas, plans, journals, reports,
+# project supervisor (status/roadmap/registry), and the archive.
+# Topic-oriented docs (00-foundation, 10-operations, 20-reference) stay tracked
+# — they're the public engineering record. The internal documentation guide
+# itself (contributing-internal.md) stays local; CONTRIBUTING.md is its public
+# counterpart.
 docs/90-archive/
 docs/95-ideas/
 docs/96-project-supervisor/

--- a/docs/00-foundation/decisions/ADR-relating-to-bash-script/2026-03-21-ADR-020-daily-external-backups.md
+++ b/docs/00-foundation/decisions/ADR-relating-to-bash-script/2026-03-21-ADR-020-daily-external-backups.md
@@ -1,0 +1,74 @@
+# ADR-020: Daily External Backups with Incremental Sends
+
+**Date:** 2026-03-21
+**Status:** Accepted
+**Supersedes:** None (updates the weekly-only external backup model from initial implementation)
+
+## Context
+
+The BTRFS pool runs Single profile — no data redundancy. External backups to WD-18TB drives are the **only protection** against disk failure. The original design sent to external drives weekly (Saturdays only) because every send was a full send: multi-hour, high I/O, wearing on the SATA external drive.
+
+The March 2026 operational excellence work (pinned parent mechanism, space pre-checks, stderr capture) proved that **incremental sends work reliably**. Tested results:
+- Full send of 8GB: ~10 minutes
+- Incremental send of 11GB: ~4 minutes
+- Incremental sends transfer only changed extents, not entire subvolumes
+
+With weekly-only external sends, the RPO was **7 days** — meaning up to a week of data could be lost if the pool fails between Saturday backups. For Tier 1 critical data (home directory, recordings, operational containers), this is unacceptable on a pool with no RAID.
+
+Additionally, the offsite drive (WD-18TB1) will be stored at a friend's location and cycled roughly **every 3 months**. The old 15-daily local retention would delete the offsite pinned parent long before the drive returns, forcing a slow full send on every offsite cycle.
+
+## Decision
+
+### 1. Daily external sends for Tier 1/2
+
+Replace the Saturday-only external gate with per-subvolume `EXTERNAL_SCHEDULE` configuration:
+- **Tier 1/2 (critical/important):** External sends every night at 02:00
+- **Tier 3 (standard):** External sends monthly (1st of month), local snapshots weekly (Saturdays)
+
+This reduces RPO from 7 days to ~1 day for critical data.
+
+### 2. Single nightly timer replaces daily+weekly
+
+The daily timer runs the full script (no `--local-only`). The weekly timer is disabled. Per-subvolume schedule config determines when each subvolume creates snapshots and sends externally.
+
+### 3. Graduated local retention (Time Machine-style)
+
+Replace flat 15-daily retention with graduated tiers:
+- **Last 14 days:** All daily snapshots kept
+- **15-60 days:** 1 per week (newest in each ISO week)
+- **61-90 days:** 1 per month (newest in each month)
+
+~21 snapshots per subvolume, covering ~149 days (~5 months). This ensures the offsite drive's pinned parent survives even beyond the planned quarterly rotation cycle.
+
+### 4. Dual pin files per drive
+
+Separate `.last-external-parent-WD-18TB` and `.last-external-parent-WD-18TB1` files maintain independent incremental chains. Both pinned parents are protected during cleanup, regardless of which drive is currently mounted.
+
+### 5. Simplified external retention
+
+Replaced the never-implemented "weekly + monthly" external retention with a single count: 14 for Tier 1/2, existing counts for Tier 3. The cleanup function uses a single count — there is no weekly/monthly distinction in snapshot naming.
+
+### 6. Graceful external drive absence
+
+When no external drive is mounted, the script logs INFO and skips external sends without recording a failure or firing Discord alerts. This prevents false-alarm notifications when the offsite drive is at the remote location.
+
+## Consequences
+
+### Positive
+- **RPO reduced from 7 days to ~1 day** for critical data
+- **Offsite rotation safe** — graduated retention keeps snapshots for 3 months
+- **No additional system load** — incremental sends take minutes, not hours
+- **Simpler scheduling** — one timer instead of two
+- **Drive-independent chains** — primary and offsite drives maintain separate incremental state
+
+### Negative
+- **External drive fills faster** — 14 daily snapshots vs 4-8 weekly. Mitigated by incremental deltas being small and 14-day retention cleanup.
+- **Offsite drive needs full send after 3+ months without common parent** — if graduated retention is thinned before the drive returns, falls back to full send (slow but safe).
+
+### Constraints
+- **Offsite cycle must not exceed ~149 days** (the graduated retention window covers ~5 months). Beyond this, full sends are required.
+- **Primary external drive must be always connected** for daily sends to work.
+
+## Related
+- Journal: `docs/98-journals/2026-03-21-backup-script-operational-excellence.md`
+- Strategy guide: `docs/20-operations/guides/backup-strategy.md`

--- a/docs/00-foundation/source-documentation/README.md
+++ b/docs/00-foundation/source-documentation/README.md
@@ -1,0 +1,21 @@
+# Source Documentation
+
+Reference documents for Urd's key dependencies and toolchain. Written to help
+Claude Code sessions apply conventions and APIs that are more recent than the
+model's training data.
+
+**Generated:** 2026-04-05
+**Rust toolchain:** 1.94.0, edition 2024
+**Context:** Urd v0.11.1
+
+| Document | Covers |
+|----------|--------|
+| [rust-2024-edition.md](rust-2024-edition.md) | Rust 2024 edition changes, new idioms, lint defaults |
+| [colored-3.md](colored-3.md) | colored 2.x -> 3.x migration, current API |
+| [rusqlite-0.39.md](rusqlite-0.39.md) | rusqlite 0.32 -> 0.39 migration, breaking changes |
+| [toml-1.md](toml-1.md) | toml 0.8 -> 1.x migration, TOML 1.1 support |
+| [nix-0.31.md](nix-0.31.md) | nix 0.29 -> 0.31 migration, I/O safety, file locking |
+| [btrfs-reference.md](btrfs-reference.md) | BTRFS snapshot, send/receive, space management |
+
+These documents are reference material, not prescriptive. Always verify against
+actual crate docs and compiler output when patterns seem uncertain.

--- a/docs/00-foundation/source-documentation/btrfs-reference.md
+++ b/docs/00-foundation/source-documentation/btrfs-reference.md
@@ -1,0 +1,116 @@
+# BTRFS Reference for Backup Tooling
+
+> Based on btrfs-progs documentation through v6.12+ (training data).
+> BTRFS is a stable, slow-moving interface — commands used by Urd have been
+> unchanged for years.
+
+## Snapshot Operations
+
+### Create Read-Only Snapshot
+
+```bash
+sudo btrfs subvolume snapshot -r <source> <dest>
+```
+
+- `-r` creates read-only snapshot (required for send)
+- Snapshot is instantaneous (COW metadata operation)
+- Snapshot appears as a regular directory at `<dest>`
+
+### Delete Snapshot/Subvolume
+
+```bash
+sudo btrfs subvolume delete <path>
+```
+
+- Deletion is asynchronous — space reclamation happens in background
+- `sync` or `btrfs filesystem sync` to force cleanup
+- `btrfs subvolume delete -c` commits after deletion (ensures space is freed)
+
+### Show Subvolume Info
+
+```bash
+sudo btrfs subvolume show <path>
+```
+
+Returns: UUID, parent UUID, creation time, send/receive status, flags.
+
+## Send/Receive Pipeline
+
+### Full Send
+
+```bash
+sudo btrfs send <snapshot> | sudo btrfs receive <dest_dir>
+```
+
+### Incremental Send (with parent)
+
+```bash
+sudo btrfs send -p <parent_snapshot> <snapshot> | sudo btrfs receive <dest_dir>
+```
+
+- Parent must exist at destination (or a clone of it)
+- Incremental sends transfer only the delta — dramatically faster and smaller
+- **The parent snapshot must not be deleted** until the child is successfully received
+
+### Best Practices
+
+- Always use `-p` (parent) for incremental sends when a common parent exists
+- Capture stderr from both `send` and `receive` — either side can fail
+- Check exit codes of both sides of the pipe
+- Clean up partial snapshots on receive failure (incomplete receive leaves a
+  directory that isn't a valid subvolume)
+- Pipe through `pv` for progress monitoring on large sends (optional)
+
+### Common Failure Modes
+
+| Failure | Cause | Recovery |
+|---------|-------|----------|
+| "cannot find parent subvolume" | Parent deleted or not present at dest | Full send required |
+| Partial receive | Interrupted pipe, disk full, I/O error | Delete partial dir, retry |
+| "received UUID already exists" | Duplicate snapshot at destination | Delete existing, re-receive |
+| Permission denied | Missing sudo or capability | Check sudoers configuration |
+
+## Space Management
+
+### Check Filesystem Usage
+
+```bash
+sudo btrfs filesystem usage <mount>
+sudo btrfs filesystem df <mount>
+sudo btrfs filesystem show <mount>
+```
+
+- `usage` gives the most complete picture (data, metadata, system, unallocated)
+- `df` shows allocated/used per profile (single, DUP, RAID1, etc.)
+- `show` lists devices and total/used per device
+
+### Space Considerations for Backup Tools
+
+- Snapshots share data blocks via COW — initial space cost is near zero
+- Space grows as source diverges from snapshot (modified blocks are unique)
+- Many snapshots of a rapidly changing subvolume can consume significant space
+  (each snapshot pins its unique blocks from garbage collection)
+- `btrfs filesystem sync` after deletions to ensure space is reclaimed
+- Monitor unallocated space, not just used space — BTRFS allocates in chunks
+- **Metadata space exhaustion** is harder to recover from than data space exhaustion
+
+### Quota Groups (qgroups)
+
+```bash
+sudo btrfs qgroup show <mount>
+sudo btrfs quota enable <mount>
+```
+
+- Can track per-subvolume space usage
+- Significant performance overhead — not recommended for general use
+- Most backup tools avoid qgroups and estimate sizes via send dry-run or
+  `btrfs filesystem du`
+
+## Urd-Specific Notes
+
+Urd wraps these commands via the `BtrfsOps` trait in `btrfs.rs`. Key conventions:
+- All paths passed as `&Path` to `Command::arg()` — never stringified
+- Stderr captured from both sides of send|receive pipe
+- Both exit codes checked
+- Partial snapshots cleaned up on receive failure
+- Pin files (`.last-external-parent-{DRIVE}`) protect incremental chain parents

--- a/docs/00-foundation/source-documentation/colored-3.md
+++ b/docs/00-foundation/source-documentation/colored-3.md
@@ -1,0 +1,59 @@
+# colored 3.x Reference
+
+> Urd dependency: `colored = "3"` (resolves to 3.1.1)
+> Previous: `colored = "2"`
+
+## Migration from 2.x to 3.x
+
+**The only breaking change is MSRV raised to 1.80.** The API is identical.
+`lazy_static` was replaced with `std::sync::OnceLock` internally.
+
+No code changes needed. Drop-in replacement.
+
+## New in 3.1 (non-breaking)
+
+Hex color support:
+```rust
+"text".color("#efabea");      // 6-digit hex
+"text".on_color("#fd0");      // 3-digit hex
+"text".ansi_color(42u8);      // arbitrary ANSI code
+```
+
+## Current API
+
+```rust
+use colored::Colorize;
+
+// Method chaining
+"bold red".red().bold();
+"green italic".green().italic();
+"on white".blue().on_white();
+
+// Available colors: black, red, green, yellow, blue, magenta (alias: purple),
+// cyan, white — plus bright_* variants for all
+
+// Styles: bold(), dimmed(), italic(), underline(), blink(),
+// reversed(), hidden(), strikethrough(), normal(), clear()
+
+// Dynamic colors
+"text".color("blue");                   // from string
+"text".truecolor(0, 255, 136);          // RGB
+"text".on_truecolor(135, 28, 167);      // RGB background
+"text".custom_color((0, 255, 136));     // via Into<CustomColor>
+```
+
+## Color Control
+
+Environment variables (respected automatically):
+- `NO_COLOR` — disables color output
+- `CLICOLOR` — standard TTY color discovery
+- `CLICOLOR_FORCE` — force color even when not a TTY
+- Priority: `CLICOLOR_FORCE` > `NO_COLOR` > `CLICOLOR`
+- Compile-time disable: `no-color` cargo feature
+
+## Deprecations
+
+- `ColoredString::fgcolor()` getter — use public `fgcolor` field directly
+- `ColoredString::bgcolor()` getter — use public `bgcolor` field directly
+- `ColoredString::style()` getter — use public `style` field directly
+- `Colorize::reverse()` — use `reversed()` instead

--- a/docs/00-foundation/source-documentation/nix-0.31.md
+++ b/docs/00-foundation/source-documentation/nix-0.31.md
@@ -1,0 +1,81 @@
+# nix 0.31 Reference
+
+> Urd dependency: `nix = { version = "0.31", features = ["fs"] }`
+> Previous: `nix = "0.29"`
+
+## Breaking Changes (0.29 -> 0.31)
+
+### 0.30.0 — Major I/O Safety Migration
+
+The biggest change. Public interfaces across nearly every module switched from
+`RawFd` to I/O-safe types (`AsFd`/`OwnedFd`/`BorrowedFd`):
+
+- `fcntl.rs` — all functions now take `AsFd` instead of `RawFd`
+- `dir.rs` — I/O-safe types
+- `sys/signal`, `sys/stat`, `unistd`, `sys/fanotify` — all migrated
+
+**If code passes raw file descriptors to nix functions, wrap them in `OwnedFd`/
+`BorrowedFd` or use types that implement `AsFd` (like `std::fs::File`).**
+
+Other 0.30 breaking changes:
+- `IpTos` renamed to `Ipv4Tos`
+- `EventFlag` renamed to `EvFlags`
+- `MemFdCreateFlag` renamed to `MFdFlags`
+- `recvmsg` takes slice for `cmsg_buffer` instead of `Vec`
+- `Copy` removed from `PollFd`
+- `EventFd::defuse()` removed
+
+### 0.31.0
+
+- `Eq`/`PartialEq` removed from `SigHandler`
+- `EpollEvent` methods are now `const`
+- libc bumped to 0.2.180
+
+## File Locking API (fcntl module)
+
+Urd uses nix for file locking in `lock.rs`. Two mechanisms:
+
+### Flock (RAII — recommended)
+
+```rust
+use nix::fcntl::{Flock, FlockArg};
+use std::fs::File;
+
+let file = File::open("lockfile")?;
+let lock = Flock::lock(file, FlockArg::LockExclusiveNonblock)
+    .map_err(|(_, errno)| errno)?;
+
+// Lock held until dropped
+lock.relock(FlockArg::LockShared)?;   // upgrade/downgrade (since 0.29)
+let file = lock.unlock()?;             // explicit unlock
+```
+
+`Flockable` is implemented for `std::fs::File` and `OwnedFd`.
+
+`FlockArg` variants: `LockShared`, `LockExclusive`, `Unlock`,
+`LockSharedNonblock`, `LockExclusiveNonblock`.
+
+### POSIX Record Locks (fcntl)
+
+```rust
+use nix::fcntl::{fcntl, FcntlArg};
+
+// FcntlArg variants for locking:
+// F_SETLK(&libc::flock)      — set/clear, non-blocking
+// F_SETLKW(&libc::flock)     — set/clear, blocking
+// F_GETLK(&mut libc::flock)  — query locks
+// F_OFD_SETLK, F_OFD_SETLKW, F_OFD_GETLK — open file description locks (Linux)
+```
+
+## Deprecations
+
+- `flock()` function — deprecated since 0.28, use `Flock` struct instead
+- `FlockArg::UnlockNonblock` — deprecated since 0.28, use `FlockArg::Unlock`
+
+## Urd-Specific Notes
+
+Urd uses nix only for file locking (`nix::fcntl` via the `fs` feature).
+The I/O safety migration in 0.30 is the main concern — `std::fs::File`
+implements `AsFd`, so if Urd passes `File` objects to nix functions (which it
+should), the migration is transparent. If any code passes `RawFd` integers,
+those calls need updating to use `AsFd`-implementing types.

--- a/docs/00-foundation/source-documentation/rusqlite-0.39.md
+++ b/docs/00-foundation/source-documentation/rusqlite-0.39.md
@@ -1,0 +1,90 @@
+# rusqlite 0.39 Reference
+
+> Urd dependency: `rusqlite = { version = "0.39", features = ["bundled"] }`
+> Previous: `rusqlite = "0.32"`
+> Bundled SQLite: 3.51.3 (was 3.46.0)
+
+## Breaking Changes (0.32 -> 0.39)
+
+### High Impact for Urd
+
+**`execute()` and `prepare()` reject multi-statement SQL (0.35)**
+If any call passes SQL with multiple statements separated by `;`, it now errors.
+Use `execute_batch()` for multi-statement SQL.
+
+```rust
+// Error in 0.35+:
+conn.execute("INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)", [])?;
+
+// Correct:
+conn.execute_batch("INSERT INTO t VALUES (1); INSERT INTO t VALUES (2)")?;
+```
+
+**u64/usize ToSql/FromSql disabled by default (0.38)**
+Storing or reading `u64`/`usize` values requires explicit casting to `i64` or
+opting in via the `i128_blob` feature. Prevents silent data loss on values
+exceeding i64 range.
+
+**Extended result codes enabled by default (0.32)**
+`SQLITE_OPEN_EXRESCODE` is always active. Error codes are more specific.
+If matching on error codes, values may differ from before.
+
+### Lower Impact
+
+- `FnMut` -> `Fn` in `create_scalar_function` (0.33)
+- `release_memory` feature removed (0.33)
+- Hook ownership checking (0.38, 0.39)
+- Statement cache made optional (0.38)
+
+## Current API Patterns
+
+```rust
+// Connection
+let conn = Connection::open("path.db")?;
+let conn = Connection::open_in_memory()?;
+
+// Execute (single statement only since 0.35)
+conn.execute("INSERT INTO t VALUES (?1, ?2)", params![val1, val2])?;
+conn.execute("INSERT INTO t VALUES (?1, ?2)", (val1, val2))?;  // tuple syntax
+conn.execute_batch("CREATE TABLE ...; INSERT ...")?;  // multi-statement
+
+// Query
+let name: String = conn.query_row(
+    "SELECT name FROM t WHERE id=?1", [id], |row| row.get(0)
+)?;
+
+// Multiple rows
+let mut stmt = conn.prepare("SELECT id, name FROM t")?;
+let rows = stmt.query_map([], |row| {
+    Ok(MyStruct { id: row.get(0)?, name: row.get(1)? })
+})?;
+
+// Transactions
+let tx = conn.transaction()?;
+tx.execute("...", [])?;
+tx.commit()?;
+
+// Parameter binding
+params![val1, val2]             // positional
+named_params!{"@name": val}     // named
+(val1, val2)                    // tuple
+&[&val1 as &dyn ToSql]          // slice
+```
+
+## New Features Since 0.32
+
+| Version | Feature |
+|---------|---------|
+| 0.39 | Unix timestamp support for chrono; `TryFrom` for `Value` |
+| 0.38 | wasm32 support; virtual table transactions; 64-bit length params |
+| 0.37 | `FromSqlError::other` convenience |
+| 0.36 | `query_one` method; column metadata; `Name` trait for `&str`/`&CStr` |
+| 0.35 | Column metadata from prepared statements |
+| 0.34 | `BindIndex` trait; `Deserialize` impls; flexible named params |
+
+## Urd-Specific Concerns
+
+Urd's `state.rs` uses straightforward open/execute/query patterns. Key things:
+- Verify no multi-statement `execute()` calls exist (use `execute_batch()` if so)
+- Verify no `u64`/`usize` values stored without casting to `i64`
+- The `bundled` feature bundles SQLite 3.51.3 — no system SQLite dependency

--- a/docs/00-foundation/source-documentation/rust-2024-edition.md
+++ b/docs/00-foundation/source-documentation/rust-2024-edition.md
@@ -1,0 +1,99 @@
+# Rust 2024 Edition Reference
+
+> Stabilized in Rust 1.85.0 (2025-02-20). Urd uses `edition = "2024"`.
+
+## Key Language Changes
+
+### RPIT Lifetime Capture (RFC 3498, 3617)
+
+All in-scope generic parameters (including lifetimes) are now implicitly captured
+in return-position `impl Trait`. The old `Captures<>` trick and outlives workaround
+(`+ 'a`) are no longer needed.
+
+```rust
+// 2021: lifetime NOT captured — needed workaround
+// 2024: lifetime captured automatically
+fn f(x: &str) -> impl Sized { x.len() }
+
+// Opt out with use<..> syntax (stable since 1.82):
+fn f<'a>(x: &'a ()) -> impl Sized + use<> { }  // capture nothing
+```
+
+### `let` Chains
+
+Chain `let` patterns with `&&` in `if` and `while`:
+
+```rust
+if let Some(first) = iter.next()
+    && let Some(second) = iter.next()
+{
+    // use both
+}
+```
+
+**Urd opportunity:** Useful in pattern-heavy code (config parsing, plan building).
+
+### Tail Expression Temporary Scope
+
+Temporaries in tail expressions drop before local variables. Fixes longstanding
+issues where temporary borrows lived too long.
+
+### `unsafe` Changes
+
+- `unsafe extern "C" { }` required (bare `extern` blocks are errors)
+- `#[unsafe(no_mangle)]`, `#[unsafe(export_name)]`, `#[unsafe(link_section)]`
+- `unsafe_op_in_unsafe_fn` is now warn-by-default
+- `static_mut_refs` is now deny-by-default — use `LazyLock`, `OnceLock`, atomics
+- `std::env::set_var` and `std::env::remove_var` are now `unsafe`
+
+### Match Ergonomics Restrictions
+
+Redundant `ref`/`ref mut` in patterns with default binding mode are now errors.
+Mixing `mut` with inherited binding modes requires fully explicit patterns.
+
+### Reserved Keywords
+
+- `gen` is reserved (future generators)
+- `#"foo"#` guarded string syntax is reserved
+
+## Cargo Changes
+
+### Resolver v3 (automatic with edition 2024)
+
+Rust-version-aware dependency resolution. Dependencies whose `rust-version`
+exceeds yours are deprioritized in favor of older compatible versions.
+
+### Cargo.toml Key Names
+
+Only hyphenated forms are valid:
+- `dev-dependencies` (not `dev_dependencies`)
+- `default-features` (not `default_features`)
+- `build-dependencies` (not `build_dependencies`)
+- `[package]` (not `[project]`)
+
+## Lint Defaults Changed
+
+| Lint | 2021 | 2024 |
+|------|------|------|
+| `unsafe_op_in_unsafe_fn` | allow | warn |
+| `static_mut_refs` | warn | deny |
+| `never_type_fallback_flowing_into_unsafe` | warn | deny |
+| `missing_unsafe_on_extern` | allow | error |
+| `unsafe_attr_outside_unsafe` | allow | error |
+| `deprecated_safe_2024` | allow | error |
+
+## Preferred Patterns
+
+- `let` chains over nested `if let`
+- `use<..>` bounds for precise RPIT lifetime control
+- Interior mutability (`LazyLock`, `OnceLock`, `Mutex`, atomics) over `static mut`
+- `&raw const`/`&raw mut` for raw pointers to statics
+- Explicit `unsafe { }` blocks inside unsafe functions
+
+## Urd-Specific Notes
+
+Urd already compiles clean on edition 2024. Key opportunities:
+- `let` chains can simplify nested option/result matching
+- No `unsafe` code in the project (by convention), so most unsafe changes are irrelevant
+- Resolver v3 is active — explains the "compatible versions" messages during `cargo build`
+- Consider adding `rustfmt.toml` with `style_edition = "2024"` for editor consistency

--- a/docs/00-foundation/source-documentation/toml-1.md
+++ b/docs/00-foundation/source-documentation/toml-1.md
@@ -1,0 +1,71 @@
+# toml 1.x Reference
+
+> Urd dependency: `toml = "1"` (resolves to 1.1.2)
+> Previous: `toml = "0.8"`
+> MSRV: 1.85
+
+## Breaking Changes (0.8 -> 1.x)
+
+### 0.8 -> 0.9 (the big jump)
+
+- `from_str`, `Deserializer` no longer preserve order by default
+  (use `preserve_order` feature if needed)
+- `impl FromStr for Value` now parses TOML *values*, not documents.
+  Use `toml::from_str` or `Table::from_str` for documents.
+- `Deserializer::new` deprecated -> use `Deserializer::parse`
+- `Serializer::new` takes `&mut Buffer` not `&mut String`
+  (invisible if using `to_string`/`to_string_pretty` convenience functions)
+- Serde support requires `serde` feature (default, so no change for most users)
+
+### 0.9 -> 1.0
+
+- `Time::second` and `Time::nanosecond` are now `Option`
+  (only relevant if manipulating TOML datetime types directly)
+- Borrowed `&str` deserialization now supported
+
+### 1.0 -> 1.1
+
+- MSRV bumped to 1.85
+- No API changes
+
+## Current API
+
+```rust
+// Deserialization (unchanged from 0.8 for common usage)
+let config: Config = toml::from_str(&contents)?;
+
+// Serialization
+let s = toml::to_string(&config)?;
+let s = toml::to_string_pretty(&config)?;
+
+// Direct value access
+let value: toml::Value = toml::from_str(&contents)?;
+let name = value["section"]["key"].as_str();
+```
+
+## TOML 1.1 Support (since 0.9.10)
+
+The parser now supports TOML 1.1 features:
+- Multi-line inline tables
+- Trailing commas in inline tables
+- `\e` and `\xHH` string escape sequences
+- Optional seconds in time values
+
+## Feature Flags
+
+| Feature | Default | Purpose |
+|---------|---------|---------|
+| `serde` | yes | Serialize/Deserialize support |
+| `std` | yes | Standard library support |
+| `preserve_order` | no | Insertion-order maps |
+| `fast_hash` | no | Performance optimization |
+| `debug` | no | Debug output |
+
+## Urd-Specific Notes
+
+Urd uses `toml::from_str` for config parsing and `toml::to_string_pretty` for
+migration output. These convenience functions are unchanged across the 0.8 -> 1.x
+boundary. No code changes were needed for the bump.
+
+The TOML 1.1 multi-line inline tables and trailing commas could improve config
+readability if adopted in future config schema iterations.


### PR DESCRIPTION
## Summary

- Track `docs/00-foundation/source-documentation/` (7 dependency reference notes) and `docs/00-foundation/decisions/ADR-relating-to-bash-script/` (bash-era ADR-020) — both previously gitignored.
- Update `.gitignore` to make the public/private split explicit: 00/10/20 form the public engineering record; the 9\*-\* range and `contributing-internal.md` remain local-only project-management workspace.

## Why

These files have existed locally for weeks but weren't part of the public record. The source-documentation notes give external contributors the same dependency-API context that internal sessions rely on (rusqlite 0.39, toml 1.x, nix 0.31, colored 3.x, Rust 2024, BTRFS). The bash-era ADR-020 anchors the pre-Urd backup decisions for historical continuity.

## Privacy

PII audit was clean before staging — no real usernames, emails, IPs, hostnames, or absolute home paths. Drive labels (`WD-18TB`/`WD-18TB1`) and subvolume names already appear in `CLAUDE.md` and are project architecture per the placeholder convention.

## Test plan

- [ ] `git ls-files docs/` shows the 8 newly-tracked files plus the 16 already-tracked
- [ ] `git check-ignore docs/contributing-internal.md` confirms it stays local
- [ ] No personal info in the diff (re-grep for `/home/`, `patriark`, real emails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)