### PR TITLE
docs: glossary, architecture, postmortems (Wave 2 of doc system improvements)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ Read `docs/96-project-supervisor/status.md` first — short current-state docume
 Follow links to `roadmap.md` for priorities and feature tracking.
 See `docs/contributing-internal.md` for documentation structure and conventions.
 
+For controlled vocabulary (promise states, voice labels, protection levels, retention
+tiers, identifier conventions) see `docs/00-foundation/glossary.md`. For a one-screen
+flow diagram of how the modules below connect, see `docs/00-foundation/architecture.md`.
+
 ## Architecture
 
 ### Core Flow

--- a/docs/00-foundation/architecture.md
+++ b/docs/00-foundation/architecture.md
@@ -1,0 +1,153 @@
+# Architecture at a Glance
+
+> **TL;DR:** Urd is a strict pipeline — *config → plan → execute → btrfs* — with a
+> ring of read-only observers (awareness, retention, drift, preflight) and a small
+> set of surfaces (voice, heartbeat, Prometheus, notifications). The planner is
+> pure; the executor is the only place state mutates; every btrfs call funnels
+> through one trait. This page is the orientation diagram and short prose; the
+> module-responsibility table in `CLAUDE.md` and the ADRs in `decisions/` are
+> authoritative for the why.
+
+**Date:** 2026-05-02
+**Audience:** Both human readers and Claude sessions. One screen of orientation
+before reading specific modules or ADRs.
+
+## The flow
+
+```mermaid
+flowchart LR
+    %% Sources
+    cfg["config.rs<br/>parse + validate TOML"]
+    fsstate["FileSystemState<br/>(snapshots, free space, mounts)"]
+    db[("state.rs<br/>SQLite history")]
+
+    %% Pure core
+    subgraph pure["Pure functions (no I/O)"]
+        direction TB
+        plan["plan.rs<br/>decide operations"]
+        awareness["awareness.rs<br/>compute promise states"]
+        retention["retention.rs<br/>which snapshots to drop"]
+        drift["drift.rs<br/>churn aggregation"]
+        preflight["preflight.rs<br/>achievability advisories"]
+        evpure["events.rs<br/>typed event payloads"]
+    end
+
+    %% I/O boundary
+    subgraph io["I/O boundary"]
+        direction TB
+        executor["executor.rs<br/>run plan, isolate failures"]
+        btrfs["btrfs.rs (BtrfsOps)"]
+        btrfsproc{{"sudo btrfs<br/>(snapshot · send · receive · delete)"}}
+        chain["chain.rs<br/>pin files"]
+    end
+
+    %% Surfaces
+    subgraph surfaces["Surfaces"]
+        direction TB
+        voice["voice.rs<br/>render text (mythic)"]
+        notify["notify.rs<br/>dispatch alerts"]
+        heartbeat["heartbeat.rs<br/>JSON health"]
+        metrics["metrics.rs<br/>Prometheus .prom"]
+    end
+
+    %% Sentinel daemon (separate process)
+    subgraph sentinel_box["Sentinel daemon (separate process)"]
+        direction TB
+        drives["drives.rs<br/>detect mounts, UUID"]
+        sentinel["sentinel.rs<br/>state machine"]
+        runner["sentinel_runner.rs<br/>I/O wrapper"]
+    end
+
+    %% Edges — main pipeline
+    cfg --> plan
+    fsstate --> plan
+    db --> plan
+    plan --> executor
+    retention -.consult.-> executor
+    executor --> btrfs --> btrfsproc
+    executor --> chain
+    executor --> db
+    executor --> evpure
+    evpure --> db
+
+    %% Edges — observers
+    fsstate --> awareness
+    db --> awareness
+    drift --> awareness
+    db --> drift
+    awareness --> voice
+    awareness --> notify
+    awareness --> heartbeat
+    awareness --> metrics
+    preflight --> voice
+
+    %% Edges — sentinel
+    drives --> sentinel
+    db --> sentinel
+    sentinel --> runner
+    runner --> notify
+    runner --> executor
+```
+
+## How to read it
+
+The diagram is shaped by three architectural rules. Each is load-bearing — the
+ADR in parentheses is the canonical statement.
+
+1. **The planner never modifies anything (ADR-100).** `plan.rs` is a pure function
+   from `(config, FileSystemState, history)` to `Vec<PlannedOperation>`. Every
+   skip/proceed decision lives there. The executor trusts the plan — it does not
+   reconsider, only acts. This is why retention, drift, awareness, and preflight
+   sit in the pure box: they feed the planner or the surfaces, but never mutate.
+
+2. **Every btrfs call goes through one trait (ADR-101).** `BtrfsOps` is the only
+   path to `sudo btrfs`. No other module spawns subprocesses. Tests inject
+   `MockBtrfs`; production injects the real wrapper. The trait is a hard boundary
+   — it makes the executor's blast radius auditable in one file.
+
+3. **Filesystem is truth, SQLite is history (ADR-102).** Pin files and snapshot
+   directories are authoritative for "what exists." The state DB records what
+   happened, but a SQLite failure never blocks a backup. This is why `state.rs`
+   appears as both an input and an output of the pipeline: callers persist
+   best-effort records, and readers (awareness, drift, sentinel) consult them
+   knowing the data may be incomplete.
+
+The ring of pure observers feeds the surfaces without ever touching btrfs.
+`awareness.rs` answers "is my data safe?"; `drift.rs` (UPI 030) aggregates churn
+for the Do-No-Harm arc (ADR-113); `preflight.rs` issues advisories for
+unachievable promises. None of them block — they describe.
+
+The sentinel runs as a separate user-space systemd service. Its state machine is
+pure; the runner around it is the only I/O surface. Sentinel does not race with
+the timer-driven backup — the executor takes a shared advisory lock with metadata
+(`lock.rs`) and the sentinel honors it.
+
+## What the events table is for (UPI 036, ADR-114)
+
+Prometheus owns gauges (current state over time). The `events` table in SQLite
+owns typed state changes and decisions with rationale: *"retention pruned snapshot
+X because daily slot was full"*, *"promise transitioned PROTECTED → AT RISK on
+drive Y"*. Pure modules emit `EventPayload` values; impure callers persist them
+(ADR-108). The events table is best-effort (ADR-102) and additive (ADR-105) —
+schema changes never break older readers.
+
+## What's *not* in the diagram
+
+- **Commands** (`commands/`): one thin handler per `urd <subcommand>`. They wire
+  pure modules to the I/O boundary. They contain no core logic — every decision
+  delegates to the modules above.
+- **Error translation** (`error.rs::translate_btrfs_error`): turns btrfs stderr
+  into actionable `BtrfsErrorDetail`. Sits between btrfs.rs and the surfaces.
+- **Migration** (`urd migrate`): a separate strategy that runs *before* config
+  load (ADR-111). It transforms legacy TOML to v1 TOML; downstream code remains
+  schema-agnostic.
+
+## See also
+
+- **Module responsibilities table:** `CLAUDE.md` "Module Responsibilities" — the
+  authoritative one-line-per-module reference.
+- **Architectural invariants:** `CLAUDE.md` "Architectural Invariants" — the
+  ten load-bearing rules with ADR references.
+- **Glossary:** `glossary.md` (this directory) — promise states, voice labels,
+  protection levels, retention tiers, identifiers.
+- **ADRs:** `decisions/ADR-100..ADR-114` — the why behind every box and edge.

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -1,0 +1,121 @@
+# Glossary
+
+> **TL;DR:** Single source for Urd's controlled vocabulary — promise states, voice
+> labels, protection levels, drive states, thread health, retention tiers, and the
+> UPI / short_name / name distinction. Definitions here are authoritative; if a doc
+> conflicts with this page, this page wins.
+
+**Date:** 2026-05-02
+**Audience:** Both human readers and Claude sessions. Read once; refer back when
+language is ambiguous in another doc.
+
+## Promise states (semantic)
+
+The awareness model assigns each subvolume one of three promise states. They answer
+the question *"is my data safe?"* in plain language. They are computed; the user
+does not set them.
+
+| State | Meaning |
+|-------|---------|
+| `PROTECTED` | The subvolume meets its declared protection level. All required copies are current. |
+| `AT RISK` | At least one required copy is older than the level's freshness threshold. Data is still recoverable, but the safety margin has eroded. |
+| `UNPROTECTED` | A required copy is missing or unusably stale. The promise is broken; user attention is warranted. |
+
+Source: `awareness.rs`, ADR-110.
+
+## Voice labels (presentation)
+
+The CLI surface renders the promise states with the mythic voice labels below. The
+mapping is one-to-one and lives in `voice.rs::exposure_label`. Daemon JSON output
+keeps the semantic names; only the interactive surface uses the voice form.
+
+| Promise state | Voice label | Color |
+|---------------|-------------|-------|
+| `PROTECTED` | `sealed` | green |
+| `AT RISK` | `waning` | yellow |
+| `UNPROTECTED` | `exposed` | red |
+
+The voice vocabulary is **frozen**. No renames unless real user feedback demands it
+(see roadmap "Strategic Context").
+
+## Protection levels (config intent)
+
+The user declares intent with a protection level; Urd derives the operations
+(snapshot interval, send interval, retention floors, drive count). Named levels are
+**opaque** — when set, derived parameters are final and operational fields cannot
+be mixed in. See ADR-110 for the maturity model and the opacity rule.
+
+| Level | What the data becomes | Survives |
+|-------|----------------------|----------|
+| `recorded` | Recorded in local history | Accidental deletion, file corruption (single host only) |
+| `sheltered` | Sheltered on at least one external drive | Drive failure on the host |
+| `fortified` | Fortified across multiple drives, including offsite | Site loss (fire, theft, flood) |
+| `custom` | The operator owns every parameter | Whatever the operator configured |
+
+`custom` is first-class, not a fallback. Until a named level earns opaque status
+through operational evidence, custom with explicit parameters is the recommended
+production choice (ADR-110 Maturity Model).
+
+## Drive states
+
+| State | Meaning | Source of truth |
+|-------|---------|-----------------|
+| `connected` | The drive is mounted and Urd can read/write it now | `drives.rs` mount detection |
+| `away` | The drive is not currently connected. Urd defers operations targeting it. | Sentinel `drive_connections` table — last disconnection event |
+
+"Away" is **physical absence**, not data staleness. The duration shown in `urd
+status` is time since disconnection, not time since the last successful send (Voice
+Contract Rule 1, presentation-layer manifesto).
+
+## Thread
+
+A **thread** is the lineage of incremental sends connecting a subvolume to a drive.
+Each successful incremental send extends the thread; a full send starts a new one.
+The pin file (`.last-external-parent-{DRIVE_LABEL}`) marks the parent the next
+incremental will use.
+
+| Thread health | Meaning |
+|--------------|---------|
+| `unbroken` | The chain of incrementals is intact; the next send will be incremental. |
+| `broken — full send (reason)` | The chain is broken; the next send will be a full send. |
+| `—` | No data yet (drive has never been written to). |
+
+Mended/established/intact are the three transition phrases used after a successful
+send (`voice.rs::render_transitions`).
+
+## Retention tiers
+
+Graduated retention thins snapshots through ordered tiers (ADR-104). Each tier
+keeps one representative per slot; everything else in the tier's window is pruned.
+
+| Tier | Slot | Keep count from config |
+|------|------|------------------------|
+| `hourly` | One per hour | `hourly` (often implicit / 0) |
+| `daily` | One per calendar day | `daily` |
+| `weekly` | One per ISO week | `weekly` |
+| `monthly` | One per year-month (0 = unlimited) | `monthly` |
+| `yearly` | One per year | (horizon — see roadmap Tech Debt) |
+
+Pinned snapshots (incremental parents) are excluded from retention at three
+independent layers (ADR-106). Retention never deletes a pin.
+
+## Identifiers
+
+| Term | What it identifies | Where it lives |
+|------|-------------------|----------------|
+| `name` | Subvolume identity in config; the on-disk snapshot directory | `[[subvolumes]] name = "..."` |
+| `short_name` | The suffix used in snapshot filenames (`YYYYMMDD-HHMM-{short_name}`) | Optional in v1 (defaults to `name`); required in legacy |
+| `UPI` | "Unique Project Identifier" — opaque sequence number (`NNN` or `NNN-a`) for tracking a feature through design → plan → review → implementation | `registry.md`, design frontmatter |
+
+UPIs are an internal documentation concept; users never see them. `name` and
+`short_name` are on-disk contracts (ADR-105) — they cannot change without a
+migration plan.
+
+## See also
+
+- **Architecture overview:** `architecture.md` (this directory) — module flow and
+  responsibilities.
+- **ADR-110:** protection promises, opacity rule, maturity model.
+- **ADR-104:** graduated retention.
+- **Presentation-layer manifesto:** the seven Voice Contract rules (in
+  `95-ideas/`, local-only).

