### PR TITLE
feat: add backup_external_expected and backup_pool_total_bytes metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Prometheus metric `backup_external_expected{subvolume}`** — emits `1` for each
+  subvolume that has an external destination configured (sends enabled and at least one
+  drive in scope); the line is absent otherwise. Lets monitoring distinguish a genuinely
+  missing offsite copy from an intentionally local-only subvolume (e.g. `send_enabled =
+  false`), via `backup_snapshot_count{location="external"} == 0 and on(subvolume)
+  backup_external_expected == 1`.
+- **Prometheus metric `backup_pool_total_bytes{uuid,role,label}`** — total BTRFS pool
+  capacity (statvfs), alongside the existing `backup_pool_free_bytes`. Enables a
+  destination free-% alert for offsite drives that `node_exporter` does not scrape. Free
+  and capacity are read from a single statvfs call so they never skew within a run.
+
 ## [0.20.5] - 2026-05-20
 
 ### Changed

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -623,20 +623,15 @@ fn build_backup_summary(
 }
 
 /// Names of subvolumes with an external destination configured: sends enabled
-/// and at least one configured drive in scope (`drives = None` means all
-/// drives). Config-derived; mirrors the planner's send gate
-/// (`plan::is_drive_in_scope`). Feeds `backup_external_expected`.
+/// and at least one configured drive in scope. Uses the same
+/// `ResolvedSubvolume::accepts_drive` predicate as the planner's send gate, so
+/// `backup_external_expected` cannot drift from what actually gets sent.
 fn externally_expected_subvolumes(config: &Config) -> HashSet<String> {
     config
         .resolved_subvolumes()
         .into_iter()
         .filter(|sv| {
-            sv.send_enabled
-                && config.drives.iter().any(|d| {
-                    sv.drives
-                        .as_ref()
-                        .is_none_or(|allowed| allowed.iter().any(|a| a == &d.label))
-                })
+            sv.send_enabled && config.drives.iter().any(|d| sv.accepts_drive(&d.label))
         })
         .map(|sv| sv.name)
         .collect()

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -622,6 +622,26 @@ fn build_backup_summary(
     }
 }
 
