### PR TITLE
docs: ADR-115 retention shape symmetry and the recommendation layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,7 @@ Dual-parser architecture supporting **legacy** and **v1** schemas. `Config::load
 - Code using path-constructing functions (`external_snapshot_dir()`, `local_snapshot_dir()`) should also have `tempfile::TempDir` tests — mocks are blind to filesystem preconditions like missing parent directories
 - Test retention logic exhaustively — it protects against data loss
 - When building features, use vertical slicing: write one test, implement to pass, repeat. Never write all tests first then all implementation.
+- **Symmetric fixes need symmetric reviews.** When a bug is rooted in a shared planning or rendering pattern (e.g. "augment local_snaps with planned_snap" in plan.rs), grep for the pattern in adjacent code paths before closing the fix. The May 2 stranded-snapshots incident: commit `0f52555` correctly fixed the transient planner branch in April; the symmetric bug in the non-transient branch went unnoticed for nearly a month. See [2026-05-02-stranded-snapshots-non-transient-planner.md](docs/98-journals/2026-05-02-stranded-snapshots-non-transient-planner.md).
 - 521+ tests, all passing, clippy clean
 
 ## Backward Compatibility (ADR-105)
@@ -259,6 +260,7 @@ cargo run -- migrate                 # Migrate config to v1 schema
 | 112 | SemVer and release workflow | Versioning, CHANGELOG, git tags, /release skill |
 | 113 | The Do-No-Harm invariant | Layered, probabilistic defense against Urd-induced host burden |
 | 114 | Structured event log | Typed change-and-decision history; complement to Prometheus gauges and UPI 030 drift_samples |
+| 115 | Retention shape symmetry and the recommendation layer | Symmetric data-cost model + advisory recommendation surface; amends ADR-110 |
 
 ## Development Workflow
 

--- a/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
+++ b/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
@@ -6,10 +6,11 @@
 > earn opaque status through operational track record. Current taxonomy:
 > recorded/sheltered/fortified (renamed 2026-04-03 from guarded/protected/resilient).
 
-**Date:** 2026-03-26 (revised 2026-03-27, addendum 2026-03-31, vocabulary 2026-04-03)
-**Status:** Accepted (taxonomy renamed 2026-04-03 — see Maturity Model)
+**Date:** 2026-03-26 (revised 2026-03-27, addendum 2026-03-31, vocabulary 2026-04-03, amendment 2026-05-09)
+**Status:** Accepted (taxonomy renamed 2026-04-03 — see Maturity Model; recommendation-layer amendment 2026-05-09 — see [Amendment 2026-05-09](#amendment-2026-05-09-recommendation-layer-as-graduation-evidence-path-adr-115))
 **Depends on:** ADR-100 (planner/executor separation), ADR-108 (pure function modules),
 ADR-109 (config boundary validation), ADR-111 (config system architecture)
+**Amended by:** ADR-115 (Retention shape symmetry and the recommendation layer)
 **Ownership:** This ADR is authoritative for protection promise *semantics* — what levels
 mean, how they derive policy, the maturity model, and the opacity rule. ADR-111 is
 authoritative for config *structure* — what fields exist, how validation works, versioning.
@@ -292,6 +293,88 @@ additional constraint based on protection level.
 - See Design 6-E (`docs/95-ideas/2026-03-31-design-e-promise-redundancy-encoding.md`) for
   full rationale and review findings.
 
+## Amendment 2026-05-09: Recommendation Layer as Graduation Evidence Path (ADR-115)
+
+**Context:** Phase D-2 (UPI 041) introduces a recommendation layer over
+the symmetric data-cost model — see ADR-115. The recommendation layer
+surfaces, per subvolume, a retention shape that fits the observed churn,
+and tells the user what the current shape costs. This amendment names
+the recommendation layer as the **path by which named levels accumulate
+the operational evidence this ADR's Maturity Model required for
+graduation to opaque status**.
+
+### How named levels graduate under the amended model
+
+Phase 1 (Custom-first, current) is unchanged. Custom remains the
+recommended default until named levels earn opaque status.
+
+The amended graduation criteria (replacing the original four) are:
+
+1. **Operational track record** — run as a template-based custom policy
+   in production for a meaningful period without operator intervention.
+   *(Unchanged from original.)*
+2. **Distinct operational identity** — parameters meaningfully different
+   from every other level. *(Unchanged from original.)*
+3. **Self-explanatory name** — operator can infer what the level does
+   from its name without reading documentation. *(Unchanged from
+   original.)*
+4. **ADR documentation** — rationale for the level's specific parameter
+   choices, grounded in operational evidence from Phase 1. *(Unchanged
+   from original.)*
+5. **Alignment with the recommendation engine across enough hosts to
+   constitute a track record (NEW).** A named level is calibrated when
+   the recommendation engine, given representative real-world drift
+   signals, produces shapes that match the level's derived retention
+   for the kind of subvolume the level is supposed to fit. Persistent
+   divergence — the engine consistently recommending tighter or looser
+   shapes than the named level produces — is evidence that the level's
+   parameters are miscalibrated and not yet ready for opaque status.
+
+### Why this amendment
+
+ADR-110 originally framed graduation as "operational track record +
+ADR documentation." It did not specify *what evidence track-record
+generates*. The recommendation layer fills that gap: the engine's
+output **is** the evidence. Named levels graduate when their derived
+shapes consistently match what the engine recommends for representative
+data. Until then, named levels remain provisional templates — useful
+scaffolding for new operators, not yet sealed policies.
+
+This is consistent with ADR-110's original intent ("you can't design a
+battle-tested level at a desk") — it just makes the evidence channel
+concrete.
+
+### What this amendment does NOT change
+
+- **Opacity of named levels remains absolute.** When `protection_level`
+  is set to a named level, derived parameters are final. No per-field
+  overrides. This is enforced by config validation (ADR-111).
+- **The recommendation engine never mutates `derive_policy()`** (ADR-115
+  invariant 2). Recommendations are advisory; if a recommendation
+  differs from a named-level shape, the user must switch to `custom`
+  to apply it. Voice surfaces this transition explicitly per the X1
+  design.
+- **The maturity model remains evidence-based, not process-based.**
+  Graduation is not a vote or a committee decision; it is a finding
+  that the recommendation engine and the named level converge on
+  representative data.
+
+### Phase 2 trigger
+
+Phase 2 (Named levels graduate) is triggered when, across a population
+of hosts running Urd in production, the recommendation engine's outputs
+align with at least one named level's derived shapes for the
+characteristic subvolumes that level is meant to serve. The arc's
+done-ness criterion 6 (post-X4 evidence checkpoint) is the first
+opportunity to evaluate this on a single host; broader graduation
+requires multi-host evidence as Urd matures toward v1.0.
+
+If the evidence shows persistent divergence — recommendations
+consistently differ from named-level shapes — the named-level taxonomy
+itself may be miscalibrated and warrant rework rather than graduation.
+Either outcome is honest: graduation on alignment, taxonomy revision on
+divergence, both grounded in evidence.
+
 ## Implementation Gates
 
 This ADR is considered implemented when:
@@ -304,6 +387,7 @@ This ADR is considered implemented when:
 - [x] `--confirm-retention-change` flag gates retention tightening
 - [x] `urd status` shows promise level column
 - [x] Pin-protection safety tests pass with derived retention
+- [ ] Recommendation layer ships and surfaces per-subvolume shape advice (UPI 041 / ADR-115)
 
 ## Related
 

--- a/docs/00-foundation/decisions/2026-05-09-ADR-115-retention-shape-symmetry-and-recommendation-layer.md
+++ b/docs/00-foundation/decisions/2026-05-09-ADR-115-retention-shape-symmetry-and-recommendation-layer.md
@@ -1,0 +1,334 @@
+# ADR-115: Retention Shape Symmetry and the Recommendation Layer
+
+> **TL;DR:** The cost of retaining a snapshot is **symmetric across source and
+> destination pools** — the same arithmetic over the same drift signal projects
+> pinned CoW delta on `/mnt/btrfs-pool` and projected delta on a destination
+> drive. X1 of Phase D-2 (UPI 041) ships an **advisory** recommendation layer
+> over this symmetric cost model: `urd doctor --thorough` surfaces a
+> per-subvolume shape that fits the observed churn, and the user applies it
+> by editing `urd.toml`. The engine never mutates `derive_policy()` or config.
+> X1 models **data delta only** (inter-slot formula); metadata cost is
+> deferred to UPI 043 (file-count telemetry) + UPI 044 (metadata cost model).
+> Auto-tune — Urd applying recommendations on the user's behalf — is the
+> documented long-term north star, scoped to a future arc gated on the
+> evidence this layer generates.
+
+**Date:** 2026-05-09
+**Status:** Accepted
+**Depends on:** ADR-108 (pure function modules), ADR-110 (protection promises),
+ADR-113 (do-no-harm invariant), ADR-114 (structured event log)
+**Complemented by:** UPI 030 (drift telemetry — the signal this layer consumes)
+**Amends:** ADR-110 (see [amendment](2026-03-26-ADR-110-protection-promises.md#amendment-2026-05-09-recommendation-layer-as-graduation-evidence-path-adr-115))
+
+## Context
+
+Six weeks of autonomous operation produced the first evidence-based view of
+per-subvolume cost
+([report](../../99-reports/2026-05-09-retention-tuning-from-real-world-data.md)).
+Two patterns emerged:
+
+1. **Named-level retention shapes are decoupled from real cost.** The same
+   shape applied to a 7 MB/day subvolume and a 2,700 MB/day subvolume costs
+   ~400× more on the latter. On this host, `containers` alone pinned ~165 GB
+   of CoW delta on `/mnt/btrfs-pool` — 94% of all source-side cost — purely
+   because it inherited the same shape its quieter siblings use. A user has
+   no way to discover this without manually digging through `drift_samples`
+   and reasoning about retention shapes themselves.
+
+2. **The cost is symmetric across pools.** Local snapshot pinning and
+   external send retention share the same cost-projection math: a retained
+   slot pins its inter-slot wire bytes, regardless of which pool it lives
+   on. Yet `derive_policy()` happens to give the *more* generous shape to
+   local retention — exactly the wrong asymmetry for a constrained source
+   pool like NVMe. ADR-113 (Do-No-Harm) recognized this defensively for
+   the source pool; this ADR closes the loop with **honest advice across
+   both pools**.
+
+The user has only two surfaces today that touch retention shape:
+`derive_policy()` (named-level shapes, opaque/provisional per ADR-110) and
+the user's `urd.toml` (Custom shapes, hand-edited). Neither tells the user
+*what shape fits their data* or *what the current shape costs*.
+
+UPI 030's drift telemetry made the underlying signal observable. This ADR
+turns the signal into actionable advice without taking control of retention
+out of the user's hands.
+
+## Decision
+
+### The symmetric data-cost claim
+
+The cost of retaining a graduated snapshot shape `S = {hourly, daily, weekly, monthly}`
+under an observed mean churn rate `r` (bytes/second) is:
+
+```
+data_bytes(S, r) = r × Σ_W W_total_seconds(S)
+```
+
+where `W_total_seconds(S)` is the **outer-edge span** of window W under shape `S`:
+
+| Window  | `W_total_seconds(S)`             |
+|---------|----------------------------------|
+| hourly  | `S.hourly × 3600`                |
+| daily   | `S.daily × 86400`                |
+| weekly  | `S.weekly × 7 × 86400`           |
+| monthly | `S.monthly × 30 × 86400`         |
+
+The formula is **symmetric**: the same function projects pinned CoW delta on
+the source pool and projected delta on a destination drive. Local and external
+retention serve different recovery objectives (local = fast restore; external
+= survives drive loss), but their **costs are governed by the same arithmetic
+over the same drift signal**.
+
+#### Why inter-slot, not age-midpoint
+
+A retained slot pins **inter-slot delta** — the wire bytes between it and the
+previous retained slot in the same window. The naive alternative,
+`mean × W_avg_age × slot_count`, double-charges old slots: a 12-month window
+contributes `mean × Σ(1..12) months` ≈ `mean × 78 months` instead of
+`mean × 12 months`, a ~6× overcount on the monthly window alone. Inter-slot
+matches the physical cost of pinned CoW delta on BTRFS.
+
+The inter-slot formula has an elegant collapse: total data cost is
+`mean × total_chain_span`. **Slot density inside a window does not affect
+data cost** — only metadata cost (deferred to UPI 044). Window outer edges
+drive data cost; slot density is a separate axis.
+
+#### What this formula does *not* model
+
+- **Variance / burstiness.** `r` is the time-weighted mean over a 7-day
+  rolling window. For subvolumes whose churn is bimodal (long dormancy
+  punctuated by active periods), `r` understates active-period cadence
+  needs. The recommendation layer flags this case (`BurstyPattern` note)
+  rather than committing to a stateful bimodal model.
+- **Metadata cost.** Per-snapshot extent-tree overhead is real (the
+  2026-05-09 report documented 98.98% metadata DUP on WD-18TB from 156
+  snapshots' overhead) and roughly proportional to file count — not data
+  delta. X1 does not model it. UPI 043 (file-count telemetry) + UPI 044
+  (metadata cost model) introduce it. Until UPI 044 ships, X1 may
+  over-recommend retention for cold-with-many-files subvolumes; no such
+  subvolume exists on this host's evidence.
+- **Chain integration.** The formula uses pre-window-stack arithmetic,
+  not integration over the actual chain history. UPI 044 / future
+  refinements may revisit if evidence shows the approximation is
+  materially limiting.
+
+The arc's reading-list report frames the data-delta math as accurate to
+±30%, and the 350× spread between this host's hottest and coldest
+subvolume dwarfs the modeling error.
+
+### The recommendation-layer pattern
+
+The recommendation layer is a **pure module** (`src/policy.rs`, ADR-108)
+that:
+
+1. **Reads** drift telemetry (`drift::ChurnEstimate`) and the user's
+   resolved retention shape (`ResolvedGraduatedRetention`).
+2. **Computes** a recommended shape under the symmetric cost model.
+3. **Returns** the recommendation as data — no I/O, no persistence, no
+   mutation of `derive_policy()`, no mutation of config.
+4. **Surfaces** through `urd doctor --thorough` only. Heartbeat,
+   Prometheus, and `urd status` are unchanged in X1.
+
+The friction floor for users is **"ignore the suggestion."** Anyone who
+disagrees with a recommendation does nothing and Urd continues with the
+user's existing config. Anyone who agrees edits `urd.toml`.
+
+#### Advisory only
+
+- `derive_policy()` is unchanged.
+- Config is unchanged.
+- Snapshot creation, retention, and send behavior are unchanged.
+- No event is recorded in the ADR-114 event log when a recommendation is
+  computed (recommendations are not Urd decisions; routine recommendation
+  emissions are not "non-trivial decisions worth recording"). When future
+  auto-tune work *applies* a recommendation, that **is** a decision and
+  becomes an event — but applying is out of scope for this ADR and Phase D-2.
+
+#### Independence from UPI 031
+
+The recommendation layer and the `storage_critical` bundle (UPI 031,
+ADR-113 Layer 1) are **independent surfaces over the same drift
+telemetry**. They serve different purposes — recommendations help the
+user choose a better-fitting shape; the storage_critical bundle defends
+against pressure incidents in real time — and they should not contradict
+each other. Future coordination is its own UPI if contradiction emerges
+in evidence.
+
+### Internal model parameters
+
+The recommendation algorithm has the following tunables, **fixed in code,
+documented here, and not user-configurable**. Per arc decision F (no
+user-tunable thresholds): friction floor is "ignore the suggestion," not
+"edit the threshold." Tunable thresholds become backward-compat contracts
+(ADR-105); fixed thresholds keep evolution cheap.
+
+| Parameter             | Local        | External     |
+|-----------------------|--------------|--------------|
+| `data_budget_bytes`   | 50 GB        | 100 GB       |
+| `slot_share` (h/d/w/m)| 0.05/0.30/0.40/0.25 | 0/0.30/0.40/0.30 |
+| `clamp_min` (h/d/w/m) | 0/3/0/0      | 0/3/0/0      |
+| `clamp_max` (h/d/w/m) | 24/60/52/24  | 0/60/52/24   |
+
+#### Calibration rationale
+
+`data_budget_bytes` is a per-pool target for total pinned data delta the
+engine will recommend retaining. It directly translates to "how many
+weeks/months back the chain reaches" via the symmetric formula:
+`Σ_W W_total_seconds = data_budget_bytes / mean_bytes_per_second`.
+
+Validated against the 2026-05-09 report's two host extremes:
+
+- `containers` at 2,700 MB/day (~31,250 B/s mean): `50 GB / 31,250 B/s ≈
+  18.5 days total chain` → engine recommends 24 h + ~17 d (clamps tight).
+  Matches the report's intuition for a hot subvolume.
+- `subvol1-docs` at 7 MB/day (~81 B/s): `50 GB / 81 B/s ≈ 19.6 years` →
+  engine recommends MAX clamps everywhere (24 h + 60 d + 52 w + 24 m).
+  Matches the report's intuition that docs is essentially free to retain.
+
+`slot_share` distributes the data budget across windows (which determines
+each window's outer edge under the inter-slot formula). The local
+distribution emphasizes recent dailies and a long weekly tail; the
+external distribution drops hourlies entirely (external retention is
+about durability, not point-in-time recovery within the day).
+
+`clamp_min` ensures degenerate inputs (e.g., extreme churn) still produce
+a usable shape with at least 3 daily slots.
+
+`clamp_max` keeps shapes within sane bounds at the cold end. 60 dailies +
+52 weeks + 24 months caps the chain at ~5 years, which is enough for
+any plausible recovery scenario and prevents runaway shapes from numeric
+artifacts.
+
+#### Anticipated revision
+
+These constants are committed in this ADR but explicitly **soft**:
+arc done-ness criterion 6 (post-X4 evidence checkpoint, ~30 days of
+operation) is the anticipated revision point. Revising the constants
+amends this ADR; revision is not a breaking change because the
+recommendation surface is advisory.
+
+### What this ADR does NOT decide
+
+These are deliberately deferred to the arc's later UPIs or to future
+ADRs:
+
+- **Metadata cost model.** UPI 043 (file-count telemetry) + UPI 044
+  (metadata cost model). When 044 ships, this ADR may amend with a
+  metadata symmetry claim and a `metadata_budget_bytes` constant set.
+- **Headroom-aware adjustments.** UPI X4 of the arc. The recommendation
+  engine grows optional headroom inputs already; UPI X4 wires them.
+- **Tier/classifier exposure** as a heartbeat or Prometheus field. Per
+  arc decision F: internal-only. The recommendation surface is human-
+  readable only.
+- **Dedicated `urd recommend` command.** `urd doctor --thorough` is the
+  right home — recommendations belong with health diagnostics.
+- **Auto-apply** (`urd config apply-suggestion` or similar). The
+  long-term north star, scoped to a future arc gated on evidence.
+- **Drift signal from local snapshot deltas.** Today, send-disabled
+  subvolumes have no churn signal. A future UPI may extend `drift.rs`
+  to measure CoW deltas between consecutive local snapshots; out of
+  scope for the Phase D-2 arc.
+
+## Consequences
+
+### Positive
+
+- **Honest retention.** The user can see what their current shape costs
+  and what shape fits their data. The decoupling between named-level
+  shapes and real cost (the report's central finding) becomes
+  user-visible.
+- **Symmetric cost is now load-bearing.** ADR-113's Do-No-Harm invariant
+  generalizes from "defend the source pool reactively" to "the same
+  cost model governs both pools." This is the conceptual foundation for
+  future arc work.
+- **Auto-tune becomes designable.** The recommendation layer is the
+  evidence-generating step that makes auto-tune feasible on safe,
+  validated foundations rather than guessed ones. Phase D-3 (if it
+  happens) builds on this evidence.
+- **Named levels accumulate graduation evidence.** ADR-110's maturity
+  model required operational track record for graduation. The
+  recommendation layer surfaces that evidence as a side effect of normal
+  operation. (See [ADR-110 amendment](2026-03-26-ADR-110-protection-promises.md#amendment-2026-05-09-recommendation-layer-as-graduation-evidence-path-adr-115).)
+- **No new on-disk contracts.** Heartbeat schema, Prometheus metric set,
+  and pin-file format are unchanged. ADR-105 risk is zero in X1.
+
+### Negative
+
+- **Metadata cost is unmodeled in X1.** Cold-with-many-files subvolumes
+  may be over-recommended retention until UPI 044. Risk accepted; no
+  such subvolume exists on this host's evidence.
+- **Send-disabled subvolumes get no recommendation.** They fall through
+  the existing "no churn observed yet" path. A future UPI for
+  drift-from-local-snapshots is the proper fix.
+- **Constants are calibrated on N=1 host's evidence.** The post-X4
+  evidence checkpoint may revise. Until then, recommendations may be
+  miscalibrated for hosts with very different cost distributions.
+- **The user must hand-edit `urd.toml` to apply.** No automation. For
+  named-level subvolumes, applying a recommendation requires switching
+  to `custom`, which voice surfaces with a per-row hint but is still
+  manual.
+
+### Neutral
+
+- **Does not replace `derive_policy()`.** Named levels remain
+  opaque/provisional per ADR-110. The recommendation engine reads them
+  via `derive_policy()` and the user's resolved config; it does not
+  write to them.
+- **Does not replace `storage_critical` (UPI 031).** Independent surface
+  over the same drift telemetry; serves a different purpose.
+
+## Invariants
+
+1. **The cost-projection math is symmetric across source and destination
+   pools.** The same arithmetic over the same drift signal projects
+   pinned delta on either pool. (R1)
+2. **Recommendations are advisory.** The recommendation layer never
+   mutates `derive_policy()`, config, snapshot creation, retention, or
+   send behavior. (Recommendation-layer pattern)
+3. **Internal model parameters are fixed in code.** No
+   `[recommendations]` config section, no per-host threshold overrides.
+   Friction floor is "ignore the suggestion." (Arc decision F)
+4. **Recommendation outputs are shapes, not labels.** No tier name
+   ("hot", "warm", "cold") escapes the engine. The user sees a
+   `ResolvedGraduatedRetention`-shaped suggestion with cost framing.
+   (Arc decision F)
+5. **Recommendation events are not logged in the ADR-114 event log.**
+   Routine recommendation emissions are not Urd decisions. Future
+   auto-tune *applying* a shape is the right Event hook.
+6. **The recommendation layer and `storage_critical` (UPI 031) are
+   independent.** Same telemetry, different purposes. They should not
+   contradict each other; future coordination is its own UPI if
+   contradiction emerges in evidence.
+
+## Open concerns (to revisit on evidence)
+
+1. **Constant calibration.** Post-X4 evidence checkpoint (~30 days of
+   operation) may show the budgets are off. Anticipated revision via
+   ADR-115 amendment.
+2. **Metadata cost integration.** UPI 044 will introduce the metadata
+   axis. Whether the symmetry claim extends to metadata (it should,
+   structurally) becomes an ADR-115 amendment when 044 lands.
+3. **Bursty subvolumes.** The `BurstyPattern` advisory note is the X1
+   handling for bimodal churn. If the post-X4 checkpoint shows bursty
+   patterns are common and the steady-state recommendation actively
+   misleads users, a future ADR may introduce a stateful bimodal model
+   (out of scope for Phase D-2).
+4. **Recommendation/storage_critical coordination.** Independence is
+   the X1 stance. If evidence shows the two surfaces contradict each
+   other in user-visible ways, a coordination ADR follows.
+
+## Related
+
+- **ADR-108** — Pure function modules. The recommendation layer is a
+  pure module (`policy.rs`).
+- **ADR-110** — Protection promises. The recommendation layer is the
+  path by which named levels accumulate graduation evidence (see
+  amendment).
+- **ADR-113** — Do-No-Harm invariant. Source-pool stewardship; this
+  ADR generalizes the cost insight to both pools.
+- **ADR-114** — Structured event log. Recommendation emissions are
+  *not* events; future auto-tune *applies* are.
+- **UPI 030** — Drift telemetry. The signal this layer consumes.
+- **Arc proposal:** `docs/95-ideas/2026-05-09-arc-proposal-retention-symmetry.md`
+- **X1 design:** `docs/95-ideas/2026-05-09-design-041-recommendation-mvp.md`
+- **Evidence base:** `docs/99-reports/2026-05-09-retention-tuning-from-real-world-data.md`


### PR DESCRIPTION
## Summary

- New **ADR-115** establishes the symmetric data-cost model (same arithmetic projects pinned CoW delta on source pool and destination drive) and the advisory recommendation layer that Phase D-2 (UPI 041) ships over it. X1 covers data delta only — metadata cost deferred to UPI 043/044. Internal constants fixed in code per arc decision F; engine never mutates `derive_policy()` or config.
- **ADR-110 amended:** the recommendation layer is named as the evidence channel by which named protection levels accumulate the track record required for graduation to opaque status. Adds a fifth Maturity Model criterion (engine alignment) and a concrete Phase 2 trigger; opacity and advisory-only behavior are preserved.
- **CLAUDE.md:** ADR-115 added to the index. Captures the "symmetric fixes need symmetric reviews" testing rule from the May 2 stranded-snapshots incident.

## Testing

- cargo clippy: not applicable (docs-only)
- cargo test: not applicable (docs-only)
- Integration tests: not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)