--- a/docs/10-operations/postmortems/2026-03-24-local-space-exhaustion.md
+++ b/docs/10-operations/postmortems/2026-03-24-local-space-exhaustion.md
@@ -1,0 +1,127 @@
+# Postmortem: Local Space Exhaustion on System Drive
+
+> **TL;DR:** Urd filled the host's NVMe system drive with local snapshots and
+> caused a near-fatal congestion spiral. The root cause was a missing planner
+> guard — `min_free_bytes` drove retention but did not gate creation. The
+> incident produced ADR-113 (the Do-No-Harm invariant) and seeded the layered
+> defense arc (UPIs 030–034). A backup tool that causes the storage pressure
+> it should help manage has failed both its job and its promise simultaneously.
+
+**Date:** 2026-05-02 (postmortem written)
+**Incident date:** 2026-03-24
+**Severity:** host-impacting
+
+## Timeline
+
+1. Urd was running on a systemd timer, creating local snapshots every 15 minutes
+   for `htpc-home` and hourly for six other subvolumes on the BTRFS pool.
+2. The NVMe system drive (118 GB total, holding `/`, `/home`, and `~/.snapshots/`)
+   accumulated snapshots of `htpc-home` and `htpc-root` faster than they expired.
+3. Available free space dropped below the configured `min_free_bytes` threshold
+   (10 GB).
+4. Retention switched into space-pressure mode and began thinning aggressively,
+   but it could not free space fast enough — the remaining snapshots either
+   carried CoW exclusivity that thinning could not reclaim, or were protected
+   by pin files for incremental sends.
+5. Space exhaustion cascaded: processes failed on `ENOSPC`, the active session
+   froze, and the host became unstable.
+6. The operator rebooted, manually deleted snapshots after boot, and the host
+   recovered at roughly 64 % usage (~44 GB free).
+
+## Cause
+
+`plan_local_snapshot` decided whether to create a snapshot based on two criteria:
+*has the interval elapsed?* and *does a snapshot with this name already exist?*
+It never asked *is there room?*. The `min_free_bytes` field was parsed from
+config and consumed only by `plan_local_retention`, where it triggered
+`space_pressure = true` and accelerated thinning. That is reactive, not
+preventive — it speeds up deletion but does not gate creation.
+
+Three contributing factors:
+
+1. **A half-connected safety mechanism.** `min_free_bytes` looked complete from
+   the outside (config field present, default set, retention honoring it). But
+   the wire to the create path was never connected. Operators had no way to know.
+2. **The constrained case wasn't tested.** Development testing targeted the
+   multi-terabyte BTRFS pool where space is abundant. The 118 GB NVMe with
+   sub-hourly snapshots of an active home directory was the real pressure point.
+3. **The "fail open" principle had no stated limit.** ADR-107 said *"when in
+   doubt, back up rather than refuse."* Nothing said *"backups must not destroy
+   the system the backup runs on."* The principle needed a corollary, and the
+   corollary did not exist yet.
+
+## Mitigation
+
+- **Immediate:** operator-driven reboot and manual snapshot deletion. Time to
+  restore: ~minutes once the operator was at the keyboard.
+- **Code (within days):** the planner gained an explicit space guard
+  (`plan.rs::plan_local_snapshot`). When `min_free_bytes > 0` and free space
+  on the snapshot root is below the threshold, the planner skips the create
+  with a clear reason ("`local filesystem low on space (N free, M required)`")
+  and the skip surfaces in `urd plan`, logs, and downstream advisories.
+- **`force` does not override the space guard.** A forced snapshot on a full
+  filesystem is still catastrophic; the operator must reclaim space first.
+
+## Invariant Added
+
+[ADR-113 — The Do-No-Harm Invariant](../../00-foundation/decisions/2026-04-18-ADR-113-do-no-harm-invariant.md).
+
+The ADR codifies *"Urd shall not be the proximate cause of local storage
+pressure on monitored filesystems"* as a first-class architectural rule,
+alongside the planner/executor separation (ADR-100) and the BtrfsOps
+abstraction (ADR-101). It also names the **layered probabilistic defense**
+pattern: stack independent mechanisms with distinct failure modes so that
+combined failure is vanishingly rare. The Do-No-Harm rule is the third
+north-star test in `CLAUDE.md`'s Vision section.
+
+The ADR explicitly supersedes the earlier UPI 011 design (a hard cap of 1
+local snapshot for transient subvolumes) — that was a patch, not a design.
+The replacement is a coherent arc: ephemeral lifecycle for storage-critical
+subvolumes, predictive guards before sends, mid-operation watchdog during
+sends, emergency eject under catastrophic pressure.
+
+## Prevention
+
+Implemented:
+
+- **Local space guard in the planner** (`plan_local_snapshot`) — refuses to
+  create when free space is below `min_free_bytes`. Honors `fail open` semantics
+  for unreadable free-space queries (`unwrap_or(u64::MAX)`).
+- **Drift telemetry — UPI 030 / ADR-113 Layer 0** — per-subvolume churn history
+  in the state DB. Provides the data needed by predictive guards. Surfaces in
+  `awareness.rs` and the heartbeat. Observability only; no behavior change.
+
+Recommended but not yet adopted (Do-No-Harm arc, in flight):
+
+- **UPI 031 — `storage_critical` bundle.** Auto-detect heavy-write subvolumes
+  on small filesystems (`source = "/"`, FS usage ≥ 70 %, known heavy-write
+  paths). Switch them to an ephemeral lifecycle so no pin parent accumulates
+  CoW delta in a 24 h window.
+- **UPI 032 — Predictive guards.** Pre-flight drift projection. Defers sends
+  whose projected drift would cross the free-space threshold.
+- **UPI 033 — Mid-operation watchdog and reserve file.** Polls free space and
+  write rate during sends. A pre-allocated `.urd-reserve` file is deleted first
+  on trigger for instant reclaim.
+- **UPI 034 — Emergency eject.** Sentinel drops Urd-owned snapshots when
+  pressure crosses a catastrophic floor outside an active send. Host survival
+  over backup-chain continuity.
+
+Process changes adopted as a result of this incident:
+
+- **Test the constrained case, not just the happy case.** Integration tests
+  should include a simulated low-space scenario.
+- **A safety mechanism that only accelerates cleanup but does not gate
+  creation is not a safety mechanism.** It is an optimization. Future
+  config fields with safety semantics get wired into both creation and
+  retention paths, or the field is renamed to remove the implication.
+- **"Fail open" has limits.** Backups proceed when in doubt about *data*.
+  Backups defer when in doubt about *the host's ability to keep running*.
+
+## See also
+
+- **Raw incident journal:** stays local in `98-journals/`. Contains the original
+  diagnosis, sketch fix, and reasoning as it was understood at the time.
+- **Brainstorm that produced ADR-113:** `2026-04-18` — "storage pressure,
+  safe by construction" (local-only).
+- **CLAUDE.md Vision section:** the third north-star test ("does Urd do no
+  harm to the host she protects?") points to this ADR.

--- a/docs/10-operations/postmortems/template.md
+++ b/docs/10-operations/postmortems/template.md
@@ -1,0 +1,57 @@
+# Postmortem: {Incident Title}
+
+> **TL;DR:** {What happened, what the blast radius was, what invariant was added
+> as a result. Two to three sentences. Lead with the host-impacting part.}
+
+**Date:** YYYY-MM-DD (postmortem written)
+**Incident date:** YYYY-MM-DD (when it happened)
+**Severity:** {host-impacting | data-at-risk | prevented | near-miss}
+
+## Timeline
+
+{Phase-by-phase or minute-by-minute narrative. What was running, what users
+observed, what the system did, what was tried, what restored normal. Use real
+sequence — do not editorialize. Times in local time with the timezone offset
+where it matters.}
+
+## Cause
+
+{Root cause, not symptom. Why did the system behave this way? What was the
+gap between expected behavior and actual behavior, and what produced the gap?
+If multiple layers contributed, name each one and how it failed.}
+
+## Mitigation
+
+{What stopped the bleed. What restored normal operation. What manual steps the
+operator took. Include the time-to-restore if known.}
+
+## Invariant Added
+
+{The architectural rule, test, or runbook entry adopted as a result of this
+incident. Link to the ADR or runbook by relative path. If the incident produced
+no new invariant — say so explicitly and explain why; "we accepted the risk"
+is a valid answer when written down.}
+
+## Prevention
+
+{Concrete checks, alerts, or process changes that would catch a recurrence
+earlier. List them as bullet points so they are auditable. Differentiate
+between *implemented* and *recommended but not yet adopted*.}
+
+---
+
+## Authoring notes (delete before committing)
+
+- **Use placeholders.** This file is tracked. Replace real usernames with
+  `<user>`, real hostnames with `<hostname>`, `/home/<user>/...` paths with `~/...`
+  (see `contributing-internal.md` Privacy section).
+- **Keep journals raw.** The raw incident journal lives in `98-journals/` and
+  may contain real paths and command output — do not sanitize it. This
+  postmortem is the public-safe distillation.
+- **Filename:** `YYYY-MM-DD-{slug}.md` where the date is the incident date
+  (matches the journal filename, makes pairs easy to find).
+- **Severity guidance:**
+  - `host-impacting` — the host system became degraded or unusable
+  - `data-at-risk` — backups stopped, chains broke, or recovery was in question
+  - `prevented` — a defense layer caught the problem before user-visible impact
+  - `near-miss` — no impact occurred, but the analysis surfaced a real gap


### PR DESCRIPTION
## Summary

Wave 2 of the documentation-system review queued in the local Wave-1 report. All
files land in tracked engineering-record territory (`00-foundation/` and
`10-operations/`) with placeholders.

- **`00-foundation/glossary.md`** — single source for the controlled vocabulary:
  promise states (PROTECTED / AT RISK / UNPROTECTED), voice labels (sealed /
  waning / exposed), protection levels (recorded / sheltered / fortified /
  custom), drive states, thread health, retention tiers, and the
  UPI / short_name / name distinction. Replaces dozens of grep cycles into
  `voice.rs` and ADR-110.
- **`00-foundation/architecture.md`** — one mermaid flow diagram (`config → plan
  → execute` with ring of pure observers and surface modules) plus short prose
  orientation. Cross-linked from `CLAUDE.md`.
- **`10-operations/postmortems/template.md`** — matches the postmortem template
  in `contributing-internal.md` (TL;DR · Timeline · Cause · Mitigation ·
  Invariant Added · Prevention).
- **`10-operations/postmortems/2026-03-24-local-space-exhaustion.md`** —
  sanitized backfill of the host-impacting NVMe exhaustion incident that
  produced ADR-113. Raw journal stays local in `98-journals/`.
- **`CLAUDE.md`** — one paragraph in "Orient Yourself" pointing to glossary and
  architecture.

Postmortems land under `10-operations/postmortems/` rather than
`00-foundation/postmortems/` (the handoff's default) — operational artifacts
fit the operations bucket; the local `contributing-internal.md` was updated to
match.

No production code changes.

## Test plan

- [ ] Mermaid diagram in `architecture.md` renders on GitHub
- [ ] Relative link from postmortem to ADR-113 resolves
- [ ] Glossary cross-link from `CLAUDE.md` resolves
- [ ] PII scan: no `/home/<user>` paths, real emails, hostnames, or IPs in
      the tracked diff
- [ ] `contributing-internal.md` (local-only) still consistent — postmortem
      section now points to `10-operations/postmortems/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)