### PR TITLE
refactor: split FileSystemState into FilesystemQuery + HistoryQuery (UPI 052 PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Internal refactor: `FileSystemState` read-side split, PR 1** (UPI 052).
+  Split the 14-method `plan::FileSystemState` trait into two narrow query traits
+  along the ADR-102 axis — `FilesystemQuery` (filesystem-of-truth + drive
+  availability) and `HistoryQuery` (SQLite history) — in a new `observation.rs`
+  module. A `FileSystemState` bridge supertrait + blanket impl keeps every
+  existing caller and mock compiling unchanged while the seam is narrowed
+  incrementally in later PRs. No behavior, on-disk, or config-schema change.
+
 ## [0.21.0] - 2026-05-25
 
 ### Added

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -280,6 +280,21 @@ The suggested shape preserves the outer-edge span (365 days) while thinning the
 interior — same data cost, fewer pins to manage. The tightened shape shortens
 the outer edge in response to destination pressure; that does reduce data cost.
 
+## Cluster: Read-side query seams (ADR-102)
+
+The read side of the backup pipeline is split along the ADR-102 axis —
+*filesystem is truth, SQLite is history* — into two narrow query traits in
+`observation.rs` (UPI 052). A caller depends only on the half it actually
+reads, rather than on the full fused surface.
+
+| Term | Meaning |
+|------|---------|
+| `FilesystemQuery` | The filesystem-of-truth + drive-availability half: local/external snapshot listings, pin files, mount/availability, free space, and the BTRFS generation counter. Answers "what is on disk right now?" Lives in `observation.rs`. |
+| `HistoryQuery` | The SQLite-history half: last send sizes (same-drive and cross-drive), calibrated size, and send/drive timestamps. Answers "what happened before?" Lives in `observation.rs`. SQLite failures here never block backups (ADR-102). |
+| `FileSystemState` | Bridge supertrait (`FilesystemQuery + HistoryQuery`) with a blanket impl. Preserves every pre-split `&dyn FileSystemState` caller and mock while the seam is narrowed incrementally; slated for removal once no caller needs both halves. |
+
+Source: `observation.rs`, ADR-102.
+
 ## Flagged Ambiguities
 
 Terms in transition, or with a known gap between their canonical definition and

--- a/src/commands/calibrate.rs
+++ b/src/commands/calibrate.rs
@@ -1,8 +1,7 @@
 use crate::cli::CalibrateArgs;
 use crate::config::Config;
 use crate::output::{CalibrateEntry, CalibrateOutput, CalibrateResult, OutputMode};
-use crate::plan::FileSystemState;
-use crate::plan::RealFileSystemState;
+use crate::plan::{FilesystemQuery, RealFileSystemState};
 use crate::state::StateDb;
 use crate::voice;
 

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -5,7 +5,7 @@ use crate::cli::VerifyArgs;
 use crate::config::Config;
 use crate::drives;
 use crate::output::{OutputMode, VerifyCheck, VerifyDrive, VerifyOutput, VerifySubvolume};
-use crate::plan::{FileSystemState, RealFileSystemState};
+use crate::plan::{FileSystemState, FilesystemQuery, RealFileSystemState};
 use crate::voice;
 
 pub fn run(config: Config, args: VerifyArgs, mode: OutputMode) -> anyhow::Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod heartbeat;
 mod lock;
 mod metrics;
 mod notify;
+mod observation;
 mod output;
 mod plan;
 mod pools;

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -1,0 +1,112 @@
+//! Read-side query traits, split along the ADR-102 axis
+//! (*filesystem is truth, SQLite is history*).
+//!
+//! [`FilesystemQuery`] is the filesystem-of-truth + drive-availability
+//! surface (snapshot dirs, pin files, mounts, free space). [`HistoryQuery`]
+//! is the SQLite-history surface (send sizes, calibration, send/drive
+//! timestamps). The [`FileSystemState`] bridge supertrait + blanket impl
+//! preserve every existing `&dyn FileSystemState` caller while the seam is
+//! narrowed incrementally (UPI 052).
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use chrono::NaiveDateTime;
+
+use crate::config::DriveConfig;
+use crate::drives::DriveAvailability;
+use crate::types::{DriveEvent, SendKind, SnapshotName};
+
+// ── FilesystemQuery (filesystem is truth) ─────────────────────────────────
+
+/// Filesystem-of-truth and drive-availability queries: snapshot directories,
+/// pin files, mounts, and free space. The "what is on disk right now?" half.
+pub trait FilesystemQuery {
+    /// List snapshot names in a local snapshot directory.
+    fn local_snapshots(
+        &self,
+        root: &Path,
+        subvol_name: &str,
+    ) -> crate::error::Result<Vec<SnapshotName>>;
+
+    /// List snapshot names on an external drive for a subvolume.
+    fn external_snapshots(
+        &self,
+        drive: &DriveConfig,
+        subvol_name: &str,
+    ) -> crate::error::Result<Vec<SnapshotName>>;
+
+    /// Check if a drive is currently mounted.
+    fn is_drive_mounted(&self, drive: &DriveConfig) -> bool {
+        self.drive_availability(drive) == DriveAvailability::Available
+    }
+
+    /// Check if a drive is mounted and UUID-verified.
+    fn drive_availability(&self, drive: &DriveConfig) -> DriveAvailability;
+
+    /// Get free bytes on the filesystem containing the given path.
+    fn filesystem_free_bytes(&self, path: &Path) -> crate::error::Result<u64>;
+
+    /// Read the pin file for a specific drive from a local snapshot directory.
+    fn read_pin_file(
+        &self,
+        local_dir: &Path,
+        drive_label: &str,
+    ) -> crate::error::Result<Option<SnapshotName>>;
+
+    /// Collect all pinned snapshot names for a subvolume across all drives.
+    fn pinned_snapshots(&self, local_dir: &Path, drive_labels: &[String]) -> HashSet<SnapshotName>;
+
+    /// Get the BTRFS generation counter for a subvolume or snapshot path.
+    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64>;
+}
+
+// ── HistoryQuery (SQLite is history) ──────────────────────────────────────
+
+/// SQLite-history queries: send sizes, calibration, and send/drive
+/// timestamps. The "what happened before?" half.
+pub trait HistoryQuery {
+    /// Get the bytes_transferred from the most recent successful send of a given kind.
+    /// Returns None if no history exists (e.g., first-ever send).
+    fn last_send_size(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+        send_kind: SendKind,
+    ) -> Option<u64>;
+
+    /// Get the bytes_transferred from the most recent successful send of a given kind
+    /// across **all** drives. Cross-drive fallback for drive swap scenarios.
+    fn last_send_size_any_drive(&self, subvol_name: &str, send_kind: SendKind) -> Option<u64>;
+
+    /// Get a calibrated size estimate for a subvolume (from `urd calibrate`).
+    /// Returns `(estimated_bytes, measured_at)` or None if not calibrated.
+    fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)>;
+
+    /// Get the timestamp of the most recent successful send (full or incremental)
+    /// for a subvolume to a specific drive. Returns None if no send history exists.
+    fn last_successful_send_time(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+    ) -> Option<NaiveDateTime>;
+
+    /// Most recent mount/unmount event for a drive from `drive_connections`.
+    /// None if no event recorded (drive never seen by sentinel).
+    fn last_drive_event(&self, drive_label: &str) -> Option<DriveEvent>;
+
+    /// Most recent successful send timestamp for this drive (any subvolume).
+    /// None when no successful send has ever completed for this drive.
+    fn last_successful_operation_at(&self, drive_label: &str) -> Option<NaiveDateTime>;
+}
+
+// ── FileSystemState bridge ────────────────────────────────────────────────
+
+/// Bridge supertrait uniting both query halves. Preserves every existing
+/// `&dyn FileSystemState` caller and `MockFileSystemState` setup unchanged
+/// while the seam is narrowed incrementally (UPI 052). The blanket impl
+/// means any type implementing both halves is automatically a
+/// `FileSystemState`.
+pub trait FileSystemState: FilesystemQuery + HistoryQuery {}
+
+impl<T: FilesystemQuery + HistoryQuery + ?Sized> FileSystemState for T {}

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -55,81 +55,11 @@ fn stamp_context(events: &mut [Event], subvolume: Option<&str>, drive_label: Opt
     }
 }
 
