### PR TITLE
feat: doctor --thorough Recommendations section (UPI 041)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `urd doctor --thorough` Recommendations section: per-subvolume retention
+  shape advice derived from observed churn (UPI 041, ADR-115). New pure
+  module `src/policy.rs` projects steady-state data cost and recommends
+  a four-slot shape per role. Advisory only; nothing is applied
+  automatically. Rows are sorted by recovery magnitude descending and
+  suppressed when current matches the suggestion.
+
 ## [0.15.1] - 2026-05-02
 
 ### Fixed

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -3,13 +3,15 @@ use crate::cli::{DoctorArgs, VerifyArgs};
 use crate::config::Config;
 use crate::drives;
 use crate::output::{
-    DoctorCheck, DoctorCheckStatus, DoctorDataSafety, DoctorOutput, DoctorSentinelStatus,
-    DoctorVerdict, InitStatus, OutputMode,
+    DoctorCheck, DoctorCheckStatus, DoctorDataSafety, DoctorOutput, DoctorRecommendationRow,
+    DoctorRecommendationView, DoctorSentinelStatus, DoctorVerdict, InitStatus, OutputMode,
 };
 use crate::plan::RealFileSystemState;
+use crate::policy::{self, ShapeRole};
 use crate::preflight;
 use crate::sentinel_runner;
 use crate::state::StateDb;
+use crate::types::{LocalRetentionPolicy, ProtectionLevel};
 use crate::voice;
 
 use crate::commands::{init, verify};
@@ -242,7 +244,14 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
 
     // ── 5.5 Churn (UPI 030 — only with --thorough) ────────────────
     let churn_view = if args.thorough {
-        Some(build_doctor_churn_view(&config))
+        Some(build_doctor_churn_view(&config, state_db.as_ref()))
+    } else {
+        None
+    };
+
+    // ── 5.6 Recommendations (UPI 041 — only with --thorough) ──────
+    let recommendation_view = if args.thorough {
+        Some(build_doctor_recommendation_view(&config, state_db.as_ref()))
     } else {
         None
     };
@@ -274,6 +283,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         sentinel,
         verify: verify_output,
         churn: churn_view,
+        recommendations: recommendation_view,
         verdict,
     };
 
@@ -284,12 +294,131 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
 
 /// Build the `--thorough` Churn-section view from `drift_samples` history.
 ///
-/// Opens the state DB once; falls back to all-NotMeasured when unavailable.
 /// Best-effort per-subvolume: a query failure renders as `NotMeasured`.
-fn build_doctor_churn_view(config: &Config) -> crate::output::DoctorChurnView {
-    let state_db = StateDb::open(&config.general.state_db).ok();
+fn build_doctor_churn_view(
+    config: &Config,
+    state_db: Option<&StateDb>,
+) -> crate::output::DoctorChurnView {
     let now = chrono::Local::now().naive_local();
-    build_doctor_churn_view_inner(config, state_db.as_ref(), now)
+    build_doctor_churn_view_inner(config, state_db, now)
+}
+
+/// Build the `--thorough` Recommendations-section view (UPI 041).
+///
+/// Iterates resolved subvolumes, computes a recommendation per role from
+/// the same rolling-churn aggregate the Churn section uses, drops aligned
+/// rows, and sorts by recovery magnitude descending.
+fn build_doctor_recommendation_view(
+    config: &Config,
+    state_db: Option<&StateDb>,
+) -> DoctorRecommendationView {
+    let now = chrono::Local::now().naive_local();
+    build_doctor_recommendation_view_inner(config, state_db, now)
+}
+
+fn build_doctor_recommendation_view_inner(
+    config: &Config,
+    state_db: Option<&StateDb>,
+    now: chrono::NaiveDateTime,
+) -> DoctorRecommendationView {
+    let window = crate::drift::default_window();
+    let since = now - window;
+    let header = format!(
+        "based on {}-day churn observation; apply by editing ~/.config/urd/urd.toml",
+        window.num_days()
+    );
+    let resolved = config.resolved_subvolumes();
+    let mut rows: Vec<DoctorRecommendationRow> = Vec::new();
+
+    for sv in resolved.iter().filter(|sv| sv.enabled) {
+        let churn = compute_churn_for(state_db, &sv.name, since, window, now);
+
+        let local = match &sv.local_retention {
+            LocalRetentionPolicy::Transient => None,
+            LocalRetentionPolicy::Graduated(g) => {
+                policy::recommend_shape(g, &churn, ShapeRole::Local)
+            }
+        };
+
+        let external = if sv.send_enabled {
+            policy::recommend_shape(&sv.external_retention, &churn, ShapeRole::External)
+        } else {
+            None
+        };
+
+        let local = local.filter(|r| r.suggested != r.current);
+        let external = external.filter(|r| r.suggested != r.current);
+
+        if local.is_none() && external.is_none() {
+            continue;
+        }
+
+        let note = local
+            .as_ref()
+            .and_then(|r| r.note)
+            .or_else(|| external.as_ref().and_then(|r| r.note));
+
+        let was_named_level = sv
+            .protection_level
+            .filter(|p| *p != ProtectionLevel::Custom);
+
+        rows.push(DoctorRecommendationRow {
+            name: sv.name.clone(),
+            local,
+            external,
+            note,
+            was_named_level,
+        });
+    }
+
+    rows.sort_by_key(|r| std::cmp::Reverse(recovery_bytes(r)));
+
+    DoctorRecommendationView { header, rows }
+}
+
+fn recovery_bytes(row: &DoctorRecommendationRow) -> u64 {
+    let local = row
+        .local
+        .as_ref()
+        .map(|r| {
+            r.current_cost
+                .data_bytes
+                .saturating_sub(r.suggested_cost.data_bytes)
+        })
+        .unwrap_or(0);
+    let external = row
+        .external
+        .as_ref()
+        .map(|r| {
+            r.current_cost
+                .data_bytes
+                .saturating_sub(r.suggested_cost.data_bytes)
+        })
+        .unwrap_or(0);
+    local.saturating_add(external)
+}
+
+fn compute_churn_for(
+    state_db: Option<&StateDb>,
+    name: &str,
+    since: chrono::NaiveDateTime,
+    window: chrono::Duration,
+    now: chrono::NaiveDateTime,
+) -> crate::drift::ChurnEstimate {
+    state_db
+        .and_then(|db| db.drift_samples_for_subvolume(name, since).ok())
+        .map(|rows| {
+            let samples: Vec<_> = rows.into_iter().map(StateDb::drift_row_to_sample).collect();
+            crate::drift::compute_rolling_churn(&samples, window, now)
+        })
+        .unwrap_or(crate::drift::ChurnEstimate {
+            mean_bytes_per_second: None,
+            incremental_count: 0,
+            full_count: 0,
+            median_full_bytes: None,
+            latest_full_bytes: None,
+            latest_full_interval_secs: None,
+        })
 }
 
 /// Pure-ish core (still does DB I/O via `state_db`) — extracted so unit tests
@@ -419,5 +548,397 @@ source = "/data/gamma"
             view.rows[1].state,
             crate::output::ChurnRender::FirstMeasurement { .. }
         ));
