### PR TITLE
feat: UPI 043 — pool-level observability (heartbeat v4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- UPI 043 — pool-level observability. Four new Prometheus gauges
+  (`backup_pool_free_bytes`, `backup_pool_metadata_utilization_ratio`,
+  `backup_subvolume_local_snapshot_count`,
+  `backup_subvolume_estimated_local_pinned_delta_bytes`), heartbeat
+  schema v4 with `pools`, `drives`, and per-subvolume `pool_uuid` /
+  `local_snapshot_count` / `estimated_local_pinned_delta_bytes` fields.
+  Source-pool detection via `findmnt --target`; metadata utilization
+  from BTRFS sysfs. Heartbeat schema contract softened to SHOULD/MAY
+  semantics (additive forward-compat by serde default). ADR-105 amended;
+  companion homelab ADR-021 update in `vonrobak/fedora-homelab-containers`.
+
 ## [0.17.0] - 2026-05-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ All backup logic flows through: config -> plan -> execute. No exceptions.
 | `notify.rs` | Compute and dispatch notifications | Decide promise states (uses awareness) |
 | `drift.rs` | Pure: rolling time-windowed churn aggregation from `drift_samples` (UPI 030) | Perform I/O or persist |
 | `drives.rs` | Detect mounted drives, UUID fingerprinting, check space | Mount/unmount drives |
+| `pools.rs` | Detect BTRFS pools (source + destination), group subvolumes by pool UUID, read sysfs metadata utilization and statvfs free bytes | Know about retention, plans, drive lifecycle, or notification policy |
 | `output.rs` | Define structured output types | Render text (voice.rs does that) |
 | `voice.rs` | Render structured output as text (mythic voice) | Perform I/O or compute state |
 | `voice_events.rs` | Per-variant `EventPayload` renderer (columnar + NDJSON) | Perform I/O or query state |

--- a/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
@@ -139,6 +139,88 @@ converted to `monthly = "unlimited"`. The original is preserved verbatim in a `.
 `.legacy`) backup file. See ADR-111 Amendment 2026-05-15 for the dispatcher and migration
 command details.
 
+## Amendment 2026-05-15 (UPI 043): pool-observability metrics + heartbeat v4 fields
+
+UPI 043 adds pool-level observability signals as new on-disk contracts.
+Four new Prometheus gauges and a heartbeat schema bump v3 → v4 (additive;
+softened contract — see "Heartbeat contract" below).
+
+### New Prometheus metrics (additive; existing metrics unchanged)
+
+- `backup_pool_free_bytes{uuid, role, label}` — free bytes on a BTRFS pool.
+  Snapshot at backup-run cadence; not a live signal. `role` is one of
+  `"source"` or `"destination"`. `label` is the configured drive label for
+  destinations; the canonical (shortest) mountpoint string for sources.
+  Identity is `uuid`; `label` is informational only.
+- `backup_pool_metadata_utilization_ratio{uuid, role, label}` — BTRFS
+  metadata utilization (0.0–1.0) read from
+  `/sys/fs/btrfs/<uuid>/allocation/metadata/`. Covers both source and
+  destination pools.
+- `backup_subvolume_local_snapshot_count{subvolume}` — local snapshot count
+  for a subvolume. Line **absent** when local snapshots are not configured
+  (matches `Option::None` semantics of the heartbeat field). Coexists with
+  the legacy `backup_snapshot_count{subvolume,location="local"}`, which
+  uses `usize` always-present semantics per this ADR (the two metrics carry
+  the same physical fact but different contract shapes).
+- `backup_subvolume_estimated_local_pinned_delta_bytes{subvolume}` —
+  wire-bytes-derived estimate; mean over in-window incrementals × local
+  snapshot count. Emit policy: `Some(0)` when local snapshots are disabled
+  or `local_snapshot_count == 0` (known zero); line **omitted** when cold-
+  start (`local_snapshot_count > 0` and `mean_incremental_bytes` unknown).
+  Understates active periods of bimodal subvolumes; overstates dormancy.
+
+The existing `backup_external_free_bytes` (single-drive, global) is
+unchanged — sacred under this ADR. New per-pool free-bytes is additive.
+
+### Heartbeat contract (softened)
+
+The heartbeat module's schema contract is amended in UPI 043 from "MUST
+refuse higher versions" to "SHOULD check version; MAY refuse." Additive
+bumps (new fields with `#[serde(default, skip_serializing_if)]`) are
+forward-compatible by serde default — older readers transparently see new
+fields as absent. Field removal remains a breaking change requiring an
+ADR-105 amendment and a major version bump. This brings the contract text
+into agreement with how serde-default tolerance actually works and makes
+cross-repo parser-tolerance interlocks (R7) contractually meaningful.
+
+### Heartbeat schema v4
+
+Strict additive over v3. New top-level fields:
+
+- `pools: Vec<PoolHeartbeat>` — deduplicated BTRFS pools (source + mounted
+  destinations).
+- `drives: Vec<DriveHeartbeat>` — configured destination drives, mounted
+  or not.
+
+New `SubvolumeHeartbeat` fields:
+
+- `pool_uuid: Option<String>` — joins to a `PoolHeartbeat` by UUID.
+  `None` when detection failed.
+- `local_snapshot_count: Option<u32>` — `Some(_)` when local snapshots are
+  configured for the subvolume; `None` otherwise. UPI 044 reads this field
+  to scope retention recommendations.
+- `estimated_local_pinned_delta_bytes: Option<u64>` — exhaustive emit policy:
+  `Some(0)` when `local_snapshot_count` is `Some(0)` or `None`; `None` when
+  `local_snapshot_count > 0` and `mean_incremental_bytes` is unknown
+  (cold-start); `Some(count × mean)` otherwise. The "configured-with-zero"
+  and "not-configured" cases collapse to the same logical answer
+  (both pin zero local delta).
+
+All new fields use `#[serde(default, skip_serializing_if = …)]`. A v3
+reader parsing a v4 heartbeat sees the new fields as unknown JSON keys
+and ignores them (serde default). A v4 reader parsing a v3 heartbeat
+gets empty vecs and `None` for the new fields.
+
+### Cross-repo coordination
+
+Per the homelab integration reference: a corresponding amendment to
+`vonrobak/fedora-homelab-containers` ADR-021 lists the four new metric
+names and heartbeat fields. The Urd PR for UPI 043 does not merge until
+the homelab ADR-021 amendment is **merged** on the homelab side and the
+homelab repo's parser-tolerance test (v3-reader on v4 heartbeat passes
+without erroring) is green. The tolerance test is now contractually
+correct under the softened heartbeat contract above.
+
 ## Related
 
 - ADR-020: Daily external backups (established the dual pin file format)

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -17,14 +17,16 @@ use crate::executor::{
 };
 use crate::heartbeat;
 use crate::lock;
-use crate::metrics::{self, MetricsData, SubvolumeMetrics};
+use crate::heartbeat::{DriveHeartbeat, PoolHeartbeat};
+use crate::metrics::{self, MetricsData, PoolMetric, SubvolumeMetrics};
 use crate::output::{
     BackupSummary, ChurnHeartbeatFields, ChurnRender, DeferredInfo, EmptyPlanExplanation,
     OutputMode, SendSummary, SkipCategory, SkippedSubvolume, StatusAssessment, StructuredError,
-    SubvolumeSummary, TransitionEvent,
+    SubvolumeExtras, SubvolumeSummary, TransitionEvent,
 };
 use crate::notify;
 use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
+use crate::pools;
 use crate::sentinel_runner;
 use crate::preflight;
 use crate::state::StateDb;
@@ -119,11 +121,27 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         }
         let heartbeat_now = chrono::Local::now().naive_local();
         let churn_views = build_churn_views(&config, state_db.as_ref(), heartbeat_now);
-        write_metrics_for_skipped(&config, &backup_plan, now, &fs_state, &churn_views)?;
+        let observability = gather_pool_observability(&config, &churn_views, &fs_state);
+        write_metrics_for_skipped(
+            &config,
+            &backup_plan,
+            now,
+            &fs_state,
+            &churn_views,
+            &observability,
+        )?;
         let previous_hb = heartbeat::read(&config.general.heartbeat_file);
         let mut assessments = awareness::assess(&config, heartbeat_now, &fs_state);
         awareness::overlay_offsite_freshness(&mut assessments, &config);
-        let hb = heartbeat::build_empty(&config, heartbeat_now, &assessments, &churn_views);
+        let hb = heartbeat::build_empty(
+            &config,
+            heartbeat_now,
+            &assessments,
+            &churn_views,
+            observability.pools_heartbeat,
+            observability.drives_heartbeat,
+            &observability.subvol_extras,
+        );
         if let Err(e) = heartbeat::write(&config.general.heartbeat_file, &hb) {
             log::warn!("Failed to write heartbeat: {e}");
         }
@@ -299,14 +317,32 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // the same projection into both metrics and heartbeat (UPI 030).
     let heartbeat_now = chrono::Local::now().naive_local();
     let churn_views = build_churn_views(&config, state_db.as_ref(), heartbeat_now);
+    let observability = gather_pool_observability(&config, &churn_views, &fs_state);
 
     // Write metrics
-    write_metrics_after_execution(&config, &result, &backup_plan, now, &fs_state, &churn_views)?;
+    write_metrics_after_execution(
+        &config,
+        &result,
+        &backup_plan,
+        now,
+        &fs_state,
+        &churn_views,
+        &observability,
+    )?;
 
     // Write heartbeat (fresh timestamp — `now` is from before execution)
     let mut assessments = awareness::assess(&config, heartbeat_now, &fs_state);
     awareness::overlay_offsite_freshness(&mut assessments, &config);
-    let hb = heartbeat::build_from_run(&config, heartbeat_now, &result, &assessments, &churn_views);
+    let hb = heartbeat::build_from_run(
+        &config,
+        heartbeat_now,
+        &result,
+        &assessments,
+        &churn_views,
+        observability.pools_heartbeat,
+        observability.drives_heartbeat,
+        &observability.subvol_extras,
+    );
     if let Err(e) = heartbeat::write(&config.general.heartbeat_file, &hb) {
         log::warn!("Failed to write heartbeat: {e}");
     }
