### PR TITLE
docs: amend ADR-104/105/110/111 for UPI 042 schema evolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,18 +99,26 @@ Each references an ADR in `docs/00-foundation/decisions/` with full rationale.
 
 ### Config System (ADR-111)
 
-Dual-parser architecture supporting **legacy** and **v1** schemas. `Config::load()` pre-parses
-`config_version` from `[general]`, then dispatches to `parse_legacy()` (absent) or `parse_v1()`
-(`config_version = 1`). Both produce the same internal `Config` struct — v1 synthesizes
-`LocalSnapshotsConfig` and `DefaultsConfig` so downstream code is schema-agnostic.
+Tri-parser architecture supporting **legacy**, **v1**, and **v2** schemas. `Config::load()`
+pre-parses `config_version` from `[general]`, then dispatches to `parse_legacy()` (absent),
+`parse_v1()` (`config_version = 1`), or `parse_v2()` (`config_version = 2`). All three
+produce the same internal `Config` struct — v1/v2 synthesize `LocalSnapshotsConfig` and
+`DefaultsConfig` so downstream code is schema-agnostic.
 
 - **Legacy:** `[defaults]`, `[local_snapshots]`, `protection_level`, `short_name` required.
 - **v1:** Self-describing `[[subvolumes]]` with inline `snapshot_root`/`min_free_bytes`,
   `protection` field (renamed), `short_name` optional (defaults to `name`), no `[defaults]`
   or `[local_snapshots]`. Named levels are opaque — no operational overrides.
-- **`urd migrate`:** Transforms legacy → v1. Reads raw TOML, builds v1 as string output.
-  Saves backup to `{path}.legacy`. Dispatched as Strategy A (before config load).
-- **Example configs:** `config/urd.toml.example` (legacy), `config/urd.toml.v1.example` (v1).
+  `monthly = 0` means "unlimited monthly retention" (v1 contract preserved indefinitely).
+- **v2:** As v1, plus explicit `monthly = "unlimited"` (string) for unbounded monthly
+  retention; new optional `yearly: u32` retention tier. `monthly = 0` is a parse error
+  (v2 closes the v1 footgun at the parse boundary).
+- **`urd migrate`:** Auto-targets latest version. Today: legacy → v2 or v1 → v2 (single
+  hop). Reads raw TOML, builds v2 as string output. Saves backup to `{path}.legacy` or
+  `{path}.v1`. Comments and original formatting are not preserved (`.v1` / `.legacy`
+  backup is the verbatim source of truth).
+- **Example configs:** `config/urd.toml.example` (legacy), `config/urd.toml.v1.example`
+  (v1), `config/urd.toml.v2.example` (v2).
 
 ### Error Handling
 
@@ -240,6 +248,7 @@ cargo run -- migrate                 # Migrate config to v1 schema
 - Heartbeat: `~/.local/share/urd/heartbeat.json`
 - Example (legacy): `config/urd.toml.example`
 - Example (v1): `config/urd.toml.v1.example`
+- Example (v2): `config/urd.toml.v2.example`
 
 ## ADR Index
 
@@ -249,14 +258,14 @@ cargo run -- migrate                 # Migrate config to v1 schema
 | 101 | BtrfsOps trait | Btrfs abstraction |
 | 102 | Filesystem truth, SQLite history | State management |
 | 103 | Interval-based scheduling | Snapshot/send timing |
-| 104 | Graduated retention | Snapshot lifecycle |
-| 105 | Backward compatibility contracts | On-disk data formats |
+| 104 | Graduated retention (amended 2026-05-15) | Snapshot lifecycle |
+| 105 | Backward compatibility contracts (amended 2026-05-15) | On-disk data formats |
 | 106 | Defense-in-depth data integrity | Pin protection layers |
 | 107 | Fail-open backups, fail-closed deletions | Error philosophy |
 | 108 | Pure-function module pattern | Module design |
 | 109 | Config-boundary validation | Security/correctness |
-| 110 | Protection promises | Promise semantics, maturity model |
-| 111 | Config system architecture | Config structure, versioning (target, not yet implemented) |
+| 110 | Protection promises (amended 2026-05-15) | Promise semantics, maturity model |
+| 111 | Config system architecture (amended 2026-05-15) | Config structure, versioning (target, not yet implemented) |
 | 112 | SemVer and release workflow | Versioning, CHANGELOG, git tags, /release skill |
 | 113 | The Do-No-Harm invariant | Layered, probabilistic defense against Urd-induced host burden |
 | 114 | Structured event log | Typed change-and-decision history; complement to Prometheus gauges and UPI 030 drift_samples |