+/// Names of subvolumes with an external destination configured: sends enabled
+/// and at least one configured drive in scope (`drives = None` means all
+/// drives). Config-derived; mirrors the planner's send gate
+/// (`plan::is_drive_in_scope`). Feeds `backup_external_expected`.
+fn externally_expected_subvolumes(config: &Config) -> HashSet<String> {
+    config
+        .resolved_subvolumes()
+        .into_iter()
+        .filter(|sv| {
+            sv.send_enabled
+                && config.drives.iter().any(|d| {
+                    sv.drives
+                        .as_ref()
+                        .is_none_or(|allowed| allowed.iter().any(|a| a == &d.label))
+                })
+        })
+        .map(|sv| sv.name)
+        .collect()
+}
+
 fn write_metrics_after_execution(
     config: &Config,
     result: &crate::executor::ExecutionResult,
@@ -632,6 +652,7 @@ fn write_metrics_after_execution(
     observability: &PoolObservability,
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
+    let external_expected = externally_expected_subvolumes(config);
     let mut subvolume_metrics = Vec::new();
 
     // Metrics for executed subvolumes
@@ -656,6 +677,7 @@ fn write_metrics_after_execution(
             local_snapshot_count: local_count,
             external_snapshot_count: external_count,
             send_type: sv_result.send_type.metric_value(),
+            external_expected: external_expected.contains(&sv_result.name),
             churn_bytes_per_second: churn.churn_bytes_per_second,
             last_full_send_bytes: churn.last_full_send_bytes,
             local_snapshot_count_v4: extras.and_then(|e| e.local_snapshot_count),
@@ -818,7 +840,7 @@ fn gather_pool_observability(
     let pool_metrics = pools::compute_pool_metrics_from(
         &source_pools,
         &drive_resolutions,
-        |mp| pools::pool_free_bytes(mp).ok(),
+        |mp| pools::pool_space(mp).ok(),
         pools::metadata_utilization_ratio,
     );
 
@@ -1009,6 +1031,7 @@ fn append_skipped_metrics(
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
     observability: &PoolObservability,
 ) {
+    let external_expected = externally_expected_subvolumes(config);
     let mut seen = already_emitted.clone();
 
     for (name, _reason) in &plan.skipped {
@@ -1029,6 +1052,7 @@ fn append_skipped_metrics(
             local_snapshot_count: local_count,
             external_snapshot_count: external_count,
             send_type: 2,
+            external_expected: external_expected.contains(name),
             churn_bytes_per_second: churn.churn_bytes_per_second,
             last_full_send_bytes: churn.last_full_send_bytes,
             local_snapshot_count_v4: extras.and_then(|e| e.local_snapshot_count),

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,6 +144,19 @@ pub struct ResolvedSubvolume {
     pub min_free_bytes: Option<u64>,
 }
 
+impl ResolvedSubvolume {
+    /// True if `drive_label` is in scope for this subvolume's external sends.
+    /// `drives = None` means all configured drives are in scope; `Some(list)`
+    /// restricts to the listed labels. Shared by the planner's send gate and
+    /// the `backup_external_expected` metric so the two cannot drift.
+    #[must_use]
+    pub fn accepts_drive(&self, drive_label: &str) -> bool {
+        self.drives
+            .as_ref()
+            .is_none_or(|allowed| allowed.iter().any(|a| a == drive_label))
+    }
+}
+
 impl SubvolumeConfig {
     /// Resolve this subvolume config against the provided defaults and run frequency.
     ///

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -30,6 +30,11 @@ pub struct PoolMetric {
     pub role: String,
     pub label: String,
     pub free_bytes: Option<u64>,
+    /// Total capacity bytes (statvfs `blocks * fragment_size`). Feeds
+    /// `backup_pool_total_bytes`. `None` when the pool's mountpoint couldn't be
+    /// statvfs'd; paired with `free_bytes` from the same syscall so the two
+    /// never skew within a run.
+    pub capacity_bytes: Option<u64>,
     pub metadata_utilization_ratio: Option<f64>,
 }
 
@@ -56,6 +61,13 @@ pub struct SubvolumeMetrics {
     pub external_snapshot_count: usize,
     /// 0 = full, 1 = incremental, 2 = no send
     pub send_type: u8,
+    /// True when the subvolume has an external destination configured (sends
+    /// enabled and ≥1 configured drive in scope). Config-derived, independent
+    /// of this run's outcome. Feeds `backup_external_expected` — emitted only
+    /// when true, so consumers can join `... == 0 and on(subvolume)
+    /// backup_external_expected == 1` to distinguish a missing offsite copy
+    /// from an intentionally local-only subvolume.
+    pub external_expected: bool,
     /// Rolling time-windowed churn rate (UPI 030). Emitted only when `Some`.
     /// Absent for cold-start subvolumes and for subvolumes whose latest
     /// in-window send was a full send (use `last_full_send_bytes` instead).
@@ -253,6 +265,25 @@ fn format_metrics(data: &MetricsData) -> String {
         .unwrap();
     }
 
+    // backup_external_expected
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP backup_external_expected 1 if the subvolume has an external destination configured (sends enabled and at least one drive in scope). Line absent otherwise."
+    )
+    .unwrap();
+    writeln!(out, "# TYPE backup_external_expected gauge").unwrap();
+    for sv in &data.subvolumes {
+        if sv.external_expected {
+            writeln!(
+                out,
+                "backup_external_expected{{subvolume=\"{}\"}} 1",
+                escape_label_value(&sv.name)
+            )
+            .unwrap();
+        }
+    }
+
     // backup_external_drive_mounted
     writeln!(out).unwrap();
     writeln!(
@@ -358,6 +389,27 @@ fn format_metrics(data: &MetricsData) -> String {
             writeln!(
                 out,
                 "backup_pool_free_bytes{{uuid=\"{}\",role=\"{}\",label=\"{}\"}} {}",
+                escape_label_value(&pool.uuid),
+                escape_label_value(&pool.role),
+                escape_label_value(&pool.label),
+                bytes
+            )
+            .unwrap();
+        }
+    }
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP backup_pool_total_bytes Total capacity bytes of a BTRFS pool (statvfs). Snapshot at backup-run cadence; not a live signal."
+    )
+    .unwrap();
+    writeln!(out, "# TYPE backup_pool_total_bytes gauge").unwrap();
+    for pool in &data.pools {
+        if let Some(bytes) = pool.capacity_bytes {
+            writeln!(
+                out,
+                "backup_pool_total_bytes{{uuid=\"{}\",role=\"{}\",label=\"{}\"}} {}",
                 escape_label_value(&pool.uuid),
                 escape_label_value(&pool.role),
                 escape_label_value(&pool.label),
@@ -530,6 +582,7 @@ mod tests {
                     local_snapshot_count: 15,
                     external_snapshot_count: 14,
                     send_type: 1,
+                    external_expected: false,
                     churn_bytes_per_second: None,
                     last_full_send_bytes: None,
                     local_snapshot_count_v4: None,
@@ -543,6 +596,7 @@ mod tests {
                     local_snapshot_count: 20,
                     external_snapshot_count: 18,
                     send_type: 2,
+                    external_expected: false,
                     churn_bytes_per_second: None,
                     last_full_send_bytes: None,
                     local_snapshot_count_v4: None,
@@ -694,6 +748,7 @@ mod tests {
                 local_snapshot_count: 5,
                 external_snapshot_count: 3,
                 send_type: 1,
+                external_expected: false,
                 churn_bytes_per_second: None,
                 last_full_send_bytes: None,
                 local_snapshot_count_v4: None,
@@ -707,6 +762,7 @@ mod tests {
                 local_snapshot_count: 5,
                 external_snapshot_count: 3,
                 send_type: 2,
+                external_expected: false,
                 churn_bytes_per_second: None,
                 last_full_send_bytes: None,
                 local_snapshot_count_v4: None,
@@ -720,6 +776,7 @@ mod tests {
                 local_snapshot_count: 5,
                 external_snapshot_count: 3,
                 send_type: 2,
+                external_expected: false,
                 churn_bytes_per_second: None,
                 last_full_send_bytes: None,
                 local_snapshot_count_v4: None,
@@ -753,6 +810,7 @@ mod tests {
                 local_snapshot_count: 5,
                 external_snapshot_count: 3,
                 send_type: 1,
+                external_expected: false,
                 churn_bytes_per_second: None,
                 last_full_send_bytes: None,
                 local_snapshot_count_v4: None,
@@ -776,6 +834,7 @@ mod tests {
             local_snapshot_count: 5,
             external_snapshot_count: 3,
             send_type: 2,
+            external_expected: false,
             churn_bytes_per_second: None,
             last_full_send_bytes: None,
             local_snapshot_count_v4: None,
@@ -908,6 +967,7 @@ mod tests {
             role: role.to_string(),
             label: label.to_string(),
             free_bytes: None,
+            capacity_bytes: None,
             metadata_utilization_ratio: None,
         }
     }
@@ -1059,5 +1119,52 @@ mod tests {
         data.pools.push(p);
         let output = format_metrics(&data);
         assert!(output.contains("label=\"/bar\""));
+    }
+
+    // ── backup_external_expected ──────────────────────────────────
+
+    #[test]
+    fn format_metrics_emits_external_expected_when_true() {
+        let mut data = sample_data();
+        data.subvolumes[0].external_expected = true;
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_external_expected"));
+        assert!(output.contains("# TYPE backup_external_expected gauge"));
+        assert!(output.contains("backup_external_expected{subvolume=\"subvol3-opptak\"} 1"));
+    }
+
+    #[test]
+    fn format_metrics_omits_external_expected_when_false() {
+        let data = sample_data(); // all external_expected: false
+        let output = format_metrics(&data);
+        // HELP/TYPE still present unconditionally.
+        assert!(output.contains("# HELP backup_external_expected"));
+        // No value line for a local-only subvolume.
+        assert!(!output.contains("backup_external_expected{"));
+    }
+
+    // ── backup_pool_total_bytes ───────────────────────────────────
+
+    #[test]
+    fn format_metrics_emits_pool_total_bytes_when_some() {
+        let mut data = sample_data();
+        let mut p = pool("uuid-a", "destination", "WD-18TB");
+        p.capacity_bytes = Some(18_000_191_160_320);
+        data.pools.push(p);
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_pool_total_bytes"));
+        assert!(output.contains("# TYPE backup_pool_total_bytes gauge"));
+        assert!(output.contains(
+            "backup_pool_total_bytes{uuid=\"uuid-a\",role=\"destination\",label=\"WD-18TB\"} 18000191160320"
+        ));
+    }
+
+    #[test]
+    fn format_metrics_omits_pool_total_bytes_when_none() {
+        let mut data = sample_data();
+        data.pools.push(pool("uuid-a", "source", "/home")); // capacity None
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_pool_total_bytes"));
+        assert!(!output.contains("backup_pool_total_bytes{"));
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -181,14 +181,6 @@ pub struct PlanFilters {
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-/// Check if a drive is in scope for a subvolume (respects `drives` field).
-fn is_drive_in_scope(subvol: &ResolvedSubvolume, drive_label: &str) -> bool {
-    subvol
-        .drives
-        .as_ref()
-        .is_none_or(|allowed| allowed.iter().any(|a| a == drive_label))
-}
-
 /// Check if a drive can receive sends. Returns true if available, false (with
 /// skip reason emitted) if not. Handles all DriveAvailability variants.
 fn check_drive_availability(
@@ -375,7 +367,7 @@ pub fn plan(
         let usable_drives: Vec<&DriveConfig> = config
             .drives
             .iter()
-            .filter(|d| is_drive_in_scope(subvol, &d.label))
+            .filter(|d| subvol.accepts_drive(&d.label))
             .filter(|d| {
                 matches!(
                     fs.drive_availability(d),
@@ -469,7 +461,7 @@ pub fn plan(
         // ── External operations ─────────────────────────────────────
         if !filters.local_only && subvol.send_enabled {
             for drive in &config.drives {
-                if !is_drive_in_scope(subvol, &drive.label) {
+                if !subvol.accepts_drive(&drive.label) {
                     continue;
                 }
 
@@ -854,7 +846,7 @@ fn plan_transient_lifecycle(
     let mut any_send_due = false;
 
     for drive in &config.drives {
-        if !is_drive_in_scope(subvol, &drive.label) {
+        if !subvol.accepts_drive(&drive.label) {
             continue;
         }
         if !check_drive_availability(&subvol.name, drive, fs, skipped, events, now) {

--- a/src/pools.rs
+++ b/src/pools.rs
@@ -224,14 +224,15 @@ pub(crate) fn metadata_utilization_ratio_from(sysfs_root: &Path, uuid: &str) -> 
 /// `role` label. A UUID that is both a source and a configured drive gets one
 /// row per role.
 ///
-/// `free_bytes_resolver` and `metadata_resolver` are accepted as closures so
-/// tests can substitute pure stand-ins; production callers pass
-/// `pool_free_bytes` / `metadata_utilization_ratio`.
+/// `space_resolver` and `metadata_resolver` are accepted as closures so tests
+/// can substitute pure stand-ins; production callers pass `pool_space` /
+/// `metadata_utilization_ratio`. `space_resolver` returns free + capacity from
+/// a single statvfs so the two never skew within a run.
 #[must_use]
 pub fn compute_pool_metrics_from(
     detected_pools: &[SourcePool],
     drives: &[DriveResolution],
-    mut free_bytes_resolver: impl FnMut(&Path) -> Option<u64>,
+    mut space_resolver: impl FnMut(&Path) -> Option<PoolSpace>,
     mut metadata_resolver: impl FnMut(&str) -> Option<f64>,
 ) -> Vec<PoolMetric> {
     let mut out: Vec<PoolMetric> = Vec::new();
@@ -239,16 +240,14 @@ pub fn compute_pool_metrics_from(
     // Sources first — sorted by uuid for stable output.
     for pool in detected_pools {
         let label = canonical_mountpoint_label(&pool.mountpoints);
-        let free = pool
-            .mountpoints
-            .first()
-            .and_then(|mp| free_bytes_resolver(mp));
+        let space = pool.mountpoints.first().and_then(|mp| space_resolver(mp));
         let meta = metadata_resolver(&pool.uuid);
         out.push(PoolMetric {
             uuid: pool.uuid.clone(),
             role: "source".to_string(),
             label,
-            free_bytes: free,
+            free_bytes: space.map(|s| s.free_bytes),
+            capacity_bytes: space.map(|s| s.capacity_bytes),
             metadata_utilization_ratio: meta,
         });
     }
@@ -261,16 +260,14 @@ pub fn compute_pool_metrics_from(
         if !drive.mounted {
             continue;
         }
-        let free = drive
-            .mountpoint
-            .as_deref()
-            .and_then(&mut free_bytes_resolver);
+        let space = drive.mountpoint.as_deref().and_then(&mut space_resolver);
         let meta = metadata_resolver(uuid);
         out.push(PoolMetric {
             uuid: uuid.clone(),
             role: "destination".to_string(),
             label: drive.label.clone(),
-            free_bytes: free,
+            free_bytes: space.map(|s| s.free_bytes),
+            capacity_bytes: space.map(|s| s.capacity_bytes),
             metadata_utilization_ratio: meta,
         });
     }
@@ -452,18 +449,25 @@ mod tests {
             mountpoint: Some(PathBuf::from("/mnt/wd")),
         }];
 
-        let free = |_: &Path| Some(42_u64);
+        let space = |_: &Path| {
+            Some(PoolSpace {
+                free_bytes: 42,
+                capacity_bytes: 100,
+            })
+        };
         let meta = |_: &str| Some(0.25_f64);
-        let metrics = compute_pool_metrics_from(&pools, &drives, free, meta);
+        let metrics = compute_pool_metrics_from(&pools, &drives, space, meta);
 
         assert_eq!(metrics.len(), 2);
         assert_eq!(metrics[0].uuid, "uuid-src");
         assert_eq!(metrics[0].role, "source");
         assert_eq!(metrics[0].label, "/home");
         assert_eq!(metrics[0].free_bytes, Some(42));
+        assert_eq!(metrics[0].capacity_bytes, Some(100));
         assert_eq!(metrics[1].uuid, "uuid-dst");
         assert_eq!(metrics[1].role, "destination");
         assert_eq!(metrics[1].label, "WD-18TB");
+        assert_eq!(metrics[1].capacity_bytes, Some(100));
     }
 
     #[test]
@@ -474,7 +478,17 @@ mod tests {
             mounted: false,
             mountpoint: None,
         }];
-        let metrics = compute_pool_metrics_from(&[], &drives, |_| Some(0), |_| None);
+        let metrics = compute_pool_metrics_from(
+            &[],
+            &drives,
+            |_| {
+                Some(PoolSpace {
+                    free_bytes: 0,
+                    capacity_bytes: 0,
+                })
+            },
+            |_| None,
+        );
         assert!(metrics.is_empty());
     }
 
@@ -532,7 +546,17 @@ mod tests {
             mounted: true,
             mountpoint: Some(PathBuf::from("/mnt/wd")),
         }];
-        let metrics = compute_pool_metrics_from(&[], &drives, |_| Some(0), |_| None);
+        let metrics = compute_pool_metrics_from(
+            &[],
+            &drives,
+            |_| {
+                Some(PoolSpace {
+                    free_bytes: 0,
+                    capacity_bytes: 0,
+                })
+            },
+            |_| None,
+        );
         assert!(metrics.is_empty());
     }
 }

--- a/src/pools.rs
+++ b/src/pools.rs
@@ -320,6 +320,17 @@ mod tests {
         std::fs::write(dir.join("total_bytes"), total).unwrap();
     }
 
+    /// A `space_resolver` that ignores the path and always reports the same
+    /// free/capacity. For "no rows emitted" tests the values are irrelevant.
+    fn fixed_space(free: u64, capacity: u64) -> impl Fn(&Path) -> Option<PoolSpace> {
+        move |_| {
+            Some(PoolSpace {
+                free_bytes: free,
+                capacity_bytes: capacity,
+            })
+        }
+    }
+
     #[test]
     fn metadata_utilization_ratio_returns_none_when_sysfs_missing() {
         let tmp = TempDir::new().unwrap();
@@ -449,14 +460,8 @@ mod tests {
             mountpoint: Some(PathBuf::from("/mnt/wd")),
         }];
 
-        let space = |_: &Path| {
-            Some(PoolSpace {
-                free_bytes: 42,
-                capacity_bytes: 100,
-            })
-        };
         let meta = |_: &str| Some(0.25_f64);
-        let metrics = compute_pool_metrics_from(&pools, &drives, space, meta);
+        let metrics = compute_pool_metrics_from(&pools, &drives, fixed_space(42, 100), meta);
 
         assert_eq!(metrics.len(), 2);
         assert_eq!(metrics[0].uuid, "uuid-src");
@@ -478,17 +483,7 @@ mod tests {
             mounted: false,
             mountpoint: None,
         }];
-        let metrics = compute_pool_metrics_from(
-            &[],
-            &drives,
-            |_| {
-                Some(PoolSpace {
-                    free_bytes: 0,
-                    capacity_bytes: 0,
-                })
-            },
-            |_| None,
-        );
+        let metrics = compute_pool_metrics_from(&[], &drives, fixed_space(0, 0), |_| None);
         assert!(metrics.is_empty());
     }
 
@@ -546,17 +541,7 @@ mod tests {
             mounted: true,
             mountpoint: Some(PathBuf::from("/mnt/wd")),
         }];
-        let metrics = compute_pool_metrics_from(
-            &[],
-            &drives,
-            |_| {
-                Some(PoolSpace {
-                    free_bytes: 0,
-                    capacity_bytes: 0,
-                })
-            },
-            |_| None,
-        );
+        let metrics = compute_pool_metrics_from(&[], &drives, fixed_space(0, 0), |_| None);
         assert!(metrics.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Two additive Prometheus metrics for the homelab's backup-observability alerting. Both are emitted once per backup run through the existing metrics path; no changes to existing series (ADR-105 safe).

- **`backup_external_expected{subvolume} 1`** — emitted for each subvolume with an external destination configured (resolved `send_enabled` AND ≥1 in-scope drive; `drives = None` means all drives), line absent otherwise. Computed in a new `externally_expected_subvolumes()` helper that mirrors the planner's send gate. Lets monitoring gate `ExternalBackupMissing` as `backup_snapshot_count{location="external"} == 0 and on(subvolume) backup_external_expected == 1`, cleanly excluding intentionally local-only subvolumes (e.g. `send_enabled = false`).
- **`backup_pool_total_bytes{uuid,role,label}`** — total BTRFS pool capacity (statvfs), alongside `backup_pool_free_bytes`, enabling a destination free-% alert for the offsite drive that `node_exporter` does not scrape. `PoolMetric` gains `capacity_bytes`; `compute_pool_metrics_from` now takes a single `PoolSpace` resolver (`pool_space`) so free and capacity come from one syscall and never skew within a run.

## Downstream coordination

These are external-interface additions — the homelab's ADR-021 should be updated to register the two new series before alerts depend on them (per CLAUDE.md downstream-consumer note). Additive only; nothing existing changes.

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: 1435 passed, 3 ignored (pre-existing UPI 045-a stubs)
- `cargo build --release`: pass
- New unit tests cover emit-when-set / omit-when-absent for both metrics; `pools.rs` resolver tests updated to `PoolSpace`.
- Not run: live `urd backup` (would need sudo, mutate snapshots, and overwrite the homelab's scraped `.prom`). Format is unit-tested; numbers below are from live statvfs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)