### PR TITLE
fix: scope retention space-recovery short-circuit to space-pressure kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Retention thinning no longer silently skipped after the first delete per
+  location.** The executor's space-recovery short-circuit (introduced with
+  UPI 016) was applied to every delete, including policy-driven graduated
+  retention. Because the `space_recovered` map is keyed by location (drive
+  label or local snapshot-root path) and shared across subvolumes, on a
+  filesystem with comfortable free space the very first delete at a location
+  tipped recovery to "satisfied" and every subsequent delete — across all
+  subvolumes sharing that location — was skipped with
+  `space recovered, deletion skipped`. Symptom: snapshot counts grew unbounded
+  even though `urd plan` reported correct retention targets (e.g. 61 local
+  snapshots for a `daily=7, weekly=4` policy that targets ~11).
+  Fix: introduced `DeleteKind { Policy, SpacePressure }` derived from
+  `PruneRule` at the retention boundary; the short-circuit now only applies
+  to `SpacePressure` deletes (hourly thinning under pressure, space-governed
+  extras, emergency reclaim). `Policy` deletes always execute, subject to
+  the unchanged pin re-check (ADR-106 layer 3). Pin protection invariants
+  preserved; no on-disk format changes; `urd plan` output unchanged.
+
 ## [0.20.2] - 2026-05-19
 
 ### Fixed

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1538,7 +1538,8 @@ fn run_emergency_preflight(
 
             // Map snap → its emitted event (by snapshot name) so we can
             // persist only events whose underlying delete succeeded.
-            for (snap, _reason) in &result.delete {
+            for rd in &result.delete {
+                let snap = &rd.snapshot;
                 let snap_path = local_dir.join(snap.as_str());
 
                 // Defense-in-depth (ADR-106 layer 3)
@@ -1738,7 +1739,7 @@ mod tests {
         TransientCleanupOutcome,
     };
     use crate::types::Interval;
-    use crate::types::{FullSendReason, PlannedOperation};
+    use crate::types::{DeleteKind, FullSendReason, PlannedOperation};
     use std::path::PathBuf;
 
     fn make_outcome(
@@ -1968,11 +1969,13 @@ mod tests {
                     path: PathBuf::from("/snaps/sv1/20260320-0400-sv1"),
                     reason: "retention".to_string(),
                     subvolume_name: "sv1".to_string(),
+                    kind: DeleteKind::Policy,
                 },
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/snaps/sv1/20260319-0400-sv1"),
                     reason: "retention".to_string(),
                     subvolume_name: "sv1".to_string(),
+                    kind: DeleteKind::Policy,
                 },
             ],
             timestamp: chrono::NaiveDateTime::default(),

--- a/src/commands/emergency.rs
+++ b/src/commands/emergency.rs
@@ -173,8 +173,8 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
                 chrono::Local::now().naive_local(),
             );
 
-            for (snap, _reason) in &result.delete {
-                let snap_path = local_dir.join(snap.as_str());
+            for rd in &result.delete {
+                let snap_path = local_dir.join(rd.snapshot.as_str());
 
                 // Defense-in-depth (ADR-106 layer 3): shared re-check
                 if chain::is_pinned_at_delete_time(&snap_path, &detail.name, &config) {

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -206,6 +206,7 @@ fn build_operation_entry(
             path,
             reason,
             subvolume_name,
+            kind: _,
         } => {
             let snap_name = path.file_name().unwrap_or_default().to_string_lossy();
             PlanOperationEntry {
@@ -225,7 +226,7 @@ fn build_operation_entry(
 mod tests {
     use super::*;
     use crate::plan::MockFileSystemState;
-    use crate::types::{SendKind, SnapshotName};
+    use crate::types::{BackupPlan, SendKind, SnapshotName};
     use std::path::PathBuf;
 
     fn dummy_snap(subvol: &str) -> SnapshotName {
@@ -469,5 +470,65 @@ source = "/data/htpc-docs"
         };
         let output = build_plan_output(&plan, &fs, &test_config());
         assert_eq!(output.summary.estimated_total_bytes, None);
+    }
+
+    #[test]
+    fn delete_kind_is_invariant_across_render_surfaces() {
+        // The user-visible output of every render surface must NOT change based on
+        // `DeleteKind`. Two plans identical except for `kind` should produce
+        // byte-identical Display output and byte-identical PlanOperationEntry.
+        // This guards the on-disk / monitoring contract (ADR-105) against
+        // accidental kind-leaks via Display, plan_cmd, or downstream renderers.
+        use crate::types::DeleteKind;
+
+        let make_plan = |kind: DeleteKind| BackupPlan {
+            operations: vec![PlannedOperation::DeleteSnapshot {
+                path: PathBuf::from("/snap/htpc-home/20260329-0404-htpc-home"),
+                reason: "graduated: weekly thinning".to_string(),
+                subvolume_name: "htpc-home".to_string(),
+                kind,
+            }],
+            timestamp: chrono::NaiveDate::from_ymd_opt(2026, 3, 22)
+                .unwrap()
+                .and_hms_opt(14, 30, 0)
+                .unwrap(),
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let policy_plan = make_plan(DeleteKind::Policy);
+        let pressure_plan = make_plan(DeleteKind::SpacePressure);
+
+        // Surface 1: PlannedOperation::Display (the operation-level format used by
+        // logs, voice helpers, and any consumer of `to_string()`).
+        let policy_display = format!("{}", policy_plan.operations[0]);
+        let pressure_display = format!("{}", pressure_plan.operations[0]);
+        assert_eq!(policy_display, pressure_display);
+
+        // Surface 2: build_plan_output produces PlanOperationEntry for voice::render_plan
+        // and any JSON/structured consumer.
+        let fs = MockFileSystemState::new();
+        let config = test_config();
+        let policy_out = build_plan_output(&policy_plan, &fs, &config);
+        let pressure_out = build_plan_output(&pressure_plan, &fs, &config);
+
+        assert_eq!(policy_out.operations.len(), 1);
+        assert_eq!(pressure_out.operations.len(), 1);
+        let p_entry = &policy_out.operations[0];
+        let s_entry = &pressure_out.operations[0];
+        assert_eq!(p_entry.subvolume, s_entry.subvolume);
+        assert_eq!(p_entry.operation, s_entry.operation);
+        assert_eq!(p_entry.detail, s_entry.detail);
+        assert_eq!(p_entry.drive_label, s_entry.drive_label);
+        assert_eq!(p_entry.estimated_bytes, s_entry.estimated_bytes);
+        assert_eq!(p_entry.is_full_send, s_entry.is_full_send);
+        assert_eq!(p_entry.full_send_reason, s_entry.full_send_reason);
+
+        // Surface 3: PlanSummaryOutput — the counter that drives `urd plan` summary
+        // and downstream metrics. Deletions count must be identical.
+        assert_eq!(
+            policy_out.summary.deletions,
+            pressure_out.summary.deletions,
+        );
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -13,7 +13,7 @@ use crate::config::Config;
 use crate::drives;
 use crate::error::BtrfsOperation;
 use crate::state::{DriftSampleRow, OperationRecord, StateDb};
-use crate::types::{BackupPlan, FullSendReason, PlannedOperation, SendKind};
+use crate::types::{BackupPlan, DeleteKind, FullSendReason, PlannedOperation, SendKind};
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -453,8 +453,9 @@ impl<'a> Executor<'a> {
                 PlannedOperation::DeleteSnapshot {
                     path,
                     subvolume_name,
+                    kind,
                     ..
-                } => self.execute_delete(path, subvolume_name, space_recovered),
+                } => self.execute_delete(path, subvolume_name, *kind, space_recovered),
             };
 
             if outcome.result == OpResult::Failure {
@@ -846,15 +847,22 @@ impl<'a> Executor<'a> {
         &self,
         path: &Path,
         subvolume_name: &str,
+        kind: DeleteKind,
         space_recovered: &mut HashMap<String, bool>,
     ) -> OperationOutcome {
         let start = Instant::now();
 
-        // Space recovery re-check: if space has already been recovered for this
-        // location (external drive or local snapshot root), skip further deletes.
-        // Prevents over-deletion when only a few deletes were needed to free space.
+        // Space recovery re-check: if this is a `SpacePressure` delete and space has
+        // already been recovered for this location, skip further deletes. Prevents
+        // over-deletion when only a few deletes were needed to free space.
+        //
+        // `Policy` deletes are not subject to this short-circuit — the user's declared
+        // retention policy is the contract, and graduated/transient retention must run
+        // regardless of whether space is currently abundant. The post-delete update
+        // (below) still publishes recovery so any trailing SpacePressure deletes honor it.
         let recovery_key = self.space_recovery_key(path, subvolume_name);
-        if let Some(ref key) = recovery_key
+        if kind == DeleteKind::SpacePressure
+            && let Some(ref key) = recovery_key
             && *space_recovered.get(key).unwrap_or(&false)
         {
             log::info!(
@@ -1313,6 +1321,7 @@ source = "/data/b"
                     path: PathBuf::from("/snap/sv-a/20260310-a"),
                     reason: "expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::Policy,
                 },
             ],
             timestamp: ts,
@@ -1562,16 +1571,19 @@ source = "/data/b"
                     path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260301-a"),
                     reason: "expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::SpacePressure,
                 },
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260302-a"),
                     reason: "expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::SpacePressure,
                 },
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260303-a"),
                     reason: "expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::SpacePressure,
                 },
             ],
             timestamp: ts,
@@ -1643,7 +1655,7 @@ source = "/data/b"
     }
 
     #[test]
-    fn space_recovered_shared_across_subvolumes() {
+    fn space_recovered_shared_across_subvolumes_for_space_pressure_kind() {
         let mock = MockBtrfs::new();
         // Free space is above threshold — after first delete, space is recovered
         *mock.free_bytes.borrow_mut() = 200_000_000_000; // 200GB > 100GB threshold
@@ -1656,19 +1668,21 @@ source = "/data/b"
             .unwrap()
             .and_hms_opt(14, 30, 0)
             .unwrap();
-        // sv-a deletes on external drive, recovers space.
-        // sv-b's deletions on the SAME drive should be skipped.
+        // sv-a's SpacePressure delete on external drive recovers space.
+        // sv-b's SpacePressure deletion on the SAME drive should be skipped.
         let plan = BackupPlan {
             operations: vec![
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260301-a"),
-                    reason: "expired".to_string(),
+                    reason: "space pressure: expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::SpacePressure,
                 },
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/mnt/test/.snapshots/sv-b/20260301-b"),
-                    reason: "expired".to_string(),
+                    reason: "space pressure: expired".to_string(),
                     subvolume_name: "sv-b".to_string(),
+                    kind: DeleteKind::SpacePressure,
                 },
             ],
             timestamp: ts,
@@ -1696,6 +1710,151 @@ source = "/data/b"
             .filter(|c| matches!(c, MockBtrfsCall::DeleteSubvolume { .. }))
             .count();
         assert_eq!(delete_count, 1);
+    }
+
+    #[test]
+    fn policy_deletes_do_not_share_space_recovery() {
+        // Inverse of space_recovered_shared_across_subvolumes_for_space_pressure_kind:
+        // two subvolumes share the same external drive, both with Policy-kind deletes,
+        // free space already above min_free_bytes. The short-circuit must NOT engage —
+        // every delete executes because policy is the user's declared contract.
+        let mock = MockBtrfs::new();
+        *mock.free_bytes.borrow_mut() = 200_000_000_000; // 200GB > 100GB threshold
+
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260301-a"),
+                    reason: "graduated: weekly thinning".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::Policy,
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260302-a"),
+                    reason: "graduated: weekly thinning".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::Policy,
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/mnt/test/.snapshots/sv-b/20260301-b"),
+                    reason: "graduated: weekly thinning".to_string(),
+                    subvolume_name: "sv-b".to_string(),
+                    kind: DeleteKind::Policy,
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: PathBuf::from("/mnt/test/.snapshots/sv-b/20260302-b"),
+                    reason: "graduated: weekly thinning".to_string(),
+                    subvolume_name: "sv-b".to_string(),
+                    kind: DeleteKind::Policy,
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        // Every operation across both subvolumes should succeed — no short-circuit.
+        for sv in &result.subvolume_results {
+            for op in &sv.operations {
+                assert_eq!(
+                    op.result,
+                    OpResult::Success,
+                    "policy delete for {} unexpectedly skipped (error: {:?})",
+                    sv.name,
+                    op.error,
+                );
+            }
+        }
+
+        // Mock should record all four delete calls (one per planned op).
+        let delete_count = mock
+            .calls()
+            .iter()
+            .filter(|c| matches!(c, MockBtrfsCall::DeleteSubvolume { .. }))
+            .count();
+        assert_eq!(delete_count, 4);
+    }
+
+    #[test]
+    fn mixed_kinds_in_same_run() {
+        // Policy deletes interleaved with SpacePressure deletes for one subvolume on the
+        // same drive. Free space already above min_free_bytes — so:
+        //   - Policy deletes (first two) execute and publish space-recovered.
+        //   - SpacePressure deletes (third) short-circuit because the location is
+        //     above threshold by then.
+        // Pins down the kind-discrimination contract and the observation order:
+        // mock receives exactly the Policy-delete paths, in plan order, then nothing.
+        let mock = MockBtrfs::new();
+        *mock.free_bytes.borrow_mut() = 200_000_000_000;
+
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+
+        let ts = NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap();
+        let policy_a = PathBuf::from("/mnt/test/.snapshots/sv-a/20260301-policy-a");
+        let policy_b = PathBuf::from("/mnt/test/.snapshots/sv-a/20260302-policy-b");
+        let pressure_c = PathBuf::from("/mnt/test/.snapshots/sv-a/20260303-pressure-c");
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::DeleteSnapshot {
+                    path: policy_a.clone(),
+                    reason: "graduated: weekly thinning".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::Policy,
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: policy_b.clone(),
+                    reason: "graduated: weekly thinning".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::Policy,
+                },
+                PlannedOperation::DeleteSnapshot {
+                    path: pressure_c.clone(),
+                    reason: "space pressure: hourly thinning".to_string(),
+                    subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::SpacePressure,
+                },
+            ],
+            timestamp: ts,
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        let ops = &result.subvolume_results[0].operations;
+        assert_eq!(ops[0].result, OpResult::Success);
+        assert_eq!(ops[1].result, OpResult::Success);
+        assert_eq!(ops[2].result, OpResult::Skipped);
+        assert_eq!(
+            ops[2].error.as_deref(),
+            Some("space recovered, deletion skipped"),
+        );
+
+        // Mock observation: exactly the two Policy paths, in plan order, no pressure path.
+        let deleted: Vec<PathBuf> = mock
+            .calls()
+            .iter()
+            .filter_map(|c| match c {
+                MockBtrfsCall::DeleteSubvolume { path } => Some(path.clone()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(deleted, vec![policy_a, policy_b]);
     }
 
     fn test_config_with_local_min_free() -> Config {
@@ -1739,7 +1898,7 @@ source = "/data/b"
     }
 
     #[test]
-    fn local_space_recovery_stops_further_deletes() {
+    fn local_space_recovery_stops_further_deletes_for_space_pressure_kind() {
         let mock = MockBtrfs::new();
         // Free space is above threshold — after first delete, space is recovered
         *mock.free_bytes.borrow_mut() = 200_000_000_000; // 200GB > 100GB threshold
@@ -1758,16 +1917,19 @@ source = "/data/b"
                     path: PathBuf::from("/snap/sv-a/20260301-a"),
                     reason: "space pressure".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::SpacePressure,
                 },
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/snap/sv-a/20260302-a"),
                     reason: "space pressure".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::SpacePressure,
                 },
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/snap/sv-a/20260303-a"),
                     reason: "space pressure".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::SpacePressure,
                 },
             ],
             timestamp: ts,
@@ -1848,6 +2010,7 @@ source = "/data/b"
                 path: PathBuf::from("/snap/a/old"),
                 reason: "expired".to_string(),
                 subvolume_name: "sv-a".to_string(),
+                kind: DeleteKind::Policy,
             },
         ];
 
@@ -3004,11 +3167,13 @@ local_retention = "transient"
                     path: PathBuf::from("/snap/sv-a/20260301-a"),
                     reason: "expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::Policy,
                 },
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/snap/sv-a/20260302-a"),
                     reason: "expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::Policy,
                 },
             ],
             timestamp: ts,