+    }
+
+    // ── UPI 041 Recommendations builder ────────────────────────────
+
+    fn empty_cfg() -> Config {
+        let toml_str = r#"
+drives = []
+subvolumes = []
+
+[general]
+state_db = "/tmp/urd-doctor-rec-test/urd.db"
+metrics_file = "/tmp/urd-doctor-rec-test/backup.prom"
+log_dir = "/tmp/urd-doctor-rec-test"
+heartbeat_file = "/tmp/urd-doctor-rec-test/heartbeat.json"
+
+[local_snapshots]
+roots = []
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    /// Three subvolumes — containers (hot), photos (warmer), docs (cold).
+    /// Configured retention covers the symmetry case for recovery sorting.
+    fn three_subvols_cfg() -> Config {
+        let toml_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-doctor-rec-test/urd.db"
+metrics_file = "/tmp/urd-doctor-rec-test/backup.prom"
+log_dir = "/tmp/urd-doctor-rec-test"
+heartbeat_file = "/tmp/urd-doctor-rec-test/heartbeat.json"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["containers", "photos", "docs"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+daily = 60
+weekly = 52
+monthly = 24
+[defaults.external_retention]
+hourly = 0
+daily = 60
+weekly = 52
+monthly = 24
+
+[[subvolumes]]
+name = "containers"
+short_name = "containers"
+source = "/data/containers"
+
+[[subvolumes]]
+name = "photos"
+short_name = "photos"
+source = "/data/photos"
+
+[[subvolumes]]
+name = "docs"
+short_name = "docs"
+source = "/data/docs"
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    fn seed_incremental(db: &StateDb, name: &str, sampled_at: chrono::NaiveDateTime, bytes: u64) {
+        db.record_drift_sample_best_effort(&crate::state::DriftSampleRow {
+            run_id: None,
+            subvolume: name.to_string(),
+            sampled_at,
+            seconds_since_prev_send: Some(86_400),
+            bytes_transferred: bytes,
+            source_free_bytes: None,
+            send_kind: crate::types::SendKind::Incremental,
+        });
+    }
+
+    fn now_fixed() -> chrono::NaiveDateTime {
+        chrono::NaiveDateTime::parse_from_str("2026-05-01T12:00:00", "%Y-%m-%dT%H:%M:%S").unwrap()
+    }
+
+    #[test]
+    fn recommendation_view_empty_when_no_subvolumes() {
+        let config = empty_cfg();
+        let db = StateDb::open_memory().unwrap();
+        let view = build_doctor_recommendation_view_inner(&config, Some(&db), now_fixed());
+        assert!(view.rows.is_empty());
+    }
+
+    #[test]
+    fn recommendation_view_suppresses_aligned_shapes() {
+        // Build a config whose configured shape already matches the
+        // engine's output: a single cold subvolume with retention =
+        // {24, 60, 52, 24} for both local and external. With churn ≈ 81 B/s
+        // the engine clamps to the same max-shape, so suggested == current
+        // and the row is dropped.
+        let toml_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-doctor-rec-test/urd.db"
+metrics_file = "/tmp/urd-doctor-rec-test/backup.prom"
+log_dir = "/tmp/urd-doctor-rec-test"
+heartbeat_file = "/tmp/urd-doctor-rec-test/heartbeat.json"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["cold"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+daily = 60
+weekly = 52
+monthly = 24
+[defaults.external_retention]
+hourly = 0
+daily = 60
+weekly = 52
+monthly = 24
+
+[[subvolumes]]
+name = "cold"
+short_name = "cold"
+source = "/data/cold"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let db = StateDb::open_memory().unwrap();
+        let now = now_fixed();
+        // ~81 B/s — clamps every slot to clamp_max for both roles.
+        // bytes_transferred = 81 * 86_400 ≈ 7_000_000 over one-day interval.
+        seed_incremental(&db, "cold", now - chrono::Duration::hours(12), 7_000_000);
+        let view = build_doctor_recommendation_view_inner(&config, Some(&db), now);
+        assert!(
+            view.rows.is_empty(),
+            "aligned shape must be suppressed: {:?}",
+            view.rows
+        );
+    }
+
+    #[test]
+    fn recommendation_view_emits_row_when_one_role_differs() {
+        // Hot churn against the max-shape config: at minimum the local
+        // recommendation tightens. Some external slots may also clamp,
+        // but the test only needs *some* row to surface.
+        let config = three_subvols_cfg();
+        let db = StateDb::open_memory().unwrap();
+        let now = now_fixed();
+        // Hot rate ~ 31_250 B/s = ~2.7 GB/day. bytes for 1-day interval.
+        seed_incremental(&db, "containers", now - chrono::Duration::hours(12), 2_700_000_000);
+        let view = build_doctor_recommendation_view_inner(&config, Some(&db), now);
+        let containers_row = view
+            .rows
+            .iter()
+            .find(|r| r.name == "containers")
+            .expect("containers row present");
+        assert!(
+            containers_row.local.is_some() || containers_row.external.is_some(),
+            "containers must have at least one role recommendation"
+        );
+    }
+
+    #[test]
+    fn recommendation_view_skips_local_for_transient() {
+        let toml_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-doctor-rec-test/urd.db"
+metrics_file = "/tmp/urd-doctor-rec-test/backup.prom"
+log_dir = "/tmp/urd-doctor-rec-test"
+heartbeat_file = "/tmp/urd-doctor-rec-test/heartbeat.json"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["transient"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+daily = 60
+weekly = 52
+monthly = 24
+[defaults.external_retention]
+hourly = 0
+daily = 60
+weekly = 52
+monthly = 24
+
+[[subvolumes]]
+name = "transient"
+short_name = "transient"
+source = "/data/transient"
+local_retention = "transient"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let db = StateDb::open_memory().unwrap();
+        let now = now_fixed();
+        seed_incremental(&db, "transient", now - chrono::Duration::hours(12), 2_700_000_000);
+        let view = build_doctor_recommendation_view_inner(&config, Some(&db), now);
+        let row = view
+            .rows
+            .iter()
+            .find(|r| r.name == "transient")
+            .expect("transient row should surface from external recommendation");
+        assert!(row.local.is_none(), "transient must have no local rec");
+        assert!(
+            row.external.is_some(),
+            "transient row should be carried by external recommendation"
+        );
+    }
+
+    #[test]
+    fn recommendation_view_omits_external_for_send_disabled() {
+        let toml_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-doctor-rec-test/urd.db"
+metrics_file = "/tmp/urd-doctor-rec-test/backup.prom"
+log_dir = "/tmp/urd-doctor-rec-test"
+heartbeat_file = "/tmp/urd-doctor-rec-test/heartbeat.json"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["local-only"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+daily = 60
+weekly = 52
+monthly = 24
+[defaults.external_retention]
+hourly = 0
+daily = 60
+weekly = 52
+monthly = 24
+
+[[subvolumes]]
+name = "local-only"
+short_name = "local-only"
+source = "/data/local-only"
+send_enabled = false
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let db = StateDb::open_memory().unwrap();
+        let now = now_fixed();
+        seed_incremental(&db, "local-only", now - chrono::Duration::hours(12), 2_700_000_000);
+        let view = build_doctor_recommendation_view_inner(&config, Some(&db), now);
+        let row = view
+            .rows
+            .iter()
+            .find(|r| r.name == "local-only")
+            .expect("local-only row should surface from local recommendation");
+        assert!(
+            row.external.is_none(),
+            "send_enabled=false must have no external rec"
+        );
+        assert!(
+            row.local.is_some(),
+            "local-only row should be carried by local recommendation"
+        );
+    }
+
+    #[test]
+    fn recommendation_view_sorts_by_recovery_magnitude_descending() {
+        // Three subvolumes with rates that produce ordered recovery
+        // magnitudes: containers (hot) → photos (warm) → docs (cold).
+        // docs is already at max-shape (the engine's output for cold
+        // churn) so its recovery is zero.
+        let config = three_subvols_cfg();
+        let db = StateDb::open_memory().unwrap();
+        let now = now_fixed();
+        seed_incremental(&db, "containers", now - chrono::Duration::hours(12), 2_700_000_000); // ~31_250 B/s
+        seed_incremental(&db, "photos", now - chrono::Duration::hours(12), 50_000_000); // ~580 B/s
+        seed_incremental(&db, "docs", now - chrono::Duration::hours(12), 7_000_000); // ~81 B/s (cold)
+        let view = build_doctor_recommendation_view_inner(&config, Some(&db), now);
+        // At least the first two rows must be ordered by descending
+        // recovery; the third may or may not exist depending on whether
+        // docs gets suppressed by the aligned-shape filter.
+        let names: Vec<&str> = view.rows.iter().map(|r| r.name.as_str()).collect();
+        let containers_idx = names.iter().position(|n| *n == "containers");
+        let photos_idx = names.iter().position(|n| *n == "photos");
+        assert!(containers_idx.is_some(), "containers must surface");
+        if let (Some(c), Some(p)) = (containers_idx, photos_idx) {
+            assert!(
+                c < p,
+                "containers (higher recovery) must precede photos: {names:?}"
+            );
+        }
+        // docs is already aligned with the engine's cold-clamp output,
+        // so it should be suppressed.
+        assert!(
+            !names.contains(&"docs"),
+            "docs at max-shape should be suppressed: {names:?}"
+        );
+    }
+
+    #[test]
+    fn recommendation_view_populates_was_named_level_for_named_level_subvol() {
+        // Two subvolumes: one declares protection_level = "sheltered",
+        // the other "custom". Both have a differing recommendation.
+        let toml_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-doctor-rec-test/urd.db"
+metrics_file = "/tmp/urd-doctor-rec-test/backup.prom"
+log_dir = "/tmp/urd-doctor-rec-test"
+heartbeat_file = "/tmp/urd-doctor-rec-test/heartbeat.json"
+run_frequency = "daily"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sheltered-sv", "custom-sv"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+daily = 60
+weekly = 52
+monthly = 24
+[defaults.external_retention]
+hourly = 0
+daily = 60
+weekly = 52
+monthly = 24
+
+[[subvolumes]]
+name = "sheltered-sv"
+short_name = "sheltered-sv"
+source = "/data/sheltered-sv"
+protection_level = "sheltered"
+
+[[subvolumes]]
+name = "custom-sv"
+short_name = "custom-sv"
+source = "/data/custom-sv"
+protection_level = "custom"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let db = StateDb::open_memory().unwrap();
+        let now = now_fixed();
+        // Hot enough to force a differing recommendation in both rows.
+        seed_incremental(&db, "sheltered-sv", now - chrono::Duration::hours(12), 2_700_000_000);
+        seed_incremental(&db, "custom-sv", now - chrono::Duration::hours(12), 2_700_000_000);
+        let view = build_doctor_recommendation_view_inner(&config, Some(&db), now);
+
+        let sheltered_row = view
+            .rows
+            .iter()
+            .find(|r| r.name == "sheltered-sv")
+            .expect("sheltered-sv row");
+        assert_eq!(
+            sheltered_row.was_named_level,
+            Some(crate::types::ProtectionLevel::Sheltered)
+        );
+
+        let custom_row = view
+            .rows
+            .iter()
+            .find(|r| r.name == "custom-sv")
+            .expect("custom-sv row");
+        assert!(custom_row.was_named_level.is_none(),
+            "custom protection_level must not populate was_named_level"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod metrics;
 mod notify;
 mod output;
 mod plan;
+mod policy;
 mod preflight;
 mod retention;
 mod sentinel;

--- a/src/output.rs
+++ b/src/output.rs
@@ -474,7 +474,47 @@ pub struct DoctorOutput {
     /// `None` for default `urd doctor` (no Churn section). UPI 030.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub churn: Option<DoctorChurnView>,
+    /// Per-subvolume retention shape recommendations under
+    /// `urd doctor --thorough` (UPI 041, ADR-115). Advisory only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommendations: Option<DoctorRecommendationView>,
     pub verdict: DoctorVerdict,
+}
+
+// ── Recommendations (UPI 041, ADR-115) ─────────────────────────────────
+
+/// `urd doctor --thorough` Recommendations-section view: an apply-hint
+/// header and one row per subvolume whose current retention diverges
+/// from the engine's suggestion. Advisory only; nothing here is applied
+/// automatically.
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorRecommendationView {
+    pub header: String,
+    /// Rows pre-sorted by recovery magnitude descending (largest recovery
+    /// first; looser-recommendation rows sort to the bottom because their
+    /// recovery is zero).
+    pub rows: Vec<DoctorRecommendationRow>,
+}
+
+/// One row of the Recommendations section — at most one suggestion per
+/// role. At least one of `local` / `external` is `Some` (rows with
+/// nothing to say are omitted by the builder).
+#[derive(Debug, Clone, Serialize)]
+pub struct DoctorRecommendationRow {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local: Option<crate::policy::ShapeRecommendation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external: Option<crate::policy::ShapeRecommendation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<crate::policy::RecommendationNote>,
+    /// `Some(level)` only when (a) the subvolume's `protection_level` is
+    /// non-Custom AND (b) at least one role's recommendation differs from
+    /// current. Voice renders the dimmed hint unconditionally on
+    /// `Some(_)`; the builder is the single source of truth for this
+    /// gate.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub was_named_level: Option<crate::types::ProtectionLevel>,
 }
 
 // ── Churn (UPI 030) ────────────────────────────────────────────────────
@@ -2083,6 +2123,7 @@ source = "/data/sv2"
             },
             verify: None,
             churn: None,
+            recommendations: None,
             verdict: DoctorVerdict::healthy(),
         };
         let json = serde_json::to_string(&output).unwrap();

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,486 @@
+// Recommendation engine for retention shapes (UPI 041, ADR-115).
+//
+// Pure module (ADR-108): inputs in, outputs out, no I/O. Output is advisory
+// — the doctor presentation layer surfaces recommendations under
+// `urd doctor --thorough`. Nothing here mutates config or behavior.
+//
+// Model contract (ADR-115):
+//   - Inter-slot data model. `chain_span_seconds()` is the sum of the four
+//     window seconds; data cost is `mean_bytes_per_second * chain_span`.
+//     No within-window double-charge.
+//   - `project_cost(shape, churn)` is role-agnostic by type: the same shape
+//     and churn yield the same `data_bytes` regardless of which role
+//     consumes the result (ADR-115 invariant 1).
+//   - X1-scope: data-only cost projection. Metadata cost is deferred to
+//     X3+ (R4 in the design doc).
+//   - Engine output is the four-slot shape; no tier label escapes.
+//
+// Internal constants `LOCAL_PARAMS` / `EXTERNAL_PARAMS` mirror the soft
+// parameters in ADR-115 §"Internal model parameters". They are the
+// authoritative copy; the ADR table is documentation. Keep in sync.
+
+use serde::Serialize;
+
+use crate::drift::ChurnEstimate;
+use crate::types::ResolvedGraduatedRetention;
+
+/// Which role a retention shape plays — Local (on-host) vs External (sent drive).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShapeRole {
+    Local,
+    External,
+}
+
+/// Projected steady-state cost of a retention shape under a churn rate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct CostProjection {
+    pub data_bytes: u64,
+    pub snapshot_count: u32,
+}
+
+/// Optional hint about churn pattern — flagged when full sends exceed
+/// incrementals in the observation window. Voice layer renders this as
+/// a dimmed line under the recommendation row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecommendationNote {
+    BurstyPattern,
+}
+
+/// A recommendation for one (subvolume, role) pair. The doctor builder
+/// collates Local + External rows per subvolume; this struct represents
+/// one of those rows.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ShapeRecommendation {
+    pub role: ShapeRole,
+    pub current: ResolvedGraduatedRetention,
+    pub suggested: ResolvedGraduatedRetention,
+    pub current_cost: CostProjection,
+    pub suggested_cost: CostProjection,
+    pub note: Option<RecommendationNote>,
+}
+
+// ── Internal model parameters (ADR-115 §"Internal model parameters") ──
+
+/// Soft parameters that drive the recommendation engine for one role.
+/// Slot indexing is `[hourly, daily, weekly, monthly]`.
+struct RoleParams {
+    data_budget_bytes: u64,
+    slot_share: [f64; 4],
+    clamp_min: [u32; 4],
+    clamp_max: [u32; 4],
+}
+
+const LOCAL_PARAMS: RoleParams = RoleParams {
+    data_budget_bytes: 50 * 1_000_000_000,
+    slot_share: [0.05, 0.30, 0.40, 0.25],
+    clamp_min: [0, 3, 0, 0],
+    clamp_max: [24, 60, 52, 24],
+};
+
+const EXTERNAL_PARAMS: RoleParams = RoleParams {
+    data_budget_bytes: 100 * 1_000_000_000,
+    slot_share: [0.0, 0.30, 0.40, 0.30],
+    clamp_min: [0, 3, 0, 0],
+    clamp_max: [0, 60, 52, 24],
+};
+
+fn params(role: ShapeRole) -> &'static RoleParams {
+    match role {
+        ShapeRole::Local => &LOCAL_PARAMS,
+        ShapeRole::External => &EXTERNAL_PARAMS,
+    }
+}
+
+/// Inter-slot chain span in seconds for a four-slot shape (ADR-115).
+/// `h*3600 + d*86400 + w*7*86400 + m*30*86400`, saturating in u64.
+#[must_use]
+pub fn chain_span_seconds(shape: &ResolvedGraduatedRetention) -> u64 {
+    let h = u64::from(shape.hourly).saturating_mul(3_600);
+    let d = u64::from(shape.daily).saturating_mul(86_400);
+    let w = u64::from(shape.weekly).saturating_mul(7 * 86_400);
+    let m = u64::from(shape.monthly).saturating_mul(30 * 86_400);
+    h.saturating_add(d).saturating_add(w).saturating_add(m)
+}
+
+/// Project the steady-state cost of `shape` under `churn`.
+///
+/// Returns `data_bytes = 0` when `churn.mean_bytes_per_second` is `None`.
+/// Role-agnostic by type (ADR-115 invariant 1).
+#[must_use]
+pub fn project_cost(
+    shape: &ResolvedGraduatedRetention,
+    churn: &ChurnEstimate,
+) -> CostProjection {
+    let snapshot_count = shape
+        .hourly
+        .saturating_add(shape.daily)
+        .saturating_add(shape.weekly)
+        .saturating_add(shape.monthly);
+
+    let data_bytes = match churn.mean_bytes_per_second {
+        None => 0,
+        Some(mean) => {
+            let span = chain_span_seconds(shape);
+            #[allow(clippy::cast_precision_loss)]
+            let bytes_f = mean * span as f64;
+            // Saturating cast to u64 (Rust 1.45+ semantics): NaN → 0,
+            // negative → 0, overflow → u64::MAX. Defensive against any
+            // odd ChurnEstimate input even though drift.rs guarantees a
+            // positive finite mean.
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let bytes = bytes_f as u64;
+            bytes
+        }
+    };
+
+    CostProjection {
+        data_bytes,
+        snapshot_count,
+    }
+}
+
+/// Recommend a retention shape for the given role under observed `churn`.
+///
+/// Returns `None` whenever `churn.mean_bytes_per_second.is_none()` — this
+/// is stricter than just `(incremental_count == 0, full_count == 0)`. It
+/// covers full-only-send windows (chain-break recovery, transient
+/// subvolumes) where the algorithm would otherwise divide by an absent
+/// mean and emit a misleading "extend to max" recommendation. The doctor
+/// builder treats `None` here as the silent cold-start case.
+///
+/// When a recommendation fires, the four slot counts are computed by
+/// `slots = clamp(budget_w / r / w_step, clamp_min, clamp_max)`. NaN /
+/// infinity are caught explicitly and routed to `clamp_max`.
+#[must_use]
+pub fn recommend_shape(
+    current: &ResolvedGraduatedRetention,
+    churn: &ChurnEstimate,
+    role: ShapeRole,
+) -> Option<ShapeRecommendation> {
+    let r = churn.mean_bytes_per_second?;
+    let p = params(role);
+
+    let w_step_seconds: [f64; 4] = [
+        3_600.0,
+        86_400.0,
+        7.0 * 86_400.0,
+        30.0 * 86_400.0,
+    ];
+
+    let mut slots = [0_u32; 4];
+    for idx in 0..4 {
+        #[allow(clippy::cast_precision_loss)]
+        let budget_w = p.data_budget_bytes as f64 * p.slot_share[idx];
+        let total_seconds_target = budget_w / r;
+        let outer_edge = total_seconds_target / w_step_seconds[idx];
+
+        let bounded = if !outer_edge.is_finite() {
+            // Infinity from r → 0 is excluded above (the `?` discards
+            // None means; mean > 0 is enforced by drift.rs). NaN can
+            // arise here only from 0/0 when budget_w == 0 AND r == 0,
+            // and that r=0 branch can't be reached given drift.rs
+            // contract. Defensive: route to clamp_max.
+            p.clamp_max[idx]
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            let clamped = outer_edge.clamp(0.0, f64::from(p.clamp_max[idx]));
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+            let v = clamped as u32;
+            v
+        };
+        slots[idx] = bounded.max(p.clamp_min[idx]);
+    }
+
+    let suggested = ResolvedGraduatedRetention {
+        hourly: slots[0],
+        daily: slots[1],
+        weekly: slots[2],
+        monthly: slots[3],
+    };
+
+    let current_cost = project_cost(current, churn);
+    let suggested_cost = project_cost(&suggested, churn);
+
+    let note = (churn.full_count > churn.incremental_count)
+        .then_some(RecommendationNote::BurstyPattern);
+
+    Some(ShapeRecommendation {
+        role,
+        current: *current,
+        suggested,
+        current_cost,
+        suggested_cost,
+        note,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    // Several tests below assert specific numerical outputs that depend on
+    // the ADR-115 internal model parameters (LOCAL_PARAMS / EXTERNAL_PARAMS
+    // in this module). ADR-115 commits these as "soft" with a post-X4
+    // evidence checkpoint as the revision point. When revising the
+    // constants, expect these tests to update.
+
+    use super::*;
+
+    fn churn_with_mean(mean: Option<f64>) -> ChurnEstimate {
+        ChurnEstimate {
+            mean_bytes_per_second: mean,
+            incremental_count: if mean.is_some() { 2 } else { 0 },
+            full_count: 0,
+            median_full_bytes: None,
+            latest_full_bytes: None,
+            latest_full_interval_secs: None,
+        }
+    }
+
+    fn churn_with_counts(mean: Option<f64>, incremental: usize, full: usize) -> ChurnEstimate {
+        ChurnEstimate {
+            mean_bytes_per_second: mean,
+            incremental_count: incremental,
+            full_count: full,
+            median_full_bytes: None,
+            latest_full_bytes: None,
+            latest_full_interval_secs: None,
+        }
+    }
+
+    fn shape(h: u32, d: u32, w: u32, m: u32) -> ResolvedGraduatedRetention {
+        ResolvedGraduatedRetention {
+            hourly: h,
+            daily: d,
+            weekly: w,
+            monthly: m,
+        }
+    }
+
+    // ── project_cost ────────────────────────────────────────────────
+
+    #[test]
+    fn project_cost_zero_churn_returns_zero_data_bytes() {
+        let s = shape(24, 30, 26, 12);
+        let est = churn_with_mean(None);
+        let c = project_cost(&s, &est);
+        assert_eq!(c.data_bytes, 0);
+        assert_eq!(c.snapshot_count, 24 + 30 + 26 + 12);
+    }
+
+    #[test]
+    fn project_cost_matches_inter_slot_arithmetic_local() {
+        let s = shape(24, 30, 26, 12);
+        let est = churn_with_mean(Some(1000.0));
+        let c = project_cost(&s, &est);
+        let expected = 1000.0_f64 * chain_span_seconds(&s) as f64;
+        // Allow truncation of fractional bytes.
+        assert_eq!(c.data_bytes, expected as u64);
+    }
+
+    #[test]
+    fn project_cost_zero_slot_windows_contribute_zero_seconds() {
+        let s = shape(0, 7, 0, 0);
+        let est = churn_with_mean(Some(1.0));
+        let c = project_cost(&s, &est);
+        // Only daily contributes: 7 * 86_400 = 604_800 s @ 1 B/s.
+        assert_eq!(c.data_bytes, 7 * 86_400);
+        assert_eq!(c.snapshot_count, 7);
+    }
+
+    #[test]
+    fn project_cost_double_charge_regression() {
+        // Anti-regression for R1 (inter-slot, no age-midpoint double-charge).
+        // Shape {0, 0, 0, 12}, mean = 1 B/s.
+        // Correct (inter-slot): 12 * 30 * 86_400 = 31_104_000.
+        // Wrong (age-midpoint per slot): 1 * sum(1..12) * 30*86_400 = 78 * 2_592_000 = 202_176_000.
+        let s = shape(0, 0, 0, 12);
+        let est = churn_with_mean(Some(1.0));
+        let c = project_cost(&s, &est);
+        assert_eq!(c.data_bytes, 12 * 30 * 86_400);
+    }
+
+    // ── recommend_shape ─────────────────────────────────────────────
+
+    #[test]
+    fn recommend_shape_returns_none_when_no_churn_signal() {
+        let cur = shape(24, 30, 26, 12);
+        // (0, 0): no samples at all.
+        let est = churn_with_counts(None, 0, 0);
+        assert!(recommend_shape(&cur, &est, ShapeRole::Local).is_none());
+    }
+
+    #[test]
+    fn recommend_shape_returns_none_when_only_full_sends_in_window() {
+        // (incremental=0, full=3, mean=None). Tightened None-return per
+        // adversary Critical 1: prevents "extend to max" misadvice for
+        // chain-break or transient subvolumes.
+        let cur = shape(24, 30, 26, 12);
+        let est = churn_with_counts(None, 0, 3);
+        assert!(recommend_shape(&cur, &est, ShapeRole::Local).is_none());
+    }
+
+    #[test]
+    fn recommend_shape_hot_subvolume_clamps_tight_local() {
+        // Hot containers-like rate: ~31_250 B/s (~2.7 GB/day).
+        let cur = shape(24, 60, 52, 24);
+        let est = churn_with_mean(Some(31_250.0));
+        let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("hot");
+        assert!(
+            rec.suggested.daily <= 7,
+            "expected tight daily clamp on hot churn, got {}",
+            rec.suggested.daily
+        );
+        assert!(
+            rec.suggested.weekly <= 4,
+            "expected tight weekly clamp on hot churn, got {}",
+            rec.suggested.weekly
+        );
+        assert!(
+            rec.current_cost.data_bytes > rec.suggested_cost.data_bytes,
+            "tighter shape must project lower data_bytes"
+        );
+    }
+
+    #[test]
+    fn recommend_shape_cold_subvolume_clamps_max_everywhere_local() {
+        // Cold docs-like rate: ~81 B/s (~7 MB/day).
+        let cur = shape(0, 7, 4, 0);
+        let est = churn_with_mean(Some(81.0));
+        let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("cold");
+        assert_eq!(rec.suggested, shape(24, 60, 52, 24));
+    }
+
+    #[test]
+    fn recommend_shape_external_role_drops_hourlies() {
+        let cur = shape(24, 60, 52, 24);
+        let est = churn_with_mean(Some(81.0));
+        let rec = recommend_shape(&cur, &est, ShapeRole::External).expect("cold-external");
+        // External clamp_max[0] is 0 and slot_share[0] is 0 — hourly never fires.
+        assert_eq!(rec.suggested.hourly, 0);
+    }
+
+    #[test]
+    fn recommend_shape_bursty_pattern_note_when_full_exceeds_incremental() {
+        let cur = shape(24, 30, 26, 12);
+        // full=3 > incremental=1, but mean is Some so recommendation fires.
+        let est = churn_with_counts(Some(1000.0), 1, 3);
+        let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("bursty");
+        assert_eq!(rec.note, Some(RecommendationNote::BurstyPattern));
+    }
+
+    #[test]
+    fn recommend_shape_no_bursty_note_when_steady_state() {
+        let cur = shape(24, 30, 26, 12);
+        let est = churn_with_counts(Some(1000.0), 10, 1);
+        let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("steady");
+        assert_eq!(rec.note, None);
+    }
+
+    #[test]
+    fn recommend_shape_local_external_symmetric_costs_for_same_shape_and_churn() {
+        let cur = shape(12, 14, 8, 6);
+        let est = churn_with_mean(Some(2500.0));
+        let local = recommend_shape(&cur, &est, ShapeRole::Local).expect("local");
+        let external = recommend_shape(&cur, &est, ShapeRole::External).expect("external");
+        // Symmetry across roles: same current shape → same current_cost.data_bytes.
+        assert_eq!(local.current_cost.data_bytes, external.current_cost.data_bytes);
+    }
+
+    #[test]
+    fn recommend_shape_handles_nan_and_infinity_without_panic() {
+        // mean = Some(0.0) forces budget/0 → INFINITY for any nonzero
+        // slot_share, and 0/0 → NaN for the External hourly slot
+        // (slot_share[0] = 0.0). Both paths must route to clamp_max
+        // without panicking.
+        let cur = shape(24, 60, 52, 24);
+        let est = churn_with_mean(Some(0.0));
+
+        let local = recommend_shape(&cur, &est, ShapeRole::Local).expect("local");
+        assert_eq!(local.suggested, shape(24, 60, 52, 24));
+
+        let external = recommend_shape(&cur, &est, ShapeRole::External).expect("external");
+        // External hourly clamp_max is 0 → suggested.hourly = 0 even
+        // when routed via the NaN/Infinity branch.
+        assert_eq!(external.suggested, shape(0, 60, 52, 24));
+    }
+
+    #[test]
+    fn recommend_shape_current_carried_through_unchanged() {
+        let cur = shape(24, 30, 26, 12);
+        let est = churn_with_mean(Some(1000.0));
+        let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("ok");
+        assert_eq!(rec.current, cur);
+    }
+
+    #[test]
+    fn recommend_shape_with_one_incremental_emits_recommendation() {
+        let cur = shape(24, 30, 26, 12);
+        let est = churn_with_counts(Some(500.0), 1, 0);
+        assert!(recommend_shape(&cur, &est, ShapeRole::Local).is_some());
+    }
+
+    #[test]
+    fn recommend_shape_suggested_count_within_clamp_bounds() {
+        // Stress across a range of churn rates: every output slot must
+        // land in `[clamp_min, clamp_max]` for the given role.
+        let cur = shape(24, 60, 52, 24);
+        let rates = [1.0_f64, 10.0, 100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0];
+        for r in rates {
+            for role in [ShapeRole::Local, ShapeRole::External] {
+                let est = churn_with_mean(Some(r));
+                let rec = recommend_shape(&cur, &est, role).expect("rec");
+                let p = params(role);
+                let s = rec.suggested;
+                assert!(s.hourly >= p.clamp_min[0] && s.hourly <= p.clamp_max[0]);
+                assert!(s.daily >= p.clamp_min[1] && s.daily <= p.clamp_max[1]);
+                assert!(s.weekly >= p.clamp_min[2] && s.weekly <= p.clamp_max[2]);
+                assert!(s.monthly >= p.clamp_min[3] && s.monthly <= p.clamp_max[3]);
+            }
+        }
+    }
+
+    // ── Equality boundary ───────────────────────────────────────────
+
+    #[test]
+    fn recommendation_suggested_equals_current_when_shape_already_optimal() {
+        // Cold subvolume + the engine's output for cold churn: current
+        // already matches, so `suggested == current`. Doctor builder
+        // suppresses this row.
+        let est = churn_with_mean(Some(81.0));
+        let optimal_local = recommend_shape(&shape(0, 0, 0, 0), &est, ShapeRole::Local)
+            .expect("seed")
+            .suggested;
+        let rec = recommend_shape(&optimal_local, &est, ShapeRole::Local).expect("optimal");
+        assert_eq!(rec.suggested, rec.current);
+    }
+
+    #[test]
+    fn recommendation_one_slot_off_is_not_equal() {
+        let cur = shape(24, 31, 26, 12);
+        let est = churn_with_mean(Some(81.0));
+        let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("ok");
+        // Cold rate clamps to {24, 60, 52, 24}; current is {24, 31, 26, 12}.
+        assert_ne!(rec.suggested, rec.current);
+    }
+
+    #[test]
+    fn recommendation_role_does_not_affect_shape_equality() {
+        // ResolvedGraduatedRetention equality is structural — role does
+        // not enter into `suggested == current`. Hold the shape fixed
+        // and verify the equality predicate is the same under both
+        // roles.
+        let a = shape(0, 7, 4, 0);
+        let b = shape(0, 7, 4, 0);
+        assert_eq!(a, b);
+
+        // Sanity: ShapeRecommendation::role differs but does not bear
+        // on suggested/current equality.
+        let est = churn_with_mean(Some(81.0));
+        let local = recommend_shape(&a, &est, ShapeRole::Local).expect("local");
+        let external = recommend_shape(&a, &est, ShapeRole::External).expect("external");
+        assert_ne!(local.role, external.role);
+        // current is the same shape across roles regardless of suggested.
+        assert_eq!(local.current, external.current);
+    }
+}

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -2414,6 +2414,22 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
         }
     }
 
+    // Recommendations section (--thorough only). UPI 041, ADR-115.
+    if let Some(ref recs) = data.recommendations
+        && !recs.rows.is_empty()
+    {
+        writeln!(out).ok();
+        writeln!(out, "  {}", "Recommendations".bold()).ok();
+        writeln!(out, "    {}", recs.header.dimmed()).ok();
+        writeln!(out).ok();
+        for (i, row) in recs.rows.iter().enumerate() {
+            if i > 0 {
+                writeln!(out).ok();
+            }
+            write!(out, "{}", format_recommendation_row(row)).ok();
+        }
+    }
+
     // Verdict
     writeln!(out).ok();
     match data.verdict.status {
@@ -2537,6 +2553,98 @@ fn format_churn_row(
     }
 }
 
+
+// ── Recommendations (UPI 041, ADR-115) ────────────────────────────────
+
+/// Render one role-line of a Recommendations-section row: a key=value
+/// list of non-zero slots ("daily=7  weekly=4") followed by the
+/// dimmed framing tail ("(recover ~135 GB)" / "(extends chain to
+/// ~N {unit})").
+fn render_shape_kv(shape: &crate::types::ResolvedGraduatedRetention) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(4);
+    if shape.hourly != 0 {
+        parts.push(format!("hourly={}", shape.hourly));
+    }
+    if shape.daily != 0 {
+        parts.push(format!("daily={}", shape.daily));
+    }
+    if shape.weekly != 0 {
+        parts.push(format!("weekly={}", shape.weekly));
+    }
+    if shape.monthly != 0 {
+        parts.push(format!("monthly={}", shape.monthly));
+    }
+    parts.join("  ")
+}
+
+/// Recovery-or-extends-chain framing for one role-line, based on the
+/// cost delta between current and suggested. Returns an empty string
+/// when the costs are equal (which should not happen — the builder
+/// suppresses aligned rows).
+fn render_cost_delta(
+    current: u64,
+    suggested: u64,
+    suggested_shape: &crate::types::ResolvedGraduatedRetention,
+) -> String {
+    use std::cmp::Ordering;
+    use crate::types::ByteSize;
+    match suggested.cmp(&current) {
+        Ordering::Less => format!("(recover ~{})", ByteSize(current - suggested)),
+        Ordering::Greater => {
+            let secs = crate::policy::chain_span_seconds(suggested_shape);
+            let (n, unit) = if secs <= 60 * 86_400 {
+                (secs / 86_400, "days")
+            } else if secs <= 364 * 86_400 {
+                (secs / (7 * 86_400), "weeks")
+            } else {
+                (secs / (365 * 86_400), "years")
+            };
+            format!("(extends chain to ~{n} {unit})")
+        }
+        Ordering::Equal => String::new(),
+    }
+}
+
+/// Render one Recommendations-section row: subvolume name + up-to-two
+/// role lines (`local:` / `external:`) + optional bursty/named-level
+/// hint lines.
+fn format_recommendation_row(row: &crate::output::DoctorRecommendationRow) -> String {
+    let mut out = String::new();
+    writeln!(out, "    {}", row.name).ok();
+
+    let mut role_line = |label: &str, rec: &crate::policy::ShapeRecommendation| {
+        let kv = render_shape_kv(&rec.suggested);
+        let tail = render_cost_delta(
+            rec.current_cost.data_bytes,
+            rec.suggested_cost.data_bytes,
+            &rec.suggested,
+        );
+        let line = if tail.is_empty() {
+            format!("      {label:9} {kv}")
+        } else {
+            format!("      {label:9} {kv}   {}", tail.dimmed())
+        };
+        writeln!(out, "{line}").ok();
+    };
+    if let Some(ref rec) = row.local {
+        role_line("local:", rec);
+    }
+    if let Some(ref rec) = row.external {
+        role_line("external:", rec);
+    }
+    if matches!(row.note, Some(crate::policy::RecommendationNote::BurstyPattern)) {
+        writeln!(out, "      {}", "bursty pattern — frequent full sends".dimmed()).ok();
+    }
+    if let Some(level) = row.was_named_level {
+        writeln!(
+            out,
+            "      {}",
+            format!("currently {level} — applying switches to custom").dimmed()
+        )
+        .ok();
+    }
+    out
+}
 
 fn render_doctor_check_section(out: &mut String, title: &str, checks: &[DoctorCheck]) {
     writeln!(out, "  {}", title.bold()).ok();
@@ -3358,6 +3466,7 @@ pub(crate) mod test_fixtures {
             },
             verify: None,
             churn: None,
+            recommendations: None,
             verdict: DoctorVerdict::healthy(),
         }
     }