@@ -590,6 +626,7 @@ fn write_metrics_after_execution(
     now: chrono::NaiveDateTime,
     fs_state: &dyn FileSystemState,
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
+    observability: &PoolObservability,
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
     let mut subvolume_metrics = Vec::new();
@@ -606,6 +643,7 @@ fn write_metrics_after_execution(
         let local_count = count_local_snapshots(config, &sv_result.name, fs_state);
         let external_count = count_external_snapshots(config, &sv_result.name, fs_state);
         let churn = churn_views.get(&sv_result.name).copied().unwrap_or_default();
+        let extras = observability.subvol_extras.get(&sv_result.name);
 
         subvolume_metrics.push(SubvolumeMetrics {
             name: sv_result.name.clone(),
@@ -617,6 +655,9 @@ fn write_metrics_after_execution(
             send_type: sv_result.send_type.metric_value(),
             churn_bytes_per_second: churn.churn_bytes_per_second,
             last_full_send_bytes: churn.last_full_send_bytes,
+            local_snapshot_count_v4: extras.and_then(|e| e.local_snapshot_count),
+            estimated_local_pinned_delta_bytes: extras
+                .and_then(|e| e.estimated_local_pinned_delta_bytes),
         });
     }
 
@@ -633,13 +674,14 @@ fn write_metrics_after_execution(
         &mut subvolume_metrics,
         &already_emitted,
         churn_views,
+        observability,
     );
 
     // Carry forward last_success_timestamp from previous .prom file
     let carried = metrics::read_existing_timestamps(&config.general.metrics_file);
     metrics::apply_carried_forward_timestamps(&mut subvolume_metrics, &carried);
 
-    write_global_metrics(config, now_ts, subvolume_metrics)
+    write_global_metrics(config, now_ts, subvolume_metrics, observability.pool_metrics.clone())
 }
 
 fn write_metrics_for_skipped(
@@ -648,6 +690,7 @@ fn write_metrics_for_skipped(
     now: chrono::NaiveDateTime,
     fs_state: &dyn FileSystemState,
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
+    observability: &PoolObservability,
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
     let mut subvolume_metrics = Vec::new();
@@ -659,13 +702,14 @@ fn write_metrics_for_skipped(
         &mut subvolume_metrics,
         &HashSet::new(),
         churn_views,
+        observability,
     );
 
     // Carry forward last_success_timestamp from previous .prom file
     let carried = metrics::read_existing_timestamps(&config.general.metrics_file);
     metrics::apply_carried_forward_timestamps(&mut subvolume_metrics, &carried);
 
-    write_global_metrics(config, now_ts, subvolume_metrics)
+    write_global_metrics(config, now_ts, subvolume_metrics, observability.pool_metrics.clone())
 }
 
 /// Compute heartbeat / metrics churn projections for every configured
@@ -695,25 +739,190 @@ fn build_churn_views(
             rows.into_iter().map(StateDb::drift_row_to_sample).collect();
         let estimate =
             crate::drift::compute_rolling_churn(&samples, crate::drift::default_window(), now);
+        let mean_incremental_bytes = estimate.mean_incremental_bytes;
         let fields = match crate::output::render_churn(&estimate) {
-            ChurnRender::NotMeasured => ChurnHeartbeatFields::default(),
+            ChurnRender::NotMeasured => ChurnHeartbeatFields {
+                mean_incremental_bytes,
+                ..Default::default()
+            },
             ChurnRender::FirstMeasurement { bytes_per_second }
             | ChurnRender::Incremental { bytes_per_second } => ChurnHeartbeatFields {
                 churn_bytes_per_second: Some(bytes_per_second),
                 last_full_send_bytes: None,
+                mean_incremental_bytes,
             },
             ChurnRender::FullSendOnly { .. } => ChurnHeartbeatFields {
                 churn_bytes_per_second: None,
                 last_full_send_bytes: estimate.latest_full_bytes,
+                mean_incremental_bytes,
             },
             ChurnRender::FullSendOnlyFirst { bytes } => ChurnHeartbeatFields {
                 churn_bytes_per_second: None,
                 last_full_send_bytes: Some(bytes),
+                mean_incremental_bytes,
             },
         };
         out.insert(sv.name.clone(), fields);
     }
     out
+}
+
+/// UPI 043: bundled outputs from a single pool-observability pass. Threaded
+/// into both metrics emission (`write_metrics_after_execution` /
+/// `write_metrics_for_skipped`) and heartbeat construction
+/// (`heartbeat::build_from_run` / `heartbeat::build_empty`).
+struct PoolObservability {
+    pools_heartbeat: Vec<PoolHeartbeat>,
+    drives_heartbeat: Vec<DriveHeartbeat>,
+    subvol_extras: HashMap<String, SubvolumeExtras>,
+    pool_metrics: Vec<PoolMetric>,
+}
+
+/// UPI 043: detect source pools, resolve configured drives, and project both
+/// onto heartbeat + Prometheus surfaces. **Called exactly once per backup run**
+/// (M-4 acceptance) — the same snapshot of free-bytes / metadata / detection
+/// state must reach both surfaces so they don't drift between Prometheus and
+/// heartbeat for the same run.
+fn gather_pool_observability(
+    config: &Config,
+    churn_views: &HashMap<String, ChurnHeartbeatFields>,
+    fs_state: &dyn FileSystemState,
+) -> PoolObservability {
+    let source_pools = pools::detect_source_pools(config);
+
+    let mut drive_resolutions: Vec<pools::DriveResolution> = Vec::new();
+    let mut drives_heartbeat: Vec<DriveHeartbeat> = Vec::new();
+    for drive in &config.drives {
+        let mounted = drives::is_drive_mounted(drive);
+        let detected_uuid = if mounted {
+            drives::get_filesystem_uuid(&drive.mount_path).ok().flatten()
+        } else {
+            None
+        };
+        let resolved = pools::resolve_drive(drive, mounted, detected_uuid);
+        drives_heartbeat.push(DriveHeartbeat {
+            label: drive.label.clone(),
+            uuid: resolved.uuid.clone(),
+            role: drive.role.to_string(),
+            mounted,
+            pool_uuid: if mounted { resolved.uuid.clone() } else { None },
+        });
+        drive_resolutions.push(resolved);
+    }
+
+    let pool_metrics = pools::compute_pool_metrics_from(
+        &source_pools,
+        &drive_resolutions,
+        |mp| pools::pool_free_bytes(mp).ok(),
+        pools::metadata_utilization_ratio,
+    );
+
+    let mut pools_heartbeat: Vec<PoolHeartbeat> = Vec::new();
+    for pool in &source_pools {
+        let free = pool
+            .mountpoints
+            .first()
+            .and_then(|mp| pools::pool_free_bytes(mp).ok());
+        let meta = pools::metadata_utilization_ratio(&pool.uuid);
+        let mut mountpoints = pool.mountpoints.clone();
+        mountpoints.sort();
+        pools_heartbeat.push(PoolHeartbeat {
+            uuid: pool.uuid.clone(),
+            mountpoints,
+            free_bytes: free,
+            metadata_utilization_ratio: meta,
+        });
+    }
+    let source_uuids: HashSet<String> =
+        source_pools.iter().map(|p| p.uuid.clone()).collect();
+    let mut dest_seen: HashSet<String> = HashSet::new();
+    for drive_res in &drive_resolutions {
+        if !drive_res.mounted {
+            continue;
+        }
+        let Some(ref uuid) = drive_res.uuid else {
+            continue;
+        };
+        if source_uuids.contains(uuid) || !dest_seen.insert(uuid.clone()) {
+            continue;
+        }
+        let mp = drive_res.mountpoint.clone();
+        let free = mp.as_deref().and_then(|mp| pools::pool_free_bytes(mp).ok());
+        let meta = pools::metadata_utilization_ratio(uuid);
+        let mountpoints = mp.map(|p| vec![p]).unwrap_or_default();
+        pools_heartbeat.push(PoolHeartbeat {
+            uuid: uuid.clone(),
+            mountpoints,
+            free_bytes: free,
+            metadata_utilization_ratio: meta,
+        });
+    }
+
+    if pools_heartbeat.is_empty() && !config.subvolumes.is_empty() {
+        log::warn!(
+            "pool detection produced no source pools for {} configured subvolume(s); \
+             check findmnt availability and `/sys/fs/btrfs` mount",
+            config.subvolumes.len()
+        );
+    }
+
+    let pool_for_subvol: HashMap<String, String> = source_pools
+        .iter()
+        .flat_map(|p| {
+            p.subvolume_names
+                .iter()
+                .map(|n| (n.clone(), p.uuid.clone()))
+        })
+        .collect();
+    let mut subvol_extras: HashMap<String, SubvolumeExtras> = HashMap::new();
+    for sv in &config.subvolumes {
+        let pool_uuid = pool_for_subvol.get(&sv.name).cloned();
+        let configured = config.snapshot_root_for(&sv.name).is_some();
+        let local_snapshot_count = if configured {
+            let count = count_local_snapshots(config, &sv.name, fs_state);
+            Some(u32::try_from(count).unwrap_or(u32::MAX))
+        } else {
+            None
+        };
+        let mean_incremental_bytes = churn_views
+            .get(&sv.name)
+            .and_then(|c| c.mean_incremental_bytes);
+        let estimated_local_pinned_delta_bytes =
+            compute_pinned_delta(local_snapshot_count, mean_incremental_bytes);
+        subvol_extras.insert(
+            sv.name.clone(),
+            SubvolumeExtras {
+                pool_uuid,
+                local_snapshot_count,
+                estimated_local_pinned_delta_bytes,
+            },
+        );
+    }
+
+    PoolObservability {
+        pools_heartbeat,
+        drives_heartbeat,
+        subvol_extras,
+        pool_metrics,
+    }
+}
+
+/// UPI 043 R3 truth table — pure helper for the pinned-delta estimate.
+///
+/// | `local_snapshot_count` | `mean_incremental_bytes` | result   |
+/// |------------------------|--------------------------|----------|
+/// | `Some(0)`              | any                      | `Some(0)`|
+/// | `None`                 | any                      | `Some(0)`|
+/// | `Some(n>0)`            | `None`                   | `None`   |
+/// | `Some(n>0)`            | `Some(m)`                | `Some(n*m)` |
+#[must_use]
+fn compute_pinned_delta(count: Option<u32>, mean: Option<u64>) -> Option<u64> {
+    match (count, mean) {
+        (Some(0), _) => Some(0),
+        (None, _) => Some(0),
+        (Some(_), None) => None,
+        (Some(n), Some(m)) => Some(u64::from(n).saturating_mul(m)),
+    }
 }
 
 fn build_empty_plan_explanation(
@@ -793,6 +1002,7 @@ fn append_skipped_metrics(
     subvolume_metrics: &mut Vec<SubvolumeMetrics>,
     already_emitted: &HashSet<String>,
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
+    observability: &PoolObservability,
 ) {
     let mut seen = already_emitted.clone();
 
@@ -804,6 +1014,7 @@ fn append_skipped_metrics(
         let local_count = count_local_snapshots(config, name, fs_state);
         let external_count = count_external_snapshots(config, name, fs_state);
         let churn = churn_views.get(name).copied().unwrap_or_default();
+        let extras = observability.subvol_extras.get(name);
 
         subvolume_metrics.push(SubvolumeMetrics {
             name: name.clone(),
@@ -815,6 +1026,9 @@ fn append_skipped_metrics(
             send_type: 2,
             churn_bytes_per_second: churn.churn_bytes_per_second,
             last_full_send_bytes: churn.last_full_send_bytes,
+            local_snapshot_count_v4: extras.and_then(|e| e.local_snapshot_count),
+            estimated_local_pinned_delta_bytes: extras
+                .and_then(|e| e.estimated_local_pinned_delta_bytes),
         });
     }
 }
@@ -823,6 +1037,7 @@ fn write_global_metrics(
     config: &Config,
     now_ts: i64,
     subvolume_metrics: Vec<SubvolumeMetrics>,
+    pool_metrics: Vec<PoolMetric>,
 ) -> anyhow::Result<()> {
     let (drive_mounted, free_bytes) = drives::first_mounted_drive_status(config);
 
@@ -844,6 +1059,7 @@ fn write_global_metrics(
         external_free_bytes: free_bytes,
         script_last_run_timestamp: now_ts,
         event_counters,
+        pools: pool_metrics,
     };
 
     metrics::write_metrics(&config.general.metrics_file, &data)?;
@@ -2939,5 +3155,42 @@ mod tests {
         );
 
         assert!(summary.subvolumes.is_empty());
+    }
+
+    // ── UPI 043: pinned-delta truth table ──────────────────────────
+
+    #[test]
+    fn pinned_delta_emit_policy_zero_when_no_local_snapshots_count_is_zero() {
+        // Some(0), any mean → Some(0). Known zero.
+        assert_eq!(compute_pinned_delta(Some(0), None), Some(0));
+        assert_eq!(compute_pinned_delta(Some(0), Some(123)), Some(0));
+    }
+
+    #[test]
+    fn pinned_delta_emit_policy_zero_when_local_snapshots_disabled() {
+        // None (htpc-root case): collapses to Some(0).
+        assert_eq!(compute_pinned_delta(None, None), Some(0));
+        assert_eq!(compute_pinned_delta(None, Some(123)), Some(0));
+    }
+
+    #[test]
+    fn pinned_delta_emit_policy_none_when_cold_start() {
+        // Snapshots exist but no mean → None (genuine uncertainty).
+        assert_eq!(compute_pinned_delta(Some(5), None), None);
+    }
+
+    #[test]
+    fn pinned_delta_emit_policy_product_when_both_some() {
+        assert_eq!(
+            compute_pinned_delta(Some(10), Some(1_000_000)),
+            Some(10_000_000)
+        );
+    }
+
+    #[test]
+    fn pinned_delta_saturates_on_overflow() {
+        // Defensive: u32::MAX × u64::MAX should saturate, not wrap.
+        let got = compute_pinned_delta(Some(u32::MAX), Some(u64::MAX));
+        assert_eq!(got, Some(u64::MAX));
     }
 }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -427,6 +427,7 @@ fn compute_churn_for(
         })
         .unwrap_or(crate::drift::ChurnEstimate {
             mean_bytes_per_second: None,
+            mean_incremental_bytes: None,
             incremental_count: 0,
             full_count: 0,
             median_full_bytes: None,

--- a/src/drift.rs
+++ b/src/drift.rs
@@ -48,6 +48,11 @@ pub struct ChurnEstimate {
     /// `None` when no in-window incremental has a usable interval
     /// (`incremental_count == 0`).
     pub mean_bytes_per_second: Option<f64>,
+    /// Arithmetic mean of `bytes_transferred` across in-window usable
+    /// incrementals (the same slice that feeds `mean_bytes_per_second`).
+    /// `None` when `incremental_count == 0`. Integer division (estimate).
+    /// Used by UPI 043's pinned-delta computation.
+    pub mean_incremental_bytes: Option<u64>,
     /// Count of in-window samples whose `send_kind` is `Incremental` and that
     /// have a usable (non-zero, non-None) `seconds_since_prev_send`.
     pub incremental_count: usize,
@@ -107,21 +112,23 @@ pub fn compute_rolling_churn(
         .collect();
 
     let incremental_count = usable_incrementals.len();
-    let mean_bytes_per_second = if usable_incrementals.is_empty() {
-        None
+    let (mean_bytes_per_second, mean_incremental_bytes) = if usable_incrementals.is_empty() {
+        (None, None)
     } else {
         let total_bytes: u64 = usable_incrementals.iter().map(|s| s.bytes_transferred).sum();
         let total_seconds: i64 = usable_incrementals
             .iter()
             .map(|s| s.seconds_since_prev_send.unwrap_or(0))
             .sum();
-        if total_seconds > 0 {
+        let mean_bps = if total_seconds > 0 {
             #[allow(clippy::cast_precision_loss)]
             let mean = total_bytes as f64 / total_seconds as f64;
             Some(mean)
         } else {
             None
-        }
+        };
+        let mean_bytes = total_bytes / incremental_count as u64;
+        (mean_bps, Some(mean_bytes))
     };
 
     // Step 4: full aggregation.
@@ -147,6 +154,7 @@ pub fn compute_rolling_churn(
 
     ChurnEstimate {
         mean_bytes_per_second,
+        mean_incremental_bytes,
         incremental_count,
         full_count,
         median_full_bytes,
@@ -379,5 +387,109 @@ mod tests {
         let est = compute_rolling_churn(&samples, default_window(), now);
         assert_eq!(est.incremental_count, 0);
         assert_eq!(est.mean_bytes_per_second, None);
+    }
+
+    // ── UPI 043: mean_incremental_bytes ────────────────────────────
+
+    #[test]
+    fn mean_incremental_bytes_none_when_no_incrementals() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s = dt(2026, 4, 30, 12, 0);
+
+        // Empty samples
+        let est = compute_rolling_churn(&[], default_window(), now);
+        assert_eq!(est.mean_incremental_bytes, None);
+
+        // Full-only
+        let samples = vec![sample(s, Some(86_400), 12_000_000_000, SendKind::Full)];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.mean_incremental_bytes, None);
+
+        // Cold-start: incremental with `None` interval (not usable)
+        let samples = vec![sample(s, None, 86_400_000, SendKind::Incremental)];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.mean_incremental_bytes, None);
+    }
+
+    #[test]
+    fn mean_incremental_bytes_single_incremental() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s = dt(2026, 4, 30, 12, 0);
+        let samples = vec![sample(s, Some(86_400), 86_400_000, SendKind::Incremental)];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.mean_incremental_bytes, Some(86_400_000));
+    }
+
+    #[test]
+    fn mean_incremental_bytes_two_incrementals_arithmetic_mean() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s1 = dt(2026, 4, 29, 12, 0);
+        let s2 = dt(2026, 4, 30, 12, 0);
+        let samples = vec![
+            sample(s1, Some(86_400), 100_000_000, SendKind::Incremental),
+            sample(s2, Some(86_400), 200_000_000, SendKind::Incremental),
+        ];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        // (100M + 200M) / 2 = 150M
+        assert_eq!(est.mean_incremental_bytes, Some(150_000_000));
+    }
+
+    #[test]
+    fn mean_incremental_bytes_excludes_full_sends() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s1 = dt(2026, 4, 29, 12, 0);
+        let s2 = dt(2026, 4, 30, 12, 0);
+        let s3 = dt(2026, 4, 28, 12, 0);
+        let samples = vec![
+            sample(s1, Some(86_400), 100_000_000, SendKind::Incremental),
+            sample(s2, Some(86_400), 200_000_000, SendKind::Incremental),
+            sample(s3, Some(86_400), 9_999_999_999, SendKind::Full),
+        ];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        // Full excluded; mean over incrementals only
+        assert_eq!(est.mean_incremental_bytes, Some(150_000_000));
+    }
+
+    #[test]
+    fn mean_incremental_bytes_excludes_zero_interval_samples() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s1 = dt(2026, 4, 29, 12, 0);
+        let s2 = dt(2026, 4, 30, 12, 0);
+        let samples = vec![
+            sample(s1, Some(86_400), 100_000_000, SendKind::Incremental),
+            // zero-interval is filtered out of `usable_incrementals`
+            sample(s2, Some(0), 5_000_000_000, SendKind::Incremental),
+        ];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 1);
+        assert_eq!(est.mean_incremental_bytes, Some(100_000_000));
+    }
+
+    #[test]
+    fn mean_incremental_bytes_excludes_none_interval_samples() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let s1 = dt(2026, 4, 29, 12, 0);
+        let s2 = dt(2026, 4, 30, 12, 0);
+        let samples = vec![
+            sample(s1, Some(86_400), 100_000_000, SendKind::Incremental),
+            sample(s2, None, 5_000_000_000, SendKind::Incremental),
+        ];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 1);
+        assert_eq!(est.mean_incremental_bytes, Some(100_000_000));
+    }
+
+    #[test]
+    fn mean_incremental_bytes_outside_window_excluded() {
+        let now = dt(2026, 5, 1, 12, 0);
+        let recent = dt(2026, 4, 30, 12, 0);
+        let old = dt(2026, 4, 1, 12, 0); // outside 7-day window
+        let samples = vec![
+            sample(recent, Some(86_400), 100_000_000, SendKind::Incremental),
+            sample(old, Some(86_400), 9_999_999_999, SendKind::Incremental),
+        ];
+        let est = compute_rolling_churn(&samples, default_window(), now);
+        assert_eq!(est.incremental_count, 1);
+        assert_eq!(est.mean_incremental_bytes, Some(100_000_000));
     }
 }

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -4,12 +4,17 @@
 // without requiring SQLite access. It bridges the backup command and future
 // consumers (Sentinel, tray icon, external scripts).
 //
