### PR TITLE
fix: honor source_unchanged in compute_health drive-away check (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bare `urd` no longer reports "1 degraded" and recommends connecting an
+  offsite drive when a subvolume's source has had no changes since the last
+  send (#120). `compute_health`'s "drive away >7 days" check now honors
+  `source_unchanged`, mirroring the planner's skip-when-source-unchanged
+  behavior: if the absent drive's pin generation matches the live source,
+  there is nothing pending to send and the drive's absence is not an
+  operational concern. The promise-status path already had this guard; the
+  operational-health path was missing it, which is what produced the
+  contradictory "All connected drives are sealed. 1 degraded." output.
+
 ## [0.16.1] - 2026-05-14
 
 ### Fixed

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -177,6 +177,11 @@ pub struct DriveAssessment {
     pub mounted: bool,
     pub snapshot_count: Option<usize>,
     pub last_send_age: Option<Duration>,
+    /// Source generation matches this drive's pin snapshot — there is nothing
+    /// pending to send to this drive, regardless of `last_send_age`. Used by
+    /// `compute_health` to suppress "drive away" degradation when the absent
+    /// drive's data is already fully current.
+    pub source_unchanged: bool,
     #[allow(dead_code)] // consumed by verbose status display (future)
     pub configured_interval: Interval,
     pub role: DriveRole,
@@ -640,6 +645,7 @@ pub fn assess(
                     mounted,
                     snapshot_count: snap_count,
                     last_send_age,
+                    source_unchanged,
                     configured_interval: subvol.send_interval,
                     role: drive.role,
                     absent_duration_secs,
@@ -1111,8 +1117,13 @@ fn compute_health(
     }
 
     // ── Degraded: configured drive unmounted >7 days ───────────────
+    // Suppressed when `source_unchanged` for the drive: if the pin generation
+    // matches the live source, there is nothing pending to send and the
+    // drive's absence is not an operational concern. Mirrors the planner's
+    // skip-when-source-unchanged behavior (see issue #120, defect 1).
     for da in drive_assessments {
         if !da.mounted
+            && !da.source_unchanged
             && let Some(age) = da.last_send_age
             && age.num_days() > DRIVE_AWAY_DEGRADED_DAYS
         {
@@ -3146,6 +3157,72 @@ send_enabled = false
     }
 
     #[test]
+    fn health_drive_away_long_but_source_unchanged_is_healthy() {
+        // An offsite drive that's been away >7 days but whose pin generation
+        // matches the live source has nothing pending to send — degrading
+        // operational health for it would be a false alarm. The promise-status
+        // path already honors source_unchanged; this asserts compute_health
+        // does too (issue #120, defect 1).
+        let config = test_config_two_drives();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        let pin_snap = snap(dt(2026, 3, 10, 12, 0), "sv1");
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![pin_snap.clone()]);
+
+        // D1 mounted, sealed, plenty of space.
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![pin_snap.clone()],
+        );
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "D1".to_string()),
+            pin_snap.clone(),
+        );
+        fs.send_times.insert(
+            ("sv1".to_string(), "D1".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/d1"), 1_000_000_000_000);
+
+        // D2 unmounted, last send 13 days ago — but source unchanged since
+        // that send (pin generation matches live source).
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "D2".to_string()),
+            pin_snap.clone(),
+        );
+        fs.send_times.insert(
+            ("sv1".to_string(), "D2".to_string()),
+            dt(2026, 3, 10, 12, 0),
+        );
+        fs.generations
+            .insert(std::path::PathBuf::from("/data/sv1"), 42);
+        fs.generations.insert(
+            std::path::PathBuf::from(format!("/snap/sv1/{}", pin_snap.as_str())),
+            42,
+        );
+
+        let results = assess(&config, now, &fs);
+        assert_eq!(
+            results[0].health,
+            OperationalHealth::Healthy,
+            "source_unchanged on the absent drive must suppress 'away' degradation. reasons: {:?}",
+            results[0].health_reasons,
+        );
+        assert!(
+            !results[0]
+                .health_reasons
+                .iter()
+                .any(|r| r.contains("away for")),
+            "should not produce an 'away for N days' reason when source is unchanged. reasons: {:?}",
+            results[0].health_reasons,
+        );
+    }
+
+    #[test]
     fn health_multiple_reasons_collected() {
         let config = test_config_two_drives();
         let now = dt(2026, 3, 23, 14, 0);
@@ -3730,6 +3807,7 @@ drives = ["primary-drive", "offsite-drive"]
             mounted: age_days.is_some(),
             snapshot_count: Some(5),
             last_send_age: age_days.map(Duration::days),
+            source_unchanged: false,
             configured_interval: Interval::hours(24),
             role: DriveRole::Offsite,
             absent_duration_secs: None,
@@ -3744,6 +3822,7 @@ drives = ["primary-drive", "offsite-drive"]
             mounted: true,
             snapshot_count: Some(100),
             last_send_age: Some(Duration::hours(2)),
+            source_unchanged: false,
             configured_interval: Interval::hours(24),
             role: DriveRole::Primary,
             absent_duration_secs: None,
@@ -3807,6 +3886,7 @@ drives = ["primary-drive", "offsite-drive"]
             mounted: true,
             snapshot_count: Some(5),
             last_send_age: Some(Duration::days(60)),
+            source_unchanged: false,
             configured_interval: Interval::hours(24),
             role: DriveRole::Offsite,
             absent_duration_secs: None,
@@ -3847,6 +3927,7 @@ drives = ["primary-drive", "offsite-drive"]
             mounted: false,
             snapshot_count: None,
             last_send_age: Some(Duration::days(60)),
+            source_unchanged: false,
             configured_interval: Interval::hours(24),
             role: DriveRole::Offsite,
             absent_duration_secs: None,
@@ -4523,6 +4604,7 @@ drives = ["D1"]
             mounted,
             snapshot_count: Some(5),
             last_send_age: send_age_hours.map(Duration::hours),
+            source_unchanged: false,
             configured_interval: Interval::hours(24),
             role: DriveRole::Primary,
             absent_duration_secs: None,

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -2575,6 +2575,7 @@ mod tests {
             mounted: true,
             snapshot_count: count,
             last_send_age: None,
+            source_unchanged: false,
             configured_interval: Interval::hours(4),
             role: DriveRole::Primary,
             absent_duration_secs: None,

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -322,6 +322,7 @@ mod tests {
                     mounted: true,
                     snapshot_count: Some(10),
                     last_send_age: Some(chrono::Duration::hours(2)),
+                    source_unchanged: false,
                     configured_interval: Interval::hours(4),
                     role: DriveRole::Primary,
                     absent_duration_secs: None,

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -905,6 +905,7 @@ mod tests {
                 mounted: true,
                 snapshot_count: Some(3),
                 last_send_age: None,
+                source_unchanged: false,
                 configured_interval: Interval::hours(24),
                 role: DriveRole::Primary,
                 absent_duration_secs: None,


### PR DESCRIPTION
## Summary

- Addresses defect 1 from #120: bare `urd` reporting "1 degraded" and recommending the user connect an offsite drive that has nothing pending to send to it.
- Adds `source_unchanged: bool` to `DriveAssessment` and uses it in `compute_health`'s "drive away >7 days" check. Mirrors the planner's existing skip-when-source-unchanged behavior — if the pin generation matches the live source, the drive's absence is not an operational concern.
- Fixes the asymmetry where `assess_external_status` (promise status) honored `source_unchanged` but `compute_health` (operational health) did not, which produced the contradictory `"All connected drives are sealed. 1 degraded."` line.
- Vertical-slice test added: `health_drive_away_long_but_source_unchanged_is_healthy` (failing before the fix with `"D2 away for 13 days"`, passing after).

## Scope

This addresses **defect 1** only — the root cause that fires in real-world rotation workflows. #120 catalogues two remaining defects that should also land separately:

- **#103** (defect 2): `compute_health` mislabels `last_send_age` as physical-away age (orthogonal — needs `absent_duration_secs` cascade).
- **Defect 3**: `compute_advice` Branch 8 has no drive-role filter and doesn't cross-reference `health_reasons` (last-line-of-defense hardening).

Either of those would also break this specific symptom, but defect 1 is the cleanest fix because it parallels what the planner already does with the same data.

## Verification

- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 1230 pass, 0 fail, 5 ignored (was 1229; +1 new test)
- `cargo build --release`: clean
- Real-world: on the host that triggered #120 (subvol5-music, source unchanged since 2026-04-03, ~43 days), bare `urd` now reports `degraded_count: 0` (was `1`, with the offsite drive recommendation that motivated the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)