@@ -3070,6 +3235,7 @@ local_retention = "transient"
                     path: PathBuf::from("/snap/sv-a/20260301-a"),
                     reason: "expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
+                    kind: DeleteKind::Policy,
                 },
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
@@ -3106,6 +3272,7 @@ local_retention = "transient"
                 path: PathBuf::from("/mnt/test/.snapshots/sv-a/20260301-a"),
                 reason: "expired".to_string(),
                 subvolume_name: "sv-a".to_string(),
+                kind: DeleteKind::Policy,
             }],
             timestamp: ts,
             skipped: vec![],

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -11,8 +11,8 @@ use crate::error::UrdError;
 use crate::events::{DeferScope, Event, EventPayload};
 use crate::retention;
 use crate::types::{
-    BackupPlan, DriveEvent, DriveEventKind, FullSendReason, LocalRetentionPolicy, PlannedOperation,
-    SendKind, SnapshotName,
+    BackupPlan, DeleteKind, DriveEvent, DriveEventKind, FullSendReason, LocalRetentionPolicy,
+    PlannedOperation, SendKind, SnapshotName,
 };
 
 // ── Audit helpers ──────────────────────────────────────────────────────
@@ -779,12 +779,14 @@ fn plan_local_retention(
     match &subvol.local_retention {
         LocalRetentionPolicy::Transient => {
             // Transient: delete everything not in the protected set (pins + unsent).
+            // Transient lifecycle is policy-driven — always execute.
             for snap in local_snaps {
                 if !protected.contains(snap) {
                     operations.push(PlannedOperation::DeleteSnapshot {
                         path: local_dir.join(snap.as_str()),
                         reason: "transient: not pinned".to_string(),
                         subvolume_name: subvol.name.clone(),
+                        kind: DeleteKind::Policy,
                     });
                 }
             }
@@ -803,11 +805,12 @@ fn plan_local_retention(
                 space_pressure,
             );
 
-            for (snap, reason) in result.delete {
+            for rd in result.delete {
                 operations.push(PlannedOperation::DeleteSnapshot {
-                    path: local_dir.join(snap.as_str()),
-                    reason,
+                    path: local_dir.join(rd.snapshot.as_str()),
+                    reason: rd.reason,
                     subvolume_name: subvol.name.clone(),
+                    kind: rd.kind,
                 });
             }
 
@@ -1270,11 +1273,12 @@ fn plan_external_retention(
         min_free,
     );
 
-    for (snap, reason) in result.delete {
+    for rd in result.delete {
         operations.push(PlannedOperation::DeleteSnapshot {
-            path: ext_dir.join(snap.as_str()),
-            reason,
+            path: ext_dir.join(rd.snapshot.as_str()),
+            reason: rd.reason,
             subvolume_name: subvol.name.clone(),
+            kind: rd.kind,
         });
     }
 

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -10,6 +10,45 @@ use crate::types::{
     Interval, LocalRetentionPolicy, MonthlyCount, ResolvedGraduatedRetention, SnapshotName,
 };
 
+/// Classifies a delete by what motivates it. Carried from `retention.rs` through
+/// `PlannedOperation::DeleteSnapshot` to the executor, where it controls whether the
+/// space-recovery short-circuit applies. `Policy` deletes always execute; `SpacePressure`
+/// deletes stop once the location's `min_free_bytes` is satisfied to avoid over-deletion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeleteKind {
+    /// Policy-driven retention (graduated tiers, beyond-window, transient lifecycle).
+    /// The user's declared retention policy is the contract — always executed.
+    Policy,
+    /// Space-pressure-driven (hourly thinning under pressure, space-governed extras,
+    /// emergency reclaim). Subject to the executor's space-recovery short-circuit.
+    SpacePressure,
+}
+
+impl DeleteKind {
+    /// Map a `PruneRule` to its delete kind. The single source of truth for the
+    /// policy/pressure split — change here, not at construction sites.
+    #[must_use]
+    pub const fn from_rule(rule: PruneRule) -> Self {
+        match rule {
+            PruneRule::GraduatedHourly
+            | PruneRule::GraduatedDaily
+            | PruneRule::GraduatedWeekly
+            | PruneRule::GraduatedMonthly
+            | PruneRule::GraduatedYearly
+            | PruneRule::BeyondWindow => Self::Policy,
+            PruneRule::Emergency | PruneRule::SpacePressure => Self::SpacePressure,
+        }
+    }
+}
+
+/// A planned retention deletion, with the reason and kind the executor needs.
+#[derive(Debug, Clone)]
+pub struct RetentionDelete {
+    pub snapshot: SnapshotName,
+    pub reason: String,
+    pub kind: DeleteKind,
+}
+
 /// The result of a retention computation.
 ///
 /// `events` carries rationale for the planner's audit log. Pure modules
@@ -19,7 +58,7 @@ use crate::types::{
 #[derive(Debug, Clone, Default)]
 pub struct RetentionResult {
     pub keep: Vec<SnapshotName>,
-    pub delete: Vec<(SnapshotName, String)>,
+    pub delete: Vec<RetentionDelete>,
     pub events: Vec<Event>,
 }
 
@@ -129,7 +168,7 @@ pub fn graduated_retention(
          rule: PruneRule,
          delete_reason: &str,
          keep: &mut Vec<SnapshotName>,
-         delete: &mut Vec<(SnapshotName, String)>,
+         delete: &mut Vec<RetentionDelete>,
          events: &mut Vec<Event>| {
             if slot_was_empty {
                 keep.push(snap.clone());
@@ -137,7 +176,11 @@ pub fn graduated_retention(
                 keep.push(snap.clone());
                 events.push(protect_event(snap, ProtectReason::PinOverrodeThinning, now));
             } else {
-                delete.push((snap.clone(), delete_reason.to_string()));
+                delete.push(RetentionDelete {
+                    snapshot: snap.clone(),
+                    reason: delete_reason.to_string(),
+                    kind: DeleteKind::from_rule(rule),
+                });
                 events.push(prune_event(snap, rule, now));
             }
         };
@@ -229,10 +272,11 @@ pub fn graduated_retention(
             keep.push(snap.clone());
             events.push(protect_event(snap, ProtectReason::PinOverrodeWindow, now));
         } else {
-            delete.push((
-                snap.clone(),
-                "graduated: beyond retention window".to_string(),
-            ));
+            delete.push(RetentionDelete {
+                snapshot: snap.clone(),
+                reason: "graduated: beyond retention window".to_string(),
+                kind: DeleteKind::from_rule(PruneRule::BeyondWindow),
+            });
             events.push(prune_event(snap, PruneRule::BeyondWindow, now));
         }
     }
@@ -278,7 +322,11 @@ pub fn emergency_retention(
         if snap == latest || pinned.contains(snap) {
             keep.push(snap.clone());
         } else {
-            delete.push((snap.clone(), "emergency: aggressive thinning".to_string()));
+            delete.push(RetentionDelete {
+                snapshot: snap.clone(),
+                reason: "emergency: aggressive thinning".to_string(),
+                kind: DeleteKind::from_rule(PruneRule::Emergency),
+            });
             events.push(prune_event(snap, PruneRule::Emergency, now));
         }
     }
@@ -315,7 +363,7 @@ pub fn space_governed_retention(
         let mut keep_sorted = result.keep.clone();
         keep_sorted.sort(); // oldest first
 
-        let mut additional_deletes = Vec::new();
+        let mut additional_deletes: Vec<RetentionDelete> = Vec::new();
         let mut additional_events = Vec::new();
         for snap in &keep_sorted {
             if pinned.contains(snap) {
@@ -325,12 +373,19 @@ pub fn space_governed_retention(
             if keep_sorted.len() - additional_deletes.len() <= 1 {
                 break;
             }
-            additional_deletes.push((snap.clone(), "space pressure: freeing space".to_string()));
+            additional_deletes.push(RetentionDelete {
+                snapshot: snap.clone(),
+                reason: "space pressure: freeing space".to_string(),
+                kind: DeleteKind::from_rule(PruneRule::SpacePressure),
+            });
             additional_events.push(prune_event(snap, PruneRule::SpacePressure, now));
         }
 
         // Remove additional deletes from keep, add to delete
-        let delete_set: HashSet<_> = additional_deletes.iter().map(|(s, _)| s.clone()).collect();
+        let delete_set: HashSet<_> = additional_deletes
+            .iter()
+            .map(|rd| rd.snapshot.clone())
+            .collect();
         result.keep.retain(|s| !delete_set.contains(s));
         result.delete.extend(additional_deletes);
         result.events.extend(additional_events);
@@ -742,7 +797,7 @@ mod tests {
         // Week 9: keep 20260301
         assert_eq!(result.keep.len(), 2);
         assert_eq!(result.delete.len(), 1);
-        assert_eq!(result.delete[0].0.as_str(), "20260307-home");
+        assert_eq!(result.delete[0].snapshot.as_str(), "20260307-home");
     }
 
     #[test]
@@ -870,7 +925,7 @@ mod tests {
             "Snapshot at calendar-month boundary (2025-03-25) should be kept with 12-month retention"
         );
         assert!(
-            result.delete.iter().any(|(s, _)| s == &old_snap),
+            result.delete.iter().any(|rd| rd.snapshot == old_snap),
             "Snapshot from 14+ months ago should be beyond retention window"
         );
     }
@@ -1252,8 +1307,8 @@ mod tests {
         assert!(result.keep.contains(&latest));
         assert!(result.keep.contains(&snaps[2]));
         assert!(result.keep.contains(&snaps[6]));
-        for (_, reason) in &result.delete {
-            assert_eq!(reason, "emergency: aggressive thinning");
+        for rd in &result.delete {
+            assert_eq!(rd.reason, "emergency: aggressive thinning");
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::error::UrdError;
 
+pub use crate::retention::DeleteKind;
+
 // ── Interval ────────────────────────────────────────────────────────────
 
 /// A duration parsed from human-readable strings like "15m", "1h", "1d", "1w".
@@ -903,6 +905,10 @@ pub enum PlannedOperation {
         path: PathBuf,
         reason: String,
         subvolume_name: String,
+        /// Distinguishes policy-driven retention from space-pressure-driven retention.
+        /// The executor's space-recovery short-circuit applies only to `SpacePressure`
+        /// deletes; `Policy` deletes always execute (subject to pin re-check).
+        kind: DeleteKind,
     },
 }
 
@@ -1362,11 +1368,13 @@ mod tests {
                     path: PathBuf::from("/snap/old"),
                     reason: "expired".to_string(),
                     subvolume_name: "htpc-home".to_string(),
+                    kind: DeleteKind::Policy,
                 },
                 PlannedOperation::DeleteSnapshot {
                     path: PathBuf::from("/snap/old2"),
                     reason: "expired".to_string(),
                     subvolume_name: "htpc-home".to_string(),
+                    kind: DeleteKind::Policy,
                 },
             ],
             timestamp: NaiveDate::from_ymd_opt(2026, 3, 22)


### PR DESCRIPTION
## Summary

- The executor's `space_recovered` short-circuit (UPI 016) was applied to every retention delete and shared across subvolumes via location-keyed entries. On a filesystem with comfortable free space, the first delete per location tripped recovery and silently skipped every subsequent delete — across all subvolumes sharing that drive or local snapshot root — for the rest of the run. Snapshot counts grew unbounded despite correct `urd plan` output.
- Introduce `DeleteKind { Policy, SpacePressure }` derived from `PruneRule` at the retention boundary and carried through `PlannedOperation::DeleteSnapshot`. The short-circuit now applies only to `SpacePressure` deletes; `Policy` deletes always execute (subject to the unchanged pin re-check at `executor.rs:876`, ADR-106 layer 3).
- No on-disk format changes, no `urd plan` output changes, pin protection unaffected.

## Why this happened

`space_recovered` is a `HashMap<String, bool>` keyed by drive label or local snapshot-root path. Two design choices compounded:

1. The key is per-location, not per-subvolume — so once one subvolume tips recovery, the gate is closed for every other subvolume sharing that location.
2. The gate fires for **any** delete (policy or pressure). On a system with abundant free space, even the first policy-driven delete tips recovery (free space is already above `min_free_bytes`), so all subsequent deletes are skipped.

Run 79 (the user's nightly that prompted this investigation) showed the pattern unambiguously: 282 deletes planned across all subvolumes; ~273 marked `result=skipped, error="space recovered, deletion skipped"`. Exactly one delete succeeded per location.

## Test plan

- [x] `cargo test` — 1434 → 1437 passing (3 new tests, 0 failures)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo build --release` — clean
- [x] Pin pre-flight: cross-checked all 14 pin-referenced snapshots (from `.last-external-parent-*` files across `/mnt/btrfs-pool/.snapshots` and `~/.snapshots`) against the 233 planned delete targets reported by `urd plan` — empty intersection.
- [ ] First post-merge run: invoke `urd backup` manually (not via systemd) so STDERR is visible. Expected: ~282 snapshots deleted, pin files intact, heartbeat snapshot counts drop (e.g. subvol7-containers local 61 → 11).
- [ ] 48h heartbeat watch for steady-state confirmation.

## New / renamed tests

- `space_recovered_shared_across_subvolumes_for_space_pressure_kind` (renamed, retagged): existing buggy-as-feature assertions preserved under explicit SpacePressure kind.
- `local_space_recovery_stops_further_deletes_for_space_pressure_kind` (renamed, retagged): same.
- `policy_deletes_do_not_share_space_recovery` (new): two subvolumes share a drive, four Policy deletes, all execute.
- `mixed_kinds_in_same_run` (new): interleaved kinds for one subvolume; Policy deletes execute and publish recovery; trailing SpacePressure short-circuits; asserts mock observation order.
- `delete_kind_is_invariant_across_render_surfaces` (new): pins the ADR-105 contract — `kind` does not leak into Display, `build_plan_output`, or plan summary counters.

## Plan & adversary review

See `/home/patriark/.claude/plans/valiant-shimmying-sphinx.md` for the full systematic-debugging investigation, plan, arch-adversary findings, and S2 rebuttal (declining a mass-delete operator lever — see CHANGELOG and PR commit message for the argument).

🤖 Generated with [Claude Code](https://claude.com/claude-code)