-// Schema contract: consumers MUST check `schema_version` and refuse to interpret
-// fields from a higher version. The writer MUST NOT remove fields between
-// versions — only add. Additive changes bump the version.
+// Schema contract: consumers SHOULD check `schema_version`. Additive
+// version bumps (new fields with `#[serde(default, skip_serializing_if = …)]`)
+// are forward-compatible — older readers may parse newer payloads and will
+// see unknown fields as absent (serde default). Consumers MAY refuse a
+// payload from a higher version if they prefer strict semantics, but they
+// are not required to. The writer MUST NOT remove fields between minor
+// version bumps; field removal is a breaking change requiring an ADR-105
+// amendment and a major schema-version bump.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
@@ -18,10 +23,10 @@ use crate::awareness::SubvolAssessment;
 use crate::config::Config;
 use crate::error::UrdError;
 use crate::executor::{ExecutionResult, SendType};
-use crate::output::ChurnHeartbeatFields;
+use crate::output::{ChurnHeartbeatFields, SubvolumeExtras};
 
 /// Current schema version. Bump when adding fields (never remove fields).
-const SCHEMA_VERSION: u32 = 3;
+const SCHEMA_VERSION: u32 = 4;
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -39,6 +44,33 @@ pub struct Heartbeat {
     /// Defaults to true for backward compat with pre-notification heartbeats.
     #[serde(default = "default_true")]
     pub notifications_dispatched: bool,
+    /// UPI 043: detected BTRFS pools (source + mounted destinations).
+    /// Empty (and omitted from JSON) on v3-era heartbeats.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pools: Vec<PoolHeartbeat>,
+    /// UPI 043: configured destination drives, mounted or not.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub drives: Vec<DriveHeartbeat>,
+}
+
+/// UPI 043: per-pool view (one entry per deduplicated BTRFS UUID).
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PoolHeartbeat {
+    pub uuid: String,
+    pub mountpoints: Vec<PathBuf>,
+    pub free_bytes: Option<u64>,
+    pub metadata_utilization_ratio: Option<f64>,
+}
+
+/// UPI 043: per-configured-drive view.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DriveHeartbeat {
+    pub label: String,
+    pub uuid: Option<String>,
+    /// "primary" | "offsite" | "test"
+    pub role: String,
+    pub mounted: bool,
+    pub pool_uuid: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -72,20 +104,42 @@ pub struct SubvolumeHeartbeat {
     /// cold-start subvolumes).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_full_send_bytes: Option<u64>,
+    /// UPI 043: pool UUID this subvolume's source resides on. `None` if
+    /// pool detection failed for this subvolume.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pool_uuid: Option<String>,
+    /// UPI 043: count of local snapshots for this subvolume. `Some(_)` when
+    /// local snapshots are configured; `None` otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub local_snapshot_count: Option<u32>,
+    /// UPI 043: estimated local pinned CoW delta in bytes. `Some(0)` when
+    /// `local_snapshot_count` is `Some(0)` or `None`; `None` when cold-start
+    /// (`local_snapshot_count > 0` and `mean_incremental_bytes` unknown);
+    /// `Some(count × mean)` otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub estimated_local_pinned_delta_bytes: Option<u64>,
 }
 
 // ── Builder ─────────────────────────────────────────────────────────────
 
 /// Build a heartbeat from a completed backup run with awareness assessments.