@@ -3426,6 +3535,16 @@ pub(crate) mod test_fixtures {
             },
             warnings: vec![],
         }
+    }
+
+    /// Build a `DoctorOutput` populated with a single-row Recommendations
+    /// view for use by voice tests and contract tests (UPI 041).
+    pub(crate) fn recommendations_doctor_output(
+        view: crate::output::DoctorRecommendationView,
+    ) -> DoctorOutput {
+        let mut data = test_doctor_output();
+        data.recommendations = Some(view);
+        data
     }
 }
 
@@ -7743,6 +7862,401 @@ mod tests {
         assert!(
             !output.contains("Churn ("),
             "Churn section should not render when churn=None: {output}"
+        );
+    }
+
+    // ── UPI 041 Recommendations section ───────────────────────────
+
+    fn shape(h: u32, d: u32, w: u32, m: u32) -> crate::types::ResolvedGraduatedRetention {
+        crate::types::ResolvedGraduatedRetention {
+            hourly: h,
+            daily: d,
+            weekly: w,
+            monthly: m,
+        }
+    }
+
+    fn recommendation(
+        role: crate::policy::ShapeRole,
+        current: crate::types::ResolvedGraduatedRetention,
+        suggested: crate::types::ResolvedGraduatedRetention,
+        current_bytes: u64,
+        suggested_bytes: u64,
+    ) -> crate::policy::ShapeRecommendation {
+        use crate::policy::{CostProjection, ShapeRecommendation};
+        let total = |s: crate::types::ResolvedGraduatedRetention| {
+            s.hourly + s.daily + s.weekly + s.monthly
+        };
+        ShapeRecommendation {
+            role,
+            current,
+            suggested,
+            current_cost: CostProjection {
+                data_bytes: current_bytes,
+                snapshot_count: total(current),
+            },
+            suggested_cost: CostProjection {
+                data_bytes: suggested_bytes,
+                snapshot_count: total(suggested),
+            },
+            note: None,
+        }
+    }
+
+    #[test]
+    fn doctor_thorough_recommendations_renders_section_header_and_apply_hint() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorRecommendationView {
+            header: "based on 7-day churn observation; apply by editing ~/.config/urd/urd.toml"
+                .to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "containers".to_string(),
+                local: Some(recommendation(
+                    crate::policy::ShapeRole::Local,
+                    shape(24, 30, 26, 12),
+                    shape(0, 7, 4, 0),
+                    200_000_000_000,
+                    50_000_000_000,
+                )),
+                external: None,
+                note: None,
+                was_named_level: None,
+            }],
+        };
+        let output = render_doctor(
+            &recommendations_doctor_output(view),
+            OutputMode::Interactive,
+        );
+        assert!(
+            output.contains("Recommendations"),
+            "missing Recommendations header: {output}"
+        );
+        assert!(
+            output.contains("based on 7-day churn observation; apply by editing"),
+            "missing apply-hint: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_recommendations_renders_local_and_external_lines() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "containers".to_string(),
+                local: Some(recommendation(
+                    crate::policy::ShapeRole::Local,
+                    shape(24, 30, 26, 12),
+                    shape(0, 7, 4, 0),
+                    200_000_000_000,
+                    50_000_000_000,
+                )),
+                external: Some(recommendation(
+                    crate::policy::ShapeRole::External,
+                    shape(0, 30, 26, 12),
+                    shape(0, 14, 8, 6),
+                    400_000_000_000,
+                    100_000_000_000,
+                )),
+                note: None,
+                was_named_level: None,
+            }],
+        };
+        let output = render_doctor(
+            &recommendations_doctor_output(view),
+            OutputMode::Interactive,
+        );
+        assert!(output.contains("local:"), "missing local label: {output}");
+        assert!(output.contains("external:"), "missing external label: {output}");
+        assert!(output.contains("daily="), "missing daily slot label: {output}");
+        assert!(output.contains("weekly="), "missing weekly slot label: {output}");
+    }
+
+    #[test]
+    fn doctor_thorough_recommendations_omits_zero_slot_windows() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "containers".to_string(),
+                local: Some(recommendation(
+                    crate::policy::ShapeRole::Local,
+                    shape(24, 30, 26, 12),
+                    shape(0, 7, 4, 0),
+                    200_000_000_000,
+                    50_000_000_000,
+                )),
+                external: None,
+                note: None,
+                was_named_level: None,
+            }],
+        };
+        let output = render_doctor(
+            &recommendations_doctor_output(view),
+            OutputMode::Interactive,
+        );
+        assert!(output.contains("daily=7"), "missing daily=7: {output}");
+        assert!(output.contains("weekly=4"), "missing weekly=4: {output}");
+        // hourly and monthly should be omitted.
+        assert!(!output.contains("hourly="), "hourly should be omitted: {output}");
+        assert!(!output.contains("monthly="), "monthly should be omitted: {output}");
+    }
+
+    #[test]
+    fn doctor_thorough_recommendations_renders_recover_framing_for_tighter_suggestion() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "containers".to_string(),
+                local: Some(recommendation(
+                    crate::policy::ShapeRole::Local,
+                    shape(24, 30, 26, 12),
+                    shape(0, 7, 4, 0),
+                    200_000_000_000,
+                    50_000_000_000,
+                )),
+                external: None,
+                note: None,
+                was_named_level: None,
+            }],
+        };
+        let output = render_doctor(
+            &recommendations_doctor_output(view),
+            OutputMode::Interactive,
+        );
+        assert!(
+            output.contains("(recover"),
+            "missing recover framing: {output}"
+        );
+        assert!(output.contains("GB"), "missing GB unit on delta: {output}");
+    }
+
+    #[test]
+    fn doctor_thorough_recommendations_renders_extends_chain_framing_for_looser_suggestion() {
+        let _color = color_guard(false);
+        // Days branch: suggested shape with chain_span ~30 days.
+        let days_view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "docs".to_string(),
+                local: None,
+                external: Some(recommendation(
+                    crate::policy::ShapeRole::External,
+                    shape(0, 30, 0, 0),
+                    shape(0, 30, 0, 0), // 30 days chain
+                    1_000_000_000,
+                    2_000_000_000,
+                )),
+                note: None,
+                was_named_level: None,
+            }],
+        };
+        let days_out = render_doctor(
+            &recommendations_doctor_output(days_view),
+            OutputMode::Interactive,
+        );
+        assert!(
+            days_out.contains("(extends chain to ~30 days)"),
+            "days branch: {days_out}"
+        );
+
+        // Weeks branch: chain ~24 weeks (~168 days).
+        let weeks_view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "docs".to_string(),
+                local: None,
+                external: Some(recommendation(
+                    crate::policy::ShapeRole::External,
+                    shape(0, 30, 0, 0),
+                    shape(0, 0, 24, 0), // 24 weeks chain
+                    1_000_000_000,
+                    2_000_000_000,
+                )),
+                note: None,
+                was_named_level: None,
+            }],
+        };
+        let weeks_out = render_doctor(
+            &recommendations_doctor_output(weeks_view),
+            OutputMode::Interactive,
+        );
+        assert!(
+            weeks_out.contains("(extends chain to ~24 weeks)"),
+            "weeks branch: {weeks_out}"
+        );
+
+        // Years branch: chain 24 months (~720 days).
+        let years_view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "docs".to_string(),
+                local: None,
+                external: Some(recommendation(
+                    crate::policy::ShapeRole::External,
+                    shape(0, 30, 0, 0),
+                    shape(0, 0, 0, 24), // 24 months chain
+                    1_000_000_000,
+                    2_000_000_000,
+                )),
+                note: None,
+                was_named_level: None,
+            }],
+        };
+        let years_out = render_doctor(
+            &recommendations_doctor_output(years_view),
+            OutputMode::Interactive,
+        );
+        // 24 months * 30 days = 720 days; 720 / 365 = 1 (u64 truncation).
+        assert!(
+            years_out.contains("(extends chain to ~1 years)"),
+            "years branch: {years_out}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_recommendations_renders_bursty_pattern_hint_dimmed() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "containers".to_string(),
+                local: Some(recommendation(
+                    crate::policy::ShapeRole::Local,
+                    shape(24, 30, 26, 12),
+                    shape(0, 7, 4, 0),
+                    200_000_000_000,
+                    50_000_000_000,
+                )),
+                external: None,
+                note: Some(crate::policy::RecommendationNote::BurstyPattern),
+                was_named_level: None,
+            }],
+        };
+        let output = render_doctor(
+            &recommendations_doctor_output(view),
+            OutputMode::Interactive,
+        );
+        assert!(
+            output.contains("bursty pattern"),
+            "missing bursty pattern hint: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_recommendations_renders_was_named_level_hint() {
+        let _color = color_guard(false);
+        let with_level_view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "photos".to_string(),
+                local: Some(recommendation(
+                    crate::policy::ShapeRole::Local,
+                    shape(24, 30, 26, 12),
+                    shape(0, 14, 8, 6),
+                    100_000_000_000,
+                    30_000_000_000,
+                )),
+                external: None,
+                note: None,
+                was_named_level: Some(crate::types::ProtectionLevel::Sheltered),
+            }],
+        };
+        let with_level = render_doctor(
+            &recommendations_doctor_output(with_level_view),
+            OutputMode::Interactive,
+        );
+        assert!(
+            with_level.contains("currently sheltered \u{2014} applying switches to custom")
+                || with_level.contains("currently sheltered — applying switches to custom"),
+            "missing named-level hint: {with_level}"
+        );
+
+        // Inverse: was_named_level = None → no hint.
+        let no_level_view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "photos".to_string(),
+                local: Some(recommendation(
+                    crate::policy::ShapeRole::Local,
+                    shape(24, 30, 26, 12),
+                    shape(0, 14, 8, 6),
+                    100_000_000_000,
+                    30_000_000_000,
+                )),
+                external: None,
+                note: None,
+                was_named_level: None,
+            }],
+        };
+        let no_level = render_doctor(
+            &recommendations_doctor_output(no_level_view),
+            OutputMode::Interactive,
+        );
+        assert!(
+            !no_level.contains("applying switches to custom"),
+            "named-level hint should be absent when was_named_level=None: {no_level}"
+        );
+    }
+
+    #[test]
+    fn doctor_thorough_recommendations_daemon_mode_emits_json_with_recommendations_field() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "containers".to_string(),
+                local: Some(recommendation(
+                    crate::policy::ShapeRole::Local,
+                    shape(24, 30, 26, 12),
+                    shape(0, 7, 4, 0),
+                    200_000_000_000,
+                    50_000_000_000,
+                )),
+                external: None,
+                note: Some(crate::policy::RecommendationNote::BurstyPattern),
+                was_named_level: Some(crate::types::ProtectionLevel::Sheltered),
+            }],
+        };
+        let output = render_doctor(&recommendations_doctor_output(view), OutputMode::Daemon);
+        let json: serde_json::Value =
+            serde_json::from_str(&output).expect("doctor JSON must parse");
+        let recs = json
+            .get("recommendations")
+            .expect("recommendations field present");
+        let rows = recs.get("rows").and_then(|v| v.as_array()).expect("rows array");
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.get("name").and_then(|v| v.as_str()), Some("containers"));
+        let local = row.get("local").expect("local recommendation");
+        assert!(
+            local.get("role").is_some(),
+            "ShapeRecommendation.role missing from JSON"
+        );
+        assert!(
+            local.get("current").is_some(),
+            "ShapeRecommendation.current missing from JSON"
+        );
+        assert!(
+            local.get("suggested").is_some(),
+            "ShapeRecommendation.suggested missing from JSON"
+        );
+        assert!(
+            local.get("current_cost").is_some(),
+            "ShapeRecommendation.current_cost missing from JSON"
+        );
+        assert!(
+            local.get("suggested_cost").is_some(),
+            "ShapeRecommendation.suggested_cost missing from JSON"
+        );
+        assert_eq!(
+            row.get("note").and_then(|v| v.as_str()),
+            Some("bursty_pattern")
+        );
+        assert_eq!(
+            row.get("was_named_level").and_then(|v| v.as_str()),
+            Some("sheltered")
         );
     }
 }

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -38,8 +38,9 @@
 mod contract {
     use crate::output::{BackupSummary, OutputMode, TransitionEvent};
     use crate::voice::test_fixtures::{
-        color_guard, test_backup_summary, test_default_status_output, test_doctor_output,
-        test_plan_output, test_status_output, test_verify_output,
+        color_guard, recommendations_doctor_output, test_backup_summary,
+        test_default_status_output, test_doctor_output, test_plan_output, test_status_output,
+        test_verify_output,
     };
     use crate::voice::{
         render_backup_summary, render_default_status, render_doctor, render_first_time,
@@ -842,6 +843,119 @@ mod contract {
         assert!(
             !row.contains("21d") && !row.contains("3w"),
             "external_only row must not surface the suppressed local age, got: {row}"
+        );
+    }
+
+    // ── Rule 1 / 5 / 7 — Recommendations section (UPI 041) ──────────────
+
+    fn recommendation_row_with_recovery() -> crate::output::DoctorRecommendationRow {
+        use crate::policy::{CostProjection, ShapeRecommendation, ShapeRole};
+        use crate::types::ResolvedGraduatedRetention as Shape;
+        let current = Shape {
+            hourly: 24,
+            daily: 30,
+            weekly: 26,
+            monthly: 12,
+        };
+        let suggested = Shape {
+            hourly: 0,
+            daily: 7,
+            weekly: 4,
+            monthly: 0,
+        };
+        crate::output::DoctorRecommendationRow {
+            name: "containers".to_string(),
+            local: Some(ShapeRecommendation {
+                role: ShapeRole::Local,
+                current,
+                suggested,
+                current_cost: CostProjection {
+                    data_bytes: 200_000_000_000,
+                    snapshot_count: 92,
+                },
+                suggested_cost: CostProjection {
+                    data_bytes: 50_000_000_000,
+                    snapshot_count: 11,
+                },
+                note: None,
+            }),
+            external: None,
+            note: None,
+            was_named_level: None,
+        }
+    }
+
+    #[test]
+    fn rule1_recommendations_recovery_renders_with_bytesize_not_size_labels() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![recommendation_row_with_recovery()],
+        };
+        let output = render_doctor(
+            &recommendations_doctor_output(view),
+            OutputMode::Interactive,
+        );
+        let stripped = helpers::strip_ansi(&output);
+        // Rule 1 (precision): recovery framing must use ByteSize units,
+        // not approximate prose like "small" / "medium" / "huge".
+        assert!(
+            stripped.contains("GB") || stripped.contains("MB") || stripped.contains("KB"),
+            "recovery framing must use ByteSize units, got: {stripped}"
+        );
+        for prose in &["small", "medium", "large", "tiny", "huge"] {
+            assert!(
+                !stripped.contains(prose),
+                "Rule 1 violation: recommendation prose contains '{prose}': {stripped}"
+            );
+        }
+    }
+
+    #[test]
+    fn rule5_recommendations_emit_does_not_change_first_line() {
+        let _color = color_guard(false);
+        // Compare with-vs-without recommendations: emitting the
+        // Recommendations section must not change the first non-blank
+        // line. Order-independent with respect to UPI 045's verdict-as-
+        // first-line shift.
+        let without = render_doctor(&test_doctor_output(), OutputMode::Interactive);
+        let view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![recommendation_row_with_recovery()],
+        };
+        let with = render_doctor(
+            &recommendations_doctor_output(view),
+            OutputMode::Interactive,
+        );
+        let first_without = helpers::non_blank_lines(&without)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("empty doctor output without recs:\n{without}"));
+        let first_with = helpers::non_blank_lines(&with)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("empty doctor output with recs:\n{with}"));
+        assert_eq!(
+            first_without, first_with,
+            "Rule 5 violation: recommendations section changed the first non-blank line"
+        );
+    }
+
+    #[test]
+    fn rule7_recommendations_section_omitted_when_no_rows() {
+        let _color = color_guard(false);
+        let view = crate::output::DoctorRecommendationView {
+            header: "header".to_string(),
+            rows: vec![],
+        };
+        let output = render_doctor(
+            &recommendations_doctor_output(view),
+            OutputMode::Interactive,
+        );
+        let stripped = helpers::strip_ansi(&output);
+        assert!(
+            !stripped.contains("Recommendations"),
+            "Rule 7 violation: Recommendations header emitted with empty rows: {stripped}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Adds a new pure module `src/policy.rs` (UPI 041, ADR-115) that projects steady-state data cost for a retention shape under observed churn and recommends a four-slot shape per role.
- Surfaces a Recommendations section between Churn and Verdict in `urd doctor --thorough`. Rows sorted by recovery magnitude descending; aligned shapes suppressed; cold-start subvolumes silently omitted.
- Tightened `recommend_shape` `None`-return contract (mean-is-none, not just counts-both-zero) so chain-break recovery and transient-subvolume windows don't produce "extend to max" misadvice. NaN/Infinity guarded explicitly.
- Builder opens `StateDb` once and shares it with churn + recommendation builders. No on-disk contracts touched (ADR-105 unaffected).

## Testing

- cargo clippy: pass (`-D warnings`)
- cargo test: 1224 passing, 5 ignored, 0 failed (37 new tests)
- cargo build --release: clean
- Three new rule-tagged contract tests (Rule 1 precision / Rule 5 gravity / Rule 7 silence) pin the section's voice behaviour.
- Integration tests: not applicable (pure module + builder, no btrfs path touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)