### PR TITLE
feat: storage-critical truth source + doctor advisory (UPI 031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Storage-critical advisory in `urd doctor --thorough`** (UPI 031). Retires the
+  `storage_critical` stub for a pure structural rule: a subvolume is flagged when its
+  source sits on the host's root-filesystem pool (BTRFS pool UUID matches `/`'s), an
+  *enabled* subvolume entrusts `/` itself to Urd, *and* that pool is critically tight
+  now (free-ratio ≥ Pressure). The offending row gains a dimmed, stakes-not-action
+  advisory — pressure here threatens the host, not just retention — alongside (not
+  replacing) the existing retention-tightening suggestion, plus an additive
+  `storage_critical: true` field on recommendation rows (omitted-when-false; no JSON
+  schema bump). Distinct from momentary headroom pressure; behavior deferred to the
+  032/033 bundle (ADR-113 increment 2). No metric, heartbeat, on-disk, or config-schema
+  change.
+
 ## [0.21.2] - 2026-05-29
 
 ### Changed

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -248,7 +248,7 @@ runs in the backup hot path.
 | `outer-edge span` | The time span from the *outer* edge of a tier's window back to its inner edge — the only thing that changes total data cost as the shape changes. Slot density inside a window does not. |
 | `drift signal` | The rolling churn rate computed by `drift.rs` (UPI 030) from `drift_samples`. The input the recommendation engine projects cost against. |
 | `symmetric data-cost model` | ADR-115's claim: two shapes with the same outer-edge span over the same drift signal cost the same in retained data bytes, regardless of how many slots populate the interior. Metadata cost is separate and is not modelled by X1. |
-| `headroom` | Destination free-space context (`HeadroomContext`) used to scale the recommended shape. `HeadroomSeverity` is one of `Comfortable / Pressure / Critical`. Pressure and Critical produce a tightened companion shape under `HEADROOM_TIGHTEN_MULTIPLIER`. |
+| `headroom` | Destination free-space context (`HeadroomContext`) used to scale the recommended shape. `HeadroomSeverity` is one of `Healthy / Caution / Pressure / Critical` (recommendation.rs). The classifier emits `Healthy / Caution / Pressure`; Pressure produces a tightened companion shape under `HEADROOM_TIGHTEN_MULTIPLIER`. (`Critical` is dormant in production since UPI 031 — kept for the UPI 032/033 bundle.) |
 | `recommended shape` | The shape returned by `recommend_shape*()` — a `ResolvedGraduatedRetention`-shaped suggestion paired with a `CostProjection` and the `AdjustmentReason`s that explain why it differs from what the user has today. |
 
 Source: `recommendation.rs`, ADR-115.
@@ -279,6 +279,29 @@ subvol3-opptak  headroom: Pressure (12% free on WD-18TB)
 The suggested shape preserves the outer-edge span (365 days) while thinning the
 interior — same data cost, fewer pins to manage. The tightened shape shortens
 the outer edge in response to destination pressure; that does reduce data cost.
+
+### `storage_critical` (UPI 031)
+
+Distinct from `headroom`, which is a *momentary* "is this pool tight now?" signal,
+`storage_critical` is a **structural** property of where the data lives. A subvolume
+is storage-critical when **all three** hold:
+
+1. its source sits on the host's **root-filesystem pool** (the BTRFS pool UUID matches
+   `/`'s pool — caught even for a `/home`-only config whose pool mountpoints omit `/`);
+2. an **enabled** subvolume entrusts `/` itself to Urd (`source == "/"`); and
+3. that pool is **critically tight right now** (free-ratio ≥ `Pressure`, reusing
+   `recommendation::classify_free_ratio` — no new threshold).
+
+The point of the intersection is non-redundancy with headroom: only data that is *both*
+structurally fragile (pressure here threatens the **host**, not just retention) *and*
+genuinely tight is storage-critical. The rule lives in `storage_critical.rs` (pure); the
+doctor wiring resolves `/`'s pool UUID at the boundary. It surfaces as a dimmed,
+stakes-not-action advisory on the offending `urd doctor --thorough` row (and a
+`storage_critical: true` field, omitted-when-false in JSON). The **behavioral** half
+(ephemeral lifecycle, conservative intervals) is deferred to the UPI 032/033 bundle
+(ADR-113 increment 2).
+
+Source: `storage_critical.rs`, ADR-113.
 
 ## Cluster: Read-side query seams (ADR-102)
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -13,8 +13,7 @@ use crate::output::{
 };
 use crate::plan::{Observation, RealFileSystemState};
 use crate::recommendation::{
-    self, AdjustmentReason, HeadroomAwareRecommendation, HeadroomContext, HeadroomSeverity,
-    ShapeRole,
+    self, AdjustmentReason, HeadroomContext, HeadroomSeverity, ShapeRole,
 };
 use crate::pools::{self, PoolSpace};
 use crate::preflight;
