### PR TITLE
refactor: Observation cutover + ADR-101 generation-read fix (UPI 052 PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   module. A `FileSystemState` bridge supertrait + blanket impl keeps every
   existing caller and mock compiling unchanged while the seam is narrowed
   incrementally in later PRs. No behavior, on-disk, or config-schema change.
+- **Internal refactor: `Observation` cutover + ADR-101 generation-read fix, PR 2**
+  (UPI 052). Introduced `Observation<'a>` — a `{ fs, history, btrfs }` bundle of
+  read-only seams — and threaded it through `plan::plan` and `awareness::assess`,
+  replacing the wide `&dyn FileSystemState` parameter. Closed the ADR-101 loophole
+  where `subvolume_generation` ran a `sudo btrfs` subprocess from a free function
+  outside `BtrfsOps`: it now lives on a new read-only `BtrfsRead` trait
+  (`BtrfsOps: BtrfsRead`), so pure planners read generations through a non-mutating
+  seam that cannot upcast to the mutating ops. Fail-open generation semantics
+  preserved verbatim. No behavior, on-disk, or config-schema change.
 
 ## [0.21.0] - 2026-05-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,8 @@ All backup logic flows through: config -> plan -> execute. No exceptions.
 | `types.rs` | Domain types, parsing, Display, `derive_policy()` | Contain business logic |
 | `plan.rs` | Decide what operations to run (pure function) | Execute anything or call btrfs |
 | `executor.rs` | Execute planned operations, error isolation | Decide what to do (planner's job) |
-| `btrfs.rs` | Wrap `sudo btrfs` subprocess calls via `BtrfsOps` trait | Know about retention, plans, config |
+| `btrfs.rs` | Wrap `sudo btrfs` subprocess calls via `BtrfsOps` trait. Read-only generation reads go through the `BtrfsRead` supertrait (`BtrfsOps: BtrfsRead`) so pure planners get a non-mutating seam (ADR-100/101) | Know about retention, plans, config |
+| `observation.rs` | Read-side query seams (UPI 052): `FilesystemQuery` (filesystem of truth), `HistoryQuery` (SQLite history), and `Observation` — the `{ fs, history, btrfs }` bundle threaded through `plan::plan` and `awareness::assess`. Hosts the `FileSystemState` bridge supertrait | Perform I/O (defines traits only); decide anything |
 | `retention.rs` | Compute which snapshots to keep/delete (pure) | Delete anything (returns lists) |
 | `awareness.rs` | Pure: observe promise state (PROTECTED / AT RISK / UNPROTECTED) from config + filesystem + history. The "is my data safe right now?" surface | Perform I/O; translate observations into advice (`advice.rs` does that); recommend retention shapes (`recommendation.rs` does that) |
 | `advice.rs` | Pure: translate `SubvolAssessment` into actionable advice (issue/command/reason) and structured redundancy advisories. The "what should the user do?" surface — rule-based, the volatile layer where product refinements land | Perform I/O; assess promise state (`awareness.rs` does that) |

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -289,11 +289,13 @@ reads, rather than on the full fused surface.
 
 | Term | Meaning |
 |------|---------|
-| `FilesystemQuery` | The filesystem-of-truth + drive-availability half: local/external snapshot listings, pin files, mount/availability, free space, and the BTRFS generation counter. Answers "what is on disk right now?" Lives in `observation.rs`. |
+| `FilesystemQuery` | The filesystem-of-truth + drive-availability half: local/external snapshot listings, pin files, mount/availability, and free space. Answers "what is on disk right now?" Lives in `observation.rs`. (The BTRFS generation counter moved to `BtrfsRead` in PR 2.) |
 | `HistoryQuery` | The SQLite-history half: last send sizes (same-drive and cross-drive), calibrated size, and send/drive timestamps. Answers "what happened before?" Lives in `observation.rs`. SQLite failures here never block backups (ADR-102). |
+| `BtrfsRead` | The read-only btrfs seam: `subvolume_generation(path)`. Supertrait of `BtrfsOps` (`BtrfsOps: BtrfsRead`), so a read-only caller takes `&dyn BtrfsRead` and cannot upcast to the mutating `BtrfsOps` (ADR-100, ADR-101). `RealBtrfs` runs `sudo btrfs subvolume show`; `MockBtrfs` looks up injected generations. Lives in `btrfs.rs`. |
+| `Observation` | The read-only world a pure decision function observes: `{ fs: &dyn FilesystemQuery, history: &dyn HistoryQuery, btrfs: &dyn BtrfsRead }`. Threaded as `&Observation` through `plan::plan` and `awareness::assess` (UPI 052) so they read state through three narrow, non-mutating trait objects. Lives in `observation.rs`. |
 | `FileSystemState` | Bridge supertrait (`FilesystemQuery + HistoryQuery`) with a blanket impl. Preserves every pre-split `&dyn FileSystemState` caller and mock while the seam is narrowed incrementally; slated for removal once no caller needs both halves. |
 
-Source: `observation.rs`, ADR-102.
+Source: `observation.rs`, `btrfs.rs`, ADR-100, ADR-101, ADR-102.
 
 ## Flagged Ambiguities
 

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -453,6 +453,8 @@ mod tests {
         ChainBreakReason, DriveChainHealth, LocalAssessment, assess,
     };
     use crate::awareness::test_support::{dt, offsite_test_config, snap, test_config};
+    use crate::btrfs::MockBtrfs;
+    use crate::observation::Observation;
     use crate::plan::MockFileSystemState;
     use crate::types::Interval;
     use chrono::Duration;
@@ -784,7 +786,7 @@ drives = ["drive-a", "drive-b"]
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
         fs.mounted_drives.insert("drive-a".to_string());
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert_eq!(advisories.len(), 1);
@@ -808,7 +810,7 @@ drives = ["drive-a", "drive-b"]
             dt(2026, 3, 1, 12, 0),
         );
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert_eq!(advisories.len(), 1);
@@ -830,7 +832,7 @@ drives = ["drive-a", "drive-b"]
             dt(2026, 3, 3, 12, 0),
         );
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -848,7 +850,7 @@ drives = ["drive-a", "drive-b"]
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
         fs.mounted_drives.insert("primary-drive".to_string());
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -915,7 +917,7 @@ protection_level = "protected"
             dt(2026, 4, 1, 8, 0),
         );
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert_eq!(advisories.len(), 1);
@@ -934,7 +936,7 @@ protection_level = "protected"
         fs.mounted_drives.insert("drive-a".to_string());
         fs.mounted_drives.insert("drive-b".to_string());
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         // Should have NoOffsiteProtection but NOT SinglePointOfFailure
@@ -994,7 +996,7 @@ protection_level = "guarded"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1060,7 +1062,7 @@ local_retention = "transient"
             dt(2026, 3, 30, 12, 0),
         );
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1084,7 +1086,7 @@ local_retention = "transient"
             dt(2026, 4, 1, 8, 0),
         );
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1106,7 +1108,7 @@ local_retention = "transient"
             dt(2026, 3, 30, 12, 0),
         );
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         let advisory = advisories

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -13,7 +13,8 @@ use chrono::{Duration, NaiveDateTime};
 
 use crate::advice::RedundancyAdvisory;
 use crate::config::{Config, DriveConfig};
-use crate::plan::{self, FileSystemState};
+use crate::observation::Observation;
+use crate::plan;
 use crate::types::{
     DriveEventKind, DriveRole, Interval, LocalRetentionPolicy, SnapshotName,
 };