+///
+/// If a future addition pushes this past 8 args, refactor to a
+/// `HeartbeatInputs { ... }` struct instead of growing the positional list.
 #[must_use]
+#[allow(clippy::too_many_arguments)]
 pub fn build_from_run(
     config: &Config,
     now: NaiveDateTime,
     result: &ExecutionResult,
     assessments: &[SubvolAssessment],
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
+    pools: Vec<PoolHeartbeat>,
+    drives: Vec<DriveHeartbeat>,
+    subvol_extras: &HashMap<String, SubvolumeExtras>,
 ) -> Heartbeat {
-    let subvolumes = build_subvolume_entries(Some(result), assessments, churn_views);
+    let subvolumes =
+        build_subvolume_entries(Some(result), assessments, churn_views, subvol_extras);
 
     Heartbeat {
         schema_version: SCHEMA_VERSION,
@@ -97,18 +151,27 @@ pub fn build_from_run(
         run_id: result.run_id,
         subvolumes,
         notifications_dispatched: false,
+        pools,
+        drives,
     }
 }
 
 /// Build a heartbeat for an empty/skipped run (no execution result).
+///
+/// If a future addition pushes this past 8 args, refactor to a
+/// `HeartbeatInputs { ... }` struct instead of growing the positional list.
 #[must_use]
+#[allow(clippy::too_many_arguments)]
 pub fn build_empty(
     config: &Config,
     now: NaiveDateTime,
     assessments: &[SubvolAssessment],
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
+    pools: Vec<PoolHeartbeat>,
+    drives: Vec<DriveHeartbeat>,
+    subvol_extras: &HashMap<String, SubvolumeExtras>,
 ) -> Heartbeat {
-    let subvolumes = build_subvolume_entries(None, assessments, churn_views);
+    let subvolumes = build_subvolume_entries(None, assessments, churn_views, subvol_extras);
 
     Heartbeat {
         schema_version: SCHEMA_VERSION,
@@ -120,6 +183,8 @@ pub fn build_empty(
         run_id: None,
         subvolumes,
         notifications_dispatched: false,
+        pools,
+        drives,
     }
 }
 
@@ -127,6 +192,7 @@ fn build_subvolume_entries(
     result: Option<&ExecutionResult>,
     assessments: &[SubvolAssessment],
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
+    subvol_extras: &HashMap<String, SubvolumeExtras>,
 ) -> Vec<SubvolumeHeartbeat> {
     assessments
         .iter()
@@ -140,6 +206,7 @@ fn build_subvolume_entries(
             });
 
             let churn = churn_views.get(&a.name).copied().unwrap_or_default();
+            let extras = subvol_extras.get(&a.name).cloned().unwrap_or_default();
 
             SubvolumeHeartbeat {
                 name: a.name.clone(),
@@ -149,6 +216,9 @@ fn build_subvolume_entries(
                 send_completed,
                 churn_bytes_per_second: churn.churn_bytes_per_second,
                 last_full_send_bytes: churn.last_full_send_bytes,
+                pool_uuid: extras.pool_uuid,
+                local_snapshot_count: extras.local_snapshot_count,
+                estimated_local_pinned_delta_bytes: extras.estimated_local_pinned_delta_bytes,
             }
         })
         .collect()
@@ -394,11 +464,20 @@ mod tests {
         let assessments = test_assessments();
         let result = test_execution_result();
 
-        let heartbeat = build_from_run(&config, now, &result, &assessments, &HashMap::new());
+        let heartbeat = build_from_run(
+            &config,
+            now,
+            &result,
+            &assessments,
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         let json = serde_json::to_string_pretty(&heartbeat).unwrap();
         let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
 
-        assert_eq!(parsed.schema_version, 3);
+        assert_eq!(parsed.schema_version, 4);
         assert_eq!(parsed.timestamp, "2026-03-24T02:05:00");
         assert_eq!(parsed.run_result, "partial");
         assert_eq!(parsed.run_id, Some(42));
@@ -451,7 +530,15 @@ mod tests {
             NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let assessments = test_assessments();
 
-        let heartbeat = build_empty(&config, now, &assessments, &HashMap::new());
+        let heartbeat = build_empty(
+            &config,
+            now,
+            &assessments,
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
 
         assert_eq!(heartbeat.run_result, "empty");
         assert_eq!(heartbeat.run_id, None);
@@ -476,14 +563,22 @@ mod tests {
             NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let assessments = test_assessments();
 
-        let heartbeat = build_empty(&config, now, &assessments, &HashMap::new());
+        let heartbeat = build_empty(
+            &config,
+            now,
+            &assessments,
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         write(&path, &heartbeat).unwrap();
 
         // Temp file cleaned up
         assert!(!dir.path().join("heartbeat.json.tmp").exists());
         // File exists and is valid
         let read_back = read(&path).unwrap();
-        assert_eq!(read_back.schema_version, 3);
+        assert_eq!(read_back.schema_version, 4);
         assert_eq!(read_back.timestamp, "2026-03-24T02:00:00");
     }
 
@@ -495,7 +590,15 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let heartbeat = build_empty(&config, now, &test_assessments(), &HashMap::new());
+        let heartbeat = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         write(&path, &heartbeat).unwrap();
 
         assert!(path.exists());
@@ -504,12 +607,22 @@ mod tests {
     // ── UPI 030: schema v3 + churn / last-full-send fields ──────────────
 
     #[test]
-    fn heartbeat_serializes_at_schema_version_3() {
+    fn heartbeat_serializes_at_schema_version_4() {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let heartbeat = build_empty(&config, now, &test_assessments(), &HashMap::new());
-        assert_eq!(heartbeat.schema_version, 3);
+        let heartbeat = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
+        assert_eq!(heartbeat.schema_version, 4);
+        let json = serde_json::to_string(&heartbeat).unwrap();
+        assert!(json.contains("\"schema_version\":4"));
     }
 
     #[test]
@@ -523,10 +636,19 @@ mod tests {
             ChurnHeartbeatFields {
                 churn_bytes_per_second: Some(1234.5),
                 last_full_send_bytes: None,
+                mean_incremental_bytes: None,
             },
         );
 
-        let hb = build_empty(&config, now, &test_assessments(), &churn);
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &churn,
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         let json = serde_json::to_string(&hb).unwrap();
         let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
         let home = parsed.subvolumes.iter().find(|s| s.name == "home").unwrap();
@@ -545,10 +667,19 @@ mod tests {
             ChurnHeartbeatFields {
                 churn_bytes_per_second: None,
                 last_full_send_bytes: Some(12_000_000_000),
+                mean_incremental_bytes: None,
             },
         );
 
-        let hb = build_empty(&config, now, &test_assessments(), &churn);
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &churn,
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         let json = serde_json::to_string(&hb).unwrap();
         let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
         let home = parsed.subvolumes.iter().find(|s| s.name == "home").unwrap();
@@ -587,7 +718,15 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let hb = build_empty(&config, now, &test_assessments(), &HashMap::new());
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         let json = serde_json::to_string(&hb).unwrap();
         assert!(
             !json.contains("churn_bytes_per_second"),
@@ -600,7 +739,15 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let hb = build_empty(&config, now, &test_assessments(), &HashMap::new());
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         let json = serde_json::to_string(&hb).unwrap();
         assert!(
             !json.contains("last_full_send_bytes"),
@@ -652,7 +799,16 @@ mod tests {
             run_id: Some(1),
         };
 
-        let hb = build_from_run(&config, now, &result, &assessments, &HashMap::new());
+        let hb = build_from_run(
+            &config,
+            now,
+            &result,
+            &assessments,
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         assert!(hb.subvolumes[0].send_completed);
     }
 
@@ -680,7 +836,16 @@ mod tests {
             run_id: Some(1),
         };
 
-        let hb = build_from_run(&config, now, &result, &assessments, &HashMap::new());
+        let hb = build_from_run(
+            &config,
+            now,
+            &result,
+            &assessments,
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         assert!(!hb.subvolumes[0].send_completed);
     }
 
@@ -708,7 +873,16 @@ mod tests {
             run_id: Some(1),
         };
 
-        let hb = build_from_run(&config, now, &result, &assessments, &HashMap::new());
+        let hb = build_from_run(
+            &config,
+            now,
+            &result,
+            &assessments,
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
         assert!(!hb.subvolumes[0].send_completed);
     }
 
@@ -736,5 +910,216 @@ mod tests {
             parsed.subvolumes[0].send_completed,
             "v1 heartbeat without send_completed should default to true"
         );
+    }
+
+    // ── UPI 043: schema v4 + pool/drive/subvol_extras fields ────────────
+
+    #[test]
+    fn heartbeat_v3_reader_tolerates_v4_unknown_fields() {
+        // Simulate a v3 reader: deserialize a v4-on-disk payload using the
+        // same `Heartbeat` type. Serde-default tolerance means new fields
+        // either parse as empty/None or are silently consumed.
+        let json = r#"{
+            "schema_version": 4,
+            "timestamp": "2026-05-15T02:00:00",
+            "stale_after": "2026-05-15T04:00:00",
+            "run_result": "success",
+            "run_id": 99,
+            "subvolumes": [
+                {
+                    "name": "home",
+                    "backup_success": true,
+                    "promise_status": "PROTECTED",
+                    "pin_failures": 0,
+                    "send_completed": true,
+                    "pool_uuid": "uuid-a",
+                    "local_snapshot_count": 7,
+                    "estimated_local_pinned_delta_bytes": 1234567
+                }
+            ],
+            "notifications_dispatched": true,
+            "pools": [
+                {
+                    "uuid": "uuid-a",
+                    "mountpoints": ["/home"],
+                    "free_bytes": 1000,
+                    "metadata_utilization_ratio": 0.25
+                }
+            ],
+            "drives": [
+                {
+                    "label": "WD-18TB",
+                    "uuid": "uuid-x",
+                    "role": "primary",
+                    "mounted": true,
+                    "pool_uuid": "uuid-x"
+                }
+            ],
+            "future_unknown_key": "v5-or-later"
+        }"#;
+        let parsed: Heartbeat = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.schema_version, 4);
+        assert_eq!(parsed.pools.len(), 1);
+        assert_eq!(parsed.drives.len(), 1);
+        assert_eq!(parsed.subvolumes[0].pool_uuid.as_deref(), Some("uuid-a"));
+        assert_eq!(parsed.subvolumes[0].local_snapshot_count, Some(7));
+    }
+
+    #[test]
+    fn heartbeat_v4_omits_empty_pools_and_drives_lists() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-05-15T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
+        let json = serde_json::to_string(&hb).unwrap();
+        assert!(!json.contains("\"pools\""), "pools should be omitted: {json}");
+        assert!(
+            !json.contains("\"drives\""),
+            "drives should be omitted: {json}"
+        );
+    }
+
+    #[test]
+    fn heartbeat_v4_serializes_pools_with_mountpoints_preserved() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-05-15T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let pools = vec![PoolHeartbeat {
+            uuid: "uuid-a".to_string(),
+            mountpoints: vec![PathBuf::from("/b"), PathBuf::from("/a")],
+            free_bytes: Some(42),
+            metadata_utilization_ratio: Some(0.5),
+        }];
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            pools,
+            Vec::new(),
+            &HashMap::new(),
+        );
+        let json = serde_json::to_string(&hb).unwrap();
+        let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.pools.len(), 1);
+        // Sorting is the caller's job, not serde's — round-trip preserves input order.
+        assert_eq!(
+            parsed.pools[0].mountpoints,
+            vec![PathBuf::from("/b"), PathBuf::from("/a")]
+        );
+    }
+
+    #[test]
+    fn subvolume_heartbeat_omits_pool_uuid_when_none() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-05-15T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
+        let json = serde_json::to_string(&hb).unwrap();
+        assert!(!json.contains("pool_uuid"), "pool_uuid omitted: {json}");
+    }
+
+    #[test]
+    fn subvolume_heartbeat_serializes_pool_uuid_when_some() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-05-15T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let mut extras = HashMap::new();
+        extras.insert(
+            "home".to_string(),
+            SubvolumeExtras {
+                pool_uuid: Some("uuid-src".to_string()),
+                local_snapshot_count: Some(24),
+                estimated_local_pinned_delta_bytes: Some(1_000_000),
+            },
+        );
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &extras,
+        );
+        let json = serde_json::to_string(&hb).unwrap();
+        let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
+        let home = parsed.subvolumes.iter().find(|s| s.name == "home").unwrap();
+        assert_eq!(home.pool_uuid.as_deref(), Some("uuid-src"));
+        assert_eq!(home.local_snapshot_count, Some(24));
+        assert_eq!(home.estimated_local_pinned_delta_bytes, Some(1_000_000));
+    }
+
+    #[test]
+    fn drive_heartbeat_serializes_role_as_string() {
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-05-15T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let drives = vec![DriveHeartbeat {
+            label: "WD-18TB".to_string(),
+            uuid: Some("uuid-x".to_string()),
+            role: DriveRole::Primary.to_string(),
+            mounted: true,
+            pool_uuid: Some("uuid-x".to_string()),
+        }];
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            Vec::new(),
+            drives,
+            &HashMap::new(),
+        );
+        let json = serde_json::to_string(&hb).unwrap();
+        // DriveRole::Primary renders as "primary" via Display.
+        assert!(
+            json.contains("\"role\":\"primary\""),
+            "role missing or wrong: {json}"
+        );
+    }
+
+    #[test]
+    fn drive_heartbeat_round_trip_mounted_false_pool_uuid_none() {
+        let drives = vec![DriveHeartbeat {
+            label: "OFFLINE".to_string(),
+            uuid: Some("uuid-z".to_string()),
+            role: DriveRole::Offsite.to_string(),
+            mounted: false,
+            pool_uuid: None,
+        }];
+        let config = test_config(&[("home", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-05-15T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let hb = build_empty(
+            &config,
+            now,
+            &test_assessments(),
+            &HashMap::new(),
+            Vec::new(),
+            drives,
+            &HashMap::new(),
+        );
+        let json = serde_json::to_string(&hb).unwrap();
+        let parsed: Heartbeat = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.drives.len(), 1);
+        assert!(!parsed.drives[0].mounted);
+        assert_eq!(parsed.drives[0].pool_uuid, None);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod notify;
 mod output;
 mod plan;
 mod policy;
+mod pools;
 mod preflight;
 mod retention;
 mod sentinel;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,6 +15,22 @@ pub struct MetricsData {
     /// Counters derived from the events table at write time.
     /// Empty/zero when no state DB is available.
     pub event_counters: EventCounters,
+    /// UPI 043: per-pool metrics (source + destination). Empty for runs that
+    /// didn't gather pool observability.
+    pub pools: Vec<PoolMetric>,
+}
+
+/// UPI 043: one row per (uuid, role) feeding `backup_pool_free_bytes` and
+/// `backup_pool_metadata_utilization_ratio`. Source-pool `label` is the
+/// canonical (shortest) mountpoint string; destination-pool `label` is the
+/// configured drive label.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PoolMetric {
+    pub uuid: String,
+    pub role: String,
+    pub label: String,
+    pub free_bytes: Option<u64>,
+    pub metadata_utilization_ratio: Option<f64>,
 }
 
 /// Prometheus counter family derived from the events table by
@@ -47,6 +63,30 @@ pub struct SubvolumeMetrics {
     /// Bytes of the most recent in-window full send (UPI 030). Emitted only
     /// when `Some`. Absent for incremental-only and cold-start subvolumes.
     pub last_full_send_bytes: Option<u64>,
+    /// UPI 043: feeds `backup_subvolume_local_snapshot_count`. `Some(_)` when
+    /// local snapshots are configured for this subvolume; `None` otherwise.
+    /// Coexists with `local_snapshot_count: usize` (always-present, feeds the
+    /// legacy `backup_snapshot_count{location="local"}` per ADR-105).
+    pub local_snapshot_count_v4: Option<u32>,
+    /// UPI 043: feeds `backup_subvolume_estimated_local_pinned_delta_bytes`.
+    /// Emit policy: line absent when `None` (cold-start);
+    /// `Some(0)` is emitted (distinguishes "known zero" from "unknown").
+    pub estimated_local_pinned_delta_bytes: Option<u64>,
+}
+
+/// Escape `\` and `"` in a Prometheus label value per the exposition format.
+#[must_use]
+fn escape_label_value(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            other => out.push(other),
+        }
+    }
+    out
 }
 
 // ── Writer ──────────────────────────────────────────────────────────────