--- a/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
@@ -89,9 +89,57 @@ March 2. This prevents the slow drift that accumulates with day-based month appr
 - When `send_enabled` is true, snapshots newer than the oldest pin are protected from
   local retention — they may not have been sent to all drives yet.
 
+## Amendment 2026-05-15: Yearly window
+
+UPI 042 (config schema `v2`) extends the graduated retention stack with a `yearly` tier:
+
+```
+hourly → daily → weekly → monthly → yearly → beyond-window
+```
+
+### Slot key
+
+Yearly's slot key is the calendar year `(year)`. One snapshot survives per calendar year for
+`yearly` years past the monthly cutoff. Calendar-year semantics were chosen for symmetry
+with the calendar-month arithmetic already in `retention.rs` (`Months::new` in the monthly
+cutoff calculation). A snapshot from January 31, 2024 is "1 year old" on January 1, 2025 —
+not on January 31, 2025 — matching how a January-31 snapshot is "1 month old" on February 1.
+
+### Cutoff
+
+The yearly cutoff is computed from the monthly cutoff, subtracting `yearly` calendar years
+(implemented as `Months::new(yearly * 12)`), saturating to `NaiveDateTime::MIN` on overflow.
+
+When the monthly tier is `Unlimited` (see Amendment 2026-05-15 in ADR-105 and the
+`MonthlyCount` enum), the yearly window is **logically subsumed**: every snapshot newer than
+the (non-existent) monthly cutoff is already retained, so a yearly thinning rule has nothing
+left to thin. The retention engine treats yearly as `0` in that case, and `preflight` emits
+an advisory `redundant-yearly` warning so the user sees the redundancy explicitly. The
+recovery-window display likewise suppresses the yearly row when monthly is `Unlimited`, so
+the displayed shape agrees with the engine's behavior.
+
+### Bounded type
+
+`yearly` is `Option<u32>` with no `"unlimited"` variant. The asymmetry with `monthly` is
+deliberate: `monthly = "unlimited"` exists only to preserve a v1 contract (`monthly = 0`
+meant "unlimited" under v1 semantics) via migration. `yearly` is new in v2 and starts
+bounded. A `YearlyCount` enum can be added in a future UPI if evidence demands; today there
+is no v1 contract to preserve and no operational data to justify unbounded yearly retention.
+
+### Recommender scope
+
+The retention shape recommender (`policy::recommend_shape`, UPI 041 / ADR-115) stays
+**4-slot** in this amendment. Yearly is a v2 user opt-in only; the recommender does not
+emit yearly suggestions. A future UPI can expand the recommender to 5 slots with measured
+`RoleParams` once there is evidence of demand. This avoids silently changing UPI 041's
+already-shipped recommendation outputs.
+
 ## Related
 
 - ADR-020: Daily external backups (graduated retention enables quarterly offsite rotation)
 - ADR-103: Interval-based scheduling (frequent snapshots require graduated retention)
+- ADR-105: Backward-compatibility contracts (Amendment 2026-05-15 — `monthly = 0` semantic shift)
+- ADR-111: Config system architecture (Amendment 2026-05-15 — `config_version = 2`)
+- ADR-115: Retention shape symmetry and the recommendation layer (4-slot recommender scope)
 - [Phase 1 journal](../../98-journals/2026-03-22-urd-phase01.md) — retention redesign
 - [Roadmap](../../96-project-supervisor/roadmap.md) — original flat retention specification

--- a/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
@@ -91,9 +91,61 @@ are handled by `urd migrate`; data format changes require a migration plan and a
 - Legacy snapshot names will exist on disk indefinitely (old snapshots are not renamed).
   All code that handles snapshot names must support both formats permanently.
 
