### PR TITLE
docs: rename /simplify workflow command to /tidy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,13 +302,13 @@ systematic-debugging → build → /check → /commit-push-pr → /session-close
 ### Standard — medium features, clear scope, no new modules
 
 ```
-/design → /grill-me → /prepare → arch-adversary → /post-review → build → /simplify → /check → /commit-push-pr → /session-close
+/design → /grill-me → /prepare → arch-adversary → /post-review → build → /tidy → /check → /commit-push-pr → /session-close
 ```
 
 ### Full — new modules, architectural changes, ADR gates
 
 ```
-/brainstorm → /design → /grill-me → [/sequence] → /prepare → arch-adversary → /post-review → build → /simplify → /check → /commit-push-pr → /session-close
+/brainstorm → /design → /grill-me → [/sequence] → /prepare → arch-adversary → /post-review → build → /tidy → /check → /commit-push-pr → /session-close
 ```
 
 ### Tool reference
@@ -323,7 +323,7 @@ systematic-debugging → build → /check → /commit-push-pr → /session-close
 | `arch-adversary` | Plan review | Severity-ranked findings on the implementation plan |
 | `/post-review` | Plan revision | Revise the plan to address adversary findings |
 | `build` | Implementation | Execute the reviewed plan |
-| `/simplify` | Post-build | Simplification pass: abstractions, types, control flow |
+| `/tidy` | Post-build | Rust simplification pass: module boundaries, strong types, idiom, control flow (renamed from `/simplify` to avoid the built-in skill) |
 | `test-team` | Testing | Risk-proportional coverage analysis and gap identification |
 | `systematic-debugging` | Diagnosis | Four-phase root cause investigation (any tier, especially patch) |
 | `/check` | Quality gate | `cargo clippy` + `cargo test` + `cargo build --release` |


### PR DESCRIPTION
## What

Renames the project's post-build simplification command from `/simplify` to `/tidy` in CLAUDE.md (two workflow tiers + the tool-reference table).

## Why

The project command at `.claude/commands/simplify.md` collided with Claude Code's **built-in `simplify` skill**. Claude Code resolves a same-name collision by **skill-wins precedence**, so the project command could never actually run when `/simplify` was typed. `disabledSkills` is not supported in the installed CLI version (v2.1.158), so renaming is the robust fix.

`/tidy` shares no prefix with `simplify`, so autocomplete can't route to the built-in by muscle memory.

## Scope

- The command file itself (`.claude/commands/tidy.md`) lives under `.claude/`, which is **gitignored / local-only** — not part of this PR.
- This PR only updates the **tracked** `CLAUDE.md` references (3 lines).
- The command was also rewritten locally into a Rust-specialized simplification pass; that content is local-only and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)