@@ -304,6 +344,96 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
+    // ── Pool observability (UPI 043) ──────────────────────────────
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP backup_pool_free_bytes Free bytes on a BTRFS pool. Snapshot at backup-run cadence; not a live signal."
+    )
+    .unwrap();
+    writeln!(out, "# TYPE backup_pool_free_bytes gauge").unwrap();
+    for pool in &data.pools {
+        if let Some(bytes) = pool.free_bytes {
+            writeln!(
+                out,
+                "backup_pool_free_bytes{{uuid=\"{}\",role=\"{}\",label=\"{}\"}} {}",
+                escape_label_value(&pool.uuid),
+                escape_label_value(&pool.role),
+                escape_label_value(&pool.label),
+                bytes
+            )
+            .unwrap();
+        }
+    }
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP backup_pool_metadata_utilization_ratio BTRFS metadata utilization (0.0–1.0); source or destination."
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "# TYPE backup_pool_metadata_utilization_ratio gauge"
+    )
+    .unwrap();
+    for pool in &data.pools {
+        if let Some(ratio) = pool.metadata_utilization_ratio {
+            writeln!(
+                out,
+                "backup_pool_metadata_utilization_ratio{{uuid=\"{}\",role=\"{}\",label=\"{}\"}} {}",
+                escape_label_value(&pool.uuid),
+                escape_label_value(&pool.role),
+                escape_label_value(&pool.label),
+                ratio
+            )
+            .unwrap();
+        }
+    }
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP backup_subvolume_local_snapshot_count Local snapshot count for a subvolume. Line absent when local snapshots are not configured for that subvolume."
+    )
+    .unwrap();
+    writeln!(out, "# TYPE backup_subvolume_local_snapshot_count gauge").unwrap();
+    for sv in &data.subvolumes {
+        if let Some(count) = sv.local_snapshot_count_v4 {
+            writeln!(
+                out,
+                "backup_subvolume_local_snapshot_count{{subvolume=\"{}\"}} {}",
+                escape_label_value(&sv.name),
+                count
+            )
+            .unwrap();
+        }
+    }
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP backup_subvolume_estimated_local_pinned_delta_bytes Estimated local pinned CoW delta; wire-bytes-derived (mean over incrementals). Understates active periods of bimodal subvolumes; overstates dormancy."
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "# TYPE backup_subvolume_estimated_local_pinned_delta_bytes gauge"
+    )
+    .unwrap();
+    for sv in &data.subvolumes {
+        if let Some(bytes) = sv.estimated_local_pinned_delta_bytes {
+            writeln!(
+                out,
+                "backup_subvolume_estimated_local_pinned_delta_bytes{{subvolume=\"{}\"}} {}",
+                escape_label_value(&sv.name),
+                bytes
+            )
+            .unwrap();
+        }
+    }
+
     // ── Structured event counters ─────────────────────────────────
 
     let counters = &data.event_counters;