@@ -369,12 +368,18 @@ fn build_doctor_recommendation_view(
         .collect();
     let since = now - window;
 
+    // UPI 031: resolve the BTRFS pool hosting "/" once (one `findmnt /`). Only
+    // `--thorough` reaches here; no autonomous/nightly consumer calls this.
+    let root_pool_uuid = pools::pool_uuid_for_path(std::path::Path::new("/"))
+        .ok()
+        .flatten();
+
     build_doctor_recommendation_view_inner(
         config,
         state_db,
         now,
         &pools_grouped,
-        storage_critical::is_storage_critical,
+        root_pool_uuid.as_deref(),
         |mp: &Path| pools::pool_space(mp).ok(),
         |uuid: &str| pools::metadata_utilization_ratio(uuid),
         |uuid: &str| {
@@ -401,7 +406,7 @@ fn build_doctor_recommendation_view_inner(
     state_db: Option<&StateDb>,
     now: chrono::NaiveDateTime,
     pools_grouped: &[pools::SourcePool],
-    is_critical: impl Fn(&str) -> bool,
+    root_pool_uuid: Option<&str>,
     pool_space_resolver: impl Fn(&Path) -> Option<PoolSpace>,
     metadata_resolver: impl Fn(&str) -> Option<f64>,
     pool_trend_resolver: impl Fn(&str) -> Option<i64>,
@@ -465,6 +470,14 @@ fn build_doctor_recommendation_view_inner(
         };
 
     let resolved = config.resolved_subvolumes();
+
+    // UPI 031 (M1): the storage-critical gate. `/` is entrusted to Urd only
+    // when an *enabled* subvolume has `source == "/"`. A disabled root subvol
+    // does not extend structural fragility to its enabled pool siblings.
+    let root_subvol_configured = resolved
+        .iter()
+        .any(|s| s.enabled && s.source.as_path() == std::path::Path::new("/"));
+
     let mut rows: Vec<DoctorRecommendationRow> = Vec::new();
 
     for sv in resolved.iter().filter(|sv| sv.enabled) {
@@ -535,7 +548,7 @@ fn build_doctor_recommendation_view_inner(
         let severity_local = recommendation::classify_headroom_severity(ctx_local);
         let severity_external = recommendation::classify_headroom_severity(ctx_external);
 
-        let mut local = match (local_rec, severity_local, local_current_shape) {
+        let local = match (local_rec, severity_local, local_current_shape) {
             (Some(r), _, _) => Some(r),
             (None, HeadroomSeverity::Pressure, Some(cur))
             | (None, HeadroomSeverity::Critical, Some(cur)) => {
@@ -550,7 +563,7 @@ fn build_doctor_recommendation_view_inner(
             }
             _ => None,
         };
-        let mut external = match (external_rec, severity_external, external_current_shape) {
+        let external = match (external_rec, severity_external, external_current_shape) {
             (Some(r), _, _) => Some(r),
             (None, HeadroomSeverity::Pressure, Some(cur))
             | (None, HeadroomSeverity::Critical, Some(cur)) => {
@@ -570,47 +583,27 @@ fn build_doctor_recommendation_view_inner(
             _ => None,
         };
 
-        // R5: Critical injection post-classification. Clear `adjusted`
-        // AND `adjusted_cost` in lockstep.
-        let critical = is_critical(&sv.name);
-        if critical {
-            let override_critical = |h: &mut HeadroomAwareRecommendation| {
-                h.severity = HeadroomSeverity::Critical;
-                h.reason = Some(AdjustmentReason::StorageCritical);
-                h.adjusted = None;
-                h.adjusted_cost = None;
-            };
-            if let Some(ref mut h) = local {
-                override_critical(h);
-            }
-            if let Some(ref mut h) = external {
-                override_critical(h);
-            }
-            // Cold-churn-Healthy-headroom-but-Critical fallback: synthesize
-            // each role that's actually used (Some current_shape).
-            if local.is_none() && external.is_none() {
-                if let Some(cur) = local_current_shape {
-                    local = Some(recommendation::headroom_aware_pointer_only(
-                        &cur,
-                        ShapeRole::Local,
-                        HeadroomSeverity::Critical,
-                        AdjustmentReason::StorageCritical,
-                    ));
-                }
-                if let Some(cur) = external_current_shape {
-                    external = Some(recommendation::headroom_aware_pointer_only(
-                        &cur,
-                        ShapeRole::External,
-                        HeadroomSeverity::Critical,
-                        AdjustmentReason::StorageCritical,
-                    ));
-                }
-            }
-        }
-
         if local.is_none() && external.is_none() {
             continue;
         }
+
+        // UPI 031: storage-critical is a pool-level structural fact, computed
+        // once per subvolume (role-agnostic). It reads the SOURCE free-ratio
+        // only — deliberately not the combined `severity_*`, which folds in
+        // trend and destination-metadata signals. The pure rule owns the UUID
+        // comparison and the `root_subvol_configured` gate.
+        let source_free_ratio_severity = recommendation::classify_free_ratio(
+            source_space.map(|s| s.free_bytes),
+            source_space.map(|s| s.capacity_bytes),
+        );
+        let subvol_pool_uuid = subvol_pool.get(&sv.name).map(|(_, uuid)| uuid.as_str());
+        let storage_critical =
+            storage_critical::is_storage_critical(storage_critical::StorageCriticalInput {
+                subvol_pool_uuid,
+                root_pool_uuid,
+                root_subvol_configured,
+                source_free_ratio_severity,
+            });
 
         let note = local
             .as_ref()
@@ -627,6 +620,7 @@ fn build_doctor_recommendation_view_inner(
             external,
             note,
             was_named_level,
+            storage_critical,
         });
     }
 
@@ -894,7 +888,7 @@ source = "/data/docs"
             state_db,
             now,
             &[],
-            |_| false,
+            None,
             |_| None,
             |_| None,
             |_| None,
@@ -1255,6 +1249,101 @@ source = "/data/cold"
         }
     }
 
+    /// UPI 031: a config with a single enabled `root` subvolume whose
+    /// `source = "/"`. Defaults supply Graduated local retention so the row
+    /// reaches the synth path under Pressure.
+    fn root_cfg() -> Config {
+        let toml_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-doctor-031/urd.db"
+metrics_file = "/tmp/urd-doctor-031/backup.prom"
+log_dir = "/tmp/urd-doctor-031"
+heartbeat_file = "/tmp/urd-doctor-031/heartbeat.json"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["root"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+daily = 60
+weekly = 52
+monthly = 24
+[defaults.external_retention]
+hourly = 0
+daily = 60
+weekly = 52
+monthly = 24
+
+[[subvolumes]]
+name = "root"
+short_name = "root"
+source = "/"
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    /// UPI 031 (M1): a disabled `source = "/"` subvolume alongside an enabled
+    /// sibling `data` on the same pool. Verifies a disabled root does not
+    /// entrust `/`, so the sibling stays unflagged.
+    fn root_disabled_with_sibling_cfg() -> Config {
+        let toml_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-doctor-031b/urd.db"
+metrics_file = "/tmp/urd-doctor-031b/backup.prom"
+log_dir = "/tmp/urd-doctor-031b"
+heartbeat_file = "/tmp/urd-doctor-031b/heartbeat.json"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["root", "data"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+daily = 60
+weekly = 52
+monthly = 24
+[defaults.external_retention]
+hourly = 0
+daily = 60
+weekly = 52
+monthly = 24
+
+[[subvolumes]]
+name = "root"
+short_name = "root"
+source = "/"
+enabled = false
+
+[[subvolumes]]
+name = "data"
+short_name = "data"
+source = "/data"
+enabled = true
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    /// Tight PoolSpace resolver (~10% free → Pressure), ignoring mountpoint.
+    fn tight_pool_resolver(_mp: &Path) -> Option<PoolSpace> {
+        Some(PoolSpace {
+            free_bytes: 100_000_000_000,
+            capacity_bytes: 1_000_000_000_000,
+        })
+    }
+
     #[test]
     fn silent_healthy_row_omitted() {
         // Cold churn → cold engine clamps shape to max == matches default
@@ -1270,7 +1359,7 @@ source = "/data/cold"
             Some(&db),
             now,
             &pools,
-            |_| false,
+            None,
             |_mp| Some(PoolSpace { free_bytes: 500_000_000_000, capacity_bytes: 1_000_000_000_000 }),
             |_uuid| None,
             |_uuid| None,
@@ -1295,7 +1384,7 @@ source = "/data/cold"
             Some(&db),
             now,
             &pools,
-            |_| false,
+            None,
             |_mp| Some(PoolSpace { free_bytes: 200_000_000_000, capacity_bytes: 1_000_000_000_000 }),
             |_uuid| None,
             |_uuid| None,
@@ -1320,7 +1409,7 @@ source = "/data/cold"
             Some(&db),
             now,
             &pools,
-            |_| false,
+            None,
             |_mp| Some(PoolSpace { free_bytes: 100_000_000_000, capacity_bytes: 1_000_000_000_000 }),
             |_uuid| None,
             |_uuid| None,
@@ -1353,7 +1442,7 @@ source = "/data/cold"
             Some(&db),
             now,
             &pools,
-            |_| false,
+            None,
             // 20% free → Caution.
             |_mp| Some(PoolSpace { free_bytes: 200_000_000_000, capacity_bytes: 1_000_000_000_000 }),
             |_uuid| None,
@@ -1366,9 +1455,47 @@ source = "/data/cold"
     }
 
     #[test]
-    fn cold_subvolume_critical_synthesizes_row() {
-        // Cold subvol, Healthy headroom, but is_critical fires →
-        // Critical synth row appears.
+    fn storage_critical_flag_set_and_row_present() {
+        // M2: enabled `source = "/"` subvol on the root pool + tight pool →
+        // the row IS present (fallback-deletion invariant lock), the flag is
+        // set, and severity stays Pressure (NOT forced Critical).
+        let config = root_cfg();
+        let db = StateDb::open_memory().unwrap();
+        let now = now_fixed();
+        // No churn seeded → synth path; Pressure from the tight pool.
+        let pools = vec![pool_for_subvols(&["root"])];
+        let view = build_doctor_recommendation_view_inner(
+            &config,
+            Some(&db),
+            now,
+            &pools,
+            Some("pool-uuid-test"),
+            tight_pool_resolver,
+            |_uuid| None,
+            |_uuid| None,
+        );
+        let row = view
+            .rows
+            .iter()
+            .find(|r| r.name == "root")
+            .expect("storage_critical row must be present");
+        assert!(row.storage_critical, "flag must be set");
+        let local = row.local.as_ref().expect("local synth");
+        assert_eq!(
+            local.severity,
+            HeadroomSeverity::Pressure,
+            "severity stays Pressure, not forced Critical"
+        );
+        assert!(matches!(
+            local.reason,
+            Some(AdjustmentReason::SourcePoolLow { .. })
+        ));
+    }
+
+    #[test]
+    fn storage_critical_flag_clear_when_no_root_subvol_configured() {
+        // Gate off: no subvol has `source = "/"`. The cold subvol still
+        // synthesizes a Pressure row, but the flag is clear.
         let config = upi044_cfg_with_pool();
         let db = StateDb::open_memory().unwrap();
         let now = now_fixed();
@@ -1378,75 +1505,142 @@ source = "/data/cold"
             Some(&db),
             now,
             &pools,
-            |name| name == "cold",
-            |_mp| Some(PoolSpace { free_bytes: 800_000_000_000, capacity_bytes: 1_000_000_000_000 }),
+            Some("pool-uuid-test"),
+            tight_pool_resolver,
             |_uuid| None,
             |_uuid| None,
         );
-        let cold = view
+        let row = view
             .rows
             .iter()
             .find(|r| r.name == "cold")
-            .expect("Critical synth row");
-        let local = cold.local.as_ref().expect("Critical synth local");
-        assert_eq!(local.severity, HeadroomSeverity::Critical);
-        assert!(matches!(local.reason, Some(AdjustmentReason::StorageCritical)));
-        assert!(local.adjusted.is_none());
-        assert!(local.adjusted_cost.is_none());
+            .expect("cold Pressure synth row present");
+        assert!(
+            !row.storage_critical,
+            "no source=\"/\" subvol → flag clear"
+        );
     }
 
     #[test]
-    fn critical_injection_sets_both_role_severities() {
-        // Both local and external rows exist; is_critical flips both.
-        let config = upi044_cfg_with_pool();
+    fn storage_critical_flag_clear_when_root_subvol_disabled() {
+        // M1: `root` (source "/") is disabled, so it does not entrust "/".
+        // The enabled sibling `data` on the same root pool stays unflagged.
+        let config = root_disabled_with_sibling_cfg();
         let db = StateDb::open_memory().unwrap();
         let now = now_fixed();
-        // Hot churn so both roles produce a recommendation.
-        seed_incremental(&db, "hot", now - chrono::Duration::hours(12), 2_700_000_000);
-        let pools = vec![pool_for_subvols(&["hot"])];
+        let pools = vec![pool_for_subvols(&["root", "data"])];
         let view = build_doctor_recommendation_view_inner(
             &config,
             Some(&db),
             now,
             &pools,
-            |name| name == "hot",
-            |_| None,
-            |_| None,
-            |_| None,
+            Some("pool-uuid-test"),
+            tight_pool_resolver,
+            |_uuid| None,
+            |_uuid| None,
         );
-        let hot = view.rows.iter().find(|r| r.name == "hot").expect("hot row");
-        let local = hot.local.as_ref().expect("local");
-        let external = hot.external.as_ref().expect("external");
-        assert_eq!(local.severity, HeadroomSeverity::Critical);
-        assert_eq!(external.severity, HeadroomSeverity::Critical);
+        // The disabled root produces no row at all.
+        assert!(
+            !view.rows.iter().any(|r| r.name == "root"),
+            "disabled subvol is skipped"
+        );
+        let data = view
+            .rows
+            .iter()
+            .find(|r| r.name == "data")
+            .expect("enabled sibling row present");
+        assert!(
+            !data.storage_critical,
+            "disabled root must not flag an enabled sibling"
+        );
     }
 
     #[test]
-    fn critical_injection_clears_pressure_adjusted_and_reason() {
-        // R5: Critical injection clears `adjusted` AND `adjusted_cost`
-        // in lockstep (no orphaned adjusted_cost left behind).
-        let config = upi044_cfg_with_pool();
+    fn storage_critical_flag_clear_on_pool_uuid_mismatch() {
+        // The subvol's pool UUID differs from `/`'s pool → not on the root
+        // pool → flag clear (row still present from Pressure).
+        let config = root_cfg();
         let db = StateDb::open_memory().unwrap();
         let now = now_fixed();
-        seed_incremental(&db, "hot", now - chrono::Duration::hours(12), 2_700_000_000);
-        let pools = vec![pool_for_subvols(&["hot"])];
+        let pools = vec![pool_for_subvols(&["root"])]; // uuid "pool-uuid-test"
         let view = build_doctor_recommendation_view_inner(
             &config,
             Some(&db),
             now,
             &pools,
-            |name| name == "hot",
-            // 10% free → Pressure (would normally tighten).
-            |_mp| Some(PoolSpace { free_bytes: 100_000_000_000, capacity_bytes: 1_000_000_000_000 }),
-            |_| None,
-            |_| None,
+            Some("a-different-pool-uuid"),
+            tight_pool_resolver,
+            |_uuid| None,
+            |_uuid| None,
         );
-        let hot = view.rows.iter().find(|r| r.name == "hot").expect("hot row");
-        let local = hot.local.as_ref().expect("local");
-        assert_eq!(local.severity, HeadroomSeverity::Critical);
-        assert!(matches!(local.reason, Some(AdjustmentReason::StorageCritical)));
-        assert!(local.adjusted.is_none(), "Critical clears adjusted");
-        assert!(local.adjusted_cost.is_none(), "Critical clears adjusted_cost");
+        let row = view
+            .rows
+            .iter()
+            .find(|r| r.name == "root")
+            .expect("row present");
+        assert!(!row.storage_critical, "UUID mismatch → flag clear");
+    }
+
+    #[test]
+    fn storage_critical_flag_clear_when_root_pool_uuid_unresolved() {
+        // `findmnt /` failed → root_pool_uuid None → detection disabled.
+        let config = root_cfg();
+        let db = StateDb::open_memory().unwrap();
+        let now = now_fixed();
+        let pools = vec![pool_for_subvols(&["root"])];
+        let view = build_doctor_recommendation_view_inner(
+            &config,
+            Some(&db),
+            now,
+            &pools,
+            None,
+            tight_pool_resolver,
+            |_uuid| None,
+            |_uuid| None,
+        );
+        let row = view
+            .rows
+            .iter()
+            .find(|r| r.name == "root")
+            .expect("row present");
+        assert!(!row.storage_critical, "unresolved root pool → flag clear");
+    }
+
+    #[test]
+    fn storage_critical_preserves_tightened_adjusted_shape() {
+        // Inverse of the old `critical_injection_clears_*`: a storage_critical
+        // Pressure row keeps its tightened `adjusted`/`adjusted_cost` (Branch
+        // D) — the flag is purely additive, it does not force Critical or
+        // clear the role recommendation.
+        let config = root_cfg();
+        let db = StateDb::open_memory().unwrap();
+        let now = now_fixed();
+        // Hot churn so the engine produces a tightenable shape.
+        seed_incremental(&db, "root", now - chrono::Duration::hours(12), 2_700_000_000);
+        let pools = vec![pool_for_subvols(&["root"])];
+        let view = build_doctor_recommendation_view_inner(
+            &config,
+            Some(&db),
+            now,
+            &pools,
+            Some("pool-uuid-test"),
+            tight_pool_resolver,
+            |_uuid| None,
+            |_uuid| None,
+        );
+        let row = view
+            .rows
+            .iter()
+            .find(|r| r.name == "root")
+            .expect("row present");
+        assert!(row.storage_critical, "flag set");
+        let local = row.local.as_ref().expect("local");
+        assert_eq!(local.severity, HeadroomSeverity::Pressure);
+        assert!(local.adjusted.is_some(), "tightened shape preserved");
+        assert!(
+            local.adjusted_cost.is_some(),
+            "adjusted_cost preserved in lockstep"
+        );
     }
 
     #[test]
@@ -1493,6 +1687,7 @@ source = "/data/cold"
             external: Some(h),
             note: None,
             was_named_level: None,
+            storage_critical: false,
         };
         // current=200, adjusted=25 → recovery = 175 GB (not 150 GB from suggested).
         assert_eq!(recovery_bytes(&row), 175_000_000_000);
@@ -1538,75 +1733,20 @@ source = "/data/cold"
             external: None,
             note: None,
             was_named_level: None,
+            storage_critical: false,
         };
         assert_eq!(recovery_bytes(&row), 150_000_000_000);
     }
 
     #[test]
-    fn headroom_ctx_external_carries_max_drive_label() {
-        // R4: with two mounted destinations at different metadata ratios,
-        // the External row's reason embeds the max-ratio drive's label.
-        // We can verify this indirectly: configure two drives with
-        // metadata 0.80 and 0.95 via the metadata_resolver, and assert
-        // the row's reason matches "Drive-B" (the max).
-        let toml_str = r#"
-[[drives]]
-label = "Drive-A"
-uuid = "uuid-a"
-mount_path = "/mnt/a"
-snapshot_root = "/mnt/a/snap"
-role = "primary"
-
-[[drives]]
-label = "Drive-B"
-uuid = "uuid-b"
-mount_path = "/mnt/b"
-snapshot_root = "/mnt/b/snap"
-role = "primary"
-
-[general]
-state_db = "/tmp/urd-doctor-r4/urd.db"
-metrics_file = "/tmp/urd-doctor-r4/backup.prom"
-log_dir = "/tmp/urd-doctor-r4"
-heartbeat_file = "/tmp/urd-doctor-r4/heartbeat.json"
-
-[local_snapshots]
-roots = [
-  { path = "/snap", subvolumes = ["hot"] }
-]
-
-[defaults]
-snapshot_interval = "1h"
-send_interval = "4h"
-[defaults.local_retention]
-hourly = 24
-daily = 60
-weekly = 52
-monthly = 24
-[defaults.external_retention]
-hourly = 0
-daily = 60
-weekly = 52
-monthly = 24
-
-[[subvolumes]]
-name = "hot"
-short_name = "hot"
-source = "/data/hot"
-"#;
-        let config: Config = toml::from_str(toml_str).unwrap();
-        // Both drives "Available" requires mount + uuid match. Drives in
-        // tests aren't mounted, so drive_availability returns NotMounted
-        // and destination_metadata is empty. We can't easily test the
-        // metadata path without a more invasive helper, so we exercise
-        // the resolver wiring via an external_rec that picks up the
-        // headroom signal from the pool free ratio instead. This test
-        // therefore validates the contract: when External severity
-        // fires from metadata signals, the reason carries the label.
-        //
-        // For the actual label-resolution test, we drive the same path
-        // through cold-churn-Critical synthesis where the External role
-        // is used:
+    fn external_role_synthesizes_pressure_from_source_pool() {
+        // The External role synthesizes a Pressure row from the source-pool
+        // free ratio when send is enabled and churn is cold. (Adapted from
+        // the former `headroom_ctx_external_carries_max_drive_label`, which
+        // leaned on the now-deleted Critical-injection closure.) A tight pool
+        // (10% free → Pressure) synthesizes an External row because send is
+        // enabled; no churn, no metadata signal.
+        let config = upi044_cfg_with_pool();
         let db = StateDb::open_memory().unwrap();
         let now = now_fixed();
         let pools = vec![pool_for_subvols(&["hot"])];
@@ -1615,13 +1755,17 @@ source = "/data/hot"
             Some(&db),
             now,
             &pools,
-            |name| name == "hot",
-            |_| None,
+            None,
+            tight_pool_resolver,
             |_| None,
             |_| None,
         );
         let hot = view.rows.iter().find(|r| r.name == "hot").expect("hot row");
-        let external = hot.external.as_ref().expect("external Critical synth");
-        assert_eq!(external.severity, HeadroomSeverity::Critical);
+        let external = hot.external.as_ref().expect("external Pressure synth");
+        assert_eq!(external.severity, HeadroomSeverity::Pressure);
+        assert!(matches!(
+            external.reason,
+            Some(AdjustmentReason::SourcePoolLow { .. })
+        ));
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -525,6 +525,12 @@ pub struct DoctorRecommendationRow {
     /// gate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub was_named_level: Option<crate::types::ProtectionLevel>,
+    /// UPI 031: the subvolume's source is on the host's root-filesystem pool
+    /// (entrusted to Urd) and that pool is critically tight. A structural
+    /// property distinct from momentary headroom pressure. Renders a dimmed
+    /// advisory; omitted from JSON when false (additive, no schema bump).
+    #[serde(skip_serializing_if = "is_false")]
+    pub storage_critical: bool,
 }
 
 // ── Churn (UPI 030) ────────────────────────────────────────────────────
@@ -2281,6 +2287,7 @@ source = "/data/sv2"
             external: Some(pressure),
             note: None,
             was_named_level: None,
+            storage_critical: false,
         };
         let value = serde_json::to_value(&row).unwrap();
         assert_eq!(
@@ -2340,6 +2347,7 @@ source = "/data/sv2"
             external: None,
             note: None,
             was_named_level: None,
+            storage_critical: false,
         };
         let json = serde_json::to_string(&row).unwrap();
         assert!(!json.contains("\"adjusted\""), "adjusted omitted when None: {json}");

--- a/src/recommendation.rs
+++ b/src/recommendation.rs
@@ -55,15 +55,24 @@ pub struct HeadroomContext {
 
 /// Per-(subvolume, role) headroom severity (UPI 044). Ordering is
 /// load-bearing: `.iter().max()` yields the dominant tier when multiple
-/// signals fire. Critical is **not** in the classifier's output domain
-/// — doctor.rs injects it externally based on
-/// `storage_critical::is_storage_critical`.
+/// signals fire. Critical is **not** in the classifier's output domain.
+///
+/// UPI 031 retired the doctor-side Critical *injection* (the old
+/// force-Critical path), so as of this UPI nothing in production constructs
+/// `Critical` — the tier, the voice R9 pointer path, and
+/// `headroom_aware_pointer_only(.., Critical, ..)` are reachable only from
+/// tests. This is the intentional hook for the behavioral bundle (UPIs
+/// 032/033), time-boxed to that horizon; if the bundle slips, reconsider
+/// whether the tier should be deleted rather than maintained unused.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HeadroomSeverity {
     Healthy,
     Caution,
     Pressure,
+    /// Dormant in production since UPI 031 (see the type doc). Kept alive for
+    /// the UPI 032/033 bundle and exercised by tests.
+    #[allow(dead_code)]
     Critical,
 }
 
@@ -89,7 +98,14 @@ pub fn classify_headroom_severity(ctx: HeadroomContext) -> HeadroomSeverity {
         .unwrap_or(HeadroomSeverity::Healthy)
 }
 
-fn classify_free_ratio(free: Option<u64>, capacity: Option<u64>) -> HeadroomSeverity {
+/// Classify pool tightness from free/capacity by free-ratio alone.
+///
+/// Reused by the storage-critical wiring (UPI 031) as the free-ratio-only
+/// tightness gate (Branch E) — no trend or metadata signal, no new constant.
+/// Unmeasurable inputs (either `None`, zero capacity, non-finite ratio) fail
+/// toward `Healthy`.
+#[must_use]
+pub fn classify_free_ratio(free: Option<u64>, capacity: Option<u64>) -> HeadroomSeverity {
     let (Some(free), Some(capacity)) = (free, capacity) else {
         return HeadroomSeverity::Healthy;
     };
@@ -1107,6 +1123,31 @@ mod tests {
         // capacity=0 → free/capacity not meaningful → Healthy.
         let ctx = ctx_free(0, 0);
         assert_eq!(classify_headroom_severity(ctx), HeadroomSeverity::Healthy);
+    }
+
+    #[test]
+    fn classify_free_ratio_pub_threshold() {
+        // Direct check of the now-public free-ratio gate (UPI 031 reuse).
+        assert_eq!(
+            classify_free_ratio(Some(10), Some(100)),
+            HeadroomSeverity::Pressure,
+            "10% free → Pressure"
+        );
+        assert_eq!(
+            classify_free_ratio(Some(20), Some(100)),
+            HeadroomSeverity::Caution,
+            "20% free → Caution"
+        );
+        assert_eq!(
+            classify_free_ratio(Some(50), Some(100)),
+            HeadroomSeverity::Healthy,
+            "50% free → Healthy"
+        );
+        assert_eq!(
+            classify_free_ratio(None, Some(100)),
+            HeadroomSeverity::Healthy,
+            "unmeasurable free → Healthy"
+        );
     }
 
     #[test]

--- a/src/storage_critical.rs
+++ b/src/storage_critical.rs
@@ -1,32 +1,159 @@
-//! Storage-critical predicate (ADR-113 Layer 1 hook, UPI 044 → UPI 031).
+//! Storage-critical predicate (ADR-113 Layer 1, UPI 044 stub → UPI 031 rule).
 //!
-//! UPI 044 ships this as a stub returning `false`. UPI 031 replaces the
-//! body with its chosen truth source. Doctor injects this as a closure
-//! into `build_doctor_recommendation_view_inner` for testability.
+//! UPI 044 shipped this as a stub returning `false`. UPI 031 retires the stub
+//! and replaces it with a **pure structural rule**: a subvolume is
+//! storage-critical when its source lives on the host's root-filesystem pool
+//! (UUID match), an *enabled* subvolume entrusts `/` itself to Urd, *and* that
+//! pool is genuinely tight right now (free-ratio ≥ Pressure).
 //!
-//! Signature-change note: if UPI 031 needs additional inputs (state_db,
-//! sentinel state, event log, per-destination granularity, etc.), the
-//! closure call site in `src/commands/doctor.rs` must be updated
-//! simultaneously. Grep for `is_critical(` and `is_storage_critical` in
-//! `src/commands/doctor.rs` to find all call sites; the closure injection
-//! pattern means both the resolver wiring AND the test closures need
-//! updating in lockstep.
+//! This is distinct from momentary headroom pressure: headroom answers "is this
+//! pool tight now?"; `storage_critical` adds the structural dimension — pressure
+//! here threatens the *host*, not just retention. Only the intersection
+//! (structurally fragile **and** tight) is critical.
+//!
+//! Purity (ADR-108): this module takes resolved inputs and performs no I/O. The
+//! doctor wiring (`src/commands/doctor.rs`) resolves the one I/O-bound input
+//! (`root_pool_uuid`, one `findmnt /`) at the boundary and feeds it in; the
+//! per-subvolume pool UUID, the `root_subvol_configured` gate, and the
+//! free-ratio severity are all computed there from already-available data.
+//!
+//! The behavioral half (ephemeral lifecycle, conservative intervals) is
+//! deliberately *not* shipped here — per ADR-113's increment-2 sequencing it
+//! belongs with UPIs 032/033 where the safety scaffolding lands.
 
+use crate::recommendation::HeadroomSeverity;
+
+/// Resolved inputs to the storage-critical structural rule (UPI 031). All
+/// fields are pre-resolved by the doctor wiring; the rule itself is pure.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct StorageCriticalInput<'a> {
+    /// The BTRFS pool UUID hosting this subvolume's source, if resolvable.
+    pub subvol_pool_uuid: Option<&'a str>,
+    /// The BTRFS pool UUID hosting `/`, if resolvable.
+    pub root_pool_uuid: Option<&'a str>,
+    /// True when an **enabled** configured subvolume has `source == "/"`,
+    /// i.e. the user has actively entrusted the root filesystem to Urd.
+    pub root_subvol_configured: bool,
+    /// Tightness of the source pool by free-ratio only (Branch E): reuses
+    /// `recommendation::classify_free_ratio`, no trend/metadata, no new
+    /// constant. `Pressure` (or the dormant `Critical`) means genuinely tight.
+    pub source_free_ratio_severity: HeadroomSeverity,
+}
+
+/// True iff the subvolume is storage-critical under the structural rule.
+///
+/// ```text
+/// storage_critical =
+///       subvol_pool_uuid == root_pool_uuid     // on the pool hosting "/"
+///   AND root_subvol_configured                  // an ENABLED subvol has source == "/"
+///   AND source_free_ratio_severity >= Pressure  // genuinely tight NOW (<15% free)
+/// ```
+///
+/// Fails toward *not*-critical for every unmeasurable input (unresolved pool
+/// UUID, unmeasurable free-ratio → `Healthy`) — this is an advisory surface.
 #[must_use]
-pub fn is_storage_critical(subvolume: &str) -> bool {
-    let _ = subvolume;
-    false
+pub fn is_storage_critical(input: StorageCriticalInput<'_>) -> bool {
+    let on_root_pool = matches!(
+        (input.subvol_pool_uuid, input.root_pool_uuid),
+        (Some(a), Some(b)) if a == b
+    );
+    on_root_pool
+        && input.root_subvol_configured
+        && input.source_free_ratio_severity >= HeadroomSeverity::Pressure
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Build an input with the structural gate satisfied; callers override
+    /// the field under test.
+    fn on_root(severity: HeadroomSeverity) -> StorageCriticalInput<'static> {
+        StorageCriticalInput {
+            subvol_pool_uuid: Some("root-pool"),
+            root_pool_uuid: Some("root-pool"),
+            root_subvol_configured: true,
+            source_free_ratio_severity: severity,
+        }
+    }
+
     #[test]
-    fn stub_returns_false_for_any_subvolume_name() {
-        // Minimal regression guard so UPI 031's replacement is intentional.
-        assert!(!is_storage_critical(""));
-        assert!(!is_storage_critical("containers"));
-        assert!(!is_storage_critical("htpc-root"));
+    fn root_pool_match_configured_and_pressure_is_critical() {
+        assert!(is_storage_critical(on_root(HeadroomSeverity::Pressure)));
+    }
+
+    #[test]
+    fn htpc_root_archetype_is_critical() {
+        // Source `/` on a tight root NVMe (~6% free → Pressure), `/` entrusted.
+        let input = StorageCriticalInput {
+            subvol_pool_uuid: Some("nvme-root"),
+            root_pool_uuid: Some("nvme-root"),
+            root_subvol_configured: true,
+            source_free_ratio_severity: HeadroomSeverity::Pressure,
+        };
+        assert!(is_storage_critical(input));
+    }
+
+    #[test]
+    fn caution_is_not_critical() {
+        // Branch E: only Pressure+ qualifies; Caution is below the gate.
+        assert!(!is_storage_critical(on_root(HeadroomSeverity::Caution)));
+    }
+
+    #[test]
+    fn healthy_is_not_critical() {
+        assert!(!is_storage_critical(on_root(HeadroomSeverity::Healthy)));
+    }
+
+    #[test]
+    fn critical_severity_is_critical() {
+        // Defensive: `>=` accepts the dormant Critical tier.
+        assert!(is_storage_critical(on_root(HeadroomSeverity::Critical)));
+    }
+
+    #[test]
+    fn not_configured_is_not_critical() {
+        // Gate: no enabled `source == "/"` subvolume entrusts `/`.
+        let mut input = on_root(HeadroomSeverity::Pressure);
+        input.root_subvol_configured = false;
+        assert!(!is_storage_critical(input));
+    }
+
+    #[test]
+    fn uuid_mismatch_is_not_critical() {
+        // Tight + configured, but this subvol is on a different pool.
+        let input = StorageCriticalInput {
+            subvol_pool_uuid: Some("other-pool"),
+            root_pool_uuid: Some("root-pool"),
+            root_subvol_configured: true,
+            source_free_ratio_severity: HeadroomSeverity::Pressure,
+        };
+        assert!(!is_storage_critical(input));
+    }
+
+    #[test]
+    fn subvol_pool_uuid_none_is_not_critical() {
+        let mut input = on_root(HeadroomSeverity::Pressure);
+        input.subvol_pool_uuid = None;
+        assert!(!is_storage_critical(input));
+    }
+
+    #[test]
+    fn root_pool_uuid_none_is_not_critical() {
+        // Root not btrfs / unresolved findmnt → no structural claim.
+        let mut input = on_root(HeadroomSeverity::Pressure);
+        input.root_pool_uuid = None;
+        assert!(!is_storage_critical(input));
+    }
+
+    #[test]
+    fn both_uuids_none_is_not_critical() {
+        let input = StorageCriticalInput {
+            subvol_pool_uuid: None,
+            root_pool_uuid: None,
+            root_subvol_configured: true,
+            source_free_ratio_severity: HeadroomSeverity::Pressure,
+        };
+        assert!(!is_storage_critical(input));
     }
 }

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -518,6 +518,22 @@ pub(super) fn format_recommendation_row(row: &crate::output::DoctorRecommendatio
     if let Some(ref rec) = row.external {
         role_line("external:", rec);
     }
+    // UPI 031: row-level storage-critical advisory. STAKES, NOT ACTION — it
+    // names the structural fact (the source lives on the host root
+    // filesystem, so pressure here threatens the host, not just retention)
+    // and carries no action verb. The action ("expand storage / reduce
+    // subvolumes") stays on the role reason line, so this complements rather
+    // than duplicates the at-MIN tail. Never reached when severity is
+    // Critical (the R9 pointer path returns first).
+    if row.storage_critical {
+        writeln!(
+            out,
+            "      {}",
+            "storage critical — source is on the host root filesystem; pressure here risks the host itself"
+                .dimmed()
+        )
+        .ok();
+    }
     if matches!(row.note, Some(crate::recommendation::RecommendationNote::BurstyPattern)) {
         writeln!(out, "      {}", "bursty pattern — frequent full sends".dimmed()).ok();
     }

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -5185,6 +5185,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5224,6 +5225,7 @@ mod tests {
                 )),
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5253,6 +5255,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5283,6 +5286,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5314,6 +5318,7 @@ mod tests {
                 )),
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let days_out = render_doctor(
@@ -5340,6 +5345,7 @@ mod tests {
                 )),
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let weeks_out = render_doctor(
@@ -5366,6 +5372,7 @@ mod tests {
                 )),
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let years_out = render_doctor(
@@ -5396,6 +5403,7 @@ mod tests {
                 external: None,
                 note: Some(crate::recommendation::RecommendationNote::BurstyPattern),
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5425,6 +5433,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: Some(crate::types::ProtectionLevel::Sheltered),
+                storage_critical: false,
             }],
         };
         let with_level = render_doctor(
@@ -5452,6 +5461,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let no_level = render_doctor(
@@ -5481,6 +5491,7 @@ mod tests {
                 external: None,
                 note: Some(crate::recommendation::RecommendationNote::BurstyPattern),
                 was_named_level: Some(crate::types::ProtectionLevel::Sheltered),
+                storage_critical: false,
             }],
         };
         let output = render_doctor(&recommendations_doctor_output(view), OutputMode::Daemon);
@@ -5600,6 +5611,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5630,6 +5642,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5663,6 +5676,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5696,6 +5710,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5732,6 +5747,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5763,6 +5779,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5793,6 +5810,7 @@ mod tests {
                 external: None,
                 note: Some(crate::recommendation::RecommendationNote::BurstyPattern),
                 was_named_level: Some(crate::types::ProtectionLevel::Sheltered),
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5840,6 +5858,7 @@ mod tests {
                 external: Some(external_pressure),
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5869,6 +5888,7 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5894,11 +5914,159 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
+                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
         assert!(out.contains("storage critical"), "pointer line missing: {out}");
         assert!(!out.contains("daily="), "no shape: {out}");
+    }
+
+    // ── UPI 031 — storage-critical advisory ─────────────────────────
+
+    #[test]
+    fn storage_critical_advisory_rendered_and_complements_shape() {
+        // A tightenable Pressure row that is also storage_critical renders the
+        // tightened shape, the tightening reason, AND the host-stakes advisory
+        // — the advisory is purely additive (stakes, not action).
+        let _color = color_guard(false);
+        let h = ha_rec(
+            crate::recommendation::ShapeRole::Local,
+            shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+            shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0),
+            200_000_000_000,
+            50_000_000_000,
+            crate::recommendation::HeadroomSeverity::Pressure,
+            Some(crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.10 }),
+            Some(shape(16, 42, 36, crate::types::MonthlyCount::Count(16), 0)),
+            Some(25_000_000_000),
+        );
+        let view = crate::output::DoctorRecommendationView {
+            header: "h".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "root".to_string(),
+                local: Some(h),
+                external: None,
+                note: None,
+                was_named_level: None,
+                storage_critical: true,
+            }],
+        };
+        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
+        assert!(out.contains("daily=42"), "tightened shape missing: {out}");
+        assert!(out.contains("shape tightened"), "tightening reason missing: {out}");
+        assert!(
+            out.contains("risks the host itself"),
+            "storage-critical advisory missing: {out}"
+        );
+    }
+
+    #[test]
+    fn storage_critical_at_min_combined_render_no_double_action() {
+        // M3: an at-MIN Pressure row (synth, no adjusted) that is also
+        // storage_critical. The action ("expanding storage") must appear at
+        // most once — on the at-MIN reason line, not duplicated by the
+        // advisory, which supplies only the host stakes.
+        let _color = color_guard(false);
+        let cur = shape(0, 3, 0, crate::types::MonthlyCount::Count(0), 0);
+        let h = crate::recommendation::headroom_aware_pointer_only(
+            &cur,
+            crate::recommendation::ShapeRole::Local,
+            crate::recommendation::HeadroomSeverity::Pressure,
+            crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.10 },
+        );
+        let view = crate::output::DoctorRecommendationView {
+            header: "h".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "root".to_string(),
+                local: Some(h),
+                external: None,
+                note: None,
+                was_named_level: None,
+                storage_critical: true,
+            }],
+        };
+        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
+        assert!(
+            out.contains("shape already at minimum"),
+            "at-MIN guidance missing: {out}"
+        );
+        assert!(
+            out.contains("risks the host itself"),
+            "storage-critical advisory missing: {out}"
+        );
+        assert!(
+            out.matches("expanding storage").count() <= 1,
+            "action verb must not be duplicated (action + stakes, not two exhortations): {out}"
+        );
+    }
+
+    #[test]
+    fn storage_critical_advisory_absent_when_flag_false() {
+        // A Pressure row without the flag renders no host-stakes advisory.
+        let _color = color_guard(false);
+        let h = ha_rec(
+            crate::recommendation::ShapeRole::Local,
+            shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
+            shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0),
+            200_000_000_000,
+            50_000_000_000,
+            crate::recommendation::HeadroomSeverity::Pressure,
+            Some(crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.10 }),
+            Some(shape(16, 42, 36, crate::types::MonthlyCount::Count(16), 0)),
+            Some(25_000_000_000),
+        );
+        let view = crate::output::DoctorRecommendationView {
+            header: "h".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "containers".to_string(),
+                local: Some(h),
+                external: None,
+                note: None,
+                was_named_level: None,
+                storage_critical: false,
+            }],
+        };
+        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
+        assert!(
+            !out.contains("risks the host itself"),
+            "advisory must be absent when flag false: {out}"
+        );
+    }
+
+    #[test]
+    fn storage_critical_advisory_not_emitted_on_dormant_critical_path() {
+        // Dormant-path guard: a Critical-severity row (032/033 hook) takes the
+        // R9 pointer-only early return, so the additive advisory is NOT also
+        // emitted — only the single pointer line.
+        let _color = color_guard(false);
+        let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
+        let h = crate::recommendation::headroom_aware_pointer_only(
+            &cur,
+            crate::recommendation::ShapeRole::Local,
+            crate::recommendation::HeadroomSeverity::Critical,
+            crate::recommendation::AdjustmentReason::StorageCritical,
+        );
+        let view = crate::output::DoctorRecommendationView {
+            header: "h".to_string(),
+            rows: vec![crate::output::DoctorRecommendationRow {
+                name: "root".to_string(),
+                local: Some(h),
+                external: None,
+                note: None,
+                was_named_level: None,
+                storage_critical: true,
+            }],
+        };
+        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
+        assert!(
+            out.contains("see `urd doctor`"),
+            "R9 pointer line expected: {out}"
+        );
+        assert!(
+            !out.contains("risks the host itself"),
+            "additive advisory must not also fire on the Critical path: {out}"
+        );
     }
 
     // ── UPI 042 — MonthlyCount + yearly rendering ───────────────────

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -1009,6 +1009,7 @@ mod contract {
             external: None,
             note: None,
             was_named_level: None,
+            storage_critical: false,
         }
     }
 