@@ -391,7 +392,7 @@ pub fn diff_promise_states(
 pub fn assess(
     config: &Config,
     now: NaiveDateTime,
-    fs: &dyn FileSystemState,
+    obs: &Observation,
 ) -> Vec<SubvolAssessment> {
     let resolved = config.resolved_subvolumes();
     let mut assessments = Vec::new();
@@ -402,17 +403,17 @@ pub fn assess(
         .drives
         .iter()
         .map(|d| {
-            let signal = if fs.is_drive_mounted(d) {
+            let signal = if obs.fs.is_drive_mounted(d) {
                 (None, None)
             } else {
-                match fs.last_drive_event(&d.label) {
+                match obs.history.last_drive_event(&d.label) {
                     Some(event) => match event.kind {
                         DriveEventKind::Unmount => {
                             (Some((now - event.at).num_seconds()), None)
                         }
                         DriveEventKind::Mount => (None, None),
                     },
-                    None => match fs.last_successful_operation_at(&d.label) {
+                    None => match obs.history.last_successful_operation_at(&d.label) {
                         Some(op_time) => (None, Some((now - op_time).num_seconds())),
                         None => (None, None),
                     },
@@ -456,7 +457,7 @@ pub fn assess(
 
         // ── Local assessment ────────────────────────────────────────
         let mut advisories = Vec::new();
-        let local_snaps = match fs.local_snapshots(snapshot_root, &subvol.name) {
+        let local_snaps = match obs.fs.local_snapshots(snapshot_root, &subvol.name) {
             Ok(snaps) => snaps,
             Err(e) => {
                 errors.push(format!("failed to read local snapshots: {e}"));
@@ -467,7 +468,7 @@ pub fn assess(
         // Query the source generation once per subvolume and pass to both
         // local and per-drive source-unchanged checks. Fail-open: any error
         // becomes None, which falls back to age-based assessment.
-        let source_gen = fs.subvolume_generation(&subvol.source).ok();
+        let source_gen = obs.btrfs.subvolume_generation(&subvol.source).ok();
 
         // Transient subvolumes return Protected unconditionally from
         // assess_local; skip the generation query for the newest local
@@ -475,7 +476,7 @@ pub fn assess(
         let local_unchanged = !subvol.local_retention.is_transient()
             && local_snaps.iter().max().is_some_and(|newest| {
                 let snap_path = local_dir.join(newest.as_str());
-                local_source_unchanged(fs, source_gen, &snap_path)
+                local_source_unchanged(obs, source_gen, &snap_path)
             });
 
         let local = {
@@ -513,10 +514,10 @@ pub fn assess(
             };
 
             for drive in &effective_drives {
-                let mounted = fs.is_drive_mounted(drive);
+                let mounted = obs.fs.is_drive_mounted(drive);
 
                 let ext_snaps = if mounted {
-                    match fs.external_snapshots(drive, &subvol.name) {
+                    match obs.fs.external_snapshots(drive, &subvol.name) {
                         Ok(snaps) => Some(snaps),
                         Err(e) => {
                             errors.push(format!(
@@ -534,7 +535,7 @@ pub fn assess(
 
                 if let Some(ref ext) = ext_snaps {
                     chain_health_entries.push(assess_chain_health(
-                        fs,
+                        obs,
                         &local_dir,
                         drive,
                         &local_snaps,
@@ -542,11 +543,11 @@ pub fn assess(
                     ));
                 }
 
-                let last_send_time = fs.last_successful_send_time(&subvol.name, &drive.label);
+                let last_send_time = obs.history.last_successful_send_time(&subvol.name, &drive.label);
                 let last_send_age = last_send_time.map(|t| clamp_age(now - t));
 
                 let source_unchanged = external_source_unchanged(
-                    fs,
+                    obs,
                     source_gen,
                     &local_dir,
                     &drive.label,
@@ -608,7 +609,7 @@ pub fn assess(
             .filter(|&min_free| min_free > 0)
             .and_then(|min_free| {
                 let local_dir = snapshot_root.join(&subvol.name);
-                fs.filesystem_free_bytes(&local_dir).ok().and_then(|free| {
+                obs.fs.filesystem_free_bytes(&local_dir).ok().and_then(|free| {
                     let tight_threshold = min_free + min_free / (100 / SPACE_TIGHT_MARGIN_PERCENT);
                     if free < tight_threshold {
                         Some(free)
@@ -623,7 +624,7 @@ pub fn assess(
             &chain_health_entries,
             &drive_assessments,
             &config.drives,
-            fs,
+            obs,
             &subvol.name,
             local_space_tight.is_some(),
             subvol.local_retention.is_transient(),
@@ -766,7 +767,7 @@ fn assess_external_status(
 ///   appear in the list — otherwise the drive's copy is gone and the override
 ///   must not apply (drive is in a chain-broken state).
 fn external_source_unchanged(
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     source_gen: Option<u64>,
     local_dir: &std::path::Path,
     drive_label: &str,
@@ -775,7 +776,7 @@ fn external_source_unchanged(
     let Some(source_gen) = source_gen else {
         return false;
     };
-    let Ok(Some(pin)) = fs.read_pin_file(local_dir, drive_label) else {
+    let Ok(Some(pin)) = obs.fs.read_pin_file(local_dir, drive_label) else {
         return false;
     };
     // Drive is mounted and we can see its snapshots — require the pin to be
@@ -788,7 +789,7 @@ fn external_source_unchanged(
         return false;
     }
     let pin_path = local_dir.join(pin.as_str());
-    match fs.subvolume_generation(&pin_path) {
+    match obs.btrfs.subvolume_generation(&pin_path) {
         Ok(pin_gen) => source_gen == pin_gen,
         Err(_) => false,
     }
@@ -797,14 +798,14 @@ fn external_source_unchanged(
 /// Compare BTRFS generations: is the source unchanged since the newest local
 /// snapshot? Mirrors the planner's snapshot-skip logic. Fails open.
 fn local_source_unchanged(
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     source_gen: Option<u64>,
     newest_local_snap_path: &std::path::Path,
 ) -> bool {
     let Some(source_gen) = source_gen else {
         return false;
     };
-    match fs.subvolume_generation(newest_local_snap_path) {
+    match obs.btrfs.subvolume_generation(newest_local_snap_path) {
         Ok(snap_gen) => source_gen == snap_gen,
         Err(_) => false,
     }
@@ -867,7 +868,7 @@ fn compute_overall_status(local: &LocalAssessment, drives: &[DriveAssessment]) -
 /// Pure function: uses already-fetched snapshot lists and `FileSystemState`
 /// for pin file reads. No direct filesystem I/O.
 fn assess_chain_health(
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     local_dir: &std::path::Path,
     drive: &DriveConfig,
     local_snaps: &[SnapshotName],
@@ -879,7 +880,7 @@ fn assess_chain_health(
             pin_parent: None,
         }
     } else {
-        match fs.read_pin_file(local_dir, &drive.label) {
+        match obs.fs.read_pin_file(local_dir, &drive.label) {
             Ok(Some(pin)) => {
                 let pin_str = pin.as_str();
                 let parent_local = local_snaps.iter().any(|s| s.as_str() == pin_str);
@@ -937,7 +938,7 @@ fn compute_health(
     chain_health: &[DriveChainHealth],
     drive_assessments: &[DriveAssessment],
     drives_config: &[DriveConfig],
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     subvol_name: &str,
     local_space_tight: bool,
     is_transient: bool,
@@ -974,7 +975,7 @@ fn compute_health(
                 continue;
             };
 
-            let free = fs.filesystem_free_bytes(&cfg.mount_path).unwrap_or(u64::MAX);
+            let free = obs.fs.filesystem_free_bytes(&cfg.mount_path).unwrap_or(u64::MAX);
             let min_free = cfg.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
 
             // Check if chain is broken on this drive (full send will be needed)
@@ -987,7 +988,7 @@ fn compute_health(
 
             // Calibrated size is the full-subvolume footprint; estimated_send_size
             // only returns it when a full send is needed (chain broken).
-            let est_size = plan::estimated_send_size(fs, subvol_name, &da.drive_label, chain_broken);
+            let est_size = plan::estimated_send_size(obs.history, subvol_name, &da.drive_label, chain_broken);
 
             match est_size {
                 Some(size) if free.saturating_sub(min_free) < size => {
@@ -1025,7 +1026,7 @@ fn compute_health(
 
             // Surface uncertainty: chain broken means full send, but no size estimate
             let has_estimate =
-                plan::estimated_send_size(fs, subvol_name, &ch.drive_label, true).is_some();
+                plan::estimated_send_size(obs.history, subvol_name, &ch.drive_label, true).is_some();
             if !has_estimate {
                 reasons.push(format!(
                     "full send size unknown for {} \u{2014} space check unavailable",
@@ -1042,7 +1043,7 @@ fn compute_health(
         {
             let min_free = min_free_bytes.bytes();
             if min_free > 0 {
-                let free = fs.filesystem_free_bytes(&cfg.mount_path).unwrap_or(u64::MAX);
+                let free = obs.fs.filesystem_free_bytes(&cfg.mount_path).unwrap_or(u64::MAX);
                 let tight_threshold =
                     min_free + min_free / (100 / SPACE_TIGHT_MARGIN_PERCENT);
                 if free < tight_threshold {
@@ -1086,6 +1087,7 @@ fn compute_health(
 mod tests {
     use super::*;
     use super::test_support::{dt, offsite_test_config, snap, test_config};
+    use crate::btrfs::MockBtrfs;
     use crate::plan::MockFileSystemState;
     use crate::types::SnapshotName;
     use chrono::NaiveDate;
@@ -1212,7 +1214,7 @@ source = "/data/sv1"
 
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].status, PromiseStatus::Protected);
         assert_eq!(results[1].status, PromiseStatus::Protected);
@@ -1237,7 +1239,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::AtRisk);
         assert_eq!(results[0].status, PromiseStatus::AtRisk);
     }
@@ -1255,7 +1257,7 @@ source = "/data/sv1"
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 8, 0), "sv1")]);
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::Unprotected);
     }
 
@@ -1267,7 +1269,7 @@ source = "/data/sv1"
         let now = dt(2026, 3, 23, 14, 0);
         let fs = MockFileSystemState::new();
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::Unprotected);
         assert_eq!(results[0].local.snapshot_count, 0);
     }
@@ -1294,7 +1296,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].external[0].status, PromiseStatus::AtRisk);
     }
 
@@ -1319,7 +1321,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -1338,7 +1340,7 @@ source = "/data/sv1"
         fs.mounted_drives.insert("WD-18TB".to_string());
         // No send_times entry
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -1385,7 +1387,7 @@ send_enabled = false
             vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].external.len(), 0);
         assert_eq!(results[0].status, PromiseStatus::Protected);
     }
@@ -1410,7 +1412,7 @@ send_enabled = false
         );
         // Drive NOT in mounted_drives
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert!(!results[0].external[0].mounted);
         assert_eq!(results[0].external[0].status, PromiseStatus::Protected);
         assert_eq!(results[0].external[0].snapshot_count, None);
@@ -1477,7 +1479,7 @@ source = "/data/sv1"
 
         fs.mounted_drives.insert("primary".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
 
         // Primary drive is PROTECTED
         let primary = &results[0]
@@ -1519,7 +1521,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::AtRisk);
         assert_eq!(results[0].external[0].status, PromiseStatus::Protected);
         // min(AT_RISK, PROTECTED) = AT_RISK
@@ -1569,7 +1571,7 @@ enabled = false
         let now = dt(2026, 3, 23, 14, 0);
         let fs = MockFileSystemState::new();
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "sv1");
     }
@@ -1586,7 +1588,7 @@ enabled = false
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 12, 0), "sv1")]);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
 
         // 2h + 1min ago → AT_RISK (> 2×)
@@ -1595,7 +1597,7 @@ enabled = false
             vec![snap(dt(2026, 3, 23, 11, 59), "sv1")],
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::AtRisk);
     }
 
@@ -1609,14 +1611,14 @@ enabled = false
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 9, 0), "sv1")]);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::AtRisk);
 
         // 5h + 1min ago → UNPROTECTED (> 5×)
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 8, 59), "sv1")]);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::Unprotected);
     }
 
@@ -1666,7 +1668,7 @@ source = "/data/sv1"
             .insert(("sv1".to_string(), "WD-18TB".to_string()), two_days_ago);
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         // Local: 2d / 1d = 2× → PROTECTED (≤ 2×)
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         // External: 2d / 1d = 2× → AT_RISK (> 1.5×)
@@ -1728,7 +1730,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert!(results[0].errors.is_empty());
     }
 
@@ -1754,7 +1756,7 @@ source = "/data/sv1"
             dt(2026, 3, 13, 8, 0),
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert!(
             !results[0]
                 .advisories
@@ -1782,7 +1784,7 @@ source = "/data/sv1"
             dt(2026, 3, 13, 8, 0),
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert!(
             results[0].advisories.is_empty(),
             "primary drive should not get advisories: {:?}",
@@ -1877,7 +1879,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         // Age clamped to zero → evaluates as "just created" → PROTECTED
         // (not falsely PROTECTED from negative duration)
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
@@ -1909,7 +1911,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         // Send age clamped to zero → PROTECTED (not false PROTECTED from negative)
         assert_eq!(results[0].external[0].status, PromiseStatus::Protected);
         assert_eq!(results[0].external[0].last_send_age, Some(Duration::zero()));
@@ -1936,7 +1938,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results.len(), 2);
 
         // sv1: error captured, status UNPROTECTED
@@ -2015,7 +2017,7 @@ source = "/data/sv1"
             dt(2026, 3, 29, 10, 0),
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let sv = &results[0];
         assert_eq!(sv.chain_health.len(), 1);
         assert_eq!(
@@ -2048,7 +2050,7 @@ source = "/data/sv1"
             dt(2026, 3, 28, 10, 0),
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let ch = &results[0].chain_health[0];
         assert!(matches!(
             ch.status,
@@ -2081,7 +2083,7 @@ source = "/data/sv1"
             dt(2026, 3, 29, 10, 0),
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let ch = &results[0].chain_health[0];
         assert!(matches!(
             ch.status,
@@ -2111,7 +2113,7 @@ source = "/data/sv1"
             dt(2026, 3, 29, 10, 0),
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let ch = &results[0].chain_health[0];
         assert_eq!(
             ch.status,
@@ -2135,7 +2137,7 @@ source = "/data/sv1"
             .insert(("D1".to_string(), "sv1".to_string()), vec![]);
         fs.mounted_drives.insert("D1".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let ch = &results[0].chain_health[0];
         assert!(matches!(
             ch.status,
@@ -2156,7 +2158,7 @@ source = "/data/sv1"
             .insert("sv1".to_string(), vec![parse_snap("20260329-1100-s1")]);
         // Drive NOT mounted — no chain health entries
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert!(
             results[0].chain_health.is_empty(),
             "unmounted drives should not produce chain health entries"
@@ -2204,7 +2206,7 @@ source = "/data/sv1"
             .insert("sv1".to_string(), vec![parse_snap("20260329-1100-s1")]);
         fs.mounted_drives.insert("D1".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert!(
             results[0].chain_health.is_empty(),
             "send_disabled subvolumes should have no chain health"
@@ -2230,7 +2232,7 @@ source = "/data/sv1"
             "D1".to_string(),
         ));
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let ch = &results[0].chain_health[0];
         assert_eq!(
             ch.status,
@@ -2279,7 +2281,7 @@ source = "/data/sv1"
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Healthy);
         assert!(results[0].health_reasons.is_empty());
     }
@@ -2307,7 +2309,7 @@ source = "/data/sv1"
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(results[0].health_reasons[0].contains("chain broken"));
         assert!(results[0].health_reasons[0].contains("WD-18TB"));
@@ -2325,7 +2327,7 @@ source = "/data/sv1"
         );
         // No drives mounted, send_enabled=true (default in test config)
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Blocked);
         assert!(results[0].health_reasons[0].contains("no backup drives connected"));
     }
@@ -2380,7 +2382,7 @@ send_enabled = false
         );
         // No drives mounted — but send_enabled=false, so health should be Healthy
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Healthy);
     }
 
@@ -2414,7 +2416,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 105_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("space tight")));
     }
@@ -2455,7 +2457,7 @@ send_enabled = false
             60_000_000_000,
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Blocked);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("insufficient space")));
     }
@@ -2492,7 +2494,7 @@ send_enabled = false
             5_000_000_000,
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_ne!(
             results[0].health,
             OperationalHealth::Blocked,
@@ -2526,7 +2528,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 200_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_ne!(
             results[0].health,
             OperationalHealth::Blocked,
@@ -2568,7 +2570,7 @@ send_enabled = false
             50_000_000_000,
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_ne!(
             results[0].health,
             OperationalHealth::Blocked,
@@ -2595,7 +2597,7 @@ send_enabled = false
             },
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let drive = &results[0].external[0];
         assert_eq!(
             drive.absent_duration_secs,
@@ -2629,7 +2631,7 @@ send_enabled = false
         fs.last_successful_ops
             .insert("WD-18TB".to_string(), dt(2026, 3, 22, 12, 0));
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, None);
         assert_eq!(drive.last_activity_age_secs, None);
@@ -2657,7 +2659,7 @@ send_enabled = false
         fs.last_successful_ops
             .insert("WD-18TB".to_string(), dt(2026, 3, 22, 10, 0));
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, None);
         assert_eq!(
@@ -2678,7 +2680,7 @@ send_enabled = false
         fs.last_successful_ops
             .insert("WD-18TB".to_string(), dt(2026, 3, 20, 14, 0));
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, None);
         assert_eq!(
@@ -2708,7 +2710,7 @@ send_enabled = false
         fs.last_successful_ops
             .insert("WD-18TB".to_string(), dt(2026, 3, 20, 10, 0));
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, Some(4 * 3600));
         assert_eq!(
@@ -2726,7 +2728,7 @@ send_enabled = false
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, None);
         assert_eq!(drive.last_activity_age_secs, None);
@@ -2748,7 +2750,7 @@ send_enabled = false
             dt(2026, 3, 10, 12, 0), // 13 days ago
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Blocked);
         // Blocked because no drives mounted (primary check), plus degraded for away >7d
         assert!(results[0].health_reasons.iter().any(|r| r.contains("no backup drives connected")));
@@ -2790,7 +2792,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/d1"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Healthy, "health_reasons: {:?}", results[0].health_reasons);
         assert!(results[0].health_reasons.is_empty());
     }
@@ -2837,14 +2839,15 @@ send_enabled = false
             ("sv1".to_string(), "D2".to_string()),
             dt(2026, 3, 10, 12, 0),
         );
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"), 42);
-        fs.generations.insert(
+        mb.generations.borrow_mut().insert(
             std::path::PathBuf::from(format!("/snap/sv1/{}", pin_snap.as_str())),
             42,
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb });
         assert_eq!(
             results[0].health,
             OperationalHealth::Healthy,
@@ -2910,7 +2913,7 @@ send_enabled = false
             dt(2026, 3, 6, 14, 0), // 17 days ago
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert!(
             !results[0]
                 .health_reasons
@@ -2991,7 +2994,7 @@ send_enabled = false
             dt(2026, 3, 10, 12, 0),
         );
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(results[0].health_reasons.len() >= 2, "expected multiple reasons, got: {:?}", results[0].health_reasons);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("chain broken")));
@@ -3061,7 +3064,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/snap/sv1"), 11_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("local snapshot space tight")));
     }
@@ -3089,7 +3092,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(
             results[0].health_reasons.iter().any(|r| r.contains("full send size unknown")),
@@ -3156,7 +3159,7 @@ local_retention = "transient"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].name, "sv-transient");
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         assert_eq!(results[0].local.snapshot_count, 0);
@@ -3176,7 +3179,7 @@ local_retention = "transient"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         // Overall dragged down by external, not local
         assert_eq!(results[0].status, PromiseStatus::AtRisk);
@@ -3195,7 +3198,7 @@ local_retention = "transient"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         assert_eq!(results[0].status, PromiseStatus::Unprotected);
     }
@@ -3219,7 +3222,7 @@ local_retention = "transient"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         assert_eq!(results[0].local.snapshot_count, 1);
         assert!(results[0].local.newest_age.is_some());
@@ -3235,7 +3238,7 @@ local_retention = "transient"
         // No local snapshots, no external sends, drive mounted
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         // External: never sent → UNPROTECTED
         assert_eq!(results[0].external[0].status, PromiseStatus::Unprotected);
@@ -3290,7 +3293,7 @@ send_enabled = false
         let now = dt(2026, 3, 23, 14, 0);
         let fs = MockFileSystemState::new();
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(results[0].name, "sv-nosend");
         // Local returns Protected (transient branch), but overall must be Unprotected
         // because there is no external safety mechanism.
@@ -3319,7 +3322,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(
             results[0].health,
             OperationalHealth::Healthy,
@@ -3354,7 +3357,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(
             results[0].health,
             OperationalHealth::Healthy,
@@ -3395,7 +3398,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(
             results[0].health,
             OperationalHealth::Degraded,
@@ -3426,7 +3429,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         assert_eq!(
             results[0].health,
             OperationalHealth::Degraded,
@@ -3453,7 +3456,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &fs);
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         // Should not contain "full send size unknown" — chain treated as intact for transient
         assert!(
             !results[0]
@@ -3536,7 +3539,7 @@ drives = ["D1"]
         // D2 is NOT mounted — but sv1 is scoped to D1 only,
         // so D2 absence should NOT affect sv1's status.
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
 
         assert_eq!(
@@ -3566,7 +3569,7 @@ drives = ["D1"]
 
         // D2 is NOT mounted and has no send history
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
 
         // Without per-subvolume drives scoping, all configured drives appear in assessments
@@ -3592,7 +3595,7 @@ drives = ["D1"]
             dt(2026, 4, 1, 10, 0),
         );
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
 
         assert_eq!(
@@ -3631,7 +3634,7 @@ drives = ["D1"]
         // D2 would have a broken chain if assessed, but it's out of scope
         // (sv1 is scoped to D1 only). Verify health is not degraded.
 
-        let assessments = assess(&config, now, &fs);
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
         let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
 
         assert_eq!(
@@ -3674,14 +3677,15 @@ drives = ["D1"]
         );
 
         // Generations match — source unchanged since the pin snapshot.
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"), 42);
-        fs.generations.insert(
+        mb.generations.borrow_mut().insert(
             std::path::PathBuf::from(format!("/snap/sv1/{}", pin_snap.as_str())),
             42,
         );
 
-        let r = &assess(&config, now, &fs)[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
         assert_eq!(r.external[0].status, PromiseStatus::Protected);
         // Advisory explains why the old age is still PROTECTED.
         assert!(
@@ -3719,14 +3723,15 @@ drives = ["D1"]
             dt(2026, 3, 13, 10, 0),
         );
 
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"), 99);
-        fs.generations.insert(
+        mb.generations.borrow_mut().insert(
             std::path::PathBuf::from(format!("/snap/sv1/{}", pin_snap.as_str())),
             42,
         );
 
-        let r = &assess(&config, now, &fs)[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
         assert_eq!(r.external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -3756,7 +3761,7 @@ drives = ["D1"]
         );
 
         // No generations configured — queries will fail.
-        let r = &assess(&config, now, &fs)[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() })[0];
         assert_eq!(r.external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -3778,10 +3783,11 @@ drives = ["D1"]
             ("sv1".to_string(), "WD-18TB".to_string()),
             dt(2026, 3, 13, 10, 0),
         );
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"), 42);
 
-        let r = &assess(&config, now, &fs)[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
         assert_eq!(r.external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -3800,15 +3806,16 @@ drives = ["D1"]
             .insert("sv1".to_string(), vec![newest.clone()]);
 
         // Generations match — source unchanged since newest snapshot.
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"), 100);
-        fs.generations.insert(
+        mb.generations.borrow_mut().insert(
             std::path::PathBuf::from(format!("/snap/sv1/{}", newest.as_str())),
             100,
         );
 
         // No drive mounted — isolate the local assessment.
-        let r = &assess(&config, now, &fs)[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
         assert_eq!(r.local.status, PromiseStatus::Protected);
     }
 
@@ -3839,14 +3846,15 @@ drives = ["D1"]
             ("sv1".to_string(), "WD-18TB".to_string()),
             dt(2026, 3, 13, 10, 0),
         );
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"), 42);
-        fs.generations.insert(
+        mb.generations.borrow_mut().insert(
             std::path::PathBuf::from(format!("/snap/sv1/{}", pin_snap.as_str())),
             42,
         );
 
-        let r = &assess(&config, now, &fs)[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
         // 10 days since send > 3× 1d → UNPROTECTED under age-based rules.
         assert_eq!(
             r.external[0].status,
@@ -3877,14 +3885,15 @@ drives = ["D1"]
             ("sv1".to_string(), "WD-18TB".to_string()),
             dt(2026, 3, 13, 10, 0),
         );
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"), 42);
-        fs.generations.insert(
+        mb.generations.borrow_mut().insert(
             std::path::PathBuf::from(format!("/snap/sv1/{}", pin_snap.as_str())),
             42,
         );
 
-        let r = &assess(&config, now, &fs)[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
         assert_eq!(r.external[0].status, PromiseStatus::Protected);
         assert!(!r.external[0].mounted, "drive should be reported unmounted");
     }
@@ -3940,7 +3949,8 @@ source = "/data/sv1"
         // transient path is computing source_unchanged, it would hit these
         // and we'd notice via logs. The test primarily asserts assess
         // doesn't error and reports Protected for transient local.
-        fs.fail_generations
+        let mb = MockBtrfs::new();
+        mb.fail_generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"));
 
         fs.local_snapshots.insert(
@@ -3953,7 +3963,7 @@ source = "/data/sv1"
             dt(2026, 3, 23, 13, 30),
         );
 
-        let r = &assess(&config, now, &fs)[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
         // Transient local returns Protected regardless of age.
         assert_eq!(r.local.status, PromiseStatus::Protected);
     }
@@ -3985,14 +3995,15 @@ source = "/data/sv1"
             dt(2026, 3, 23, 8, 0),
         );
 
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"), 42);
-        fs.generations.insert(
+        mb.generations.borrow_mut().insert(
             std::path::PathBuf::from(format!("/snap/sv1/{}", pin_snap.as_str())),
             42,
         );
 
-        let r = &assess(&config, now, &fs)[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
         assert!(
             r.advisories
                 .iter()

--- a/src/btrfs.rs
+++ b/src/btrfs.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -16,9 +16,18 @@ pub struct SendResult {
     pub bytes_transferred: Option<u64>,
 }
 
+/// Read-only btrfs queries. Split out of `BtrfsOps` so the planner and
+/// awareness can read generation counters through a non-mutating seam
+/// (ADR-100, ADR-101): `&dyn BtrfsRead` cannot upcast to `&dyn BtrfsOps`,
+/// so a read-only caller gets no mutators at the type level.
+pub trait BtrfsRead {
+    /// Query the BTRFS generation counter for a subvolume or snapshot.
+    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64>;
+}
+
 /// Trait abstracting btrfs operations. `RealBtrfs` calls the btrfs binary;
 /// `MockBtrfs` records calls for testing.
-pub trait BtrfsOps {
+pub trait BtrfsOps: BtrfsRead {
     fn create_readonly_snapshot(&self, source: &Path, dest: &Path) -> crate::error::Result<()>;
     fn send_receive(
         &self,
@@ -93,6 +102,15 @@ impl RealBtrfs {
             bytes_counter,
             supports_compressed_data,
         }
+    }
+
+    /// Build a handle for read-only use (`BtrfsRead` generation queries).
+    /// A generation read needs no live byte counter and no compression
+    /// negotiation, so both are defaulted (UPI 052). Used by `plan`/`assess`
+    /// call sites that read generations but never send.
+    #[must_use]
+    pub fn for_reads(btrfs_path: &str) -> Self {
+        Self::new(btrfs_path, Arc::new(AtomicU64::new(0)), false)
     }
 }
 
@@ -410,7 +428,7 @@ impl BtrfsOps for RealBtrfs {
     }
 }
 
-// ── Standalone generation query ────────────────────────────────────────
+// ── Generation query (BtrfsRead) ───────────────────────────────────────
 
 /// Parse the `Generation:` field from `btrfs subvolume show` output.
 #[must_use]
@@ -424,48 +442,48 @@ pub fn parse_generation(output: &str) -> Option<u64> {
     None
 }
 
-/// Query the BTRFS generation counter for a subvolume or snapshot.
-///
-/// Standalone function (not on `BtrfsOps` trait) — same pattern as
-/// `crate::drives::filesystem_free_bytes`. All btrfs subprocess calls
-/// remain in `btrfs.rs` (invariant #2).
-pub fn subvolume_generation(path: &Path) -> crate::error::Result<u64> {
-    let output = Command::new("sudo")
-        .env("LC_ALL", "C")
-        .arg("btrfs")
-        .args(["subvolume", "show"])
-        .arg(path)
-        .output()
-        .map_err(|e| UrdError::Btrfs {
+impl BtrfsRead for RealBtrfs {
+    /// Query the BTRFS generation counter for a subvolume or snapshot.
+    ///
+    /// All btrfs subprocess calls remain in `btrfs.rs` (invariant #2).
+    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
+        let output = Command::new("sudo")
+            .env("LC_ALL", "C")
+            .arg("btrfs")
+            .args(["subvolume", "show"])
+            .arg(path)
+            .output()
+            .map_err(|e| UrdError::Btrfs {
+                context: BtrfsErrorContext {
+                    operation: BtrfsOperation::Show,
+                    exit_code: None,
+                    stderr: e.to_string(),
+                    bytes_transferred: None,
+                },
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(UrdError::Btrfs {
+                context: BtrfsErrorContext {
+                    operation: BtrfsOperation::Show,
+                    exit_code: output.status.code(),
+                    stderr,
+                    bytes_transferred: None,
+                },
+            });
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        parse_generation(&stdout).ok_or_else(|| UrdError::Btrfs {
             context: BtrfsErrorContext {
                 operation: BtrfsOperation::Show,
                 exit_code: None,
-                stderr: e.to_string(),
+                stderr: "Generation field not found in btrfs subvolume show output".to_string(),
                 bytes_transferred: None,
             },
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Show,
-                exit_code: output.status.code(),
-                stderr,
-                bytes_transferred: None,
-            },
-        });
+        })
     }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    parse_generation(&stdout).ok_or_else(|| UrdError::Btrfs {
-        context: BtrfsErrorContext {
-            operation: BtrfsOperation::Show,
-            exit_code: None,
-            stderr: "Generation field not found in btrfs subvolume show output".to_string(),
-            bytes_transferred: None,
-        },
-    })
 }
 
 // ── MockBtrfs ───────────────────────────────────────────────────────────
@@ -504,6 +522,10 @@ pub struct MockBtrfs {
     pub mock_bytes_transferred: RefCell<Option<u64>>,
     /// Partial bytes to report when a send fails (simulates partial transfer)
     pub mock_fail_send_bytes: RefCell<Option<u64>>,
+    /// Generation counters for subvolume/snapshot paths.
+    pub generations: RefCell<HashMap<PathBuf, u64>>,
+    /// Paths for which subvolume_generation() should return an error.
+    pub fail_generations: RefCell<HashSet<PathBuf>>,
 }
 
 #[allow(dead_code)]
@@ -520,6 +542,8 @@ impl MockBtrfs {
             free_bytes: RefCell::new(1_000_000_000_000), // 1TB default
             mock_bytes_transferred: RefCell::new(None),
             mock_fail_send_bytes: RefCell::new(None),
+            generations: RefCell::new(HashMap::new()),
+            fail_generations: RefCell::new(HashSet::new()),
         }
     }
 
@@ -532,6 +556,28 @@ impl MockBtrfs {
 impl Default for MockBtrfs {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl BtrfsRead for MockBtrfs {
+    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
+        if self.fail_generations.borrow().contains(path) {
+            return Err(UrdError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::other("mock: generation query failed"),
+            });
+        }
+        self.generations
+            .borrow()
+            .get(path)
+            .copied()
+            .ok_or_else(|| UrdError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "mock: no generation configured",
+                ),
+            })
     }
 }
 
@@ -664,6 +710,25 @@ mod tests {
                 .to_string()
                 .contains("mock: create snapshot failed")
         );
+    }
+
+    #[test]
+    fn mock_subvolume_generation_lookup_and_failure() {
+        let mock = MockBtrfs::new();
+        let path = PathBuf::from("/data/sv1");
+        let missing = PathBuf::from("/data/sv2");
+        let failing = PathBuf::from("/data/sv3");
+
+        mock.generations.borrow_mut().insert(path.clone(), 42);
+        mock.fail_generations.borrow_mut().insert(failing.clone());
+
+        // Configured generation returns the value.
+        assert_eq!(mock.subvolume_generation(&path).unwrap(), 42);
+        // Unconfigured path errors (caller falls open).
+        assert!(mock.subvolume_generation(&missing).is_err());
+        // Injected failure errors (caller falls open). fail_generations is
+        // checked before the lookup, so it wins even if also present.
+        assert!(mock.subvolume_generation(&failing).is_err());
     }
 
     #[test]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -67,7 +67,16 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let fs_state = RealFileSystemState {
         state: state_db.as_ref(),
     };
-    let mut backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
+    // Near-unit btrfs handle for plan/assess generation reads (UPI 052):
+    // a generation read needs no live byte counter and no compression
+    // negotiation. The executor builds its own full RealBtrfs at send time.
+    let plan_btrfs = RealBtrfs::for_reads(&config.general.btrfs_path);
+    let observation = plan::Observation {
+        fs: &fs_state,
+        history: &fs_state,
+        btrfs: &plan_btrfs,
+    };
+    let mut backup_plan = plan::plan(&config, now, &filters, &observation)?;
 
     // ADR-107: fail-closed for retention on promise-level subvolumes.
     // If a subvolume has a protection_level, skip retention deletions unless
@@ -105,7 +114,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 
     // Re-plan if emergency freed space — plan may have different space_pressure decisions
     if emergency_ran {
-        backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
+        backup_plan = plan::plan(&config, now, &filters, &observation)?;
         if !args.confirm_retention_change {
             filter_promise_retention(&config, &mut backup_plan);
         }
@@ -134,7 +143,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
             &observability,
         )?;
         let previous_hb = heartbeat::read(&config.general.heartbeat_file);
-        let mut assessments = awareness::assess(&config, heartbeat_now, &fs_state);
+        let mut assessments = awareness::assess(&config, heartbeat_now, &observation);
         advice::overlay_offsite_freshness(&mut assessments, &config);
         let hb = heartbeat::build_empty(
             &config,
@@ -272,7 +281,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // (thread restored, promise recovered, etc.) by diffing with post-backup state.
     let pre_assessments = {
         let pre_now = chrono::Local::now().naive_local();
-        let mut pre = awareness::assess(&config, pre_now, &fs_state);
+        let mut pre = awareness::assess(&config, pre_now, &observation);
         advice::overlay_offsite_freshness(&mut pre, &config);
         pre
     };
@@ -334,7 +343,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     )?;
 
     // Write heartbeat (fresh timestamp — `now` is from before execution)
-    let mut assessments = awareness::assess(&config, heartbeat_now, &fs_state);
+    let mut assessments = awareness::assess(&config, heartbeat_now, &observation);
     advice::overlay_offsite_freshness(&mut assessments, &config);
     let hb = heartbeat::build_from_run(
         &config,

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -5,7 +5,7 @@ use crate::awareness;
 use crate::config;
 use crate::error::UrdError;
 use crate::output::{DefaultStatusOutput, OutputMode};
-use crate::plan::RealFileSystemState;
+use crate::plan::{Observation, RealFileSystemState};
 use crate::state::StateDb;
 use crate::voice;
 
@@ -29,10 +29,16 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
     let fs_state = RealFileSystemState {
         state: state_db.as_ref(),
     };
+    let assess_btrfs = crate::btrfs::RealBtrfs::for_reads(&config.general.btrfs_path);
+    let observation = Observation {
+        fs: &fs_state,
+        history: &fs_state,
+        btrfs: &assess_btrfs,
+    };
 
     // Awareness assessment — lighter than status (no chain health, no drive info, no pins)
     let now = chrono::Local::now().naive_local();
-    let mut assessments = awareness::assess(&config, now, &fs_state);
+    let mut assessments = awareness::assess(&config, now, &observation);
     advice::overlay_offsite_freshness(&mut assessments, &config);
 
     let last_run = state_db.as_ref().and_then(|db| db.last_run_info());

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -11,7 +11,7 @@ use crate::output::{
     DoctorRecommendationView, DoctorSentinelStatus, DoctorVerdict, InitStatus, OutputMode,
     SchemaStatus,
 };
-use crate::plan::RealFileSystemState;
+use crate::plan::{Observation, RealFileSystemState};
 use crate::recommendation::{
     self, AdjustmentReason, HeadroomAwareRecommendation, HeadroomContext, HeadroomSeverity,
     ShapeRole,
@@ -157,8 +157,14 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     let fs_state = RealFileSystemState {
         state: state_db.as_ref(),
     };
+    let assess_btrfs = crate::btrfs::RealBtrfs::for_reads(&config.general.btrfs_path);
+    let observation = Observation {
+        fs: &fs_state,
+        history: &fs_state,
+        btrfs: &assess_btrfs,
+    };
     let now = chrono::Local::now().naive_local();
-    let assessments = awareness::assess(&config, now, &fs_state);
+    let assessments = awareness::assess(&config, now, &observation);
 
     let resolved = config.resolved_subvolumes();
     let data_safety: Vec<DoctorDataSafety> = assessments

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -5,7 +5,7 @@ use crate::output::{
     OutputMode, PlanOperationEntry, PlanOutput, PlanSummaryOutput, SkipCategory,
     SkippedSubvolume,
 };
-use crate::plan::{self, FileSystemState, PlanFilters, RealFileSystemState};
+use crate::plan::{self, FileSystemState, Observation, PlanFilters, RealFileSystemState};
 use crate::state::StateDb;
 use crate::types::PlannedOperation;
 use crate::voice;
@@ -27,7 +27,13 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
     let fs_state = RealFileSystemState {
         state: state_db.as_ref(),
     };
-    let backup_plan = plan::plan(&config, now, &filters, &fs_state)?;
+    let plan_btrfs = crate::btrfs::RealBtrfs::for_reads(&config.general.btrfs_path);
+    let observation = Observation {
+        fs: &fs_state,
+        history: &fs_state,
+        btrfs: &plan_btrfs,
+    };
+    let backup_plan = plan::plan(&config, now, &filters, &observation)?;
 
     let mut output = build_plan_output(&backup_plan, &fs_state, &config);
     populate_token_warnings(&mut output, state_db.as_ref(), &config);

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -7,7 +7,7 @@ use crate::output::{
     ChainHealth, ChainHealthEntry, DriveInfo, OutputMode, StatusAssessment,
     StatusOutput,
 };
-use crate::plan::RealFileSystemState;
+use crate::plan::{Observation, RealFileSystemState};
 use crate::retention;
 use crate::state::StateDb;
 use crate::voice;
@@ -21,11 +21,17 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     let fs_state = RealFileSystemState {
         state: state_db.as_ref(),
     };
+    let assess_btrfs = crate::btrfs::RealBtrfs::for_reads(&config.general.btrfs_path);
+    let observation = Observation {
+        fs: &fs_state,
+        history: &fs_state,
+        btrfs: &assess_btrfs,
+    };
     let drive_labels: Vec<String> = config.drives.iter().map(|d| d.label.clone()).collect();
 
     // ── Awareness model ─────────────────────────────────────────────
     let now = chrono::Local::now().naive_local();
-    let mut assessments = awareness::assess(&config, now, &fs_state);
+    let mut assessments = awareness::assess(&config, now, &observation);
     advice::overlay_offsite_freshness(&mut assessments, &config);
 
     // ── Chain health per subvolume (derived from awareness assessment) ──

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -56,9 +56,6 @@ pub trait FilesystemQuery {
 
     /// Collect all pinned snapshot names for a subvolume across all drives.
     fn pinned_snapshots(&self, local_dir: &Path, drive_labels: &[String]) -> HashSet<SnapshotName>;
-
-    /// Get the BTRFS generation counter for a subvolume or snapshot path.
-    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64>;
 }
 
 // ── HistoryQuery (SQLite is history) ──────────────────────────────────────
@@ -110,3 +107,19 @@ pub trait HistoryQuery {
 pub trait FileSystemState: FilesystemQuery + HistoryQuery {}
 
 impl<T: FilesystemQuery + HistoryQuery + ?Sized> FileSystemState for T {}
+
+// ── Observation ───────────────────────────────────────────────────────────
+
+/// The read-only world a pure decision function observes: the filesystem of
+/// truth, the SQLite history, and the btrfs generation-read seam. Threaded as
+/// `&Observation` through `plan::plan` and `awareness::assess` so those
+/// functions read state through three narrow, non-mutating trait objects
+/// rather than a single wide one (ADR-100, ADR-101, UPI 052).
+pub struct Observation<'a> {
+    /// Filesystem of truth: snapshot dirs, pin files, mounts, free space.
+    pub fs: &'a dyn FilesystemQuery,
+    /// SQLite history: send sizes, calibration, send/drive timestamps.
+    pub history: &'a dyn HistoryQuery,
+    /// Read-only btrfs generation counter access.
+    pub btrfs: &'a dyn crate::btrfs::BtrfsRead,
+}

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -59,7 +59,7 @@ fn stamp_context(events: &mut [Event], subvolume: Option<&str>, drive_label: Opt
 // the ADR-102 axis (filesystem is truth, SQLite is history). Re-exported here
 // so existing `crate::plan::{FileSystemState, ..}` import paths keep resolving
 // while the seam is narrowed incrementally (UPI 052).
-pub use crate::observation::{FileSystemState, FilesystemQuery, HistoryQuery};
+pub use crate::observation::{FileSystemState, FilesystemQuery, HistoryQuery, Observation};
 
 // ── Size estimation helper ──────────────────────────────────────────────
 
@@ -73,7 +73,7 @@ pub use crate::observation::{FileSystemState, FilesystemQuery, HistoryQuery};
 /// as not-a-constraint rather than substituting calibrated.
 #[must_use]
 pub fn estimated_send_size(
-    fs: &dyn FileSystemState,
+    history: &dyn HistoryQuery,
     subvol_name: &str,
     drive_label: &str,
     needs_full: bool,
@@ -83,11 +83,12 @@ pub fn estimated_send_size(
     } else {
         SendKind::Incremental
     };
-    fs.last_send_size(subvol_name, drive_label, send_kind)
-        .or_else(|| fs.last_send_size_any_drive(subvol_name, send_kind))
+    history
+        .last_send_size(subvol_name, drive_label, send_kind)
+        .or_else(|| history.last_send_size_any_drive(subvol_name, send_kind))
         .or_else(|| {
             if needs_full {
-                fs.calibrated_size(subvol_name).map(|(bytes, _)| bytes)
+                history.calibrated_size(subvol_name).map(|(bytes, _)| bytes)
             } else {
                 None
             }
@@ -116,12 +117,12 @@ pub struct PlanFilters {
 fn check_drive_availability(
     subvol_name: &str,
     drive: &DriveConfig,
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     skipped: &mut Vec<(String, String)>,
     events: &mut Vec<Event>,
     now: NaiveDateTime,
 ) -> bool {
-    match fs.drive_availability(drive) {
+    match obs.fs.drive_availability(drive) {
         DriveAvailability::Available => true,
         DriveAvailability::NotMounted => {
             record_defer(
@@ -226,7 +227,7 @@ pub fn plan(
     config: &Config,
     now: NaiveDateTime,
     filters: &PlanFilters,
-    fs: &dyn FileSystemState,
+    obs: &Observation,
 ) -> crate::error::Result<BackupPlan> {
     let mut operations = Vec::new();
     // Skip reason strings are classified by output::SkipCategory::from_reason().
@@ -284,12 +285,13 @@ pub fn plan(
         let local_dir = snapshot_root.join(&subvol.name);
 
         // Get existing local snapshots
-        let local_snaps = fs
+        let local_snaps = obs
+            .fs
             .local_snapshots(snapshot_root, &subvol.name)
             .unwrap_or_default();
 
         // Get pinned snapshots
-        let pinned = fs.pinned_snapshots(&local_dir, &drive_labels);
+        let pinned = obs.fs.pinned_snapshots(&local_dir, &drive_labels);
 
         // Drives in scope for this subvolume that can currently receive sends.
         // Include TokenMissing: those drives proceed with sends (line ~308),
@@ -300,7 +302,7 @@ pub fn plan(
             .filter(|d| subvol.accepts_drive(&d.label))
             .filter(|d| {
                 matches!(
-                    fs.drive_availability(d),
+                    obs.fs.drive_availability(d),
                     DriveAvailability::Available | DriveAvailability::TokenMissing
                 )
             })
@@ -309,7 +311,7 @@ pub fn plan(
         // Mounted-only pins for transient retention scoping.
         let mounted_pins: HashSet<SnapshotName> = usable_drives
             .iter()
-            .filter_map(|d| match fs.read_pin_file(&local_dir, &d.label) {
+            .filter_map(|d| match obs.fs.read_pin_file(&local_dir, &d.label) {
                 Ok(Some(snap)) => Some(snap),
                 Ok(None) => None,
                 Err(e) => {
@@ -327,7 +329,7 @@ pub fn plan(
         if subvol.local_retention.is_transient() && subvol.send_enabled {
             plan_transient_lifecycle(
                 subvol, config, &local_dir, &local_snaps, now, force, filters,
-                &pinned, &mounted_pins, fs, &mut operations, &mut skipped, &mut events,
+                &pinned, &mounted_pins, obs, &mut operations, &mut skipped, &mut events,
             );
             continue; // skip the normal two-phase flow
         }
@@ -346,7 +348,7 @@ pub fn plan(
                 force,
                 filters,
                 min_free,
-                fs,
+                obs,
                 &mut operations,
                 &mut skipped,
                 &mut events,
@@ -358,7 +360,7 @@ pub fn plan(
                 now,
                 &pinned,
                 &mounted_pins,
-                fs,
+                obs,
                 &mut operations,
                 &mut events,
             );
@@ -398,7 +400,7 @@ pub fn plan(
                 if !check_drive_availability(
                     &subvol.name,
                     drive,
-                    fs,
+                    obs,
                     &mut skipped,
                     &mut events,
                     now,
@@ -414,7 +416,7 @@ pub fn plan(
                     now,
                     force,
                     filters.skip_intervals,
-                    fs,
+                    obs,
                     &mut operations,
                     &mut skipped,
                     &mut events,
@@ -424,7 +426,7 @@ pub fn plan(
                     subvol,
                     drive,
                     now,
-                    fs,
+                    obs,
                     &pinned,
                     &mut operations,
                     &mut events,
@@ -494,7 +496,7 @@ fn plan_local_snapshot(
     force: bool,
     filters: &PlanFilters,
     min_free: u64,
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     operations: &mut Vec<PlannedOperation>,
     skipped: &mut Vec<(String, String)>,
     events: &mut Vec<Event>,
@@ -504,7 +506,7 @@ fn plan_local_snapshot(
     // filesystem. force does NOT override — a forced snapshot on a full filesystem is still
     // catastrophic. See 2026-03-24-local-space-exhaustion-postmortem.md.
     if min_free > 0 {
-        let free = fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
+        let free = obs.fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
         if free < min_free {
             use crate::types::ByteSize;
             record_defer(
@@ -557,8 +559,8 @@ fn plan_local_snapshot(
         {
             let snap_path = local_dir.join(newest.as_str());
             match (
-                fs.subvolume_generation(&subvol.source),
-                fs.subvolume_generation(&snap_path),
+                obs.btrfs.subvolume_generation(&subvol.source),
+                obs.btrfs.subvolume_generation(&snap_path),
             ) {
                 (Ok(sg), Ok(ng)) if sg == ng => {
                     let elapsed = now.signed_duration_since(newest.datetime());
@@ -652,7 +654,7 @@ fn plan_local_retention(
     now: NaiveDateTime,
     pinned: &HashSet<SnapshotName>,
     mounted_pins: &HashSet<SnapshotName>,
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     operations: &mut Vec<PlannedOperation>,
     events: &mut Vec<Event>,
 ) {
@@ -716,7 +718,7 @@ fn plan_local_retention(
         LocalRetentionPolicy::Graduated(retention_config) => {
             // Check space pressure
             let min_free = subvol.min_free_bytes.unwrap_or(0);
-            let free_bytes = fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
+            let free_bytes = obs.fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
             let space_pressure = min_free > 0 && free_bytes < min_free;
 
             let mut result = retention::graduated_retention(
@@ -765,7 +767,7 @@ fn plan_transient_lifecycle(
     filters: &PlanFilters,
     pinned: &HashSet<SnapshotName>,
     mounted_pins: &HashSet<SnapshotName>,
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     operations: &mut Vec<PlannedOperation>,
     skipped: &mut Vec<(String, String)>,
     events: &mut Vec<Event>,
@@ -779,7 +781,7 @@ fn plan_transient_lifecycle(
         if !subvol.accepts_drive(&drive.label) {
             continue;
         }
-        if !check_drive_availability(&subvol.name, drive, fs, skipped, events, now) {
+        if !check_drive_availability(&subvol.name, drive, obs, skipped, events, now) {
             continue; // skip reason already emitted
         }
 
@@ -788,7 +790,7 @@ fn plan_transient_lifecycle(
             sendable_drives.push((drive, None));
             any_send_due = true;
         } else {
-            let ext_snaps = fs.external_snapshots(drive, &subvol.name).unwrap_or_default();
+            let ext_snaps = obs.fs.external_snapshots(drive, &subvol.name).unwrap_or_default();
             let newest_ext = ext_snaps.iter().max().map(|s| s.datetime());
             let send_due = match newest_ext {
                 Some(newest_dt) => {
@@ -825,7 +827,7 @@ fn plan_transient_lifecycle(
             now,
             pinned,
             mounted_pins,
-            fs,
+            obs,
             operations,
             events,
         );
@@ -868,7 +870,7 @@ fn plan_transient_lifecycle(
             now,
             pinned,
             mounted_pins,
-            fs,
+            obs,
             operations,
             events,
         );
@@ -880,7 +882,7 @@ fn plan_transient_lifecycle(
         let min_free = subvol.min_free_bytes.unwrap_or(0);
         plan_local_snapshot(
             subvol, local_dir, local_snaps, now, force, filters,
-            min_free, fs, operations, skipped, events,
+            min_free, obs, operations, skipped, events,
         )
     } else {
         None
@@ -895,7 +897,7 @@ fn plan_transient_lifecycle(
             now,
             pinned,
             mounted_pins,
-            fs,
+            obs,
             operations,
             events,
         );
@@ -924,9 +926,9 @@ fn plan_transient_lifecycle(
     for (drive, _) in &sendable_drives {
         plan_external_send(
             subvol, drive, local_dir, effective_local_snaps, now, force,
-            filters.skip_intervals, fs, operations, skipped, events,
+            filters.skip_intervals, obs, operations, skipped, events,
         );
-        plan_external_retention(subvol, drive, now, fs, pinned, operations, events);
+        plan_external_retention(subvol, drive, now, obs, pinned, operations, events);
     }
 
     // ── Phase 4: Plan transient retention ─────────────────────────
@@ -938,7 +940,7 @@ fn plan_transient_lifecycle(
         now,
         pinned,
         mounted_pins,
-        fs,
+        obs,
         operations,
         events,
     );
@@ -953,13 +955,14 @@ fn plan_external_send(
     now: NaiveDateTime,
     force: bool,
     skip_intervals: bool,
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     operations: &mut Vec<PlannedOperation>,
     skipped: &mut Vec<(String, String)>,
     events: &mut Vec<Event>,
 ) {
     let ext_dir = crate::drives::external_snapshot_dir(drive, &subvol.name);
-    let ext_snaps = fs
+    let ext_snaps = obs
+        .fs
         .external_snapshots(drive, &subvol.name)
         .unwrap_or_default();
 
@@ -1032,7 +1035,7 @@ fn plan_external_send(
     let snap_path = local_dir.join(snap_to_send.as_str());
 
     // Resolve parent for incremental send
-    let pin = fs.read_pin_file(local_dir, &drive.label).unwrap_or(None);
+    let pin = obs.fs.read_pin_file(local_dir, &drive.label).unwrap_or(None);
     let is_incremental = if let Some(ref parent_name) = pin {
         // Parent must exist both locally and on the external drive
         let parent_exists_local = local_snaps
@@ -1051,13 +1054,14 @@ fn plan_external_send(
     } else {
         SendKind::Full
     };
-    if let Some(last_size) = fs
+    if let Some(last_size) = obs
+        .history
         .last_send_size(&subvol.name, &drive.label, send_kind)
-        .or_else(|| fs.last_send_size_any_drive(&subvol.name, send_kind))
+        .or_else(|| obs.history.last_send_size_any_drive(&subvol.name, send_kind))
     {
         // Tier 1/2: historical data from same drive or cross-drive fallback
         if let Some((estimated, available, free, min_free)) =
-            exceeds_available_space(last_size, &ext_dir, drive, fs)
+            exceeds_available_space(last_size, &ext_dir, drive, obs)
         {
             use crate::types::ByteSize;
             record_defer(
@@ -1080,7 +1084,7 @@ fn plan_external_send(
         }
     } else if !is_incremental {
         // Tier 3: Calibrated size from `urd calibrate` (only for full sends)
-        if let Some((cal_bytes, measured_at)) = fs.calibrated_size(&subvol.name) {
+        if let Some((cal_bytes, measured_at)) = obs.history.calibrated_size(&subvol.name) {
             let age_days = calibration_age_days(&measured_at);
             let staleness = if age_days > 30 {
                 format!(
@@ -1092,7 +1096,7 @@ fn plan_external_send(
             };
 
             if let Some((estimated, available, _, _)) =
-                exceeds_available_space(cal_bytes, &ext_dir, drive, fs)
+                exceeds_available_space(cal_bytes, &ext_dir, drive, obs)
             {
                 use crate::types::ByteSize;
                 record_defer(
@@ -1169,13 +1173,14 @@ fn plan_external_retention(
     subvol: &ResolvedSubvolume,
     drive: &DriveConfig,
     now: NaiveDateTime,
-    fs: &dyn FileSystemState,
+    obs: &Observation,
     pinned: &HashSet<SnapshotName>,
     operations: &mut Vec<PlannedOperation>,
     events: &mut Vec<Event>,
 ) {
     let ext_dir = crate::drives::external_snapshot_dir(drive, &subvol.name);
-    let ext_snaps = fs
+    let ext_snaps = obs
+        .fs
         .external_snapshots(drive, &subvol.name)
         .unwrap_or_default();
 
@@ -1183,7 +1188,7 @@ fn plan_external_retention(
         return;
     }
 
-    let free_bytes = fs.filesystem_free_bytes(&ext_dir).unwrap_or(u64::MAX);
+    let free_bytes = obs.fs.filesystem_free_bytes(&ext_dir).unwrap_or(u64::MAX);
     let min_free = drive.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
 
     let mut result = retention::space_governed_retention(
@@ -1233,10 +1238,11 @@ fn exceeds_available_space(
     raw_bytes: u64,
     _ext_dir: &Path,
     drive: &DriveConfig,
-    fs: &dyn FileSystemState,
+    obs: &Observation,
 ) -> Option<(u64, u64, u64, u64)> {
     let estimated = (raw_bytes as f64 * 1.2) as u64; // 20% safety margin
-    let free = fs
+    let free = obs
+        .fs
         .filesystem_free_bytes(&drive.mount_path)
         .unwrap_or(u64::MAX);
     let min_free = drive.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
@@ -1299,10 +1305,6 @@ impl FilesystemQuery for RealFileSystemState<'_> {
 
     fn pinned_snapshots(&self, local_dir: &Path, drive_labels: &[String]) -> HashSet<SnapshotName> {
         crate::chain::find_pinned_snapshots(local_dir, drive_labels)
-    }
-
-    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
-        crate::btrfs::subvolume_generation(path)
     }
 }
 
@@ -1450,10 +1452,6 @@ pub struct MockFileSystemState {
     pub fail_local_snapshots: HashSet<String>,
     /// (local_dir, drive_label) pairs for which read_pin_file() should return an error.
     pub fail_pin_reads: HashSet<(PathBuf, String)>,
-    /// Generation counters for subvolume/snapshot paths.
-    pub generations: std::collections::HashMap<PathBuf, u64>,
-    /// Paths for which subvolume_generation() should return an error.
-    pub fail_generations: HashSet<PathBuf>,
 }
 
 #[cfg(test)]
@@ -1473,8 +1471,6 @@ impl MockFileSystemState {
             last_successful_ops: std::collections::HashMap::new(),
             fail_local_snapshots: HashSet::new(),
             fail_pin_reads: HashSet::new(),
-            generations: std::collections::HashMap::new(),
-            fail_generations: HashSet::new(),
         }
     }
 }
@@ -1561,25 +1557,6 @@ impl FilesystemQuery for MockFileSystemState {
         }
         pinned
     }
-
-    fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
-        if self.fail_generations.contains(path) {
-            return Err(crate::error::UrdError::Io {
-                path: path.to_path_buf(),
-                source: std::io::Error::other("mock: generation query failed"),
-            });
-        }
-        self.generations
-            .get(path)
-            .copied()
-            .ok_or_else(|| crate::error::UrdError::Io {
-                path: path.to_path_buf(),
-                source: std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "mock: no generation configured",
-                ),
-            })
-    }
 }
 
 #[cfg(test)]
@@ -1638,6 +1615,7 @@ impl HistoryQuery for MockFileSystemState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::btrfs::MockBtrfs;
     use chrono::NaiveDate;
 
     fn test_config() -> Config {
@@ -1778,7 +1756,7 @@ priority = 2
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1795,7 +1773,7 @@ priority = 2
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1455-one")]);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1869,7 +1847,7 @@ priority = 2
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260321-1502-one")]);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1884,7 +1862,7 @@ priority = 2
         let fs = MockFileSystemState::new();
         // No snapshots exist at all
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1906,7 +1884,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1925,7 +1903,7 @@ priority = 2
             priority: Some(1),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         // Only sv1 (priority 1), not sv2 (priority 2)
         let creates: Vec<_> = result
             .operations
@@ -1956,7 +1934,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -1977,7 +1955,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2010,7 +1988,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2043,7 +2021,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let send = result
             .operations
             .iter()
@@ -2070,7 +2048,7 @@ priority = 2
             .insert("sv1".to_string(), vec![snap("20260322-1500-one")]);
         // Drive NOT mounted
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         assert!(
             result
                 .skipped
@@ -2128,7 +2106,7 @@ send_enabled = false
             .insert("sv".to_string(), vec![snap("20260322-1400-sv")]);
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         assert!(
             result
                 .skipped
@@ -2147,7 +2125,7 @@ send_enabled = false
             local_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2170,7 +2148,7 @@ send_enabled = false
             external_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -2191,7 +2169,7 @@ send_enabled = false
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends_with_pin: Vec<_> = result
             .operations
             .iter()
@@ -2237,7 +2215,7 @@ send_enabled = false
             local_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         // All snapshots newer than the pin should be protected (not deleted)
         let deletes: Vec<_> = result
             .operations
@@ -2274,7 +2252,7 @@ send_enabled = false
             local_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -2333,7 +2311,7 @@ send_enabled = false
             ],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -2364,7 +2342,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 150_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2400,7 +2378,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 500_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2424,7 +2402,7 @@ send_enabled = false
         // Tiny free space — but no history means we can't estimate, so proceed
         fs.free_bytes.insert(PathBuf::from("/mnt/d1"), 1_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2453,7 +2431,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 500_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2494,7 +2472,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 500_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2517,7 +2495,7 @@ send_enabled = false
         // No send_sizes, no calibrated_sizes — fail open
         fs.free_bytes.insert(PathBuf::from("/mnt/d1"), 1_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2546,7 +2524,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 500_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2576,7 +2554,7 @@ send_enabled = false
             vec![snap("20260322-1600-one")], // now() is 15:00, this is 16:00
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -2612,7 +2590,7 @@ send_enabled = false
             },
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         assert!(
             result
                 .skipped
@@ -2649,7 +2627,7 @@ send_enabled = false
             DriveAvailability::UuidCheckFailed("findmnt not found".to_string()),
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         assert!(
             result
                 .skipped
@@ -2669,7 +2647,7 @@ send_enabled = false
         fs.drive_availability_overrides
             .insert("D1".to_string(), DriveAvailability::Available);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2695,7 +2673,7 @@ send_enabled = false
             .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2728,7 +2706,7 @@ send_enabled = false
             },
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         assert!(
             result
                 .skipped
@@ -2762,7 +2740,7 @@ send_enabled = false
         fs.drive_availability_overrides
             .insert("D1".to_string(), DriveAvailability::TokenMissing);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2788,7 +2766,7 @@ send_enabled = false
         fs.drive_availability_overrides
             .insert("D1".to_string(), DriveAvailability::TokenExpectedButMissing);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         assert!(
             result
                 .skipped
@@ -2821,7 +2799,7 @@ send_enabled = false
         fs.drive_availability_overrides
             .insert("D1".to_string(), DriveAvailability::TokenExpectedButMissing);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -2845,7 +2823,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/snap/sv1"), 5_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         // No snapshot should be created for sv1
         let creates: Vec<_> = result
@@ -2881,7 +2859,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/snap/sv1"), 50_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -2909,7 +2887,7 @@ send_enabled = false
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -2950,11 +2928,12 @@ send_enabled = false
 
         // Source generation differs from the snapshot's, so the
         // "unchanged" generation check at plan_local_snapshot does NOT fire.
-        fs.generations.insert(PathBuf::from("/data/sv1"), 100);
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut().insert(PathBuf::from("/data/sv1"), 100);
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1").join(s1.as_str()), 50);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -2995,7 +2974,7 @@ send_enabled = false
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Note: no fs.free_bytes entry for /snap/sv1
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -3070,7 +3049,7 @@ drives = ["D1"]
         fs.mounted_drives.insert("D1".to_string());
         fs.mounted_drives.insert("D2".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         // Should only have send operations for D1, not D2
         let sends: Vec<_> = result
@@ -3182,7 +3161,7 @@ local_retention = "transient"
             vec![snap("20260320-1000-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3226,7 +3205,7 @@ local_retention = "transient"
             ],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3267,7 +3246,7 @@ local_retention = "transient"
         // No pin files — nothing has ever been sent
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3295,7 +3274,7 @@ local_retention = "transient"
         let fs = MockFileSystemState::new();
         // No local snapshots, no drives mounted
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -3410,7 +3389,7 @@ local_retention = "transient"
             vec![snap("20260320-1000-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3448,7 +3427,7 @@ local_retention = "transient"
         // Drive NOT mounted — transient should skip snapshot creation
         // (no drive to send to, creating a snapshot is pointless)
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -3475,7 +3454,7 @@ local_retention = "transient"
         // No local snapshots, no drives mounted.
         // Transient: no snapshot created — can't be sent, would be orphaned.
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -3516,7 +3495,7 @@ local_retention = "transient"
             vec![snap("20260322-1400-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3555,7 +3534,7 @@ local_retention = "transient"
             snap("20260320-1000-one"),
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3610,7 +3589,7 @@ local_retention = "transient"
             vec![snap("20260320-1000-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3704,7 +3683,7 @@ priority = 1
         fs.mounted_drives.insert("D1".to_string());
         // D2 NOT mounted
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3742,7 +3721,7 @@ priority = 1
         );
         // No pin files, no drives mounted
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3787,7 +3766,7 @@ priority = 1
             vec![snap("20260321-1000-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3823,7 +3802,7 @@ priority = 1
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -3850,7 +3829,7 @@ priority = 1
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -3881,7 +3860,7 @@ priority = 1
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -3930,7 +3909,7 @@ priority = 1
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3958,7 +3937,7 @@ priority = 1
             local_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -3987,7 +3966,7 @@ priority = 1
         let mut fs = MockFileSystemState::new();
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4010,7 +3989,7 @@ priority = 1
         let config = transient_config();
         let fs = MockFileSystemState::new();
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         assert!(
             result.operations.is_empty(),
@@ -4037,7 +4016,7 @@ priority = 1
             ],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4076,7 +4055,7 @@ priority = 1
             skip_intervals: false,
             ..Default::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4115,12 +4094,13 @@ priority = 1
             vec![snap("20260322-1400-one")],
         );
         // Same generation → unchanged
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"), 500);
-        fs.generations
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1400-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4195,7 +4175,7 @@ local_retention = "transient"
         fs.free_bytes
             .insert(PathBuf::from("/snap/sv1"), 1_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4217,7 +4197,7 @@ local_retention = "transient"
         let mut fs = MockFileSystemState::new();
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4259,12 +4239,13 @@ local_retention = "transient"
             vec![snap("20260321-1000-one")],
         );
         // Different generation so a new snapshot is created
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"), 600);
-        fs.generations
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260321-1000-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4300,7 +4281,7 @@ local_retention = "transient"
             skip_intervals: false,
             ..Default::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4333,12 +4314,13 @@ local_retention = "transient"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Source and snapshot have same generation → skip
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"), 500);
-        fs.generations
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4361,12 +4343,13 @@ local_retention = "transient"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Source gen differs from snapshot gen → create
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"), 501);
-        fs.generations
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4381,7 +4364,7 @@ local_retention = "transient"
         let fs = MockFileSystemState::new();
         // No existing snapshots → create (no generation to compare)
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4397,12 +4380,13 @@ local_retention = "transient"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Source generation fails, snapshot has generation → fail open, create
-        fs.fail_generations
+        let mb = MockBtrfs::new();
+        mb.fail_generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"));
-        fs.generations
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4418,12 +4402,13 @@ local_retention = "transient"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Source has generation, snapshot generation fails → fail open, create
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"), 500);
-        fs.fail_generations
+        mb.fail_generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"));
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4439,12 +4424,13 @@ local_retention = "transient"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Both fail → fail open, create
-        fs.fail_generations
+        let mb = MockBtrfs::new();
+        mb.fail_generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"));
-        fs.fail_generations
+        mb.fail_generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"));
 
-        let result = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4460,16 +4446,17 @@ local_retention = "transient"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Same generation, but force_snapshot → create anyway
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"), 500);
-        fs.generations
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
 
         let filters = PlanFilters {
             force_snapshot: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4485,16 +4472,17 @@ local_retention = "transient"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Same generation, but --subvolume filter → force, skip gen check
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"), 500);
-        fs.generations
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
 
         let filters = PlanFilters {
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4510,16 +4498,17 @@ local_retention = "transient"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Same generation + skip_intervals (manual run) → still skip unchanged
-        fs.generations
+        let mb = MockBtrfs::new();
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/data/sv1"), 500);
-        fs.generations
+        mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
 
         let filters = PlanFilters {
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &fs).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4578,7 +4567,7 @@ local_retention = "transient"
         fs.external_snapshots
             .insert(("D1".to_string(), "sv1".to_string()), vec![]);
 
-        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let saw_first_send = plan.events.iter().any(|e| {
             matches!(
                 &e.payload,
@@ -4620,7 +4609,7 @@ local_retention = "transient"
         fs.pin_files
             .insert((PathBuf::from("/snap/sv1"), "D1".to_string()), parent.clone());
 
-        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         // Sanity: ensure an incremental was actually chosen (else the test is moot).
         let any_incremental = plan
             .operations
@@ -4641,7 +4630,7 @@ local_retention = "transient"
             }
         }
         let fs = MockFileSystemState::new();
-        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let saw_disabled_defer = plan.events.iter().any(|e| match &e.payload {
             EventPayload::PlannerDefer { reason, scope } => {
                 reason == "disabled" && *scope == DeferScope::Subvolume
@@ -4665,7 +4654,7 @@ local_retention = "transient"
             .insert("sv1".to_string(), vec![snap("20260322-1455-one")]);
         // Drive D1 not mounted.
 
-        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let saw_drive_defer = plan.events.iter().any(|e| match &e.payload {
             EventPayload::PlannerDefer { reason, scope } => {
                 reason.contains("not mounted") && *scope == DeferScope::Drive
@@ -4687,7 +4676,7 @@ local_retention = "transient"
             }
         }
         let fs = MockFileSystemState::new();
-        let plan = plan(&config, now(), &PlanFilters::default(), &fs).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
         let sv2_defers: Vec<_> = plan
             .events
             .iter()

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -23,7 +23,7 @@ use crate::drives::{self, DriveAvailability};
 use crate::heartbeat;
 use crate::notify::{self, Notification, NotificationEvent, Urgency};
 use crate::output::{SentinelCircuitState, SentinelPromiseState, SentinelStateFile};
-use crate::plan::RealFileSystemState;
+use crate::plan::{Observation, RealFileSystemState};
 use crate::sentinel::{
     self, CircuitBreakerConfig, PromiseSnapshot, SentinelAction, SentinelEvent, SentinelState,
     TransitionResult,
@@ -376,8 +376,14 @@ impl SentinelRunner {
         let fs = RealFileSystemState {
             state: state_db.as_ref(),
         };
+        let assess_btrfs = crate::btrfs::RealBtrfs::for_reads(&self.config.general.btrfs_path);
+        let observation = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &assess_btrfs,
+        };
 
-        let mut assessments = awareness::assess(&self.config, now, &fs);
+        let mut assessments = awareness::assess(&self.config, now, &observation);
         advice::overlay_offsite_freshness(&mut assessments, &self.config);
 
         // Emit promise-transition events when the originating event was


### PR DESCRIPTION
## Summary

- **Introduces `Observation<'a>`** — a `{ fs, history, btrfs }` bundle of read-only seams — threaded through `plan::plan` and `awareness::assess` in place of the wide `&dyn FileSystemState` parameter. Pure decision functions now read state through three narrow, non-mutating trait objects.
- **Closes the ADR-101 generation-read loophole.** `subvolume_generation` was a free function running a `sudo btrfs` subprocess *outside* `BtrfsOps`. It now lives on a new read-only `BtrfsRead` trait with `BtrfsOps: BtrfsRead` as supertrait, so a read-only caller takes `&dyn BtrfsRead` and cannot upcast to the mutating ops (ADR-100/101). `RealBtrfs` keeps the literal `sudo btrfs subvolume show`; `MockBtrfs` gains injectable `generations`/`fail_generations`.
- **`estimated_send_size` narrows to `&dyn HistoryQuery`** (forced by `compute_health` taking `Observation`; production callers coerce via trait upcasting). `RealBtrfs::for_reads` consolidates the six near-unit plan/assess btrfs handles.
- **Behavior-preserving.** The four-arm fail-open generation match in `plan.rs` and the `Err`-arm age fallbacks in `awareness.rs` are byte-identical — only the receiver changed. The ~200 `MockFileSystemState` test setups migrate to `Observation`; generation tests move their data into a populated `MockBtrfs` (compiler-enforced via field removal). No on-disk or config-schema change.

Companion to PR #146 (PR 1). Final PR deletes the `FileSystemState` bridge once no caller needs both halves.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1436 tests pass (1435 baseline + 1 new MockBtrfs generation test), 0 failed
- cargo build --release: pass
- Fail-open guards verified: the generation-failure tests still assert create-anyway / age-fallback
- Smoke runs: `urd status` and `urd plan` exercise both production generation paths against the real config
- ADR honesty: `RealBtrfs::subvolume_generation` keeps literal `sudo btrfs`; no `&dyn BtrfsRead → &dyn BtrfsOps` upcast exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)