@@ -402,6 +532,8 @@ mod tests {
                     send_type: 1,
                     churn_bytes_per_second: None,
                     last_full_send_bytes: None,
+                    local_snapshot_count_v4: None,
+                    estimated_local_pinned_delta_bytes: None,
                 },
                 SubvolumeMetrics {
                     name: "htpc-home".to_string(),
@@ -413,12 +545,15 @@ mod tests {
                     send_type: 2,
                     churn_bytes_per_second: None,
                     last_full_send_bytes: None,
+                    local_snapshot_count_v4: None,
+                    estimated_local_pinned_delta_bytes: None,
                 },
             ],
             external_drive_mounted: true,
             external_free_bytes: 4_400_000_000_000,
             script_last_run_timestamp: 1_711_100_120,
             event_counters: EventCounters::default(),
+            pools: Vec::new(),
         }
     }
 
@@ -502,6 +637,7 @@ mod tests {
             external_free_bytes: 0,
             script_last_run_timestamp: 1_711_100_000,
             event_counters: EventCounters::default(),
+            pools: Vec::new(),
         };
         let output = format_metrics(&data);
         assert!(output.contains("backup_external_drive_mounted 0"));
@@ -560,6 +696,8 @@ mod tests {
                 send_type: 1,
                 churn_bytes_per_second: None,
                 last_full_send_bytes: None,
+                local_snapshot_count_v4: None,
+                estimated_local_pinned_delta_bytes: None,
             },
             SubvolumeMetrics {
                 name: "sv-b".to_string(),
@@ -571,6 +709,8 @@ mod tests {
                 send_type: 2,
                 churn_bytes_per_second: None,
                 last_full_send_bytes: None,
+                local_snapshot_count_v4: None,
+                estimated_local_pinned_delta_bytes: None,
             },
             SubvolumeMetrics {
                 name: "sv-c".to_string(),
@@ -582,6 +722,8 @@ mod tests {
                 send_type: 2,
                 churn_bytes_per_second: None,
                 last_full_send_bytes: None,
+                local_snapshot_count_v4: None,
+                estimated_local_pinned_delta_bytes: None,
             },
         ];
 
@@ -613,11 +755,14 @@ mod tests {
                 send_type: 1,
                 churn_bytes_per_second: None,
                 last_full_send_bytes: None,
+                local_snapshot_count_v4: None,
+                estimated_local_pinned_delta_bytes: None,
             }],
             external_drive_mounted: true,
             external_free_bytes: 1_000_000,
             script_last_run_timestamp: 12345,
             event_counters: EventCounters::default(),
+            pools: Vec::new(),
         };
         write_metrics(&path, &data).unwrap();
 
@@ -633,6 +778,8 @@ mod tests {
             send_type: 2,
             churn_bytes_per_second: None,
             last_full_send_bytes: None,
+            local_snapshot_count_v4: None,
+            estimated_local_pinned_delta_bytes: None,
         }];
         apply_carried_forward_timestamps(&mut svs, &carried);
 
@@ -751,5 +898,166 @@ mod tests {
         assert!(output.contains("urd_planner_defers_total{scope=\"subvolume\"} 7"));
         assert!(output.contains("urd_planner_defers_total{scope=\"drive\"} 3"));
         assert!(output.contains("urd_circuit_breaker_trips_total 5"));
+    }
+
+    // ── UPI 043: pool + per-subvolume v4 gauges ───────────────────
+
+    fn pool(uuid: &str, role: &str, label: &str) -> PoolMetric {
+        PoolMetric {
+            uuid: uuid.to_string(),
+            role: role.to_string(),
+            label: label.to_string(),
+            free_bytes: None,
+            metadata_utilization_ratio: None,
+        }
+    }
+
+    #[test]
+    fn format_metrics_emits_pool_free_bytes_help_and_type() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_pool_free_bytes"));
+        assert!(output.contains("# TYPE backup_pool_free_bytes gauge"));
+    }
+
+    #[test]
+    fn format_metrics_emits_pool_free_bytes_value_when_some() {
+        let mut data = sample_data();
+        let mut p = pool("uuid-a", "source", "/home");
+        p.free_bytes = Some(1234);
+        data.pools.push(p);
+        let output = format_metrics(&data);
+        assert!(output.contains(
+            "backup_pool_free_bytes{uuid=\"uuid-a\",role=\"source\",label=\"/home\"} 1234"
+        ));
+    }
+
+    #[test]
+    fn format_metrics_omits_pool_free_bytes_value_when_none() {
+        let mut data = sample_data();
+        data.pools.push(pool("uuid-a", "source", "/home"));
+        let output = format_metrics(&data);
+        // HELP/TYPE still present.
+        assert!(output.contains("# HELP backup_pool_free_bytes"));
+        // No value line.
+        assert!(!output.contains("backup_pool_free_bytes{"));
+    }
+
+    #[test]
+    fn format_metrics_emits_pool_metadata_ratio_value_when_some() {
+        let mut data = sample_data();
+        let mut p = pool("uuid-a", "source", "/home");
+        p.metadata_utilization_ratio = Some(0.25);
+        data.pools.push(p);
+        let output = format_metrics(&data);
+        assert!(output.contains(
+            "backup_pool_metadata_utilization_ratio{uuid=\"uuid-a\",role=\"source\",label=\"/home\"} 0.25"
+        ));
+    }
+
+    #[test]
+    fn format_metrics_omits_pool_metadata_ratio_value_when_none() {
+        let mut data = sample_data();
+        data.pools.push(pool("uuid-a", "source", "/home"));
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_pool_metadata_utilization_ratio"));
+        assert!(!output.contains("backup_pool_metadata_utilization_ratio{"));
+    }
+
+    #[test]
+    fn format_metrics_emits_local_snapshot_count_when_some() {
+        let mut data = sample_data();
+        data.subvolumes[0].local_snapshot_count_v4 = Some(7);
+        let output = format_metrics(&data);
+        assert!(output.contains(
+            "backup_subvolume_local_snapshot_count{subvolume=\"subvol3-opptak\"} 7"
+        ));
+    }
+
+    #[test]
+    fn format_metrics_omits_local_snapshot_count_when_none() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_subvolume_local_snapshot_count"));
+        assert!(!output.contains("backup_subvolume_local_snapshot_count{"));
+    }
+
+    #[test]
+    fn format_metrics_emits_local_snapshot_count_zero_when_some_zero() {
+        let mut data = sample_data();
+        data.subvolumes[0].local_snapshot_count_v4 = Some(0);
+        let output = format_metrics(&data);
+        assert!(output.contains(
+            "backup_subvolume_local_snapshot_count{subvolume=\"subvol3-opptak\"} 0"
+        ));
+    }
+
+    #[test]
+    fn format_metrics_emits_estimated_pinned_delta_when_some() {
+        let mut data = sample_data();
+        data.subvolumes[0].estimated_local_pinned_delta_bytes = Some(5_000_000);
+        let output = format_metrics(&data);
+        assert!(output.contains(
+            "backup_subvolume_estimated_local_pinned_delta_bytes{subvolume=\"subvol3-opptak\"} 5000000"
+        ));
+    }
+
+    #[test]
+    fn format_metrics_omits_estimated_pinned_delta_when_none() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_subvolume_estimated_local_pinned_delta_bytes"));
+        assert!(!output.contains("backup_subvolume_estimated_local_pinned_delta_bytes{"));
+    }
+
+    #[test]
+    fn format_metrics_emits_estimated_pinned_delta_zero_when_some_zero() {
+        let mut data = sample_data();
+        data.subvolumes[0].estimated_local_pinned_delta_bytes = Some(0);
+        let output = format_metrics(&data);
+        assert!(output.contains(
+            "backup_subvolume_estimated_local_pinned_delta_bytes{subvolume=\"subvol3-opptak\"} 0"
+        ));
+    }
+
+    #[test]
+    fn format_metrics_escapes_pool_label_quotes() {
+        let mut data = sample_data();
+        let mut p = pool("uuid-a", "source", "weird\"label");
+        p.free_bytes = Some(0);
+        data.pools.push(p);
+        let output = format_metrics(&data);
+        // Quote escaped to \".
+        assert!(
+            output.contains("label=\"weird\\\"label\""),
+            "expected escaped quote: {output}"
+        );
+    }
+
+    #[test]
+    fn format_metrics_emits_pool_role_label() {
+        let mut data = sample_data();
+        let mut src = pool("uuid-src", "source", "/home");
+        src.free_bytes = Some(10);
+        data.pools.push(src);
+        let mut dst = pool("uuid-dst", "destination", "WD-18TB");
+        dst.free_bytes = Some(20);
+        data.pools.push(dst);
+        let output = format_metrics(&data);
+        assert!(output.contains("role=\"source\""));
+        assert!(output.contains("role=\"destination\""));
+    }
+
+    #[test]
+    fn format_metrics_emits_source_pool_label_as_canonical_mountpoint() {
+        let mut data = sample_data();
+        // The caller of compute_pool_metrics_from is responsible for picking
+        // the canonical mountpoint as `label`; metrics.rs just renders what
+        // it gets. This test asserts the renderer doesn't mangle the label.
+        let mut p = pool("uuid-a", "source", "/bar");
+        p.free_bytes = Some(99);
+        data.pools.push(p);
+        let output = format_metrics(&data);
+        assert!(output.contains("label=\"/bar\""));
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -601,8 +601,13 @@ mod tests {
                     send_completed: true,
                     churn_bytes_per_second: None,
                     last_full_send_bytes: None,
+                    pool_uuid: None,
+                    local_snapshot_count: None,
+                    estimated_local_pinned_delta_bytes: None,
                 })
                 .collect(),