@@ -1112,6 +1113,7 @@ mod contract {
             external: None,
             note: None,
             was_named_level: None,
+            storage_critical: false,
         }
     }
 
@@ -1161,6 +1163,7 @@ mod contract {
             external: None,
             note: None,
             was_named_level: None,
+            storage_critical: false,
         }
     }
 
@@ -1371,6 +1374,7 @@ mod contract {
             external: None,
             note: None,
             was_named_level: None,
+            storage_critical: false,
         };
         let view = crate::output::DoctorRecommendationView {
             header: "header".to_string(),


### PR DESCRIPTION
## Summary

- Retires the `storage_critical::is_storage_critical` stub (which always returned `false`, leaving the "Critical" doctor path dead) for a **pure structural rule**: a subvolume is storage-critical when its source is on the host's root-filesystem pool (BTRFS pool UUID matches `/`'s), an *enabled* subvolume entrusts `/` itself to Urd, **and** that pool is critically tight now (free-ratio ≥ Pressure, reusing the existing `classify_free_ratio` — no new threshold). The intersection is what keeps it non-redundant with momentary headroom pressure.
- Wires it via a **value seam** (`root_pool_uuid: Option<&str>`, one `findmnt /` at the doctor boundary), so the pure rule owns the full logic and is unit-tested with literal inputs.
- `urd doctor --thorough` renders a dimmed, **stakes-not-action** advisory on the offending row (pressure here threatens the host, not just retention) **alongside** — not replacing — the existing tightening suggestion, plus an additive `storage_critical: true` field (omitted-when-false; no JSON schema bump).
- Deletes the old force-Critical injection. Nothing in production now constructs `HeadroomSeverity::Critical`; the tier + voice R9 pointer path are kept alive only by tests as the **032/033 behavioral-bundle hook** (ADR-113 increment 2), guarded by a documented `#[allow(dead_code)]` and time-boxed.
- No metric/heartbeat/on-disk/config-schema change → no homelab ADR-021 amendment. No new ADR (implements within ADR-113 / ADR-115).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1458 passed, 0 failed (3 ignored)
- cargo build --release: pass
- Integration tests: not applicable (no btrfs/drive operations changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)