-// ── FileSystemState trait ───────────────────────────────────────────────
-
-/// Abstraction over filesystem state for testing.
-pub trait FileSystemState {
-    /// List snapshot names in a local snapshot directory.
-    fn local_snapshots(
-        &self,
-        root: &Path,
-        subvol_name: &str,
-    ) -> crate::error::Result<Vec<SnapshotName>>;
-
-    /// List snapshot names on an external drive for a subvolume.
-    fn external_snapshots(
-        &self,
-        drive: &DriveConfig,
-        subvol_name: &str,
-    ) -> crate::error::Result<Vec<SnapshotName>>;
-
-    /// Check if a drive is currently mounted.
-    fn is_drive_mounted(&self, drive: &DriveConfig) -> bool {
-        self.drive_availability(drive) == DriveAvailability::Available
-    }
-
-    /// Check if a drive is mounted and UUID-verified.
-    fn drive_availability(&self, drive: &DriveConfig) -> DriveAvailability;
-
-    /// Get free bytes on the filesystem containing the given path.
-    fn filesystem_free_bytes(&self, path: &Path) -> crate::error::Result<u64>;
-
-    /// Read the pin file for a specific drive from a local snapshot directory.
-    fn read_pin_file(
-        &self,
-        local_dir: &Path,
-        drive_label: &str,
-    ) -> crate::error::Result<Option<SnapshotName>>;
-
-    /// Collect all pinned snapshot names for a subvolume across all drives.
-    fn pinned_snapshots(&self, local_dir: &Path, drive_labels: &[String]) -> HashSet<SnapshotName>;
-
-    /// Get the bytes_transferred from the most recent successful send of a given kind.
-    /// Returns None if no history exists (e.g., first-ever send).
-    fn last_send_size(
-        &self,
-        subvol_name: &str,
-        drive_label: &str,
-        send_kind: SendKind,
-    ) -> Option<u64>;
-
-    /// Get the bytes_transferred from the most recent successful send of a given kind
-    /// across **all** drives. Cross-drive fallback for drive swap scenarios.
-    fn last_send_size_any_drive(&self, subvol_name: &str, send_kind: SendKind) -> Option<u64>;
-
-    /// Get a calibrated size estimate for a subvolume (from `urd calibrate`).
-    /// Returns `(estimated_bytes, measured_at)` or None if not calibrated.
-    fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)>;
-
-    /// Get the BTRFS generation counter for a subvolume or snapshot path.
-    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64>;
-
-    /// Get the timestamp of the most recent successful send (full or incremental)
-    /// for a subvolume to a specific drive. Returns None if no send history exists.
-    fn last_successful_send_time(
-        &self,
-        subvol_name: &str,
-        drive_label: &str,
-    ) -> Option<NaiveDateTime>;
-
-    /// Most recent mount/unmount event for a drive from `drive_connections`.
-    /// None if no event recorded (drive never seen by sentinel).
-    fn last_drive_event(&self, drive_label: &str) -> Option<DriveEvent>;
-
-    /// Most recent successful send timestamp for this drive (any subvolume).
-    /// None when no successful send has ever completed for this drive.
-    fn last_successful_operation_at(&self, drive_label: &str) -> Option<NaiveDateTime>;
-}
+// The read-side query traits now live in `crate::observation`, split along
+// the ADR-102 axis (filesystem is truth, SQLite is history). Re-exported here
+// so existing `crate::plan::{FileSystemState, ..}` import paths keep resolving
+// while the seam is narrowed incrementally (UPI 052).
+pub use crate::observation::{FileSystemState, FilesystemQuery, HistoryQuery};
 
 // ── Size estimation helper ──────────────────────────────────────────────
 
