### PR TITLE
feat: ship urd-sentinel.service systemd unit

### DIFF
--- a/docs/00-foundation/guides/operating-urd.md
+++ b/docs/00-foundation/guides/operating-urd.md
@@ -138,11 +138,16 @@ urd backup --dry-run
 # 6. Run a real backup
 urd backup
 
-# 7. Install the systemd timer for nightly runs
-cp ~/projects/urd/systemd/urd-backup.{service,timer} ~/.config/systemd/user/
+# 7. Install the systemd units for nightly backups and the sentinel
+cp ~/projects/urd/systemd/urd-*.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now urd-backup.timer
+systemctl --user enable --now urd-sentinel.service   # recommended; see below
 ```
+
+The sentinel is the continuous protection layer — without it, Urd runs only at
+04:00 and promise states drift between runs. Skip the sentinel enable line if you
+want the nightly cron without the always-on watchdog.
 
 ## CLI Commands
 
@@ -236,37 +241,51 @@ urd init
 
 ## Systemd Operation
 
-### Timer and service
+### Units
 
-Urd runs nightly at 02:00 via a user-level systemd timer.
+Urd ships three systemd user units. The nightly pair is required; the sentinel
+is recommended.
 
 | Unit | Purpose |
 |------|---------|
-| `urd-backup.timer` | Triggers the service at 02:00 daily (with 5m random delay) |
+| `urd-backup.timer` | Triggers the service nightly at 04:00 (with 5m random delay) |
 | `urd-backup.service` | Runs `~/.cargo/bin/urd backup` as a oneshot |
+| `urd-sentinel.service` | Long-running daemon: drive events, promise refresh, notifications |
 
-The service runs at low priority (`Nice=19`, `IOSchedulingClass=idle`) and allows up
-to 6 hours for large sends.
+All three run at low priority (`Nice=19`, `IOSchedulingClass=idle`). The backup
+service allows up to 6 hours for large sends. The sentinel restarts on failure
+with a 30-second back-off.
+
+The sentinel is the integration layer — drive plug/unplug detection, sub-hourly
+promise-state updates, and notification dispatch all live there. Without it,
+Urd is a nightly cron job; with it, Urd is a continuous protection layer.
 
 ### Install / update units
 
 ```bash
-cp ~/projects/urd/systemd/urd-backup.{service,timer} ~/.config/systemd/user/
+cp ~/projects/urd/systemd/urd-*.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now urd-backup.timer
+systemctl --user enable --now urd-sentinel.service   # optional but recommended
 ```
 
-Re-run this after modifying unit files in the repo. Copying (rather than symlinking)
-keeps the installed unit stable across `git checkout` operations.
+Re-run this after modifying unit files in the repo. Copying (rather than
+symlinking) keeps the installed units stable across `git checkout` operations.
 
 ### Monitor
 
 ```bash
+# Backup timer
 systemctl --user status urd-backup.timer      # next scheduled run
 systemctl --user list-timers urd-backup*      # timer details
 journalctl --user -u urd-backup.service       # all run output
 journalctl --user -u urd-backup.service -f    # follow live
 journalctl --user -u urd-backup.service --since today
+
+# Sentinel daemon
+systemctl --user status urd-sentinel.service  # daemon health, restart count
+journalctl --user -u urd-sentinel.service -f  # follow live (warn-level lifecycle by default)
+urd sentinel status                           # Urd's own view of the daemon
 ```
 
 ### Manual trigger via systemd
@@ -318,9 +337,14 @@ urd plan                          # preview with new logic
 If systemd units changed too:
 
 ```bash
-cp systemd/urd-backup.{service,timer} ~/.config/systemd/user/
+cp systemd/urd-*.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
+systemctl --user restart urd-sentinel.service   # if you run the sentinel
 ```
+
+(The backup unit is a oneshot driven by the timer — no restart needed; the next
+scheduled run picks up the new unit. The sentinel is long-lived, so a restart is
+required for unit changes to take effect.)
 
 ### Backup to a specific drive
 

--- a/docs/10-operations/runbooks/sentinel-restart.md
+++ b/docs/10-operations/runbooks/sentinel-restart.md
@@ -37,7 +37,7 @@ Do **not** restart the Sentinel as a habit. If something feels wrong,
 
 ```bash
 urd sentinel status
-systemctl --user status urd-sentinel.service    # if installed
+systemctl --user status urd-sentinel.service
 journalctl --user -u urd-sentinel.service -n 50 --no-pager
 ```
 
@@ -53,8 +53,6 @@ revived it. If it didn't, check `journalctl` for the crash reason — Urd's
 philosophy is to fix the cause, not paper over it with a restart.
 
 ### Restart
-
-If installed as a user service:
 
 ```bash
 systemctl --user restart urd-sentinel.service

--- a/systemd/urd-sentinel.service
+++ b/systemd/urd-sentinel.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Urd Sentinel — passive filesystem and drive monitor
+After=default.target
+
+[Service]
+Type=simple
+ExecStart=%h/.cargo/bin/urd sentinel run
+Environment=RUST_LOG=warn
+Restart=on-failure
+RestartSec=30
+
+# Low priority — don't interfere with interactive use
+Nice=19
+IOSchedulingClass=idle
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

The sentinel daemon was already canonical in `voice.rs` and the operating runbooks, but the unit file lived only on the maintainer's machine. New contributors who followed the in-binary instruction (`systemctl --user start urd-sentinel`) hit a "Unit not found" wall.

This ships the unit alongside `urd-backup.{service,timer}` and reframes the docs so the sentinel is a first-class part of the install (opt-in, recommended).

## Changes

- **`systemd/urd-sentinel.service`** — long-running user service. `Type=simple`, `Restart=on-failure`, `RestartSec=30`, `Nice=19`, `IOSchedulingClass=idle`. Mirrors the backup service's low-priority shape; uses `%h` for the binary path so it works on any user's machine.
- **`docs/00-foundation/guides/operating-urd.md`** — updated three install/copy points to use `urd-*.{service,timer}` (catches the new unit), added the sentinel row to the systemd unit table, added monitor commands for the daemon, and reframed the section to make the sentinel's role as the integration layer explicit. Also fixes a stale "02:00" → "04:00" in the timer description.
- **`docs/10-operations/runbooks/sentinel-restart.md`** — dropped the "if installed" hedge; the runbook can now assume the unit exists.

## Positioning

The sentinel is **opt-in (recommended)**: users who want only the nightly cron can skip the `enable --now urd-sentinel.service` line. This matches CLAUDE.md's framing ("the sentinel is the integration layer") without forcing every user into always-on operation.

## Testing

- `systemd-analyze --user verify systemd/urd-sentinel.service` — clean.
- Diff vs the maintainer's working unit: only the `Description` differs (slightly broader to include drive monitoring).
- Manual link review of `operating-urd.md` and `sentinel-restart.md` — no broken refs introduced.

## Related

- Falls out of the Wave 3 docs handoff (`docs/98-journals/2026-05-02-docs-system-review-wave3-handoff.md`, "Open questions").
- Stacks naturally on top of Wave 4 (#114), but is independent — no merge order required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)