+            pools: vec![],
+            drives: vec![],
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -603,6 +603,20 @@ pub fn render_churn(estimate: &crate::drift::ChurnEstimate) -> ChurnRender {
 pub struct ChurnHeartbeatFields {
     pub churn_bytes_per_second: Option<f64>,
     pub last_full_send_bytes: Option<u64>,
+    /// Arithmetic mean of `bytes_transferred` over in-window incrementals.
+    /// Used by UPI 043's pinned-delta computation in `gather_pool_observability`.
+    pub mean_incremental_bytes: Option<u64>,
+}
+
+/// Per-subvolume "extras" populated by `gather_pool_observability` and threaded
+/// to both `heartbeat::build_from_run` and `metrics::write_metrics_after_execution`
+/// so both surfaces share the same `pool_uuid`, `local_snapshot_count`, and
+/// `estimated_local_pinned_delta_bytes` values for a given run (UPI 043).
+#[derive(Debug, Clone, Default)]
+pub struct SubvolumeExtras {
+    pub pool_uuid: Option<String>,
+    pub local_snapshot_count: Option<u32>,
+    pub estimated_local_pinned_delta_bytes: Option<u64>,
 }
 
 /// A single diagnostic check result.
@@ -2032,6 +2046,7 @@ source = "/data/sv2"
     ) -> crate::drift::ChurnEstimate {
         crate::drift::ChurnEstimate {
             mean_bytes_per_second: mean,
+            mean_incremental_bytes: None,
             incremental_count: incr,
             full_count: full,
             median_full_bytes: median_full,

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -253,6 +253,7 @@ mod tests {
     fn churn_with_mean(mean: Option<f64>) -> ChurnEstimate {
         ChurnEstimate {
             mean_bytes_per_second: mean,
+            mean_incremental_bytes: None,
             incremental_count: if mean.is_some() { 2 } else { 0 },
             full_count: 0,
             median_full_bytes: None,
@@ -264,6 +265,7 @@ mod tests {
     fn churn_with_counts(mean: Option<f64>, incremental: usize, full: usize) -> ChurnEstimate {
         ChurnEstimate {
             mean_bytes_per_second: mean,
+            mean_incremental_bytes: None,
             incremental_count: incremental,
             full_count: full,
             median_full_bytes: None,

--- a/src/pools.rs
+++ b/src/pools.rs
@@ -1,0 +1,471 @@
+//! Pool detection and per-pool sysfs/statvfs helpers (UPI 043).
+//!
+//! I/O module — sibling of `drives.rs`. Findmnt subprocess + sysfs/statvfs
+//! syscalls. Two pure helpers (`group_subvolumes_by_pool`,
+//! `compute_pool_metrics_from`) are extracted for unit testability per
+//! ADR-108's spirit. No module spawns `btrfs` subprocesses.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::config::{Config, DriveConfig};
+use crate::error::UrdError;
+
+/// A detected source pool: one BTRFS filesystem hosting one or more configured
+/// subvolume sources.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SourcePool {
+    pub uuid: String,
+    /// Sorted, deduplicated mountpoints (the same UUID may surface at multiple
+    /// mountpoints via bind-mounts or multiple subvol mounts).
+    pub mountpoints: Vec<PathBuf>,
+    /// Subvolume `name`s on this pool — used only for in-run grouping; not
+    /// written to the heartbeat (R4).
+    pub subvolume_names: Vec<String>,
+}
+
+/// One row of input to `compute_pool_metrics_from`: a drive's configured
+/// label, its resolved UUID (when mounted and detectable), and whether it
+/// was found mounted.
+#[derive(Debug, Clone)]
+pub struct DriveResolution {
+    pub label: String,
+    pub uuid: Option<String>,
+    pub mounted: bool,
+    pub mountpoint: Option<PathBuf>,
+}
+
+// Reuse `metrics::PoolMetric` as the renderable output of
+// `compute_pool_metrics_from`. The renderable shape and the computed shape
+// are deliberately the same — keeping two parallel structs would be a
+// duplicate contract.
+use crate::metrics::PoolMetric;
+
+/// Resolve the BTRFS filesystem UUID hosting an arbitrary path.
+/// `findmnt -n -o UUID --target <path>` — walks up internally. `Ok(None)`
+/// for non-BTRFS sources, missing paths, or mounts without a UUID.
+///
+/// Findmnt typically returns non-zero exit and writes to stderr for missing
+/// paths; we map non-zero exit with empty stdout to `Ok(None)`, and non-zero
+/// exit with stderr content to `Err`. Empty stdout on success → `Ok(None)`.
+pub fn pool_uuid_for_path(path: &Path) -> crate::error::Result<Option<String>> {
+    findmnt_target(path, "UUID")
+}
+
+/// Resolve the mountpoint of the filesystem hosting `path`.
+/// `findmnt -n -o TARGET --target <path>`. `Ok(None)` if unmounted.
+pub fn pool_mountpoint_for_path(path: &Path) -> crate::error::Result<Option<PathBuf>> {
+    findmnt_target(path, "TARGET").map(|opt| opt.map(PathBuf::from))
+}
+
+fn findmnt_target(path: &Path, column: &str) -> crate::error::Result<Option<String>> {
+    let path_str = path.to_str().ok_or_else(|| UrdError::Io {
+        path: path.to_path_buf(),
+        source: std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path is not valid UTF-8",
+        ),
+    })?;
+
+    let output = Command::new("findmnt")
+        .env("LC_ALL", "C")
+        .args(["-n", "-o", column, "--target", path_str])
+        .output()
+        .map_err(|e| UrdError::Io {
+            path: PathBuf::from("findmnt"),
+            source: e,
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !output.status.success() {
+        if stdout.is_empty() {
+            // findmnt complained about a missing path; treat as "no UUID".
+            return Ok(None);
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(UrdError::Io {
+            path: path.to_path_buf(),
+            source: std::io::Error::other(format!("findmnt failed: {}", stderr.trim())),
+        });
+    }
+
+    if stdout.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(stdout))
+    }
+}
+
+/// Group configured subvolume sources by source-pool UUID. Subvolumes whose
+/// `pool_uuid_for_path` returns `Ok(None)` are excluded from the returned
+/// `Vec<SourcePool>` (their `SubvolumeHeartbeat.pool_uuid` will be `None` —
+/// see R4). I/O is read-only (findmnt + sysfs); no subprocess spawn beyond
+/// findmnt.
+pub fn detect_source_pools(config: &Config) -> Vec<SourcePool> {
+    let pairs: Vec<(String, Option<String>, Option<PathBuf>)> = config
+        .subvolumes
+        .iter()
+        .map(|sv| {
+            let uuid = pool_uuid_for_path(&sv.source).ok().flatten();
+            let mp = pool_mountpoint_for_path(&sv.source).ok().flatten();
+            (sv.name.clone(), uuid, mp)
+        })
+        .collect();
+    group_subvolumes_by_pool(&pairs)
+}
+
+/// Pure transformation from already-resolved `(subvol_name, uuid, mountpoint)`
+/// triples to a `Vec<SourcePool>`. Subvolumes with `uuid == None` are
+/// excluded; mountpoints are deduplicated and sorted per pool.
+#[must_use]
+pub fn group_subvolumes_by_pool(
+    pairs: &[(String, Option<String>, Option<PathBuf>)],
+) -> Vec<SourcePool> {
+    let mut by_uuid: std::collections::BTreeMap<String, SourcePool> =
+        std::collections::BTreeMap::new();
+    for (name, uuid, mp) in pairs {
+        let Some(uuid) = uuid.clone() else {
+            continue;
+        };
+        let entry = by_uuid.entry(uuid.clone()).or_insert(SourcePool {
+            uuid,
+            mountpoints: Vec::new(),
+            subvolume_names: Vec::new(),
+        });
+        if !entry.subvolume_names.contains(name) {
+            entry.subvolume_names.push(name.clone());
+        }
+        if let Some(mp) = mp
+            && !entry.mountpoints.contains(mp)
+        {
+            entry.mountpoints.push(mp.clone());
+        }
+    }
+    for pool in by_uuid.values_mut() {
+        pool.mountpoints.sort();
+    }
+    by_uuid.into_values().collect()
+}
+
+/// Free bytes on a BTRFS pool by mountpoint (statvfs). Returns `Err` on
+/// statvfs failure; caller maps `Err` → `None` for emission. Same pattern as
+/// `drives::filesystem_free_bytes`.
+///
+/// TOCTOU note (M-2): callers typically pair this with a prior
+/// `pool_uuid_for_path` to attribute the bytes to a UUID. Between findmnt
+/// and statvfs (tens of milliseconds), the mountpoint could change
+/// (umount, remount-elsewhere) and the bytes get attributed to a different
+/// filesystem. The race window is too narrow to justify re-verification
+/// complexity; downstream consumers (heartbeat, Prometheus) treat the
+/// snapshot as point-in-time and tolerate one-run discrepancies.
+pub fn pool_free_bytes(mountpoint: &Path) -> crate::error::Result<u64> {
+    let stat = nix::sys::statvfs::statvfs(mountpoint).map_err(|e| UrdError::Io {
+        path: mountpoint.to_path_buf(),
+        source: std::io::Error::other(e.to_string()),
+    })?;
+    Ok(stat.blocks_available() * stat.fragment_size())
+}
+
+/// Metadata utilization ratio (0.0–1.0) for a BTRFS filesystem, from sysfs
+/// (`/sys/fs/btrfs/<uuid>/allocation/metadata/{bytes_used,total_bytes}`).
+/// Returns `None` if sysfs is missing, values can't be parsed, or
+/// `total_bytes == 0`. No sudo required.
+#[must_use]
+pub fn metadata_utilization_ratio(uuid: &str) -> Option<f64> {
+    metadata_utilization_ratio_from(Path::new("/sys/fs/btrfs"), uuid)
+}
+
+/// Test-injectable version of `metadata_utilization_ratio` that takes the
+/// sysfs root path. The public version delegates here with `/sys/fs/btrfs`.
+#[must_use]
+pub(crate) fn metadata_utilization_ratio_from(sysfs_root: &Path, uuid: &str) -> Option<f64> {
+    let dir = sysfs_root.join(uuid).join("allocation").join("metadata");
+    let used: u64 = std::fs::read_to_string(dir.join("bytes_used"))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    let total: u64 = std::fs::read_to_string(dir.join("total_bytes"))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    if total == 0 {
+        return None;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let ratio = used as f64 / total as f64;
+    Some(ratio)
+}
+
+/// Pure transformation from detected pools and drive resolutions to a
+/// renderable `Vec<PoolMetric>`. Sources and destinations are unified via the
+/// `role` label. A UUID that is both a source and a configured drive gets one
+/// row per role.
+///
+/// `free_bytes_resolver` and `metadata_resolver` are accepted as closures so
+/// tests can substitute pure stand-ins; production callers pass
+/// `pool_free_bytes` / `metadata_utilization_ratio`.
+#[must_use]
+pub fn compute_pool_metrics_from(
+    detected_pools: &[SourcePool],
+    drives: &[DriveResolution],
+    mut free_bytes_resolver: impl FnMut(&Path) -> Option<u64>,
+    mut metadata_resolver: impl FnMut(&str) -> Option<f64>,
+) -> Vec<PoolMetric> {
+    let mut out: Vec<PoolMetric> = Vec::new();
+
+    // Sources first — sorted by uuid for stable output.
+    for pool in detected_pools {
+        let label = canonical_mountpoint_label(&pool.mountpoints);
+        let free = pool
+            .mountpoints
+            .first()
+            .and_then(|mp| free_bytes_resolver(mp));
+        let meta = metadata_resolver(&pool.uuid);
+        out.push(PoolMetric {
+            uuid: pool.uuid.clone(),
+            role: "source".to_string(),
+            label,
+            free_bytes: free,
+            metadata_utilization_ratio: meta,
+        });
+    }
+
+    // Destinations — emitted only for mounted drives with a resolved UUID.
+    for drive in drives {
+        let Some(ref uuid) = drive.uuid else {
+            continue;
+        };
+        if !drive.mounted {
+            continue;
+        }
+        let free = drive
+            .mountpoint
+            .as_deref()
+            .and_then(&mut free_bytes_resolver);
+        let meta = metadata_resolver(uuid);
+        out.push(PoolMetric {
+            uuid: uuid.clone(),
+            role: "destination".to_string(),
+            label: drive.label.clone(),
+            free_bytes: free,
+            metadata_utilization_ratio: meta,
+        });
+    }
+
+    out
+}
+
+/// Pure: convert a sorted `mountpoints` list to a canonical (shortest)
+/// mountpoint string. Used as the source-pool `label` (M-3). Returns "" when
+/// the list is empty.
+#[must_use]
+pub fn canonical_mountpoint_label(mountpoints: &[PathBuf]) -> String {
+    mountpoints
+        .iter()
+        .min_by_key(|p| p.as_os_str().len())
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_default()
+}
+
+/// Construct a `DriveResolution` from a config drive plus its observed mount
+/// state. Intended for callers in `commands/backup.rs` (slice 5); kept here
+/// so all pool-input bundling lives next to the pure helper that consumes it.
+#[must_use]
+pub fn resolve_drive(
+    drive: &DriveConfig,
+    mounted: bool,
+    detected_uuid: Option<String>,
+) -> DriveResolution {
+    DriveResolution {
+        label: drive.label.clone(),
+        uuid: drive.uuid.clone().or(detected_uuid),
+        mounted,
+        mountpoint: if mounted {
+            Some(drive.mount_path.clone())
+        } else {
+            None
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_sysfs_fixture(root: &Path, uuid: &str, used: &str, total: &str) {
+        let dir = root.join(uuid).join("allocation").join("metadata");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("bytes_used"), used).unwrap();
+        std::fs::write(dir.join("total_bytes"), total).unwrap();
+    }
+
+    #[test]
+    fn metadata_utilization_ratio_returns_none_when_sysfs_missing() {
+        let tmp = TempDir::new().unwrap();
+        let ratio =
+            metadata_utilization_ratio_from(tmp.path(), "00000000-0000-0000-0000-000000000000");
+        assert_eq!(ratio, None);
+    }
+
+    #[test]
+    fn metadata_utilization_ratio_parses_known_fixture() {
+        let tmp = TempDir::new().unwrap();
+        write_sysfs_fixture(tmp.path(), "fixture-uuid", "1000", "2000");
+        let ratio = metadata_utilization_ratio_from(tmp.path(), "fixture-uuid");
+        assert_eq!(ratio, Some(0.5));
+    }
+
+    #[test]
+    fn metadata_utilization_ratio_returns_none_on_total_zero() {
+        let tmp = TempDir::new().unwrap();
+        write_sysfs_fixture(tmp.path(), "fixture-uuid", "0", "0");
+        let ratio = metadata_utilization_ratio_from(tmp.path(), "fixture-uuid");
+        assert_eq!(ratio, None);
+    }
+
+    #[test]
+    fn metadata_utilization_ratio_returns_none_on_unparseable() {
+        let tmp = TempDir::new().unwrap();
+        write_sysfs_fixture(tmp.path(), "fixture-uuid", "100", "foo");
+        let ratio = metadata_utilization_ratio_from(tmp.path(), "fixture-uuid");
+        assert_eq!(ratio, None);
+    }
+
+    #[test]
+    fn group_subvolumes_by_pool_groups_by_uuid() {
+        let pairs = vec![
+            (
+                "home".to_string(),
+                Some("uuid-a".to_string()),
+                Some(PathBuf::from("/home")),
+            ),
+            (
+                "etc".to_string(),
+                Some("uuid-a".to_string()),
+                Some(PathBuf::from("/")),
+            ),
+            (
+                "data".to_string(),
+                Some("uuid-b".to_string()),
+                Some(PathBuf::from("/data")),
+            ),
+        ];
+        let pools = group_subvolumes_by_pool(&pairs);
+        assert_eq!(pools.len(), 2);
+        let a = pools.iter().find(|p| p.uuid == "uuid-a").unwrap();
+        assert_eq!(a.subvolume_names, vec!["home", "etc"]);
+        assert_eq!(a.mountpoints, vec![PathBuf::from("/"), PathBuf::from("/home")]);
+        let b = pools.iter().find(|p| p.uuid == "uuid-b").unwrap();
+        assert_eq!(b.subvolume_names, vec!["data"]);
+    }
+
+    #[test]
+    fn group_subvolumes_by_pool_skips_unknown_uuid_subvolumes() {
+        let pairs = vec![
+            (
+                "home".to_string(),
+                Some("uuid-a".to_string()),
+                Some(PathBuf::from("/home")),
+            ),
+            ("orphan".to_string(), None, None),
+        ];
+        let pools = group_subvolumes_by_pool(&pairs);
+        assert_eq!(pools.len(), 1);
+        assert_eq!(pools[0].subvolume_names, vec!["home"]);
+    }
+
+    #[test]
+    fn group_subvolumes_by_pool_dedups_mountpoints() {
+        let pairs = vec![
+            (
+                "home".to_string(),
+                Some("uuid-a".to_string()),
+                Some(PathBuf::from("/home")),
+            ),
+            (
+                "var".to_string(),
+                Some("uuid-a".to_string()),
+                Some(PathBuf::from("/home")),
+            ),
+        ];
+        let pools = group_subvolumes_by_pool(&pairs);
+        assert_eq!(pools.len(), 1);
+        assert_eq!(pools[0].mountpoints, vec![PathBuf::from("/home")]);
+    }
+
+    #[test]
+    fn group_subvolumes_by_pool_empty_config_returns_empty() {
+        let pools = group_subvolumes_by_pool(&[]);
+        assert!(pools.is_empty());
+    }
+
+    #[test]
+    fn canonical_mountpoint_label_picks_shortest() {
+        let mp = vec![
+            PathBuf::from("/mnt/long/path/here"),
+            PathBuf::from("/mnt"),
+            PathBuf::from("/mnt/x"),
+        ];
+        assert_eq!(canonical_mountpoint_label(&mp), "/mnt");
+    }
+
+    #[test]
+    fn canonical_mountpoint_label_empty_returns_empty_string() {
+        assert_eq!(canonical_mountpoint_label(&[]), "");
+    }
+
+    #[test]
+    fn compute_pool_metrics_from_emits_source_and_destination_rows() {
+        let pools = vec![SourcePool {
+            uuid: "uuid-src".to_string(),
+            mountpoints: vec![PathBuf::from("/home")],
+            subvolume_names: vec!["home".to_string()],
+        }];
+        let drives = vec![DriveResolution {
+            label: "WD-18TB".to_string(),
+            uuid: Some("uuid-dst".to_string()),
+            mounted: true,
+            mountpoint: Some(PathBuf::from("/mnt/wd")),
+        }];
+
+        let free = |_: &Path| Some(42_u64);
+        let meta = |_: &str| Some(0.25_f64);
+        let metrics = compute_pool_metrics_from(&pools, &drives, free, meta);
+
+        assert_eq!(metrics.len(), 2);
+        assert_eq!(metrics[0].uuid, "uuid-src");
+        assert_eq!(metrics[0].role, "source");
+        assert_eq!(metrics[0].label, "/home");
+        assert_eq!(metrics[0].free_bytes, Some(42));
+        assert_eq!(metrics[1].uuid, "uuid-dst");
+        assert_eq!(metrics[1].role, "destination");
+        assert_eq!(metrics[1].label, "WD-18TB");
+    }
+
+    #[test]
+    fn compute_pool_metrics_from_skips_unmounted_drives() {
+        let drives = vec![DriveResolution {
+            label: "WD-18TB".to_string(),
+            uuid: Some("uuid-dst".to_string()),
+            mounted: false,
+            mountpoint: None,
+        }];
+        let metrics = compute_pool_metrics_from(&[], &drives, |_| Some(0), |_| None);
+        assert!(metrics.is_empty());
+    }
+
+    #[test]
+    fn compute_pool_metrics_from_skips_drives_without_uuid() {
+        let drives = vec![DriveResolution {
+            label: "WD-18TB".to_string(),
+            uuid: None,
+            mounted: true,
+            mountpoint: Some(PathBuf::from("/mnt/wd")),
+        }];
+        let metrics = compute_pool_metrics_from(&[], &drives, |_| Some(0), |_| None);
+        assert!(metrics.is_empty());
+    }
+}

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -1299,6 +1299,8 @@ mod tests {
             run_id: Some(1),
             notifications_dispatched: true,
             subvolumes: vec![],
+            pools: vec![],
+            drives: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary

- **Four new Prometheus gauges (additive):** `backup_pool_free_bytes`, `backup_pool_metadata_utilization_ratio`, `backup_subvolume_local_snapshot_count`, `backup_subvolume_estimated_local_pinned_delta_bytes`. Source pools detected via `findmnt --target`; metadata utilization read from BTRFS sysfs.
- **Heartbeat schema v3 → v4 (additive):** new top-level `pools` / `drives` arrays + per-subvolume `pool_uuid` / `local_snapshot_count` / `estimated_local_pinned_delta_bytes`. All new fields use serde-default + skip_serializing_if so v3 readers tolerate v4 transparently.
- **Heartbeat contract softened** from "MUST refuse higher versions" to SHOULD/MAY semantics — brings text into agreement with how additive serde-default tolerance actually works, and makes cross-repo parser-tolerance interlocks contractually meaningful.
- **New `pools.rs` module** (I/O sibling of `drives.rs`) carries the detection + sysfs/statvfs helpers. Pure helpers (`group_subvolumes_by_pool`, `compute_pool_metrics_from`) handle the testable transformations.
- **`gather_pool_observability` called exactly once per run** (M-4 acceptance) and threads results into both metrics and heartbeat — preventing cross-surface drift on the same run.
- **ADR-105 amended** with the new metric contracts and softened heartbeat contract.

## Cross-repo gate

This PR is gated on the corresponding homelab ADR-021 amendment merging first (R7 interlock). A handoff doc for the homelab Claude session lives locally at `docs/97-plans/2026-05-16-handoff-043-homelab-cross-repo.md` (gitignored).

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: 1331 passed, 0 failed, 5 ignored (+46 new tests this PR — drift 7, pools 13, heartbeat 7, metrics 14, backup 5)
- `cargo build --release`: pass
- Integration tests: not run (require real drives; no changes in this scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)