### PR TITLE
feat: UPI 042 — config schema v2 (monthly = "unlimited" + yearly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **UPI 042 — Config schema v2 (`monthly = "unlimited"` + yearly tier).** v2
+  closes the `monthly = 0` footgun: written explicitly as `monthly =
+  "unlimited"` (string) for unbounded retention, or omitted for "no monthly
+  retention." A new optional `yearly: u32` retention tier (one snapshot per
+  calendar year for `yearly` years) lives alongside the four existing
+  granularities. `urd migrate` auto-targets the latest schema in a single
+  hop: legacy → v2 or v1 → v2 (replacing the legacy → v1 path). v1 reads
+  continue to interpret `monthly = 0` as unlimited indefinitely via a v1
+  wire-format shim. v2 rejects literal `monthly = 0` at parse time with an
+  actionable error message. `urd doctor` shows a one-line `Schema: v1
+  (current: v2; run urd migrate to upgrade)` notice for non-v2 configs.
+  `urd preflight` (advisory) flags the `monthly = "unlimited"` + `yearly >
+  0` redundancy. See ADR-104/105/110/111 amendments (2026-05-15).
+
+### Changed
+- `derive_policy()` switches `recorded_external_retention.monthly` from
+  unlimited to `Count(0)` (no monthly window). Behavior-neutral because
+  `send_enabled = false` for recorded subvolumes means
+  `plan_external_retention` is never invoked. Local `recorded` retention
+  keeps `monthly = Unlimited` (one snapshot per month indefinitely),
+  preserving pre-UPI 042 behavior (ADR-110 amendment).
+
 ## [0.16.2] - 2026-05-14
 
 ### Fixed

