### PR TITLE
refactor: thread PromiseStatus through the output boundary (UPI 053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Internal refactor: thread `PromiseStatus` through the output boundary** (UPI 053).
+  Typed all eight structured-output promise-status fields (`status`, `local_status`,
+  `worst_safety`, heartbeat `promise_status`, the sentinel state file, `doctor`/`backup
+  --json`) as the `PromiseStatus` enum instead of `String`, and deleted the
+  `notify::status_rank` / `voice::status_severity` re-derivation in favor of the enum's
+  `Ord`. Unified `PromiseStatus`'s serde form on SCREAMING (matching `Display`) via
+  per-variant `rename` + permanent legacy `snake_case` `alias`. No external contract
+  change: every write-form is byte-identical, except the internal `events`-table payload
+  (`at_risk` → `AT RISK`), which is read-compatible via the alias (see ADR-114 amendment
+  2026-05-29). Closes the "Status string fragility" known issue.
+
 ## [0.21.1] - 2026-05-29
 
 ### Changed

--- a/docs/00-foundation/decisions/2026-04-30-ADR-114-structured-event-log.md
+++ b/docs/00-foundation/decisions/2026-04-30-ADR-114-structured-event-log.md
@@ -8,7 +8,8 @@
 > data-driven development possible.
 
 **Date:** 2026-04-30
-**Status:** Accepted (principle); implementation pending UPI 036
+**Status:** Accepted (principle); implementation pending UPI 036 (`PromiseStatus`
+serialized-form amendment 2026-05-29 — see [Amendment 2026-05-29](#amendment-2026-05-29-promisestatus-serialized-form))
 **Complements:** UPI 030 (drift_samples — quantitative per-run signal)
 
 ## Context
@@ -220,3 +221,36 @@ These are deliberately deferred to `/design` (UPI 036):
   analysis that motivated this ADR.
 - **Handoff:** `docs/98-journals/2026-04-30-data-driven-development-handoff.md`
   — design session brief for UPI 036.
+
+## Amendment 2026-05-29 (`PromiseStatus` serialized form)
+
+UPI 053 threads the `PromiseStatus` enum (`awareness.rs`) through the structured
+output boundary instead of flattening it to `String` at each surface. Two facts
+about wire format are load-bearing for this event log and must be recorded here.
+
+**Serialized form is unchanged on every surface; read-tolerance narrows.** Before
+UPI 053, `PromiseStatus` carried `#[serde(rename_all = "snake_case")]`, so its
+`Serialize` form (`at_risk`) disagreed with its `Display` form (`AT RISK`). The
+`PromiseTransition` event payload — the one place this enum reaches the SQLite
+`events` table — therefore persisted `snake_case`. UPI 053 replaces the container
+rename with per-variant `#[serde(rename = "AT RISK", alias = "at_risk")]` (and the
+PROTECTED/UNPROTECTED equivalents). The serialized form is now SCREAMING on every
+surface — heartbeat JSON, `status`/`backup`/`doctor --json`, the sentinel state
+file, the `events`-table payload, and the `urd events --format ndjson` render —
+matching `Display` and the glossary's "SCREAMING on every machine surface,
+including NDJSON" rule. On the **read** side, deserialization of `promise_status` /
+`status` / `worst_safety` is now restricted to the closed `PromiseStatus` set plus
+the `at_risk` (etc.) aliases — an unknown value causes the containing
+heartbeat/sentinel-state file to be treated as absent (fail-open via `.ok()`), not
+retained. The ephemeral self-rebuilding files (heartbeat, sentinel state) are
+unaffected in practice; the **events table is the surface this ADR governs**.
+
+**The legacy `snake_case` alias is permanent.** Events are append-only and
+immutable (this ADR's core property), so `PromiseTransition` rows written before
+2026-05-29 carry `from`/`to` values like `"at_risk"` and live indefinitely. The
+serde `alias` on each variant reads them back to the correct enum value forever;
+it must not be removed. The internal `events`-table payload value form is the only
+thing that changes (`at_risk` → `AT RISK` for new rows) — no external consumer
+reads the events payload (design Assumption #4), and the `urd events --format
+ndjson` sibling render is documented internal-only. No `schema_version` bump: the
+sentinel state file and heartbeat **write-forms are byte-identical** to before.

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -188,10 +188,19 @@ pub(crate) fn cascade_age_source(
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
 )]
-#[serde(rename_all = "snake_case")]
 pub enum PromiseStatus {
+    // Serialized form is SCREAMING on every surface, matching `Display` and the
+    // glossary's "SCREAMING on every machine surface, including NDJSON" rule
+    // (UPI 053, ADR-114 amendment 2026-05-29). The lower-case `alias` reads
+    // legacy `snake_case` rows written before the unification — events are
+    // append-only, so those rows live indefinitely; the alias is permanent.
+    // Variant order is worst-to-best so `min()`/`<` yields the worst status —
+    // do not reorder.
+    #[serde(rename = "UNPROTECTED", alias = "unprotected")]
     Unprotected,
+    #[serde(rename = "AT RISK", alias = "at_risk")]
     AtRisk,
+    #[serde(rename = "PROTECTED", alias = "protected")]
     Protected,
 }
 
@@ -1859,6 +1868,49 @@ source = "/data/sv1"
         assert_eq!(PromiseStatus::Protected.to_string(), "PROTECTED");
         assert_eq!(PromiseStatus::AtRisk.to_string(), "AT RISK");
         assert_eq!(PromiseStatus::Unprotected.to_string(), "UNPROTECTED");
+    }
+
+    #[test]
+    fn promise_status_serializes_screaming() {
+        // Serialized form must match `Display` (SCREAMING) on every wire surface
+        // (UPI 053). This is the write-form byte-identity guarantee.
+        assert_eq!(
+            serde_json::to_string(&PromiseStatus::Protected).unwrap(),
+            "\"PROTECTED\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PromiseStatus::AtRisk).unwrap(),
+            "\"AT RISK\""
+        );
+        assert_eq!(
+            serde_json::to_string(&PromiseStatus::Unprotected).unwrap(),
+            "\"UNPROTECTED\""
+        );
+    }
+
+    #[test]
+    fn promise_status_deserializes_screaming_and_legacy_alias() {
+        // Both the current SCREAMING form and the legacy snake_case alias must
+        // decode to the same variant — the permanent back-compat contract for
+        // append-only event rows (ADR-114 amendment 2026-05-29).
+        for json in ["\"PROTECTED\"", "\"protected\""] {
+            assert_eq!(
+                serde_json::from_str::<PromiseStatus>(json).unwrap(),
+                PromiseStatus::Protected
+            );
+        }
+        for json in ["\"AT RISK\"", "\"at_risk\""] {
+            assert_eq!(
+                serde_json::from_str::<PromiseStatus>(json).unwrap(),
+                PromiseStatus::AtRisk
+            );
+        }
+        for json in ["\"UNPROTECTED\"", "\"unprotected\""] {
+            assert_eq!(
+                serde_json::from_str::<PromiseStatus>(json).unwrap(),
+                PromiseStatus::Unprotected
+            );
+        }
     }
 
     // ── Clock skew tests ───────────────────────────────────────────

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1745,8 +1745,8 @@ fn detect_transitions(
         if post_a.status > pre_a.status {
             transitions.push(TransitionEvent::PromiseRecovered {
                 subvolume: post_a.name.clone(),
-                from: format!("{}", pre_a.status),
-                to: format!("{}", post_a.status),
+                from: pre_a.status,
+                to: post_a.status,
             });
         }
     }
@@ -2197,7 +2197,7 @@ mod tests {
 
         assert_eq!(summary.assessments.len(), 1);
         assert_eq!(summary.assessments[0].name, "htpc-home");
-        assert_eq!(summary.assessments[0].status, "PROTECTED");
+        assert_eq!(summary.assessments[0].status, PromiseStatus::Protected);
     }
 
     #[test]
@@ -2928,8 +2928,8 @@ mod tests {
         let transitions = detect_transitions(&pre, &post);
         assert!(transitions.contains(&TransitionEvent::PromiseRecovered {
             subvolume: "htpc-home".to_string(),
-            from: "UNPROTECTED".to_string(),
-            to: "PROTECTED".to_string(),
+            from: PromiseStatus::Unprotected,
+            to: PromiseStatus::Protected,
         }));
     }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -212,7 +212,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
             };
             DoctorDataSafety {
                 name: a.name.clone(),
-                status: a.status.to_string(),
+                status: a.status,
                 health: a.health.to_string(),
                 issue,
                 suggestion,
@@ -291,7 +291,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     // ── 6. Verdict ────────────────────────────────────────────────
     let degraded_count = data_safety
         .iter()
-        .filter(|d| d.status == "PROTECTED" && d.health != "healthy")
+        .filter(|d| d.status == PromiseStatus::Protected && d.health != "healthy")
         .count();
 
     // NOTE: When --thorough is used, verify's drive-mounted warnings inflate warn_count.

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
-use crate::awareness::SubvolAssessment;
+use crate::awareness::{PromiseStatus, SubvolAssessment};
 use crate::config::Config;
 use crate::error::UrdError;
 use crate::executor::{ExecutionResult, SendType};
@@ -83,8 +83,12 @@ pub struct SubvolumeHeartbeat {
     pub name: String,
     /// `None` if not attempted (empty/skipped run), `Some(true/false)` if attempted.
     pub backup_success: Option<bool>,
-    /// Promise status from the awareness model: "PROTECTED", "AT RISK", "UNPROTECTED".
-    pub promise_status: String,
+    /// Promise status from the awareness model. Serializes SCREAMING
+    /// ("PROTECTED" / "AT RISK" / "UNPROTECTED"); deserialization accepts the
+    /// closed set plus legacy `snake_case` aliases. An out-of-set value fails
+    /// the whole heartbeat parse, which the reader treats as absent
+    /// (fail-open via `.ok()` — see `read`).
+    pub promise_status: PromiseStatus,
     /// Number of sends that succeeded but whose pin file write failed.
     /// Defaults to 0 for backward compat with pre-pin-tracking heartbeats.
     #[serde(default)]
@@ -211,7 +215,7 @@ fn build_subvolume_entries(
             SubvolumeHeartbeat {
                 name: a.name.clone(),
                 backup_success: sv_result.map(|sv| sv.success),
-                promise_status: a.status.to_string(),
+                promise_status: a.status,
                 pin_failures: sv_result.map(|sv| sv.pin_failures).unwrap_or(0),
                 send_completed,
                 churn_bytes_per_second: churn.churn_bytes_per_second,
@@ -485,12 +489,12 @@ mod tests {
         assert_eq!(parsed.subvolumes.len(), 2);
         assert_eq!(parsed.subvolumes[0].name, "home");
         assert_eq!(parsed.subvolumes[0].backup_success, Some(true));
-        assert_eq!(parsed.subvolumes[0].promise_status, "PROTECTED");
+        assert_eq!(parsed.subvolumes[0].promise_status, PromiseStatus::Protected);
         // "home" has send_type: Incremental → send_completed: true
         assert!(parsed.subvolumes[0].send_completed);
         assert_eq!(parsed.subvolumes[1].name, "docs");
         assert_eq!(parsed.subvolumes[1].backup_success, Some(false));
-        assert_eq!(parsed.subvolumes[1].promise_status, "AT RISK");
+        assert_eq!(parsed.subvolumes[1].promise_status, PromiseStatus::AtRisk);
         // "docs" has send_type: NoSend → send_completed: false
         assert!(!parsed.subvolumes[1].send_completed);
     }
@@ -547,8 +551,8 @@ mod tests {
             assert_eq!(sv.backup_success, None);
         }
         // Promise statuses still present
-        assert_eq!(heartbeat.subvolumes[0].promise_status, "PROTECTED");
-        assert_eq!(heartbeat.subvolumes[1].promise_status, "AT RISK");
+        assert_eq!(heartbeat.subvolumes[0].promise_status, PromiseStatus::Protected);
+        assert_eq!(heartbeat.subvolumes[1].promise_status, PromiseStatus::AtRisk);
     }
 
     // ── Atomic write ────────────────────────────────────────────────────
@@ -758,6 +762,38 @@ mod tests {
     #[test]
     fn read_nonexistent_returns_none() {
         assert!(read(Path::new("/tmp/nonexistent-heartbeat-test.json")).is_none());
+    }
+
+    #[test]
+    fn read_out_of_set_promise_status_fails_open_to_none() {
+        // UPI 053 F1 contract lock: `promise_status` deserialization now
+        // narrows from "any string" to the closed `PromiseStatus` set (+
+        // legacy aliases). An out-of-set value must make `read` return `None`
+        // (file treated as absent, rebuilt on next run) — never panic, never
+        // propagate an error. This guards against a future `.ok()` → `?` /
+        // `.expect()` "cleanup" that would turn a benign garbage file into a
+        // hard failure on the read path.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("heartbeat.json");
+        let json = r#"{
+            "schema_version": 4,
+            "timestamp": "2026-03-24T02:00:00",
+            "stale_after": "2026-03-24T04:00:00",
+            "run_result": "success",
+            "run_id": 1,
+            "subvolumes": [
+                {
+                    "name": "home",
+                    "backup_success": true,
+                    "promise_status": "DEGRADED",
+                    "pin_failures": 0,
+                    "send_completed": true
+                }
+            ],
+            "notifications_dispatched": true
+        }"#;
+        std::fs::write(&path, json).unwrap();
+        assert!(read(&path).is_none());
     }
 
     // ── send_completed tests ───────────────────────────────────────────

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -14,6 +14,7 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
+use crate::awareness::PromiseStatus;
 use crate::heartbeat::Heartbeat;
 
 // ── Event types ────────────────────────────────────────────────────────
@@ -204,12 +205,12 @@ pub fn compute_notifications(
                 .find(|s| s.name == current_sv.name)
                 .filter(|prev_sv| prev_sv.promise_status != current_sv.promise_status)
             {
-                if is_degradation(&prev_sv.promise_status, &current_sv.promise_status) {
+                if is_degradation(prev_sv.promise_status, current_sv.promise_status) {
                     notifications.push(Notification {
                         event: NotificationEvent::PromiseDegraded {
                             subvolume: current_sv.name.clone(),
-                            from: prev_sv.promise_status.clone(),
-                            to: current_sv.promise_status.clone(),
+                            from: prev_sv.promise_status.to_string(),
+                            to: current_sv.promise_status.to_string(),
                         },
                         urgency: Urgency::Warning,
                         title: format!(
@@ -226,8 +227,8 @@ pub fn compute_notifications(
                     notifications.push(Notification {
                         event: NotificationEvent::PromiseRecovered {
                             subvolume: current_sv.name.clone(),
-                            from: prev_sv.promise_status.clone(),
-                            to: current_sv.promise_status.clone(),
+                            from: prev_sv.promise_status.to_string(),
+                            to: current_sv.promise_status.to_string(),
                         },
                         urgency: Urgency::Info,
                         title: format!(
@@ -249,7 +250,7 @@ pub fn compute_notifications(
         && current
             .subvolumes
             .iter()
-            .all(|sv| sv.promise_status == "UNPROTECTED");
+            .all(|sv| sv.promise_status == PromiseStatus::Unprotected);
 
     if all_unprotected {
         notifications.push(Notification {
@@ -319,18 +320,11 @@ pub fn compute_notifications(
     notifications
 }
 
-/// Status ordering for degradation detection: PROTECTED > AT RISK > UNPROTECTED.
-fn status_rank(status: &str) -> u8 {
-    match status {
-        "PROTECTED" => 2,
-        "AT RISK" => 1,
-        "UNPROTECTED" => 0,
-        _ => 0,
-    }
-}
-
-fn is_degradation(from: &str, to: &str) -> bool {
-    status_rank(from) > status_rank(to)
+/// True when the promise status worsened. `PromiseStatus`'s `Ord` is
+/// worst-to-best (`Unprotected < AtRisk < Protected`), so a degradation is
+/// `to < from`. Named helper documents direction; mirrors `events.rs`.
+fn is_degradation(from: PromiseStatus, to: PromiseStatus) -> bool {
+    to < from
 }
 
 // ── Drive reconnection notifications ──────────────────────────────────
@@ -576,12 +570,12 @@ mod tests {
     use super::*;
     use crate::heartbeat::{Heartbeat, SubvolumeHeartbeat};
 
-    fn make_heartbeat(statuses: &[(&str, &str, Option<bool>)]) -> Heartbeat {
+    fn make_heartbeat(statuses: &[(&str, PromiseStatus, Option<bool>)]) -> Heartbeat {
         make_heartbeat_with_pins(statuses, 0)
     }
 
     fn make_heartbeat_with_pins(
-        statuses: &[(&str, &str, Option<bool>)],
+        statuses: &[(&str, PromiseStatus, Option<bool>)],
         pin_failures: u32,
     ) -> Heartbeat {
         Heartbeat {
@@ -595,7 +589,7 @@ mod tests {
                 .iter()
                 .map(|(name, status, success)| SubvolumeHeartbeat {
                     name: name.to_string(),
-                    promise_status: status.to_string(),
+                    promise_status: *status,
                     backup_success: *success,
                     pin_failures,
                     send_completed: true,
@@ -615,8 +609,8 @@ mod tests {
 
     #[test]
     fn degraded_generates_notification() {
-        let prev = make_heartbeat(&[("home", "PROTECTED", Some(true))]);
-        let curr = make_heartbeat(&[("home", "AT RISK", Some(true))]);
+        let prev = make_heartbeat(&[("home", PromiseStatus::Protected, Some(true))]);
+        let curr = make_heartbeat(&[("home", PromiseStatus::AtRisk, Some(true))]);
 
         let notifications = compute_notifications(Some(&prev), &curr);
 
@@ -631,8 +625,8 @@ mod tests {
 
     #[test]
     fn recovered_generates_notification() {
-        let prev = make_heartbeat(&[("home", "AT RISK", Some(true))]);
-        let curr = make_heartbeat(&[("home", "PROTECTED", Some(true))]);
+        let prev = make_heartbeat(&[("home", PromiseStatus::AtRisk, Some(true))]);
+        let curr = make_heartbeat(&[("home", PromiseStatus::Protected, Some(true))]);
 
         let notifications = compute_notifications(Some(&prev), &curr);
 
@@ -647,8 +641,8 @@ mod tests {
 
     #[test]
     fn no_change_no_notification() {
-        let prev = make_heartbeat(&[("home", "PROTECTED", Some(true))]);
-        let curr = make_heartbeat(&[("home", "PROTECTED", Some(true))]);
+        let prev = make_heartbeat(&[("home", PromiseStatus::Protected, Some(true))]);
+        let curr = make_heartbeat(&[("home", PromiseStatus::Protected, Some(true))]);
 
         let notifications = compute_notifications(Some(&prev), &curr);
 
@@ -667,7 +661,7 @@ mod tests {
 
     #[test]
     fn first_heartbeat_no_degradation() {
-        let curr = make_heartbeat(&[("home", "AT RISK", Some(true))]);
+        let curr = make_heartbeat(&[("home", PromiseStatus::AtRisk, Some(true))]);
 
         let notifications = compute_notifications(None, &curr);
 
@@ -689,8 +683,8 @@ mod tests {
     #[test]
     fn all_unprotected_is_critical() {
         let curr = make_heartbeat(&[
-            ("home", "UNPROTECTED", Some(true)),
-            ("docs", "UNPROTECTED", Some(true)),
+            ("home", PromiseStatus::Unprotected, Some(true)),
+            ("docs", PromiseStatus::Unprotected, Some(true)),
         ]);
 
         let notifications = compute_notifications(None, &curr);
@@ -706,8 +700,8 @@ mod tests {
     #[test]
     fn partial_unprotected_not_all_unprotected() {
         let curr = make_heartbeat(&[
-            ("home", "UNPROTECTED", Some(true)),
-            ("docs", "PROTECTED", Some(true)),
+            ("home", PromiseStatus::Unprotected, Some(true)),
+            ("docs", PromiseStatus::Protected, Some(true)),
         ]);
 
         let notifications = compute_notifications(None, &curr);
@@ -724,8 +718,8 @@ mod tests {
     #[test]
     fn partial_failures_generate_warning() {
         let curr = make_heartbeat(&[
-            ("home", "PROTECTED", Some(true)),
-            ("docs", "AT RISK", Some(false)),
+            ("home", PromiseStatus::Protected, Some(true)),
+            ("docs", PromiseStatus::AtRisk, Some(false)),
         ]);
 
         let notifications = compute_notifications(None, &curr);
@@ -742,8 +736,8 @@ mod tests {
     #[test]
     fn all_failures_is_critical() {
         let curr = make_heartbeat(&[
-            ("home", "AT RISK", Some(false)),
-            ("docs", "AT RISK", Some(false)),
+            ("home", PromiseStatus::AtRisk, Some(false)),
+            ("docs", PromiseStatus::AtRisk, Some(false)),
         ]);
 
         let notifications = compute_notifications(None, &curr);
@@ -759,8 +753,8 @@ mod tests {
     #[test]
     fn no_failures_no_notification() {
         let curr = make_heartbeat(&[
-            ("home", "PROTECTED", Some(true)),
-            ("docs", "PROTECTED", Some(true)),
+            ("home", PromiseStatus::Protected, Some(true)),
+            ("docs", PromiseStatus::Protected, Some(true)),
         ]);
 
         let notifications = compute_notifications(None, &curr);
@@ -775,7 +769,7 @@ mod tests {
     #[test]
     fn empty_run_no_failure_notification() {
         // backup_success = None means not attempted (empty run)
-        let curr = make_heartbeat(&[("home", "PROTECTED", None)]);
+        let curr = make_heartbeat(&[("home", PromiseStatus::Protected, None)]);
 
         let notifications = compute_notifications(None, &curr);
 
@@ -791,7 +785,7 @@ mod tests {
     #[test]
     fn pin_failures_generate_warning() {
         let curr = make_heartbeat_with_pins(
-            &[("home", "PROTECTED", Some(true))],
+            &[("home", PromiseStatus::Protected, Some(true))],
             2,
         );
 
@@ -808,7 +802,7 @@ mod tests {
 
     #[test]
     fn no_pin_failures_no_notification() {
-        let curr = make_heartbeat(&[("home", "PROTECTED", Some(true))]);
+        let curr = make_heartbeat(&[("home", PromiseStatus::Protected, Some(true))]);
 
         let notifications = compute_notifications(None, &curr);
 
@@ -828,12 +822,27 @@ mod tests {
         assert!(Urgency::Info < Urgency::Critical);
     }
 
-    // ── Status ranking ─────────────────────────────────────────────
+    // ── Degradation direction ──────────────────────────────────────
 
     #[test]
-    fn status_rank_ordering() {
-        assert!(status_rank("PROTECTED") > status_rank("AT RISK"));
-        assert!(status_rank("AT RISK") > status_rank("UNPROTECTED"));
+    fn is_degradation_follows_ord() {
+        // Worsening (to < from) is a degradation; improving is not.
+        assert!(is_degradation(
+            PromiseStatus::Protected,
+            PromiseStatus::AtRisk
+        ));
+        assert!(is_degradation(
+            PromiseStatus::AtRisk,
+            PromiseStatus::Unprotected
+        ));
+        assert!(!is_degradation(
+            PromiseStatus::AtRisk,
+            PromiseStatus::Protected
+        ));
+        assert!(!is_degradation(
+            PromiseStatus::Protected,
+            PromiseStatus::Protected
+        ));
     }
 
     // ── Multiple events in one transition ──────────────────────────
@@ -841,12 +850,12 @@ mod tests {
     #[test]
     fn multiple_degradations_produce_multiple_notifications() {
         let prev = make_heartbeat(&[
-            ("home", "PROTECTED", Some(true)),
-            ("docs", "PROTECTED", Some(true)),
+            ("home", PromiseStatus::Protected, Some(true)),
+            ("docs", PromiseStatus::Protected, Some(true)),
         ]);
         let curr = make_heartbeat(&[
-            ("home", "AT RISK", Some(true)),
-            ("docs", "UNPROTECTED", Some(false)),
+            ("home", PromiseStatus::AtRisk, Some(true)),
+            ("docs", PromiseStatus::Unprotected, Some(false)),
         ]);
 
         let notifications = compute_notifications(Some(&prev), &curr);
@@ -868,8 +877,8 @@ mod tests {
             channels: vec![NotificationChannel::Log],
         };
 
-        let prev = make_heartbeat(&[("home", "PROTECTED", Some(true))]);
-        let curr = make_heartbeat(&[("home", "AT RISK", Some(true))]);
+        let prev = make_heartbeat(&[("home", PromiseStatus::Protected, Some(true))]);
+        let curr = make_heartbeat(&[("home", PromiseStatus::AtRisk, Some(true))]);
 
         let notifications = compute_notifications(Some(&prev), &curr);
         // Warning-level notification should not fire through Critical-minimum config

--- a/src/output.rs
+++ b/src/output.rs
@@ -8,7 +8,7 @@ use std::io::IsTerminal;
 use serde::{Deserialize, Serialize};
 
 use crate::advice::{ActionableAdvice, RedundancyAdvisory, RedundancyAdvisoryKind};
-use crate::awareness::{DriveAssessment, SubvolAssessment};
+use crate::awareness::{DriveAssessment, PromiseStatus, SubvolAssessment};
 use crate::types::{ByteSize, DriveRole};
 
 // ── OutputMode ──────────────────────────────────────────────────────────
@@ -138,7 +138,8 @@ pub struct StatusOutput {
 #[derive(Debug, Serialize)]
 pub struct StatusAssessment {
     pub name: String,
-    pub status: String,
+    /// Promise status (serializes SCREAMING: "PROTECTED" / "AT RISK" / "UNPROTECTED").
+    pub status: PromiseStatus,
     /// Operational health: "healthy", "degraded", or "blocked".
     pub health: String,
     /// Reasons for non-healthy operational health (empty when healthy).
@@ -151,7 +152,7 @@ pub struct StatusAssessment {
     /// Age of newest local snapshot in seconds, if available.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub local_newest_age_secs: Option<i64>,
-    pub local_status: String,
+    pub local_status: PromiseStatus,
     pub external: Vec<StatusDriveAssessment>,
     pub advisories: Vec<String>,
     /// Structured redundancy advisories (e.g., no offsite, single point of failure).
@@ -171,13 +172,13 @@ impl StatusAssessment {
     pub fn from_assessment(a: &SubvolAssessment) -> Self {
         Self {
             name: a.name.clone(),
-            status: a.status.to_string(),
+            status: a.status,
             health: a.health.to_string(),
             health_reasons: a.health_reasons.clone(),
             promise_level: None,
             local_snapshot_count: a.local.snapshot_count,
             local_newest_age_secs: a.local.newest_age.map(|d| d.num_seconds()),
-            local_status: a.local.status.to_string(),
+            local_status: a.local.status,
             external: a
                 .external
                 .iter()
@@ -196,7 +197,8 @@ impl StatusAssessment {
 #[derive(Debug, Serialize)]
 pub struct StatusDriveAssessment {
     pub drive_label: String,
-    pub status: String,
+    /// Promise status (serializes SCREAMING: "PROTECTED" / "AT RISK" / "UNPROTECTED").
+    pub status: PromiseStatus,
     pub mounted: bool,
     pub snapshot_count: Option<usize>,
     /// Age of last send in seconds, if available (even when unmounted).
@@ -220,7 +222,7 @@ impl StatusDriveAssessment {
     pub fn from_assessment(a: &DriveAssessment) -> Self {
         Self {
             drive_label: a.drive_label.clone(),
-            status: a.status.to_string(),
+            status: a.status,
             mounted: a.mounted,
             snapshot_count: a.snapshot_count,
             last_send_age_secs: a.last_send_age.map(|d| d.num_seconds()),
@@ -635,7 +637,8 @@ pub enum DoctorCheckStatus {
 #[derive(Debug, Clone, Serialize)]
 pub struct DoctorDataSafety {
     pub name: String,
-    pub status: String,
+    /// Promise status (serializes SCREAMING: "PROTECTED" / "AT RISK" / "UNPROTECTED").
+    pub status: PromiseStatus,
     pub health: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub issue: Option<String>,
@@ -816,8 +819,8 @@ pub enum TransitionEvent {
     /// A subvolume's promise status improved (e.g., Unprotected → Protected).
     PromiseRecovered {
         subvolume: String,
-        from: String,
-        to: String,
+        from: PromiseStatus,
+        to: PromiseStatus,
     },
 }
 
@@ -1380,7 +1383,12 @@ pub struct HealthCounts {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VisualState {
     pub icon: VisualIcon,
-    pub worst_safety: String,
+    /// Worst promise status across subvolumes (serializes SCREAMING).
+    pub worst_safety: PromiseStatus,
+    /// Worst operational health across subvolumes. Stays `String`:
+    /// `OperationalHealth` has no SCREAMING serde form and is out of scope for
+    /// UPI 053 — the `worst_safety: PromiseStatus` / `worst_health: String`
+    /// asymmetry is deliberate, not an omission.
     pub worst_health: String,
     pub safety_counts: SafetyCounts,
     pub health_counts: HealthCounts,
@@ -1414,7 +1422,11 @@ pub struct SentinelStateFile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SentinelPromiseState {
     pub name: String,
-    pub status: String,
+    /// Promise status (serializes SCREAMING: "PROTECTED" / "AT RISK" / "UNPROTECTED").
+    /// Deserialization accepts the closed `PromiseStatus` set plus legacy
+    /// `snake_case` aliases; an out-of-set value fails the whole state-file
+    /// parse, which the reader treats as absent (fail-open via `.ok()`).
+    pub status: PromiseStatus,
     /// Operational health (VFM-B, schema v2+). Defaults to "healthy" for v1 files.
     #[serde(default = "default_healthy")]
     pub health: String,

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -736,7 +736,7 @@ pub fn compute_visual_state(assessments: &[SubvolAssessment]) -> crate::output::
 
     VisualState {
         icon,
-        worst_safety: worst_safety.to_string(),
+        worst_safety,
         worst_health: worst_health.to_string(),
         safety_counts,
         health_counts,
@@ -1864,7 +1864,7 @@ mod tests {
         let vs = compute_visual_state(&assessments);
         assert_eq!(vs.icon, crate::output::VisualIcon::Warning);
         assert_eq!(vs.safety_counts.aging, 1);
-        assert_eq!(vs.worst_safety, "AT RISK");
+        assert_eq!(vs.worst_safety, PromiseStatus::AtRisk);
     }
 
     #[test]

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -654,7 +654,7 @@ impl SentinelRunner {
                         .find(|h| h.name == p.name);
                     SentinelPromiseState {
                         name: p.name.clone(),
-                        status: p.status.to_string(),
+                        status: p.status,
                         health: health_snap
                             .map(|h| h.health.to_string())
                             .unwrap_or_else(|| "healthy".to_string()),
@@ -983,7 +983,7 @@ mod tests {
             tick_interval_secs: 900,
             promise_states: vec![SentinelPromiseState {
                 name: "home".to_string(),
-                status: "PROTECTED".to_string(),
+                status: PromiseStatus::Protected,
                 health: "degraded".to_string(),
                 health_reasons: vec!["chain broken on WD-18TB".to_string()],
             }],
@@ -993,7 +993,7 @@ mod tests {
             },
             visual_state: Some(crate::output::VisualState {
                 icon: crate::output::VisualIcon::Warning,
-                worst_safety: "PROTECTED".to_string(),
+                worst_safety: PromiseStatus::Protected,
                 worst_health: "degraded".to_string(),
                 safety_counts: crate::output::SafetyCounts {
                     ok: 1,
@@ -1041,6 +1041,32 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("sentinel-state.json");
         std::fs::write(&path, "not json").unwrap();
+        assert!(read_sentinel_state_file(&path).is_none());
+    }
+
+    #[test]
+    fn state_file_read_out_of_set_status_fails_open_to_none() {
+        // UPI 053 F1 contract lock: `promise_states[].status` and
+        // `visual_state.worst_safety` deserialization now narrow from "any
+        // string" to the closed `PromiseStatus` set (+ legacy aliases). An
+        // out-of-set value must make `read_sentinel_state_file` return `None`
+        // (state file treated as absent, rebuilt on next tick) — never panic,
+        // never propagate. Guards against a future `.ok()` → `?` regression.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("sentinel-state.json");
+        let json = r#"{
+            "schema_version": 2,
+            "pid": 1,
+            "started": "2026-03-27T10:00:00",
+            "last_assessment": null,
+            "mounted_drives": [],
+            "tick_interval_secs": 120,
+            "promise_states": [
+                { "name": "home", "status": "DEGRADED", "health": "healthy" }
+            ],
+            "circuit_breaker": { "state": "closed", "failure_count": 0 }
+        }"#;
+        std::fs::write(&path, json).unwrap();
         assert!(read_sentinel_state_file(&path).is_none());
     }
 
@@ -1106,7 +1132,7 @@ mod tests {
             tick_interval_secs: 120,
             promise_states: vec![SentinelPromiseState {
                 name: "home".to_string(),
-                status: "PROTECTED".to_string(),
+                status: PromiseStatus::Protected,
                 health: "healthy".to_string(),
                 health_reasons: vec![],
             }],

--- a/src/state.rs
+++ b/src/state.rs
@@ -2632,6 +2632,41 @@ mod tests {
         }
     }
 
+    #[test]
+    fn legacy_snake_case_promise_transition_decodes_via_alias() {
+        // ADR-114 amendment 2026-05-29 back-compat guard: event rows written
+        // before the SCREAMING unification carry `snake_case` promise-status
+        // spellings (e.g. "at_risk"). Events are append-only, so those rows
+        // live indefinitely. The serde `alias` must keep decoding them.
+        let db = StateDb::open_memory().unwrap();
+        db.conn
+            .execute(
+                "INSERT INTO events (kind, occurred_at, payload)
+                 VALUES (?1, ?2, ?3)",
+                rusqlite::params![
+                    EventKind::Promise.as_str(),
+                    "2026-04-30T03:00:00",
+                    r#"{"type":"PromiseTransition","from":"protected","to":"at_risk","trigger":"run"}"#,
+                ],
+            )
+            .unwrap();
+        let rows = db
+            .query_events(&EventQueryFilter {
+                kind: Some(EventKind::Promise),
+                limit: 1,
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        match &rows[0].payload {
+            EventPayload::PromiseTransition { from, to, .. } => {
+                assert_eq!(*from, crate::awareness::PromiseStatus::Protected);
+                assert_eq!(*to, crate::awareness::PromiseStatus::AtRisk);
+            }
+            other => panic!("unexpected payload: {other:?}"),
+        }
+    }
+
     // ── Drift sample tests (UPI 030) ─────────────────────────────────
 
     fn drift_dt(s: &str) -> chrono::NaiveDateTime {

--- a/src/voice/backup.rs
+++ b/src/voice/backup.rs
@@ -9,6 +9,7 @@ use std::fmt::Write;
 
 use colored::Colorize;
 
+use crate::awareness::PromiseStatus;
 use crate::output::{BackupSummary, OutputMode, PreActionSummary, SkipCategory};
 use crate::types::{ByteSize, DriveRole};
 
@@ -130,7 +131,7 @@ fn render_backup_interactive(data: &BackupSummary) -> String {
     render_skipped_block(&data.skipped, &mut out);
 
     // ── Awareness table ──────────────────────────────────────────────
-    let any_not_protected = data.assessments.iter().any(|a| a.status != "PROTECTED");
+    let any_not_protected = data.assessments.iter().any(|a| a.status != PromiseStatus::Protected);
     if any_not_protected {
         writeln!(out).ok();
         render_assessment_table(data, &mut out);
@@ -197,8 +198,8 @@ fn render_transitions(transitions: &[crate::output::TransitionEvent], out: &mut 
                     out,
                     "  {}: {} \u{2192} {}.",
                     subvolume,
-                    exposure_label(from),
-                    exposure_label(to),
+                    exposure_label(*from),
+                    exposure_label(*to),
                 )
                 .ok();
             }
@@ -319,7 +320,7 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
     // Build rows
     let mut rows: Vec<Vec<String>> = Vec::new();
     for assessment in &data.assessments {
-        let mut row = vec![exposure_label(&assessment.status)];
+        let mut row = vec![exposure_label(assessment.status)];
         if has_promises {
             row.push(
                 assessment

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -11,6 +11,7 @@ use std::fmt::Write;
 
 use colored::Colorize;
 
+use crate::awareness::PromiseStatus;
 use crate::output::{DoctorCheck, DoctorCheckStatus, DoctorOutput, DoctorVerdictStatus, OutputMode};
 use crate::plan::format_duration_short;
 
@@ -84,7 +85,7 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
     let sealed_count = data
         .data_safety
         .iter()
-        .filter(|d| d.status == "PROTECTED")
+        .filter(|d| d.status == PromiseStatus::Protected)
         .count();
     let total = data.data_safety.len();
     if sealed_count == total {
@@ -100,7 +101,7 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
         writeln!(
             out,
             "    {} {} of {} sealed",
-            if data.data_safety.iter().any(|d| d.status == "UNPROTECTED") {
+            if data.data_safety.iter().any(|d| d.status == PromiseStatus::Unprotected) {
                 "\u{2717}".red().to_string()
             } else {
                 "\u{26a0}".yellow().to_string()

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -11,6 +11,7 @@ use std::fmt::Write;
 
 use colored::Colorize;
 
+use crate::awareness::PromiseStatus;
 use crate::output::{SkipCategory, StatusAssessment, VerifyCheck, VerifyOutput};
 // Test-only imports — moved-renderer types still referenced by parent tests
 // (renderer extractions per UPI 050 phases 1 + 2).
@@ -98,12 +99,11 @@ pub(super) fn pluralize(count: usize, singular: &str, plural: &str) -> String {
     }
 }
 
-pub(super) fn exposure_label(status: &str) -> String {
+pub(super) fn exposure_label(status: PromiseStatus) -> String {
     match status {
-        "PROTECTED" => "sealed".to_string(),
-        "AT RISK" => "waning".to_string(),
-        "UNPROTECTED" => "exposed".to_string(),
-        other => other.to_string(),
+        PromiseStatus::Protected => "sealed".to_string(),
+        PromiseStatus::AtRisk => "waning".to_string(),
+        PromiseStatus::Unprotected => "exposed".to_string(),
     }
 }
 
@@ -318,39 +318,33 @@ pub(super) fn truncate_str(s: &str, max_len: usize) -> String {
 
 // ── Staleness Escalation (4a) ──────────────────────────────────────────
 
-/// Severity ranking for promise status strings (higher = worse).
-pub(super) fn status_severity(status: &str) -> u8 {
-    match status {
-        "UNPROTECTED" => 2,
-        "AT RISK" => 1,
-        _ => 0,
-    }
-}
-
 /// Single-pass aggregation of per-drive presentation fields. The drive-level
 /// fields (`absent_duration_secs`, `last_activity_age_secs`) co-travel across
 /// all subvolume `DriveAssessment` entries on the same drive, so we take the
 /// first populated value we see; they are invariant per drive. The worst
 /// promise status across subvolumes drives the gravity escalation.
-pub(super) struct DriveAggregate<'a> {
-    worst_status: &'a str,
+pub(super) struct DriveAggregate {
+    worst_status: PromiseStatus,
     absent_duration_secs: Option<i64>,
     last_activity_age_secs: Option<i64>,
 }
 
-pub(super) fn aggregate_drive_info<'a>(
-    assessments: &'a [StatusAssessment],
+pub(super) fn aggregate_drive_info(
+    assessments: &[StatusAssessment],
     drive_label: &str,
-) -> DriveAggregate<'a> {
-    let mut worst: &str = "PROTECTED";
+) -> DriveAggregate {
+    // `PromiseStatus`'s `Ord` is worst-to-best (`Unprotected < AtRisk <
+    // Protected`), so "worst" is the minimum: start at the best (`Protected`)
+    // and keep any status that compares `<`.
+    let mut worst = PromiseStatus::Protected;
     let mut absent_duration_secs: Option<i64> = None;
     let mut last_activity_age_secs: Option<i64> = None;
 
     for assessment in assessments {
         for ext in &assessment.external {
             if ext.drive_label == drive_label {
-                if status_severity(&ext.status) > status_severity(worst) {
-                    worst = &ext.status;
+                if ext.status < worst {
+                    worst = ext.status;
                 }
                 if absent_duration_secs.is_none() {
                     absent_duration_secs = ext.absent_duration_secs;
@@ -381,7 +375,7 @@ pub(super) fn unmounted_drive_label(
     drive_label: &str,
     absent_duration_secs: Option<i64>,
     last_activity_age_secs: Option<i64>,
-    worst_status: &str,
+    worst_status: PromiseStatus,
 ) -> String {
     // Fallback field is `last_activity_age_secs` (broader: any activity)
     // rather than `last_send_age` (awareness's narrower backup-only signal).
@@ -405,21 +399,23 @@ pub(super) fn unmounted_drive_label(
 pub(super) fn format_drive_age_label(
     drive_label: &str,
     age_secs: i64,
-    worst_status: &str,
+    worst_status: PromiseStatus,
     phrase: &str,
 ) -> String {
     let age_str = humanize_duration(age_secs);
     match worst_status {
-        "UNPROTECTED" => format!(
+        PromiseStatus::Unprotected => format!(
             "{} {phrase} {age_str} — protection aging",
             drive_label.bold(),
         ),
-        "AT RISK" => format!(
+        PromiseStatus::AtRisk => format!(
             "{} {phrase} {} — consider connecting",
             drive_label.bold(),
             age_str.yellow(),
         ),
-        _ => format!("{} {phrase} — {}", drive_label.bold(), age_str.dimmed()),
+        PromiseStatus::Protected => {
+            format!("{} {phrase} — {}", drive_label.bold(), age_str.dimmed())
+        }
     }
 }
 
@@ -520,16 +516,16 @@ pub(crate) mod test_fixtures {
             assessments: vec![
                 StatusAssessment {
                     name: "htpc-home".to_string(),
-                    status: "PROTECTED".to_string(),
+                    status: PromiseStatus::Protected,
                     health: "healthy".to_string(),
                     health_reasons: vec![],
                     promise_level: None,
                     local_snapshot_count: 47,
                     local_newest_age_secs: Some(1800),
-                    local_status: "PROTECTED".to_string(),
+                    local_status: PromiseStatus::Protected,
                     external: vec![StatusDriveAssessment {
                         drive_label: "WD-18TB".to_string(),
-                        status: "PROTECTED".to_string(),
+                        status: PromiseStatus::Protected,
                         mounted: true,
                         snapshot_count: Some(12),
                         last_send_age_secs: Some(7200),
@@ -545,7 +541,7 @@ pub(crate) mod test_fixtures {
                 },
                 StatusAssessment {
                     name: "htpc-docs".to_string(),
-                    status: "AT RISK".to_string(),
+                    status: PromiseStatus::AtRisk,
                     health: "degraded".to_string(),
                     health_reasons: vec![
                         "chain broken on WD-18TB \u{2014} next send will be full".to_string(),
@@ -553,10 +549,10 @@ pub(crate) mod test_fixtures {
                     promise_level: None,
                     local_snapshot_count: 5,
                     local_newest_age_secs: Some(10800),
-                    local_status: "AT RISK".to_string(),
+                    local_status: PromiseStatus::AtRisk,
                     external: vec![StatusDriveAssessment {
                         drive_label: "WD-18TB".to_string(),
-                        status: "UNPROTECTED".to_string(),
+                        status: PromiseStatus::Unprotected,
                         mounted: true,
                         snapshot_count: Some(0),
                         last_send_age_secs: None,
@@ -651,13 +647,13 @@ pub(crate) mod test_fixtures {
             ],
             assessments: vec![StatusAssessment {
                 name: "htpc-home".to_string(),
-                status: "PROTECTED".to_string(),
+                status: PromiseStatus::Protected,
                 health: "healthy".to_string(),
                 health_reasons: vec![],
                 promise_level: None,
                 local_snapshot_count: 12,
                 local_newest_age_secs: None,
-                local_status: "PROTECTED".to_string(),
+                local_status: PromiseStatus::Protected,
                 external: vec![],
                 advisories: vec![],
                 redundancy_advisories: vec![],
@@ -697,7 +693,7 @@ pub(crate) mod test_fixtures {
             data_safety: vec![
                 DoctorDataSafety {
                     name: "htpc-home".to_string(),
-                    status: "PROTECTED".to_string(),
+                    status: PromiseStatus::Protected,
                     health: "healthy".to_string(),
                     issue: None,
                     suggestion: None,
@@ -705,7 +701,7 @@ pub(crate) mod test_fixtures {
                 },
                 DoctorDataSafety {
                     name: "htpc-docs".to_string(),
-                    status: "PROTECTED".to_string(),
+                    status: PromiseStatus::Protected,
                     health: "healthy".to_string(),
                     issue: None,
                     suggestion: None,
@@ -852,7 +848,7 @@ mod tests {
         let mut data = test_status_output();
         // Set a promise level but all statuses are PROTECTED — no conflict
         data.assessments[0].promise_level = Some("sheltered".to_string());
-        data.assessments[1].status = "PROTECTED".to_string();
+        data.assessments[1].status = PromiseStatus::Protected;
         data.assessments[1].promise_level = Some("fortified".to_string());
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
@@ -901,7 +897,7 @@ mod tests {
         });
         data.assessments[0].external.push(StatusDriveAssessment {
             drive_label: "Backup-2TB".to_string(),
-            status: "AT RISK".to_string(),
+            status: PromiseStatus::AtRisk,
             mounted: false,
             snapshot_count: None,
             last_send_age_secs: Some(604800), // 7 days
@@ -1312,7 +1308,7 @@ mod tests {
     fn backup_interactive_shows_table_when_at_risk() {
         let _color = color_guard(false);
         let mut data = test_backup_summary();
-        data.assessments[0].status = "AT RISK".to_string();
+        data.assessments[0].status = PromiseStatus::AtRisk;
         let output = render_backup_summary(&data, OutputMode::Interactive);
         assert!(
             output.contains("SUBVOLUME"),
@@ -2812,7 +2808,7 @@ mod tests {
                 tick_interval_secs: 900,
                 promise_states: vec![SentinelPromiseState {
                     name: "home".to_string(),
-                    status: "PROTECTED".to_string(),
+                    status: PromiseStatus::Protected,
                     health: "healthy".to_string(),
                     health_reasons: vec![],
                 }],
@@ -2893,7 +2889,7 @@ mod tests {
         let mut data = test_status_output();
         // Make all assessments safe and healthy
         for a in &mut data.assessments {
-            a.status = "PROTECTED".to_string();
+            a.status = PromiseStatus::Protected;
             a.health = "healthy".to_string();
             a.health_reasons = vec![];
         }
@@ -2925,10 +2921,11 @@ mod tests {
 
     #[test]
     fn exposure_label_maps_all_statuses() {
-        assert_eq!(exposure_label("PROTECTED"), "sealed");
-        assert_eq!(exposure_label("AT RISK"), "waning");
-        assert_eq!(exposure_label("UNPROTECTED"), "exposed");
-        assert_eq!(exposure_label("UNKNOWN"), "UNKNOWN");
+        // Match is exhaustive over the closed `PromiseStatus` set — no
+        // pass-through arm remains (UPI 053).
+        assert_eq!(exposure_label(PromiseStatus::Protected), "sealed");
+        assert_eq!(exposure_label(PromiseStatus::AtRisk), "waning");
+        assert_eq!(exposure_label(PromiseStatus::Unprotected), "exposed");
     }
 
     #[test]
@@ -2988,8 +2985,8 @@ mod tests {
     fn summary_line_differentiates_exposed_and_waning() {
         let _color = color_guard(false);
         let mut data = test_status_output();
-        data.assessments[0].status = "UNPROTECTED".to_string();
-        data.assessments[1].status = "AT RISK".to_string();
+        data.assessments[0].status = PromiseStatus::Unprotected;
+        data.assessments[1].status = PromiseStatus::AtRisk;
         let output = render_status(&data, OutputMode::Interactive);
         assert!(output.contains("exposed"), "missing exposed in summary");
         assert!(output.contains("waning"), "missing waning in summary");
@@ -3003,7 +3000,7 @@ mod tests {
         // Add an unmounted Primary drive with send history
         data.assessments[0].external.push(StatusDriveAssessment {
             drive_label: "Test-Drive".to_string(),
-            status: "PROTECTED".to_string(),
+            status: PromiseStatus::Protected,
             mounted: false,
             snapshot_count: None,
             last_send_age_secs: Some(86400),
@@ -3072,7 +3069,7 @@ mod tests {
         // Add an unmounted drive with send history to one assessment
         data.assessments[0].external.push(StatusDriveAssessment {
             drive_label: "Offsite-4TB".to_string(),
-            status: "PROTECTED".to_string(),
+            status: PromiseStatus::Protected,
             mounted: false,
             snapshot_count: None,
             last_send_age_secs: Some(172800), // 2 days
@@ -3418,7 +3415,7 @@ mod tests {
         let mut data = test_doctor_output();
         data.data_safety[1] = DoctorDataSafety {
             name: "htpc-docs".to_string(),
-            status: "UNPROTECTED".to_string(),
+            status: PromiseStatus::Unprotected,
             health: "blocked".to_string(),
             issue: Some("exposed — data may not be recoverable".to_string()),
             suggestion: Some("Run `urd backup` or connect a drive.".to_string()),
@@ -3714,7 +3711,7 @@ mod tests {
     fn doctor_verdict_singular_issue() {
         let _color = color_guard(false);
         let mut data = test_doctor_output();
-        data.data_safety[0].status = "UNPROTECTED".to_string();
+        data.data_safety[0].status = PromiseStatus::Unprotected;
         data.data_safety[0].health = "blocked".to_string();
         data.data_safety[0].issue = Some("exposed".to_string());
         data.verdict = DoctorVerdict::issues(1);
@@ -3790,7 +3787,7 @@ mod tests {
         let mut data = test_doctor_output();
         data.data_safety[0] = DoctorDataSafety {
             name: "htpc-home".to_string(),
-            status: "AT RISK".to_string(),
+            status: PromiseStatus::AtRisk,
             health: "degraded".to_string(),
             issue: Some("waning — last backup 48 hours ago".to_string()),
             suggestion: Some("Run `urd backup --force-full --subvolume htpc-home`.".to_string()),
@@ -3814,7 +3811,7 @@ mod tests {
         let mut data = test_doctor_output();
         data.data_safety[0] = DoctorDataSafety {
             name: "htpc-home".to_string(),
-            status: "UNPROTECTED".to_string(),
+            status: PromiseStatus::Unprotected,
             health: "blocked".to_string(),
             issue: Some("exposed — all drives disconnected".to_string()),
             suggestion: None,
@@ -3983,33 +3980,35 @@ mod tests {
     // ── 4a: Staleness Escalation Tests ────────────────────────────────
 
     #[test]
-    fn status_severity_ordering() {
-        assert!(status_severity("UNPROTECTED") > status_severity("AT RISK"));
-        assert!(status_severity("AT RISK") > status_severity("PROTECTED"));
-        assert_eq!(status_severity("PROTECTED"), 0);
-        assert_eq!(status_severity("unknown"), 0);
+    fn promise_status_ord_is_worst_to_best() {
+        // The `status_severity` helper was deleted in UPI 053; gravity now
+        // rides `PromiseStatus`'s `Ord`. Worst-to-best means the worst status
+        // is the minimum — `aggregate_drive_info`/`compute_visual_state` rely
+        // on this for their `.min()`/`<` selection.
+        assert!(PromiseStatus::Unprotected < PromiseStatus::AtRisk);
+        assert!(PromiseStatus::AtRisk < PromiseStatus::Protected);
     }
 
     // ── Unmounted-drive cascade: unmounted_drive_label + aggregate_drive_info ───
 
     fn drive_aggregate_assessment(
         drive_label: &str,
-        status: &str,
+        status: PromiseStatus,
         absent: Option<i64>,
         last_activity: Option<i64>,
     ) -> StatusAssessment {
         StatusAssessment {
             name: "sv1".to_string(),
-            status: status.to_string(),
+            status,
             health: "healthy".to_string(),
             health_reasons: vec![],
             promise_level: None,
             local_snapshot_count: 10,
             local_newest_age_secs: Some(3600),
-            local_status: "PROTECTED".to_string(),
+            local_status: PromiseStatus::Protected,
             external: vec![StatusDriveAssessment {
                 drive_label: drive_label.to_string(),
-                status: status.to_string(),
+                status,
                 mounted: false,
                 snapshot_count: None,
                 last_send_age_secs: None,
@@ -4027,18 +4026,21 @@ mod tests {
 
     #[test]
     fn aggregate_drive_info_picks_worst_status() {
+        // Ord-inversion guard: "worst" is the MIN under `PromiseStatus`'s
+        // worst-to-best `Ord`. One AtRisk + one Unprotected must yield
+        // Unprotected; a stray `max`/`>` would yield AtRisk and fail here.
         let assessments = vec![
-            drive_aggregate_assessment("WD-18TB", "PROTECTED", Some(86400), None),
-            drive_aggregate_assessment("WD-18TB", "UNPROTECTED", Some(86400), None),
+            drive_aggregate_assessment("WD-18TB", PromiseStatus::AtRisk, Some(86400), None),
+            drive_aggregate_assessment("WD-18TB", PromiseStatus::Unprotected, Some(86400), None),
         ];
         let agg = aggregate_drive_info(&assessments, "WD-18TB");
-        assert_eq!(agg.worst_status, "UNPROTECTED");
+        assert_eq!(agg.worst_status, PromiseStatus::Unprotected);
     }
 
     #[test]
     fn aggregate_drive_info_propagates_absent_duration() {
         let assessments =
-            vec![drive_aggregate_assessment("WD-18TB", "AT RISK", Some(604800), None)];
+            vec![drive_aggregate_assessment("WD-18TB", PromiseStatus::AtRisk, Some(604800), None)];
         let agg = aggregate_drive_info(&assessments, "WD-18TB");
         assert_eq!(agg.absent_duration_secs, Some(604800));
         assert_eq!(agg.last_activity_age_secs, None);
@@ -4047,7 +4049,7 @@ mod tests {
     #[test]
     fn aggregate_drive_info_propagates_last_activity() {
         let assessments =
-            vec![drive_aggregate_assessment("WD-18TB", "AT RISK", None, Some(86400))];
+            vec![drive_aggregate_assessment("WD-18TB", PromiseStatus::AtRisk, None, Some(86400))];
         let agg = aggregate_drive_info(&assessments, "WD-18TB");
         assert_eq!(agg.absent_duration_secs, None);
         assert_eq!(agg.last_activity_age_secs, Some(86400));
@@ -4055,10 +4057,14 @@ mod tests {
 
     #[test]
     fn aggregate_drive_info_no_match_defaults_protected_and_none() {
-        let assessments =
-            vec![drive_aggregate_assessment("WD-18TB", "UNPROTECTED", Some(86400), None)];
+        let assessments = vec![drive_aggregate_assessment(
+            "WD-18TB",
+            PromiseStatus::Unprotected,
+            Some(86400),
+            None,
+        )];
         let agg = aggregate_drive_info(&assessments, "MISSING-DRIVE");
-        assert_eq!(agg.worst_status, "PROTECTED");
+        assert_eq!(agg.worst_status, PromiseStatus::Protected);
         assert_eq!(agg.absent_duration_secs, None);
         assert_eq!(agg.last_activity_age_secs, None);
     }
@@ -4066,7 +4072,7 @@ mod tests {
     #[test]
     fn unmounted_with_physical_event_renders_away() {
         let _color = color_guard(false);
-        let label = unmounted_drive_label("WD-18TB", Some(259200), None, "PROTECTED");
+        let label = unmounted_drive_label("WD-18TB", Some(259200), None, PromiseStatus::Protected);
         assert!(label.contains("WD-18TB"), "missing label: {label}");
         assert!(label.contains("away"), "missing 'away': {label}");
         assert!(label.contains("3d"), "missing age: {label}");
@@ -4075,7 +4081,7 @@ mod tests {
     #[test]
     fn unmounted_without_event_with_ops_renders_last_backup() {
         let _color = color_guard(false);
-        let label = unmounted_drive_label("WD-18TB", None, Some(259200), "PROTECTED");
+        let label = unmounted_drive_label("WD-18TB", None, Some(259200), PromiseStatus::Protected);
         assert!(label.contains("WD-18TB"), "missing label: {label}");
         assert!(label.contains("last backup"), "missing 'last backup': {label}");
         assert!(label.contains("3d"), "missing age: {label}");
@@ -4084,7 +4090,7 @@ mod tests {
     #[test]
     fn unmounted_no_data_renders_disconnected_silent() {
         let _color = color_guard(false);
-        let label = unmounted_drive_label("WD-18TB", None, None, "PROTECTED");
+        let label = unmounted_drive_label("WD-18TB", None, None, PromiseStatus::Protected);
         assert!(label.contains("WD-18TB"), "missing label: {label}");
         assert!(
             label.contains("disconnected"),
@@ -4103,7 +4109,7 @@ mod tests {
         // (sentinel-missed-unmount case, verified by awareness tests), voice
         // must stay silent — no "away" or "last backup".
         let _color = color_guard(false);
-        let label = unmounted_drive_label("WD-18TB", None, None, "AT RISK");
+        let label = unmounted_drive_label("WD-18TB", None, None, PromiseStatus::AtRisk);
         assert!(label.contains("disconnected"), "must be silent: {label}");
         assert!(!label.contains("away"));
         assert!(!label.contains("last backup"));
@@ -4112,7 +4118,7 @@ mod tests {
     #[test]
     fn at_risk_escalation_away() {
         let _color = color_guard(false);
-        let label = unmounted_drive_label("WD-18TB", Some(604800), None, "AT RISK");
+        let label = unmounted_drive_label("WD-18TB", Some(604800), None, PromiseStatus::AtRisk);
         assert!(label.contains("away"), "missing 'away': {label}");
         assert!(label.contains("7d"), "missing age: {label}");
         assert!(
@@ -4124,7 +4130,7 @@ mod tests {
     #[test]
     fn at_risk_escalation_last_backup() {
         let _color = color_guard(false);
-        let label = unmounted_drive_label("WD-18TB", None, Some(604800), "AT RISK");
+        let label = unmounted_drive_label("WD-18TB", None, Some(604800), PromiseStatus::AtRisk);
         assert!(label.contains("last backup"), "missing 'last backup': {label}");
         assert!(label.contains("7d"), "missing age: {label}");
         assert!(
@@ -4136,7 +4142,7 @@ mod tests {
     #[test]
     fn unprotected_escalation_away() {
         let _color = color_guard(false);
-        let label = unmounted_drive_label("WD-18TB1", Some(2592000), None, "UNPROTECTED");
+        let label = unmounted_drive_label("WD-18TB1", Some(2592000), None, PromiseStatus::Unprotected);
         assert!(label.contains("WD-18TB1"), "missing label: {label}");
         assert!(label.contains("away"), "missing 'away': {label}");
         assert!(label.contains("30d"), "missing age: {label}");
@@ -4154,7 +4160,7 @@ mod tests {
     #[test]
     fn unprotected_escalation_last_backup() {
         let _color = color_guard(false);
-        let label = unmounted_drive_label("WD-18TB", None, Some(2592000), "UNPROTECTED");
+        let label = unmounted_drive_label("WD-18TB", None, Some(2592000), PromiseStatus::Unprotected);
         assert!(label.contains("last backup"), "missing 'last backup': {label}");
         assert!(label.contains("30d"), "missing age: {label}");
         assert!(
@@ -4168,7 +4174,7 @@ mod tests {
         // Voice-Contract-Rule-1 seed test: absent_duration_secs wins over
         // last_activity_age_secs; the right field drives the right label.
         let _color = color_guard(false);
-        let label = unmounted_drive_label("WD-18TB", Some(15 * 60), Some(7 * 86400), "PROTECTED");
+        let label = unmounted_drive_label("WD-18TB", Some(15 * 60), Some(7 * 86400), PromiseStatus::Protected);
         assert!(label.contains("15m"), "should render 15m: {label}");
         assert!(
             !label.contains("7d"),
@@ -4331,8 +4337,8 @@ mod tests {
             },
             TransitionEvent::PromiseRecovered {
                 subvolume: "htpc-home".to_string(),
-                from: "UNPROTECTED".to_string(),
-                to: "PROTECTED".to_string(),
+                from: PromiseStatus::Unprotected,
+                to: PromiseStatus::Protected,
             },
             TransitionEvent::AllSealed,
         ];

--- a/src/voice/sentinel.rs
+++ b/src/voice/sentinel.rs
@@ -6,6 +6,7 @@ use std::fmt::Write;
 
 use colored::Colorize;
 
+use crate::awareness::PromiseStatus;
 use crate::output::{OutputMode, SentinelStatusOutput};
 
 /// Render sentinel status output according to the given mode.
@@ -74,21 +75,13 @@ fn format_tick_description(tick_secs: u64, promise_states: &[crate::output::Sent
         format!("{tick_secs}s")
     };
 
-    let worst = promise_states
-        .iter()
-        .map(|p| p.status.as_str())
-        .min_by_key(|s| match *s {
-            "UNPROTECTED" => 0,
-            "AT RISK" => 1,
-            "PROTECTED" => 2,
-            _ => 0,
-        });
+    // `PromiseStatus`'s `Ord` is worst-to-best, so `.min()` yields the worst.
+    let worst = promise_states.iter().map(|p| p.status).min();
 
     let state_desc = match worst {
-        Some("PROTECTED") | None => "all promises held",
-        Some("AT RISK") => "promises at risk",
-        Some("UNPROTECTED") => "promises broken",
-        Some(_) => "assessing",
+        Some(PromiseStatus::Protected) | None => "all promises held",
+        Some(PromiseStatus::AtRisk) => "promises at risk",
+        Some(PromiseStatus::Unprotected) => "promises broken",
     };
 
     format!("{tick_str} — {state_desc}")

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -10,6 +10,7 @@ use std::fmt::Write;
 use colored::Colorize;
 
 use crate::advice::RedundancyAdvisoryKind;
+use crate::awareness::PromiseStatus;
 use crate::output::{ChainHealth, DefaultStatusOutput, OutputMode, StatusOutput};
 use crate::types::{ByteSize, DriveRole};
 
@@ -92,7 +93,7 @@ pub(super) fn render_summary_line(data: &StatusOutput, out: &mut String) {
     let safe_count = data
         .assessments
         .iter()
-        .filter(|a| a.status == "PROTECTED")
+        .filter(|a| a.status == PromiseStatus::Protected)
         .count();
     let has_health_issues = data.assessments.iter().any(|a| a.health != "healthy");
 
@@ -102,13 +103,13 @@ pub(super) fn render_summary_line(data: &StatusOutput, out: &mut String) {
         let exposed_names: Vec<&str> = data
             .assessments
             .iter()
-            .filter(|a| a.status == "UNPROTECTED")
+            .filter(|a| a.status == PromiseStatus::Unprotected)
             .map(|a| a.name.as_str())
             .collect();
         let waning_names: Vec<&str> = data
             .assessments
             .iter()
-            .filter(|a| a.status == "AT RISK")
+            .filter(|a| a.status == PromiseStatus::AtRisk)
             .map(|a| a.name.as_str())
             .collect();
         let mut parts = vec![format!("{} of {} sealed.", safe_count, total)];
@@ -188,7 +189,7 @@ pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
 
     // Show PROTECTION only when exposure conflicts with promise (sealed but degraded, waning, exposed)
     let show_protection = data.assessments.iter().any(|a| {
-        a.promise_level.is_some() && a.status != "PROTECTED"
+        a.promise_level.is_some() && a.status != PromiseStatus::Protected
     });
     // Only show HEALTH column when at least one subvolume is non-healthy
     let show_health = data.assessments.iter().any(|a| a.health != "healthy");
@@ -216,7 +217,7 @@ pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
     let mut rows: Vec<Vec<String>> = Vec::new();
     for assessment in &data.assessments {
         // Safety column — new vocabulary
-        let safety = exposure_label(&assessment.status);
+        let safety = exposure_label(assessment.status);
         let mut row = vec![safety];
 
         if show_health {

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -36,6 +36,7 @@
 
 #[cfg(test)]
 mod contract {
+    use crate::awareness::PromiseStatus;
     use crate::output::{BackupSummary, OutputMode, TransitionEvent};
     use crate::voice::test_fixtures::{
         color_guard, recommendations_doctor_output, test_backup_summary,
@@ -550,8 +551,8 @@ mod contract {
         let _color = color_guard(false);
         let s = backup_with_transitions(vec![TransitionEvent::PromiseRecovered {
             subvolume: "htpc-home".to_string(),
-            from: "UNPROTECTED".to_string(),
-            to: "PROTECTED".to_string(),
+            from: PromiseStatus::Unprotected,
+            to: PromiseStatus::Protected,
         }]);
         let output = render_backup_summary(&s, OutputMode::Interactive);
         // The recovered transition uses exposure vocabulary, not raw promise strings.
@@ -808,12 +809,12 @@ mod contract {
     fn all_sealed_status() -> crate::output::StatusOutput {
         let mut data = test_status_output();
         for a in &mut data.assessments {
-            a.status = "PROTECTED".to_string();
+            a.status = PromiseStatus::Protected;
             a.health = "healthy".to_string();
             a.health_reasons.clear();
-            a.local_status = "PROTECTED".to_string();
+            a.local_status = PromiseStatus::Protected;
             for e in a.external.iter_mut() {
-                e.status = "PROTECTED".to_string();
+                e.status = PromiseStatus::Protected;
                 e.mounted = true;
                 if e.snapshot_count.is_none() {
                     e.snapshot_count = Some(12);
@@ -863,7 +864,7 @@ mod contract {
     fn rule6_unprotected_row_emits_red_on_exposure_cell() {
         let _color = color_guard(true);
         let mut data = test_status_output();
-        data.assessments[1].status = "UNPROTECTED".to_string();
+        data.assessments[1].status = PromiseStatus::Unprotected;
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
             helpers::count_red(&output) >= 1,
@@ -890,7 +891,7 @@ mod contract {
     fn rule6_blocked_health_emits_red_only_on_health_cell() {
         let _color = color_guard(true);
         let mut data = test_status_output();
-        data.assessments[0].status = "PROTECTED".to_string();
+        data.assessments[0].status = PromiseStatus::Protected;
         data.assessments[0].health = "blocked".to_string();
         data.assessments[0].health_reasons = vec!["chain broken on WD-18TB".to_string()];
         let output = render_status(&data, OutputMode::Interactive);
@@ -918,7 +919,7 @@ mod contract {
         let mut data = test_status_output();
         // Promote the AT RISK assessment to UNPROTECTED so the exposure
         // label becomes "exposed" — earned-red territory.
-        data.assessments[1].status = "UNPROTECTED".to_string();
+        data.assessments[1].status = PromiseStatus::Unprotected;
         let output = render_status(&data, OutputMode::Interactive);
         let rows = helpers::data_rows_by_exposure(&output);
         let exposed = rows


### PR DESCRIPTION
## Summary

- Types all eight promise-status boundary fields (`status`, `local_status`, `worst_safety`, heartbeat `promise_status`, the sentinel state file, `doctor`/`backup --json`) as the `PromiseStatus` enum instead of `String` — the type system now enforces the closed state set end-to-end.
- Deletes the `notify::status_rank` / `voice::status_severity` re-derivation in favor of the enum's existing `Ord` (worst-to-best); also removes a manual `min_by_key` ranking in `voice/sentinel.rs` and a dropped lifetime on `DriveAggregate`.
- Unifies `PromiseStatus`'s serde form on SCREAMING (matching `Display`) via per-variant `rename` + a permanent legacy `snake_case` `alias`, making the glossary's "SCREAMING on every machine surface" rule literally true and resolving the latent NDJSON deviation.
- **No external contract change:** every write-form is byte-identical except the internal events-table payload (`at_risk` → `AT RISK`), read-compatible via the alias. Read-tolerance on the three `Deserialize` fields narrows to the closed set + aliases — benign because both persisted-file readers fail-open via `.ok()` (locked by new tests). No `schema_version` bump. Gated by an ADR-114 amendment (2026-05-29).
- Closes the "Status string fragility" known issue.

## Testing

- cargo clippy --all-targets -- -D warnings: pass (clean)
- cargo test: 1441 passed, 0 failed
- cargo build --release: pass
- Integration tests: not applicable (no btrfs/drive behavior changed)

New tests lock the contracts: SCREAMING round-trip + legacy-alias deserialization (`awareness.rs`), legacy `at_risk` event-row read via the normal event path (`state.rs`), and fail-open-to-`None` on out-of-set values for both the heartbeat and sentinel state-file readers (`heartbeat.rs`, `sentinel_runner.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)