@@ -1333,7 +1263,7 @@ pub struct RealFileSystemState<'a> {
     pub state: Option<&'a crate::state::StateDb>,
 }
 
-impl FileSystemState for RealFileSystemState<'_> {
+impl FilesystemQuery for RealFileSystemState<'_> {
     fn local_snapshots(
         &self,
         root: &Path,
@@ -1371,6 +1301,12 @@ impl FileSystemState for RealFileSystemState<'_> {
         crate::chain::find_pinned_snapshots(local_dir, drive_labels)
     }
 
+    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
+        crate::btrfs::subvolume_generation(path)
+    }
+}
+
+impl HistoryQuery for RealFileSystemState<'_> {
     fn last_send_size(
         &self,
         subvol_name: &str,
@@ -1415,10 +1351,6 @@ impl FileSystemState for RealFileSystemState<'_> {
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)> {
         self.state
             .and_then(|db| db.calibrated_size(subvol_name).ok().flatten())
-    }
-
-    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
-        crate::btrfs::subvolume_generation(path)
     }
 
     fn last_successful_send_time(
@@ -1548,7 +1480,7 @@ impl MockFileSystemState {
 }
 
 #[cfg(test)]
-impl FileSystemState for MockFileSystemState {
+impl FilesystemQuery for MockFileSystemState {
     fn local_snapshots(
         &self,
         _root: &Path,
@@ -1630,6 +1562,28 @@ impl FileSystemState for MockFileSystemState {
         pinned
     }
 
+    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
+        if self.fail_generations.contains(path) {
+            return Err(crate::error::UrdError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::other("mock: generation query failed"),
+            });
+        }
+        self.generations
+            .get(path)
+            .copied()
+            .ok_or_else(|| crate::error::UrdError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "mock: no generation configured",
+                ),
+            })
+    }
+}
+
+#[cfg(test)]
+impl HistoryQuery for MockFileSystemState {
     fn last_send_size(
         &self,
         subvol_name: &str,
@@ -1654,25 +1608,6 @@ impl FileSystemState for MockFileSystemState {
             .filter(|((sv, _, st), _)| sv == subvol_name && *st == send_kind)
             .map(|(_, &bytes)| bytes)
             .max()
-    }
-
-    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
-        if self.fail_generations.contains(path) {
-            return Err(crate::error::UrdError::Io {
-                path: path.to_path_buf(),
-                source: std::io::Error::other("mock: generation query failed"),
-            });
-        }
-        self.generations
-            .get(path)
-            .copied()
-            .ok_or_else(|| crate::error::UrdError::Io {
-                path: path.to_path_buf(),
-                source: std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "mock: no generation configured",
-                ),
-            })
     }
 
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)> {


### PR DESCRIPTION
## Summary

- **PR 1 of UPI 052** — narrows the 14-method `plan::FileSystemState` read-side trait into two query traits split along the ADR-102 axis (*filesystem is truth, SQLite is history*): `FilesystemQuery` (snapshot listings, mounts, pin files, free space, btrfs generation) and `HistoryQuery` (send sizes, calibration, send/drive timestamps), in a new `observation.rs` module.
- **Purely additive, zero risk.** A `FileSystemState` bridge supertrait + blanket impl keeps all 27 callers and ~200 mock setups compiling unchanged. No behavior change, no dead code, no `#[allow]`.
- `RealFileSystemState` / `MockFileSystemState` impls split into the two halves verbatim (`subvolume_generation` stays on `FilesystemQuery` through PR 1 — it leaves for `BtrfsRead` in PR 2 so the bridge union equals the old trait).
- `calibrate.rs` / `verify.rs` gain a `FilesystemQuery` import: concrete-receiver method resolution needs the declaring trait in scope, whereas trait-object callers dispatch through the bridge unchanged. (The plan's "no caller edits" claim held only for `&dyn` receivers.)
- No on-disk (ADR-105) or config-schema (ADR-111) contract change; no cross-repo/homelab impact. Glossary gains a "Read-side query seams" cluster; `Observation`/`BtrfsRead` entries + CLAUDE.md row land with their code in PR 2.

## Testing

- cargo clippy `--all-targets -- -D warnings`: pass (clean)
- cargo test: 1435 passed, 0 failed, 3 ignored — **no test edits**, which is the bridge's correctness proof
- cargo build --release: pass
- Integration tests: not applicable (pure refactor, no btrfs/drive behavior touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)