### PR TITLE
docs: 20-reference triplet + 10-operations runbooks (Wave 3)

### DIFF
--- a/docs/10-operations/runbooks/doctor-walk.md
+++ b/docs/10-operations/runbooks/doctor-walk.md
@@ -1,0 +1,184 @@
+# Runbook: Walking the Doctor Output
+
+> **TL;DR:** `urd doctor` is the first thing to run when something feels
+> off. It groups its findings into six sections — config preflight,
+> infrastructure, data safety, Sentinel, and (with `--thorough`) thread
+> verification and churn. The verdict at the bottom (Healthy / Warnings /
+> Degraded / Issues) summarizes severity. This runbook walks each section,
+> explains what raises which severity, and points at the next move.
+
+**Audience:** Operators interpreting `urd doctor` output and deciding what
+to do next.
+
+---
+
+## When to run
+
+- After any unexpected failure or notification.
+- After a config change, before the next backup ("does this validate?").
+- Periodically during onboarding, while the system is settling.
+- As the first step of any incident triage.
+
+```bash
+urd doctor             # default battery, fast (read-only, no thread walk)
+urd doctor --thorough  # adds thread verification + churn view; slower
+```
+
+`urd doctor` is read-only. It is always safe to run, including during a
+backup.
+
+---
+
+## Verdict (read this first)
+
+The verdict line at the bottom rolls everything up:
+
+| Verdict | Meaning | Exit code |
+|---------|---------|-----------|
+| **Healthy** | No warnings, no errors, all subvolumes `PROTECTED` and `healthy`. | `0` |
+| **Degraded** (N) | All subvolumes `PROTECTED` but N show non-healthy operational state (chain issues, advisories). No warnings or errors elsewhere. | `0` |
+| **Warnings** (N) | N warnings across any section. No errors. | `0` |
+| **Issues** (N) | N errors. Investigate immediately. | `1` |
+
+`Issues` is the only verdict that exits non-zero. `Warnings` and `Degraded`
+are advisory — the operator decides whether to act now or schedule it.
+
+There is a known interaction with `--thorough`: when absent drives are the
+only problem, the extra verify-section warnings can mask `Degraded` as
+`Warnings`. Use plain `urd doctor` to disambiguate.
+
+---
+
+## Section 1 — Config preflight
+
+What it checks: structural sanity of the config (subvolume / drive count,
+weakening overrides, level/interval mismatches). Pure function from
+`preflight.rs`.
+
+| Status | What it means | Action |
+|--------|---------------|--------|
+| `ok` (single line: "N subvolumes, M drives") | Config parses and passes preflight. | None. |
+| `warn — weakening-override` | A subvolume's `protection` is named but operational fields are mixed in (forbidden in v1; see ADR-110/111). | Reduce the interval to match the level, or change `protection` to `custom`. |
+| Other `warn` | Various preflight advisories. | Read the message; usually a config nudge. |
+
+Preflight never errors — by design, structural problems block at config
+load (before doctor runs at all).
+
+---
+
+## Section 2 — Infrastructure
+
+What it checks:
+
+- State DB exists and is openable.
+- Heartbeat / metrics / log directories exist and are writable.
+- `sudo btrfs` is reachable (a no-op test invocation).
+- Each `[[drives]]` entry has a UUID (or surfaces the snippet to add one).
+- Local snapshot roots are within `2 ×` of `min_free_bytes` (space-trend
+  warning).
+
+| Status | Likely cause | Action |
+|--------|--------------|--------|
+| `ok` per row | Infrastructure is in place. | None. |
+| `warn — no UUID configured` | A drive in config hasn't been adopted into Urd's identity system yet. | `urd drives adopt <LABEL>` while the drive is mounted. |
+| `warn — N free, threshold M` | Approaching `min_free_bytes` on a snapshot root. | `urd emergency` to reclaim now, or wait for graduated retention to thin on the next run. |
+| `warn — Space pressure active` | Below `min_free_bytes`. The planner will refuse new local snapshots until space frees up (ADR-113). | `urd emergency` immediately. |
+| `error` | A required directory is missing / unwritable, the state DB is corrupt, or sudo btrfs failed. | Read the detail; fix the underlying cause. Do not work around. |
+
+---
+
+## Section 3 — Data safety (awareness)
+
+The heart of doctor — per-subvolume promise state plus an actionable
+suggestion when not `PROTECTED & healthy`.
+
+| Promise state | Operational health | Issue line | Action |
+|---------------|--------------------|------------|--------|
+| `PROTECTED` | `healthy` | (none) | None. |
+| `PROTECTED` | other | `degraded — <reason>` | Read the suggestion (often "run `urd verify`"). The promise still holds; the underlying chain or pin condition is shaky. |
+| `AT RISK` | any | `waning` (or specific advice) | "Run `urd backup` to refresh." Often resolves on the next scheduled run. |
+| `UNPROTECTED` | any | `exposed — data may not be recoverable` (or specific advice) | Investigate immediately. Run `urd backup` and/or connect a drive. This is what `Issues` verdicts usually look like. |
+
+The advice strings are computed by `awareness::compute_advice` and reflect
+the specific failure mode (drive away, no snapshots, send-disabled with no
+recent send, etc.). Trust the advice — it is more specific than this table.
+
+---
+
+## Section 4 — Sentinel status
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| `running, pid N, uptime Xh Ym` | Sentinel is alive and observing. | None. |
+| `not running` | Sentinel state file is missing or its PID is dead. | Counts as a warning. See [sentinel-restart runbook](sentinel-restart.md). |
+
+Doctor does not introspect the Sentinel's circuit breaker — for that, run
+`urd sentinel status` directly.
+
+---
+
+## Section 5 — Verify (`--thorough` only)
+
+Walks every subvolume × drive pair and checks pin-file integrity:
+
+- Pin file exists, points at a snapshot present in both the local snapshot
+  dir and on the drive.
+- Or, no pin file but the chain origin is sound (next send will be a
+  legitimate full).
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| Per-pair OK | Thread is intact. Next send will be incremental. | None. |
+| Per-pair `warn` | Recoverable issue (pin missing on a drive that hasn't received yet, or a not-yet-significant inconsistency). | Often resolves on next backup. |
+| Per-pair `fail` | Pin points at a snapshot that no longer exists, or other definite breakage. | Next send will be a full send. Decide whether to allow it (`urd backup --force-full`) or investigate the cause first. |
+
+Verify failures count toward `Issues`. A standalone `urd verify` returns
+exit code `1` when there are failures — same data, different framing.
+
+---
+
+## Section 6 — Churn (`--thorough` only)
+
+Reports the rolling time-windowed churn rate per subvolume from the
+`drift_samples` table (UPI 030; see
+[ADR-113](../../00-foundation/decisions/2026-04-18-ADR-113-do-no-harm-invariant.md)
+for the Do-No-Harm context).
+
+| Row | Meaning |
+|-----|---------|
+| Numeric rate (e.g. `12.4 MiB/s`) | Rolling churn over the default window. |
+| `cold-start` / `not measured` | Insufficient samples in the window — common for new subvolumes or after a long absence. |
+| Last full-send size | Shown for transient/storage-critical subvolumes whose latest in-window send was a full send. |
+
+Churn is observability, not a verdict — it informs predictive guards in
+the Do-No-Harm arc. Sustained high churn on a subvolume backed by a small
+filesystem is a signal worth investigating.
+
+---
+
+## Decision tree
+
+```
+Verdict = Issues?       → Investigate now. Start with the section that
+                          contributed the error count.
+Verdict = Degraded?     → Investigate within the day. Promise still holds,
+                          but operational health is shaky.
+Verdict = Warnings?     → Triage by section:
+  - Infra warning      → see Section 2 actions
+  - Data-safety warn   → AT RISK; usually resolves on next backup
+  - Sentinel not running → sentinel-restart runbook
+  - --thorough verify  → if drives are away, ignore; otherwise plan a
+                         force-full or investigate
+Verdict = Healthy?      → Done. Move on.
+```
+
+---
+
+## Related
+
+- [Sentinel restart runbook](sentinel-restart.md)
+- [Drive rotation runbook](drive-rotation.md)
+- [Mapper zombie runbook](mapper-zombie.md)
+- [CLI reference](../../20-reference/cli.md) — `urd doctor`, `urd verify`, `urd emergency`
+- [Local space exhaustion postmortem](../postmortems/2026-03-24-local-space-exhaustion.md) — origin of the space-trend warnings
+- [ADR-113 — The Do-No-Harm invariant](../../00-foundation/decisions/2026-04-18-ADR-113-do-no-harm-invariant.md)

--- a/docs/10-operations/runbooks/drive-rotation.md
+++ b/docs/10-operations/runbooks/drive-rotation.md
@@ -1,0 +1,143 @@
+# Runbook: Drive Rotation
+
+> **TL;DR:** Removable backup drives can be disconnected and reconnected
+> freely. Urd treats drive absence as deferred work, not failure. While a
+> drive is `away`, sends queue; when it reconnects, the next scheduled
+> backup catches up. The Sentinel emits a notification on reconnect so the
+> operator knows catch-up is possible.
+
+**Audience:** Operators rotating an external backup drive (e.g., taking it
+offsite or swapping in a sibling).
+
+---
+
+## Mental model
+
+A configured drive lives in one of two states (see
+[glossary](../../00-foundation/glossary.md#drive-states)):
+
+- **`connected`** — mounted, Urd can read and write it now.
+- **`away`** — not currently mounted. Urd defers operations targeting it.
+
+`away` is *physical absence*, not data staleness. The duration shown by
+`urd status` is time since last disconnection, not time since last
+successful send.
+
+---
+
+## Procedure
+
+### Disconnecting
+
+1. Quiesce backups (optional). If a backup is currently writing to the drive,
+   `urd status` will show the run in progress. Wait for it, or accept that
+   the in-flight send will fail and be retried on the next run.
+
+2. Unmount via your desktop / shell (`udisksctl unmount` or eject from the
+   file manager). The drive cleanly detaches.
+
+3. Confirm:
+
+   ```bash
+   urd status
+   ```
+
+   The drive's row will show `away` with a fresh "since" duration. Subvolumes
+   that depended only on this drive may transition to `AT RISK` or
+   `UNPROTECTED` — that is expected.
+
+### While the drive is away
+
+- **Backups continue locally.** Snapshot creation never depends on an external
+  drive. Local promise states stay current.
+- **Sends are deferred.** The planner records `send_type = 3` (deferred) for
+  subvolumes whose target drive is away. `backup_send_type{subvolume="..."} 3`
+  shows up in metrics.
+- **No catch-up retries.** Urd does not poll for the drive between scheduled
+  runs. The Sentinel notices reconnection in real time but does not trigger
+  backups itself.
+
+### Reconnecting
+
+1. Plug the drive in and unlock / mount it the way you normally would
+   (Files, `udisksctl`, `cryptsetup` for LUKS).
+
+2. The Sentinel detects the mount and dispatches a "drive reconnected"
+   notification (configurable via `[notifications]`).
+
+3. Confirm:
+
+   ```bash
+   urd status
+   ```
+
+   The drive shows `connected`. Subvolumes that defer to this drive will
+   show their pending send count and updated promise states.
+
+4. Run a backup or wait for the scheduled timer:
+
+   ```bash
+   urd backup        # immediate; runs every subvolume that has work
+   ```
+
+   Or let the systemd timer pick it up at the next scheduled fire. Catch-up
+   is incremental whenever the chain is intact (the pin file from the last
+   successful send still points to a snapshot present on both sides).
+
+### When the chain breaks
+
+If the drive was away long enough that the local pin parent has been pruned
+(or the drive's last received snapshot has been deleted offline), the
+incremental chain is broken. The next send will be a **full send**.
+
+In autonomous mode (`--auto`, used by the systemd timer), full sends due to
+chain breaks are **skipped** to avoid surprising the operator with a
+multi-TB transfer. Re-run with `--force-full` to allow them:
+
+```bash
+urd backup --force-full --subvolume <name>
+```
+
+`urd plan` previews the same decision without executing.
+
+---
+
+## What `urd status` shows
+
+| Drive state | Subvolume promise | Likely meaning |
+|-------------|-------------------|----------------|
+| `connected`, recent send | `PROTECTED` | Normal. |
+| `away`, recent send | depends on level | Drive is offsite or swapped; data on it is current. |
+| `away`, stale send | `AT RISK` / `UNPROTECTED` | Drive has been away long enough that the protection level's freshness threshold lapsed. |
+| `connected`, no recent send | `AT RISK` / `UNPROTECTED` | The drive is here but Urd hasn't sent yet (just reconnected; first send pending). |
+
+---
+
+## Common questions
+
+**Q: Will Urd back up immediately when I plug a drive in?**
+No. The Sentinel notifies you, but it does not run backups. Either run
+`urd backup` manually or wait for the next timer fire.
+
+**Q: Can I rotate between two drives with the same configured slot?**
+Yes — give each drive a distinct label in `[[drives]]`. Each maintains its
+own pin file (`.last-external-parent-<LABEL>`), so the chains are independent.
+
+**Q: Is it safe to power-cycle the drive mid-send?**
+Sends are atomic at the snapshot level: a partial receive is cleaned up by
+the executor on failure (ADR-107). The chain stays intact because the pin
+file is only updated after a confirmed-complete send.
+
+**Q: How do I know when catch-up is done?**
+`urd status` shows `PROTECTED` once every subvolume's send has caught up.
+Metrics: `backup_last_success_timestamp{subvolume="...",location="external"}`
+will reflect the post-reconnect run.
+
+---
+
+## Related
+
+- [Sentinel restart runbook](sentinel-restart.md) — if the reconnect notification doesn't fire
+- [Mapper zombie runbook](mapper-zombie.md) — when re-unlocking a LUKS drive fails with "File exists"
+- [Doctor walk runbook](doctor-walk.md) — when something feels wrong after rotation
+- [CLI reference](../../20-reference/cli.md) — `urd status`, `urd backup`, `urd plan`

--- a/docs/10-operations/runbooks/mapper-zombie.md
+++ b/docs/10-operations/runbooks/mapper-zombie.md
@@ -1,0 +1,153 @@
+# Runbook: "File exists" on Re-unlocking a LUKS Backup Drive
+
+> **TL;DR:** When a removable LUKS drive is unplugged and reconnected, the
+> re-unlock can fail with `Failed to activate device: File exists`. The
+> cause is almost never Urd or BTRFS — it's that monitoring containers
+> running on the host have recursively bind-mounted the host's mount tree
+> into their namespaces, so the device-mapper node from the previous
+> session is still pinned. Restart the offending container(s) and unlock
+> normally.
+
+**Audience:** Operators on hosts that run monitoring/observability
+containers (Prometheus node_exporter, cAdvisor, similar) which bind-mount
+the host filesystem.
+
+**Severity:** Operator-blocked, not data-at-risk. The drive's content is
+intact; the problem is purely that the kernel can't activate the LUKS
+mapper because something still holds a reference.
+
+---
+
+## Symptom
+
+After reconnecting a LUKS-encrypted backup drive, attempting to unlock it
+(via Files / `udisksctl` / `cryptsetup luksOpen`) fails with:
+
+```
+Failed to activate device: File exists
+```
+
+`lsof` and `fuser` against the underlying block device return nothing.
+`cryptsetup close luks-<uuid>` and `dmsetup remove --force` both fail with
+`Device or resource busy`. Re-inserting the drive does not help.
+
+---
+
+## Root cause
+
+Monitoring containers (the canonical examples are `node_exporter` and
+`cAdvisor`, but anything with a recursive `/host` or `/rootfs` bind-mount
+qualifies) inherited the LUKS mapper's mount when the drive was first
+unlocked. When the drive was unplugged, the host's `udisks` cleanly
+unmounted its view, but the container's namespace still holds the mount
+because:
+
+1. The container was started with the host filesystem bind-mounted
+   recursively (`--volume /:/host` or `--mount type=bind,source=/,target=/rootfs`).
+2. Mount events that happen *after* container start propagate into the
+   container only if the source mount has `shared` or `rshared`
+   propagation. Unmount events do **not** propagate the same way — the
+   container retains the mount in its private namespace.
+3. The kernel's device-mapper subsystem refuses to activate a new mapper
+   with a UUID that still has open holders, even if those holders are in
+   another mount namespace.
+
+The `cryptsetup`/`dmsetup` tools running on the host see "no holders" via
+the host's `/proc` views and report success or `EBUSY` confusingly — they
+can't see the container's namespace.
+
+This is not a Urd issue or a LUKS issue. It is a side effect of the
+monitoring stack's mount topology.
+
+---
+
+## Diagnosis (optional — confirm before acting)
+
+```bash
+# Identify processes pinning the mapper across all namespaces
+sudo grep -lE "luks-<uuid>|<dm-major>:<dm-minor>" /proc/*/mountinfo 2>/dev/null
+```
+
+Where `<uuid>` is the LUKS UUID from the failure message and
+`<dm-major>:<dm-minor>` (e.g. `252:0`) is its device-mapper number. The
+PIDs that match are the holders. In practice they are the monitoring
+containers' main processes.
+
+This step is purely confirmatory — the fix is the same whether you
+confirm or skip.
+
+---
+
+## Fix
+
+Restart the container(s) that pin the mapper. For a typical Docker /
+Podman setup:
+
+```bash
+# Replace with the actual container names on this host.
+docker restart node_exporter cadvisor
+# or:
+podman restart node_exporter cadvisor
+```
+
+The host's deferred-removal logic fires once the holders release, and the
+mapper auto-cleans. If it doesn't (rare), close it manually:
+
+```bash
+sudo cryptsetup close luks-<uuid>
+```
+
+Then unlock the drive normally (Files, `udisksctl`, etc.).
+
+---
+
+## What does NOT work
+
+- **`umount -l` inside the container's namespace.** Most monitoring
+  containers drop mount capabilities or run with a user-namespace mapping
+  that refuses unmount. Returns `Permission denied`.
+- **`nsenter -m -- umount`** from the host into the container's namespace.
+  Same permission problem.
+- **`cryptsetup close --force` on the host.** It can't see the
+  cross-namespace holder; it either reports `EBUSY` or appears to succeed
+  but the mapper persists.
+- **Re-unlocking with a slightly different command.** This is a kernel
+  refcount, not a userspace state issue.
+
+Don't burn time on these. Restart the container.
+
+---
+
+## Prevention
+
+Long-term, restrict the monitoring containers' mount propagation so host
+mount events don't leak into them:
+
+1. Mount the host bind with `slave` (not `shared`/`rshared`) propagation,
+   so container mounts don't propagate back to the host but host mounts
+   *also* don't propagate into the container's view of removable media.
+2. Or, exclude `/run/media` (and any other removable-mount path) from the
+   bind, so mounts under it never appear inside the container at all.
+
+Either change is owned by the monitoring stack's configuration, not Urd.
+
+---
+
+## When to escalate
+
+If the symptom appears without monitoring containers in the picture
+(server-class system, no Prometheus stack, no recursive host bind-mounts),
+the root cause is something else — a stuck filesystem-level holder, a
+genuine kernel bug, or hardware. In that case:
+
+- `dmesg | tail -100` — look for I/O errors, mapper warnings.
+- `lsblk -f` — confirm the device topology.
+- `systemctl status systemd-udevd` — udev sometimes wedges on rapid
+  plug/unplug cycles; restarting it can help.
+
+---
+
+## Related
+
+- [Drive rotation runbook](drive-rotation.md) — the normal connect/disconnect flow this runbook recovers from
+- [Doctor walk runbook](doctor-walk.md) — for verifying everything is well after recovery

--- a/docs/10-operations/runbooks/sentinel-restart.md
+++ b/docs/10-operations/runbooks/sentinel-restart.md
@@ -1,0 +1,140 @@
+# Runbook: Restarting the Sentinel
+
+> **TL;DR:** The Sentinel is a stateless observer of the SQLite event log
+> and the filesystem. It can be restarted at any time without losing data
+> or backup history — every fact it cares about is persisted (filesystem
+> is truth, SQLite is history; ADR-102). The only state that does not
+> survive a restart is the in-memory circuit-breaker timer, which resets
+> to closed.
+
+**Audience:** Operators who suspect the Sentinel daemon has wedged, or
+who need to apply a config change without a full reboot.
+
+---
+
+## When to restart
+
+Restart the Sentinel when:
+
+- `urd sentinel status` reports the daemon is not running (PID dead, state
+  file stale).
+- A `[notifications]` or `[sentinel]` config change needs to take effect
+  (the Sentinel reads config at startup; live reload is not supported).
+- Drive reconnect notifications stop firing, but `urd status` correctly
+  reports `connected`. Suggests the Sentinel's mount-detection loop has
+  stalled.
+- The circuit breaker is stuck open and you want to give it a clean slate
+  while you investigate the underlying cause.
+
+Do **not** restart the Sentinel as a habit. If something feels wrong,
+`urd doctor` first — see [doctor-walk runbook](doctor-walk.md).
+
+---
+
+## Procedure
+
+### Diagnose first
+
+```bash
+urd sentinel status
+systemctl --user status urd-sentinel.service    # if installed
+journalctl --user -u urd-sentinel.service -n 50 --no-pager
+```
+
+The status output reports:
+
+- Whether the daemon process is alive.
+- Last activity timestamp.
+- Circuit breaker state (closed / open with reason).
+- Any pending actions queued.
+
+If the process is dead, the systemd unit's `Restart=on-failure` should have
+revived it. If it didn't, check `journalctl` for the crash reason — Urd's
+philosophy is to fix the cause, not paper over it with a restart.
+
+### Restart
+
+If installed as a user service:
+
+```bash
+systemctl --user restart urd-sentinel.service
+```
+
+Then confirm:
+
+```bash
+sleep 2
+urd sentinel status
+journalctl --user -u urd-sentinel.service -n 20 --no-pager
+```
+
+You want to see lifecycle log lines (`warn`-level by convention so they
+appear at default log levels) and the new PID matched in `urd sentinel status`.
+
+If running ad-hoc (e.g., debugging in a terminal):
+
+```bash
+# Stop the running instance (Ctrl-C in its terminal, or kill its PID).
+# Start fresh in foreground:
+urd sentinel run --verbose
+```
+
+### Verify behavior
+
+After restart:
+
+1. `urd status` — should be unchanged. Promise states come from the
+   filesystem and SQLite, not the Sentinel's memory.
+2. Trigger a drive reconnect (or wait for the next idle poll) — the
+   Sentinel should emit a notification on the next mount event.
+3. Check the heartbeat freshness: `cat <heartbeat_file> | jq .timestamp`.
+   The Sentinel does not write the heartbeat (the backup runner does), so
+   this only changes on the next backup.
+
+---
+
+## What survives a restart
+
+| State | Survives? | Source |
+|-------|-----------|--------|
+| Backup history | Yes | SQLite `runs`, `subvolume_results` |
+| Promise states | Yes (recomputed from filesystem on next read) | `awareness.rs` |
+| Pin files (chain parents) | Yes | Filesystem (`.last-external-parent-<LABEL>`) |
+| Drive UUID adoption | Yes | SQLite `drive_identities` |
+| Notification dispatch ledger | Yes | Heartbeat `notifications_dispatched` field |
+| Structured event log | Yes | SQLite `events` |
+| Circuit breaker state | **No** — resets to closed | In-memory only |
+| Pending actions queue | **No** — recomputed from current state | In-memory only |
+
+The circuit breaker's reset to closed is intentional. If the underlying
+condition that tripped it persists, it will trip again immediately on the
+next observation. A restart that "fixes" repeated tripping has masked a
+real problem — investigate the structured event log:
+
+```bash
+urd events --kind sentinel --since 24h
+```
+
+---
+
+## When restart does not help
+
+If the symptom persists after restart, escalate to:
+
+- `urd doctor --thorough` — full diagnostic battery, including thread
+  verification ([doctor-walk runbook](doctor-walk.md)).
+- Inspect the events log: `urd events --kind sentinel --limit 100`.
+- Read the journals: `journalctl --user -u urd-sentinel.service --since "1 day ago"`.
+- Check for filesystem-level problems (`btrfs filesystem show`, `dmesg | tail`).
+
+The Sentinel is a thin observer; persistent misbehavior usually points at
+something below it — a wedged mount, a permission change, a stale lock.
+
+---
+
+## Related
+
+- [Drive rotation runbook](drive-rotation.md)
+- [Doctor walk runbook](doctor-walk.md)
+- [CLI reference](../../20-reference/cli.md) — `urd sentinel run`, `urd sentinel status`, `urd events`
+- [ADR-102 — Filesystem is truth, SQLite is history](../../00-foundation/decisions/2026-03-24-ADR-102-filesystem-truth-sqlite-history.md)

--- a/docs/20-reference/cli.md
+++ b/docs/20-reference/cli.md
@@ -1,0 +1,454 @@
+# CLI Reference
+
+> **TL;DR:** Reference for every `urd` subcommand — its contract (what it
+> guarantees and what it refuses), notable flags, output channels, and exit
+> codes. This is not a `--help` mirror; it documents the *behavior contract*
+> a script or operator can rely on. For flag spelling and shell completion,
+> use `urd <subcommand> --help`.
+
+**Source of truth:** `src/cli.rs` (parser) and `src/commands/` (handlers).
+**Binary name:** `urd`.
+
+---
+
+## Conventions
+
+### Output mode
+
+Urd auto-detects its output mode from stdout:
+
+- **Interactive (TTY):** human-readable text, colored, with the mythic voice
+  carried in `voice.rs`. Format may evolve across versions.
+- **Daemon (non-TTY):** machine-readable JSON, no ANSI codes. Schema is
+  internal but stable enough for monitoring scripts.
+
+Pipe output to force daemon mode (e.g., `urd status | jq`). Set `NO_COLOR=1`
+to suppress colors even on a TTY.
+
+### Exit codes
+
+All commands return the standard Unix convention:
+
+- **0** — success or advisory output only (warnings do not raise).
+- **1** — failure. Either an `anyhow::Error` propagated from the command,
+  or an explicit `std::process::exit(1)` for partial-success cases (see
+  `backup` and `verify` below).
+
+There is no richer code mapping. Distinguish failure causes by parsing the
+diagnostic message or, for monitoring, by reading the heartbeat / metrics
+files instead of the exit code.
+
+### stdout vs stderr
+
+- **stdout** carries the command's primary output (status text, plan tables,
+  restored file content for `urd get`).
+- **stderr** carries log lines (suppressed below `Error` on TTY, `Warn`
+  off-TTY; `--verbose` raises to `Debug` on both). `RUST_LOG` overrides.
+
+### Global flags
+
+| Flag | Semantics |
+|------|-----------|
+| `--config <PATH>` / `-c` | Override config path. Default: `~/.config/urd/urd.toml`. |
+| `--verbose` / `-v` | Raise log level to `Debug`. Affects stderr only. |
+
+### Config requirements
+
+Each subcommand declares whether it requires a config load:
+
+- **No config required:** `completions`, `migrate`. Run on a fresh system.
+- **Config required:** all other subcommands. A missing or invalid config
+  fails fast with a diagnostic; no partial behavior.
+
+---
+
+## Subcommands
+
+### `urd` (no subcommand)
+
+**Contract.** Bare `urd` invocation prints orientation: project name, version,
+config status, and a one-screen summary of what to try next. Falls back to
+help-style output when config is absent or invalid. Never modifies state.
+
+**Output.** Stdout — text orientation block.
+
+**Exit codes.** `0` always (no operation can fail; missing config is a
+displayable state, not an error).
+
+---
+
+### `urd plan`
+
+**Contract.** Pure preview. Computes what `urd backup` *would* do given the
+current config and filesystem state, without executing anything. Reads
+filesystem and SQLite state; never writes. Safe to run any time, on any
+host, without sudo.
+
+**Notable flags.**
+
+| Flag | Semantics |
+|------|-----------|
+| `--auto` | Apply interval gating (skip subvolumes whose interval has not elapsed). Without this, plan shows what an immediate manual run would do. |
+| `--priority <1-3>` | Restrict to subvolumes of the given priority. |
+| `--subvolume <name>` | Restrict to a single subvolume by name. |
+| `--local-only` / `--external-only` | Restrict to local or external operations. |
+| `--force-snapshot` | Include snapshot creation even for unchanged subvolumes. |
+
+**Output.** Interactive — table per subvolume. Daemon — JSON.
+
+**Exit codes.** `0` on success; `1` on config or filesystem read failure.
+
+---
+
+### `urd backup`
+
+**Contract.** Executes the plan: snapshots, sends, retention, heartbeat,
+metrics. Requires sudo for btrfs operations (configured via sudoers). Per
+[ADR-100](../00-foundation/decisions/2026-03-24-ADR-100-planner-executor-separation.md),
+individual subvolume failures do not abort the run — the executor isolates
+errors and continues. Per
+[ADR-107](../00-foundation/decisions/2026-03-24-ADR-107-fail-open-cleanup-on-failure.md),
+backups proceed when in doubt; deletions refuse when in doubt. Per
+[ADR-113](../00-foundation/decisions/2026-04-18-ADR-113-do-no-harm-invariant.md),
+the planner refuses to create local snapshots when free space is below
+`min_free_bytes` (no override).
+
+**Notable flags.**
+
+| Flag | Semantics |
+|------|-----------|
+| `--dry-run` | Plan + simulate; no btrfs operations executed, no state writes. |
+| `--auto` | Automated run mode — apply interval gating, suppress non-essential output. Used by the systemd timer. |
+| `--confirm-retention-change` | Required to delete snapshots whose protection level was relaxed in this config session. Fail-closed: without the flag, retention is skipped for affected subvolumes. |
+| `--force-full` | Force full sends for chain-broken subvolumes. Without this, chain-break full sends are skipped in `--auto` mode (avoids surprise multi-TB sends from the timer). |
+| `--priority <1-3>`, `--subvolume <name>`, `--local-only`, `--external-only`, `--force-snapshot` | Same scoping as `plan`. |
+
+**Output.** Interactive — per-subvolume summary plus an aggregated voice
+block. Daemon — JSON. Heartbeat and metrics files are written regardless of
+output mode.
+
+**Exit codes.** `0` if `result.overall == Success` (every subvolume succeeded
+or was legitimately skipped). `1` for `Partial` (some subvolume failed) or
+`Failure` (run-level failure). Distinguishing partial vs total failure
+requires reading the heartbeat or metrics, not the exit code.
+
+---
+
+### `urd status`
+
+**Contract.** Read-only. Reports current promise states per subvolume,
+drive presence, and overall data safety. Reads filesystem, SQLite, and the
+heartbeat file; writes nothing. Safe under any condition, including a
+running backup (advisory locking via `lock.rs` makes the read non-conflicting).
+
+**Output.** Interactive — voice-rendered status block answering "is my data
+safe?" Daemon — JSON.
+
+**Exit codes.** `0` always (an unprotected subvolume is a displayable state,
+not an error).
+
+---
+
+### `urd history`
+
+**Contract.** Reads the SQLite `runs` and per-run tables and renders the most
+recent N runs. Read-only.
+
+**Notable flags.**
+
+| Flag | Semantics |
+|------|-----------|
+| `--last <N>` | Number of recent runs to show (default 10). |
+| `--subvolume <name>` | Filter by subvolume. |
+| `--failures` | Show only failed operations. |
+
+**Output.** Interactive — table. Daemon — JSON.
+
+**Exit codes.** `0` on success; `1` on SQLite read failure.
+
+---
+
+### `urd verify`
+
+**Contract.** Diagnoses thread integrity and pin health: walks every
+subvolume × drive pair, checks that the pin file points at a snapshot that
+exists locally and on the drive (or that the chain origin is sound).
+Read-only with respect to the filesystem and state. Used standalone or as
+part of `urd doctor --thorough`.
+
+**Notable flags.**
+
+| Flag | Semantics |
+|------|-----------|
+| `--subvolume <name>` | Scope to a single subvolume. |
+| `--drive <label>` | Scope to a single drive. |
+| `--detail` | Show every check, not just findings. |
+
+**Output.** Interactive — voice-rendered verify block. Daemon — JSON.
+
+**Exit codes.** `0` if every check passed. `1` if any check failed
+(`fail_count > 0`). Warnings alone do not raise.
+
+---
+
+### `urd init`
+
+**Contract.** Sets up Urd's environment: ensures the state DB directory and
+heartbeat directory exist, runs the same infrastructure checks `doctor`
+runs, and exits cleanly. Idempotent — safe to run multiple times. May
+prompt for sudo if the configured `btrfs_path` requires testing.
+
+**Output.** Interactive — checklist of infrastructure items.
+
+**Exit codes.** `0` on success; `1` if any required infrastructure
+cannot be created or verified.
+
+---
+
+### `urd calibrate`
+
+**Contract.** Measures snapshot sizes (via `du`) to improve send-time
+estimates. Reads the filesystem; may take significant wall-clock time on
+large subvolumes. Writes calibration data to the state DB.
+
+**Notable flags.**
+
+| Flag | Semantics |
+|------|-----------|
+| `--subvolume <name>` | Restrict to a single subvolume. |
+
+**Output.** Interactive — per-subvolume size summary. Daemon — JSON.
+
+**Exit codes.** `0` on success; `1` on filesystem or state DB error.
+
+---
+
+### `urd get`
+
+**Contract.** Restores a single file from a past snapshot to stdout (or to
+`--output`). Read-only with respect to all Urd state. Subvolume is
+auto-detected from the source path or selected via `--subvolume`. Refuses
+when no snapshot exists at or before the target date, or when the target
+file does not exist in the selected snapshot.
+
+**Required positional + flags.**
+
+| Argument | Semantics |
+|----------|-----------|
+| `<path>` (positional) | File to retrieve. Resolved against the working directory. |
+| `--at <DATE>` | Date reference. Accepts `YYYY-MM-DD`, `YYYYMMDD`, `today`, `yesterday`. |
+| `--output <PATH>` / `-o` | Write to file instead of stdout. |
+| `--subvolume <name>` | Override automatic subvolume detection. |
+
+**Output.** Stdout — file contents (binary-safe), or human summary if
+`--output` is set.
+
+**Exit codes.** `0` on success; `1` on any failure (no matching subvolume,
+no snapshot before date, file absent in snapshot, write failure).
+
+---
+
+### `urd sentinel run`
+
+**Contract.** Starts the Sentinel daemon in the foreground. Designed to be
+run by systemd as a user service (`urd-sentinel.service`); `Restart=on-failure`
+in the unit handles crash recovery. Owns sub-hourly monitoring, drive
+detection, and overdue-backup notifications. The Sentinel never executes
+backups itself — it triggers them via `urd backup` invocations.
+
+**No flags.** Configuration is via `urd.toml`'s `[notifications]` and
+`[sentinel]` sections.
+
+**Output.** Stderr — log lines (lifecycle events at `warn` level by
+convention so they remain visible at default log levels). Stdout is
+unused.
+
+**Exit codes.** `0` on clean shutdown (SIGTERM); `1` on crash or
+configuration error.
+
+---
+
+### `urd sentinel status`
+
+**Contract.** Reads the Sentinel's state file (PID, last activity, circuit
+breaker state) and reports it. Read-only.
+
+**Output.** Interactive — daemon status block. Daemon — JSON.
+
+**Exit codes.** `0` if Sentinel is running. `1` if state file missing or
+PID is dead.
+
+---
+
+### `urd drives` (no subcommand)
+
+**Contract.** Lists configured drives and their current state (mounted /
+absent / unrecognized UUID). Read-only.
+
+**Output.** Interactive — drive table. Daemon — JSON.
+
+**Exit codes.** `0` always.
+
+---
+
+### `urd drives adopt <LABEL>`
+
+**Contract.** Accepts a drive into Urd's identity system by recording its
+BTRFS UUID against the configured label. Refuses if the drive is not
+mounted, if the label is not in the config, or if the drive already has
+a different UUID recorded (the operator must reconcile the conflict in
+config first). Writes to the state DB.
+
+**Output.** Interactive — adoption confirmation. Daemon — JSON.
+
+**Exit codes.** `0` on success; `1` on refusal or write failure.
+
+---
+
+### `urd doctor`
+
+**Contract.** Runs the full diagnostic battery: config preflight,
+infrastructure checks (DB, dirs, sudo btrfs), drive UUID fingerprinting,
+and local-space trend warnings. Read-only. Designed to be the first thing
+an operator runs when something feels off.
+
+**Notable flags.**
+
+| Flag | Semantics |
+|------|-----------|
+| `--thorough` | Add thread-verification (`urd verify`) to the battery. Slower; reads every pin file. |
+
+**Output.** Interactive — voice-rendered diagnostic block with severity
+icons and suggested next steps. Daemon — JSON.
+
+**Exit codes.** `0` if no checks reached `Error` severity (warnings allowed).
+`1` if any check is `Error`.
+
+See [doctor-walk runbook](../10-operations/runbooks/doctor-walk.md) for
+interpretation of findings.
+
+---
+
+### `urd emergency`
+
+**Contract.** Guided interactive flow for space recovery. Surfaces eligible
+snapshots for emergency deletion, prompts for confirmation, and executes
+the deletion via `BtrfsOps`. Refuses non-interactive use (no `--yes`
+available by design — this is the human-in-the-loop mode for catastrophic
+pressure). Honors pin protection: pinned snapshots never appear in the
+delete-eligible list.
+
+**Output.** Interactive — guided prompts. Daemon mode is not supported
+(non-interactive runs are refused).
+
+**Exit codes.** `0` on completion (whether the operator deleted anything
+or not); `1` on hard failure.
+
+---
+
+### `urd retention-preview`
+
+**Contract.** Shows what retention would prune on the next run, per
+subvolume, given the current config. Read-only. Useful for evaluating a
+config change before running `backup`.
+
+**Notable flags.**
+
+| Flag | Semantics |
+|------|-----------|
+| `<subvolume>` (positional) | Single subvolume to preview. |
+| `--all` | Preview every configured subvolume. |
+| `--compare` | Show the transient/graduated comparison alongside. |
+
+**Output.** Interactive — per-subvolume keep/prune table. Daemon — JSON.
+
+**Exit codes.** `0` on success; `1` on filesystem or state read failure.
+
+---
+
+### `urd events`
+
+**Contract.** Reads the structured event log (see
+[ADR-114](../00-foundation/decisions/2026-04-30-ADR-114-structured-event-log.md))
+and prints filtered events. Read-only.
+
+**Notable flags.**
+
+| Flag | Semantics |
+|------|-----------|
+| `--since <DURATION>` | Only events from the last duration (e.g., `7d`, `24h`, `30m`). |
+| `--kind <KIND>` | Filter by kind: `retention`, `planner`, `promise`, `sentinel`, `config`, `drive`. |
+| `--subvolume <name>` | Filter by subvolume. |
+| `--drive <label>` | Filter by drive label. |
+| `--limit <N>` | Maximum events to display. Default `50`, max `1000`. |
+| `--json` | Line-delimited JSON output. **Not** a stable public contract — additive but versioned-by-evolution; expect new fields and event variants. |
+
+**Output.** Interactive — columnar event log. Daemon or `--json` —
+NDJSON.
+
+**Exit codes.** `0` on success; `1` on state DB read failure.
+
+---
+
+### `urd migrate`
+
+**Contract.** Transforms a legacy `urd.toml` to the v1 schema (see
+[ADR-111](../00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md)).
+Reads the raw TOML, builds v1 as string output, writes it back to the
+config path, and saves the original to `<path>.legacy` as a backup.
+Refuses configs already at `config_version = 1` or higher (no-op with
+diagnostic).
+
+This is one of two **config-free** commands — it is dispatched before
+config load, so it works on a config that the regular loader would reject.
+
+**Notable flags.**
+
+| Flag | Semantics |
+|------|-----------|
+| `--dry-run` | Show what would change without writing files. |
+
+**Output.** Interactive — diff summary. The `--dry-run` summary contains
+the proposed v1 TOML for review.
+
+**Exit codes.** `0` on success or no-op; `1` on parse failure or write
+failure.
+
+---
+
+### `urd completions <SHELL>`
+
+**Contract.** Generates a shell completion script for the named shell
+(`bash`, `zsh`, `fish`, `elvish`, `powershell`) and prints it to stdout.
+Config-free — does not load `urd.toml`.
+
+**Output.** Stdout — completion script.
+
+**Exit codes.** `0` always (clap rejects unknown shells before reaching
+the handler).
+
+---
+
+## Stability classes
+
+| Surface | Stability |
+|---------|-----------|
+| Subcommand names (`backup`, `status`, ...) | Stable. Renames require ADR + deprecation period. |
+| Flag spelling | Stable for documented flags. New flags are additive. |
+| Exit code semantics (`0` / `1`) | Stable. |
+| Interactive (TTY) text format | Evolving. Do not parse. |
+| Daemon JSON output | Internal — additive evolution, but no formal contract. Use heartbeat / metrics for monitoring. |
+| `urd events --json` | Explicitly **not** a stable contract. Expect new fields and new event variants. |
+
+For monitoring, prefer the heartbeat ([heartbeat-schema.md](heartbeat-schema.md))
+and metrics ([metrics.md](metrics.md)) over parsing CLI output.
+
+---
+
+## See also
+
+- [Prometheus metrics reference](metrics.md)
+- [Heartbeat schema reference](heartbeat-schema.md)
+- [Runbooks](../10-operations/runbooks/) — operational procedures that use these commands
+- [ADR-111 — Config system architecture](../00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md) — `urd migrate` design
+- [ADR-114 — Structured event log](../00-foundation/decisions/2026-04-30-ADR-114-structured-event-log.md) — `urd events` data source

--- a/docs/20-reference/heartbeat-schema.md
+++ b/docs/20-reference/heartbeat-schema.md
@@ -1,0 +1,171 @@
+# Heartbeat Schema Reference
+
+> **TL;DR:** `heartbeat.json` is a JSON health signal Urd writes after every
+> backup run, including no-send and skipped runs. It answers "when did Urd
+> last run, and is the data safe?" without requiring SQLite access. The
+> current schema is **v3**. Consumers MUST check `schema_version` and refuse
+> higher versions; writers MUST add fields, never remove. Atomic write via
+> temp+rename guarantees consumers never observe a partial file.
+
+**Source of truth:** `src/heartbeat.rs`.
+**Default path:** configured via `[general] heartbeat_file` (no implicit default).
+**Format:** pretty-printed JSON, UTF-8.
+**Write semantics:** atomic — `*.json.tmp` then `rename(2)`.
+**Write cadence:** every backup run, including `empty` and skipped runs.
+
+---
+
+## Compatibility contract
+
+1. **Additive evolution only.** Fields are added across versions; existing
+   fields are never removed or repurposed. The `schema_version` integer is
+   bumped when the writer adds a field.
+2. **Consumers check `schema_version`.** A consumer reading a version it does
+   not recognize must refuse to interpret unknown fields, not guess. Reading
+   a *lower* version than the consumer expects is safe — added fields default
+   sensibly via serde defaults (see field reference below).
+3. **Atomic write.** A reader that opens the file mid-run cannot observe a
+   half-written document. Implementation: write to `heartbeat.json.tmp` then
+   `rename(2)` to `heartbeat.json`.
+4. **Written on every run.** Including the `empty` outcome (no work to do)
+   and partial/failed runs. Absence of the file means Urd has never run on
+   this host; staleness of the file's mtime / `timestamp` field means Urd
+   has stopped.
+5. **`stale_after` is advisory.** It is a hint to consumers about when this
+   heartbeat should be considered out of date — `now + 2 × min(snapshot_intervals)`,
+   with a 24 h fallback when no enabled subvolumes exist. It is not a contract
+   on Urd's behavior.
+6. **Independent of app version.** `schema_version` versions the heartbeat
+   contract, not Urd's SemVer. See
+   [ADR-105](../00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md)
+   and [ADR-112](../00-foundation/decisions/2026-03-28-ADR-112-semver-and-release-workflow.md).
+
+---
+
+## Current schema (v3)
+
+### Top-level object
+
+| Field | Type | Nullable | Notes |
+|-------|------|----------|-------|
+| `schema_version` | integer | no | Always `3` for current writer. Consumers MUST check this first. |
+| `timestamp` | string | no | ISO-8601 local time, format `YYYY-MM-DDTHH:MM:SS`. When this heartbeat was written. |
+| `stale_after` | string | no | ISO-8601 local time. Advisory: `timestamp + 2 × min(snapshot_intervals)`, 24 h fallback. |
+| `run_result` | string | no | One of `success`, `partial`, `failure`, `empty`. `empty` means no execution result (no work scheduled). |
+| `run_id` | integer | yes | SQLite `runs.id` for this execution. `null` for `empty` runs and when the state DB is unavailable. |
+| `subvolumes` | array | no | One entry per configured subvolume (see below). |
+| `notifications_dispatched` | bool | no | `false` immediately after write; `true` once notifications have been dispatched. Used for crash-recovery: a reader seeing `false` re-computes and re-sends. Defaults to `true` when absent (pre-notification heartbeats). |
+
+### Per-subvolume object (`subvolumes[]`)
+
+| Field | Type | Nullable | Notes |
+|-------|------|----------|-------|
+| `name` | string | no | Subvolume `name` (the directory under the snapshot root, not `short_name`). |
+| `backup_success` | bool | yes | `null` if not attempted in this run (skipped or `empty`); `true` / `false` if attempted. |
+| `promise_status` | string | no | One of `PROTECTED`, `AT RISK`, `UNPROTECTED`. From the awareness model. |
+| `pin_failures` | integer | no | Count of sends that succeeded but whose pin file write failed. Defaults to `0` for backward-compat with pre-pin-tracking heartbeats. |
+| `send_completed` | bool | no | `true` when at least one `Full` or `Incremental` send completed for this subvolume in this run. `false` for deferred / no-send / skipped. Defaults to `true` for v1 backward-compat. |
+| `churn_bytes_per_second` | float | yes | Rolling time-windowed churn rate (UPI 030). **Omitted** when `null` (`skip_serializing_if`). Absent for cold-start subvolumes and for subvolumes whose latest in-window send was a full send. |
+| `last_full_send_bytes` | integer | yes | Bytes of the most recent in-window full send (UPI 030). **Omitted** when `null`. Absent for incremental-only and cold-start subvolumes. |
+
+### Example
+
+```json
+{
+  "schema_version": 3,
+  "timestamp": "2026-04-30T03:00:00",
+  "stale_after": "2026-04-30T05:00:00",
+  "run_result": "partial",
+  "run_id": 42,
+  "subvolumes": [
+    {
+      "name": "home",
+      "backup_success": true,
+      "promise_status": "PROTECTED",
+      "pin_failures": 0,
+      "send_completed": true,
+      "churn_bytes_per_second": 1234.5
+    },
+    {
+      "name": "docs",
+      "backup_success": false,
+      "promise_status": "AT RISK",
+      "pin_failures": 0,
+      "send_completed": false
+    }
+  ],
+  "notifications_dispatched": false
+}
+```
+
+(`docs` omits the UPI-030 fields because they are `null` and `skip_serializing_if`
+elides them from the wire.)
+
+---
+
+## Migration notes (v2 → v3)
+
+**Added fields** (per-subvolume, both nullable and `skip_serializing_if = "Option::is_none"`):
+
+- `churn_bytes_per_second` — rolling drift rate from UPI 030's `drift_samples`.
+- `last_full_send_bytes` — most recent in-window full-send size from UPI 030.
+
+**Removed:** none.
+**Renamed:** none.
+**Semantic changes to existing fields:** none.
+
+**Reader impact.** A v2 consumer reading a v3 file:
+
+- Will see `schema_version: 3` and should refuse interpretation per the
+  compatibility contract — or accept that unknown fields exist and ignore
+  them, depending on the consumer's strictness.
+- If the consumer is permissive and ignores unknown fields, no behavior
+  change: the v2-known fields are unchanged.
+
+**Writer impact.** A v3 writer producing data for a v2 reader:
+
+- The two new fields are omitted when `null`. For incremental-only or
+  unchanged subvolumes, the wire format is identical to v2.
+- For subvolumes where the new fields are populated, a strict v2 reader
+  will reject the document by `schema_version`; a permissive one will
+  ignore the new fields and read the rest cleanly.
+
+---
+
+## Older schemas
+
+For `schema_version` ≤ 2, consult `git log -- src/heartbeat.rs` and check
+out the relevant tag. Highlights:
+
+- **v2** added `send_completed` (per-subvolume bool, defaults `true` when
+  absent for v1 reads).
+- **v1** was the original schema — no `send_completed`, no `pin_failures`
+  (defaults to `0`), no UPI-030 fields.
+
+The current writer can read all prior versions cleanly (serde defaults
+fill missing fields). The current writer always emits the latest version.
+
+---
+
+## Reading the file
+
+```rust
+// Reader returns None on missing file or parse failure (safe fallback).
+let hb = heartbeat::read(path);
+```
+
+Consumers outside Urd (Sentinel, tray icons, external scripts) should:
+
+1. Open the file. If missing, treat as "Urd has never run."
+2. Parse as JSON. If parse fails, treat as "stale or corrupt — refresh expected."
+3. Check `schema_version`. Refuse if higher than the consumer knows.
+4. Use `timestamp` and `stale_after` for freshness; use `subvolumes[].promise_status`
+   for the per-subvolume state.
+
+---
+
+## See also
+
+- [Prometheus metrics reference](metrics.md) — the `.prom` sibling of this file
+- [ADR-105 — Backward compatibility contracts](../00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md)
+- [ADR-112 — SemVer and release workflow](../00-foundation/decisions/2026-03-28-ADR-112-semver-and-release-workflow.md) (data formats vs. app version)

--- a/docs/20-reference/metrics.md
+++ b/docs/20-reference/metrics.md
@@ -1,0 +1,219 @@
+# Prometheus Metrics Reference
+
+> **TL;DR:** Urd writes a Prometheus textfile (`backup.prom`) consumed by
+> external monitoring. The `backup_*` metric family is a load-bearing public
+> contract under [ADR-105](../00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md):
+> renames are breaking changes. The `urd_*` family is internal and may evolve.
+> All values are gauges or counters; cardinality is small and stable
+> (`subvolume`, `location`, `reason`, `scope`, `rule`).
+
+**Source of truth:** `src/metrics.rs`.
+**Output format:** Prometheus textfile exposition (one file, atomic temp+rename).
+**Default path:** configured via `[general] metrics_file` (no implicit default).
+**Write cadence:** every backup run, including no-send and skip outcomes.
+
+---
+
+## Contract
+
+These properties are guaranteed and load-bearing for downstream consumers
+(alerts, dashboards, ad-hoc queries):
+
+1. **Metric names are the contract.** Renames or removals to any `backup_*`
+   metric require an [ADR-105](../00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md)-grade
+   change with coordinated downstream updates. The `urd_*` namespace is
+   reserved for Urd internals and may evolve freely.
+2. **Encoding stability.** `backup_send_type`'s value mapping
+   (`0=full / 1=incremental / 2=no-send / 3=deferred`) and
+   `backup_success`'s mapping (`0=failure / 1=success / 2=schedule-skipped`)
+   are part of the contract. A consumer that filters on `backup_send_type == 2`
+   to suppress alerts on cold subvolumes will silently break if the encoding shifts.
+3. **`backup_script_last_run_timestamp` is the heartbeat.** Updated on every
+   run regardless of outcome. A monitor can detect "Urd itself stopped" by
+   the absence of recent updates. Removing this guarantee breaks "is Urd alive?"
+   monitoring.
+4. **Series presence beats value.** Prometheus does not fire `==0` rules on
+   missing series. When a subvolume has nothing on external yet, Urd emits
+   `backup_snapshot_count{location="external", subvolume="..."} 0` rather than
+   omitting the line — that lets monitors detect "external never received this
+   subvolume" without false positives from new subvolumes.
+5. **Atomic write.** The file is written to `*.prom.tmp` and renamed into place.
+   Mid-run reads by a textfile collector cannot observe a partial file.
+6. **Conditional series document their absence.** `backup_subvolume_churn_bytes_per_second`
+   and `backup_subvolume_last_full_send_bytes` are absent for cold-start
+   subvolumes and for subvolumes whose latest in-window send was the wrong kind
+   (full / incremental respectively). The `# HELP` text states this explicitly;
+   alerts must not assume the series exists.
+7. **Carry-forward of `backup_last_success_timestamp`.** When a subvolume is
+   not attempted in a run (interval gating, skip), its previous timestamp is
+   read from the existing `.prom` file and re-emitted unchanged. The series
+   does not disappear during quiet periods.
+8. **Label cardinality is stable.** `subvolume`, `location` (`local|external`),
+   `reason`, `scope`, `rule` are the only labels. No host labels, no path
+   encoding, no hashes. Series identity must remain queryable across config
+   refactors.
+9. **The `backup_restore_test_*` namespace is not Urd's.** Restore-test
+   metrics are written by external tooling. Urd must never emit those names.
+10. **Reserved namespace.** Urd writes only `backup_*` (public contract) and
+    `urd_*` (internal). Other prefixes are out of scope.
+
+---
+
+## Per-subvolume gauges
+
+All carry `subvolume="<name>"` as the primary label.
+
+### `backup_success`
+
+Gauge. Value: `0=failure`, `1=success`, `2=schedule-skipped`.
+
+The subvolume's outcome for the most recent run. `2` means the planner
+skipped this subvolume (interval gating, disabled, no work) — distinguished
+from `0` to keep cold subvolumes from firing failure alerts.
+
+### `backup_last_success_timestamp`
+
+Gauge. Unix epoch seconds. Emitted only for subvolumes with a recorded
+successful backup.
+
+Carried forward from the previous `.prom` file when a subvolume was not
+attempted in this run, so the series does not vanish during interval gaps.
+Used by staleness alerts to detect "this subvolume hasn't backed up in N days."
+
+### `backup_duration_seconds`
+
+Gauge. Wall-clock duration of this subvolume's backup work in this run.
+
+`0` for skipped subvolumes. Used to spot regressions ("this used to take 5 minutes,
+now it takes 2 hours"). Auto-resolves on next short run, so alerts should require
+sustained elevation.
+
+### `backup_snapshot_count`
+
+Gauge. Two series per subvolume — one with `location="local"`, one with
+`location="external"`. Both are always emitted, even when zero, so consumers
+can detect "external never received this subvolume" via `==0`.
+
+The external count comes from the first mounted external drive (multi-drive
+configurations report the primary's count). Snapshots that exist on a drive
+not currently mounted are not counted.
+
+### `backup_send_type`
+
+Gauge. Value: `0=full`, `1=incremental`, `2=no-send`, `3=deferred`.
+
+What the planner decided for this subvolume in this run. `2` means no send
+was scheduled (cold subvolume, interval not elapsed); `3` means a send was
+scheduled but deferred (drive absent, lock held, predictive guard tripped).
+
+The encoding is part of the contract. Downstream alerts use
+`backup_send_type == 2` to exclude cold subvolumes from staleness rules
+("subvolume has not backed up in 2 days, but its send_type is 2 — that's fine").
+
+### `backup_subvolume_churn_bytes_per_second`
+
+Gauge. Rolling time-windowed churn rate per subvolume, computed by `drift.rs`
+from the `drift_samples` table (UPI 030).
+
+**Conditional.** Absent for cold-start subvolumes and for subvolumes whose
+latest in-window send was a full send — for those, see
+`backup_subvolume_last_full_send_bytes` instead.
+
+The `# HELP` line documents this absence. Alerts must not assume presence.
+
+### `backup_subvolume_last_full_send_bytes`
+
+Gauge. Bytes of the most recent in-window full send (UPI 030).
+
+**Conditional.** Absent for incremental-only subvolumes and cold-start
+subvolumes. Emitted for transient/storage-critical subvolumes whose latest
+send was a full send (so the previous incremental rate doesn't apply).
+
+---
+
+## Global gauges
+
+No labels (single-series each).
+
+### `backup_external_drive_mounted`
+
+Gauge. `1` if any external backup drive is currently mounted, `0` otherwise.
+
+### `backup_external_free_bytes`
+
+Gauge. Free bytes on the mounted external backup drive. `0` when no drive
+is mounted (intentionally, so capacity dashboards show "drive away" as a
+flat-line at zero rather than a gap).
+
+### `backup_script_last_run_timestamp`
+
+Gauge. Unix epoch seconds of the most recent Urd run, regardless of outcome.
+
+This is the "Urd itself is alive" canary. Monitors detect a stuck or crashed
+Urd by the staleness of this timestamp. Must be updated on every invocation
+that reaches the metrics writer, including no-send and full-skip runs.
+
+---
+
+## Internal counters (`urd_*`)
+
+These belong to Urd. Schema, labels, and presence may evolve without
+breaking-change ceremony. Downstream consumers should treat them as
+informational, not contractual.
+
+All four are derived from the structured event log
+([ADR-114](../00-foundation/decisions/2026-04-30-ADR-114-structured-event-log.md))
+at write time. When the state DB is unavailable, they emit zeros so the
+series exist.
+
+### `urd_circuit_breaker_trips_total`
+
+Counter, no labels. Number of times the Sentinel's circuit breaker has
+opened. Emits `0` when the events table is empty.
+
+### `urd_planner_full_sends_total`
+
+Counter, label `reason`. Full-send choices by reason
+(`first_send`, `chain_broken`, `forced`, ...). Emits
+`urd_planner_full_sends_total{reason="none"} 0` when no events exist, so
+consumers can detect that the metric family is being written.
+
+### `urd_planner_defers_total`
+
+Counter, label `scope`. Planner deferrals by scope (`subvolume`, `drive`).
+Same `scope="none"` zero sentinel as above.
+
+### `urd_retention_prunes_total`
+
+Counter, label `rule`. Snapshot prunes by retention rule
+(`graduated_hourly`, `graduated_daily`, `emergency`, ...). Same `rule="none"`
+zero sentinel as above.
+
+---
+
+## Naming and addition policy
+
+- **`backup_*`** — public contract. Add only with downstream coordination.
+  Renames forbidden. Removals require ADR-105 supersession.
+- **`urd_*`** — Urd internals. Add freely. Renames discouraged but not
+  contractual.
+- **No other prefixes.** Anything that is neither monitoring contract nor
+  Urd internal does not belong in the `.prom` file.
+
+When adding a new `backup_*` metric:
+
+1. Coordinate with downstream consumers before merging.
+2. Follow the carry-forward / sentinel-zero patterns above for any series
+   that may be conditionally absent.
+3. Document conditional presence in the `# HELP` line.
+4. Update this reference doc and any cross-repo monitoring ADR as a
+   load-bearing dependency.
+
+---
+
+## See also
+
+- [ADR-105 — Backward compatibility contracts](../00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md)
+- [ADR-113 — The Do-No-Harm invariant](../00-foundation/decisions/2026-04-18-ADR-113-do-no-harm-invariant.md) (rationale for drift telemetry)
+- [ADR-114 — Structured event log](../00-foundation/decisions/2026-04-30-ADR-114-structured-event-log.md) (source of `urd_*` counters)
+- [Heartbeat schema reference](heartbeat-schema.md) — the JSON sibling of this file


### PR DESCRIPTION
## Summary

Wave 3 of the documentation system improvements queued in
`docs/99-reports/2026-05-02-review-analysis-documentation-system.md`. Closes
the two "ghost directories" identified in that review — `20-reference/` and
`10-operations/runbooks/` were placeholders; this populates both.

- **`20-reference/` (canonical contracts under ADR-105):**
  `metrics.md` — every Prometheus metric, label cardinality, value
  encodings, and the 10 properties downstream consumers depend on.
  `heartbeat-schema.md` — heartbeat.json v3 in full + v2 → v3 diff +
  pointer to git for older. `cli.md` — every `urd` subcommand's contract
  (guarantees, refusals, stdout/stderr, exit codes), not a `--help` mirror.

- **`10-operations/runbooks/` (operational procedures):**
  `drive-rotation.md`, `sentinel-restart.md`, `doctor-walk.md`,
  `mapper-zombie.md`. Each covers a procedure that previously lived only
  in tribal knowledge or journal entries.

- **No production code touched.** All cross-references resolve;
  placeholders used per Privacy rules.

## Testing

- cargo clippy: not applicable (docs-only)
- cargo test: not applicable (docs-only)
- Integration tests: not applicable
- Link integrity: verified — every relative `.md` link in the seven new
  files resolves
- PII scan: clean (no username, email, hostname, or absolute home paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)