### PR TITLE
chore: doc-system automation seams (Wave 4 of doc system improvements)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,9 @@ docs/97-plans/
 docs/98-journals/
 docs/99-reports/
 docs/contributing-internal.md
-scripts/
+# Local scripts and prompts stay private; tracked dev tooling is whitelisted below.
+scripts/*
+!scripts/install-hooks.sh
+!scripts/pre-commit-pii.sh
+!scripts/check-docs.sh
+!scripts/check-registry.sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,31 @@ cargo build --release       # Binary at target/release/urd
 cargo install --path .      # Install to ~/.cargo/bin/urd
 ```
 
+## Local dev setup
+
+Install the repo's git hooks once after cloning:
+
+```bash
+scripts/install-hooks.sh
+```
+
+This wires up a `pre-commit` PII guard that scans staged diffs for the operator's
+username, hostname, and home/mount paths. The repo is public — accidental leaks
+have happened before. See `scripts/pre-commit-pii.sh` for the patterns scanned.
+
+## Doc checks
+
+Two helper scripts validate the documentation tree:
+
+```bash
+scripts/check-docs.sh       # all relative links in tracked markdown resolve
+scripts/check-registry.sh   # UPI registry ↔ design files are consistent (local-only)
+```
+
+`check-docs.sh` is CI-safe. `check-registry.sh` requires the gitignored
+`docs/96-project-supervisor/registry.md` and `docs/95-ideas/`, so it short-circuits
+in environments where those are absent.
+
 ## Testing
 
 ```bash

--- a/docs/00-foundation/guides/operating-urd.md
+++ b/docs/00-foundation/guides/operating-urd.md
@@ -256,9 +256,8 @@ systemctl --user daemon-reload
 systemctl --user enable --now urd-backup.timer
 ```
 
-Re-run this after modifying unit files in the repo. See
-[CONTRIBUTING.md](../../CONTRIBUTING.md#systemd-deployment) for the rationale behind
-copying rather than symlinking.
+Re-run this after modifying unit files in the repo. Copying (rather than symlinking)
+keeps the installed unit stable across `git checkout` operations.
 
 ### Monitor
 

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# check-docs.sh — Verify all relative markdown links in tracked docs resolve.
+#
+# Walks every markdown file tracked by git, extracts relative link targets,
+# and asserts each target exists on disk. External links (http/https/mailto)
+# and same-doc anchors are skipped. Anchors on cross-file links are stripped
+# (we only validate that the target file exists, not the anchor itself).
+#
+# Designed to be CI-safe: works against a tracked-files-only checkout. A
+# tracked doc linking into a gitignored area (e.g. docs/95-ideas/) will
+# correctly flag as broken — that boundary is intentional.
+#
+# Usage: scripts/check-docs.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+errors=0
+checked=0
+mapfile -t files < <(git ls-files '*.md')
+
+if [[ ${#files[@]} -eq 0 ]]; then
+    echo "No tracked markdown files found." >&2
+    exit 0
+fi
+
+for file in "${files[@]}"; do
+    [[ -f "$file" ]] || continue
+    dir="$(dirname "$file")"
+
+    # grep -noP with \K captures only the link target, prefixed with line number.
+    while IFS= read -r match; do
+        [[ -z "$match" ]] && continue
+        lineno="${match%%:*}"
+        target="${match#*:}"
+
+        [[ -z "$target" ]] && continue
+        [[ "$target" =~ ^https?:// ]] && continue
+        [[ "$target" =~ ^mailto: ]] && continue
+        [[ "$target" =~ ^# ]] && continue
+
+        # Strip anchor — we only verify the file exists.
+        path="${target%%#*}"
+        [[ -z "$path" ]] && continue
+
+        if [[ "$path" = /* ]]; then
+            resolved="$path"
+        else
+            resolved="${dir}/${path}"
+        fi
+        resolved_abs="$(realpath -m "$resolved" 2>/dev/null || echo "$resolved")"
+
+        checked=$((checked + 1))
+        if [[ ! -e "$resolved_abs" ]]; then
+            display="${resolved_abs#$REPO_ROOT/}"
+            echo "ERROR: ${file}:${lineno}: broken link → ${target}"
+            echo "       (resolved: ${display})"
+            errors=$((errors + 1))
+        fi
+    done < <(grep -noP '\]\(\K[^)]+' "$file" 2>/dev/null || true)
+done
+
+echo
+echo "Checked ${checked} link(s) across ${#files[@]} tracked markdown file(s)."
+
+if [[ $errors -gt 0 ]]; then
+    echo "FAIL: ${errors} broken link(s)."
+    exit 1
+fi
+
+echo "PASS: All links resolve."

--- a/scripts/check-registry.sh
+++ b/scripts/check-registry.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# check-registry.sh — Verify the UPI registry is consistent with design files.
+#
+# Two checks:
+#   1. Forward — every linked design/review path in registry.md resolves.
+#   2. Reverse — every docs/95-ideas/*-design-NNN[a-z]?-*.md file has a
+#      registry row whose UPI matches NNN.
+#
+# Local-only: registry.md and 95-ideas/ are gitignored. This script will
+# exit 0 with an explanatory message in environments where they are absent
+# (e.g. CI checkouts), so it can be wired into /check without breaking.
+#
+# Usage: scripts/check-registry.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+REGISTRY="docs/96-project-supervisor/registry.md"
+IDEAS_DIR="docs/95-ideas"
+
+if [[ ! -f "$REGISTRY" ]]; then
+    echo "Registry not present (${REGISTRY} missing — local-only). Skipping." >&2
+    exit 0
+fi
+
+if [[ ! -d "$IDEAS_DIR" ]]; then
+    echo "Ideas directory not present (${IDEAS_DIR} missing — local-only). Skipping." >&2
+    exit 0
+fi
+
+errors=0
+warnings=0
+
+# --- Check 1: Forward — every link in registry resolves -------------------
+echo "--- Forward: registry links resolve ---"
+
+reg_dir="$(dirname "$REGISTRY")"
+checked_links=0
+while IFS= read -r match; do
+    [[ -z "$match" ]] && continue
+    lineno="${match%%:*}"
+    target="${match#*:}"
+    [[ -z "$target" ]] && continue
+    [[ "$target" =~ ^https?:// ]] && continue
+    [[ "$target" =~ ^# ]] && continue
+
+    path="${target%%#*}"
+    [[ -z "$path" ]] && continue
+
+    if [[ "$path" = /* ]]; then
+        resolved="$path"
+    else
+        resolved="${reg_dir}/${path}"
+    fi
+    resolved_abs="$(realpath -m "$resolved" 2>/dev/null || echo "$resolved")"
+
+    checked_links=$((checked_links + 1))
+    if [[ ! -e "$resolved_abs" ]]; then
+        echo "ERROR: registry.md:${lineno}: broken link → ${target}"
+        errors=$((errors + 1))
+    fi
+done < <(grep -noP '\]\(\K[^)]+' "$REGISTRY")
+echo "  Checked ${checked_links} link(s)."
+echo
+
+# --- Check 2: Reverse — every design file has a registry row --------------
+echo "--- Reverse: design files have registry rows ---"
+
+# Extract UPI numbers (with optional letter suffix) listed in registry table.
+# Table rows look like: | 026 | Title | ... or | 010-a | ... — capture col 1.
+mapfile -t registered_upis < <(
+    grep -oP '^\|\s*\K[0-9]+[a-z]?(?:-[a-z])?(?=\s*\|)' "$REGISTRY" | sort -u
+)
+
+declare -A registered_set=()
+for upi in "${registered_upis[@]}"; do
+    # Normalize "010-a" → "010a" for matching against filenames.
+    normalized="${upi/-/}"
+    registered_set["$normalized"]=1
+done
+
+missing=0
+designs_checked=0
+for design in "${IDEAS_DIR}"/*-design-[0-9]*-*.md; do
+    [[ -f "$design" ]] || continue
+    base="$(basename "$design")"
+    # Pull the UPI from filenames like 2026-04-30-design-036-foo.md
+    # or 2026-04-03-design-010a-foo.md
+    if [[ "$base" =~ -design-([0-9]+[a-z]?)- ]]; then
+        upi="${BASH_REMATCH[1]}"
+        designs_checked=$((designs_checked + 1))
+        if [[ -z "${registered_set[$upi]:-}" ]]; then
+            echo "WARNING: design file without registry row: ${design} (UPI ${upi})"
+            warnings=$((warnings + 1))
+            missing=$((missing + 1))
+        fi
+    fi
+done
+echo "  Checked ${designs_checked} design file(s); ${missing} missing from registry."
+echo
+
+# --- Summary --------------------------------------------------------------
+echo "=== Summary ==="
+echo "Errors:   ${errors}"
+echo "Warnings: ${warnings}"
+
+if [[ $errors -gt 0 ]]; then
+    echo "FAIL: ${errors} error(s)."
+    exit 1
+fi
+
+echo "PASS: registry consistent."

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# install-hooks.sh — Install Urd's local git hooks.
+#
+# Hooks live under scripts/ (tracked) and are linked into .git/hooks/
+# (untracked). Run from anywhere inside the repo:
+#
+#     scripts/install-hooks.sh
+#
+# Currently installs:
+#     pre-commit -> scripts/pre-commit-pii.sh   (PII guard)
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+HOOKS_DIR="${REPO_ROOT}/.git/hooks"
+SCRIPT_DIR="${REPO_ROOT}/scripts"
+
+install_hook() {
+    local name="$1"
+    local source="$2"
+    local target="${HOOKS_DIR}/${name}"
+    local source_abs="${SCRIPT_DIR}/${source}"
+
+    if [[ ! -f "$source_abs" ]]; then
+        echo "ERROR: hook source missing: ${source_abs}" >&2
+        return 1
+    fi
+
+    chmod +x "$source_abs"
+
+    if [[ -e "$target" || -L "$target" ]]; then
+        if [[ -L "$target" && "$(readlink "$target")" == "$source_abs" ]]; then
+            echo "  ${name}: already linked"
+            return 0
+        fi
+        local backup="${target}.bak.$(date +%s)"
+        echo "  ${name}: existing hook found, backing up to $(basename "$backup")"
+        mv "$target" "$backup"
+    fi
+
+    ln -s "$source_abs" "$target"
+    echo "  ${name} -> scripts/${source}"
+}
+
+echo "Installing Urd git hooks into ${HOOKS_DIR}"
+install_hook "pre-commit" "pre-commit-pii.sh"
+
+echo
+echo "Done. Bypass any hook for a single commit with: git commit --no-verify"

--- a/scripts/pre-commit-pii.sh
+++ b/scripts/pre-commit-pii.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# pre-commit-pii.sh — PII guard for staged commits.
+#
+# Scans the staged diff for the operator's username, hostname, and home/mount
+# paths. The repo is public (github.com/vonrobak/urd); see ADR-105 and the
+# CONTRIBUTING.md privacy section for the discipline this mechanizes.
+#
+# Behavior:
+#   - No matches:      exits 0 silently.
+#   - Matches found, TTY available: prints findings, prompts y/N to continue.
+#   - Matches found, no TTY (e.g. agent-driven commits): prints findings to
+#     stderr and exits 1, so the operator must either fix the diff or pass
+#     --no-verify deliberately.
+#
+# Bypass for a single commit (use sparingly): git commit --no-verify
+# Install: scripts/install-hooks.sh
+
+set -euo pipefail
+
+# Resolve identifiers we will scan for.
+USERNAME="$(whoami)"
+HOSTNAME_VAL=""
+if [[ -r /etc/hostname ]]; then
+    HOSTNAME_VAL="$(tr -d '[:space:]' < /etc/hostname)"
+fi
+if [[ -z "$HOSTNAME_VAL" ]] && command -v hostname >/dev/null 2>&1; then
+    HOSTNAME_VAL="$(hostname 2>/dev/null || true)"
+fi
+
+# Patterns to flag. High-signal first; the standalone username/hostname
+# are broader and may produce acceptable matches in docs.
+HOME_PATH="/home/${USERNAME}/"
+MEDIA_PATH="/run/media/${USERNAME}/"
+
+# Pull only the staged additions. -U0 strips context so we only see new lines.
+DIFF="$(git diff --cached --no-color -U0 --diff-filter=ACMR || true)"
+
+if [[ -z "$DIFF" ]]; then
+    exit 0
+fi
+
+# Walk the diff, tracking the current file header and classifying matches.
+# Source/config matches are bugs (must reach a clean fix). Docs matches may
+# be operational context (journals, postmortems, runbooks); the operator
+# decides.
+declare -A CODE_HITS=()
+declare -A DOCS_HITS=()
+TOTAL=0
+current_file=""
+
+while IFS= read -r line; do
+    case "$line" in
+        '+++ b/'*)
+            current_file="${line#+++ b/}"
+            continue
+            ;;
+        '+++ /dev/null')
+            current_file=""
+            continue
+            ;;
+        '+++ '*|'--- '*|'@@ '*|'-'*|' '*|'')
+            continue
+            ;;
+        '+'*)
+            ;;
+        *)
+            continue
+            ;;
+    esac
+
+    [[ -z "$current_file" ]] && continue
+
+    matched=0
+    if [[ "$line" == *"$HOME_PATH"* ]]; then
+        matched=1
+    elif [[ "$line" == *"$MEDIA_PATH"* ]]; then
+        matched=1
+    elif [[ "$line" == *"$USERNAME"* ]]; then
+        matched=1
+    elif [[ -n "$HOSTNAME_VAL" && "$line" == *"$HOSTNAME_VAL"* ]]; then
+        matched=1
+    fi
+
+    if [[ $matched -eq 1 ]]; then
+        TOTAL=$((TOTAL + 1))
+        case "$current_file" in
+            *.md|*.txt|docs/*)
+                DOCS_HITS["$current_file"]=$(( ${DOCS_HITS["$current_file"]:-0} + 1 ))
+                ;;
+            *)
+                CODE_HITS["$current_file"]=$(( ${CODE_HITS["$current_file"]:-0} + 1 ))
+                ;;
+        esac
+    fi
+done <<< "$DIFF"
+
+if [[ $TOTAL -eq 0 ]]; then
+    exit 0
+fi
+
+{
+    echo
+    echo "================================================================="
+    echo "  PII pre-commit scan: ${TOTAL} potential match(es) in staged diff"
+    echo "================================================================="
+
+    if [[ ${#CODE_HITS[@]} -gt 0 ]]; then
+        echo
+        echo "  In source/config — these reach GitHub. Replace with placeholders:"
+        for f in "${!CODE_HITS[@]}"; do
+            printf '    %-60s %d match(es)\n' "$f" "${CODE_HITS[$f]}"
+        done
+    fi
+
+    if [[ ${#DOCS_HITS[@]} -gt 0 ]]; then
+        echo
+        echo "  In docs — operational context may be acceptable (journals, runbooks):"
+        for f in "${!DOCS_HITS[@]}"; do
+            printf '    %-60s %d match(es)\n' "$f" "${DOCS_HITS[$f]}"
+        done
+    fi
+
+    echo
+    echo "  Patterns scanned:"
+    echo "    ${HOME_PATH}"
+    echo "    ${MEDIA_PATH}"
+    echo "    ${USERNAME} (standalone)"
+    [[ -n "$HOSTNAME_VAL" ]] && echo "    ${HOSTNAME_VAL} (standalone)"
+    echo
+    echo "  Review with: git diff --cached"
+    echo
+} >&2
+
+# Try to prompt on the controlling TTY. If unavailable (agent commit, CI),
+# fail closed — the operator can rerun with --no-verify after deciding.
+have_tty=0
+if [[ -t 0 ]]; then
+    have_tty=1
+elif { exec </dev/tty; } 2>/dev/null; then
+    have_tty=1
+fi
+
+if [[ $have_tty -eq 1 ]]; then
+    printf '  Continue with commit anyway? [y/N] ' >&2
+    read -r answer || answer=""
+    case "$answer" in
+        [yY]|[yY][eE][sS])
+            echo "  Proceeding." >&2
+            exit 0
+            ;;
+        *)
+            echo "  Commit aborted. Fix the diff or rerun with --no-verify." >&2
+            exit 1
+            ;;
+    esac
+fi
+
+echo "  No TTY available — blocking. Rerun with --no-verify if intentional." >&2
+exit 1


### PR DESCRIPTION
## Summary

Final wave from the documentation-system review. Three independent automation seams that mechanize disciplines previously held by attention alone — no production code touched.

- **`scripts/pre-commit-pii.sh` + `scripts/install-hooks.sh`** — pre-commit guard that scans staged diffs for the operator's username, hostname, `/home/$USER/`, and `/run/media/$USER/`. Categorizes findings (source/config = bug, docs = judgment call). Warn-and-confirm on TTY; fail-closed without one (so agent commits can't silently leak — they need a deliberate `--no-verify`).
- **`scripts/check-docs.sh`** — walks every tracked markdown file and asserts each relative link resolves. CI-safe. Found one real bug on first run (broken cross-link in `operating-urd.md`), fixed inline.
- **`scripts/check-registry.sh`** — forward (registry → file exists) + reverse (every `*-design-NNN-*.md` has a registry row). Local-only (registry is gitignored); short-circuits cleanly in environments without it.
- **`.gitignore`** — `scripts/` stays private by default; whitelisted the four shipped tools.
- **`CONTRIBUTING.md`** — new "Local dev setup" and "Doc checks" sections so contributors can wire up the hooks and run the validators.

## Notes

- The existing local-only `scripts/validate.sh` overlaps with the new tools. Left untouched (it's untracked) — feel free to delete it locally now or keep it as a personal alias.
- Not wired into `/check` — that's a workflow change to opt into separately. Both `check-docs.sh` and `check-registry.sh` are happy to be added as advisory steps.
- Tracked-doc → gitignored-target links will (correctly) flag as broken in CI checkouts; this enforces the public/private boundary as a side effect.

## Testing

- `scripts/pre-commit-pii.sh`: 4 manual scenarios — clean diff (silent), code-PII (blocks), docs-PII (blocks with right classification), mixed (both buckets shown). Real `git commit` invocation also blocked correctly.
- `scripts/check-docs.sh`: green after fixing the one broken link it surfaced. 86 links across 39 files.
- `scripts/check-registry.sh`: green. 65 forward links, 33 design files, 0 missing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)