### PR TITLE
fix: UPI 045 — voice evolution pt 1 (Rule 5 hoists + #103 cascade)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- UPI 045 — Voice evolution pt 1. `urd doctor` and `urd plan` now lead with
+  the verdict ("All clear." / "N warnings." / "All sealed." / "N operations
+  planned." / "No subvolumes configured.") instead of "Checking Urd health…"
+  / "Urd backup plan for {ts}" (Rule 5 contract). The new four-arm plan
+  verdict closes Finding 1: a zero-subvolume config no longer renders as
+  "All sealed.", and `urd doctor` on a zero-subvolume config surfaces a
+  Warning rather than the misleading "All clear." (R-10).
+- Issue [#103] — `awareness.rs` no longer labels a recently-unplugged drive
+  as "away for N days" when N is the stale-send age. A shared
+  `cascade_age_source` primitive consults physical `Unmount` truth first
+  (`absent_duration_secs`) and only falls back to the per-caller ops-log
+  age, with the source word ("away" vs "last backup") matching the source.
+
+### Changed
+- Two `#[ignore]`'d Rule 5 contract stubs in `voice_contract.rs` are now
+  active and passing. Three deferred stubs (rule3 / rule4-drive / rule7)
+  now point at UPI 045-a as the next owner.
+
 ## [0.18.0] - 2026-05-16
 
 ### Added

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -41,6 +41,31 @@ const SPACE_TIGHT_MARGIN_PERCENT: u64 = 20;
 /// Operational health: an unmounted drive degrades health after this many days.
 const DRIVE_AWAY_DEGRADED_DAYS: i64 = 7;
 
+/// Cascade between physical-absence truth and an ops-log fallback age.
+///
+/// Returns `(age_secs, source_word)` where:
+/// - `Some((absent, "away"))` when `absent_duration_secs` is set — physical
+///   `Unmount` truth wins.
+/// - `Some((fallback.max(0), "last backup"))` when only the fallback is set —
+///   negatives clamp to 0 to guard against clock skew.
+/// - `None` when neither is set — caller must stay silent (Rule 1).
+///
+/// The fallback field is **per-caller**, not baked in: voice uses
+/// `last_activity_age_secs` (broader "when was this drive last active?");
+/// awareness uses `last_send_age` (narrower "when did the backup last
+/// succeed?"). The cascade *decision* is singular; the *fallback semantic*
+/// belongs to each consumer. See ADR-110 amendment / UPI 045 plan R4.
+pub(crate) fn cascade_age_source(
+    absent_duration_secs: Option<i64>,
+    fallback_secs: Option<i64>,
+) -> Option<(i64, &'static str)> {
+    match (absent_duration_secs, fallback_secs) {
+        (Some(absent), _) => Some((absent, "away")),
+        (None, Some(fallback)) => Some((fallback.max(0), "last backup")),
+        (None, None) => None,
+    }
+}
+
 // ── Types ──────────────────────────────────────────────────────────────
 
 /// Promise status for a subvolume or assessment dimension.
@@ -1124,15 +1149,19 @@ fn compute_health(
     for da in drive_assessments {
         if !da.mounted
             && !da.source_unchanged
-            && let Some(age) = da.last_send_age
-            && age.num_days() > DRIVE_AWAY_DEGRADED_DAYS
+            && let Some((age_secs, source_word)) = cascade_age_source(
+                da.absent_duration_secs,
+                da.last_send_age.map(|d| d.num_seconds()),
+            )
         {
-            reasons.push(format!(
-                "{} away for {} days",
-                da.drive_label,
-                age.num_days()
-            ));
-            worst = worst.min(OperationalHealth::Degraded);
+            let age_days = age_secs / 86400;
+            if age_days > DRIVE_AWAY_DEGRADED_DAYS {
+                reasons.push(format!(
+                    "{} {source_word} for {age_days} days",
+                    da.drive_label,
+                ));
+                worst = worst.min(OperationalHealth::Degraded);
+            }
         }
     }
 
@@ -3220,6 +3249,106 @@ send_enabled = false
             "should not produce an 'away for N days' reason when source is unchanged. reasons: {:?}",
             results[0].health_reasons,
         );
+    }
+
+    #[test]
+    fn health_drive_recently_unplugged_but_stale_send_does_not_label_away_17_days() {
+        // Issue #103 regression: when a drive was unplugged 1h ago but its
+        // last send was 17 days ago, awareness must label health from physical
+        // truth ("away 0d" — under the 7d threshold → no reason emitted), not
+        // from the stale send age ("away 17 days" — false statement that the
+        // drive has been *physically* gone for 17 days).
+        use crate::types::{DriveEvent, DriveEventKind};
+        let config = test_config_two_drives();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+
+        let pin_snap = snap(dt(2026, 3, 23, 12, 0), "sv1");
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![pin_snap.clone()]);
+
+        // D1 mounted & healthy so we isolate D2's degradation contribution.
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![pin_snap.clone()]);
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "D1".to_string()),
+            pin_snap.clone(),
+        );
+        fs.send_times.insert(
+            ("sv1".to_string(), "D1".to_string()),
+            dt(2026, 3, 23, 12, 0),
+        );
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/d1"), 1_000_000_000_000);
+
+        // D2: unmounted, Unmount event 1h ago → absent_duration_secs = 3600.
+        // Send 17 days ago → last_send_age = 17d. Source NOT unchanged (no
+        // matching generations), so the source_unchanged suppression doesn't
+        // mask the bug. Without #103's fix, awareness would emit
+        // "D2 away for 17 days" — with it, the cascade picks absent_duration
+        // (3600s → 0 days), which is under the 7d threshold → no reason.
+        fs.drive_events.insert(
+            "D2".to_string(),
+            DriveEvent {
+                kind: DriveEventKind::Unmount,
+                at: dt(2026, 3, 23, 13, 0),
+            },
+        );
+        fs.send_times.insert(
+            ("sv1".to_string(), "D2".to_string()),
+            dt(2026, 3, 6, 14, 0), // 17 days ago
+        );
+
+        let results = assess(&config, now, &fs);
+        assert!(
+            !results[0]
+                .health_reasons
+                .iter()
+                .any(|r| r.contains("17 days")),
+            "must not emit any '17 days' reason — physical absence wins. reasons: {:?}",
+            results[0].health_reasons,
+        );
+        assert!(
+            !results[0]
+                .health_reasons
+                .iter()
+                .any(|r| r.contains("D2 away")),
+            "1h absence is under the 7d threshold — no away reason should fire. reasons: {:?}",
+            results[0].health_reasons,
+        );
+    }
+
+    #[test]
+    fn cascade_age_source_absent_wins_over_fallback() {
+        // Physical truth wins over ops-log fallback when both are present.
+        let r = cascade_age_source(Some(3600), Some(17 * 86400));
+        assert_eq!(r, Some((3600, "away")));
+    }
+
+    #[test]
+    fn cascade_age_source_absent_alone() {
+        let r = cascade_age_source(Some(3600), None);
+        assert_eq!(r, Some((3600, "away")));
+    }
+
+    #[test]
+    fn cascade_age_source_fallback_alone() {
+        let r = cascade_age_source(None, Some(2 * 86400));
+        assert_eq!(r, Some((2 * 86400, "last backup")));
+    }
+
+    #[test]
+    fn cascade_age_source_fallback_negative_clamps_to_zero() {
+        // Clock skew or arithmetic glitches must not surface as negative ages.
+        let r = cascade_age_source(None, Some(-5));
+        assert_eq!(r, Some((0, "last backup")));
+    }
+
+    #[test]
+    fn cascade_age_source_both_none_stays_silent() {
+        let r = cascade_age_source(None, None);
+        assert_eq!(r, None);
     }
 
     #[test]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -79,7 +79,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // Dry run: print plan and exit (no lock needed)
     if args.dry_run {
         let mut plan_output =
-            crate::commands::plan_cmd::build_plan_output(&backup_plan, &fs_state);
+            crate::commands::plan_cmd::build_plan_output(&backup_plan, &fs_state, &config);
         crate::commands::plan_cmd::populate_token_warnings(
             &mut plan_output,
             state_db.as_ref(),
@@ -169,7 +169,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // Pre-action briefing for manual TTY runs
     if !args.auto && std::io::stdout().is_terminal() {
         let plan_output =
-            crate::commands::plan_cmd::build_plan_output(&backup_plan, &fs_state);
+            crate::commands::plan_cmd::build_plan_output(&backup_plan, &fs_state, &config);
         let pre_filters = crate::output::PreActionFilters {
             local_only: filters.local_only,
             external_only: filters.external_only,

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -30,12 +30,28 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
             .filter(|s| s.enabled.unwrap_or(true))
             .count();
         let drive_count = config.drives.len();
-        vec![DoctorCheck {
-            name: format!("{subvol_count} subvolumes, {drive_count} drives"),
-            status: DoctorCheckStatus::Ok,
-            detail: None,
-            suggestion: None,
-        }]
+        // UPI 045 R-10: a zero-subvolume config is not "All clear" — it has
+        // nothing to protect. Surface as a config warning so the verdict
+        // becomes Warnings rather than the misleading Healthy.
+        if subvol_count == 0 {
+            warn_count += 1;
+            vec![DoctorCheck {
+                name: "No subvolumes configured.".to_string(),
+                status: DoctorCheckStatus::Warn,
+                detail: Some(
+                    "Add a [[subvolumes]] entry to config.toml — Urd has nothing to back up."
+                        .to_string(),
+                ),
+                suggestion: Some("Edit ~/.config/urd/urd.toml.".to_string()),
+            }]
+        } else {
+            vec![DoctorCheck {
+                name: format!("{subvol_count} subvolumes, {drive_count} drives"),
+                status: DoctorCheckStatus::Ok,
+                detail: None,
+                suggestion: None,
+            }]
+        }
     } else {
         preflight_results
             .iter()

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -27,7 +27,7 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
     };
     let backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
 
-    let mut output = build_plan_output(&backup_plan, &fs_state);
+    let mut output = build_plan_output(&backup_plan, &fs_state, &config);
     populate_token_warnings(&mut output, state_db.as_ref(), &config);
     print!("{}", voice::render_plan(&output, mode));
 
@@ -39,6 +39,7 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
 pub fn build_plan_output(
     backup_plan: &crate::types::BackupPlan,
     fs_state: &dyn FileSystemState,
+    config: &Config,
 ) -> PlanOutput {
     let summary = backup_plan.summary();
 
@@ -69,6 +70,12 @@ pub fn build_plan_output(
         None
     };
 
+    let configured_subvolumes = config
+        .subvolumes
+        .iter()
+        .filter(|s| s.enabled.unwrap_or(true))
+        .count();
+
     PlanOutput {
         timestamp: backup_plan.timestamp.format("%Y-%m-%d %H:%M").to_string(),
         operations,
@@ -79,6 +86,7 @@ pub fn build_plan_output(
             deletions: summary.deletions,
             skipped: summary.skipped,
             estimated_total_bytes,
+            configured_subvolumes,
         },
         warnings: Vec::new(),
     }
@@ -220,6 +228,52 @@ mod tests {
 
     fn dummy_snap(subvol: &str) -> SnapshotName {
         SnapshotName::parse(&format!("20260329-0404-{subvol}")).unwrap()
+    }
+
+    fn test_config() -> Config {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["htpc-home", "htpc-docs"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "WD-18TB"
+mount_path = "/mnt/wd"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "htpc-home"
+short_name = "htpc-home"
+source = "/data/htpc-home"
+
+[[subvolumes]]
+name = "htpc-docs"
+short_name = "htpc-docs"
+source = "/data/htpc-docs"
+"#;
+        toml::from_str(toml_str).expect("test config should parse")
     }
 
     fn mock_send_full(subvol: &str, drive: &str) -> PlannedOperation {
@@ -378,7 +432,7 @@ mod tests {
             skipped: vec![],
             events: Vec::new(),
         };
-        let output = build_plan_output(&plan, &fs);
+        let output = build_plan_output(&plan, &fs, &test_config());
         assert_eq!(output.summary.estimated_total_bytes, Some(54_200_000_000));
     }
 
@@ -398,7 +452,7 @@ mod tests {
             skipped: vec![],
             events: Vec::new(),
         };
-        let output = build_plan_output(&plan, &fs);
+        let output = build_plan_output(&plan, &fs, &test_config());
         assert_eq!(output.summary.estimated_total_bytes, Some(53_000_000_000));
     }
 
@@ -411,7 +465,7 @@ mod tests {
             skipped: vec![],
             events: Vec::new(),
         };
-        let output = build_plan_output(&plan, &fs);
+        let output = build_plan_output(&plan, &fs, &test_config());
         assert_eq!(output.summary.estimated_total_bytes, None);
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -666,6 +666,11 @@ pub struct DoctorSentinelStatus {
 
 /// Overall verdict from doctor.
 /// Serializes as `{ "status": "healthy", "count": 0 }` for uniform JSON shape.
+///
+/// `count` invariant (UPI 045 R-1 / Step 1.5): the count is a sum across
+/// contributing check categories, not filterable from any single field on
+/// `DoctorOutput`. Constructor signatures carry the count from the build
+/// site (`commands/doctor.rs`). `Healthy` always carries `count: 0`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct DoctorVerdict {
     pub status: DoctorVerdictStatus,
@@ -1021,6 +1026,12 @@ pub struct PlanSummaryOutput {
     /// Aggregated estimated bytes across all sends with estimates.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub estimated_total_bytes: Option<u64>,
+    /// Count of enabled subvolumes in the config that produced this plan.
+    /// Used by the plan verdict line to distinguish "nothing to do because
+    /// all subvolumes are sealed" from "nothing to do because no subvolumes
+    /// are configured" (UPI 045 Finding 1).
+    #[serde(default)]
+    pub configured_subvolumes: usize,
 }
 
 // ── EmptyPlanExplanation ───────────────────────────────────────────────
@@ -1569,6 +1580,27 @@ mod tests {
         assert!(matches!(result, ChainHealth::Full(_)));
     }
 
+    // ── DoctorVerdict constructor invariants (UPI 045 R-1 / Step 1.5) ──
+    //
+    // Each variant carries the caller's count; Healthy is always 0. A
+    // future refactor that breaks the constructor signature trips this
+    // before the verdict line lies to a user.
+
+    #[test]
+    fn doctor_verdict_constructors_carry_status_and_count() {
+        use DoctorVerdictStatus::*;
+        let cases = [
+            (DoctorVerdict::healthy(), Healthy, 0),
+            (DoctorVerdict::warnings(3), Warnings, 3),
+            (DoctorVerdict::issues(7), Issues, 7),
+            (DoctorVerdict::degraded(2), Degraded, 2),
+        ];
+        for (verdict, status, count) in cases {
+            assert_eq!(verdict.status, status);
+            assert_eq!(verdict.count, count);
+        }
+    }
+
     // ── RedundancyAdvisory tests ────────────────────────────────────────
 
     #[test]
@@ -1895,6 +1927,7 @@ mod tests {
                 deletions: 0,
                 skipped: 2,
                 estimated_total_bytes: Some(10_000_500_000),
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -1073,12 +1073,22 @@ pub fn render_plan(data: &PlanOutput, mode: OutputMode) -> String {
 fn render_plan_interactive(data: &PlanOutput) -> String {
     let mut out = String::new();
 
-    writeln!(
-        out,
-        "{}",
-        format!("Urd backup plan for {}", data.timestamp).bold()
-    )
-    .ok();
+    // Verdict line first (UPI 045 Rule 5 — first line is the answer).
+    // 4-arm match per Finding 1: the zero-subvolume arm prevents a
+    // trust failure where "no subvolumes configured" rendered as
+    // "All sealed." (same well-meaning lie as Finding 1's plan analogue
+    // for `urd doctor` — see R-10).
+    let configured = data.summary.configured_subvolumes;
+    let ops_empty = data.operations.is_empty();
+    let skips_len = data.skipped.len();
+    let op_count = data.operations.len();
+    let verdict_line = match (configured, ops_empty, skips_len) {
+        (0, _, _) => "No subvolumes configured.".dimmed().to_string(),
+        (_, true, 0) => "All sealed.".green().bold().to_string(),
+        (_, true, _) => "No backups planned (all skipped \u{2014} see below).".yellow().to_string(),
+        (_, false, _) => format!("{op_count} operations planned.").bold().to_string(),
+    };
+    writeln!(out, "{verdict_line}").ok();
     writeln!(out).ok();
 
     // === Warnings ===
@@ -1089,8 +1099,7 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
         writeln!(out).ok();
     }
 
-    if data.operations.is_empty() && data.skipped.is_empty() {
-        writeln!(out, "{}", "Nothing to do.".dimmed()).ok();
+    if ops_empty && skips_len == 0 {
         return out;
     }
 
@@ -1120,9 +1129,6 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
             };
             writeln!(out, "  {:<10} {}{}", label, entry.detail, size_annotation.dimmed()).ok();
         }
-        writeln!(out).ok();
-    } else {
-        writeln!(out, "{}", "No operations planned.".dimmed()).ok();
         writeln!(out).ok();
     }
 
@@ -2247,7 +2253,27 @@ pub fn render_doctor(data: &DoctorOutput, mode: OutputMode) -> String {
 fn render_doctor_interactive(data: &DoctorOutput) -> String {
     let mut out = String::new();
 
-    writeln!(out, "{}", "Checking Urd health...".bold()).ok();
+    // Verdict line first (UPI 045 Rule 5 — first line is the answer).
+    let verdict_line = match data.verdict.status {
+        DoctorVerdictStatus::Healthy => "All clear.".green().bold().to_string(),
+        DoctorVerdictStatus::Warnings => {
+            format!("{}.", pluralize(data.verdict.count, "warning", "warnings"))
+                .yellow()
+                .to_string()
+        }
+        DoctorVerdictStatus::Issues => {
+            format!("{} found.", pluralize(data.verdict.count, "issue", "issues"))
+                .red()
+                .to_string()
+        }
+        DoctorVerdictStatus::Degraded => format!(
+            "{} degraded. Data is safe \u{2014} drives are absent.",
+            pluralize(data.verdict.count, "subvolume", "subvolumes")
+        )
+        .yellow()
+        .to_string(),
+    };
+    writeln!(out, "{verdict_line}").ok();
     writeln!(out).ok();
 
     // UPI 042 Branch G: schema deprecation notice. Emitted near the top so
@@ -2447,43 +2473,8 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
         }
     }
 
-    // Verdict
-    writeln!(out).ok();
-    match data.verdict.status {
-        DoctorVerdictStatus::Healthy => {
-            writeln!(out, "{}", "All clear.".green().bold()).ok();
-        }
-        DoctorVerdictStatus::Warnings => {
-            writeln!(
-                out,
-                "{}",
-                format!("{}.", pluralize(data.verdict.count, "warning", "warnings")).yellow()
-            )
-            .ok();
-        }
-        DoctorVerdictStatus::Issues => {
-            writeln!(
-                out,
-                "{}",
-                format!("{} found.", pluralize(data.verdict.count, "issue", "issues")).red()
-            )
-            .ok();
-        }
-        DoctorVerdictStatus::Degraded => {
-            writeln!(
-                out,
-                "{}",
-                format!(
-                    "{} degraded. Data is safe \u{2014} drives are absent.",
-                    pluralize(data.verdict.count, "subvolume", "subvolumes")
-                )
-                .yellow()
-            )
-            .ok();
-        }
-    }
-
-    // Doctor verdict already provides guidance; suggestion is always None.
+    // Doctor verdict already provides guidance (rendered at the top now);
+    // suggestion is always None.
     append_suggestion(&SuggestionContext::Doctor, &mut out);
 
     out
@@ -2967,10 +2958,14 @@ fn unmounted_drive_label(
     last_activity_age_secs: Option<i64>,
     worst_status: &str,
 ) -> String {
-    match (absent_duration_secs, last_activity_age_secs) {
-        (Some(d), _) => format_drive_age_label(drive_label, d, worst_status, "away"),
-        (None, Some(a)) => format_drive_age_label(drive_label, a, worst_status, "last backup"),
-        (None, None) => format!("{} {}", drive_label.bold(), "disconnected".dimmed()),
+    // Fallback field is `last_activity_age_secs` (broader: any activity)
+    // rather than `last_send_age` (awareness's narrower backup-only signal).
+    // Shared cascade primitive — divergent fallback semantic. See UPI 045 R4.
+    match crate::awareness::cascade_age_source(absent_duration_secs, last_activity_age_secs) {
+        Some((age_secs, phrase)) => {
+            format_drive_age_label(drive_label, age_secs, worst_status, phrase)
+        }
+        None => format!("{} {}", drive_label.bold(), "disconnected".dimmed()),
     }
 }
 
@@ -3555,6 +3550,7 @@ pub(crate) mod test_fixtures {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         }
@@ -4356,6 +4352,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4377,6 +4374,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4412,6 +4410,7 @@ mod tests {
                 deletions: 0,
                 skipped: 1,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4440,13 +4439,18 @@ mod tests {
                 deletions: 0,
                 skipped: 1,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
         let output = render_plan(&data, OutputMode::Interactive);
+        // UPI 045: the ops-empty+skips-non-empty branch now renders the
+        // verdict "No backups planned (all skipped — see below)." on line 1
+        // and lets the Skipped section carry the detail. The old
+        // "No operations planned." string is deleted.
         assert!(
-            output.contains("No operations planned."),
-            "missing no-ops message"
+            output.contains("No backups planned"),
+            "missing no-backups verdict line: {output}"
         );
         assert!(
             !output.contains("=== Planned operations ==="),
@@ -4483,6 +4487,7 @@ mod tests {
                 deletions: 0,
                 skipped: 3,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4537,6 +4542,7 @@ mod tests {
                 deletions: 0,
                 skipped: 3,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4580,6 +4586,7 @@ mod tests {
                 deletions: 0,
                 skipped: 2,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4620,6 +4627,7 @@ mod tests {
                 deletions: 0,
                 skipped: 3,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4664,6 +4672,7 @@ mod tests {
                 deletions: 0,
                 skipped: 1,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4695,6 +4704,7 @@ mod tests {
                 deletions: 0,
                 skipped: 1,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4762,6 +4772,7 @@ mod tests {
                 deletions: 0,
                 skipped: 3,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4795,6 +4806,7 @@ mod tests {
                 deletions: 0,
                 skipped: 1,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4840,6 +4852,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: Some(54_200_000_000),
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4876,6 +4889,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: Some(5_500_000),
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4918,6 +4932,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: Some(53_000_000_000),
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4949,6 +4964,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -4983,6 +4999,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: Some(53_000_000_000),
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -5018,6 +5035,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -5051,6 +5069,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![
                 "Drive WD-18TB token mismatch \u{2014} possible drive swap. Sends blocked."
@@ -5080,6 +5099,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -5103,6 +5123,7 @@ mod tests {
                 deletions: 0,
                 skipped: 0,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec!["Drive X identity suspect".to_string()],
         };
@@ -5173,6 +5194,7 @@ mod tests {
                 deletions: 0,
                 skipped: 1,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };
@@ -7533,6 +7555,7 @@ mod tests {
                 deletions: 0,
                 skipped: 1,
                 estimated_total_bytes: None,
+                configured_subvolumes: 2,
             },
             warnings: vec![],
         };

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -348,6 +348,36 @@ mod contract {
     }
 
     #[test]
+    fn rule1_status_recently_unplugged_with_stale_activity_does_not_render_17_days() {
+        // Issue #103 regression at the render layer: an unmounted drive whose
+        // most recent activity was 17 days ago but was physically unplugged
+        // 1h ago must render "1h"/"away" — never "17 days" or "away for 17".
+        // The render-layer cascade (unmounted_drive_label) consults
+        // absent_duration_secs first; this test pins that contract.
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        unmount_wd18tb(&mut data, Some(3600), Some(17 * 86400));
+        let output = render_status(&data, OutputMode::Interactive);
+        let stripped = helpers::strip_ansi(&output);
+        let drives_line = stripped
+            .lines()
+            .find(|l| l.contains("WD-18TB") && l.starts_with("Drives:"))
+            .unwrap_or_else(|| panic!("no Drives: line for WD-18TB in:\n{stripped}"));
+        assert!(
+            !drives_line.contains("17d") && !drives_line.contains("17 days"),
+            "physical-truth cascade must not surface stale-activity age (17d): {drives_line}"
+        );
+        assert!(
+            !drives_line.contains("away for 17"),
+            "must never render 'away for 17 …' — that's the #103 falsehood: {drives_line}"
+        );
+        assert!(
+            drives_line.contains("away"),
+            "expected 'away' label from the absent_duration_secs branch: {drives_line}"
+        );
+    }
+
+    #[test]
     fn rule1_status_no_data_renders_silent() {
         let _color = color_guard(false);
         let mut data = test_status_output();
@@ -589,16 +619,11 @@ mod contract {
         );
     }
 
-    /// FINDING (Rule 5 violation in current rendering): `render_plan`
-    /// emits "Urd backup plan for {timestamp}" as its first non-blank
-    /// line. The list of operations (or "Nothing to do.") only appears
-    /// after the header. Rule 5 demands the first non-blank line answer
-    /// the question. File as a fast-follow under the "Voice gravity
-    /// audit" UPI alongside the doctor finding (PD-3 / R4). Marked
-    /// `#[ignore]` so the contract is documented without breaking the
-    /// suite.
+    /// Rule 5: `render_plan` first non-blank line answers the question
+    /// ("N operations planned." / "All sealed." / "No backups planned…" /
+    /// "No subvolumes configured."). UPI 045 hoisted the verdict and
+    /// deleted the old "Urd backup plan for {ts}" header.
     #[test]
-    #[ignore = "finding: plan first non-blank line is 'Urd backup plan for {ts}' rather than the operation count or 'Nothing to do.'; fix in voice gravity audit UPI"]
     fn rule5_plan_first_line_contains_operations_or_sealed_or_no_backups() {
         let _color = color_guard(false);
         // Non-empty plan: lifted fixture has 2 operations, 1 send.
@@ -609,11 +634,14 @@ mod contract {
             .next()
             .unwrap_or_else(|| panic!("empty plan output:\n{output}"));
         assert!(
-            first.contains("operations") || first.contains("All sealed") || first.contains("No backups planned"),
-            "first non-blank line of `urd plan` must answer the question \
-             ('operations'/'All sealed'/'No backups planned'), got: {first}"
+            first.contains("operations")
+                || first.contains("All sealed")
+                || first.contains("No backups planned")
+                || first.contains("No subvolumes configured"),
+            "first non-blank line of `urd plan` must answer the question, got: {first}"
         );
-        // Empty plan branch.
+        // Empty plan branch — operations cleared, summary zeroed.
+        // (Zero-subvolume case has its own focused contract test below.)
         let mut empty = test_plan_output();
         empty.operations.clear();
         empty.summary = crate::output::PlanSummaryOutput {
@@ -622,6 +650,7 @@ mod contract {
             deletions: 0,
             skipped: 0,
             estimated_total_bytes: None,
+            configured_subvolumes: 2,
         };
         let output = render_plan(&empty, OutputMode::Interactive);
         let first = helpers::non_blank_lines(&output)
@@ -629,8 +658,8 @@ mod contract {
             .next()
             .unwrap_or_else(|| panic!("empty plan output:\n{output}"));
         assert!(
-            first.contains("operations") || first.contains("All sealed") || first.contains("No backups planned"),
-            "first non-blank line of empty `urd plan` must answer the question, got: {first}"
+            first.contains("All sealed") || first.contains("No backups planned"),
+            "first non-blank line of empty `urd plan` must be the All-sealed verdict, got: {first}"
         );
     }
 
@@ -648,16 +677,12 @@ mod contract {
         );
     }
 
-    /// FINDING (Rule 5 violation in current rendering): `render_doctor`
-    /// emits "Checking Urd health..." as its first non-blank line, then
-    /// the verdict line ("All clear." / "N warnings." / "N issues found.")
-    /// only at the END of the output. Rule 5 demands the first non-blank
-    /// line answer the question. File as a fast-follow under the
-    /// "Voice gravity audit" UPI (PD-3 / R4). Marked `#[ignore]` so the
-    /// contract is documented but the suite is green; remove the
-    /// `#[ignore]` once doctor's verdict is hoisted to the first line.
+    /// Rule 5: `render_doctor` first non-blank line answers the question
+    /// ("All clear." / "N warning(s)." / "N issue(s) found." /
+    /// "N subvolume(s) degraded…"). UPI 045 hoisted the verdict above the
+    /// section blocks; the singular-keyword assertions cover both 1-count
+    /// and N-count plurals via substring match.
     #[test]
-    #[ignore = "finding: doctor first non-blank line is 'Checking Urd health...' rather than the verdict; fix in voice gravity audit UPI"]
     fn rule5_doctor_first_line_is_verdict_or_check_count() {
         let _color = color_guard(false);
         let output = render_doctor(&test_doctor_output(), OutputMode::Interactive);
@@ -666,11 +691,97 @@ mod contract {
             .next()
             .unwrap_or_else(|| panic!("empty doctor output:\n{output}"));
         assert!(
-            first.contains("warnings")
-                || first.contains("checks")
-                || first.contains("All clear"),
+            first.contains("warning")
+                || first.contains("issue")
+                || first.contains("All clear")
+                || first.contains("degraded"),
             "first non-blank line of `urd doctor` must answer the question \
-             ('warnings'/'checks'/'All clear'), got: {first}"
+             ('warning'/'issue'/'All clear'/'degraded'), got: {first}"
+        );
+    }
+
+    #[test]
+    fn rule5_doctor_verdict_variants_render_on_first_line() {
+        use crate::output::DoctorVerdict;
+        let _color = color_guard(false);
+        let cases = [
+            (DoctorVerdict::warnings(3), "3 warning"),
+            (DoctorVerdict::issues(2), "2 issue"),
+            (DoctorVerdict::degraded(1), "degraded"),
+        ];
+        for (verdict, expected) in cases {
+            let mut data = test_doctor_output();
+            data.verdict = verdict;
+            let output = render_doctor(&data, OutputMode::Interactive);
+            let first = helpers::non_blank_lines(&output)
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| panic!("empty doctor output:\n{output}"));
+            assert!(
+                first.contains(expected),
+                "verdict variant must surface '{expected}' on first line, got: {first}"
+            );
+        }
+    }
+
+    #[test]
+    fn rule5_plan_no_backups_all_skipped_renders_verdict() {
+        let _color = color_guard(false);
+        let mut data = test_plan_output();
+        data.operations.clear();
+        // Keep `data.assessments` populated via the canonical fixture so
+        // configured_subvolumes > 0; force the ops-empty + skips-non-empty
+        // branch by leaving one skipped entry in place.
+        data.skipped = vec![crate::output::SkippedSubvolume {
+            name: "htpc-docs".to_string(),
+            reason: "interval not elapsed".to_string(),
+            category: crate::output::SkipCategory::IntervalNotElapsed,
+        }];
+        data.summary = crate::output::PlanSummaryOutput {
+            snapshots: 0,
+            sends: 0,
+            deletions: 0,
+            skipped: 1,
+            estimated_total_bytes: None,
+            configured_subvolumes: 2,
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        let first = helpers::non_blank_lines(&output)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("plan output empty:\n{output}"));
+        assert!(
+            first.contains("No backups planned"),
+            "ops-empty + skips-non-empty must render the 'No backups planned' \
+             verdict on line 1, got: {first}"
+        );
+    }
+
+    #[test]
+    fn rule5_plan_zero_subvolumes_renders_no_subvolumes_configured() {
+        // Permanent contract for UPI 045 Finding 1. Without this test, a
+        // future refactor could silently re-introduce "All sealed." on a
+        // zero-subvolume config — a quiet but cardinal trust failure.
+        let _color = color_guard(false);
+        let mut data = test_plan_output();
+        data.operations.clear();
+        data.skipped.clear();
+        data.summary = crate::output::PlanSummaryOutput {
+            snapshots: 0,
+            sends: 0,
+            deletions: 0,
+            skipped: 0,
+            estimated_total_bytes: None,
+            configured_subvolumes: 0,
+        };
+        let output = render_plan(&data, OutputMode::Interactive);
+        let first = helpers::non_blank_lines(&output)
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| panic!("zero-subvol plan output empty:\n{output}"));
+        assert!(
+            first.contains("No subvolumes configured"),
+            "zero-subvolume verdict must surface 'No subvolumes configured', got: {first}"
         );
     }
 
@@ -736,6 +847,15 @@ mod contract {
              (regression-prevention for UPI 026's false 'blocked' red on a \
              healthy drive); count_red parses both bare \\x1b[31m and \
              compound \\x1b[1;31m / \\x1b[31;1m. Got output:\n{output}"
+        );
+        // UPI 045 R5 extension: the ✗ glyph is itself a load-bearing red
+        // signal even with ANSI stripped — terminals or pipes may erase the
+        // colour. A sealed row must not surface the cross at all.
+        let stripped = helpers::strip_ansi(&output);
+        assert!(
+            !stripped.contains('\u{2717}'),
+            "fully-sealed status output must not surface the ✗ glyph \
+             (it reads as a problem mark even without colour). Got:\n{stripped}"
         );
     }
 
@@ -961,12 +1081,12 @@ mod contract {
         );
     }
 
-    // ── Deferred — Rules 3, 4-drive, 7 (UPI 024+ Voice Evolution) ─────
+    // ── Deferred — Rules 3, 4-drive, 7 (UPI 045-a Voice Evolution pt 2) ──
     //
     // These rules require primitives that don't ship yet (per-status
     // time-aware label tiers, sentinel→awareness→voice drive-event ack,
     // last-shown-N-runs-ago state). The stubs document the intended
-    // assertions so future-us can fill them in once UPI 024+ lands.
+    // assertions so future-us can fill them in once UPI 045-a lands.
     //
     // `unimplemented!()` is used over `todo!()` per F7 — same panic
     // semantics, but signals "this isn't on the current TODO list" more
@@ -974,26 +1094,26 @@ mod contract {
     // by design.
 
     #[test]
-    #[ignore = "Unblocked by UPI 024+ Voice Evolution (Phase 2: time-aware messaging)"]
+    #[ignore = "Unblocked by UPI 045-a Voice Evolution pt 2 (time-aware messaging)"]
     fn rule3_repeated_advisory_must_change_language_or_position() {
-        // When 024+ ships per-status time-aware label tiers, render two
+        // When 045-a ships per-status time-aware label tiers, render two
         // consecutive status outputs with the same advisory and assert
         // the second's wording differs from the first.
-        unimplemented!("UPI 024+ Voice Evolution — see voice_contract.rs header");
+        unimplemented!("UPI 045-a Voice Evolution pt 2 — see voice_contract.rs header");
     }
 
     #[test]
-    #[ignore = "Unblocked by UPI 024+ Voice Evolution (sentinel→awareness→voice path)"]
+    #[ignore = "Unblocked by UPI 045-a Voice Evolution pt 2 (sentinel→awareness→voice path)"]
     fn rule4_drive_reconnect_after_absence_acks_the_event() {
-        // When 024+ wires drive-event acknowledgement through awareness,
+        // When 045-a wires drive-event acknowledgement through awareness,
         // simulate a drive reconnect after absence and assert the next
         // backup summary calls out the reconnection (e.g. "WD-18TB
         // returned").
-        unimplemented!("UPI 024+ Voice Evolution — see voice_contract.rs header");
+        unimplemented!("UPI 045-a Voice Evolution pt 2 — see voice_contract.rs header");
     }
 
     #[test]
-    #[ignore = "Unblocked by UPI 024+ or beyond (last-shown N runs ago state)"]
+    #[ignore = "Unblocked by UPI 045-a or beyond (last-shown N runs ago state)"]
     fn rule7_repeated_advisory_must_be_suppressed_when_unchanged() {
         // When the last-shown-N-runs-ago state ships, render the same
         // advisory across multiple consecutive runs and assert it


### PR DESCRIPTION
## Summary

- **Rule 5 verdict hoists.** `urd doctor` and `urd plan` lead with the verdict line ("All clear." / "N warnings." / "All sealed." / "N operations planned." / "No subvolumes configured."). The old "Checking Urd health…" and "Urd backup plan for {ts}" headers are deleted.
- **Finding 1 / R-10 trust failure closed.** A zero-subvolume config no longer renders as "All sealed." in `urd plan` (new four-arm verdict match with `configured_subvolumes` field on `PlanSummaryOutput`). `urd doctor` on a zero-subvolume config surfaces a Warning rather than the misleading "All clear."
- **Issue #103 fix.** New `cascade_age_source` primitive in `awareness.rs` consults physical `Unmount` truth (`absent_duration_secs`) before falling back to ops-log age. `awareness::compute_health` no longer emits "WD-18TB away for 17 days" when the drive was unplugged 1h ago and the last send happened to be 17 days old. Voice's `unmounted_drive_label` routes through the same primitive with its broader `last_activity_age_secs` fallback (R4 rebuttal — divergent fallback semantic, shared cascade decision).
- **Voice contract.** Two `#[ignore]`'d Rule 5 stubs (`rule5_plan_first_line…`, `rule5_doctor_first_line…`) are now active and passing. Three deferred stubs (rule3 / rule4-drive / rule7) re-point at UPI 045-a as the next owner. Rule 6 audit walked all 107 colour sites in `voice.rs` — every red/bold earns its gravity post-UPI-026, so no demotions were warranted; a regression test now bans the ✗ glyph on a fully-sealed status row.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 1344 passed, 0 failed, 3 ignored (045-a stubs)
- cargo build --release: pass
- Daemon-mode JSON contract preserved (`verdict` shape unchanged; `configured_subvolumes` added with `#[serde(default)]` — backward-compatible).

Plan: `docs/97-plans/2026-05-14-plan-045-voice-evolution.md` (adversary-reviewed). Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)