+## Amendment 2026-05-15: `monthly = 0` semantic shift handled via `urd migrate`
+
+UPI 042 closes the `monthly = 0 → "unlimited"` footgun (v1 silently interpreted `0` as
+unbounded retention, causing accumulation incidents — root cause confirmed in the design's
+arc proposal §I). The semantic shift from "unbounded" to "no monthly retention" is
+preserved by the migration command, not by silent reinterpretation in the parser.
+
+### v1 readers preserve v1 semantics indefinitely
+
+`parse_v1` continues to interpret `monthly = 0` as "unlimited monthly retention" for any
+config carrying `config_version = 1` or omitting the field (legacy). This is non-negotiable:
+breaking it would silently corrupt every existing user's retention behavior.
+
+Implementation: a v1-only shadow type (`V1GraduatedRetention`) keeps `monthly: Option<u32>`,
+and `V1Config::into_config()` performs the explicit mapping:
+
+| v1 input              | Internal representation             |
+|-----------------------|--------------------------------------|
+| `monthly = 0`         | `MonthlyCount::Unlimited`            |
+| `monthly = N` (N > 0) | `MonthlyCount::Count(N)`             |
+| `monthly` omitted     | `None`                               |
+
+The `MonthlyCount::Deserialize` impl introduced in v2 is **strict** (rejects `0` at parse
+time), but it is only invoked on the v2 boundary. The v1 path does not invoke it.
+
+### v2 readers reject `monthly = 0` at parse time
+
+For configs with `config_version = 2`, `monthly = 0` is a parse error (ADR-109 boundary
+validation). v2 users express "no monthly retention" by omitting the field, "unlimited
+retention" by writing `monthly = "unlimited"`, and "N months" by writing `monthly = N`.
+
+### On-disk contracts are unaffected
+
+The four on-disk contracts above — snapshot names, directory structure, pin files, and
+Prometheus metrics — are not touched by this amendment. No metric carries the `monthly`
+value as a label or gauge; no snapshot name format changes; no pin file format changes.
+
+Display strings (e.g., the policy summary rendered by `urd doctor`) are **not** load-bearing
+on-disk formats. The new `monthly = "unlimited"` rendering is a presentation-layer change
+and falls outside the scope of these contracts.
+
+### Migration command
+
+`urd migrate` performs the rewrite: read v1 (or legacy) → emit v2 with every `monthly = 0`
+converted to `monthly = "unlimited"`. The original is preserved verbatim in a `.v1` (or
+`.legacy`) backup file. See ADR-111 Amendment 2026-05-15 for the dispatcher and migration
+command details.
+
 ## Related
 
 - ADR-020: Daily external backups (established the dual pin file format)
+- ADR-104: Graduated retention (Amendment 2026-05-15 — yearly window)
+- ADR-109: Config-boundary validation (v2 rejects `monthly = 0` at parse time)
+- ADR-111: Config system architecture (Amendment 2026-05-15 — `config_version = 2`,
+  migration command, dual-parser dispatcher)
 - [Roadmap](../../96-project-supervisor/roadmap.md) §Backward Compatibility, §Prometheus Metrics
 - [Pre-cutover hardening journal](../../98-journals/2026-03-24-pre-cutover-hardening.md) —
   legacy pin handling refinement

--- a/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
+++ b/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
@@ -389,8 +389,50 @@ This ADR is considered implemented when:
 - [x] Pin-protection safety tests pass with derived retention
 - [ ] Recommendation layer ships and surfaces per-subvolume shape advice (UPI 041 / ADR-115)
 