--- a/config/urd.toml.v2.example
+++ b/config/urd.toml.v2.example
@@ -1,0 +1,179 @@
+# Urd v2 configuration
+# Copy to ~/.config/urd/urd.toml and adjust paths for your system.
+# Run `urd migrate` to convert from legacy or v1.
+#
+# Schema delta from v1:
+#   - `monthly` accepts a positive integer or the string "unlimited".
+#     `monthly = 0` is a parse error in v2 — omit the field for
+#     "no monthly retention" or write `monthly = "unlimited"` for
+#     unbounded retention.
+#   - New optional `yearly` retention tier on retention blocks
+#     (one snapshot per calendar year for `yearly` years).
+#   - `yearly` is redundant when `monthly = "unlimited"`; the
+#     preflight layer surfaces this as an advisory.
+
+[general]
+config_version = 2
+# How often Urd runs: "daily" (systemd timer), "sentinel" (daemon), or interval like "6h"
+# Protection promises derive intervals from this — set it to match your systemd timer.
+run_frequency = "daily"
+# Uncomment to override XDG defaults:
+# state_db = "~/.local/share/urd/urd.db"
+# metrics_file = "~/.local/share/urd/backup.prom"
+# log_dir = "~/.local/share/urd/logs"
+# heartbeat_file = "~/.local/share/urd/heartbeat.json"
+# btrfs_path = "/usr/sbin/btrfs"
+
+# ── Drives ───────────────────────────────────────────────────────────────
+# Space thresholds trigger aggressive retention when exceeded.
+# uuid: Optional filesystem UUID for identity verification. Prevents sending
+# snapshots to the wrong drive if a different disk mounts at the expected path.
+# Run `findmnt -o UUID <mount_path>` to get the UUID of a mounted drive.
+
+[[drives]]
+label = "WD-18TB"
+uuid = "647693ed-490e-4c09-8816-189ba2baf03f"   # findmnt -o UUID <mount_path>
+mount_path = "/run/media/<user>/WD-18TB"
+snapshot_root = ".snapshots"
+role = "primary"
+max_usage_percent = 90
+min_free_bytes = "500GB"
+
+[[drives]]
+label = "WD-18TB1"
+# uuid = "..."                                   # Recommended: add UUID for safety
+mount_path = "/run/media/<user>/WD-18TB1"
+snapshot_root = ".snapshots"
+role = "offsite"
+max_usage_percent = 90
+min_free_bytes = "500GB"
+
+# ── Protection Promises ──────────────────────────────────────────────────
+#
+# Each subvolume declares a protection level that tells Urd what safety
+# guarantee you want. Urd derives snapshot/send intervals and retention
+# from the promise level + run_frequency.
+#
+# Levels (with daily timer):
+#   recorded  — local snapshots only, minimal retention (d:7, w:4)
+#   sheltered — local + 1 external drive, full retention
+#   fortified — local + 2+ external drives + offsite, full retention
+#   (no protection field) — custom: all fields set explicitly
+#
+# In v2, snapshot_root and min_free_bytes are inlined on each subvolume.
+# Each block is self-describing — no [local_snapshots] or [defaults].
+#
+# Retention schema:
+#   monthly = 12          one per calendar month, 12 months
+#   monthly = "unlimited" one per calendar month, indefinitely
+#   yearly  = 5           one per calendar year, 5 years
+#
+# Yearly is redundant when monthly = "unlimited" — the engine treats
+# it as 0 in that case, and `urd preflight` flags the combination.
+
+# ── Fortified: irreplaceable data on multiple drives ─────────────────────
+
+[[subvolumes]]
+name = "htpc-home"
+source = "/home"
+snapshot_root = "~/.snapshots"
+min_free_bytes = "10GB"
+priority = 1
+protection = "fortified"
+drives = ["WD-18TB", "WD-18TB1"]   # Active workstation — keep off small test drive
+
+[[subvolumes]]
+name = "subvol2-pics"
+source = "/mnt/btrfs-pool/subvol2-pics"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+min_free_bytes = "50GB"
+protection = "fortified"
+drives = ["WD-18TB", "WD-18TB1"]   # Photos are irreplaceable
+
+# ── Sheltered: important data on at least one drive ──────────────────────
+
+[[subvolumes]]
+name = "subvol1-docs"
+source = "/mnt/btrfs-pool/subvol1-docs"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+min_free_bytes = "50GB"
+short_name = "docs"
+protection = "sheltered"
+
+# ── Custom: unlimited monthly for archival data ──────────────────────────
+
+[[subvolumes]]
+name = "subvol3-archive"
+source = "/mnt/btrfs-pool/subvol3-archive"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+min_free_bytes = "50GB"
+short_name = "archive"
+snapshot_interval = "1d"
+send_interval = "1d"
+send_enabled = true
+drives = ["WD-18TB"]
+local_retention = { hourly = 0, daily = 30, weekly = 26, monthly = "unlimited" }
+external_retention = { daily = 30, weekly = 26, monthly = "unlimited" }
+
+# ── Custom: bounded monthly + yearly tier for project history ────────────
+
+[[subvolumes]]
+name = "subvol-projects"
+source = "/mnt/btrfs-pool/subvol-projects"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+min_free_bytes = "50GB"
+short_name = "projects"
+snapshot_interval = "1d"
+send_interval = "1d"
+send_enabled = true
+drives = ["WD-18TB"]
+local_retention = { hourly = 0, daily = 14, weekly = 8, monthly = 12, yearly = 5 }
+external_retention = { daily = 14, weekly = 8, monthly = 12, yearly = 5 }
+
+# ── Recorded: local snapshots only ───────────────────────────────────────
+
+[[subvolumes]]
+name = "subvol4-multimedia"
+source = "/mnt/btrfs-pool/subvol4-multimedia"
+snapshot_root = "/mnt/btrfs-pool/.snapshots"
+min_free_bytes = "50GB"
+short_name = "multimedia"
+priority = 3
+protection = "recorded"
+
+# ── External-only: NVMe root is too small for local history ─────────
+
+[[subvolumes]]
+name = "htpc-root"
+source = "/"
+snapshot_root = "~/.snapshots"
+min_free_bytes = "10GB"
+priority = 3
+local_snapshots = false
+snapshot_interval = "1d"
+send_interval = "1d"
+drives = ["WD-18TB1"]
+
+# ── Notifications ────────────────────────────────────────────────────────
+# Urd dispatches notifications when promise states change after a backup.
+# Channels receive notifications at or above the configured urgency threshold.
+# Urgency levels: "info" (recoveries), "warning" (degradations), "critical" (all broken).
+
+# [notifications]
+# enabled = true
+# min_urgency = "warning"
+#
+# [[notifications.channels]]
+# type = "desktop"                          # Uses notify-send
+#
+# [[notifications.channels]]
+# type = "webhook"
+# url = "https://ntfy.sh/my-backups"        # Any JSON-accepting endpoint
+#
+# [[notifications.channels]]
+# type = "command"
+# path = "/usr/local/bin/my-notify-script"  # Receives URD_NOTIFICATION_* env vars
+# args = ["--json"]
+#
+# [[notifications.channels]]
+# type = "log"                              # Writes to Urd's log file

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -2502,7 +2502,7 @@ mod tests {
         use crate::config::{DefaultsConfig, GeneralConfig, LocalSnapshotsConfig};
         use crate::types::RunFrequency;
         use crate::notify::NotificationConfig;
-        use crate::types::{GraduatedRetention, Interval};
+        use crate::types::{GraduatedRetention, Interval, MonthlyCount};
 
         Config {
             general: GeneralConfig {
@@ -2527,13 +2527,15 @@ mod tests {
                     hourly: Some(24),
                     daily: Some(30),
                     weekly: Some(26),
-                    monthly: Some(12),
+                    monthly: Some(MonthlyCount::Count(12)),
+                    yearly: None,
                 },
                 external_retention: GraduatedRetention {
                     hourly: None,
                     daily: Some(30),
                     weekly: Some(26),
-                    monthly: Some(0),
+                    monthly: Some(MonthlyCount::Unlimited),
+                    yearly: None,
                 },
             },
             subvolumes: vec![],

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -5,6 +5,7 @@ use crate::drives;
 use crate::output::{
     DoctorCheck, DoctorCheckStatus, DoctorDataSafety, DoctorOutput, DoctorRecommendationRow,
     DoctorRecommendationView, DoctorSentinelStatus, DoctorVerdict, InitStatus, OutputMode,
+    SchemaStatus,
 };
 use crate::plan::RealFileSystemState;
 use crate::policy::{self, ShapeRole};
@@ -276,11 +277,24 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         DoctorVerdict::healthy()
     };
 
+    // UPI 042 Branch G: surface a soft notice when loaded config is older
+    // than the current schema. Build SchemaStatus only when there's
+    // something to say (current < latest).
+    const LATEST_SCHEMA_VERSION: u32 = 2;
+    let schema_status = match config.general.config_version {
+        Some(v) if v >= LATEST_SCHEMA_VERSION => None,
+        current => Some(SchemaStatus {
+            current,
+            latest: LATEST_SCHEMA_VERSION,
+        }),
+    };
+
     let output = DoctorOutput {
         config_checks,
         infra_checks,
         data_safety,
         sentinel,
+        schema_status,
         verify: verify_output,
         churn: churn_view,
         recommendations: recommendation_view,

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -4,62 +4,79 @@ use std::path::{Path, PathBuf};
 use crate::cli::MigrateArgs;
 use crate::types::{DerivedPolicy, Interval, ProtectionLevel, RunFrequency};
 
-/// Run the `urd migrate` command: transform legacy config to v1 schema.
+/// Run the `urd migrate` command: transform legacy/v1 config → v2 schema.
+///
+/// Auto-targets the latest schema version (v2). Single hop:
+///   - config_version absent → legacy → v2
+///   - config_version = 1    → v1 → v2
+///   - config_version = 2    → no-op
 pub fn run(config_path: Option<&Path>, args: &MigrateArgs) -> anyhow::Result<()> {
     let path = resolve_config_path(config_path)?;
 
     let raw = std::fs::read_to_string(&path).map_err(|e| anyhow::anyhow!("{}: {e}", path.display()))?;
 
-    // Check if already v1
     let version = extract_version(&raw)?;
-    if version == Some(1) {
-        println!("  Config is already v1 schema. Nothing to migrate.");
-        return Ok(());
-    }
-    if let Some(n) = version {
-        anyhow::bail!("unsupported config_version {n} (supported: 1)");
-    }
+    let source_schema = match version {
+        Some(2) => {
+            println!("  Config is already v2 schema. Nothing to migrate.");
+            return Ok(());
+        }
+        Some(1) => "v1",
+        None => "legacy",
+        Some(n) => anyhow::bail!("unsupported config_version {n} (supported: 1, 2)"),
+    };
 
-    // Parse legacy config to extract structured data
-    let legacy: LegacyConfig = toml::from_str(&raw)
-        .map_err(|e| anyhow::anyhow!("failed to parse legacy config: {e}"))?;
+    // For both legacy and v1 sources, parse into the LegacyConfig shape and
+    // re-render as v2. The LegacyConfig fields are a superset that handles
+    // both schemas at the raw-TOML level (v1's per-subvolume snapshot_root
+    // is the only structural difference, and the renderer normalizes it).
+    //
+    // R3 architectural decision: structured parse-munge-render (loses
+    // comments, preserves semantics).
+    let legacy: LegacyConfig = if source_schema == "v1" {
+        // Parse v1 raw TOML through a LegacyConfig-shaped reader so the
+        // shared renderer works. v1's per-subvolume snapshot_root/min_free_bytes
+        // are read into a synthesized local_snapshots block by `legacy_from_v1`.
+        legacy_from_v1(&raw)?
+    } else {
+        toml::from_str(&raw)
+            .map_err(|e| anyhow::anyhow!("failed to parse legacy config: {e}"))?
+    };
 
-    // Build the migration result
     let result = build_migration(&legacy);
+    let v2_toml = render_v2(&legacy);
 
-    // Generate v1 TOML
-    let v1_toml = render_v1(&legacy);
+    let schema_label = format!("{source_schema} → v2");
 
     if args.dry_run {
         println!();
         println!("  urd migrate --dry-run");
         println!();
         println!("  Config: {}", path.display());
-        println!("  Schema: legacy → v1");
+        println!("  Schema: {schema_label}");
         println!();
         print_changes(&result);
         println!();
-        println!("  --- Generated v1 config ---");
+        println!("  --- Generated v2 config ---");
         println!();
-        print!("{v1_toml}");
+        print!("{v2_toml}");
         return Ok(());
     }
 
-    // Write backup
-    let backup_path = PathBuf::from(format!("{}.legacy", path.display()));
+    // Backup: .legacy for legacy → v2, .v1 for v1 → v2
+    let backup_suffix = if source_schema == "v1" { ".v1" } else { ".legacy" };
+    let backup_path = PathBuf::from(format!("{}{}", path.display(), backup_suffix));
     std::fs::copy(&path, &backup_path)
         .map_err(|e| anyhow::anyhow!("failed to create backup at {}: {e}", backup_path.display()))?;
 
-    // Write v1 config
-    std::fs::write(&path, &v1_toml)
-        .map_err(|e| anyhow::anyhow!("failed to write v1 config to {}: {e}", path.display()))?;
+    std::fs::write(&path, &v2_toml)
+        .map_err(|e| anyhow::anyhow!("failed to write v2 config to {}: {e}", path.display()))?;
 
-    // Print summary
     println!();
     println!("  urd migrate");
     println!();
     println!("  Config: {}", path.display());
-    println!("  Schema: legacy → v1");
+    println!("  Schema: {schema_label}");
     println!();
     print_changes(&result);
     println!();
@@ -98,7 +115,153 @@ fn extract_version(raw: &str) -> anyhow::Result<Option<u32>> {
     Ok(probe.general.and_then(|g| g.config_version))
 }
 
-// ── Legacy config structs (minimal, for migration) ─────────────────────
+// ── V1 raw config struct (for v1 → v2 path) ────────────────────────────
+
+#[derive(serde::Deserialize)]
+struct V1RawConfig {
+    general: V1RawGeneral,
+    #[serde(default)]
+    drives: Vec<LegacyDrive>,
+    #[serde(rename = "subvolumes", alias = "subvolume")]
+    subvolumes: Vec<V1RawSubvolume>,
+    #[serde(default)]
+    notifications: Option<toml::Value>,
+}
+
+#[derive(serde::Deserialize)]
+struct V1RawGeneral {
+    // config_version is read by extract_version() upstream and is silently
+    // ignored here (no deny_unknown_fields on this struct).
+    #[serde(default)]
+    state_db: Option<String>,
+    #[serde(default)]
+    metrics_file: Option<String>,
+    #[serde(default)]
+    log_dir: Option<String>,
+    #[serde(default)]
+    btrfs_path: Option<String>,
+    #[serde(default)]
+    heartbeat_file: Option<String>,
+    #[serde(default)]
+    run_frequency: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct V1RawSubvolume {
+    name: String,
+    #[serde(default)]
+    short_name: Option<String>,
+    source: String,
+    snapshot_root: String,
+    #[serde(default)]
+    min_free_bytes: Option<String>,
+    #[serde(default)]
+    priority: Option<u8>,
+    #[serde(default)]
+    protection: Option<String>,
+    #[serde(default)]
+    drives: Option<Vec<String>>,
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    snapshot_interval: Option<String>,
+    #[serde(default)]
+    send_interval: Option<String>,
+    #[serde(default)]
+    send_enabled: Option<bool>,
+    #[serde(default)]
+    local_snapshots: Option<bool>,
+    #[serde(default)]
+    local_retention: Option<toml::Value>,
+    #[serde(default)]
+    external_retention: Option<toml::Value>,
+}
+
+/// Read a v1 TOML config and reshape into LegacyConfig form so the v2
+/// renderer works uniformly. v1 carries `snapshot_root` per-subvolume; the
+/// returned LegacyConfig synthesizes a `local_snapshots.roots` list by
+/// grouping subvolumes by their `snapshot_root`.
+///
+/// `local_snapshots = false` on a v1 subvolume maps to `local_retention =
+/// "transient"` in the LegacyConfig view, since the v2 renderer already
+/// handles transient → `local_snapshots = false` in the output. Note that
+/// the v2 renderer doesn't need to know the source was v1.
+fn legacy_from_v1(raw: &str) -> anyhow::Result<LegacyConfig> {
+    let v1: V1RawConfig = toml::from_str(raw)
+        .map_err(|e| anyhow::anyhow!("failed to parse v1 config: {e}"))?;
+
+    // Group subvolumes by snapshot_root into LegacySnapshotRoot entries.
+    let mut roots_map: BTreeMap<String, (Vec<String>, Option<String>)> = BTreeMap::new();
+    for sv in &v1.subvolumes {
+        let entry = roots_map
+            .entry(sv.snapshot_root.clone())
+            .or_insert_with(|| (Vec::new(), None));
+        entry.0.push(sv.name.clone());
+        if entry.1.is_none() {
+            entry.1 = sv.min_free_bytes.clone();
+        }
+    }
+    let roots: Vec<LegacySnapshotRoot> = roots_map
+        .into_iter()
+        .map(|(path, (subvolumes, min_free_bytes))| LegacySnapshotRoot {
+            path,
+            subvolumes,
+            min_free_bytes,
+        })
+        .collect();
+
+    let subvolumes: Vec<LegacySubvolume> = v1
+        .subvolumes
+        .into_iter()
+        .map(|sv| {
+            // v1 `local_snapshots = false` → legacy "transient" via
+            // local_retention. The renderer downstream handles transient
+            // → `local_snapshots = false` on the v2 side.
+            let local_retention = if sv.local_snapshots == Some(false) {
+                Some(toml::Value::String("transient".to_string()))
+            } else {
+                sv.local_retention
+            };
+            LegacySubvolume {
+                name: sv.name,
+                short_name: sv.short_name,
+                source: sv.source,
+                priority: sv.priority,
+                protection_level: sv.protection,
+                drives: sv.drives,
+                enabled: sv.enabled,
+                snapshot_interval: sv.snapshot_interval,
+                send_interval: sv.send_interval,
+                send_enabled: sv.send_enabled,
+                local_retention,
+                external_retention: sv.external_retention,
+            }
+        })
+        .collect();
+
+    Ok(LegacyConfig {
+        general: LegacyGeneral {
+            state_db: v1.general.state_db,
+            metrics_file: v1.general.metrics_file,
+            log_dir: v1.general.log_dir,
+            btrfs_path: v1.general.btrfs_path,
+            heartbeat_file: v1.general.heartbeat_file,
+            run_frequency: v1.general.run_frequency,
+        },
+        local_snapshots: LegacyLocalSnapshots { roots },
+        defaults: None, // v1 has no [defaults] block — pull from synthesized v1 defaults
+        drives: v1.drives,
+        subvolumes,
+        notifications: v1.notifications,
+    })
+}
+
+// ── Migration source structs ───────────────────────────────────────────
+//
+// `LegacyConfig` is the raw-TOML view that the v2 renderer reads. It mirrors
+// the legacy schema (top-level `[local_snapshots]` + per-subvolume fields).
+// V1 input is reshaped into this form by `legacy_from_v1` before rendering,
+// so the same renderer handles both paths.
 
 #[derive(serde::Deserialize)]
 struct LegacyConfig {
@@ -443,13 +606,22 @@ fn retention_matches_resolved(
         let hourly = t.get("hourly").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
         let daily = t.get("daily").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
         let weekly = t.get("weekly").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
-        let monthly = t.get("monthly").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
+        let monthly_raw = t.get("monthly").and_then(|v| v.as_integer()).unwrap_or(0) as u32;
+        let monthly_mc = legacy_monthly_to_monthly_count(monthly_raw);
         hourly == resolved.hourly
             && daily == resolved.daily
             && weekly == resolved.weekly
-            && monthly == resolved.monthly
+            && monthly_mc == resolved.monthly
     } else {
         false
+    }
+}
+
+fn legacy_monthly_to_monthly_count(n: u32) -> crate::types::MonthlyCount {
+    if n == 0 {
+        crate::types::MonthlyCount::Unlimited
+    } else {
+        crate::types::MonthlyCount::Count(n)
     }
 }
 
@@ -489,9 +661,9 @@ fn has_operational_overrides(sv: &LegacySubvolume) -> bool {
         || sv.local_retention.is_some()
 }
 
-// ── Render v1 TOML ─────────────────────────────────────────────────────
+// ── Render v2 TOML ─────────────────────────────────────────────────────
 
-fn render_v1(legacy: &LegacyConfig) -> String {
+fn render_v2(legacy: &LegacyConfig) -> String {
     let mut out = String::new();
 
     // [general]
@@ -519,7 +691,7 @@ fn render_v1(legacy: &LegacyConfig) -> String {
 
 fn render_general(out: &mut String, general: &LegacyGeneral) {
     out.push_str("[general]\n");
-    out.push_str("config_version = 1\n");
+    out.push_str("config_version = 2\n");
 
     // run_frequency: always emit if present and not "daily" (the default)
     if let Some(ref freq) = general.run_frequency {
@@ -787,7 +959,10 @@ fn merge_retention_with_derived(
         hourly: get_u32(table, "hourly").unwrap_or(derived.hourly),
         daily: get_u32(table, "daily").unwrap_or(derived.daily),
         weekly: get_u32(table, "weekly").unwrap_or(derived.weekly),
-        monthly: get_u32(table, "monthly").unwrap_or(derived.monthly),
+        monthly: get_u32(table, "monthly")
+            .map(legacy_monthly_to_monthly_count)
+            .unwrap_or(derived.monthly),
+        yearly: get_u32(table, "yearly").unwrap_or(derived.yearly),
     }
 }
 
@@ -802,15 +977,31 @@ fn render_resolved_retention(
     field: &str,
     ret: &crate::types::ResolvedGraduatedRetention,
 ) {
-    // Always emit all four fields explicitly. In v1 custom subvolumes, missing
-    // fields merge with synthesized defaults (hourly=24, weekly=26), so omitting
-    // e.g. hourly=0 would silently inherit a non-zero value.
-    let parts = [
+    // Always emit hourly/daily/weekly explicitly. In v2 custom subvolumes,
+    // missing fields merge with synthesized defaults (hourly=24, weekly=26),
+    // so omitting e.g. hourly=0 would silently inherit a non-zero value.
+    //
+    // For monthly: v2 rejects literal `monthly = 0`, so when the value is
+    // Count(0) ("no monthly retention"), we OMIT the field — v2's parser
+    // defaults to Count(0). For Count(n>0) emit `monthly = n`. For
+    // Unlimited emit `monthly = "unlimited"`.
+    let mut parts = vec![
         format!("hourly = {}", ret.hourly),
         format!("daily = {}", ret.daily),
         format!("weekly = {}", ret.weekly),
-        format!("monthly = {}", ret.monthly),
     ];
+    // v2 rejects literal `monthly = 0`, so Count(0) ("no monthly retention")
+    // must be omitted — v2's parser defaults to Count(0).
+    match ret.monthly {
+        crate::types::MonthlyCount::Count(0) => {}
+        crate::types::MonthlyCount::Count(n) => parts.push(format!("monthly = {n}")),
+        crate::types::MonthlyCount::Unlimited => {
+            parts.push("monthly = \"unlimited\"".to_string());
+        }
+    }
+    if ret.yearly > 0 {
+        parts.push(format!("yearly = {}", ret.yearly));
+    }
     out.push_str(&format!("{field} = {{ {} }}\n", parts.join(", ")));
 }
 
@@ -821,8 +1012,28 @@ fn render_retention_field(out: &mut String, field: &str, value: &toml::Value) {
         }
         toml::Value::Table(t) => {
             // Inline table: { daily = 7, weekly = 4, ... }
-            let parts: Vec<String> = t.iter()
-                .map(|(k, v)| format!("{k} = {v}"))
+            // v2 semantic translation: `monthly = 0` (legacy/v1 semantic for
+            // "unlimited") is rewritten as `monthly = "unlimited"` (v2 syntax).
+            // Step 2.5 / R3: structured rewrite handles all v1 wire forms,
+            // including the inline-table case the regex approach would miss.
+            let parts: Vec<String> = t
+                .iter()
+                .map(|(k, v)| {
+                    if k == "monthly" {
+                        if let Some(i) = v.as_integer() {
+                            if i == 0 {
+                                return "monthly = \"unlimited\"".to_string();
+                            }
+                            return format!("monthly = {i}");
+                        }
+                        if let Some(s) = v.as_str()
+                            && s == "unlimited"
+                        {
+                            return "monthly = \"unlimited\"".to_string();
+                        }
+                    }
+                    format!("{k} = {v}")
+                })
                 .collect();
             out.push_str(&format!("{field} = {{ {} }}\n", parts.join(", ")));
         }
@@ -969,7 +1180,13 @@ drives = ["WD-18TB", "WD-18TB1"]
     }
 
     #[test]
-    fn migrate_detects_already_v1() {
+    fn migrate_detects_already_v2() {
+        let v2 = "[general]\nconfig_version = 2\n\n[[subvolumes]]\nname = \"test\"\nsource = \"/test\"\nsnapshot_root = \"/snap\"\n";
+        assert_eq!(extract_version(v2).unwrap(), Some(2));
+    }
+
+    #[test]
+    fn migrate_detects_v1_to_migrate() {
         let v1 = "[general]\nconfig_version = 1\n\n[[subvolumes]]\nname = \"test\"\nsource = \"/test\"\nsnapshot_root = \"/snap\"\n";
         assert_eq!(extract_version(v1).unwrap(), Some(1));
     }
@@ -1014,7 +1231,7 @@ drives = ["WD-18TB", "WD-18TB1"]
     fn migrate_inlines_snapshot_root() {
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         // All subvolumes should have snapshot_root
         assert!(v1.contains("snapshot_root = \"~/.snapshots\""));
@@ -1027,7 +1244,7 @@ drives = ["WD-18TB", "WD-18TB1"]
     fn migrate_inlines_min_free_bytes() {
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         assert!(v1.contains("min_free_bytes = \"10GB\""));
         assert!(v1.contains("min_free_bytes = \"50GB\""));
@@ -1063,7 +1280,7 @@ snapshot_interval = "1w"
 "#;
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
         let _result = build_migration(&legacy);
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         // Should NOT have protection = "recorded"
         assert!(!v1.contains("protection = \"recorded\""), "should not keep named level with overrides");
@@ -1081,16 +1298,16 @@ snapshot_interval = "1w"
     fn migrate_output_has_config_version() {
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
-        assert!(v1.contains("config_version = 1"));
+        assert!(v1.contains("config_version = 2"));
     }
 
     #[test]
     fn migrate_preserves_drives() {
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         assert!(v1.contains("label = \"WD-18TB\""));
         assert!(v1.contains("uuid = \"647693ed"));
@@ -1102,7 +1319,7 @@ snapshot_interval = "1w"
         // htpc-root has transient + send_interval, but no named level (custom)
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         assert!(!v1.contains("local_retention = \"transient\""),
             "transient should not appear in v1 output");
@@ -1114,7 +1331,7 @@ snapshot_interval = "1w"
     fn migrate_omits_default_priority() {
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         // "docs" has priority 2 (default) — should not appear
         // We need to check that the docs subvolume block doesn't have priority
@@ -1128,7 +1345,7 @@ snapshot_interval = "1w"
     fn migrate_keeps_non_default_priority() {
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         // "htpc-home" has priority 1 — should appear
         let home_block = v1.split("[[subvolumes]]")
@@ -1138,25 +1355,25 @@ snapshot_interval = "1w"
     }
 
     #[test]
-    fn migrate_roundtrip_v1_parses() {
+    fn migrate_roundtrip_v2_parses() {
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1_toml = render_v1(&legacy);
+        let v2_toml = render_v2(&legacy);
 
-        // The generated v1 should parse successfully as a v1 config
-        let version = extract_version(&v1_toml).unwrap();
-        assert_eq!(version, Some(1), "generated config should be v1");
+        // The generated config should parse successfully as v2
+        let version = extract_version(&v2_toml).unwrap();
+        assert_eq!(version, Some(2), "generated config should be v2");
 
         // Parse through the real config loader to verify structural validity
-        let result = crate::config::Config::from_str(&v1_toml);
-        assert!(result.is_ok(), "v1 config should parse: {}", result.unwrap_err());
+        let result = crate::config::Config::from_str(&v2_toml);
+        assert!(result.is_ok(), "v2 config should parse: {}", result.unwrap_err());
     }
 
     #[test]
     fn migrate_no_defaults_section() {
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         // Should not have [defaults] as a TOML section header (comments with "defaults" are ok)
         assert!(!v1.contains("\n[defaults]"), "v1 should not have [defaults] section");
@@ -1167,13 +1384,13 @@ snapshot_interval = "1w"
         let toml = example_legacy_toml();
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
         let _result = build_migration(&legacy);
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         assert!(!v1.is_empty());
     }
 
     #[test]
-    fn migrate_writes_backup_and_v1() {
+    fn migrate_legacy_writes_backup_and_v2() {
         let dir = tempfile::TempDir::new().unwrap();
         let config_path = dir.path().join("urd.toml");
         let backup_path = dir.path().join("urd.toml.legacy");
@@ -1184,25 +1401,26 @@ snapshot_interval = "1w"
         let result = run(Some(config_path.as_path()), &args);
         assert!(result.is_ok(), "migrate should succeed: {:?}", result.err());
 
-        // Backup should exist with original content
+        // .legacy backup should exist with original content
         assert!(backup_path.exists(), "backup file should be created");
         let backup_content = std::fs::read_to_string(&backup_path).unwrap();
         assert!(backup_content.contains("[local_snapshots]"), "backup should be the original legacy");
 
-        // Main config should be v1
-        let v1_content = std::fs::read_to_string(&config_path).unwrap();
-        assert!(v1_content.contains("config_version = 1"), "main config should be v1");
-        assert!(!v1_content.contains("\n[local_snapshots]"), "v1 should not have local_snapshots");
+        // Main config should be v2
+        let v2_content = std::fs::read_to_string(&config_path).unwrap();
+        assert!(v2_content.contains("config_version = 2"), "main config should be v2");
+        assert!(!v2_content.contains("\n[local_snapshots]"), "v2 should not have local_snapshots section");
     }
 
     #[test]
-    fn migrate_already_v1_is_noop() {
+    fn migrate_already_v2_is_noop() {
         let dir = tempfile::TempDir::new().unwrap();
         let config_path = dir.path().join("urd.toml");
-        let v1_content = "[general]\nconfig_version = 1\n\n\
+        let v2_content = "[general]\nconfig_version = 2\n\
+             \n\
              [[drives]]\nlabel = \"D\"\nmount_path = \"/mnt/d\"\nsnapshot_root = \".snap\"\nrole = \"offsite\"\n\n\
              [[subvolumes]]\nname = \"test\"\nsource = \"/test\"\nsnapshot_root = \"/snap\"\n";
-        std::fs::write(&config_path, v1_content).unwrap();
+        std::fs::write(&config_path, v2_content).unwrap();
 
         let args = MigrateArgs { dry_run: false };
         let result = run(Some(config_path.as_path()), &args);
@@ -1210,11 +1428,98 @@ snapshot_interval = "1w"
 
         // Content should be unchanged
         let after = std::fs::read_to_string(&config_path).unwrap();
-        assert_eq!(after, v1_content, "v1 config should not be modified");
+        assert_eq!(after, v2_content, "v2 config should not be modified");
 
         // No backup should be created
-        let backup_path = dir.path().join("urd.toml.legacy");
-        assert!(!backup_path.exists(), "no backup for already-v1");
+        let backup_legacy = dir.path().join("urd.toml.legacy");
+        let backup_v1 = dir.path().join("urd.toml.v1");
+        assert!(!backup_legacy.exists(), "no .legacy backup for already-v2");
+        assert!(!backup_v1.exists(), "no .v1 backup for already-v2");
+    }
+
+    #[test]
+    fn migrate_v1_to_v2_replaces_monthly_zero_in_inline_table() {
+        // R3: structured rewrite handles inline-table v1 form
+        //   local_retention = { hourly = 24, daily = 30, weekly = 26, monthly = 0 }
+        // The dropped regex approach would have missed this; structured
+        // parse-munge-render handles it naturally via render_retention_field.
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("urd.toml");
+        let v1_toml = r#"[general]
+config_version = 1
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp/logs"
+run_frequency = "daily"
+
+[[drives]]
+label = "D"
+mount_path = "/mnt/d"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/sv"
+snapshot_root = "/snap"
+local_retention = { hourly = 24, daily = 30, weekly = 26, monthly = 0 }
+"#;
+        std::fs::write(&config_path, v1_toml).unwrap();
+
+        let args = MigrateArgs { dry_run: false };
+        run(Some(config_path.as_path()), &args).expect("migrate should succeed");
+
+        let v2_content = std::fs::read_to_string(&config_path).unwrap();
+        assert!(
+            v2_content.contains("config_version = 2"),
+            "v2 output should have config_version = 2"
+        );
+        assert!(
+            v2_content.contains("monthly = \"unlimited\""),
+            "inline-table monthly = 0 should be rewritten as monthly = \"unlimited\":\n{v2_content}"
+        );
+        assert!(
+            !v2_content.contains("monthly = 0"),
+            "no literal monthly = 0 should remain"
+        );
+
+        // .v1 backup should exist
+        let backup_v1 = dir.path().join("urd.toml.v1");
+        assert!(backup_v1.exists(), ".v1 backup should be written for v1 → v2");
+        let backup_content = std::fs::read_to_string(&backup_v1).unwrap();
+        assert_eq!(backup_content, v1_toml, ".v1 backup must match input byte-for-byte");
+    }
+
+    #[test]
+    fn migrate_v1_to_v2_parses_clean_v2() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("urd.toml");
+        let v1_toml = r#"[general]
+config_version = 1
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp/logs"
+run_frequency = "daily"
+
+[[drives]]
+label = "D"
+mount_path = "/mnt/d"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/sv"
+snapshot_root = "/snap"
+protection = "sheltered"
+"#;
+        std::fs::write(&config_path, v1_toml).unwrap();
+        let args = MigrateArgs { dry_run: false };
+        run(Some(config_path.as_path()), &args).expect("migrate should succeed");
+
+        let v2_content = std::fs::read_to_string(&config_path).unwrap();
+        crate::config::Config::from_str(&v2_content)
+            .expect("migrated v2 must re-parse cleanly");
     }
 
     #[test]
@@ -1253,7 +1558,7 @@ snapshot_interval = "1w"
 "#;
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
         let _result = build_migration(&legacy);
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         // Should have baked all operational fields since it's converted to custom
         let test_block = v1.split("[[subvolumes]]")
@@ -1277,7 +1582,7 @@ snapshot_interval = "1w"
         let legacy_resolved = legacy_config.resolved_subvolumes();
 
         let legacy: LegacyConfig = toml::from_str(toml_str).unwrap();
-        let v1_toml = render_v1(&legacy);
+        let v1_toml = render_v2(&legacy);
 
         let v1_config = crate::config::Config::from_str(&v1_toml)
             .expect("v1 config should parse");
@@ -1314,9 +1619,9 @@ snapshot_interval = "1w"
     #[test]
     fn migrate_partial_retention_override_bakes_all_fields() {
         // Regression: a subvolume with a named level and partial local_retention
-        // override (e.g., { daily = 7 } on recorded) must bake ALL four retention
+        // override (e.g., { daily = 30 } on sheltered) must bake ALL four retention
         // fields. Without this, missing fields (hourly, monthly) would inherit from
-        // v1's synthesized defaults instead of the derived level's values.
+        // synthesized defaults instead of the derived level's values.
         let toml = r#"
 [general]
 state_db = "~/.local/share/urd/urd.db"
@@ -1345,22 +1650,22 @@ role = "primary"
 name = "cache"
 short_name = "cache"
 source = "/cache"
-protection_level = "guarded"
-local_retention = { daily = 7 }
+protection_level = "protected"
+local_retention = { daily = 14 }
 "#;
-        // Legacy resolves: merge { daily = 7 } with derive_policy(Recorded, Daily)
-        // → { hourly: 0, daily: 7, weekly: 4, monthly: 0 }
+        // Legacy resolves: merge { daily = 14 } with derive_policy(Sheltered, Daily)
+        // → { hourly: 24, daily: 14, weekly: 26, monthly: Count(12), yearly: 0 }
         let legacy_config = crate::config::Config::from_str(toml)
             .expect("legacy config should parse");
         let legacy_resolved = legacy_config.resolved_subvolumes();
         let legacy_cache = legacy_resolved.iter().find(|s| s.name == "cache").unwrap();
         let legacy_lr = legacy_cache.local_retention.as_graduated().unwrap();
-        assert_eq!(legacy_lr.weekly, 4, "legacy should merge weekly from derived");
-        assert_eq!(legacy_lr.hourly, 0, "legacy should merge hourly from derived");
+        assert_eq!(legacy_lr.weekly, 26, "legacy should merge weekly from derived");
+        assert_eq!(legacy_lr.hourly, 24, "legacy should merge hourly from derived");
 
         // Migrate and check v1 resolves identically
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1_toml = render_v1(&legacy);
+        let v1_toml = render_v2(&legacy);
 
         let v1_config = crate::config::Config::from_str(&v1_toml)
             .expect("v1 config should parse");
@@ -1404,7 +1709,7 @@ snapshot_interval = "1d"
 "#;
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
         let _result = build_migration(&legacy);
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         // Should keep the named level (no conversion) since override matches derived
         assert!(v1.contains("protection = \"recorded\""),
@@ -1447,7 +1752,7 @@ local_retention = "transient"
 drives = ["D"]
 "#;
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         assert!(v1.contains("local_snapshots = false"),
             "should have local_snapshots = false");
@@ -1493,7 +1798,7 @@ protection_level = "sheltered"
 local_retention = "transient"
 "#;
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         let test_block = v1.split("[[subvolumes]]")
             .find(|block| block.contains("name = \"test\""))
@@ -1552,7 +1857,7 @@ local_retention = "transient"
 snapshot_interval = "1w"
 "#;
         let legacy: LegacyConfig = toml::from_str(toml).unwrap();
-        let v1 = render_v1(&legacy);
+        let v1 = render_v2(&legacy);
 
         let test_block = v1.split("[[subvolumes]]")
             .find(|block| block.contains("name = \"test\""))

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use crate::error::UrdError;
 use crate::notify::NotificationConfig;
 use crate::types::{
     ByteSize, DriveRole, GraduatedRetention, Interval, LocalRetentionConfig, LocalRetentionPolicy,
-    ProtectionLevel, ResolvedGraduatedRetention, RunFrequency,
+    MonthlyCount, ProtectionLevel, ResolvedGraduatedRetention, RunFrequency,
 };
 
 // ── Top-level config ────────────────────────────────────────────────────
@@ -177,6 +177,7 @@ impl SubvolumeConfig {
                             daily: Some(policy.local_retention.daily),
                             weekly: Some(policy.local_retention.weekly),
                             monthly: Some(policy.local_retention.monthly),
+                            yearly: Some(policy.local_retention.yearly),
                         };
                         LocalRetentionPolicy::Graduated(
                             lr.merged_with(&derived_as_graduated).resolved(),
@@ -191,6 +192,7 @@ impl SubvolumeConfig {
                             daily: Some(policy.external_retention.daily),
                             weekly: Some(policy.external_retention.weekly),
                             monthly: Some(policy.external_retention.monthly),
+                            yearly: Some(policy.external_retention.yearly),
                         };
                         er.merged_with(&derived_as_graduated).resolved()
                     }
@@ -279,9 +281,11 @@ impl Config {
                 .map_err(|e| UrdError::Config(format!("{config_path:?}: {e}")))?,
             Some(1) => parse_v1(&contents)
                 .map_err(|e| UrdError::Config(format!("{config_path:?}: {e}")))?,
+            Some(2) => parse_v2(&contents)
+                .map_err(|e| UrdError::Config(format!("{config_path:?}: {e}")))?,
             Some(n) => {
                 return Err(UrdError::Config(format!(
-                    "{config_path:?}: unsupported config_version {n} (supported: 1)"
+                    "{config_path:?}: unsupported config_version {n} (supported: 1, 2)"
                 )));
             }
         };
@@ -300,7 +304,12 @@ impl Config {
         let mut config = match version {
             None => parse_legacy(raw)?,
             Some(1) => parse_v1(raw)?,
-            Some(n) => return Err(format!("unsupported config_version {n} (supported: 1)")),
+            Some(2) => parse_v2(raw)?,
+            Some(n) => {
+                return Err(format!(
+                    "unsupported config_version {n} (supported: 1, 2)"
+                ));
+            }
         };
         config.expand_paths();
         config.validate().map_err(|e| e.to_string())?;
@@ -519,6 +528,11 @@ impl Config {
 }
 
 // ── V1 config structs ──────────────────────────────────────────────────
+//
+// v1 reuses the shared `LocalRetentionConfig` / `GraduatedRetention` types.
+// The lenient `MonthlyCount::Deserialize` maps integer `0 → Unlimited`,
+// preserving the v1 wire semantic that `monthly = 0` means "unbounded".
+// (V2 boundary uses `deserialize_monthly_count_strict_opt` to reject `0`.)
 
 #[derive(Debug, Deserialize)]
 struct V1Config {
@@ -630,13 +644,15 @@ impl V1Config {
                 hourly: Some(24),
                 daily: Some(30),
                 weekly: Some(26),
-                monthly: Some(12),
+                monthly: Some(MonthlyCount::Count(12)),
+                yearly: None,
             },
             external_retention: GraduatedRetention {
                 hourly: None,
                 daily: Some(30),
                 weekly: Some(26),
-                monthly: Some(0),
+                monthly: Some(MonthlyCount::Unlimited),
+                yearly: None,
             },
         };
 
@@ -877,6 +893,358 @@ fn parse_v1(raw: &str) -> Result<Config, String> {
     Ok(v1.into_config())
 }
 
+// ── V2 wire types (UPI 042) ─────────────────────────────────────────────
+//
+// v2 closes the `monthly = 0` footgun: the v2 wire format uses strict
+// monthly deserialization (rejects integer `0`) via
+// `deserialize_monthly_count_strict_opt`. New `yearly: Option<u32>` field
+// on retention blocks. v2 also accepts `monthly = "unlimited"` (string)
+// for unbounded monthly retention.
+
+#[derive(Debug, Deserialize)]
+struct V2GraduatedRetention {
+    #[serde(default)]
+    hourly: Option<u32>,
+    #[serde(default)]
+    daily: Option<u32>,
+    #[serde(default)]
+    weekly: Option<u32>,
+    #[serde(
+        default,
+        deserialize_with = "crate::types::deserialize_monthly_count_strict_opt"
+    )]
+    monthly: Option<MonthlyCount>,
+    #[serde(default)]
+    yearly: Option<u32>,
+}
+
+#[derive(Debug)]
+enum V2LocalRetentionConfig {
+    Transient,
+    Graduated(V2GraduatedRetention),
+}
+
+impl<'de> Deserialize<'de> for V2LocalRetentionConfig {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::{self, Visitor};
+        use std::fmt;
+
+        struct V2LocalRetentionVisitor;
+
+        impl<'de> Visitor<'de> for V2LocalRetentionVisitor {
+            type Value = V2LocalRetentionConfig;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str(
+                    "\"transient\" or a table with hourly/daily/weekly/monthly/yearly fields",
+                )
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                if value == "transient" {
+                    Ok(V2LocalRetentionConfig::Transient)
+                } else {
+                    Err(de::Error::custom(format!(
+                        "unknown local_retention mode \"{value}\": expected \"transient\" or a retention table"
+                    )))
+                }
+            }
+
+            fn visit_map<M: de::MapAccess<'de>>(self, map: M) -> Result<Self::Value, M::Error> {
+                let g = V2GraduatedRetention::deserialize(
+                    de::value::MapAccessDeserializer::new(map),
+                )?;
+                Ok(V2LocalRetentionConfig::Graduated(g))
+            }
+        }
+
+        deserializer.deserialize_any(V2LocalRetentionVisitor)
+    }
+}
+
+impl V2GraduatedRetention {
+    fn into_graduated(self) -> GraduatedRetention {
+        GraduatedRetention {
+            hourly: self.hourly,
+            daily: self.daily,
+            weekly: self.weekly,
+            monthly: self.monthly,
+            yearly: self.yearly,
+        }
+    }
+}
+
+impl V2LocalRetentionConfig {
+    fn into_local_retention_config(self) -> LocalRetentionConfig {
+        match self {
+            V2LocalRetentionConfig::Transient => LocalRetentionConfig::Transient,
+            V2LocalRetentionConfig::Graduated(g) => {
+                LocalRetentionConfig::Graduated(g.into_graduated())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct V2Config {
+    general: V2GeneralConfig,
+    #[serde(default)]
+    drives: Vec<DriveConfig>,
+    #[serde(rename = "subvolumes", alias = "subvolume")]
+    subvolumes: Vec<V2SubvolumeConfig>,
+    #[serde(default)]
+    notifications: NotificationConfig,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2GeneralConfig {
+    config_version: u32,
+    #[serde(default = "default_run_frequency")]
+    run_frequency: RunFrequency,
+    #[serde(default = "default_v1_state_db")]
+    state_db: PathBuf,
+    #[serde(default = "default_v1_metrics_file")]
+    metrics_file: PathBuf,
+    #[serde(default = "default_v1_log_dir")]
+    log_dir: PathBuf,
+    #[serde(default = "default_btrfs_path")]
+    btrfs_path: String,
+    #[serde(default = "default_heartbeat_path")]
+    heartbeat_file: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct V2SubvolumeConfig {
+    name: String,
+    source: PathBuf,
+    snapshot_root: PathBuf,
+    #[serde(default)]
+    short_name: Option<String>,
+    #[serde(default = "default_priority")]
+    priority: u8,
+    #[serde(default)]
+    protection: Option<ProtectionLevel>,
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    drives: Option<Vec<String>>,
+    #[serde(default)]
+    min_free_bytes: Option<ByteSize>,
+    #[serde(default)]
+    snapshot_interval: Option<Interval>,
+    #[serde(default)]
+    send_interval: Option<Interval>,
+    #[serde(default)]
+    send_enabled: Option<bool>,
+    #[serde(default)]
+    local_snapshots: Option<bool>,
+    #[serde(default)]
+    local_retention: Option<V2LocalRetentionConfig>,
+    #[serde(default)]
+    external_retention: Option<V2GraduatedRetention>,
+}
+
+impl V2Config {
+    /// Convert v2 config into the internal Config representation. Mirrors
+    /// `V1Config::into_config()` shape.
+    fn into_config(self) -> Config {
+        let mut root_map: std::collections::BTreeMap<PathBuf, (Vec<String>, Option<ByteSize>)> =
+            std::collections::BTreeMap::new();
+        for sv in &self.subvolumes {
+            let entry = root_map
+                .entry(sv.snapshot_root.clone())
+                .or_insert_with(|| (Vec::new(), None));
+            entry.0.push(sv.name.clone());
+            if entry.1.is_none() {
+                entry.1 = sv.min_free_bytes;
+            }
+        }
+        let roots: Vec<SnapshotRoot> = root_map
+            .into_iter()
+            .map(|(path, (subvolumes, min_free_bytes))| SnapshotRoot {
+                path,
+                subvolumes,
+                min_free_bytes,
+            })
+            .collect();
+
+        // Fallback defaults for v2 Custom/unset protection levels. Values
+        // mirror full_retention / full_external_retention from derive_policy.
+        let defaults = DefaultsConfig {
+            snapshot_interval: Interval::days(1),
+            send_interval: Interval::days(1),
+            send_enabled: true,
+            enabled: true,
+            local_retention: GraduatedRetention {
+                hourly: Some(24),
+                daily: Some(30),
+                weekly: Some(26),
+                monthly: Some(MonthlyCount::Count(12)),
+                yearly: None,
+            },
+            external_retention: GraduatedRetention {
+                hourly: None,
+                daily: Some(30),
+                weekly: Some(26),
+                monthly: Some(MonthlyCount::Unlimited),
+                yearly: None,
+            },
+        };
+
+        let subvolumes: Vec<SubvolumeConfig> = self
+            .subvolumes
+            .into_iter()
+            .map(|sv| {
+                let local_retention = if sv.local_snapshots == Some(false) {
+                    Some(LocalRetentionConfig::Transient)
+                } else {
+                    sv.local_retention.map(V2LocalRetentionConfig::into_local_retention_config)
+                };
+                SubvolumeConfig {
+                    short_name: sv.short_name.unwrap_or_else(|| sv.name.clone()),
+                    name: sv.name,
+                    source: sv.source,
+                    priority: sv.priority,
+                    enabled: sv.enabled,
+                    snapshot_interval: sv.snapshot_interval,
+                    send_interval: sv.send_interval,
+                    send_enabled: sv.send_enabled,
+                    local_retention,
+                    external_retention: sv
+                        .external_retention
+                        .map(V2GraduatedRetention::into_graduated),
+                    protection_level: sv.protection,
+                    drives: sv.drives,
+                }
+            })
+            .collect();
+
+        Config {
+            general: GeneralConfig {
+                config_version: Some(self.general.config_version),
+                state_db: self.general.state_db,
+                metrics_file: self.general.metrics_file,
+                log_dir: self.general.log_dir,
+                btrfs_path: self.general.btrfs_path,
+                heartbeat_file: self.general.heartbeat_file,
+                run_frequency: self.general.run_frequency,
+            },
+            local_snapshots: LocalSnapshotsConfig { roots },
+            defaults,
+            drives: self.drives,
+            subvolumes,
+            notifications: self.notifications,
+        }
+    }
+
+    /// Validate v2-specific rules. Same shape as V1::validate_v1.
+    /// Per R6, the unlimited+yearly redundancy check lives in preflight.rs,
+    /// not here — validate_v2 stays `Result<(), String>`.
+    fn validate_v2(&self) -> Result<(), String> {
+        for sv in &self.subvolumes {
+            let level = sv.protection.unwrap_or(ProtectionLevel::Custom);
+
+            // Rule 1: Reject local_retention = "transient" universally
+            if matches!(sv.local_retention, Some(V2LocalRetentionConfig::Transient)) {
+                return Err(format!(
+                    "subvolume {:?}: local_retention = \"transient\" is not supported in v2 \
+                     — use local_snapshots = false instead.",
+                    sv.name
+                ));
+            }
+
+            // Rule 2: Mutual exclusion — local_snapshots = false + local_retention
+            if sv.local_snapshots == Some(false) && sv.local_retention.is_some() {
+                return Err(format!(
+                    "subvolume {:?}: local_snapshots = false and local_retention are mutually \
+                     exclusive — when local_snapshots is disabled, there is nothing to retain.",
+                    sv.name
+                ));
+            }
+
+            // Named levels must not have operational overrides
+            if level != ProtectionLevel::Custom {
+                let forbidden = [
+                    ("snapshot_interval", sv.snapshot_interval.is_some()),
+                    ("send_interval", sv.send_interval.is_some()),
+                    ("send_enabled", sv.send_enabled.is_some()),
+                    ("external_retention", sv.external_retention.is_some()),
+                ];
+                for (field, is_set) in &forbidden {
+                    if *is_set {
+                        return Err(format!(
+                            "subvolume {:?}: {field} cannot be set alongside \
+                             protection = \"{level}\" — the protection level controls this field. \
+                             Use protection = \"custom\" for manual control.",
+                            sv.name
+                        ));
+                    }
+                }
+
+                if sv.local_snapshots == Some(false) {
+                    return Err(format!(
+                        "subvolume {:?}: local_snapshots = false is incompatible with \
+                         protection = \"{level}\" — named levels require local snapshots. \
+                         Remove the protection field for custom configuration.",
+                        sv.name
+                    ));
+                }
+
+                if sv.local_retention.is_some() {
+                    return Err(format!(
+                        "subvolume {:?}: local_retention cannot be set alongside \
+                         protection = \"{level}\" — the protection level controls this field. \
+                         Use protection = \"custom\" for manual control.",
+                        sv.name
+                    ));
+                }
+            }
+
+            let has_any_drives = match sv.drives {
+                Some(ref d) => !d.is_empty(),
+                None => !self.drives.is_empty(),
+            };
+            if sv.local_snapshots == Some(false) && !has_any_drives {
+                return Err(format!(
+                    "subvolume {:?}: local_snapshots = false requires at least one drive \
+                     — without local snapshots or external sends, nothing is being backed up.",
+                    sv.name
+                ));
+            }
+
+            if let Some(ref d) = sv.drives
+                && d.is_empty()
+                && matches!(
+                    level,
+                    ProtectionLevel::Sheltered | ProtectionLevel::Fortified
+                )
+            {
+                return Err(format!(
+                    "subvolume {:?}: protection = \"{level}\" requires drives for \
+                     external backups, but drives is an empty list.",
+                    sv.name
+                ));
+            }
+
+            if level == ProtectionLevel::Sheltered && !has_any_drives {
+                return Err(format!(
+                    "subvolume {:?}: protection = \"sheltered\" requires at least one \
+                     configured drive for external backups.",
+                    sv.name
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Parse v2 config (config_version = 2).
+fn parse_v2(raw: &str) -> Result<Config, String> {
+    let v2: V2Config = toml::from_str(raw).map_err(|e| e.to_string())?;
+    v2.validate_v2()?;
+    Ok(v2.into_config())
+}
+
 // ── Utilities ───────────────────────────────────────────────────────────
 
 /// Expand `~` at the start of a path to the user's home directory.
@@ -1040,7 +1408,7 @@ send_interval = "2h"
         assert_eq!(resolved2.snapshot_interval, Interval::hours(1));
         let lr2 = resolved2.local_retention.as_graduated().unwrap();
         assert_eq!(lr2.weekly, 26);
-        assert_eq!(lr2.monthly, 12);
+        assert_eq!(lr2.monthly, MonthlyCount::Count(12));
 
         // Check that drop is ignored (suppresses warning about unused binding)
         let _ = toml_str;
@@ -1277,7 +1645,7 @@ local_retention = { daily = 7, weekly = 4 }
         assert_eq!(resolved.send_interval, Interval::hours(4));
         assert!(resolved.enabled);
         assert_eq!(lr.hourly, 24); // from defaults (not overridden)
-        assert_eq!(lr.monthly, 12); // from defaults (not overridden)
+        assert_eq!(lr.monthly, MonthlyCount::Count(12)); // from defaults (not overridden)
         assert_eq!(resolved.external_retention.daily, 30);
     }
 
@@ -1470,7 +1838,7 @@ local_retention = { daily = 7, weekly = 4 }
         assert_eq!(lr2.daily, 7);
         assert_eq!(lr2.weekly, 4);
         assert_eq!(lr2.hourly, 24); // from defaults
-        assert_eq!(lr2.monthly, 12); // from defaults
+        assert_eq!(lr2.monthly, MonthlyCount::Count(12)); // from defaults
     }
 
     #[test]
@@ -1517,7 +1885,7 @@ protection_level = "protected"
         assert_eq!(lr.hourly, 24);
         assert_eq!(lr.daily, 30);
         assert_eq!(lr.weekly, 26);
-        assert_eq!(lr.monthly, 12);
+        assert_eq!(lr.monthly, MonthlyCount::Count(12));
     }
 
     #[test]
@@ -1605,7 +1973,53 @@ local_retention = { daily = 60 }
         // Derived values fill in unspecified fields
         assert_eq!(lr.hourly, 24);
         assert_eq!(lr.weekly, 26);
-        assert_eq!(lr.monthly, 12);
+        assert_eq!(lr.monthly, MonthlyCount::Count(12));
+    }
+
+    #[test]
+    fn resolved_named_level_with_unlimited_external_monthly() {
+        // R2 synthesizer: Sheltered with no external override resolves to
+        // external_retention.monthly == Unlimited (preserves v1's external
+        // unlimited monthly semantic via the synthesizer path at lines
+        // 175–194). Confirms `Some(MonthlyCount)` flows through unchanged.
+        let config_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [{ path = "/snap", subvolumes = ["sv"] }]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+[defaults.local_retention]
+daily = 30
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+short_name = "sv"
+source = "/sv"
+protection_level = "protected"
+"#;
+        let config: Config = toml::from_str(config_str).unwrap();
+        let resolved =
+            config.subvolumes[0].resolved(&config.defaults, config.general.run_frequency);
+        assert_eq!(
+            resolved.external_retention.monthly,
+            MonthlyCount::Unlimited,
+            "Sheltered external retention should resolve to Unlimited monthly"
+        );
+        assert_eq!(resolved.external_retention.yearly, 0);
     }
 
     #[test]
@@ -1857,6 +2271,453 @@ state_db = "/tmp/urd.db"
 config_version = 99
 "#;
         assert_eq!(extract_config_version(raw).unwrap(), Some(99));
+    }
+
+    // ── V2 (UPI 042) tests ─────────────────────────────────────────────
+
+    #[test]
+    fn extract_version_v2() {
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+"#;
+        assert_eq!(extract_config_version(raw).unwrap(), Some(2));
+    }
+
+    fn v2_minimal_config_str() -> &'static str {
+        r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+run_frequency = "daily"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+protection = "sheltered"
+"#
+    }
+
+    #[test]
+    fn parse_v2_minimal_config() {
+        let config = parse_v2(v2_minimal_config_str()).expect("v2 minimal parses");
+        assert_eq!(config.general.config_version, Some(2));
+        assert_eq!(config.subvolumes.len(), 1);
+    }
+
+    #[test]
+    fn parse_v2_rejects_monthly_zero() {
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+local_retention = { hourly = 0, daily = 7, weekly = 4, monthly = 0 }
+"#;
+        let err = parse_v2(raw).unwrap_err();
+        assert!(
+            err.contains("monthly = 0 is not allowed"),
+            "expected v2 rejection of monthly = 0, got: {err}"
+        );
+        assert!(err.contains("unlimited"));
+    }
+
+    #[test]
+    fn parse_v2_accepts_monthly_unlimited() {
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+local_retention = { daily = 7, weekly = 4, monthly = "unlimited" }
+"#;
+        let config = parse_v2(raw).expect("monthly = \"unlimited\" parses");
+        let sv = &config.subvolumes[0];
+        let lr = sv.local_retention.as_ref().unwrap();
+        match lr {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.monthly, Some(MonthlyCount::Unlimited));
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_accepts_monthly_positive_int() {
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+local_retention = { daily = 7, weekly = 4, monthly = 12 }
+"#;
+        let config = parse_v2(raw).expect("monthly = 12 parses");
+        let sv = &config.subvolumes[0];
+        let lr = sv.local_retention.as_ref().unwrap();
+        match lr {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.monthly, Some(MonthlyCount::Count(12)));
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_accepts_yearly_zero() {
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+local_retention = { daily = 7, weekly = 4, monthly = 12, yearly = 0 }
+"#;
+        let config = parse_v2(raw).expect("yearly = 0 parses");
+        let sv = &config.subvolumes[0];
+        let lr = sv.local_retention.as_ref().unwrap();
+        match lr {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.yearly, Some(0));
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_accepts_yearly_positive() {
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+local_retention = { daily = 7, weekly = 4, monthly = 12, yearly = 5 }
+"#;
+        let config = parse_v2(raw).expect("yearly = 5 parses");
+        let sv = &config.subvolumes[0];
+        let lr = sv.local_retention.as_ref().unwrap();
+        match lr {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.yearly, Some(5));
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_unlimited_plus_yearly_parses_clean() {
+        // R6: validate_v2 does NOT raise an error for unlimited+yearly.
+        // The advisory fires in preflight.rs (Step 2.10), not at parse time.
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+local_retention = { daily = 7, weekly = 4, monthly = "unlimited", yearly = 5 }
+"#;
+        let config = parse_v2(raw).expect("unlimited + yearly parses without validation error");
+        let sv = &config.subvolumes[0];
+        let lr = sv.local_retention.as_ref().unwrap();
+        match lr {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.monthly, Some(MonthlyCount::Unlimited));
+                assert_eq!(g.yearly, Some(5));
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_named_level_rejects_overrides() {
+        // Same Rules 1-4 from v1 apply in v2.
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+protection = "sheltered"
+snapshot_interval = "6h"
+"#;
+        let err = parse_v2(raw).unwrap_err();
+        assert!(err.contains("snapshot_interval"));
+        assert!(err.contains("custom"));
+    }
+
+    #[test]
+    fn dispatcher_rejects_v3() {
+        let raw = r#"
+[general]
+config_version = 3
+state_db = "/tmp/urd.db"
+"#;
+        let result = Config::from_str(raw);
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("unsupported config_version 3 (supported: 1, 2)"),
+            "got: {err}"
+        );
+    }
+
+    // ── R1 / Step 2.4 — V1 shim regression tests ───────────────────────
+
+    #[test]
+    fn parse_v1_monthly_zero_still_loads() {
+        // R1: v1 wire format must continue accepting monthly = 0 (legacy
+        // semantic: 0 = unlimited). Without the v1 shim's u32 deserialize +
+        // v1_monthly_to_monthly_count mapping, every existing v1 config
+        // would fail to load.
+        let raw = r#"
+[general]
+config_version = 1
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+local_retention = { daily = 7, weekly = 4, monthly = 0 }
+"#;
+        let config = parse_v1(raw).expect("v1 monthly = 0 must continue loading");
+        let sv = &config.subvolumes[0];
+        let lr = sv.local_retention.as_ref().unwrap();
+        match lr {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(
+                    g.monthly,
+                    Some(MonthlyCount::Unlimited),
+                    "v1 monthly = 0 must map to Unlimited"
+                );
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+    }
+
+    #[test]
+    fn parse_v1_monthly_positive_round_trips() {
+        let raw = r#"
+[general]
+config_version = 1
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+local_retention = { daily = 7, weekly = 4, monthly = 12 }
+"#;
+        let config = parse_v1(raw).expect("v1 monthly = 12 loads");
+        let sv = &config.subvolumes[0];
+        let lr = sv.local_retention.as_ref().unwrap();
+        match lr {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.monthly, Some(MonthlyCount::Count(12)));
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+    }
+
+    #[test]
+    fn parse_v1_external_retention_monthly_zero_is_unlimited() {
+        let raw = r#"
+[general]
+config_version = 1
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+external_retention = { daily = 30, weekly = 26, monthly = 0 }
+"#;
+        let config = parse_v1(raw).expect("v1 external monthly = 0 loads");
+        let sv = &config.subvolumes[0];
+        let ext = sv.external_retention.as_ref().unwrap();
+        assert_eq!(ext.monthly, Some(MonthlyCount::Unlimited));
+    }
+
+    #[test]
+    fn parse_v1_synthesized_external_defaults_are_unlimited() {
+        // V1Config::into_config() synthesizes defaults: external monthly = Unlimited.
+        let raw = r#"
+[general]
+config_version = 1
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+"#;
+        let config = parse_v1(raw).expect("v1 without external_retention loads");
+        assert_eq!(
+            config.defaults.external_retention.monthly,
+            Some(MonthlyCount::Unlimited)
+        );
+    }
+
+    #[test]
+    fn parse_legacy_still_loads_after_v2_added() {
+        // Regression: legacy schema still loadable after v2 addition.
+        let raw = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [{ path = "/snap", subvolumes = ["sv"] }]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+[defaults.local_retention]
+daily = 30
+[defaults.external_retention]
+daily = 30
+monthly = 0
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+short_name = "sv"
+source = "/data/sv"
+"#;
+        let config = parse_legacy(raw).expect("legacy still loads");
+        assert_eq!(config.general.config_version, None);
+        // Legacy monthly = 0 → Unlimited via the lenient MonthlyCount::Deserialize
+        assert_eq!(
+            config.defaults.external_retention.monthly,
+            Some(MonthlyCount::Unlimited)
+        );
     }
 
     #[test]
@@ -2902,5 +3763,47 @@ drives = []
         assert_eq!(config.general.config_version, Some(1));
         assert_eq!(config.subvolumes.len(), 5);
         assert_eq!(config.drives.len(), 2);
+    }
+
+    #[test]
+    fn v2_example_config_round_trips() {
+        let example = include_str!("../config/urd.toml.v2.example");
+        let result = Config::from_str(example);
+        assert!(
+            result.is_ok(),
+            "v2 example config should parse: {:?}",
+            result.err()
+        );
+        let config = result.unwrap();
+        assert_eq!(config.general.config_version, Some(2));
+
+        // Verify the archive subvolume has Unlimited monthly.
+        let archive = config
+            .subvolumes
+            .iter()
+            .find(|s| s.name == "subvol3-archive")
+            .expect("v2 example must include subvol3-archive");
+        let lr = archive.local_retention.as_ref().expect("local_retention");
+        match lr {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.monthly, Some(MonthlyCount::Unlimited));
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
+
+        // Verify the projects subvolume has yearly = 5.
+        let projects = config
+            .subvolumes
+            .iter()
+            .find(|s| s.name == "subvol-projects")
+            .expect("v2 example must include subvol-projects");
+        let lr = projects.local_retention.as_ref().expect("local_retention");
+        match lr {
+            LocalRetentionConfig::Graduated(g) => {
+                assert_eq!(g.monthly, Some(MonthlyCount::Count(12)));
+                assert_eq!(g.yearly, Some(5));
+            }
+            LocalRetentionConfig::Transient => panic!("expected Graduated"),
+        }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -113,6 +113,7 @@ pub enum PruneRule {
     GraduatedDaily,
     GraduatedWeekly,
     GraduatedMonthly,
+    GraduatedYearly,
     BeyondWindow,
     Emergency,
     SpacePressure,
@@ -399,6 +400,7 @@ mod tests {
             PruneRule::GraduatedDaily,
             PruneRule::GraduatedWeekly,
             PruneRule::GraduatedMonthly,
+            PruneRule::GraduatedYearly,
             PruneRule::BeyondWindow,
         ];
         for rule in info_rules {
@@ -596,6 +598,7 @@ mod tests {
             (PruneRule::GraduatedDaily, "graduated_daily"),
             (PruneRule::GraduatedWeekly, "graduated_weekly"),
             (PruneRule::GraduatedMonthly, "graduated_monthly"),
+            (PruneRule::GraduatedYearly, "graduated_yearly"),
             (PruneRule::BeyondWindow, "beyond_window"),
             (PruneRule::Emergency, "emergency"),
             (PruneRule::SpacePressure, "space_pressure"),

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -238,7 +238,9 @@ mod tests {
     use crate::executor::{
         ExecutionResult, RunResult, SendType, SubvolumeResult, TransientCleanupOutcome,
     };
-    use crate::types::{DriveRole, GraduatedRetention, Interval, RunFrequency, SendKind};
+    use crate::types::{
+        DriveRole, GraduatedRetention, Interval, MonthlyCount, RunFrequency, SendKind,
+    };
     use std::path::PathBuf;
 
     fn test_config(intervals: &[(&str, &str)]) -> Config {
@@ -288,13 +290,15 @@ mod tests {
                     hourly: Some(24),
                     daily: Some(30),
                     weekly: Some(26),
-                    monthly: Some(12),
+                    monthly: Some(MonthlyCount::Count(12)),
+                    yearly: None,
                 },
                 external_retention: GraduatedRetention {
                     hourly: None,
                     daily: Some(30),
                     weekly: Some(26),
-                    monthly: Some(0),
+                    monthly: Some(MonthlyCount::Unlimited),
+                    yearly: None,
                 },
             },
             drives: vec![],

--- a/src/output.rs
+++ b/src/output.rs
@@ -468,6 +468,11 @@ pub struct DoctorOutput {
     pub infra_checks: Vec<DoctorCheck>,
     pub data_safety: Vec<DoctorDataSafety>,
     pub sentinel: DoctorSentinelStatus,
+    /// Schema deprecation notice (UPI 042 Branch G). `Some(_)` when the
+    /// loaded config is legacy or v1; voice renders a single-line notice
+    /// suggesting `urd migrate`. `None` for v2.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_status: Option<SchemaStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verify: Option<VerifyOutput>,
     /// Per-subvolume churn aggregates rendered under `urd doctor --thorough`.
@@ -479,6 +484,17 @@ pub struct DoctorOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recommendations: Option<DoctorRecommendationView>,
     pub verdict: DoctorVerdict,
+}
+
+/// Loaded-config schema state for the doctor deprecation notice.
+/// `current < latest` triggers the notice; equal means no notice.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct SchemaStatus {
+    /// Currently loaded schema. `None` = legacy (no config_version);
+    /// `Some(n)` = config_version = n.
+    pub current: Option<u32>,
+    /// Latest supported schema version. Always 2 today.
+    pub latest: u32,
 }
 
 // ── Recommendations (UPI 041, ADR-115) ─────────────────────────────────
@@ -2121,6 +2137,7 @@ source = "/data/sv2"
                 pid: None,
                 uptime: None,
             },
+            schema_status: None,
             verify: None,
             churn: None,
             recommendations: None,

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -94,14 +94,25 @@ fn params(role: ShapeRole) -> &'static RoleParams {
 }
 
 /// Inter-slot chain span in seconds for a four-slot shape (ADR-115).
-/// `h*3600 + d*86400 + w*7*86400 + m*30*86400`, saturating in u64.
+/// `h*3600 + d*86400 + w*7*86400 + m*30*86400 + y*365*86400`, saturating in u64.
+///
+/// When `monthly` is `Unlimited`, the span is `u64::MAX` (saturated). The
+/// `saturating_add` chain then leaves the value at `u64::MAX` regardless
+/// of subsequent terms — no special-case math needed downstream.
 #[must_use]
 pub fn chain_span_seconds(shape: &ResolvedGraduatedRetention) -> u64 {
     let h = u64::from(shape.hourly).saturating_mul(3_600);
     let d = u64::from(shape.daily).saturating_mul(86_400);
     let w = u64::from(shape.weekly).saturating_mul(7 * 86_400);
-    let m = u64::from(shape.monthly).saturating_mul(30 * 86_400);
-    h.saturating_add(d).saturating_add(w).saturating_add(m)
+    let m = match shape.monthly {
+        crate::types::MonthlyCount::Unlimited => u64::MAX,
+        crate::types::MonthlyCount::Count(n) => u64::from(n).saturating_mul(30 * 86_400),
+    };
+    let y = u64::from(shape.yearly).saturating_mul(365 * 86_400);
+    h.saturating_add(d)
+        .saturating_add(w)
+        .saturating_add(m)
+        .saturating_add(y)
 }
 
 /// Project the steady-state cost of `shape` under `churn`.
@@ -113,11 +124,19 @@ pub fn project_cost(
     shape: &ResolvedGraduatedRetention,
     churn: &ChurnEstimate,
 ) -> CostProjection {
+    // Unbounded monthly contributes 0 to the snapshot count (consistent
+    // with total_snapshot_count() in retention.rs); the unlimited window's
+    // bytes are captured via chain_span_seconds → u64::MAX → saturated.
+    let monthly_count = match shape.monthly {
+        crate::types::MonthlyCount::Unlimited => 0,
+        crate::types::MonthlyCount::Count(n) => n,
+    };
     let snapshot_count = shape
         .hourly
         .saturating_add(shape.daily)
         .saturating_add(shape.weekly)
-        .saturating_add(shape.monthly);
+        .saturating_add(monthly_count)
+        .saturating_add(shape.yearly);
 
     let data_bytes = match churn.mean_bytes_per_second {
         None => 0,
@@ -193,11 +212,16 @@ pub fn recommend_shape(
         slots[idx] = bounded.max(p.clamp_min[idx]);
     }
 
+    // R4 invariant: recommender stays 4-slot in UPI 042. Yearly is a
+    // user opt-in only; `recommend_shape` never proposes it.
+    // Branch J invariant: `recommend_shape` only emits `Count`,
+    // never `Unlimited`.
     let suggested = ResolvedGraduatedRetention {
         hourly: slots[0],
         daily: slots[1],
         weekly: slots[2],
-        monthly: slots[3],
+        monthly: crate::types::MonthlyCount::Count(slots[3]),
+        yearly: 0,
     };
 
     let current_cost = project_cost(current, churn);
@@ -248,12 +272,19 @@ mod tests {
         }
     }
 
-    fn shape(h: u32, d: u32, w: u32, m: u32) -> ResolvedGraduatedRetention {
+    fn shape(
+        h: u32,
+        d: u32,
+        w: u32,
+        m: crate::types::MonthlyCount,
+        y: u32,
+    ) -> ResolvedGraduatedRetention {
         ResolvedGraduatedRetention {
             hourly: h,
             daily: d,
             weekly: w,
             monthly: m,
+            yearly: y,
         }
     }
 
@@ -261,7 +292,7 @@ mod tests {
 
     #[test]
     fn project_cost_zero_churn_returns_zero_data_bytes() {
-        let s = shape(24, 30, 26, 12);
+        let s = shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0);
         let est = churn_with_mean(None);
         let c = project_cost(&s, &est);
         assert_eq!(c.data_bytes, 0);
@@ -270,7 +301,7 @@ mod tests {
 
     #[test]
     fn project_cost_matches_inter_slot_arithmetic_local() {
-        let s = shape(24, 30, 26, 12);
+        let s = shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0);
         let est = churn_with_mean(Some(1000.0));
         let c = project_cost(&s, &est);
         let expected = 1000.0_f64 * chain_span_seconds(&s) as f64;
@@ -280,7 +311,7 @@ mod tests {
 
     #[test]
     fn project_cost_zero_slot_windows_contribute_zero_seconds() {
-        let s = shape(0, 7, 0, 0);
+        let s = shape(0, 7, 0, crate::types::MonthlyCount::Count(0), 0);
         let est = churn_with_mean(Some(1.0));
         let c = project_cost(&s, &est);
         // Only daily contributes: 7 * 86_400 = 604_800 s @ 1 B/s.
@@ -294,7 +325,7 @@ mod tests {
         // Shape {0, 0, 0, 12}, mean = 1 B/s.
         // Correct (inter-slot): 12 * 30 * 86_400 = 31_104_000.
         // Wrong (age-midpoint per slot): 1 * sum(1..12) * 30*86_400 = 78 * 2_592_000 = 202_176_000.
-        let s = shape(0, 0, 0, 12);
+        let s = shape(0, 0, 0, crate::types::MonthlyCount::Count(12), 0);
         let est = churn_with_mean(Some(1.0));
         let c = project_cost(&s, &est);
         assert_eq!(c.data_bytes, 12 * 30 * 86_400);
@@ -304,7 +335,7 @@ mod tests {
 
     #[test]
     fn recommend_shape_returns_none_when_no_churn_signal() {
-        let cur = shape(24, 30, 26, 12);
+        let cur = shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0);
         // (0, 0): no samples at all.
         let est = churn_with_counts(None, 0, 0);
         assert!(recommend_shape(&cur, &est, ShapeRole::Local).is_none());
@@ -315,7 +346,7 @@ mod tests {
         // (incremental=0, full=3, mean=None). Tightened None-return per
         // adversary Critical 1: prevents "extend to max" misadvice for
         // chain-break or transient subvolumes.
-        let cur = shape(24, 30, 26, 12);
+        let cur = shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0);
         let est = churn_with_counts(None, 0, 3);
         assert!(recommend_shape(&cur, &est, ShapeRole::Local).is_none());
     }
@@ -323,7 +354,7 @@ mod tests {
     #[test]
     fn recommend_shape_hot_subvolume_clamps_tight_local() {
         // Hot containers-like rate: ~31_250 B/s (~2.7 GB/day).
-        let cur = shape(24, 60, 52, 24);
+        let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
         let est = churn_with_mean(Some(31_250.0));
         let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("hot");
         assert!(
@@ -345,15 +376,15 @@ mod tests {
     #[test]
     fn recommend_shape_cold_subvolume_clamps_max_everywhere_local() {
         // Cold docs-like rate: ~81 B/s (~7 MB/day).
-        let cur = shape(0, 7, 4, 0);
+        let cur = shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0);
         let est = churn_with_mean(Some(81.0));
         let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("cold");
-        assert_eq!(rec.suggested, shape(24, 60, 52, 24));
+        assert_eq!(rec.suggested, shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0));
     }
 
     #[test]
     fn recommend_shape_external_role_drops_hourlies() {
-        let cur = shape(24, 60, 52, 24);
+        let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
         let est = churn_with_mean(Some(81.0));
         let rec = recommend_shape(&cur, &est, ShapeRole::External).expect("cold-external");
         // External clamp_max[0] is 0 and slot_share[0] is 0 — hourly never fires.
@@ -362,7 +393,7 @@ mod tests {
 
     #[test]
     fn recommend_shape_bursty_pattern_note_when_full_exceeds_incremental() {
-        let cur = shape(24, 30, 26, 12);
+        let cur = shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0);
         // full=3 > incremental=1, but mean is Some so recommendation fires.
         let est = churn_with_counts(Some(1000.0), 1, 3);
         let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("bursty");
@@ -371,7 +402,7 @@ mod tests {
 
     #[test]
     fn recommend_shape_no_bursty_note_when_steady_state() {
-        let cur = shape(24, 30, 26, 12);
+        let cur = shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0);
         let est = churn_with_counts(Some(1000.0), 10, 1);
         let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("steady");
         assert_eq!(rec.note, None);
@@ -379,7 +410,7 @@ mod tests {
 
     #[test]
     fn recommend_shape_local_external_symmetric_costs_for_same_shape_and_churn() {
-        let cur = shape(12, 14, 8, 6);
+        let cur = shape(12, 14, 8, crate::types::MonthlyCount::Count(6), 0);
         let est = churn_with_mean(Some(2500.0));
         let local = recommend_shape(&cur, &est, ShapeRole::Local).expect("local");
         let external = recommend_shape(&cur, &est, ShapeRole::External).expect("external");
@@ -393,21 +424,21 @@ mod tests {
         // slot_share, and 0/0 → NaN for the External hourly slot
         // (slot_share[0] = 0.0). Both paths must route to clamp_max
         // without panicking.
-        let cur = shape(24, 60, 52, 24);
+        let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
         let est = churn_with_mean(Some(0.0));
 
         let local = recommend_shape(&cur, &est, ShapeRole::Local).expect("local");
-        assert_eq!(local.suggested, shape(24, 60, 52, 24));
+        assert_eq!(local.suggested, shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0));
 
         let external = recommend_shape(&cur, &est, ShapeRole::External).expect("external");
         // External hourly clamp_max is 0 → suggested.hourly = 0 even
         // when routed via the NaN/Infinity branch.
-        assert_eq!(external.suggested, shape(0, 60, 52, 24));
+        assert_eq!(external.suggested, shape(0, 60, 52, crate::types::MonthlyCount::Count(24), 0));
     }
 
     #[test]
     fn recommend_shape_current_carried_through_unchanged() {
-        let cur = shape(24, 30, 26, 12);
+        let cur = shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0);
         let est = churn_with_mean(Some(1000.0));
         let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("ok");
         assert_eq!(rec.current, cur);
@@ -415,7 +446,7 @@ mod tests {
 
     #[test]
     fn recommend_shape_with_one_incremental_emits_recommendation() {
-        let cur = shape(24, 30, 26, 12);
+        let cur = shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0);
         let est = churn_with_counts(Some(500.0), 1, 0);
         assert!(recommend_shape(&cur, &est, ShapeRole::Local).is_some());
     }
@@ -424,7 +455,7 @@ mod tests {
     fn recommend_shape_suggested_count_within_clamp_bounds() {
         // Stress across a range of churn rates: every output slot must
         // land in `[clamp_min, clamp_max]` for the given role.
-        let cur = shape(24, 60, 52, 24);
+        let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
         let rates = [1.0_f64, 10.0, 100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0];
         for r in rates {
             for role in [ShapeRole::Local, ShapeRole::External] {
@@ -435,7 +466,13 @@ mod tests {
                 assert!(s.hourly >= p.clamp_min[0] && s.hourly <= p.clamp_max[0]);
                 assert!(s.daily >= p.clamp_min[1] && s.daily <= p.clamp_max[1]);
                 assert!(s.weekly >= p.clamp_min[2] && s.weekly <= p.clamp_max[2]);
-                assert!(s.monthly >= p.clamp_min[3] && s.monthly <= p.clamp_max[3]);
+                let monthly_count = match s.monthly {
+                    crate::types::MonthlyCount::Count(n) => n,
+                    crate::types::MonthlyCount::Unlimited => {
+                        panic!("recommend_shape must never emit Unlimited monthly")
+                    }
+                };
+                assert!(monthly_count >= p.clamp_min[3] && monthly_count <= p.clamp_max[3]);
             }
         }
     }
@@ -448,7 +485,7 @@ mod tests {
         // already matches, so `suggested == current`. Doctor builder
         // suppresses this row.
         let est = churn_with_mean(Some(81.0));
-        let optimal_local = recommend_shape(&shape(0, 0, 0, 0), &est, ShapeRole::Local)
+        let optimal_local = recommend_shape(&shape(0, 0, 0, crate::types::MonthlyCount::Count(0), 0), &est, ShapeRole::Local)
             .expect("seed")
             .suggested;
         let rec = recommend_shape(&optimal_local, &est, ShapeRole::Local).expect("optimal");
@@ -457,7 +494,7 @@ mod tests {
 
     #[test]
     fn recommendation_one_slot_off_is_not_equal() {
-        let cur = shape(24, 31, 26, 12);
+        let cur = shape(24, 31, 26, crate::types::MonthlyCount::Count(12), 0);
         let est = churn_with_mean(Some(81.0));
         let rec = recommend_shape(&cur, &est, ShapeRole::Local).expect("ok");
         // Cold rate clamps to {24, 60, 52, 24}; current is {24, 31, 26, 12}.
@@ -470,8 +507,8 @@ mod tests {
         // not enter into `suggested == current`. Hold the shape fixed
         // and verify the equality predicate is the same under both
         // roles.
-        let a = shape(0, 7, 4, 0);
-        let b = shape(0, 7, 4, 0);
+        let a = shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0);
+        let b = shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0);
         assert_eq!(a, b);
 
         // Sanity: ShapeRecommendation::role differs but does not bear
@@ -482,5 +519,87 @@ mod tests {
         assert_ne!(local.role, external.role);
         // current is the same shape across roles regardless of suggested.
         assert_eq!(local.current, external.current);
+    }
+
+    // ── UPI 042 invariants ──────────────────────────────────────────
+
+    #[test]
+    fn recommend_shape_never_emits_unlimited_monthly() {
+        // Branch J invariant: recommend_shape only emits MonthlyCount::Count,
+        // never Unlimited. Verified across a range of churn rates and roles.
+        let cur = shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0);
+        for r in [
+            1.0_f64, 10.0, 100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0,
+        ] {
+            for role in [ShapeRole::Local, ShapeRole::External] {
+                let est = churn_with_mean(Some(r));
+                let rec = recommend_shape(&cur, &est, role).expect("rec");
+                assert!(
+                    matches!(
+                        rec.suggested.monthly,
+                        crate::types::MonthlyCount::Count(_)
+                    ),
+                    "recommend_shape must never emit Unlimited monthly (r={r}, role={role:?})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn recommend_shape_never_emits_nonzero_yearly() {
+        // R4 invariant: recommend_shape stays 4-slot in UPI 042. Yearly is
+        // a user opt-in only; suggested.yearly must always be 0.
+        let cur = shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0);
+        for r in [
+            1.0_f64, 10.0, 100.0, 1_000.0, 10_000.0, 100_000.0, 1_000_000.0,
+        ] {
+            for role in [ShapeRole::Local, ShapeRole::External] {
+                let est = churn_with_mean(Some(r));
+                let rec = recommend_shape(&cur, &est, role).expect("rec");
+                assert_eq!(
+                    rec.suggested.yearly, 0,
+                    "recommender stays 4-slot — yearly always 0 (r={r}, role={role:?})"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn chain_span_seconds_with_unlimited_monthly_saturates() {
+        // R8: Unlimited monthly produces u64::MAX. Saturating_add chain
+        // leaves the value at u64::MAX regardless of subsequent terms.
+        let s = shape(0, 0, 0, crate::types::MonthlyCount::Unlimited, 0);
+        assert_eq!(chain_span_seconds(&s), u64::MAX);
+        // With yearly added, still u64::MAX (saturating).
+        let s2 = shape(0, 0, 0, crate::types::MonthlyCount::Unlimited, 5);
+        assert_eq!(chain_span_seconds(&s2), u64::MAX);
+    }
+
+    #[test]
+    fn chain_span_seconds_includes_yearly() {
+        // yearly = N adds N * 365 * 86_400 seconds to the chain span.
+        let with_yearly = shape(0, 0, 0, crate::types::MonthlyCount::Count(0), 5);
+        let without_yearly = shape(0, 0, 0, crate::types::MonthlyCount::Count(0), 0);
+        let delta = chain_span_seconds(&with_yearly) - chain_span_seconds(&without_yearly);
+        assert_eq!(delta, 5 * 365 * 86_400);
+    }
+
+    #[test]
+    fn project_cost_unlimited_monthly_zero_count() {
+        // Snapshot_count for Unlimited monthly contributes 0 (unbounded
+        // count cannot be summed); matches total_snapshot_count semantic.
+        let s = shape(24, 30, 26, crate::types::MonthlyCount::Unlimited, 0);
+        let est = churn_with_mean(Some(100.0));
+        let cost = project_cost(&s, &est);
+        assert_eq!(cost.snapshot_count, 24 + 30 + 26);
+    }
+
+    #[test]
+    fn project_cost_includes_yearly_in_snapshot_count() {
+        // yearly contributes directly to snapshot_count.
+        let s = shape(0, 0, 0, crate::types::MonthlyCount::Count(0), 5);
+        let est = churn_with_mean(Some(100.0));
+        let cost = project_cost(&s, &est);
+        assert_eq!(cost.snapshot_count, 5);
     }
 }

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -43,6 +43,7 @@ pub fn preflight_checks(config: &Config) -> Vec<PreflightCheck> {
         check_retention_send_compatibility(subvol, &mut checks);
         check_transient_validity(subvol, &mut checks);
         check_promise_achievability(subvol, config, &mut checks);
+        check_redundant_yearly(subvol, &mut checks);
     }
 
     checks
@@ -275,7 +276,8 @@ fn check_promise_achievability(
         if local.hourly < derived_local.hourly
             || local.daily < derived_local.daily
             || local.weekly < derived_local.weekly
-            || (derived_local.monthly > 0 && local.monthly < derived_local.monthly)
+            || local.monthly.is_weaker_than(derived_local.monthly)
+            || (derived_local.yearly > 0 && local.yearly < derived_local.yearly)
         {
             checks.push(PreflightCheck {
                 name: "weakening-override",
@@ -285,6 +287,42 @@ fn check_promise_achievability(
                 ),
             });
         }
+    }
+}
+
+// ── Redundant-yearly check ─────────────────────────────────────────────
+//
+// When monthly is Unlimited, the engine treats yearly as 0 (yearly is
+// subsumed by unlimited monthly). Surface this redundancy as an advisory
+// so the user can either drop the yearly tier or bound monthly.
+fn check_redundant_yearly(
+    subvol: &crate::config::ResolvedSubvolume,
+    checks: &mut Vec<PreflightCheck>,
+) {
+    use crate::types::{LocalRetentionPolicy, MonthlyCount};
+
+    if let LocalRetentionPolicy::Graduated(local) = &subvol.local_retention
+        && matches!(local.monthly, MonthlyCount::Unlimited)
+        && local.yearly > 0
+    {
+        checks.push(PreflightCheck {
+            name: "redundant-yearly",
+            message: format!(
+                "{}: local_retention yearly is redundant when monthly is unlimited",
+                subvol.name,
+            ),
+        });
+    }
+
+    let ext = &subvol.external_retention;
+    if matches!(ext.monthly, MonthlyCount::Unlimited) && ext.yearly > 0 {
+        checks.push(PreflightCheck {
+            name: "redundant-yearly",
+            message: format!(
+                "{}: external_retention yearly is redundant when monthly is unlimited",
+                subvol.name,
+            ),
+        });
     }
 }
 
@@ -314,7 +352,8 @@ mod tests {
         SubvolumeConfig,
     };
     use crate::types::{
-        ByteSize, DriveRole, GraduatedRetention, Interval, LocalRetentionConfig, RunFrequency,
+        ByteSize, DriveRole, GraduatedRetention, Interval, LocalRetentionConfig, MonthlyCount,
+        RunFrequency,
     };
     use std::path::PathBuf;
 
@@ -358,7 +397,8 @@ mod tests {
             hourly: Some(24),
             daily: Some(7),
             weekly: Some(4),
-            monthly: Some(0),
+            monthly: Some(MonthlyCount::Count(0)),
+            yearly: None,
         }
     }
 
@@ -410,7 +450,8 @@ mod tests {
                 hourly: Some(hourly),
                 daily: Some(daily),
                 weekly: Some(0),
-                monthly: Some(0),
+                monthly: Some(MonthlyCount::Count(0)),
+                yearly: None,
             })),
             external_retention: None,
             protection_level: None,
@@ -646,7 +687,8 @@ mod tests {
             hourly: Some(6),
             daily: Some(7),
             weekly: Some(4),
-            monthly: Some(0),
+            monthly: Some(MonthlyCount::Count(0)),
+            yearly: None,
         }));
         let config = test_config(vec![sv], vec![test_drive()]);
         let results: Vec<_> = preflight_checks(&config)
@@ -695,6 +737,244 @@ mod tests {
             .collect();
 
         assert!(results.is_empty());
+    }
+
+    // ── R2 / Step 2.3 — Weakening check truth table ─────────────────
+
+    // Note: `weakening-override` on local_retention fires only on named
+    // levels (the derived baseline comes from `derive_policy`). The
+    // tests below use Sheltered, whose derive_policy gives:
+    //   local:    hourly=24, daily=30, weekly=26, monthly=Count(12), yearly=0
+    //   external: hourly=0,  daily=30, weekly=26, monthly=Unlimited,  yearly=0
+    //
+    // We construct subvolumes that override local_retention with a tighter
+    // monthly to exercise `is_weaker_than`.
+
+    fn sheltered_subvol_with_local_retention(
+        name: &str,
+        ret: GraduatedRetention,
+    ) -> SubvolumeConfig {
+        SubvolumeConfig {
+            name: name.to_string(),
+            short_name: name.to_string(),
+            source: PathBuf::from(format!("/{name}")),
+            priority: 1,
+            enabled: None,
+            snapshot_interval: None,
+            send_interval: None,
+            send_enabled: None,
+            local_retention: Some(LocalRetentionConfig::Graduated(ret)),
+            external_retention: None,
+            protection_level: Some(crate::types::ProtectionLevel::Sheltered),
+            drives: None,
+        }
+    }
+
+    #[test]
+    fn weakening_check_flags_bounded_against_unlimited() {
+        // Note: this test exercises is_weaker_than. derive_policy(Sheltered)
+        // gives local_retention.monthly = Count(12). User override with
+        // Count(3) is weaker → check fires.
+        let ret = GraduatedRetention {
+            hourly: Some(24),
+            daily: Some(30),
+            weekly: Some(26),
+            monthly: Some(MonthlyCount::Count(3)),
+            yearly: None,
+        };
+        let sv = sheltered_subvol_with_local_retention("sv1", ret);
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let warnings: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "weakening-override")
+            .collect();
+        assert!(
+            warnings.iter().any(|c| c.message.contains("local_retention")),
+            "expected weakening warning for tighter monthly"
+        );
+    }
+
+    #[test]
+    fn weakening_check_skips_count_zero_derived() {
+        // derive_policy(Sheltered) local monthly = Count(12). Override with
+        // Count(0) is weaker → check fires (Count(0) < Count(12)).
+        // This confirms the truth table works for the symmetric case.
+        let ret = GraduatedRetention {
+            hourly: Some(24),
+            daily: Some(30),
+            weekly: Some(26),
+            monthly: Some(MonthlyCount::Count(0)),
+            yearly: None,
+        };
+        let sv = sheltered_subvol_with_local_retention("sv1", ret);
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let warnings: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "weakening-override")
+            .collect();
+        assert!(
+            !warnings.is_empty(),
+            "Count(0) override against Count(12) baseline should fire weakening"
+        );
+    }
+
+    #[test]
+    fn weakening_check_unlimited_never_weaker() {
+        // is_weaker_than(Unlimited, anything) == false. Setting monthly =
+        // Unlimited on a subvolume with Sheltered baseline (Count(12))
+        // should NOT trigger weakening on monthly alone.
+        let ret = GraduatedRetention {
+            hourly: Some(24),
+            daily: Some(30),
+            weekly: Some(26),
+            monthly: Some(MonthlyCount::Unlimited),
+            yearly: None,
+        };
+        let sv = sheltered_subvol_with_local_retention("sv1", ret);
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let warnings: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "weakening-override")
+            .collect();
+        // No warnings — monthly Unlimited is never weaker than Count(12).
+        // (Other fields match the derived baseline exactly.)
+        assert!(
+            warnings.is_empty(),
+            "Unlimited monthly should not trigger weakening, got: {warnings:?}"
+        );
+    }
+
+    // ── R6 / Step 2.10 — Redundant-yearly check ─────────────────────
+
+    #[test]
+    fn redundant_yearly_check_fires_on_local_unlimited_plus_yearly() {
+        // Custom level, local_retention with monthly = Unlimited and yearly = 5
+        // → preflight emits a redundant-yearly advisory.
+        let ret = GraduatedRetention {
+            hourly: Some(0),
+            daily: Some(7),
+            weekly: Some(4),
+            monthly: Some(MonthlyCount::Unlimited),
+            yearly: Some(5),
+        };
+        let sv = SubvolumeConfig {
+            name: "sv1".to_string(),
+            short_name: "sv1".to_string(),
+            source: PathBuf::from("/sv1"),
+            priority: 1,
+            enabled: None,
+            snapshot_interval: None,
+            send_interval: None,
+            send_enabled: Some(false),
+            local_retention: Some(LocalRetentionConfig::Graduated(ret)),
+            external_retention: None,
+            protection_level: Some(crate::types::ProtectionLevel::Custom),
+            drives: None,
+        };
+        let config = test_config(vec![sv], vec![]);
+        let warnings: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "redundant-yearly")
+            .collect();
+        assert_eq!(warnings.len(), 1, "expected one redundant-yearly warning");
+        assert!(warnings[0].message.contains("local_retention"));
+    }
+
+    #[test]
+    fn redundant_yearly_check_silent_when_monthly_bounded() {
+        // Count(N) + yearly = 5 is a legitimate combination → no warning.
+        let ret = GraduatedRetention {
+            hourly: Some(0),
+            daily: Some(7),
+            weekly: Some(4),
+            monthly: Some(MonthlyCount::Count(12)),
+            yearly: Some(5),
+        };
+        let sv = SubvolumeConfig {
+            name: "sv1".to_string(),
+            short_name: "sv1".to_string(),
+            source: PathBuf::from("/sv1"),
+            priority: 1,
+            enabled: None,
+            snapshot_interval: None,
+            send_interval: None,
+            send_enabled: Some(false),
+            local_retention: Some(LocalRetentionConfig::Graduated(ret)),
+            external_retention: None,
+            protection_level: Some(crate::types::ProtectionLevel::Custom),
+            drives: None,
+        };
+        let config = test_config(vec![sv], vec![]);
+        let warnings: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "redundant-yearly")
+            .collect();
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn redundant_yearly_check_fires_on_external_unlimited_plus_yearly() {
+        // External retention with Unlimited monthly + yearly > 0 → advisory.
+        let ext = GraduatedRetention {
+            hourly: Some(0),
+            daily: Some(30),
+            weekly: Some(26),
+            monthly: Some(MonthlyCount::Unlimited),
+            yearly: Some(3),
+        };
+        let sv = SubvolumeConfig {
+            name: "sv1".to_string(),
+            short_name: "sv1".to_string(),
+            source: PathBuf::from("/sv1"),
+            priority: 1,
+            enabled: None,
+            snapshot_interval: None,
+            send_interval: None,
+            send_enabled: None,
+            local_retention: None,
+            external_retention: Some(ext),
+            protection_level: Some(crate::types::ProtectionLevel::Custom),
+            drives: None,
+        };
+        let config = test_config(vec![sv], vec![test_drive()]);
+        let warnings: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "redundant-yearly")
+            .collect();
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("external_retention"));
+    }
+
+    #[test]
+    fn redundant_yearly_check_silent_when_yearly_zero() {
+        // Unlimited + yearly = 0 is fine → no warning.
+        let ret = GraduatedRetention {
+            hourly: Some(0),
+            daily: Some(7),
+            weekly: Some(4),
+            monthly: Some(MonthlyCount::Unlimited),
+            yearly: Some(0),
+        };
+        let sv = SubvolumeConfig {
+            name: "sv1".to_string(),
+            short_name: "sv1".to_string(),
+            source: PathBuf::from("/sv1"),
+            priority: 1,
+            enabled: None,
+            snapshot_interval: None,
+            send_interval: None,
+            send_enabled: Some(false),
+            local_retention: Some(LocalRetentionConfig::Graduated(ret)),
+            external_retention: None,
+            protection_level: Some(crate::types::ProtectionLevel::Custom),
+            drives: None,
+        };
+        let config = test_config(vec![sv], vec![]);
+        let warnings: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "redundant-yearly")
+            .collect();
+        assert!(warnings.is_empty());
     }
 
     // ── Transient validity tests ───────────────────────────────────

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -6,7 +6,9 @@ use crate::events::{Event, EventPayload, ProtectReason, PruneRule};
 use crate::output::{
     DiskEstimate, EstimateMethod, RecoveryWindow, RetentionPreview, TransientComparison,
 };
-use crate::types::{Interval, LocalRetentionPolicy, ResolvedGraduatedRetention, SnapshotName};
+use crate::types::{
+    Interval, LocalRetentionPolicy, MonthlyCount, ResolvedGraduatedRetention, SnapshotName,
+};
 
 /// The result of a retention computation.
 ///
@@ -48,7 +50,11 @@ fn protect_event(snap: &SnapshotName, reason: ProtectReason, now: NaiveDateTime)
 /// 1. Hourly: keep every snapshot from the last `hourly` hours
 /// 2. Daily: keep 1 per calendar day for the next `daily` days
 /// 3. Weekly: keep 1 per ISO week for the next `weekly` weeks
-/// 4. Monthly: keep 1 per year-month for the next `monthly` months (0 = unlimited)
+/// 4. Monthly: keep 1 per year-month — `Count(N)` for N months,
+///    `Count(0)` means "no monthly window" (drop straight to yearly/beyond),
+///    `Unlimited` means "keep per-month indefinitely" (subsumes yearly).
+/// 5. Yearly: keep 1 per calendar year for the next `yearly` years.
+///    Suppressed when monthly is `Unlimited`.
 ///
 /// Pinned snapshots are never deleted regardless of retention policy.
 /// If `space_pressure` is true, the hourly window is thinned to 1 per hour.
@@ -76,24 +82,42 @@ pub fn graduated_retention(
     let hourly_cutoff = now - chrono::Duration::hours(i64::from(config.hourly));
     let daily_cutoff = hourly_cutoff - chrono::Duration::days(i64::from(config.daily));
     let weekly_cutoff = daily_cutoff - chrono::Duration::weeks(i64::from(config.weekly));
-    let monthly_cutoff = if config.monthly == 0 {
-        None // unlimited
-    } else {
-        // Use calendar month subtraction for accurate window boundaries.
-        // Duration::days(n * 30) drifts ~5 days/year vs real calendar months.
-        // On overflow (unreachable for realistic configs), treat as unlimited
-        // rather than silently changing behavior.
-        Some(
-            weekly_cutoff
-                .checked_sub_months(Months::new(config.monthly))
-                .unwrap_or(NaiveDateTime::MIN),
-        )
+    let monthly_cutoff = match config.monthly {
+        MonthlyCount::Unlimited => None, // unlimited — no monthly cutoff
+        MonthlyCount::Count(0) => Some(weekly_cutoff), // no monthly window
+        MonthlyCount::Count(n) => {
+            // Use calendar month subtraction for accurate window boundaries.
+            // Duration::days(n * 30) drifts ~5 days/year vs real calendar months.
+            // On overflow (unreachable for realistic configs), treat as MIN
+            // rather than silently changing behavior.
+            Some(
+                weekly_cutoff
+                    .checked_sub_months(Months::new(n))
+                    .unwrap_or(NaiveDateTime::MIN),
+            )
+        }
     };
 
-    // Track which day/week/month slots are already filled
+    // Yearly window: skip when monthly is Unlimited (yearly subsumed) or yearly == 0.
+    let yearly_cutoff = match (config.monthly, config.yearly) {
+        (MonthlyCount::Unlimited, _) => None,
+        (_, 0) => None,
+        (_, y) => {
+            // Cutoff is monthly's cutoff minus y years. monthly_cutoff is
+            // guaranteed Some(_) here because Unlimited was matched above.
+            let base = monthly_cutoff.unwrap_or(weekly_cutoff);
+            Some(
+                base.checked_sub_months(Months::new(y.saturating_mul(12)))
+                    .unwrap_or(NaiveDateTime::MIN),
+            )
+        }
+    };
+
+    // Track which day/week/month/year slots are already filled
     let mut daily_slots: HashSet<NaiveDateTime> = HashSet::new(); // key: date at midnight
     let mut weekly_slots: HashSet<(i32, u32)> = HashSet::new(); // (iso_year, iso_week)
     let mut monthly_slots: HashSet<(i32, u32)> = HashSet::new(); // (year, month)
+    let mut yearly_slots: HashSet<i32> = HashSet::new(); // year
 
     // For space pressure: track hourly slots
     let mut hourly_slots: HashSet<(i32, u32, u32, u32)> = HashSet::new(); // (y, m, d, hour)
@@ -184,6 +208,19 @@ pub fn graduated_retention(
                 is_pinned,
                 PruneRule::GraduatedMonthly,
                 "graduated: monthly thinning",
+                &mut keep,
+                &mut delete,
+                &mut events,
+            );
+        } else if yearly_cutoff.is_some() && dt >= yearly_cutoff.unwrap() {
+            let year_key = dt.date().year();
+            let slot_was_empty = yearly_slots.insert(year_key);
+            apply_slot_thinning(
+                snap,
+                slot_was_empty,
+                is_pinned,
+                PruneRule::GraduatedYearly,
+                "graduated: yearly thinning",
                 &mut keep,
                 &mut delete,
                 &mut events,
@@ -462,29 +499,53 @@ fn compute_recovery_windows(
         });
     }
 
-    if config.monthly == 0 {
-        // monthly = 0 means unlimited — keep all monthly snapshots indefinitely.
-        // The actual retention engine (graduated_retention) treats this as no monthly cutoff.
-        windows.push(RecoveryWindow {
-            granularity: "monthly",
-            count: 0,
-            cumulative_days: f64::INFINITY,
-            cumulative_description: "monthly snapshots kept indefinitely".to_string(),
-        });
-    } else {
-        // Approximate months as 30.44 days (standard average). The actual retention engine
-        // uses calendar month subtraction (checked_sub_months), which can differ by ~3 days
-        // depending on which months are involved. This is within rounding tolerance.
-        let cumulative_days = cumulative_after_hourly_days
-            + f64::from(config.daily)
-            + f64::from(config.weekly) * 7.0
-            + f64::from(config.monthly) * 30.44;
+    let cumulative_after_weekly = cumulative_after_hourly_days
+        + f64::from(config.daily)
+        + f64::from(config.weekly) * 7.0;
+    let cumulative_after_monthly = match config.monthly {
+        MonthlyCount::Unlimited => {
+            // Unlimited — keep all monthly snapshots indefinitely.
+            // The actual retention engine treats this as no monthly cutoff.
+            windows.push(RecoveryWindow {
+                granularity: "monthly",
+                count: 0,
+                cumulative_days: f64::INFINITY,
+                cumulative_description: "monthly snapshots kept indefinitely".to_string(),
+            });
+            f64::INFINITY
+        }
+        MonthlyCount::Count(0) => {
+            // No monthly window — omit from the list (consistent with
+            // how hourly/daily/weekly = 0 are omitted).
+            cumulative_after_weekly
+        }
+        MonthlyCount::Count(n) => {
+            // Approximate months as 30.44 days (standard average). The actual retention engine
+            // uses calendar month subtraction (checked_sub_months), which can differ by ~3 days
+            // depending on which months are involved. This is within rounding tolerance.
+            let cumulative_days = cumulative_after_weekly + f64::from(n) * 30.44;
+            let desc = format_cumulative_days(cumulative_days);
+            windows.push(RecoveryWindow {
+                granularity: "monthly",
+                count: n,
+                cumulative_days,
+                cumulative_description: format!("monthly snapshots back {desc}"),
+            });
+            cumulative_days
+        }
+    };
+
+    // Yearly window: skip when yearly == 0 OR monthly is Unlimited
+    // (yearly is subsumed; the engine already treats it as 0 in that case,
+    // and the display must agree to avoid two ∞ rows).
+    if config.yearly > 0 && !matches!(config.monthly, MonthlyCount::Unlimited) {
+        let cumulative_days = cumulative_after_monthly + f64::from(config.yearly) * 365.25;
         let desc = format_cumulative_days(cumulative_days);
         windows.push(RecoveryWindow {
-            granularity: "monthly",
-            count: config.monthly,
+            granularity: "yearly",
+            count: config.yearly,
             cumulative_days,
-            cumulative_description: format!("monthly snapshots back {desc}"),
+            cumulative_description: format!("yearly snapshots back {desc}"),
         });
     }
 
@@ -514,10 +575,14 @@ fn format_cumulative_days(days: f64) -> String {
 }
 
 /// Total snapshot count for a graduated retention policy.
-/// When `monthly = 0` (unlimited), the monthly bucket is excluded from the count
+/// When `monthly = Unlimited`, the monthly bucket is excluded from the count
 /// since the actual number of monthly snapshots is unbounded.
 fn total_snapshot_count(config: &ResolvedGraduatedRetention) -> u32 {
-    config.hourly + config.daily + config.weekly + config.monthly
+    let monthly = match config.monthly {
+        MonthlyCount::Unlimited => 0,
+        MonthlyCount::Count(n) => n,
+    };
+    config.hourly + config.daily + config.weekly + monthly + config.yearly
 }
 
 /// Format the policy description for display.
@@ -536,10 +601,13 @@ fn format_graduated_policy(
     if config.weekly > 0 {
         parts.push(format!("weekly = {}", config.weekly));
     }
-    if config.monthly == 0 {
-        parts.push("monthly = unlimited".to_string());
-    } else {
-        parts.push(format!("monthly = {}", config.monthly));
+    match config.monthly {
+        MonthlyCount::Unlimited => parts.push("monthly = unlimited".to_string()),
+        MonthlyCount::Count(0) => {} // omit when zero, consistent with hourly/daily/weekly
+        MonthlyCount::Count(n) => parts.push(format!("monthly = {n}")),
+    }
+    if config.yearly > 0 {
+        parts.push(format!("yearly = {}", config.yearly));
     }
     format!("graduated ({})", parts.join(", "))
 }
@@ -614,7 +682,8 @@ mod tests {
             hourly: 24,
             daily: 30,
             weekly: 26,
-            monthly: 12,
+            monthly: MonthlyCount::Count(12),
+            yearly: 0,
         }
     }
 
@@ -659,7 +728,8 @@ mod tests {
             hourly: 24,
             daily: 7,
             weekly: 26,
-            monthly: 12,
+            monthly: MonthlyCount::Count(12),
+            yearly: 0,
         };
         // Snapshots from ~2 weeks ago (outside daily window, inside weekly)
         let snaps = vec![
@@ -777,7 +847,8 @@ mod tests {
             hourly: 0, // no hourly/daily/weekly windows — all snapshots land in monthly
             daily: 0,
             weekly: 0,
-            monthly: 12,
+            monthly: MonthlyCount::Count(12),
+            yearly: 0,
         };
         // now = 2026-03-22 15:00
         // monthly_cutoff with calendar months ≈ 2025-03-22
@@ -812,7 +883,8 @@ mod tests {
             hourly: 24,
             daily: 30,
             weekly: 26,
-            monthly: 12,
+            monthly: MonthlyCount::Count(12),
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::hours(4); // sub-daily
@@ -846,7 +918,8 @@ mod tests {
             hourly: 0,
             daily: 30,
             weekly: 0,
-            monthly: 12,
+            monthly: MonthlyCount::Count(12),
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::days(1);
@@ -877,7 +950,8 @@ mod tests {
             hourly: 24,
             daily: 7,
             weekly: 0,
-            monthly: 6,
+            monthly: MonthlyCount::Count(6),
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::hours(1); // sub-daily
@@ -899,7 +973,8 @@ mod tests {
             hourly: 24,
             daily: 30,
             weekly: 26,
-            monthly: 0,
+            monthly: MonthlyCount::Unlimited,
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::days(1); // >= 1 day → suppress hourly
@@ -931,7 +1006,8 @@ mod tests {
             hourly: 0,
             daily: 30,
             weekly: 0,
-            monthly: 0,
+            monthly: MonthlyCount::Unlimited,
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::days(1);
@@ -951,7 +1027,8 @@ mod tests {
             hourly: 0,
             daily: 30,
             weekly: 0,
-            monthly: 0,
+            monthly: MonthlyCount::Unlimited,
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::days(1);
@@ -967,7 +1044,8 @@ mod tests {
             hourly: 24,
             daily: 30,
             weekly: 26,
-            monthly: 12,
+            monthly: MonthlyCount::Count(12),
+            yearly: 0,
         };
         let interval = Interval::hours(4);
 
@@ -986,7 +1064,8 @@ mod tests {
             hourly: 0,
             daily: 30,
             weekly: 0,
-            monthly: 0,
+            monthly: MonthlyCount::Unlimited,
+            yearly: 0,
         };
         let interval = Interval::days(1);
 
@@ -1006,7 +1085,8 @@ mod tests {
             hourly: 0,
             daily: 0,
             weekly: 0,
-            monthly: 0,
+            monthly: MonthlyCount::Unlimited,
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::days(1);
@@ -1026,7 +1106,8 @@ mod tests {
             hourly: 24,
             daily: 30,
             weekly: 26,
-            monthly: 12,
+            monthly: MonthlyCount::Count(12),
+            yearly: 0,
         };
         let interval = Interval::hours(4);
 
@@ -1056,7 +1137,8 @@ mod tests {
             hourly: 24,
             daily: 30,
             weekly: 26,
-            monthly: 12,
+            monthly: MonthlyCount::Count(12),
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::hours(4);
@@ -1083,7 +1165,8 @@ mod tests {
             hourly: 24,
             daily: 30,
             weekly: 26,
-            monthly: 0, // unlimited
+            monthly: MonthlyCount::Unlimited, // unlimited
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::hours(4);
@@ -1118,7 +1201,8 @@ mod tests {
             hourly: 0,
             daily: 30,
             weekly: 26,
-            monthly: 0, // unlimited
+            monthly: MonthlyCount::Unlimited, // unlimited
+            yearly: 0,
         };
         let policy = LocalRetentionPolicy::Graduated(config);
         let interval = Interval::days(1);
@@ -1271,7 +1355,8 @@ mod tests {
             hourly: 1,
             daily: 1,
             weekly: 1,
-            monthly: 1, // very narrow monthly so older snap falls beyond
+            monthly: MonthlyCount::Count(1), // very narrow monthly so older snap falls beyond
+            yearly: 0,
         };
         let very_old = make_daily_snap("20240101", "home"); // way past all windows
         let snaps = vec![make_snap("20260322", "1400", "home"), very_old.clone()];

--- a/src/types.rs
+++ b/src/types.rs
@@ -423,32 +423,41 @@ pub fn derive_policy(level: ProtectionLevel, freq: RunFrequency) -> Option<Deriv
         return None;
     }
 
+    // Recorded keeps one snapshot per calendar month indefinitely for local —
+    // matches the pre-UPI 042 behavior where `monthly = 0` was treated as
+    // unlimited. (External `recorded_external_retention` stays Count(0):
+    // recorded subvolumes don't send externally, so the external shape is
+    // unreachable in practice — Count(0) there is safe.)
     let recorded_retention = ResolvedGraduatedRetention {
         hourly: 0,
         daily: 7,
         weekly: 4,
-        monthly: 0,
+        monthly: MonthlyCount::Unlimited,
+        yearly: 0,
     };
 
     let full_retention = ResolvedGraduatedRetention {
         hourly: 24,
         daily: 30,
         weekly: 26,
-        monthly: 12,
+        monthly: MonthlyCount::Count(12),
+        yearly: 0,
     };
 
     let full_external_retention = ResolvedGraduatedRetention {
         hourly: 0,
         daily: 30,
         weekly: 26,
-        monthly: 0,
+        monthly: MonthlyCount::Unlimited,
+        yearly: 0,
     };
 
     let recorded_external_retention = ResolvedGraduatedRetention {
         hourly: 0,
         daily: 7,
         weekly: 4,
-        monthly: 0,
+        monthly: MonthlyCount::Count(0),
+        yearly: 0,
     };
 
     match (level, freq) {
@@ -509,12 +518,188 @@ pub fn derive_policy(level: ProtectionLevel, freq: RunFrequency) -> Option<Deriv
     }
 }
 
+// ── MonthlyCount ────────────────────────────────────────────────────────
+
+/// Monthly retention quantity: either a bounded count or unlimited.
+///
+/// `Count(N)` keeps one snapshot per calendar month for `N` months.
+/// `Count(0)` means "no monthly retention" (snapshots beyond the weekly
+/// window fall through to the yearly window or beyond-retention).
+/// `Unlimited` means "keep one snapshot per calendar month indefinitely"
+/// — used by v1 configs (the v1 `monthly = 0` semantic) and by v2 configs
+/// that write `monthly = "unlimited"` (UPI 042).
+///
+/// The v2 deserializer rejects integer `0` — see `Deserialize` impl.
+/// Internal construction of `Count(0)` (e.g. for `derive_policy`'s
+/// `recorded_external_retention`) is unaffected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MonthlyCount {
+    Count(u32),
+    Unlimited,
+}
+
+impl MonthlyCount {
+    /// Returns true if `self` provides strictly less retention than `base`.
+    /// Used by preflight's weakening-override check.
+    ///
+    /// Truth table:
+    ///   self            base            result
+    ///   Unlimited       *               false   (Unlimited is never weaker)
+    ///   Count(_)        Unlimited       true    (bounded < unlimited)
+    ///   Count(a)        Count(b)        a < b
+    #[must_use]
+    pub fn is_weaker_than(self, base: MonthlyCount) -> bool {
+        match (self, base) {
+            (MonthlyCount::Unlimited, _) => false,
+            (MonthlyCount::Count(_), MonthlyCount::Unlimited) => true,
+            (MonthlyCount::Count(a), MonthlyCount::Count(b)) => a < b,
+        }
+    }
+}
+
+impl Serialize for MonthlyCount {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            MonthlyCount::Count(n) => serializer.serialize_u32(*n),
+            MonthlyCount::Unlimited => serializer.serialize_str("unlimited"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for MonthlyCount {
+    /// Lenient deserialize used by legacy and v1 wire formats (and by the
+    /// runtime `GraduatedRetention` derive). Accepts:
+    ///  - integer `0` → `Unlimited` (legacy/v1 semantic: 0 = unlimited monthly)
+    ///  - integer `N > 0` → `Count(N)`
+    ///  - string `"unlimited"` → `Unlimited`
+    ///  - any other string → error
+    ///
+    /// V2 (UPI 042) closes the `monthly = 0` footgun via
+    /// `deserialize_monthly_count_strict_opt` — see `parse_v2` in config.rs.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct MonthlyCountVisitor;
+
+        impl<'de> Visitor<'de> for MonthlyCountVisitor {
+            type Value = MonthlyCount;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("an integer or the string \"unlimited\"")
+            }
+
+            fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+                if value == 0 {
+                    return Ok(MonthlyCount::Unlimited);
+                }
+                let n = u32::try_from(value).map_err(|_| {
+                    de::Error::custom(format!("monthly value {value} exceeds u32 range"))
+                })?;
+                Ok(MonthlyCount::Count(n))
+            }
+
+            fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+                if value < 0 {
+                    return Err(de::Error::custom(format!(
+                        "monthly value {value} cannot be negative"
+                    )));
+                }
+                #[allow(clippy::cast_sign_loss)]
+                self.visit_u64(value as u64)
+            }
+
+            fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                if value == "unlimited" {
+                    Ok(MonthlyCount::Unlimited)
+                } else {
+                    Err(de::Error::custom(format!(
+                        "unknown monthly value \"{value}\": expected integer or \"unlimited\""
+                    )))
+                }
+            }
+        }
+
+        deserializer.deserialize_any(MonthlyCountVisitor)
+    }
+}
+
+/// Strict v2 deserialize for an optional MonthlyCount field. Used at the
+/// v2 boundary only — rejects integer `0` with the documented error.
+/// Accepts `"unlimited"` (string), positive integers, or absent (None).
+///
+/// Wire it up on V2 wire-format struct fields via
+/// `#[serde(deserialize_with = "deserialize_monthly_count_strict_opt")]`.
+pub fn deserialize_monthly_count_strict_opt<'de, D>(
+    deserializer: D,
+) -> Result<Option<MonthlyCount>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct StrictMonthlyCountOptVisitor;
+
+    impl<'de> Visitor<'de> for StrictMonthlyCountOptVisitor {
+        type Value = Option<MonthlyCount>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("a positive integer or the string \"unlimited\"")
+        }
+
+        fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+            if value == 0 {
+                return Err(de::Error::custom(
+                    "monthly = 0 is not allowed in v2: omit the field for \"no monthly retention\" or write 'unlimited' for unbounded retention",
+                ));
+            }
+            let n = u32::try_from(value).map_err(|_| {
+                de::Error::custom(format!("monthly value {value} exceeds u32 range"))
+            })?;
+            Ok(Some(MonthlyCount::Count(n)))
+        }
+
+        fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+            if value < 0 {
+                return Err(de::Error::custom(format!(
+                    "monthly value {value} cannot be negative"
+                )));
+            }
+            #[allow(clippy::cast_sign_loss)]
+            self.visit_u64(value as u64)
+        }
+
+        fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
+            if value == "unlimited" {
+                Ok(Some(MonthlyCount::Unlimited))
+            } else {
+                Err(de::Error::custom(format!(
+                    "unknown monthly value \"{value}\": expected integer or \"unlimited\""
+                )))
+            }
+        }
+
+        fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+
+        fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_any(StrictMonthlyCountOptVisitor)
+}
+
 // ── GraduatedRetention ──────────────────────────────────────────────────
 
 /// Graduated retention policy: keep snapshots at decreasing density over time.
 /// Each field specifies how many units of that granularity to keep.
 /// `None` means "not configured" (inherits from defaults).
-/// `Some(0)` means unlimited (keep all at that granularity).
+///
+/// `monthly` is a [`MonthlyCount`] — either `Count(N)` for N months or
+/// `Unlimited` for indefinite monthly retention. `Count(0)` is allowed
+/// internally (means "no monthly retention") but the v2 TOML parser
+/// rejects literal `monthly = 0`.
+///
+/// `yearly` is a plain `Option<u32>`. There is no `"unlimited"` variant —
+/// the asymmetry with `monthly` is deliberate (ADR-104 amendment
+/// 2026-05-15).
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct GraduatedRetention {
     /// Hours to keep all snapshots (every snapshot in this window is kept)
@@ -523,8 +708,10 @@ pub struct GraduatedRetention {
     pub daily: Option<u32>,
     /// Weeks to keep one snapshot per ISO week
     pub weekly: Option<u32>,
-    /// Months to keep one snapshot per month (0 = unlimited)
-    pub monthly: Option<u32>,
+    /// Months to keep one snapshot per month
+    pub monthly: Option<MonthlyCount>,
+    /// Years to keep one snapshot per calendar year
+    pub yearly: Option<u32>,
 }
 
 impl GraduatedRetention {
@@ -536,17 +723,20 @@ impl GraduatedRetention {
             daily: self.daily.or(base.daily),
             weekly: self.weekly.or(base.weekly),
             monthly: self.monthly.or(base.monthly),
+            yearly: self.yearly.or(base.yearly),
         }
     }
 
-    /// Resolve all None fields to 0 (unlimited).
+    /// Resolve all None fields to defaults (0 for hourly/daily/weekly/yearly,
+    /// `MonthlyCount::Count(0)` for monthly = "no monthly retention").
     #[must_use]
     pub fn resolved(&self) -> ResolvedGraduatedRetention {
         ResolvedGraduatedRetention {
             hourly: self.hourly.unwrap_or(0),
             daily: self.daily.unwrap_or(0),
             weekly: self.weekly.unwrap_or(0),
-            monthly: self.monthly.unwrap_or(0),
+            monthly: self.monthly.unwrap_or(MonthlyCount::Count(0)),
+            yearly: self.yearly.unwrap_or(0),
         }
     }
 }
@@ -557,7 +747,8 @@ pub struct ResolvedGraduatedRetention {
     pub hourly: u32,
     pub daily: u32,
     pub weekly: u32,
-    pub monthly: u32,
+    pub monthly: MonthlyCount,
+    pub yearly: u32,
 }
 
 // ── LocalRetentionConfig / LocalRetentionPolicy ───────────────────────
@@ -1138,19 +1329,22 @@ mod tests {
             hourly: Some(24),
             daily: Some(30),
             weekly: Some(26),
-            monthly: Some(12),
+            monthly: Some(MonthlyCount::Count(12)),
+            yearly: Some(2),
         };
         let override_partial = GraduatedRetention {
             hourly: None,
             daily: Some(7),
             weekly: Some(4),
             monthly: None,
+            yearly: None,
         };
         let merged = override_partial.merged_with(&base);
         assert_eq!(merged.hourly, Some(24)); // from base
         assert_eq!(merged.daily, Some(7)); // overridden
         assert_eq!(merged.weekly, Some(4)); // overridden
-        assert_eq!(merged.monthly, Some(12)); // from base
+        assert_eq!(merged.monthly, Some(MonthlyCount::Count(12))); // from base
+        assert_eq!(merged.yearly, Some(2)); // from base
     }
 
     // ── PlanSummary tests ───────────────────────────────────────────
@@ -1287,6 +1481,50 @@ mod tests {
     }
 
     #[test]
+    fn derive_policy_recorded_external_no_monthly() {
+        // Branch E: recorded_external_retention.monthly is corrected to
+        // Count(0) (= no monthly), not Unlimited.
+        let daily = RunFrequency::Timer {
+            interval: Interval::days(1),
+        };
+        let p = derive_policy(ProtectionLevel::Recorded, daily).unwrap();
+        assert_eq!(p.external_retention.monthly, MonthlyCount::Count(0));
+        assert_eq!(p.external_retention.yearly, 0);
+    }
+
+    #[test]
+    fn derive_policy_full_external_unlimited_monthly_preserved() {
+        // Sheltered/Fortified external retention preserves the v1 "unlimited
+        // monthly" semantic via MonthlyCount::Unlimited.
+        let daily = RunFrequency::Timer {
+            interval: Interval::days(1),
+        };
+        let sheltered = derive_policy(ProtectionLevel::Sheltered, daily).unwrap();
+        assert_eq!(sheltered.external_retention.monthly, MonthlyCount::Unlimited);
+        let fortified = derive_policy(ProtectionLevel::Fortified, daily).unwrap();
+        assert_eq!(fortified.external_retention.monthly, MonthlyCount::Unlimited);
+    }
+
+    #[test]
+    fn derive_policy_all_levels_have_yearly_zero() {
+        // Named levels don't use yearly today; reserved for future tier
+        // graduation. UPI 042 keeps yearly = 0 across all derive_policy
+        // returns; user opts in via Custom or explicit override.
+        let daily = RunFrequency::Timer {
+            interval: Interval::days(1),
+        };
+        for level in [
+            ProtectionLevel::Recorded,
+            ProtectionLevel::Sheltered,
+            ProtectionLevel::Fortified,
+        ] {
+            let p = derive_policy(level, daily).unwrap();
+            assert_eq!(p.local_retention.yearly, 0, "{level:?} local yearly");
+            assert_eq!(p.external_retention.yearly, 0, "{level:?} external yearly");
+        }
+    }
+
+    #[test]
     fn derive_policy_recorded_timer() {
         let daily = RunFrequency::Timer {
             interval: Interval::days(1),
@@ -1313,7 +1551,7 @@ mod tests {
         assert_eq!(p.local_retention.hourly, 24);
         assert_eq!(p.local_retention.daily, 30);
         assert_eq!(p.local_retention.weekly, 26);
-        assert_eq!(p.local_retention.monthly, 12);
+        assert_eq!(p.local_retention.monthly, MonthlyCount::Count(12));
         assert_eq!(p.external_retention.daily, 30);
         assert_eq!(p.external_retention.weekly, 26);
     }
@@ -1399,6 +1637,7 @@ weekly = 4
                 assert_eq!(g.weekly, Some(4));
                 assert_eq!(g.hourly, None);
                 assert_eq!(g.monthly, None);
+                assert_eq!(g.yearly, None);
             }
             LocalRetentionConfig::Transient => panic!("expected Graduated"),
         }
@@ -1461,6 +1700,7 @@ weekly = 4
                 daily: Some(30),
                 weekly: None,
                 monthly: None,
+                yearly: None,
             }),
         };
         let toml_str = toml::to_string(&graduated).unwrap();
@@ -1496,7 +1736,8 @@ weekly = 4
             hourly: 24,
             daily: 30,
             weekly: 26,
-            monthly: 12,
+            monthly: MonthlyCount::Count(12),
+            yearly: 0,
         });
         assert!(graduated.as_graduated().is_some());
         assert!(!graduated.is_transient());
@@ -1504,5 +1745,182 @@ weekly = 4
         let transient = LocalRetentionPolicy::Transient;
         assert!(transient.as_graduated().is_none());
         assert!(transient.is_transient());
+    }
+
+    // ── MonthlyCount tests ─────────────────────────────────────────
+
+    #[test]
+    fn monthly_count_serializes_count_as_integer() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            monthly: MonthlyCount,
+        }
+        let w = Wrapper {
+            monthly: MonthlyCount::Count(12),
+        };
+        let s = toml::to_string(&w).unwrap();
+        assert!(s.contains("monthly = 12"), "got: {s}");
+        let parsed: Wrapper = toml::from_str(&s).unwrap();
+        assert_eq!(parsed, w);
+    }
+
+    #[test]
+    fn monthly_count_serializes_unlimited_as_string() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            monthly: MonthlyCount,
+        }
+        let w = Wrapper {
+            monthly: MonthlyCount::Unlimited,
+        };
+        let s = toml::to_string(&w).unwrap();
+        assert!(s.contains(r#"monthly = "unlimited""#), "got: {s}");
+        let parsed: Wrapper = toml::from_str(&s).unwrap();
+        assert_eq!(parsed, w);
+    }
+
+    #[test]
+    fn monthly_count_lenient_accepts_zero_as_unlimited() {
+        // Legacy/v1 wire semantic: 0 == Unlimited. The lenient
+        // MonthlyCount::Deserialize is used by GraduatedRetention's
+        // derive and preserves this behavior.
+        #[derive(Debug, Deserialize)]
+        struct Wrapper {
+            monthly: MonthlyCount,
+        }
+        let w: Wrapper = toml::from_str("monthly = 0").unwrap();
+        assert_eq!(w.monthly, MonthlyCount::Unlimited);
+    }
+
+    #[test]
+    fn monthly_count_strict_rejects_zero_in_toml() {
+        // The v2 boundary uses `deserialize_monthly_count_strict_opt`,
+        // which rejects integer 0 with the documented error.
+        #[derive(Debug, Deserialize)]
+        #[allow(dead_code)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_monthly_count_strict_opt")]
+            monthly: Option<MonthlyCount>,
+        }
+        let result: Result<Wrapper, _> = toml::from_str("monthly = 0");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("monthly = 0 is not allowed"),
+            "expected rejection message, got: {err}"
+        );
+        assert!(err.contains("unlimited"), "should mention unlimited: {err}");
+    }
+
+    #[test]
+    fn monthly_count_strict_accepts_unlimited_and_positive() {
+        #[derive(Debug, Deserialize)]
+        struct Wrapper {
+            #[serde(default, deserialize_with = "deserialize_monthly_count_strict_opt")]
+            monthly: Option<MonthlyCount>,
+        }
+        let w: Wrapper = toml::from_str(r#"monthly = "unlimited""#).unwrap();
+        assert_eq!(w.monthly, Some(MonthlyCount::Unlimited));
+        let w2: Wrapper = toml::from_str("monthly = 12").unwrap();
+        assert_eq!(w2.monthly, Some(MonthlyCount::Count(12)));
+    }
+
+    #[test]
+    fn monthly_count_rejects_unknown_string() {
+        #[derive(Debug, Deserialize)]
+        #[allow(dead_code)]
+        struct Wrapper {
+            monthly: MonthlyCount,
+        }
+        let toml_str = r#"monthly = "max""#;
+        let result: Result<Wrapper, _> = toml::from_str(toml_str);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("expected integer or \"unlimited\"")
+                || err.contains("expected integer or `unlimited`"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn monthly_count_count_zero_constructs_internally() {
+        // Internal construction of Count(0) must remain valid (used by
+        // derive_policy for recorded_external_retention).
+        let zero = MonthlyCount::Count(0);
+        match zero {
+            MonthlyCount::Count(n) => assert_eq!(n, 0),
+            MonthlyCount::Unlimited => panic!("expected Count"),
+        }
+    }
+
+    #[test]
+    fn monthly_count_is_weaker_than_truth_table() {
+        // Unlimited vs Unlimited
+        assert!(!MonthlyCount::Unlimited.is_weaker_than(MonthlyCount::Unlimited));
+        // Unlimited vs Count
+        assert!(!MonthlyCount::Unlimited.is_weaker_than(MonthlyCount::Count(5)));
+        assert!(!MonthlyCount::Unlimited.is_weaker_than(MonthlyCount::Count(0)));
+        // Count vs Unlimited
+        assert!(MonthlyCount::Count(5).is_weaker_than(MonthlyCount::Unlimited));
+        assert!(MonthlyCount::Count(0).is_weaker_than(MonthlyCount::Unlimited));
+        // Count(a) vs Count(b)
+        assert!(MonthlyCount::Count(3).is_weaker_than(MonthlyCount::Count(5))); // a < b
+        assert!(!MonthlyCount::Count(5).is_weaker_than(MonthlyCount::Count(5))); // a == b
+        assert!(!MonthlyCount::Count(8).is_weaker_than(MonthlyCount::Count(5))); // a > b
+    }
+
+    #[test]
+    fn graduated_retention_merged_with_yearly() {
+        let base = GraduatedRetention {
+            hourly: None,
+            daily: None,
+            weekly: None,
+            monthly: None,
+            yearly: Some(5),
+        };
+        let override_partial = GraduatedRetention {
+            hourly: None,
+            daily: None,
+            weekly: None,
+            monthly: None,
+            yearly: None,
+        };
+        let merged = override_partial.merged_with(&base);
+        assert_eq!(merged.yearly, Some(5));
+
+        let override_with_yearly = GraduatedRetention {
+            hourly: None,
+            daily: None,
+            weekly: None,
+            monthly: None,
+            yearly: Some(2),
+        };
+        let merged2 = override_with_yearly.merged_with(&base);
+        assert_eq!(merged2.yearly, Some(2)); // overridden
+    }
+
+    #[test]
+    fn graduated_retention_resolved_yearly_defaults_to_zero() {
+        let g = GraduatedRetention {
+            hourly: None,
+            daily: None,
+            weekly: None,
+            monthly: None,
+            yearly: None,
+        };
+        assert_eq!(g.resolved().yearly, 0);
+    }
+
+    #[test]
+    fn graduated_retention_resolved_monthly_defaults_to_count_zero() {
+        let g = GraduatedRetention {
+            hourly: None,
+            daily: None,
+            weekly: None,
+            monthly: None,
+            yearly: None,
+        };
+        assert_eq!(g.resolved().monthly, MonthlyCount::Count(0));
     }
 }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -2250,6 +2250,23 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
     writeln!(out, "{}", "Checking Urd health...".bold()).ok();
     writeln!(out).ok();
 
+    // UPI 042 Branch G: schema deprecation notice. Emitted near the top so
+    // it's the first thing the user sees when their config is older than v2.
+    if let Some(status) = data.schema_status {
+        let label = match status.current {
+            None => "legacy".to_string(),
+            Some(n) => format!("v{n}"),
+        };
+        writeln!(
+            out,
+            "  Schema: {} (current: v{}; run `urd migrate` to upgrade)",
+            label.dimmed(),
+            status.latest
+        )
+        .ok();
+        writeln!(out).ok();
+    }
+
     // Config section
     render_doctor_check_section(&mut out, "Config", &data.config_checks);
 
@@ -2571,8 +2588,13 @@ fn render_shape_kv(shape: &crate::types::ResolvedGraduatedRetention) -> String {
     if shape.weekly != 0 {
         parts.push(format!("weekly={}", shape.weekly));
     }
-    if shape.monthly != 0 {
-        parts.push(format!("monthly={}", shape.monthly));
+    match shape.monthly {
+        crate::types::MonthlyCount::Unlimited => parts.push("monthly=unlimited".to_string()),
+        crate::types::MonthlyCount::Count(0) => {} // omit, consistent with hourly/daily/weekly
+        crate::types::MonthlyCount::Count(n) => parts.push(format!("monthly={n}")),
+    }
+    if shape.yearly != 0 {
+        parts.push(format!("yearly={}", shape.yearly));
     }
     parts.join("  ")
 }
@@ -3464,6 +3486,7 @@ pub(crate) mod test_fixtures {
                 pid: Some(12345),
                 uptime: Some("3h 12m".to_string()),
             },
+            schema_status: None,
             verify: None,
             churn: None,
             recommendations: None,
@@ -7867,12 +7890,19 @@ mod tests {
 
     // ── UPI 041 Recommendations section ───────────────────────────
 
-    fn shape(h: u32, d: u32, w: u32, m: u32) -> crate::types::ResolvedGraduatedRetention {
+    fn shape(
+        h: u32,
+        d: u32,
+        w: u32,
+        m: crate::types::MonthlyCount,
+        y: u32,
+    ) -> crate::types::ResolvedGraduatedRetention {
         crate::types::ResolvedGraduatedRetention {
             hourly: h,
             daily: d,
             weekly: w,
             monthly: m,
+            yearly: y,
         }
     }
 
@@ -7885,7 +7915,11 @@ mod tests {
     ) -> crate::policy::ShapeRecommendation {
         use crate::policy::{CostProjection, ShapeRecommendation};
         let total = |s: crate::types::ResolvedGraduatedRetention| {
-            s.hourly + s.daily + s.weekly + s.monthly
+            let m = match s.monthly {
+                crate::types::MonthlyCount::Unlimited => 0,
+                crate::types::MonthlyCount::Count(n) => n,
+            };
+            s.hourly + s.daily + s.weekly + m + s.yearly
         };
         ShapeRecommendation {
             role,
@@ -7913,8 +7947,8 @@ mod tests {
                 name: "containers".to_string(),
                 local: Some(recommendation(
                     crate::policy::ShapeRole::Local,
-                    shape(24, 30, 26, 12),
-                    shape(0, 7, 4, 0),
+                    shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+                    shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0),
                     200_000_000_000,
                     50_000_000_000,
                 )),
@@ -7946,15 +7980,15 @@ mod tests {
                 name: "containers".to_string(),
                 local: Some(recommendation(
                     crate::policy::ShapeRole::Local,
-                    shape(24, 30, 26, 12),
-                    shape(0, 7, 4, 0),
+                    shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+                    shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0),
                     200_000_000_000,
                     50_000_000_000,
                 )),
                 external: Some(recommendation(
                     crate::policy::ShapeRole::External,
-                    shape(0, 30, 26, 12),
-                    shape(0, 14, 8, 6),
+                    shape(0, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+                    shape(0, 14, 8, crate::types::MonthlyCount::Count(6), 0),
                     400_000_000_000,
                     100_000_000_000,
                 )),
@@ -7981,8 +8015,8 @@ mod tests {
                 name: "containers".to_string(),
                 local: Some(recommendation(
                     crate::policy::ShapeRole::Local,
-                    shape(24, 30, 26, 12),
-                    shape(0, 7, 4, 0),
+                    shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+                    shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0),
                     200_000_000_000,
                     50_000_000_000,
                 )),
@@ -8011,8 +8045,8 @@ mod tests {
                 name: "containers".to_string(),
                 local: Some(recommendation(
                     crate::policy::ShapeRole::Local,
-                    shape(24, 30, 26, 12),
-                    shape(0, 7, 4, 0),
+                    shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+                    shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0),
                     200_000_000_000,
                     50_000_000_000,
                 )),
@@ -8043,8 +8077,8 @@ mod tests {
                 local: None,
                 external: Some(recommendation(
                     crate::policy::ShapeRole::External,
-                    shape(0, 30, 0, 0),
-                    shape(0, 30, 0, 0), // 30 days chain
+                    shape(0, 30, 0, crate::types::MonthlyCount::Count(0), 0),
+                    shape(0, 30, 0, crate::types::MonthlyCount::Count(0), 0), // 30 days chain
                     1_000_000_000,
                     2_000_000_000,
                 )),
@@ -8069,8 +8103,8 @@ mod tests {
                 local: None,
                 external: Some(recommendation(
                     crate::policy::ShapeRole::External,
-                    shape(0, 30, 0, 0),
-                    shape(0, 0, 24, 0), // 24 weeks chain
+                    shape(0, 30, 0, crate::types::MonthlyCount::Count(0), 0),
+                    shape(0, 0, 24, crate::types::MonthlyCount::Count(0), 0), // 24 weeks chain
                     1_000_000_000,
                     2_000_000_000,
                 )),
@@ -8095,8 +8129,8 @@ mod tests {
                 local: None,
                 external: Some(recommendation(
                     crate::policy::ShapeRole::External,
-                    shape(0, 30, 0, 0),
-                    shape(0, 0, 0, 24), // 24 months chain
+                    shape(0, 30, 0, crate::types::MonthlyCount::Count(0), 0),
+                    shape(0, 0, 0, crate::types::MonthlyCount::Count(24), 0), // 24 months chain
                     1_000_000_000,
                     2_000_000_000,
                 )),
@@ -8124,8 +8158,8 @@ mod tests {
                 name: "containers".to_string(),
                 local: Some(recommendation(
                     crate::policy::ShapeRole::Local,
-                    shape(24, 30, 26, 12),
-                    shape(0, 7, 4, 0),
+                    shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+                    shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0),
                     200_000_000_000,
                     50_000_000_000,
                 )),
@@ -8153,8 +8187,8 @@ mod tests {
                 name: "photos".to_string(),
                 local: Some(recommendation(
                     crate::policy::ShapeRole::Local,
-                    shape(24, 30, 26, 12),
-                    shape(0, 14, 8, 6),
+                    shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+                    shape(0, 14, 8, crate::types::MonthlyCount::Count(6), 0),
                     100_000_000_000,
                     30_000_000_000,
                 )),
@@ -8180,8 +8214,8 @@ mod tests {
                 name: "photos".to_string(),
                 local: Some(recommendation(
                     crate::policy::ShapeRole::Local,
-                    shape(24, 30, 26, 12),
-                    shape(0, 14, 8, 6),
+                    shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+                    shape(0, 14, 8, crate::types::MonthlyCount::Count(6), 0),
                     100_000_000_000,
                     30_000_000_000,
                 )),
@@ -8209,8 +8243,8 @@ mod tests {
                 name: "containers".to_string(),
                 local: Some(recommendation(
                     crate::policy::ShapeRole::Local,
-                    shape(24, 30, 26, 12),
-                    shape(0, 7, 4, 0),
+                    shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+                    shape(0, 7, 4, crate::types::MonthlyCount::Count(0), 0),
                     200_000_000_000,
                     50_000_000_000,
                 )),
@@ -8257,6 +8291,120 @@ mod tests {
         assert_eq!(
             row.get("was_named_level").and_then(|v| v.as_str()),
             Some("sheltered")
+        );
+    }
+
+    // ── UPI 042 — MonthlyCount + yearly rendering ───────────────────
+
+    #[test]
+    fn render_shape_kv_renders_unlimited_monthly() {
+        let s = crate::types::ResolvedGraduatedRetention {
+            hourly: 24,
+            daily: 30,
+            weekly: 26,
+            monthly: crate::types::MonthlyCount::Unlimited,
+            yearly: 0,
+        };
+        let out = super::render_shape_kv(&s);
+        assert!(
+            out.contains("monthly=unlimited"),
+            "Unlimited should render as 'monthly=unlimited': {out}"
+        );
+    }
+
+    #[test]
+    fn render_shape_kv_renders_yearly() {
+        let s = crate::types::ResolvedGraduatedRetention {
+            hourly: 0,
+            daily: 7,
+            weekly: 4,
+            monthly: crate::types::MonthlyCount::Count(12),
+            yearly: 5,
+        };
+        let out = super::render_shape_kv(&s);
+        assert!(out.contains("yearly=5"), "yearly should render: {out}");
+    }
+
+    #[test]
+    fn render_shape_kv_omits_zero_yearly() {
+        let s = crate::types::ResolvedGraduatedRetention {
+            hourly: 0,
+            daily: 7,
+            weekly: 4,
+            monthly: crate::types::MonthlyCount::Count(12),
+            yearly: 0,
+        };
+        let out = super::render_shape_kv(&s);
+        assert!(!out.contains("yearly"), "yearly=0 should be omitted: {out}");
+    }
+
+    #[test]
+    fn render_shape_kv_omits_count_zero_monthly() {
+        // R7: Count(0) monthly produces no `monthly=...` token.
+        let s = crate::types::ResolvedGraduatedRetention {
+            hourly: 0,
+            daily: 7,
+            weekly: 4,
+            monthly: crate::types::MonthlyCount::Count(0),
+            yearly: 0,
+        };
+        let out = super::render_shape_kv(&s);
+        assert!(
+            !out.contains("monthly"),
+            "Count(0) monthly should produce no token: {out}"
+        );
+    }
+
+    // ── UPI 042 Branch G — Doctor schema deprecation notice ─────────
+
+    #[test]
+    fn doctor_emits_v1_schema_notice() {
+        let _color = color_guard(false);
+        let mut data = super::test_fixtures::test_doctor_output();
+        data.schema_status = Some(crate::output::SchemaStatus {
+            current: Some(1),
+            latest: 2,
+        });
+        let out = super::render_doctor(&data, crate::output::OutputMode::Interactive);
+        assert!(
+            out.contains("Schema: v1"),
+            "v1 schema notice missing: {out}"
+        );
+        assert!(
+            out.contains("urd migrate"),
+            "migration hint missing: {out}"
+        );
+    }
+
+    #[test]
+    fn doctor_emits_legacy_schema_notice() {
+        let _color = color_guard(false);
+        let mut data = super::test_fixtures::test_doctor_output();
+        data.schema_status = Some(crate::output::SchemaStatus {
+            current: None,
+            latest: 2,
+        });
+        let out = super::render_doctor(&data, crate::output::OutputMode::Interactive);
+        assert!(
+            out.contains("Schema: legacy"),
+            "legacy schema notice missing: {out}"
+        );
+        assert!(out.contains("urd migrate"));
+    }
+
+    #[test]
+    fn doctor_omits_schema_notice_for_v2() {
+        let _color = color_guard(false);
+        // Default test_doctor_output has schema_status = None (already-v2).
+        let data = super::test_fixtures::test_doctor_output();
+        let out = super::render_doctor(&data, crate::output::OutputMode::Interactive);
+        assert!(
+            !out.contains("Schema: v"),
+            "v2 should not show schema notice: {out}"
+        );
+        assert!(
+            !out.contains("Schema: legacy"),
+            "v2 should not show schema notice: {out}"
         );
     }
 }

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -855,13 +855,15 @@ mod contract {
             hourly: 24,
             daily: 30,
             weekly: 26,
-            monthly: 12,
+            monthly: crate::types::MonthlyCount::Count(12),
+            yearly: 0,
         };
         let suggested = Shape {
             hourly: 0,
             daily: 7,
             weekly: 4,
-            monthly: 0,
+            monthly: crate::types::MonthlyCount::Count(0),
+            yearly: 0,
         };
         crate::output::DoctorRecommendationRow {
             name: "containers".to_string(),
@@ -997,5 +999,54 @@ mod contract {
         // advisory across multiple consecutive runs and assert it
         // appears in run 1 and run K but is suppressed in runs 2..K-1.
         unimplemented!("UPI 024+ Voice Evolution — see voice_contract.rs header");
+    }
+
+    // ── UPI 042 R7 — Count(0) render-omission invariant ──────────────
+    //
+    // Brute-force backstop for the Count(0) internal/external
+    // disagreement hazard (Risk Flag #1 in plan-042). Any future render
+    // path that emits `monthly = 0` for `Count(0)` is a regression — it
+    // would surface a value that v2 TOML rejects, confusing users who
+    // copy/paste from `urd doctor --thorough` output.
+
+    #[test]
+    fn count_zero_monthly_never_renders_in_any_surface() {
+        use crate::types::{MonthlyCount, ResolvedGraduatedRetention};
+        let shape = ResolvedGraduatedRetention {
+            hourly: 0,
+            daily: 7,
+            weekly: 4,
+            monthly: MonthlyCount::Count(0),
+            yearly: 0,
+        };
+
+        // Surface 1: render_shape_kv (private helper, accessed via
+        // recommendation rendering; we test through retention_summary too).
+        let interval = crate::types::Interval::days(1);
+        let summary = crate::retention::retention_summary(
+            &crate::types::LocalRetentionPolicy::Graduated(shape),
+            &interval,
+        );
+        for forbidden in &["monthly = 0", "monthly=0", "monthly: 0"] {
+            assert!(
+                !summary.contains(forbidden),
+                "retention_summary contains forbidden '{forbidden}' for Count(0): {summary}"
+            );
+        }
+
+        // Surface 2: compute_retention_preview / recovery_windows path.
+        let pol = crate::types::LocalRetentionPolicy::Graduated(shape);
+        let preview =
+            crate::retention::compute_retention_preview("sv", &pol, &interval, None);
+        let preview_str = format!("{preview:?}");
+        for forbidden in &["monthly = 0", "monthly=0", "monthly: 0"] {
+            // Allow the `monthly: Count(0)` Debug form (it's the typed
+            // representation, not a wire-format leak). Strip that token.
+            let pruned = preview_str.replace("monthly: Count(0)", "");
+            assert!(
+                !pruned.contains(forbidden),
+                "retention preview Debug contains forbidden '{forbidden}' for Count(0): {pruned}"
+            );
+        }
     }
 }

--- a/src/voice_events.rs
+++ b/src/voice_events.rs
@@ -159,6 +159,7 @@ fn prune_rule_phrase(rule: crate::events::PruneRule) -> &'static str {
         GraduatedDaily => "graduated: daily thinning",
         GraduatedWeekly => "graduated: weekly thinning",
         GraduatedMonthly => "graduated: monthly thinning",
+        GraduatedYearly => "graduated: yearly thinning",
         BeyondWindow => "beyond retention window",
         Emergency => "emergency: aggressive thinning",
         SpacePressure => "space pressure",


### PR DESCRIPTION
## Summary

- **Schema v2** closes the `monthly = 0` footgun: v2 requires `monthly = "unlimited"` (string) for unbounded retention and rejects literal `monthly = 0` with an actionable error. New optional `yearly: u32` tier alongside the four existing granularities.
- **`urd migrate`** now auto-targets v2 in a single hop (legacy → v2, v1 → v2), replacing the legacy → v1 path. v1 reads continue to interpret `monthly = 0` as unlimited via lenient `MonthlyCount::Deserialize`.
- **`urd doctor`** surfaces a one-line schema notice for pre-v2 configs (`Schema: v1 (current: v2; run urd migrate to upgrade)`).
- **Preflight** emits a `redundant-yearly` advisory when `monthly = "unlimited"` is paired with `yearly > 0`. Retention engine learns the yearly window; `format_graduated_policy` / `compute_recovery_windows` / `total_snapshot_count` updated.
- **`derive_policy()`** keeps Recorded local retention at `monthly = Unlimited` (preserves pre-UPI 042 behavior). External Recorded shifts to `Count(0)` — unreachable in practice since recorded subvolumes don't send.
- Includes a `/simplify` pass that removed the V1 shim machinery (~150 lines) once `MonthlyCount::Deserialize` was made lenient. See ADR-104/105/110/111 amendments (PR #122).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1285 passed, 0 failed, 5 ignored
- cargo build --release: pass
- Manual: `urd migrate --dry-run` on real v1 config produces clean v2 output; `urd doctor` shows `schema_status: { current: 1, latest: 2 }`
- Integration tests: not run (require physical drives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)