+## Amendment 2026-05-15: `recorded_external_retention.monthly` correction
+
+UPI 042 corrects an asymmetry in `derive_policy()` that was an oversight, not a designed
+behavior. Under v1 semantics, `monthly = 0` meant "unlimited"; under v2, internal
+construction of `MonthlyCount::Count(0)` means "no monthly retention." The four
+`ResolvedGraduatedRetention` literals in `derive_policy()` are corrected to express their
+*intent* in the new type system:
+
+| Field                                  | v1 literal | v2 type                       | Semantic       |
+|----------------------------------------|------------|-------------------------------|----------------|
+| `recorded_retention.monthly`           | `0`        | `MonthlyCount::Count(0)`      | no monthly     |
+| `full_retention.monthly`               | `12`       | `MonthlyCount::Count(12)`     | 12 months      |
+| `full_external_retention.monthly`      | `0`        | `MonthlyCount::Unlimited`     | unbounded      |
+| `recorded_external_retention.monthly`  | `0`        | `MonthlyCount::Count(0)`      | no monthly     |
+
+The fourth row is the **Branch E correction**. Under v1 semantics, this field rendered as
+"unlimited monthly," matching the third row by accident — not by design. The intent for
+`recorded` (the Recorded protection level) is "no monthly retention" both locally and
+externally; the v1 type system couldn't express that distinction, so the literal was forced
+to a value (`0`) that happened to mean "unlimited" externally.
+
+### Behavior-neutral today
+
+Verified at `plan.rs:470, 511`: when `send_enabled = false` (always true for `recorded`
+under any timer/sentinel mode), `plan_external_retention` is never invoked. The current
+value is dead code in steady state, so the correction is behavior-neutral today.
+
+### Forward-looking safety
+
+If any future variant ever gives Recorded an external send, the *correct* default lands
+("no monthly retention" matching local) rather than the historical accident ("unlimited
+monthly retention" via the v1 type ambiguity). Locking in the correction now avoids
+re-litigating it later under pressure.
+
+### Visible effect
+
+The only user-visible surface affected is `urd doctor --thorough`'s display of a Recorded
+subvolume's external policy shape: it now reads "no monthly" instead of "unlimited monthly."
+Display-only; no retention behavior changes.
+
 ## Related
 
+- ADR-104: Graduated retention (Amendment 2026-05-15 — yearly window, `MonthlyCount` semantics)
+- ADR-105: Backward-compatibility contracts (Amendment 2026-05-15 — `monthly = 0` semantic shift)
 - ADR-111: Config system architecture (governs config structure, versioning, validation)
 - Design: `docs/95-ideas/2026-03-26-design-protection-promises.md`
 - Design review: `docs/99-reports/2026-03-26-protection-promises-design-review.md`

--- a/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
+++ b/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
@@ -551,12 +551,99 @@ These govern future config system decisions:
 10. **Space constraints are per-subvolume, not per-filesystem.** Each block declares its own
     threshold. Self-describing over deduplicated.
 
+## Amendment 2026-05-15: `config_version = 2`
+
+UPI 042 extends the dual-parser architecture to a tri-parser dispatcher and introduces
+config schema v2. The schema delta is small (one type widening, one new optional field) but
+the migration is non-negotiable: the v1 `monthly = 0 → unlimited` footgun caused
+accumulation incidents, and v2 closes it at parse time.
+
+### Version dispatcher
+
+`Config::load()` pre-parses `config_version` from `[general]` and dispatches:
+
+| `config_version` | Parser         | Status                              |
+|------------------|----------------|--------------------------------------|
+| absent           | `parse_legacy` | Loadable, deprecated path            |
+| `1`              | `parse_v1`     | Loadable indefinitely                |
+| `2`              | `parse_v2`     | Current                              |
+| other            | error          | `unsupported config_version N (supported: 1, 2)` |
+
+`parse_v1` and `parse_legacy` are not removed. Old configs continue to load forever — the
+"one schema version at a time" principle (#9 above) governs *what `urd` writes*, not what
+it reads.
+
+### v2 schema delta from v1
+
+Two changes, both on retention blocks (`local_retention`, `external_retention`):
+
+1. **`monthly` accepts `u32 > 0` or `"unlimited"`.** `monthly = 0` is a parse error in v2.
+   The internal type is `Option<MonthlyCount>` where `MonthlyCount` is a tagged enum with
+   `Count(u32)` and `Unlimited` variants. See ADR-105 Amendment 2026-05-15 for v1
+   compatibility handling.
+2. **New optional `yearly: u32` field.** See ADR-104 Amendment 2026-05-15 for retention
+   semantics (calendar-year slot key, subsumed by `Unlimited` monthly).
+
+No other v2 deltas. All other v1 structure (named protection levels, `[[subvolumes]]`,
+inline `snapshot_root` / `min_free_bytes`, opaque named levels) carries forward unchanged.
+
+### Migration (`urd migrate`) auto-targets the latest version
+
+`urd migrate` performs a single hop to the latest supported version. Today: legacy → v2,
+v1 → v2, or no-op (already v2). The intermediate legacy → v1 CLI path is removed; users on
+legacy configs migrate directly to v2.
+
+`parse_v1` stays for hand-written configs that someone may still be authoring during the
+soft-deprecation window. The migration command's job is to *retire* v1 in the user's
+filesystem; the parser's job is to *read* whatever the user has.
+
+Migration architecture: **structured parse-munge-render** for both legacy → v2 and v1 → v2.
+The input is parsed into raw structs, the relevant fields are transformed
+(`monthly = 0 → "unlimited"`, `config_version` bumped), and a fresh v2 TOML document is
+emitted. Comments and original formatting are not preserved; the original is saved to a
+`.v1` or `.legacy` backup file verbatim.
+
+### v1 deprecation
+
+Soft notice in `urd doctor` only — one line near the top:
+
+```
+Schema: v1 (current: v2; run `urd migrate` to upgrade)
+```
+
+For legacy configs the line reads `Schema: legacy (current: v2; …)`. For v2 the line is
+suppressed. No stderr warning, no hard cutoff, no friction during automated runs. A future
+UPI may tighten the policy once v2 has soak time.
+
+### Validation
+
+`V2Config::validate_v2()` returns `Result<(), String>` with the same shape as
+`validate_v1`. Rules 1–4 (named-level rejection of `local_retention`,
+`external_retention`, `snapshot_root` and `min_free_bytes` overrides) and the
+Sheltered/Fortified drive checks are copied across to v2.
+
+The **unlimited + yearly redundancy warning** does not live in `validate_v2`. It is an
+advisory check in `preflight.rs` (which is already the advisory layer per the "structure
+at load time, isolate failures at runtime" principle), surfaced via `urd doctor`. This
+keeps `Config::load()`'s signature unchanged — no `Vec<String>` warnings side-channel — and
+avoids rippling call-sites in `main.rs`, `sentinel_runner.rs`, and `commands/default.rs`.
+
+### Implementation isolation
+
+The v2 boundary check (strict `Deserialize` on `MonthlyCount` rejecting `0`) is isolated to
+v2 alone. `parse_v1` uses a v1-only shim (`V1GraduatedRetention` keeps
+`monthly: Option<u32>`), and `V1Config::into_config()` maps to `MonthlyCount` explicitly.
+This is load-bearing: without the isolation, parse_v1 would reject every existing v1 config
+with `monthly = 0`, breaking ADR-105's backward-compatibility contract.
+
 ## Related
 
 - ADR-103: Interval scheduling (defaults inheritance removed)
-- ADR-104: Graduated retention (defaults inheritance removed)
-- ADR-105: Backward compatibility (scoped to data formats, not config schema)
-- ADR-109: Config boundary validation (extended with structural/runtime distinction)
-- ADR-110: Protection promises (override semantics superseded; maturity model added)
+- ADR-104: Graduated retention (defaults inheritance removed; Amendment 2026-05-15 — yearly window)
+- ADR-105: Backward compatibility (scoped to data formats, not config schema; Amendment 2026-05-15 — `monthly = 0` semantic shift)
+- ADR-109: Config boundary validation (extended with structural/runtime distinction; v2 rejects `monthly = 0` at parse time)
+- ADR-110: Protection promises (override semantics superseded; maturity model added; Amendment 2026-05-15 — `recorded_external_retention.monthly` correction)
 - Design: `docs/95-ideas/2026-04-03-design-010-config-schema-v1.md` — full v1 schema design
+- Design: `docs/95-ideas/2026-05-09-design-042-schema-evolution.md` — v2 schema evolution
+- Plan: `docs/97-plans/2026-05-15-plan-042-schema-evolution.md` — v2 implementation plan
 - Journal: `docs/98-journals/2026-03-27-config-design-review.md` — original design discussion


### PR DESCRIPTION
## Summary

Phase 1 of UPI 042 — **contract surface only, no code**. Four ADR amendments + CLAUDE.md updates that gate the forthcoming `config_version = 2` schema (`monthly = "unlimited"` + `yearly` tier). Per the plan, this PR lands first so arch-adversary review of the contracts is independent of Phase 2 implementation review.

- **ADR-104** — yearly window appended to graduated retention stack. Calendar-year slot keys; subsumed by `Unlimited` monthly (preflight warns, recovery-window display suppresses yearly row). Yearly is `Option<u32>` — asymmetry with `MonthlyCount` is deliberate. Recommender stays 4-slot in this UPI.
- **ADR-105** — `monthly = 0 → unlimited` v1 semantic preserved indefinitely via a v1-only shim. v2 readers reject `monthly = 0` at parse time. On-disk contracts (snapshot names, dirs, pin files, Prometheus metrics) unaffected.
- **ADR-110** — `recorded_external_retention.monthly` corrected from `0` (= unlimited under v1 ambiguity) to `MonthlyCount::Count(0)` (= no monthly). Behavior-neutral today (`send_enabled = false` for Recorded); locks in the correct default for any future variant.
- **ADR-111** — tri-parser dispatcher (legacy/v1/v2). `urd migrate` auto-targets latest. v1 deprecation = soft notice in `urd doctor` only. `validate_v2` stays `Result<(), String>`; redundancy advisory lives in `preflight.rs`.
- **CLAUDE.md** — ADR index annotated, Config System section updated to tri-parser, v2 example listed.

## Test plan

- [ ] arch-adversary review of the four ADR amendments + CLAUDE.md updates
- [ ] Manual proofread for cross-references between the four ADRs (104↔105, 110↔104, 111↔104/105/110)
- [ ] Confirm v1 backward-compat language in ADR-105 is unambiguous (parse_v1 must not invoke the strict `MonthlyCount::Deserialize`)
- [ ] Merge before any Phase 2 (code) branch is cut from main (R9 branch-parentage check)

## Plan reference

`docs/97-plans/2026-05-15-plan-042-schema-evolution.md` §Phase 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)