### PR TITLE
feat: storage-state + awareness rework (UPI 031-a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Storage-critical advisory in `urd doctor --thorough`** (UPI 031). Retires the
-  `storage_critical` stub for a pure structural rule: a subvolume is flagged when its
-  source sits on the host's root-filesystem pool (BTRFS pool UUID matches `/`'s), an
-  *enabled* subvolume entrusts `/` itself to Urd, *and* that pool is critically tight
-  now (free-ratio ≥ Pressure). The offending row gains a dimmed, stakes-not-action
-  advisory — pressure here threatens the host, not just retention — alongside (not
-  replacing) the existing retention-tightening suggestion, plus an additive
-  `storage_critical: true` field on recommendation rows (omitted-when-false; no JSON
-  schema bump). Distinct from momentary headroom pressure; behavior deferred to the
-  032/033 bundle (ADR-113 increment 2). No metric, heartbeat, on-disk, or config-schema
-  change.
+- **Storage-pressure state in `urd status`** (UPI 031-a, reworks the unreleased UPI 031).
+  Splits 031's single `is_storage_critical` predicate — which conflated host-root-ness
+  with current pressure and inverted the severity/response ladder — into two orthogonal
+  axes: a **tightness tier** (`Roomy / Tight / Critical`, free-ratio only on the source
+  pool) and a **host-root** escalation flag. The tier is now surfaced **told-not-silent**
+  in `urd status` and bare `urd` (per-pool: "your `/data` runs tight — N subvolumes
+  affected"; host-root pressure adds "…pressure here risks the machine itself"), backed
+  by a persisted, best-effort, hysteresis-stabilized per-pool armed tier
+  (`pool_armed_tier` SQLite table) so the state survives runs and does not flap. Backup
+  runs dispatch a best-effort `notify.rs` notification on escalation (status-only when no
+  channel is configured); de-escalation is silent. The inverted `doctor --thorough` row
+  advisory and its `storage_critical` field are removed — the posture now appears in the
+  `doctor` data-safety section instead, and the recommendation row returns to pure
+  retention-shape advice. The detection + state foundation that UPIs 032 (predictive
+  guards) and 033 (mid-op watchdog) build behavior on; ships with them as ADR-113
+  increment 2. No metric or heartbeat schema change (Cross-Repo Impact: None); no on-disk
+  or config-schema change.
 
 ## [0.21.2] - 2026-05-29
 

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -280,28 +280,42 @@ The suggested shape preserves the outer-edge span (365 days) while thinning the
 interior — same data cost, fewer pins to manage. The tightened shape shortens
 the outer edge in response to destination pressure; that does reduce data cost.
 
-### `storage_critical` (UPI 031)
+## Cluster: Storage pressure (ADR-113 Do-No-Harm)
 
-Distinct from `headroom`, which is a *momentary* "is this pool tight now?" signal,
-`storage_critical` is a **structural** property of where the data lives. A subvolume
-is storage-critical when **all three** hold:
+The source-pool tightness surface (UPI 031-a). It reworks UPI 031's single
+`is_storage_critical` predicate — which conflated *host-root-ness* with *current
+pressure* and inverted the severity/response ladder — into two orthogonal axes plus a
+persisted, hysteresis-stabilized state. Lives in `storage_critical.rs` (pure derivation)
+with I/O at the command boundary (`commands/storage_signals.rs`). It surfaces
+**told-not-silent** in `urd status` and bare `urd`, notifies on backup escalations, and
+appears as a diagnostic line in `doctor --thorough`'s data-safety section. The
+**behavioral** half (defer, ephemeral lifecycle, mid-op watchdog) is deferred to the UPI
+032/033 bundle (ADR-113 increment 2).
 
-1. its source sits on the host's **root-filesystem pool** (the BTRFS pool UUID matches
-   `/`'s pool — caught even for a `/home`-only config whose pool mountpoints omit `/`);
-2. an **enabled** subvolume entrusts `/` itself to Urd (`source == "/"`); and
-3. that pool is **critically tight right now** (free-ratio ≥ `Pressure`, reusing
-   `recommendation::classify_free_ratio` — no new threshold).
+| Term | Meaning |
+|------|---------|
+| `tightness tier` | Source-pool free-space tier, **free-ratio only**: `TightnessTier { Roomy, Tight, Critical }` (`storage_critical.rs`). Boundaries reuse `recommendation::classify_free_ratio_value` (`< 0.25` → Tight, `< 0.15` → Critical) — the single source of truth, **no new threshold**. The imperative-bundle axis the Do-No-Harm response climbs with. |
+| `tight` / `critical` | User-facing names for the `Tight` / `Critical` tiers (state vocabulary). `Roomy` is silent — Urd says nothing about a roomy pool. |
+| `host-root axis` | The structural escalation flag (`storage_critical::host_root`): the subvolume's source is on the pool hosting `/` (UUID match) **and** an *enabled* subvolume entrusts `/` itself (`source == "/"`). Orthogonal to the tier — pressure on the host-root pool risks the **machine itself**, not just retention. This is the relocated home of UPI 031's stakes-not-action advisory prose. |
+| `storage posture` | The per-subvolume `StoragePosture { tier, host_root }` carried on `SubvolAssessment` — `Some` only when `tier >= Tight`. A separate presentation axis from the data-safety `PromiseStatus` (ADR-110 R4): "Urd is watching a tight pool," not "your data is unsafe." |
+| `watching` | The posture verb: Urd is *watching* a tight pool (told-not-silent), as distinct from a data-safety promise degradation. |
+| `armed tier` / `operational-adaptation state` | The persisted, hysteresis-stabilized tier per pool (`pool_armed_tier` table: `pool_uuid → (armed_tier, since)`). Best-effort SQLite (ADR-102) — never blocks a run; if lost, Urd re-derives statelessly (degraded, never unsafe). The seed of the future managed-config/autonomy layer; lives in Urd's state, **never** in `urd.toml`. |
+| `hysteresis band` | `HYSTERESIS_BAND_PP = 0.05` — escalate immediately when the current ratio classifies worse than the armed tier; de-escalate only once free recovers to `arm_threshold + 5pp` (Critical→Tight at `> 0.20`, Tight→Roomy at `> 0.30`). Anti-flap: stops a pool hovering at a boundary from re-notifying every run. 031-a's one new constant; revisited at the ADR-113 30-day checkpoint. |
+| `transition` | A change in armed tier, computed **only** at the backup boundary (`advance_and_writeback`). Escalations dispatch a best-effort `notify.rs` notification; de-escalation is silent (status reflects recovery). Read paths (`status`, bare `urd`, `doctor`) reflect the stabilized tier and **never** fire a transition (S1). |
 
-The point of the intersection is non-redundancy with headroom: only data that is *both*
-structurally fragile (pressure here threatens the **host**, not just retention) *and*
-genuinely tight is storage-critical. The rule lives in `storage_critical.rs` (pure); the
-doctor wiring resolves `/`'s pool UUID at the boundary. It surfaces as a dimmed,
-stakes-not-action advisory on the offending `urd doctor --thorough` row (and a
-`storage_critical: true` field, omitted-when-false in JSON). The **behavioral** half
-(ephemeral lifecycle, conservative intervals) is deferred to the UPI 032/033 bundle
-(ADR-113 increment 2).
+**`headroom` vs `tightness tier` (do not confuse).** `headroom` (recommendation.rs) is a
+*composite* `HeadroomSeverity` — free-ratio **+** time-to-empty trend **+** destination
+metadata — that scales retention-shape advice. The `tightness tier` is **free-ratio only**
+on the *source* pool: trend is handled separately in 032's projection, destination metadata
+is irrelevant to source-pool tightness. Same free-ratio boundaries, different composites and
+different jobs.
 
-Source: `storage_critical.rs`, ADR-113.
+> **Note.** `constrained` (`tier >= Tight && Urd writes to that pool`) is a **UPI 032**
+> term — deferred, not part of 031-a. 031-a's surface gates inline on `tier >= Tight`.
+
+Source: `storage_critical.rs`, `commands/storage_signals.rs`, `state.rs` (`pool_armed_tier`),
+ADR-113. See also the user-facing rename `drift` → "churn" on the Recommendation cluster's
+`drift signal`.
 
 ## Cluster: Read-side query seams (ADR-102)
 

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -531,6 +531,7 @@ drives = ["primary-drive", "offsite-drive"]
             advisories: vec![],
             redundancy_advisories: vec![],
             errors: vec![],
+            storage_posture: None,
         }
     }
 
@@ -786,7 +787,7 @@ drives = ["drive-a", "drive-b"]
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
         fs.mounted_drives.insert("drive-a".to_string());
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert_eq!(advisories.len(), 1);
@@ -810,7 +811,7 @@ drives = ["drive-a", "drive-b"]
             dt(2026, 3, 1, 12, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert_eq!(advisories.len(), 1);
@@ -832,7 +833,7 @@ drives = ["drive-a", "drive-b"]
             dt(2026, 3, 3, 12, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -850,7 +851,7 @@ drives = ["drive-a", "drive-b"]
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
         fs.mounted_drives.insert("primary-drive".to_string());
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -917,7 +918,7 @@ protection_level = "protected"
             dt(2026, 4, 1, 8, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert_eq!(advisories.len(), 1);
@@ -936,7 +937,7 @@ protection_level = "protected"
         fs.mounted_drives.insert("drive-a".to_string());
         fs.mounted_drives.insert("drive-b".to_string());
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         // Should have NoOffsiteProtection but NOT SinglePointOfFailure
@@ -996,7 +997,7 @@ protection_level = "guarded"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1062,7 +1063,7 @@ local_retention = "transient"
             dt(2026, 3, 30, 12, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1086,7 +1087,7 @@ local_retention = "transient"
             dt(2026, 4, 1, 8, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1108,7 +1109,7 @@ local_retention = "transient"
             dt(2026, 3, 30, 12, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         let advisory = advisories
@@ -1151,6 +1152,7 @@ local_retention = "transient"
             advisories: vec![],
             redundancy_advisories: vec![],
             errors: vec![],
+            storage_posture: None,
         }
     }
 

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -256,7 +256,38 @@ pub struct SubvolAssessment {
     pub redundancy_advisories: Vec<RedundancyAdvisory>,
     /// Per-subvolume assessment failures (e.g., can't read snapshot directory).
     pub errors: Vec<String>,
+    /// Source-pool storage posture (UPI 031-a): the hysteresis-stabilized
+    /// tightness tier + host-root flag for this subvolume's source pool.
+    /// `Some` only when the pool is at least `Tight` (a Roomy pool is silent).
+    /// A separate presentation axis from `status`/`health` (ADR-110 R4): it
+    /// reflects Urd's posture toward a tight pool, not the data-safety promise.
+    pub storage_posture: Option<crate::storage_critical::StoragePosture>,
 }
+
+/// Per-subvolume raw storage signal fed into `assess()` (UPI 031-a). Resolved
+/// by the command layer (`commands/storage_signals.rs`) from `pools::pool_space`
+/// (free-ratio), `findmnt /` (host-root), and the persisted prior armed tier;
+/// `assess()` consumes it purely (ADR-108) — it performs no I/O of its own.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResolvedStorageSignal {
+    /// Source pool free / capacity ratio; `None` when unmeasurable (holds the
+    /// prior armed tier rather than silently disarming).
+    pub free_ratio: Option<f64>,
+    /// This subvolume's source is on the host-root pool and `/` is entrusted.
+    pub host_root: bool,
+    /// The hysteresis-stabilized armed tier read back from `pool_armed_tier`
+    /// (defaults to `Roomy` for an untracked / UUID-less pool).
+    pub prior_armed_tier: crate::storage_critical::TightnessTier,
+    /// When the armed tier last changed (the "flagged since" timestamp).
+    pub prior_since: Option<NaiveDateTime>,
+}
+
+/// Per-subvolume storage signals keyed by subvolume name (UPI 031-a). Built at
+/// the command boundary; threaded into `assess()` as a pure input so the query
+/// seams stay narrow (parallels the 032 churn-map decision, arc R8). Subvolumes
+/// absent from the map get no posture.
+pub type StorageSignalMap =
+    std::collections::HashMap<String, ResolvedStorageSignal>;
 
 /// Chain health for a single subvolume/drive pair.
 ///
@@ -402,6 +433,7 @@ pub fn assess(
     config: &Config,
     now: NaiveDateTime,
     obs: &Observation,
+    storage_signals: &StorageSignalMap,
 ) -> Vec<SubvolAssessment> {
     let resolved = config.resolved_subvolumes();
     let mut assessments = Vec::new();
@@ -457,6 +489,7 @@ pub fn assess(
                     "no snapshot root configured for subvolume {:?}",
                     subvol.name
                 )],
+                storage_posture: None,
             });
             continue;
         };
@@ -639,6 +672,19 @@ pub fn assess(
             subvol.local_retention.is_transient(),
         );
 
+        // ── Storage posture (UPI 031-a) ──────────────────────────────
+        // Pure: resolve the hysteresis-stabilized armed tier from the
+        // command-supplied signal, then derive the posture. No I/O, no
+        // write-back (the backup boundary advances state — read paths
+        // only reflect). Subvolumes with no signal get no posture.
+        let storage_posture = storage_signals.get(&subvol.name).and_then(|sig| {
+            let armed = crate::storage_critical::resolve_armed_tier(
+                sig.prior_armed_tier,
+                sig.free_ratio,
+            );
+            crate::storage_critical::derive_posture(armed, sig.host_root)
+        });
+
         assessments.push(SubvolAssessment {
             name: subvol.name.clone(),
             status: overall,
@@ -650,6 +696,7 @@ pub fn assess(
             advisories,
             redundancy_advisories: Vec::new(),
             errors,
+            storage_posture,
         });
     }
 
@@ -1223,10 +1270,178 @@ source = "/data/sv1"
 
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].status, PromiseStatus::Protected);
         assert_eq!(results[1].status, PromiseStatus::Protected);
+    }
+
+    // ── UPI 031-a: storage posture from the signal map ──────────────
+
+    /// Build a healthy two-subvol fixture; callers inject the signal map.
+    fn posture_fixture() -> (Config, NaiveDateTime, MockFileSystemState) {
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        fs.local_snapshots
+            .insert("sv2".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv2")]);
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        (config, now, fs)
+    }
+
+    fn posture_of(
+        results: &[SubvolAssessment],
+        name: &str,
+    ) -> Option<crate::storage_critical::StoragePosture> {
+        results.iter().find(|a| a.name == name).unwrap().storage_posture
+    }
+
+    #[test]
+    fn storage_posture_populated_when_tight() {
+        use crate::storage_critical::TightnessTier;
+        let (config, now, fs) = posture_fixture();
+        let mut signals = crate::awareness::StorageSignalMap::new();
+        signals.insert(
+            "sv1".to_string(),
+            ResolvedStorageSignal {
+                free_ratio: Some(0.20), // < 0.25 → Tight
+                host_root: false,
+                prior_armed_tier: TightnessTier::Roomy,
+                prior_since: None,
+            },
+        );
+
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let posture = posture_of(&results, "sv1").expect("sv1 should have posture");
+        assert_eq!(posture.tier, TightnessTier::Tight);
+        assert!(!posture.host_root);
+    }
+
+    #[test]
+    fn storage_posture_critical_carries_host_root() {
+        use crate::storage_critical::TightnessTier;
+        let (config, now, fs) = posture_fixture();
+        let mut signals = crate::awareness::StorageSignalMap::new();
+        signals.insert(
+            "sv1".to_string(),
+            ResolvedStorageSignal {
+                free_ratio: Some(0.05), // < 0.15 → Critical
+                host_root: true,
+                prior_armed_tier: TightnessTier::Roomy,
+                prior_since: None,
+            },
+        );
+
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let posture = posture_of(&results, "sv1").expect("sv1 should have posture");
+        assert_eq!(posture.tier, TightnessTier::Critical);
+        assert!(posture.host_root);
+    }
+
+    #[test]
+    fn storage_posture_none_when_roomy() {
+        use crate::storage_critical::TightnessTier;
+        let (config, now, fs) = posture_fixture();
+        let mut signals = crate::awareness::StorageSignalMap::new();
+        signals.insert(
+            "sv1".to_string(),
+            ResolvedStorageSignal {
+                free_ratio: Some(0.50), // roomy
+                host_root: true,
+                prior_armed_tier: TightnessTier::Roomy,
+                prior_since: None,
+            },
+        );
+
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        // Roomy → no posture even though host_root is true (Urd stays silent).
+        assert_eq!(posture_of(&results, "sv1"), None);
+    }
+
+    #[test]
+    fn storage_posture_none_when_signal_absent() {
+        let (config, now, fs) = posture_fixture();
+        // Empty map: no subvolume has a signal.
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &crate::awareness::StorageSignalMap::new(),
+        );
+        assert_eq!(posture_of(&results, "sv1"), None);
+        assert_eq!(posture_of(&results, "sv2"), None);
+    }
+
+    #[test]
+    fn storage_posture_signal_less_subvol_unaffected() {
+        use crate::storage_critical::TightnessTier;
+        let (config, now, fs) = posture_fixture();
+        let mut signals = crate::awareness::StorageSignalMap::new();
+        // Only sv1 has a signal; sv2 must stay posture-free.
+        signals.insert(
+            "sv1".to_string(),
+            ResolvedStorageSignal {
+                free_ratio: Some(0.10),
+                host_root: false,
+                prior_armed_tier: TightnessTier::Roomy,
+                prior_since: None,
+            },
+        );
+
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        assert!(posture_of(&results, "sv1").is_some());
+        assert_eq!(posture_of(&results, "sv2"), None);
+    }
+
+    #[test]
+    fn storage_posture_stale_divergence_escalates_immediately() {
+        // Min2: prior armed Roomy, current ratio Tight ⇒ the pure derivation
+        // escalates immediately to Tight inside assess(). assess() takes no
+        // StateDb, so it cannot (and must not) mutate persisted state — this
+        // is a read-path reflection only.
+        use crate::storage_critical::TightnessTier;
+        let (config, now, fs) = posture_fixture();
+        let mut signals = crate::awareness::StorageSignalMap::new();
+        signals.insert(
+            "sv1".to_string(),
+            ResolvedStorageSignal {
+                free_ratio: Some(0.18), // classifies Tight; prior was Roomy
+                host_root: false,
+                prior_armed_tier: TightnessTier::Roomy,
+                prior_since: None,
+            },
+        );
+
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let posture = posture_of(&results, "sv1").expect("sv1 should have posture");
+        assert_eq!(posture.tier, TightnessTier::Tight);
     }
 
     // ── Test 2: Local stale → AT_RISK ──────────────────────────────
@@ -1248,7 +1463,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::AtRisk);
         assert_eq!(results[0].status, PromiseStatus::AtRisk);
     }
@@ -1266,7 +1481,7 @@ source = "/data/sv1"
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 8, 0), "sv1")]);
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::Unprotected);
     }
 
@@ -1278,7 +1493,7 @@ source = "/data/sv1"
         let now = dt(2026, 3, 23, 14, 0);
         let fs = MockFileSystemState::new();
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::Unprotected);
         assert_eq!(results[0].local.snapshot_count, 0);
     }
@@ -1305,7 +1520,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].external[0].status, PromiseStatus::AtRisk);
     }
 
@@ -1330,7 +1545,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -1349,7 +1564,7 @@ source = "/data/sv1"
         fs.mounted_drives.insert("WD-18TB".to_string());
         // No send_times entry
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -1396,7 +1611,7 @@ send_enabled = false
             vec![snap(dt(2026, 3, 23, 13, 30), "sv1")],
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].external.len(), 0);
         assert_eq!(results[0].status, PromiseStatus::Protected);
     }
@@ -1421,7 +1636,7 @@ send_enabled = false
         );
         // Drive NOT in mounted_drives
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert!(!results[0].external[0].mounted);
         assert_eq!(results[0].external[0].status, PromiseStatus::Protected);
         assert_eq!(results[0].external[0].snapshot_count, None);
@@ -1488,7 +1703,7 @@ source = "/data/sv1"
 
         fs.mounted_drives.insert("primary".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
 
         // Primary drive is PROTECTED
         let primary = &results[0]
@@ -1530,7 +1745,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::AtRisk);
         assert_eq!(results[0].external[0].status, PromiseStatus::Protected);
         // min(AT_RISK, PROTECTED) = AT_RISK
@@ -1580,7 +1795,7 @@ enabled = false
         let now = dt(2026, 3, 23, 14, 0);
         let fs = MockFileSystemState::new();
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, "sv1");
     }
@@ -1597,7 +1812,7 @@ enabled = false
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 12, 0), "sv1")]);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
 
         // 2h + 1min ago → AT_RISK (> 2×)
@@ -1606,7 +1821,7 @@ enabled = false
             vec![snap(dt(2026, 3, 23, 11, 59), "sv1")],
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::AtRisk);
     }
 
@@ -1620,14 +1835,14 @@ enabled = false
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 9, 0), "sv1")]);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::AtRisk);
 
         // 5h + 1min ago → UNPROTECTED (> 5×)
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 8, 59), "sv1")]);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::Unprotected);
     }
 
@@ -1677,7 +1892,7 @@ source = "/data/sv1"
             .insert(("sv1".to_string(), "WD-18TB".to_string()), two_days_ago);
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         // Local: 2d / 1d = 2× → PROTECTED (≤ 2×)
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         // External: 2d / 1d = 2× → AT_RISK (> 1.5×)
@@ -1739,7 +1954,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert!(results[0].errors.is_empty());
     }
 
@@ -1765,7 +1980,7 @@ source = "/data/sv1"
             dt(2026, 3, 13, 8, 0),
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert!(
             !results[0]
                 .advisories
@@ -1793,7 +2008,7 @@ source = "/data/sv1"
             dt(2026, 3, 13, 8, 0),
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert!(
             results[0].advisories.is_empty(),
             "primary drive should not get advisories: {:?}",
@@ -1931,7 +2146,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         // Age clamped to zero → evaluates as "just created" → PROTECTED
         // (not falsely PROTECTED from negative duration)
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
@@ -1963,7 +2178,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         // Send age clamped to zero → PROTECTED (not false PROTECTED from negative)
         assert_eq!(results[0].external[0].status, PromiseStatus::Protected);
         assert_eq!(results[0].external[0].last_send_age, Some(Duration::zero()));
@@ -1990,7 +2205,7 @@ source = "/data/sv1"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results.len(), 2);
 
         // sv1: error captured, status UNPROTECTED
@@ -2069,7 +2284,7 @@ source = "/data/sv1"
             dt(2026, 3, 29, 10, 0),
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let sv = &results[0];
         assert_eq!(sv.chain_health.len(), 1);
         assert_eq!(
@@ -2102,7 +2317,7 @@ source = "/data/sv1"
             dt(2026, 3, 28, 10, 0),
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let ch = &results[0].chain_health[0];
         assert!(matches!(
             ch.status,
@@ -2135,7 +2350,7 @@ source = "/data/sv1"
             dt(2026, 3, 29, 10, 0),
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let ch = &results[0].chain_health[0];
         assert!(matches!(
             ch.status,
@@ -2165,7 +2380,7 @@ source = "/data/sv1"
             dt(2026, 3, 29, 10, 0),
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let ch = &results[0].chain_health[0];
         assert_eq!(
             ch.status,
@@ -2189,7 +2404,7 @@ source = "/data/sv1"
             .insert(("D1".to_string(), "sv1".to_string()), vec![]);
         fs.mounted_drives.insert("D1".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let ch = &results[0].chain_health[0];
         assert!(matches!(
             ch.status,
@@ -2210,7 +2425,7 @@ source = "/data/sv1"
             .insert("sv1".to_string(), vec![parse_snap("20260329-1100-s1")]);
         // Drive NOT mounted — no chain health entries
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert!(
             results[0].chain_health.is_empty(),
             "unmounted drives should not produce chain health entries"
@@ -2258,7 +2473,7 @@ source = "/data/sv1"
             .insert("sv1".to_string(), vec![parse_snap("20260329-1100-s1")]);
         fs.mounted_drives.insert("D1".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert!(
             results[0].chain_health.is_empty(),
             "send_disabled subvolumes should have no chain health"
@@ -2284,7 +2499,7 @@ source = "/data/sv1"
             "D1".to_string(),
         ));
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let ch = &results[0].chain_health[0];
         assert_eq!(
             ch.status,
@@ -2333,7 +2548,7 @@ source = "/data/sv1"
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Healthy);
         assert!(results[0].health_reasons.is_empty());
     }
@@ -2361,7 +2576,7 @@ source = "/data/sv1"
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(results[0].health_reasons[0].contains("chain broken"));
         assert!(results[0].health_reasons[0].contains("WD-18TB"));
@@ -2379,7 +2594,7 @@ source = "/data/sv1"
         );
         // No drives mounted, send_enabled=true (default in test config)
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Blocked);
         assert!(results[0].health_reasons[0].contains("no backup drives connected"));
     }
@@ -2434,7 +2649,7 @@ send_enabled = false
         );
         // No drives mounted — but send_enabled=false, so health should be Healthy
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Healthy);
     }
 
@@ -2468,7 +2683,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 105_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("space tight")));
     }
@@ -2509,7 +2724,7 @@ send_enabled = false
             60_000_000_000,
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Blocked);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("insufficient space")));
     }
@@ -2546,7 +2761,7 @@ send_enabled = false
             5_000_000_000,
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_ne!(
             results[0].health,
             OperationalHealth::Blocked,
@@ -2580,7 +2795,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 200_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_ne!(
             results[0].health,
             OperationalHealth::Blocked,
@@ -2622,7 +2837,7 @@ send_enabled = false
             50_000_000_000,
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_ne!(
             results[0].health,
             OperationalHealth::Blocked,
@@ -2649,7 +2864,7 @@ send_enabled = false
             },
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let drive = &results[0].external[0];
         assert_eq!(
             drive.absent_duration_secs,
@@ -2683,7 +2898,7 @@ send_enabled = false
         fs.last_successful_ops
             .insert("WD-18TB".to_string(), dt(2026, 3, 22, 12, 0));
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, None);
         assert_eq!(drive.last_activity_age_secs, None);
@@ -2711,7 +2926,7 @@ send_enabled = false
         fs.last_successful_ops
             .insert("WD-18TB".to_string(), dt(2026, 3, 22, 10, 0));
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, None);
         assert_eq!(
@@ -2732,7 +2947,7 @@ send_enabled = false
         fs.last_successful_ops
             .insert("WD-18TB".to_string(), dt(2026, 3, 20, 14, 0));
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, None);
         assert_eq!(
@@ -2762,7 +2977,7 @@ send_enabled = false
         fs.last_successful_ops
             .insert("WD-18TB".to_string(), dt(2026, 3, 20, 10, 0));
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, Some(4 * 3600));
         assert_eq!(
@@ -2780,7 +2995,7 @@ send_enabled = false
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let drive = &results[0].external[0];
         assert_eq!(drive.absent_duration_secs, None);
         assert_eq!(drive.last_activity_age_secs, None);
@@ -2802,7 +3017,7 @@ send_enabled = false
             dt(2026, 3, 10, 12, 0), // 13 days ago
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Blocked);
         // Blocked because no drives mounted (primary check), plus degraded for away >7d
         assert!(results[0].health_reasons.iter().any(|r| r.contains("no backup drives connected")));
@@ -2844,7 +3059,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/d1"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Healthy, "health_reasons: {:?}", results[0].health_reasons);
         assert!(results[0].health_reasons.is_empty());
     }
@@ -2899,7 +3114,7 @@ send_enabled = false
             42,
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(
             results[0].health,
             OperationalHealth::Healthy,
@@ -2965,7 +3180,7 @@ send_enabled = false
             dt(2026, 3, 6, 14, 0), // 17 days ago
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert!(
             !results[0]
                 .health_reasons
@@ -3046,7 +3261,7 @@ send_enabled = false
             dt(2026, 3, 10, 12, 0),
         );
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(results[0].health_reasons.len() >= 2, "expected multiple reasons, got: {:?}", results[0].health_reasons);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("chain broken")));
@@ -3116,7 +3331,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/snap/sv1"), 11_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("local snapshot space tight")));
     }
@@ -3144,7 +3359,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(
             results[0].health_reasons.iter().any(|r| r.contains("full send size unknown")),
@@ -3211,7 +3426,7 @@ local_retention = "transient"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].name, "sv-transient");
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         assert_eq!(results[0].local.snapshot_count, 0);
@@ -3231,7 +3446,7 @@ local_retention = "transient"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         // Overall dragged down by external, not local
         assert_eq!(results[0].status, PromiseStatus::AtRisk);
@@ -3250,7 +3465,7 @@ local_retention = "transient"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         assert_eq!(results[0].status, PromiseStatus::Unprotected);
     }
@@ -3274,7 +3489,7 @@ local_retention = "transient"
         );
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         assert_eq!(results[0].local.snapshot_count, 1);
         assert!(results[0].local.newest_age.is_some());
@@ -3290,7 +3505,7 @@ local_retention = "transient"
         // No local snapshots, no external sends, drive mounted
         fs.mounted_drives.insert("WD-18TB".to_string());
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].local.status, PromiseStatus::Protected);
         // External: never sent → UNPROTECTED
         assert_eq!(results[0].external[0].status, PromiseStatus::Unprotected);
@@ -3345,7 +3560,7 @@ send_enabled = false
         let now = dt(2026, 3, 23, 14, 0);
         let fs = MockFileSystemState::new();
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(results[0].name, "sv-nosend");
         // Local returns Protected (transient branch), but overall must be Unprotected
         // because there is no external safety mechanism.
@@ -3374,7 +3589,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(
             results[0].health,
             OperationalHealth::Healthy,
@@ -3409,7 +3624,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(
             results[0].health,
             OperationalHealth::Healthy,
@@ -3450,7 +3665,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(
             results[0].health,
             OperationalHealth::Degraded,
@@ -3481,7 +3696,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         assert_eq!(
             results[0].health,
             OperationalHealth::Degraded,
@@ -3508,7 +3723,7 @@ send_enabled = false
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/wd"), 1_000_000_000_000);
 
-        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         // Should not contain "full send size unknown" — chain treated as intact for transient
         assert!(
             !results[0]
@@ -3591,7 +3806,7 @@ drives = ["D1"]
         // D2 is NOT mounted — but sv1 is scoped to D1 only,
         // so D2 absence should NOT affect sv1's status.
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
 
         assert_eq!(
@@ -3621,7 +3836,7 @@ drives = ["D1"]
 
         // D2 is NOT mounted and has no send history
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
 
         // Without per-subvolume drives scoping, all configured drives appear in assessments
@@ -3647,7 +3862,7 @@ drives = ["D1"]
             dt(2026, 4, 1, 10, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
 
         assert_eq!(
@@ -3686,7 +3901,7 @@ drives = ["D1"]
         // D2 would have a broken chain if assessed, but it's out of scope
         // (sv1 is scoped to D1 only). Verify health is not degraded.
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() });
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let sv1 = assessments.iter().find(|a| a.name == "sv1").unwrap();
 
         assert_eq!(
@@ -3737,7 +3952,7 @@ drives = ["D1"]
             42,
         );
 
-        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new())[0];
         assert_eq!(r.external[0].status, PromiseStatus::Protected);
         // Advisory explains why the old age is still PROTECTED.
         assert!(
@@ -3783,7 +3998,7 @@ drives = ["D1"]
             42,
         );
 
-        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new())[0];
         assert_eq!(r.external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -3813,7 +4028,7 @@ drives = ["D1"]
         );
 
         // No generations configured — queries will fail.
-        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() })[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new())[0];
         assert_eq!(r.external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -3839,7 +4054,7 @@ drives = ["D1"]
         mb.generations.borrow_mut()
             .insert(std::path::PathBuf::from("/data/sv1"), 42);
 
-        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new())[0];
         assert_eq!(r.external[0].status, PromiseStatus::Unprotected);
     }
 
@@ -3867,7 +4082,7 @@ drives = ["D1"]
         );
 
         // No drive mounted — isolate the local assessment.
-        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new())[0];
         assert_eq!(r.local.status, PromiseStatus::Protected);
     }
 
@@ -3906,7 +4121,7 @@ drives = ["D1"]
             42,
         );
 
-        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new())[0];
         // 10 days since send > 3× 1d → UNPROTECTED under age-based rules.
         assert_eq!(
             r.external[0].status,
@@ -3945,7 +4160,7 @@ drives = ["D1"]
             42,
         );
 
-        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new())[0];
         assert_eq!(r.external[0].status, PromiseStatus::Protected);
         assert!(!r.external[0].mounted, "drive should be reported unmounted");
     }
@@ -4015,7 +4230,7 @@ source = "/data/sv1"
             dt(2026, 3, 23, 13, 30),
         );
 
-        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new())[0];
         // Transient local returns Protected regardless of age.
         assert_eq!(r.local.status, PromiseStatus::Protected);
     }
@@ -4055,7 +4270,7 @@ source = "/data/sv1"
             42,
         );
 
-        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb })[0];
+        let r = &assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new())[0];
         assert!(
             r.advisories
                 .iter()
@@ -4084,6 +4299,7 @@ source = "/data/sv1"
             advisories: vec![],
             redundancy_advisories: vec![],
             errors: vec![],
+            storage_posture: None,
         }
     }
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -10,6 +10,7 @@ use crate::advice;
 use crate::awareness::{self, ChainStatus, PromiseStatus, SubvolAssessment};
 use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::cli::BackupArgs;
+use crate::commands::storage_signals;
 use crate::config::Config;
 use crate::drives;
 use crate::executor::{
@@ -143,7 +144,15 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
             &observability,
         )?;
         let previous_hb = heartbeat::read(&config.general.heartbeat_file);
-        let mut assessments = awareness::assess(&config, heartbeat_now, &observation);
+        // Empty-plan path: storage posture is not surfaced here (the heartbeat
+        // projection carries no posture — S4), so skip the findmnt sweep and
+        // pass an empty signal map.
+        let mut assessments = awareness::assess(
+            &config,
+            heartbeat_now,
+            &observation,
+            &awareness::StorageSignalMap::new(),
+        );
         advice::overlay_offsite_freshness(&mut assessments, &config);
         let hb = heartbeat::build_empty(
             &config,
@@ -281,7 +290,14 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // (thread restored, promise recovered, etc.) by diffing with post-backup state.
     let pre_assessments = {
         let pre_now = chrono::Local::now().naive_local();
-        let mut pre = awareness::assess(&config, pre_now, &observation);
+        // Pre-execution snapshot is used only to diff promise-state transitions;
+        // posture is not a promise state, so an empty signal map suffices.
+        let mut pre = awareness::assess(
+            &config,
+            pre_now,
+            &observation,
+            &awareness::StorageSignalMap::new(),
+        );
         advice::overlay_offsite_freshness(&mut pre, &config);
         pre
     };
@@ -342,8 +358,13 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         &observability,
     )?;
 
-    // Write heartbeat (fresh timestamp — `now` is from before execution)
-    let mut assessments = awareness::assess(&config, heartbeat_now, &observation);
+    // Write heartbeat (fresh timestamp — `now` is from before execution).
+    // Gather storage signals once: the post-execution assess reflects the
+    // current tier, then `advance_and_writeback` persists it and surfaces
+    // escalation transitions for the notification path (D6).
+    let signals = storage_signals::gather(&config, state_db.as_ref());
+    let mut assessments =
+        awareness::assess(&config, heartbeat_now, &observation, &signals.by_subvol);
     advice::overlay_offsite_freshness(&mut assessments, &config);
     let hb = heartbeat::build_from_run(
         &config,
@@ -357,6 +378,29 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     );
     if let Err(e) = heartbeat::write(&config.general.heartbeat_file, &hb) {
         log::warn!("Failed to write heartbeat: {e}");
+    }
+
+    // ── Storage posture (UPI 031-a) ─────────────────────────────────
+    // Persist the hysteresis-stabilized armed tier per UUID-resolvable pool and
+    // dispatch a best-effort notification for each escalation. The sentinel is
+    // blind to posture (D6), so backup is the sole dispatcher — this is separate
+    // from the heartbeat-driven promise notifications below and runs regardless
+    // of whether the sentinel is up. Best-effort throughout: never blocks a run.
+    if let Some(ref db) = state_db {
+        let escalations = storage_signals::advance_and_writeback(db, heartbeat_now, &signals);
+        let notes: Vec<notify::Notification> = escalations
+            .iter()
+            .map(|e| {
+                notify::build_storage_pressure_notification(
+                    &e.pool_label,
+                    e.transition,
+                    e.host_root,
+                )
+            })
+            .collect();
+        if !notes.is_empty() {
+            notify::dispatch(&notes, &config.notifications);
+        }
     }
 
     // Dispatch notifications for promise state changes (unless Sentinel handles it).
@@ -1838,6 +1882,7 @@ mod tests {
             advisories: vec![],
             redundancy_advisories: vec![],
             errors: vec![],
+            storage_posture: None,
         }]
     }
 
@@ -2819,6 +2864,7 @@ mod tests {
             advisories: vec![],
             redundancy_advisories: vec![],
             errors: vec![],
+            storage_posture: None,
         }
     }
 

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use crate::advice;
 use crate::awareness;
+use crate::commands::storage_signals;
 use crate::config;
 use crate::error::UrdError;
 use crate::output::{DefaultStatusOutput, OutputMode};
@@ -38,7 +39,9 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
 
     // Awareness assessment — lighter than status (no chain health, no drive info, no pins)
     let now = chrono::Local::now().naive_local();
-    let mut assessments = awareness::assess(&config, now, &observation);
+    let signals = storage_signals::gather(&config, state_db.as_ref());
+    let mut assessments =
+        awareness::assess(&config, now, &observation, &signals.by_subvol);
     advice::overlay_offsite_freshness(&mut assessments, &config);
 
     let last_run = state_db.as_ref().and_then(|db| db.last_run_info());
@@ -77,6 +80,11 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
     let total_needing_attention = advice_items.len();
     let best_advice = advice_items.into_iter().next();
 
+    // Worst tight pool drives the compact bare-`urd` clause.
+    let storage_posture = storage_signals::aggregate(&assessments, &signals, now)
+        .into_iter()
+        .max_by(|a, b| a.tier.cmp(&b.tier).then(a.host_root.cmp(&b.host_root)));
+
     let output = DefaultStatusOutput {
         total,
         waning_names,
@@ -87,6 +95,7 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         last_run_age_secs,
         best_advice,
         total_needing_attention,
+        storage_posture,
     };
 
     let rendered = voice::render_default_status(&output, output_mode);

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -539,19 +539,10 @@ fn build_doctor_recommendation_view_inner(
         // Synth-path fallback reason (M3): the Pressure/Critical branch is only
         // reached when the source pool is genuinely low, so `SourcePoolLow` is
         // the honest reason when `pick_reason` returns None (it renders prose;
-        // the retired `StorageCritical` reason rendered blank).
-        let source_free_ratio = match (
-            source_space.map(|s| s.free_bytes),
-            source_space.map(|s| s.capacity_bytes),
-        ) {
-            (Some(free), Some(cap)) if cap > 0 => {
-                #[allow(clippy::cast_precision_loss)]
-                {
-                    free as f64 / cap as f64
-                }
-            }
-            _ => 0.0,
-        };
+        // the retired `StorageCritical` reason rendered blank). Unmeasurable
+        // free-ratio falls back to `0.0` — only ever read on the genuinely-low
+        // branch, where most-tight is the safe direction.
+        let source_free_ratio = source_space.and_then(PoolSpace::free_ratio).unwrap_or(0.0);
 
         let local = match (local_rec, severity_local, local_current_shape) {
             (Some(r), _, _) => Some(r),

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -19,7 +19,6 @@ use crate::pools::{self, PoolSpace};
 use crate::preflight;
 use crate::sentinel_runner;
 use crate::state::StateDb;
-use crate::storage_critical;
 use crate::types::{LocalRetentionPolicy, ProtectionLevel};
 use crate::voice;
 
@@ -163,7 +162,10 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         btrfs: &assess_btrfs,
     };
     let now = chrono::Local::now().naive_local();
-    let assessments = awareness::assess(&config, now, &observation);
+    // Read-only gather: thread storage posture into the data-safety section.
+    let signals = crate::commands::storage_signals::gather(&config, state_db.as_ref());
+    let assessments =
+        awareness::assess(&config, now, &observation, &signals.by_subvol);
 
     let resolved = config.resolved_subvolumes();
     let data_safety: Vec<DoctorDataSafety> = assessments
@@ -216,6 +218,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
                 issue,
                 suggestion,
                 reason,
+                storage_posture: a.storage_posture,
             }
         })
         .collect();
@@ -368,18 +371,11 @@ fn build_doctor_recommendation_view(
         .collect();
     let since = now - window;
 
-    // UPI 031: resolve the BTRFS pool hosting "/" once (one `findmnt /`). Only
-    // `--thorough` reaches here; no autonomous/nightly consumer calls this.
-    let root_pool_uuid = pools::pool_uuid_for_path(std::path::Path::new("/"))
-        .ok()
-        .flatten();
-
     build_doctor_recommendation_view_inner(
         config,
         state_db,
         now,
         &pools_grouped,
-        root_pool_uuid.as_deref(),
         |mp: &Path| pools::pool_space(mp).ok(),
         |uuid: &str| pools::metadata_utilization_ratio(uuid),
         |uuid: &str| {
@@ -406,7 +402,6 @@ fn build_doctor_recommendation_view_inner(
     state_db: Option<&StateDb>,
     now: chrono::NaiveDateTime,
     pools_grouped: &[pools::SourcePool],
-    root_pool_uuid: Option<&str>,
     pool_space_resolver: impl Fn(&Path) -> Option<PoolSpace>,
     metadata_resolver: impl Fn(&str) -> Option<f64>,
     pool_trend_resolver: impl Fn(&str) -> Option<i64>,
@@ -470,13 +465,6 @@ fn build_doctor_recommendation_view_inner(
         };
 
     let resolved = config.resolved_subvolumes();
-
-    // UPI 031 (M1): the storage-critical gate. `/` is entrusted to Urd only
-    // when an *enabled* subvolume has `source == "/"`. A disabled root subvol
-    // does not extend structural fragility to its enabled pool siblings.
-    let root_subvol_configured = resolved
-        .iter()
-        .any(|s| s.enabled && s.source.as_path() == std::path::Path::new("/"));
 
     let mut rows: Vec<DoctorRecommendationRow> = Vec::new();
 
@@ -548,12 +536,31 @@ fn build_doctor_recommendation_view_inner(
         let severity_local = recommendation::classify_headroom_severity(ctx_local);
         let severity_external = recommendation::classify_headroom_severity(ctx_external);
 
+        // Synth-path fallback reason (M3): the Pressure/Critical branch is only
+        // reached when the source pool is genuinely low, so `SourcePoolLow` is
+        // the honest reason when `pick_reason` returns None (it renders prose;
+        // the retired `StorageCritical` reason rendered blank).
+        let source_free_ratio = match (
+            source_space.map(|s| s.free_bytes),
+            source_space.map(|s| s.capacity_bytes),
+        ) {
+            (Some(free), Some(cap)) if cap > 0 => {
+                #[allow(clippy::cast_precision_loss)]
+                {
+                    free as f64 / cap as f64
+                }
+            }
+            _ => 0.0,
+        };
+
         let local = match (local_rec, severity_local, local_current_shape) {
             (Some(r), _, _) => Some(r),
             (None, HeadroomSeverity::Pressure, Some(cur))
             | (None, HeadroomSeverity::Critical, Some(cur)) => {
                 let reason = recommendation::pick_reason(ctx_local, severity_local, None)
-                    .unwrap_or(AdjustmentReason::StorageCritical);
+                    .unwrap_or(AdjustmentReason::SourcePoolLow {
+                        free_ratio: source_free_ratio,
+                    });
                 Some(recommendation::headroom_aware_pointer_only(
                     &cur,
                     ShapeRole::Local,
@@ -572,7 +579,9 @@ fn build_doctor_recommendation_view_inner(
                     severity_external,
                     max_metadata_label.as_deref(),
                 )
-                .unwrap_or(AdjustmentReason::StorageCritical);
+                .unwrap_or(AdjustmentReason::SourcePoolLow {
+                    free_ratio: source_free_ratio,
+                });
                 Some(recommendation::headroom_aware_pointer_only(
                     &cur,
                     ShapeRole::External,
@@ -586,24 +595,6 @@ fn build_doctor_recommendation_view_inner(
         if local.is_none() && external.is_none() {
             continue;
         }
-
-        // UPI 031: storage-critical is a pool-level structural fact, computed
-        // once per subvolume (role-agnostic). It reads the SOURCE free-ratio
-        // only — deliberately not the combined `severity_*`, which folds in
-        // trend and destination-metadata signals. The pure rule owns the UUID
-        // comparison and the `root_subvol_configured` gate.
-        let source_free_ratio_severity = recommendation::classify_free_ratio(
-            source_space.map(|s| s.free_bytes),
-            source_space.map(|s| s.capacity_bytes),
-        );
-        let subvol_pool_uuid = subvol_pool.get(&sv.name).map(|(_, uuid)| uuid.as_str());
-        let storage_critical =
-            storage_critical::is_storage_critical(storage_critical::StorageCriticalInput {
-                subvol_pool_uuid,
-                root_pool_uuid,
-                root_subvol_configured,
-                source_free_ratio_severity,
-            });
 
         let note = local
             .as_ref()
@@ -620,7 +611,6 @@ fn build_doctor_recommendation_view_inner(
             external,
             note,
             was_named_level,
-            storage_critical,
         });
     }
 
@@ -888,7 +878,6 @@ source = "/data/docs"
             state_db,
             now,
             &[],
-            None,
             |_| None,
             |_| None,
             |_| None,
@@ -1249,93 +1238,6 @@ source = "/data/cold"
         }
     }
 
-    /// UPI 031: a config with a single enabled `root` subvolume whose
-    /// `source = "/"`. Defaults supply Graduated local retention so the row
-    /// reaches the synth path under Pressure.
-    fn root_cfg() -> Config {
-        let toml_str = r#"
-drives = []
-
-[general]
-state_db = "/tmp/urd-doctor-031/urd.db"
-metrics_file = "/tmp/urd-doctor-031/backup.prom"
-log_dir = "/tmp/urd-doctor-031"
-heartbeat_file = "/tmp/urd-doctor-031/heartbeat.json"
-
-[local_snapshots]
-roots = [
-  { path = "/snap", subvolumes = ["root"] }
-]
-
-[defaults]
-snapshot_interval = "1h"
-send_interval = "4h"
-[defaults.local_retention]
-hourly = 24
-daily = 60
-weekly = 52
-monthly = 24
-[defaults.external_retention]
-hourly = 0
-daily = 60
-weekly = 52
-monthly = 24
-
-[[subvolumes]]
-name = "root"
-short_name = "root"
-source = "/"
-"#;
-        toml::from_str(toml_str).unwrap()
-    }
-
-    /// UPI 031 (M1): a disabled `source = "/"` subvolume alongside an enabled
-    /// sibling `data` on the same pool. Verifies a disabled root does not
-    /// entrust `/`, so the sibling stays unflagged.
-    fn root_disabled_with_sibling_cfg() -> Config {
-        let toml_str = r#"
-drives = []
-
-[general]
-state_db = "/tmp/urd-doctor-031b/urd.db"
-metrics_file = "/tmp/urd-doctor-031b/backup.prom"
-log_dir = "/tmp/urd-doctor-031b"
-heartbeat_file = "/tmp/urd-doctor-031b/heartbeat.json"
-
-[local_snapshots]
-roots = [
-  { path = "/snap", subvolumes = ["root", "data"] }
-]
-
-[defaults]
-snapshot_interval = "1h"
-send_interval = "4h"
-[defaults.local_retention]
-hourly = 24
-daily = 60
-weekly = 52
-monthly = 24
-[defaults.external_retention]
-hourly = 0
-daily = 60
-weekly = 52
-monthly = 24
-
-[[subvolumes]]
-name = "root"
-short_name = "root"
-source = "/"
-enabled = false
-
-[[subvolumes]]
-name = "data"
-short_name = "data"
-source = "/data"
-enabled = true
-"#;
-        toml::from_str(toml_str).unwrap()
-    }
-
     /// Tight PoolSpace resolver (~10% free → Pressure), ignoring mountpoint.
     fn tight_pool_resolver(_mp: &Path) -> Option<PoolSpace> {
         Some(PoolSpace {
@@ -1359,7 +1261,6 @@ enabled = true
             Some(&db),
             now,
             &pools,
-            None,
             |_mp| Some(PoolSpace { free_bytes: 500_000_000_000, capacity_bytes: 1_000_000_000_000 }),
             |_uuid| None,
             |_uuid| None,
@@ -1384,7 +1285,6 @@ enabled = true
             Some(&db),
             now,
             &pools,
-            None,
             |_mp| Some(PoolSpace { free_bytes: 200_000_000_000, capacity_bytes: 1_000_000_000_000 }),
             |_uuid| None,
             |_uuid| None,
@@ -1409,7 +1309,6 @@ enabled = true
             Some(&db),
             now,
             &pools,
-            None,
             |_mp| Some(PoolSpace { free_bytes: 100_000_000_000, capacity_bytes: 1_000_000_000_000 }),
             |_uuid| None,
             |_uuid| None,
@@ -1442,7 +1341,6 @@ enabled = true
             Some(&db),
             now,
             &pools,
-            None,
             // 20% free → Caution.
             |_mp| Some(PoolSpace { free_bytes: 200_000_000_000, capacity_bytes: 1_000_000_000_000 }),
             |_uuid| None,
@@ -1451,195 +1349,6 @@ enabled = true
         assert!(
             !view.rows.iter().any(|r| r.name == "cold"),
             "Caution must not synthesize for cold subvol"
-        );
-    }
-
-    #[test]
-    fn storage_critical_flag_set_and_row_present() {
-        // M2: enabled `source = "/"` subvol on the root pool + tight pool →
-        // the row IS present (fallback-deletion invariant lock), the flag is
-        // set, and severity stays Pressure (NOT forced Critical).
-        let config = root_cfg();
-        let db = StateDb::open_memory().unwrap();
-        let now = now_fixed();
-        // No churn seeded → synth path; Pressure from the tight pool.
-        let pools = vec![pool_for_subvols(&["root"])];
-        let view = build_doctor_recommendation_view_inner(
-            &config,
-            Some(&db),
-            now,
-            &pools,
-            Some("pool-uuid-test"),
-            tight_pool_resolver,
-            |_uuid| None,
-            |_uuid| None,
-        );
-        let row = view
-            .rows
-            .iter()
-            .find(|r| r.name == "root")
-            .expect("storage_critical row must be present");
-        assert!(row.storage_critical, "flag must be set");
-        let local = row.local.as_ref().expect("local synth");
-        assert_eq!(
-            local.severity,
-            HeadroomSeverity::Pressure,
-            "severity stays Pressure, not forced Critical"
-        );
-        assert!(matches!(
-            local.reason,
-            Some(AdjustmentReason::SourcePoolLow { .. })
-        ));
-    }
-
-    #[test]
-    fn storage_critical_flag_clear_when_no_root_subvol_configured() {
-        // Gate off: no subvol has `source = "/"`. The cold subvol still
-        // synthesizes a Pressure row, but the flag is clear.
-        let config = upi044_cfg_with_pool();
-        let db = StateDb::open_memory().unwrap();
-        let now = now_fixed();
-        let pools = vec![pool_for_subvols(&["cold"])];
-        let view = build_doctor_recommendation_view_inner(
-            &config,
-            Some(&db),
-            now,
-            &pools,
-            Some("pool-uuid-test"),
-            tight_pool_resolver,
-            |_uuid| None,
-            |_uuid| None,
-        );
-        let row = view
-            .rows
-            .iter()
-            .find(|r| r.name == "cold")
-            .expect("cold Pressure synth row present");
-        assert!(
-            !row.storage_critical,
-            "no source=\"/\" subvol → flag clear"
-        );
-    }
-
-    #[test]
-    fn storage_critical_flag_clear_when_root_subvol_disabled() {
-        // M1: `root` (source "/") is disabled, so it does not entrust "/".
-        // The enabled sibling `data` on the same root pool stays unflagged.
-        let config = root_disabled_with_sibling_cfg();
-        let db = StateDb::open_memory().unwrap();
-        let now = now_fixed();
-        let pools = vec![pool_for_subvols(&["root", "data"])];
-        let view = build_doctor_recommendation_view_inner(
-            &config,
-            Some(&db),
-            now,
-            &pools,
-            Some("pool-uuid-test"),
-            tight_pool_resolver,
-            |_uuid| None,
-            |_uuid| None,
-        );
-        // The disabled root produces no row at all.
-        assert!(
-            !view.rows.iter().any(|r| r.name == "root"),
-            "disabled subvol is skipped"
-        );
-        let data = view
-            .rows
-            .iter()
-            .find(|r| r.name == "data")
-            .expect("enabled sibling row present");
-        assert!(
-            !data.storage_critical,
-            "disabled root must not flag an enabled sibling"
-        );
-    }
-
-    #[test]
-    fn storage_critical_flag_clear_on_pool_uuid_mismatch() {
-        // The subvol's pool UUID differs from `/`'s pool → not on the root
-        // pool → flag clear (row still present from Pressure).
-        let config = root_cfg();
-        let db = StateDb::open_memory().unwrap();
-        let now = now_fixed();
-        let pools = vec![pool_for_subvols(&["root"])]; // uuid "pool-uuid-test"
-        let view = build_doctor_recommendation_view_inner(
-            &config,
-            Some(&db),
-            now,
-            &pools,
-            Some("a-different-pool-uuid"),
-            tight_pool_resolver,
-            |_uuid| None,
-            |_uuid| None,
-        );
-        let row = view
-            .rows
-            .iter()
-            .find(|r| r.name == "root")
-            .expect("row present");
-        assert!(!row.storage_critical, "UUID mismatch → flag clear");
-    }
-
-    #[test]
-    fn storage_critical_flag_clear_when_root_pool_uuid_unresolved() {
-        // `findmnt /` failed → root_pool_uuid None → detection disabled.
-        let config = root_cfg();
-        let db = StateDb::open_memory().unwrap();
-        let now = now_fixed();
-        let pools = vec![pool_for_subvols(&["root"])];
-        let view = build_doctor_recommendation_view_inner(
-            &config,
-            Some(&db),
-            now,
-            &pools,
-            None,
-            tight_pool_resolver,
-            |_uuid| None,
-            |_uuid| None,
-        );
-        let row = view
-            .rows
-            .iter()
-            .find(|r| r.name == "root")
-            .expect("row present");
-        assert!(!row.storage_critical, "unresolved root pool → flag clear");
-    }
-
-    #[test]
-    fn storage_critical_preserves_tightened_adjusted_shape() {
-        // Inverse of the old `critical_injection_clears_*`: a storage_critical
-        // Pressure row keeps its tightened `adjusted`/`adjusted_cost` (Branch
-        // D) — the flag is purely additive, it does not force Critical or
-        // clear the role recommendation.
-        let config = root_cfg();
-        let db = StateDb::open_memory().unwrap();
-        let now = now_fixed();
-        // Hot churn so the engine produces a tightenable shape.
-        seed_incremental(&db, "root", now - chrono::Duration::hours(12), 2_700_000_000);
-        let pools = vec![pool_for_subvols(&["root"])];
-        let view = build_doctor_recommendation_view_inner(
-            &config,
-            Some(&db),
-            now,
-            &pools,
-            Some("pool-uuid-test"),
-            tight_pool_resolver,
-            |_uuid| None,
-            |_uuid| None,
-        );
-        let row = view
-            .rows
-            .iter()
-            .find(|r| r.name == "root")
-            .expect("row present");
-        assert!(row.storage_critical, "flag set");
-        let local = row.local.as_ref().expect("local");
-        assert_eq!(local.severity, HeadroomSeverity::Pressure);
-        assert!(local.adjusted.is_some(), "tightened shape preserved");
-        assert!(
-            local.adjusted_cost.is_some(),
-            "adjusted_cost preserved in lockstep"
         );
     }
 
@@ -1687,7 +1396,6 @@ enabled = true
             external: Some(h),
             note: None,
             was_named_level: None,
-            storage_critical: false,
         };
         // current=200, adjusted=25 → recovery = 175 GB (not 150 GB from suggested).
         assert_eq!(recovery_bytes(&row), 175_000_000_000);
@@ -1733,7 +1441,6 @@ enabled = true
             external: None,
             note: None,
             was_named_level: None,
-            storage_critical: false,
         };
         assert_eq!(recovery_bytes(&row), 150_000_000_000);
     }
@@ -1755,7 +1462,6 @@ enabled = true
             Some(&db),
             now,
             &pools,
-            None,
             tight_pool_resolver,
             |_| None,
             |_| None,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -15,4 +15,5 @@ pub mod plan_cmd;
 pub mod retention_preview;
 pub mod status;
 pub mod sentinel;
+pub mod storage_signals;
 pub mod verify;

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -8,6 +8,7 @@ use crate::output::{
     StatusOutput,
 };
 use crate::plan::{Observation, RealFileSystemState};
+use crate::commands::storage_signals;
 use crate::retention;
 use crate::state::StateDb;
 use crate::voice;
@@ -31,8 +32,13 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
 
     // ── Awareness model ─────────────────────────────────────────────
     let now = chrono::Local::now().naive_local();
-    let mut assessments = awareness::assess(&config, now, &observation);
+    // Gather storage signals (read-only) and thread the per-subvol map into
+    // assess(); status reflects the stabilized tier but never advances it (S1).
+    let signals = storage_signals::gather(&config, state_db.as_ref());
+    let mut assessments =
+        awareness::assess(&config, now, &observation, &signals.by_subvol);
     advice::overlay_offsite_freshness(&mut assessments, &config);
+    let storage_postures = storage_signals::aggregate(&assessments, &signals, now);
 
     // ── Chain health per subvolume (derived from awareness assessment) ──
     let chain_health_entries: Vec<ChainHealthEntry> = assessments
@@ -134,6 +140,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         total_pins,
         redundancy_advisories,
         advice,
+        storage_postures,
     };
 
     let rendered = voice::render_status(&status_output, output_mode);

--- a/src/commands/storage_signals.rs
+++ b/src/commands/storage_signals.rs
@@ -1,0 +1,551 @@
+//! Storage-signal gathering, aggregation, and write-back (UPI 031-a).
+//!
+//! The command-layer I/O boundary (ADR-108) that feeds the pure storage
+//! posture: `findmnt` (pool UUID + mountpoint), `statvfs` (free-ratio), and
+//! the persisted prior armed tier. Pure derivation stays in
+//! `storage_critical.rs`; `assess()` consumes the per-subvolume signal map.
+//!
+//! - **Read paths** (`status`, bare `urd`, `doctor`) call `gather()` +
+//!   `aggregate()` only — they *reflect* the hysteresis-stabilized tier and
+//!   never advance state (S1: a read can never fire a transition).
+//! - **`backup`** additionally calls `advance_and_writeback()` after its
+//!   post-execution `assess()`: it re-runs the pure hysteresis per
+//!   UUID-resolvable pool, persists `(armed_tier, since)` best-effort, and
+//!   returns escalation transitions for the notification path (D6). UUID-less
+//!   pools are skipped entirely — status-only, never persisted (S5).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDateTime;
+
+use crate::awareness::{ResolvedStorageSignal, StorageSignalMap, SubvolAssessment};
+use crate::config::Config;
+use crate::output::PoolPostureSummary;
+use crate::pools::{self, PoolSpace};
+use crate::state::StateDb;
+use crate::storage_critical::{self, TightnessTier, Transition};
+
+/// Per-pool resolved signal (UPI 031-a). The command-layer view that backs
+/// both `aggregate()` (display) and `advance_and_writeback()` (persistence).
+/// One per distinct source pool that an enabled subvolume lives on.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PoolSignal {
+    /// Pool UUID when resolvable; `None` for a pool findmnt could not key to a
+    /// UUID — surfaced status-only, never persisted (S5).
+    pub uuid: Option<String>,
+    /// Human display label (the source pool mountpoint, e.g. `/` or `/mnt/data`).
+    pub label: String,
+    /// Enabled subvolume names whose source resolves to this pool (Min1).
+    pub subvol_names: Vec<String>,
+    /// Source free / capacity ratio; `None` when unmeasurable.
+    pub free_ratio: Option<f64>,
+    /// This pool is the host-root pool and an enabled subvol entrusts `/`.
+    pub host_root: bool,
+    /// Prior armed tier from `pool_armed_tier` (Roomy when untracked).
+    pub prior_armed_tier: TightnessTier,
+    /// When the armed tier last changed (the "flagged since" timestamp).
+    pub prior_since: Option<NaiveDateTime>,
+}
+
+/// Gathered storage signals: the per-subvolume map fed to `assess()` plus the
+/// per-pool view fed to `aggregate()` / `advance_and_writeback()`.
+#[derive(Debug, Clone)]
+pub struct StorageSignals {
+    pub by_subvol: StorageSignalMap,
+    pub pools: Vec<PoolSignal>,
+}
+
+/// An escalating pool transition surfaced by `advance_and_writeback` for the
+/// notification path (D6). Carries everything the notification needs without a
+/// back-correlation: the display label, the host-root escalation flag, and the
+/// tier change.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PostureEscalation {
+    pub pool_label: String,
+    pub host_root: bool,
+    pub transition: Transition,
+}
+
+/// Free/capacity ratio from a `PoolSpace`; `None` on zero/garbage capacity.
+fn pool_free_ratio(space: PoolSpace) -> Option<f64> {
+    if space.capacity_bytes == 0 {
+        return None;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let ratio = space.free_bytes as f64 / space.capacity_bytes as f64;
+    ratio.is_finite().then_some(ratio)
+}
+
+/// Gather storage signals for all enabled subvolumes (read-only). One
+/// `findmnt` per subvolume source (the combined UUID+mountpoint resolver — S3),
+/// one `statvfs` per distinct pool mountpoint, one batched armed-tier read.
+#[must_use]
+pub fn gather(config: &Config, state_db: Option<&StateDb>) -> StorageSignals {
+    let prior = state_db
+        .and_then(|db| db.all_armed_tiers().ok())
+        .unwrap_or_default();
+    let root_pool_uuid = pools::pool_uuid_for_path(Path::new("/")).ok().flatten();
+    gather_with(
+        config,
+        &prior,
+        root_pool_uuid.as_deref(),
+        |p| pools::resolve_source_pool(p).unwrap_or((None, None)),
+        |mp| pools::pool_space(mp).ok(),
+    )
+}
+
+/// Testable core of `gather`: I/O is injected. `resolve` maps a source path to
+/// `(pool_uuid, mountpoint)`; `space` maps a mountpoint to its `PoolSpace`.
+fn gather_with(
+    config: &Config,
+    prior_tiers: &HashMap<String, (TightnessTier, NaiveDateTime)>,
+    root_pool_uuid: Option<&str>,
+    mut resolve: impl FnMut(&Path) -> (Option<String>, Option<PathBuf>),
+    mut space: impl FnMut(&Path) -> Option<PoolSpace>,
+) -> StorageSignals {
+    let resolved = config.resolved_subvolumes();
+    let root_subvol_configured = resolved
+        .iter()
+        .any(|sv| sv.enabled && sv.source.as_path() == Path::new("/"));
+
+    // Accumulate distinct pools (insertion-ordered) and the subvol→pool map.
+    let mut order: Vec<String> = Vec::new();
+    let mut by_key: HashMap<String, PoolSignal> = HashMap::new();
+    let mut subvol_key: Vec<(String, String)> = Vec::new();
+
+    for sv in &resolved {
+        if !sv.enabled {
+            continue;
+        }
+        let (uuid, mountpoint) = resolve(&sv.source);
+        // Key pools by UUID when known; otherwise by mountpoint (so UUID-less
+        // subvols on one mount still aggregate), else by name (degenerate).
+        let key = match (&uuid, &mountpoint) {
+            (Some(u), _) => format!("uuid:{u}"),
+            (None, Some(mp)) => format!("mp:{}", mp.display()),
+            (None, None) => format!("sv:{}", sv.name),
+        };
+
+        if !by_key.contains_key(&key) {
+            let free_ratio = mountpoint
+                .as_deref()
+                .and_then(&mut space)
+                .and_then(pool_free_ratio);
+            let host_root = storage_critical::host_root(
+                uuid.as_deref(),
+                root_pool_uuid,
+                root_subvol_configured,
+            );
+            let (prior_armed_tier, prior_since) = uuid
+                .as_deref()
+                .and_then(|u| prior_tiers.get(u))
+                .map_or((TightnessTier::Roomy, None), |(t, s)| (*t, Some(*s)));
+            let label = mountpoint
+                .as_ref()
+                .map(|mp| mp.to_string_lossy().into_owned())
+                .or_else(|| uuid.clone())
+                .unwrap_or_else(|| sv.name.clone());
+            by_key.insert(
+                key.clone(),
+                PoolSignal {
+                    uuid: uuid.clone(),
+                    label,
+                    subvol_names: Vec::new(),
+                    free_ratio,
+                    host_root,
+                    prior_armed_tier,
+                    prior_since,
+                },
+            );
+            order.push(key.clone());
+        }
+        if let Some(pool) = by_key.get_mut(&key) {
+            pool.subvol_names.push(sv.name.clone());
+        }
+        subvol_key.push((sv.name.clone(), key));
+    }
+
+    // Per-subvolume signals reflect the pool each subvol lives on.
+    let mut by_subvol = StorageSignalMap::new();
+    for (name, key) in &subvol_key {
+        if let Some(pool) = by_key.get(key) {
+            by_subvol.insert(
+                name.clone(),
+                ResolvedStorageSignal {
+                    free_ratio: pool.free_ratio,
+                    host_root: pool.host_root,
+                    prior_armed_tier: pool.prior_armed_tier,
+                    prior_since: pool.prior_since,
+                },
+            );
+        }
+    }
+
+    let pools = order
+        .into_iter()
+        .filter_map(|k| by_key.remove(&k))
+        .collect();
+    StorageSignals { by_subvol, pools }
+}
+
+/// Re-run the hysteresis per UUID-resolvable pool, persist `(armed_tier,
+/// since)` best-effort, and return the **escalation** transitions (backup
+/// path only — read paths must never call this). `since` advances to `now`
+/// only when the tier changes; otherwise the prior `since` is preserved so
+/// the "flagged since" timestamp stays stable. UUID-less pools are skipped
+/// (S5) — no persist, no notification, status-only degrade.
+#[must_use]
+pub fn advance_and_writeback(
+    state_db: &StateDb,
+    now: NaiveDateTime,
+    signals: &StorageSignals,
+) -> Vec<PostureEscalation> {
+    let mut escalations = Vec::new();
+    for pool in &signals.pools {
+        let Some(uuid) = pool.uuid.as_deref() else {
+            continue; // UUID-less: status-only (S5)
+        };
+        let new = storage_critical::resolve_armed_tier(
+            pool.prior_armed_tier,
+            pool.free_ratio,
+        );
+        let since = if new == pool.prior_armed_tier {
+            pool.prior_since.unwrap_or(now)
+        } else {
+            now
+        };
+        state_db.upsert_armed_tier_best_effort(uuid, new, since);
+
+        if let Some(transition) = storage_critical::transition(pool.prior_armed_tier, new)
+            && transition.is_escalation()
+        {
+            escalations.push(PostureEscalation {
+                pool_label: pool.label.clone(),
+                host_root: pool.host_root,
+                transition,
+            });
+        }
+    }
+    escalations
+}
+
+/// Aggregate the per-subvolume postures into one display line per tight pool
+/// (D1). Pure. A pool whose subvolumes are all Roomy/posture-less yields no
+/// summary (Urd stays silent). `tier`/`host_root` are read from the
+/// `assess()`-computed posture (single source of truth); `affected_count` is
+/// the count of enabled subvolumes on the pool (Min1); `since_secs` is the
+/// age of the per-pool `prior_since`.
+#[must_use]
+pub fn aggregate(
+    assessments: &[SubvolAssessment],
+    signals: &StorageSignals,
+    now: NaiveDateTime,
+) -> Vec<PoolPostureSummary> {
+    let mut summaries = Vec::new();
+    for pool in &signals.pools {
+        // The pool's subvolumes share a posture; take the first that carries one.
+        let posture = pool.subvol_names.iter().find_map(|n| {
+            assessments
+                .iter()
+                .find(|a| &a.name == n)
+                .and_then(|a| a.storage_posture)
+        });
+        let Some(posture) = posture else {
+            continue; // Roomy / posture-less → silent
+        };
+        let since_secs = pool.prior_since.map(|s| (now - s).num_seconds());
+        summaries.push(PoolPostureSummary {
+            pool_label: pool.label.clone(),
+            tier: posture.tier,
+            host_root: posture.host_root,
+            affected_count: pool.subvol_names.len(),
+            since_secs,
+        });
+    }
+    summaries
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage_critical::{StoragePosture, TightnessTier};
+
+    fn dt(s: &str) -> NaiveDateTime {
+        NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").unwrap()
+    }
+
+    /// Two subvolumes `alpha` + `beta` sharing one pool (source `/data`), plus
+    /// `root` on `/`. `root` is enabled, so `/` is entrusted.
+    fn cfg() -> Config {
+        let toml_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-031a-signals/urd.db"
+metrics_file = "/tmp/urd-031a-signals/backup.prom"
+log_dir = "/tmp/urd-031a-signals"
+heartbeat_file = "/tmp/urd-031a-signals/heartbeat.json"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["alpha", "beta", "root"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+daily = 60
+weekly = 52
+monthly = 24
+[defaults.external_retention]
+hourly = 0
+daily = 60
+weekly = 52
+monthly = 24
+
+[[subvolumes]]
+name = "alpha"
+short_name = "alpha"
+source = "/data/alpha"
+
+[[subvolumes]]
+name = "beta"
+short_name = "beta"
+source = "/data/beta"
+
+[[subvolumes]]
+name = "root"
+short_name = "root"
+source = "/"
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    /// Resolver: `/data/*` → pool `data-uuid` at `/data`; `/` → `root-uuid` at `/`.
+    fn resolver(p: &Path) -> (Option<String>, Option<PathBuf>) {
+        let s = p.to_string_lossy();
+        if s == "/" {
+            (Some("root-uuid".to_string()), Some(PathBuf::from("/")))
+        } else if s.starts_with("/data") {
+            (Some("data-uuid".to_string()), Some(PathBuf::from("/data")))
+        } else {
+            (None, None)
+        }
+    }
+
+    fn space_full(_mp: &Path) -> Option<PoolSpace> {
+        // 50% free → Roomy.
+        Some(PoolSpace {
+            free_bytes: 50,
+            capacity_bytes: 100,
+        })
+    }
+
+    fn space_tight(mp: &Path) -> Option<PoolSpace> {
+        // Only `/data` is tight (20% free → Tight); `/` stays roomy (50%), so
+        // the root pool does not also escalate and muddy the assertions.
+        if mp == Path::new("/data") {
+            Some(PoolSpace {
+                free_bytes: 20,
+                capacity_bytes: 100,
+            })
+        } else {
+            Some(PoolSpace {
+                free_bytes: 50,
+                capacity_bytes: 100,
+            })
+        }
+    }
+
+    #[test]
+    fn gather_builds_per_subvol_and_per_pool_views() {
+        let prior = HashMap::new();
+        let signals = gather_with(
+            &cfg(),
+            &prior,
+            Some("root-uuid"),
+            resolver,
+            space_tight,
+        );
+        // Two pools: data-uuid (alpha+beta) and root-uuid (root).
+        assert_eq!(signals.pools.len(), 2);
+        let data = signals
+            .pools
+            .iter()
+            .find(|p| p.uuid.as_deref() == Some("data-uuid"))
+            .unwrap();
+        assert_eq!(data.subvol_names.len(), 2);
+        assert!(!data.host_root); // data pool is not the root pool
+        assert_eq!(data.free_ratio, Some(0.2));
+
+        let root = signals
+            .pools
+            .iter()
+            .find(|p| p.uuid.as_deref() == Some("root-uuid"))
+            .unwrap();
+        assert!(root.host_root); // on root pool + `/` entrusted
+
+        // Every enabled subvol has a signal.
+        assert!(signals.by_subvol.contains_key("alpha"));
+        assert!(signals.by_subvol.contains_key("beta"));
+        assert!(signals.by_subvol.contains_key("root"));
+    }
+
+    #[test]
+    fn gather_reads_prior_armed_tier() {
+        let mut prior = HashMap::new();
+        prior.insert(
+            "data-uuid".to_string(),
+            (TightnessTier::Critical, dt("2026-05-20T04:00:00")),
+        );
+        let signals =
+            gather_with(&cfg(), &prior, Some("root-uuid"), resolver, space_tight);
+        let data = signals
+            .pools
+            .iter()
+            .find(|p| p.uuid.as_deref() == Some("data-uuid"))
+            .unwrap();
+        assert_eq!(data.prior_armed_tier, TightnessTier::Critical);
+        assert_eq!(data.prior_since, Some(dt("2026-05-20T04:00:00")));
+    }
+
+    #[test]
+    fn advance_writes_back_and_emits_escalation() {
+        let db = StateDb::open_memory().unwrap();
+        let now = dt("2026-05-30T04:00:00");
+        // data-uuid escalates Roomy→Tight (20% free).
+        let signals =
+            gather_with(&cfg(), &HashMap::new(), Some("root-uuid"), resolver, space_tight);
+
+        let transitions = advance_and_writeback(&db, now, &signals);
+        // Both pools start Roomy; data escalates to Tight, root stays Roomy.
+        assert_eq!(transitions.len(), 1);
+        assert_eq!(transitions[0].pool_label, "/data");
+        assert_eq!(transitions[0].transition.to, TightnessTier::Tight);
+        assert!(!transitions[0].host_root);
+
+        // Persisted.
+        let stored = db.armed_tier_for_pool("data-uuid").unwrap();
+        assert_eq!(stored.map(|(t, _)| t), Some(TightnessTier::Tight));
+        // `since` was set to `now` (tier changed).
+        assert_eq!(stored.map(|(_, s)| s), Some(now));
+    }
+
+    #[test]
+    fn advance_preserves_since_when_tier_unchanged() {
+        let db = StateDb::open_memory().unwrap();
+        let prior_since = dt("2026-05-20T04:00:00");
+        let mut prior = HashMap::new();
+        prior.insert("data-uuid".to_string(), (TightnessTier::Tight, prior_since));
+        // Still 20% free → stays Tight (sticky); no change.
+        let signals =
+            gather_with(&cfg(), &prior, Some("root-uuid"), resolver, space_tight);
+        let now = dt("2026-05-30T04:00:00");
+
+        let transitions = advance_and_writeback(&db, now, &signals);
+        assert!(transitions.is_empty()); // no escalation on steady state
+        let stored = db.armed_tier_for_pool("data-uuid").unwrap();
+        assert_eq!(stored, Some((TightnessTier::Tight, prior_since)));
+    }
+
+    #[test]
+    fn advance_does_not_emit_on_de_escalation() {
+        let db = StateDb::open_memory().unwrap();
+        let mut prior = HashMap::new();
+        // Armed Critical; free recovered to 50% → de-escalates to Roomy.
+        prior.insert(
+            "data-uuid".to_string(),
+            (TightnessTier::Critical, dt("2026-05-20T04:00:00")),
+        );
+        let signals =
+            gather_with(&cfg(), &prior, Some("root-uuid"), resolver, space_full);
+        let now = dt("2026-05-30T04:00:00");
+
+        let escalations = advance_and_writeback(&db, now, &signals);
+        // De-escalation is silent — no notification.
+        assert!(escalations.is_empty());
+        // But the recovery IS persisted, with `since` advanced to now.
+        let stored = db.armed_tier_for_pool("data-uuid").unwrap();
+        assert_eq!(stored, Some((TightnessTier::Roomy, now)));
+    }
+
+    #[test]
+    fn advance_skips_uuidless_pool() {
+        let db = StateDb::open_memory().unwrap();
+        // Resolver yields no UUID but a mountpoint → posture surfaces, no persist.
+        let resolver_no_uuid = |_p: &Path| (None, Some(PathBuf::from("/data")));
+        let signals = gather_with(
+            &cfg(),
+            &HashMap::new(),
+            None,
+            resolver_no_uuid,
+            space_tight,
+        );
+        let transitions = advance_and_writeback(&db, dt("2026-05-30T04:00:00"), &signals);
+        assert!(transitions.is_empty());
+        // Nothing written.
+        assert!(db.all_armed_tiers().unwrap().is_empty());
+    }
+
+    #[test]
+    fn gather_is_read_only() {
+        // gather_with takes no StateDb and so cannot write; assert the public
+        // gather leaves an empty DB untouched (read-only contract).
+        let db = StateDb::open_memory().unwrap();
+        let _ = gather(&cfg(), Some(&db));
+        assert!(db.all_armed_tiers().unwrap().is_empty());
+    }
+
+    #[test]
+    fn aggregate_counts_subvols_and_since() {
+        let now = dt("2026-05-30T04:00:00");
+        let mut prior = HashMap::new();
+        prior.insert(
+            "data-uuid".to_string(),
+            (TightnessTier::Tight, dt("2026-05-29T04:00:00")),
+        );
+        let signals =
+            gather_with(&cfg(), &prior, Some("root-uuid"), resolver, space_tight);
+
+        // Synthesize assessments carrying the Tight posture for the data subvols.
+        let assessments = vec![
+            mk_assess("alpha", Some(StoragePosture { tier: TightnessTier::Tight, host_root: false })),
+            mk_assess("beta", Some(StoragePosture { tier: TightnessTier::Tight, host_root: false })),
+            mk_assess("root", None),
+        ];
+
+        let summaries = aggregate(&assessments, &signals, now);
+        assert_eq!(summaries.len(), 1);
+        let s = &summaries[0];
+        assert_eq!(s.pool_label, "/data");
+        assert_eq!(s.tier, TightnessTier::Tight);
+        assert_eq!(s.affected_count, 2);
+        assert_eq!(s.since_secs, Some(86_400)); // one day
+    }
+
+    fn mk_assess(name: &str, posture: Option<StoragePosture>) -> SubvolAssessment {
+        use crate::awareness::{LocalAssessment, OperationalHealth, PromiseStatus};
+        use crate::types::Interval;
+        SubvolAssessment {
+            name: name.to_string(),
+            status: PromiseStatus::Protected,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
+            local: LocalAssessment {
+                status: PromiseStatus::Protected,
+                snapshot_count: 1,
+                newest_age: None,
+                configured_interval: Interval::hours(1),
+            },
+            external: vec![],
+            chain_health: vec![],
+            advisories: vec![],
+            redundancy_advisories: vec![],
+            errors: vec![],
+            storage_posture: posture,
+        }
+    }
+}

--- a/src/commands/storage_signals.rs
+++ b/src/commands/storage_signals.rs
@@ -67,14 +67,15 @@ pub struct PostureEscalation {
     pub transition: Transition,
 }
 
-/// Free/capacity ratio from a `PoolSpace`; `None` on zero/garbage capacity.
-fn pool_free_ratio(space: PoolSpace) -> Option<f64> {
-    if space.capacity_bytes == 0 {
-        return None;
-    }
-    #[allow(clippy::cast_precision_loss)]
-    let ratio = space.free_bytes as f64 / space.capacity_bytes as f64;
-    ratio.is_finite().then_some(ratio)
+/// How distinct pools are grouped within `gather_with`: by UUID when known,
+/// else by mountpoint (so UUID-less subvols on one mount still aggregate),
+/// else by name (degenerate). A typed key — never persisted or displayed —
+/// so the grouping can't collide the way prefixed strings could.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum PoolKey {
+    Uuid(String),
+    Mount(PathBuf),
+    Subvol(String),
 }
 
 /// Gather storage signals for all enabled subvolumes (read-only). One
@@ -109,29 +110,29 @@ fn gather_with(
         .iter()
         .any(|sv| sv.enabled && sv.source.as_path() == Path::new("/"));
 
-    // Accumulate distinct pools (insertion-ordered) and the subvol→pool map.
-    let mut order: Vec<String> = Vec::new();
-    let mut by_key: HashMap<String, PoolSignal> = HashMap::new();
-    let mut subvol_key: Vec<(String, String)> = Vec::new();
+    // Accumulate distinct pools (insertion-ordered) and the per-subvol map in
+    // one pass: every field `by_subvol` reads is fixed when the pool is first
+    // inserted, so it can be mirrored inline rather than in a second loop.
+    let mut order: Vec<PoolKey> = Vec::new();
+    let mut by_key: HashMap<PoolKey, PoolSignal> = HashMap::new();
+    let mut by_subvol = StorageSignalMap::new();
 
     for sv in &resolved {
         if !sv.enabled {
             continue;
         }
         let (uuid, mountpoint) = resolve(&sv.source);
-        // Key pools by UUID when known; otherwise by mountpoint (so UUID-less
-        // subvols on one mount still aggregate), else by name (degenerate).
         let key = match (&uuid, &mountpoint) {
-            (Some(u), _) => format!("uuid:{u}"),
-            (None, Some(mp)) => format!("mp:{}", mp.display()),
-            (None, None) => format!("sv:{}", sv.name),
+            (Some(u), _) => PoolKey::Uuid(u.clone()),
+            (None, Some(mp)) => PoolKey::Mount(mp.clone()),
+            (None, None) => PoolKey::Subvol(sv.name.clone()),
         };
 
         if !by_key.contains_key(&key) {
             let free_ratio = mountpoint
                 .as_deref()
                 .and_then(&mut space)
-                .and_then(pool_free_ratio);
+                .and_then(PoolSpace::free_ratio);
             let host_root = storage_critical::host_root(
                 uuid.as_deref(),
                 root_pool_uuid,
@@ -162,16 +163,8 @@ fn gather_with(
         }
         if let Some(pool) = by_key.get_mut(&key) {
             pool.subvol_names.push(sv.name.clone());
-        }
-        subvol_key.push((sv.name.clone(), key));
-    }
-
-    // Per-subvolume signals reflect the pool each subvol lives on.
-    let mut by_subvol = StorageSignalMap::new();
-    for (name, key) in &subvol_key {
-        if let Some(pool) = by_key.get(key) {
             by_subvol.insert(
-                name.clone(),
+                sv.name.clone(),
                 ResolvedStorageSignal {
                     free_ratio: pool.free_ratio,
                     host_root: pool.host_root,

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -410,6 +410,7 @@ mod tests {
                 advisories: vec![],
                 redundancy_advisories: vec![],
                 errors: vec![],
+                storage_posture: None,
             },
             SubvolAssessment {
                 name: "docs".to_string(),
@@ -427,6 +428,7 @@ mod tests {
                 advisories: vec![],
                 redundancy_advisories: vec![],
                 errors: vec![],
+                storage_posture: None,
             },
         ]
     }
@@ -497,6 +499,45 @@ mod tests {
         assert_eq!(parsed.subvolumes[1].promise_status, PromiseStatus::AtRisk);
         // "docs" has send_type: NoSend → send_completed: false
         assert!(!parsed.subvolumes[1].send_completed);
+    }
+
+    /// S4 guard (UPI 031-a): the heartbeat projection (`SubvolumeHeartbeat`) is
+    /// a fixed shape, so a per-subvolume `storage_posture` must NOT leak into
+    /// the heartbeat JSON — the posture is a `urd status`/notify surface only
+    /// (D6, Cross-Repo Impact: None). Construct a Tight + Critical posture and
+    /// assert no posture field/substring survives serialization.
+    #[test]
+    fn storage_posture_never_leaks_into_heartbeat() {
+        use crate::storage_critical::{StoragePosture, TightnessTier};
+        let config = test_config(&[("home", "1h"), ("docs", "1h")]);
+        let now =
+            NaiveDateTime::parse_from_str("2026-03-24T02:05:00", "%Y-%m-%dT%H:%M:%S").unwrap();
+        let mut assessments = test_assessments();
+        assessments[0].storage_posture = Some(StoragePosture {
+            tier: TightnessTier::Critical,
+            host_root: true,
+        });
+        assessments[1].storage_posture = Some(StoragePosture {
+            tier: TightnessTier::Tight,
+            host_root: false,
+        });
+        let result = test_execution_result();
+
+        let heartbeat = build_from_run(
+            &config,
+            now,
+            &result,
+            &assessments,
+            &HashMap::new(),
+            Vec::new(),
+            Vec::new(),
+            &HashMap::new(),
+        );
+        let json = serde_json::to_string(&heartbeat).unwrap();
+        assert!(
+            !json.contains("storage_posture") && !json.contains("posture"),
+            "posture must not leak into the heartbeat JSON: {json}"
+        );
     }
 
     // ── stale_after ─────────────────────────────────────────────────────

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -356,7 +356,7 @@ fn format_metrics(data: &MetricsData) -> String {
     writeln!(out).unwrap();
     writeln!(
         out,
-        "# HELP backup_subvolume_last_full_send_bytes Bytes of the most recent in-window full send for subvolumes whose latest send was a full send (e.g., transient/storage_critical subvolumes). Absent for incremental-only and cold-start subvolumes."
+        "# HELP backup_subvolume_last_full_send_bytes Bytes of the most recent in-window full send for subvolumes whose latest send was a full send (e.g., transient subvolumes). Absent for incremental-only and cold-start subvolumes."
     )
     .unwrap();
     writeln!(

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::awareness::PromiseStatus;
 use crate::heartbeat::Heartbeat;
+use crate::storage_critical::{TightnessTier, Transition};
 
 // ── Event types ────────────────────────────────────────────────────────
 
@@ -91,6 +92,15 @@ pub enum NotificationEvent {
         root: String,
         freed_bytes: u64,
         deleted_count: usize,
+    },
+    /// A source pool's tightness tier escalated (UPI 031-a). Dispatched
+    /// best-effort by `urd backup` only — the told-not-silent "just noticed"
+    /// surface (D6). `from`/`to` are tier labels (`roomy`/`tight`/`critical`).
+    StoragePressureRising {
+        pool_label: String,
+        from: String,
+        to: String,
+        host_root: bool,
     },
 }
 
@@ -350,6 +360,58 @@ pub fn build_drive_reconnected_notification(
         urgency: Urgency::Info,
         title: format!("{label} is back"),
         body,
+    }
+}
+
+// ── Storage-pressure notifications (UPI 031-a) ────────────────────────
+
+/// Build a best-effort notification for a source pool whose tightness tier
+/// escalated (D6). Urgency scales with severity: `Critical` tier or a
+/// host-root pool fires at `Critical`; a plain `Tight` escalation fires at
+/// `Warning`. The host-root case carries the relocated 031 stakes prose.
+#[must_use]
+pub fn build_storage_pressure_notification(
+    pool_label: &str,
+    transition: Transition,
+    host_root: bool,
+) -> Notification {
+    let to_label = tier_word(transition.to);
+    let urgency = if transition.to == TightnessTier::Critical || host_root {
+        Urgency::Critical
+    } else {
+        Urgency::Warning
+    };
+
+    let mut body = format!(
+        "{pool_label} is now {to_label} on free space \
+         ({} → {to_label}). Consider freeing space or tightening retention.",
+        tier_word(transition.from),
+    );
+    if host_root {
+        body.push_str(
+            " This is your host root, so pressure here risks the machine itself.",
+        );
+    }
+
+    Notification {
+        event: NotificationEvent::StoragePressureRising {
+            pool_label: pool_label.to_string(),
+            from: transition.from.as_db_str().to_string(),
+            to: transition.to.as_db_str().to_string(),
+            host_root,
+        },
+        urgency,
+        title: format!("Storage running {to_label}: {pool_label}"),
+        body,
+    }
+}
+
+/// User-facing word for a tightness tier in notification prose.
+fn tier_word(tier: TightnessTier) -> &'static str {
+    match tier {
+        TightnessTier::Roomy => "roomy",
+        TightnessTier::Tight => "tight",
+        TightnessTier::Critical => "critically tight",
     }
 }
 
@@ -1053,5 +1115,68 @@ mod tests {
             "event: {:?}",
             n.event
         );
+    }
+
+    // ── UPI 031-a: storage-pressure notifications ───────────────────
+
+    fn trans(from: TightnessTier, to: TightnessTier) -> Transition {
+        Transition { from, to }
+    }
+
+    #[test]
+    fn storage_pressure_tight_is_warning() {
+        let n = build_storage_pressure_notification(
+            "/data",
+            trans(TightnessTier::Roomy, TightnessTier::Tight),
+            false,
+        );
+        assert_eq!(n.urgency, Urgency::Warning);
+        assert!(n.title.contains("/data"), "title: {}", n.title);
+        assert!(n.body.contains("tight"), "body: {}", n.body);
+        assert!(
+            !n.body.contains("host root"),
+            "non-host-root body must not mention host root: {}",
+            n.body
+        );
+        assert!(matches!(
+            n.event,
+            NotificationEvent::StoragePressureRising {
+                from,
+                to,
+                host_root: false,
+                ..
+            } if from == "roomy" && to == "tight"
+        ));
+    }
+
+    #[test]
+    fn storage_pressure_critical_is_critical_urgency() {
+        let n = build_storage_pressure_notification(
+            "/data",
+            trans(TightnessTier::Tight, TightnessTier::Critical),
+            false,
+        );
+        assert_eq!(n.urgency, Urgency::Critical);
+        assert!(n.body.contains("critically tight"), "body: {}", n.body);
+    }
+
+    #[test]
+    fn storage_pressure_host_root_escalates_urgency_and_prose() {
+        // A mere Tight escalation, but on the host root → Critical + stakes prose.
+        let n = build_storage_pressure_notification(
+            "/",
+            trans(TightnessTier::Roomy, TightnessTier::Tight),
+            true,
+        );
+        assert_eq!(n.urgency, Urgency::Critical);
+        assert!(
+            n.body.contains("host root") && n.body.contains("machine itself"),
+            "host-root body must carry the stakes prose: {}",
+            n.body
+        );
+        assert!(matches!(
+            n.event,
+            NotificationEvent::StoragePressureRising { host_root: true, .. }
+        ));
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::advice::{ActionableAdvice, RedundancyAdvisory, RedundancyAdvisoryKind};
 use crate::awareness::{DriveAssessment, PromiseStatus, SubvolAssessment};
+use crate::storage_critical::{StoragePosture, TightnessTier};
 use crate::types::{ByteSize, DriveRole};
 
 // ── OutputMode ──────────────────────────────────────────────────────────
@@ -108,6 +109,27 @@ impl AdvisorySummary {
     }
 }
 
+// ── PoolPostureSummary ──────────────────────────────────────────────────
+
+/// One per-pool storage-posture display line (UPI 031-a, D1). The
+/// drive-level fact stated once: a tight pool and how many subvolumes it
+/// affects. Aggregated from per-subvolume `StoragePosture` by
+/// `commands::storage_signals::aggregate`. No `transition` field — the
+/// "just noticed" prose lives in the backup-time notification (S1).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct PoolPostureSummary {
+    /// Display label for the pool (its source mountpoint, e.g. `/` or `/mnt/data`).
+    pub pool_label: String,
+    pub tier: TightnessTier,
+    /// Pressure here risks the host itself (root pool + `/` entrusted).
+    pub host_root: bool,
+    /// Enabled subvolumes whose source resolves to this pool (Min1).
+    pub affected_count: usize,
+    /// Seconds since the pool was flagged at its current tier, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub since_secs: Option<i64>,
+}
+
 // ── StatusOutput ────────────────────────────────────────────────────────
 
 /// Structured output for the `urd status` command.
@@ -132,6 +154,10 @@ pub struct StatusOutput {
     /// Actionable advice for subvolumes needing attention (omitted from JSON when empty).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub advice: Vec<ActionableAdvice>,
+    /// Per-pool storage-posture lines (UPI 031-a). Omitted from JSON when all
+    /// pools are Roomy, so roomy systems stay silent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub storage_postures: Vec<PoolPostureSummary>,
 }
 
 /// Serializable wrapper around SubvolAssessment data.
@@ -165,6 +191,10 @@ pub struct StatusAssessment {
     #[serde(default, skip_serializing_if = "is_false")]
     pub external_only: bool,
     pub errors: Vec<String>,
+    /// Per-subvolume storage posture (UPI 031-a) for `--json` and 032/033.
+    /// Omitted when the subvolume's pool is Roomy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_posture: Option<StoragePosture>,
 }
 
 impl StatusAssessment {
@@ -189,6 +219,7 @@ impl StatusAssessment {
             retention_summary: None,
             external_only: false,
             errors: a.errors.clone(),
+            storage_posture: a.storage_posture,
         }
     }
 }
@@ -295,6 +326,10 @@ pub struct DefaultStatusOutput {
     /// How many subvolumes need attention total.
     #[serde(skip_serializing_if = "is_zero")]
     pub total_needing_attention: usize,
+    /// The worst tight pool's posture (UPI 031-a) — drives the compact
+    /// bare-`urd` clause. Omitted when all pools are Roomy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_posture: Option<PoolPostureSummary>,
 }
 
 fn is_zero(n: &usize) -> bool {
@@ -525,12 +560,6 @@ pub struct DoctorRecommendationRow {
     /// gate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub was_named_level: Option<crate::types::ProtectionLevel>,
-    /// UPI 031: the subvolume's source is on the host's root-filesystem pool
-    /// (entrusted to Urd) and that pool is critically tight. A structural
-    /// property distinct from momentary headroom pressure. Renders a dimmed
-    /// advisory; omitted from JSON when false (additive, no schema bump).
-    #[serde(skip_serializing_if = "is_false")]
-    pub storage_critical: bool,
 }
 
 // ── Churn (UPI 030) ────────────────────────────────────────────────────
@@ -653,6 +682,11 @@ pub struct DoctorDataSafety {
     /// Why this command is suggested, or what physical action to take.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+    /// Source-pool storage posture (UPI 031-a). Diagnostic: `doctor --thorough`
+    /// renders a tightness line here, with `urd status` as the primary surface.
+    /// Omitted when the subvolume's pool is Roomy.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_posture: Option<StoragePosture>,
 }
 
 /// Sentinel daemon status for doctor output.
@@ -1642,6 +1676,7 @@ mod tests {
             advisories: vec![],
             redundancy_advisories: vec![advisory.clone()],
             errors: vec![],
+            storage_posture: None,
         };
 
         let sa = StatusAssessment::from_assessment(&assessment);
@@ -2287,7 +2322,6 @@ source = "/data/sv2"
             external: Some(pressure),
             note: None,
             was_named_level: None,
-            storage_critical: false,
         };
         let value = serde_json::to_value(&row).unwrap();
         assert_eq!(
@@ -2347,7 +2381,6 @@ source = "/data/sv2"
             external: None,
             note: None,
             was_named_level: None,
-            storage_critical: false,
         };
         let json = serde_json::to_string(&row).unwrap();
         assert!(!json.contains("\"adjusted\""), "adjusted omitted when None: {json}");

--- a/src/pools.rs
+++ b/src/pools.rs
@@ -52,10 +52,68 @@ pub fn pool_uuid_for_path(path: &Path) -> crate::error::Result<Option<String>> {
     findmnt_target(path, "UUID")
 }
 
-/// Resolve the mountpoint of the filesystem hosting `path`.
-/// `findmnt -n -o TARGET --target <path>`. `Ok(None)` if unmounted.
-pub fn pool_mountpoint_for_path(path: &Path) -> crate::error::Result<Option<PathBuf>> {
-    findmnt_target(path, "TARGET").map(|opt| opt.map(PathBuf::from))
+/// Resolve a source path's pool UUID **and** mountpoint in a **single**
+/// `findmnt` call (UPI 031-a, S3). Replaces the prior pair of calls
+/// (`pool_uuid_for_path` + `pool_mountpoint_for_path`) on the hot path,
+/// halving the per-subvolume fork count.
+///
+/// Both columns are returned independently: a non-BTRFS or UUID-less mount
+/// still yields its `TARGET` (so storage-signal gathering can read free-ratio
+/// for a pool it cannot key to a UUID — S5). `Err` only on a findmnt I/O
+/// failure with stderr content; a missing/unmounted path → `Ok((None, None))`.
+pub fn resolve_source_pool(
+    path: &Path,
+) -> crate::error::Result<(Option<String>, Option<PathBuf>)> {
+    let path_str = path.to_str().ok_or_else(|| UrdError::Io {
+        path: path.to_path_buf(),
+        source: std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path is not valid UTF-8",
+        ),
+    })?;
+
+    let output = Command::new("findmnt")
+        .env("LC_ALL", "C")
+        .args(["-n", "-P", "-o", "UUID,TARGET", "--target", path_str])
+        .output()
+        .map_err(|e| UrdError::Io {
+            path: PathBuf::from("findmnt"),
+            source: e,
+        })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if !output.status.success() {
+        if stdout.trim().is_empty() {
+            // findmnt complained about a missing path; treat as "unresolved".
+            return Ok((None, None));
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(UrdError::Io {
+            path: path.to_path_buf(),
+            source: std::io::Error::other(format!("findmnt failed: {}", stderr.trim())),
+        });
+    }
+
+    Ok(parse_findmnt_uuid_target(&stdout))
+}
+
+/// Pure parse of `findmnt -P -o UUID,TARGET` output:
+/// `UUID="6c1…" TARGET="/"`. Empty quoted values map to `None`. Tolerates
+/// either ordering and surrounding whitespace. Extracted for unit testing
+/// (the subprocess wrapper above stays a thin I/O shim).
+#[must_use]
+fn parse_findmnt_uuid_target(stdout: &str) -> (Option<String>, Option<PathBuf>) {
+    let extract = |key: &str| -> Option<String> {
+        let needle = format!("{key}=\"");
+        let start = stdout.find(&needle)? + needle.len();
+        let rest = &stdout[start..];
+        let end = rest.find('"')?;
+        let val = &rest[..end];
+        (!val.is_empty()).then(|| val.to_string())
+    };
+    let uuid = extract("UUID");
+    let target = extract("TARGET").map(PathBuf::from);
+    (uuid, target)
 }
 
 fn findmnt_target(path: &Path, column: &str) -> crate::error::Result<Option<String>> {
@@ -106,8 +164,9 @@ pub fn detect_source_pools(config: &Config) -> Vec<SourcePool> {
         .subvolumes
         .iter()
         .map(|sv| {
-            let uuid = pool_uuid_for_path(&sv.source).ok().flatten();
-            let mp = pool_mountpoint_for_path(&sv.source).ok().flatten();
+            // One findmnt for both columns (S3): halves the per-subvolume fork
+            // count vs. the prior `pool_uuid_for_path` + `pool_mountpoint_for_path`.
+            let (uuid, mp) = resolve_source_pool(&sv.source).unwrap_or((None, None));
             (sv.name.clone(), uuid, mp)
         })
         .collect();
@@ -318,6 +377,42 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("bytes_used"), used).unwrap();
         std::fs::write(dir.join("total_bytes"), total).unwrap();
+    }
+
+    // ── UPI 031-a: combined findmnt parser ──────────────────────────
+
+    #[test]
+    fn parse_findmnt_uuid_target_both_present() {
+        let (uuid, target) =
+            parse_findmnt_uuid_target("UUID=\"6c1a-1234\" TARGET=\"/\"\n");
+        assert_eq!(uuid.as_deref(), Some("6c1a-1234"));
+        assert_eq!(target, Some(PathBuf::from("/")));
+    }
+
+    #[test]
+    fn parse_findmnt_uuid_target_empty_uuid_is_none() {
+        // Non-BTRFS mount: TARGET resolves, UUID is empty → mountpoint still
+        // surfaces so storage-signal gathering can read free-ratio (S5).
+        let (uuid, target) =
+            parse_findmnt_uuid_target("UUID=\"\" TARGET=\"/boot\"");
+        assert_eq!(uuid, None);
+        assert_eq!(target, Some(PathBuf::from("/boot")));
+    }
+
+    #[test]
+    fn parse_findmnt_uuid_target_empty_output_is_none_none() {
+        let (uuid, target) = parse_findmnt_uuid_target("");
+        assert_eq!(uuid, None);
+        assert_eq!(target, None);
+    }
+
+    #[test]
+    fn parse_findmnt_uuid_target_tolerates_target_with_space() {
+        let (uuid, target) = parse_findmnt_uuid_target(
+            "UUID=\"abcd\" TARGET=\"/mnt/my drive\"",
+        );
+        assert_eq!(uuid.as_deref(), Some("abcd"));
+        assert_eq!(target, Some(PathBuf::from("/mnt/my drive")));
     }
 
     /// A `space_resolver` that ignores the path and always reports the same

--- a/src/pools.rs
+++ b/src/pools.rs
@@ -216,6 +216,23 @@ pub struct PoolSpace {
     pub capacity_bytes: u64,
 }
 
+impl PoolSpace {
+    /// Free / capacity as a ratio; `None` on zero (or otherwise unmeasurable)
+    /// capacity — `0` free-ratio is in-range but meaningless, so absence is an
+    /// `Option`, not a plausible-looking number. The single owner of the
+    /// free-ratio arithmetic for the two callers that hold a `PoolSpace`
+    /// (`commands::storage_signals`, `commands::doctor`).
+    #[must_use]
+    pub fn free_ratio(self) -> Option<f64> {
+        if self.capacity_bytes == 0 {
+            return None;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let ratio = self.free_bytes as f64 / self.capacity_bytes as f64;
+        ratio.is_finite().then_some(ratio)
+    }
+}
+
 /// Capacity + free bytes on a BTRFS pool by mountpoint (statvfs). One
 /// syscall, two numbers. Returns `Err` on statvfs failure; caller maps
 /// `Err` → `None` for emission. Same pattern as

--- a/src/recommendation.rs
+++ b/src/recommendation.rs
@@ -30,8 +30,8 @@ use crate::types::ResolvedGraduatedRetention;
 // Boundaries are strict (`<` / `>`): exact-threshold values land in the
 // lower tier (e.g., free_ratio == 0.25 → Healthy).
 
-const FREE_RATIO_CAUTION: f64 = 0.25;
-const FREE_RATIO_PRESSURE: f64 = 0.15;
+pub const FREE_RATIO_CAUTION: f64 = 0.25;
+pub const FREE_RATIO_PRESSURE: f64 = 0.15;
 const TIME_TO_EMPTY_CAUTION_DAYS: f64 = 90.0;
 const TIME_TO_EMPTY_PRESSURE_DAYS: f64 = 30.0;
 const METADATA_CAUTION: f64 = 0.85;
@@ -114,6 +114,17 @@ pub fn classify_free_ratio(free: Option<u64>, capacity: Option<u64>) -> Headroom
     }
     #[allow(clippy::cast_precision_loss)]
     let ratio = free as f64 / capacity as f64;
+    classify_free_ratio_value(ratio)
+}
+
+/// Classify a pre-computed free-ratio by free-ratio alone. Boundaries are
+/// strict (`<`): exact-threshold values land in the lower (roomier) tier
+/// (e.g. `0.25` → `Healthy`). Non-finite ratios fail toward `Healthy`.
+///
+/// Shared with `storage_critical::resolve_armed_tier` (UPI 031-a) so the
+/// tightness-tier boundaries have a single source of truth.
+#[must_use]
+pub fn classify_free_ratio_value(ratio: f64) -> HeadroomSeverity {
     if !ratio.is_finite() {
         return HeadroomSeverity::Healthy;
     }
@@ -200,9 +211,7 @@ pub struct ShapeRecommendation {
 
 /// Why a headroom-aware recommendation was adjusted (UPI 044). Variants
 /// embed the numeric value that drove them so the renderer can produce
-/// honest text without re-reading the context. `StorageCritical` is
-/// injected externally by doctor.rs when `is_storage_critical(name)`
-/// fires.
+/// honest text without re-reading the context.
 ///
 /// Priority tiebreak when multiple signals fire at the same severity:
 /// `DestinationMetadataPressure > SourcePoolLow > SourcePoolShrinking`.
@@ -212,7 +221,6 @@ pub enum AdjustmentReason {
     SourcePoolLow { free_ratio: f64 },
     SourcePoolShrinking { days_to_empty: f64 },
     DestinationMetadataPressure { drive_label: String, ratio: f64 },
-    StorageCritical,
 }
 
 impl HeadroomAwareRecommendation {
@@ -1393,7 +1401,7 @@ mod tests {
             &cur,
             ShapeRole::Local,
             HeadroomSeverity::Pressure,
-            AdjustmentReason::StorageCritical,
+            AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
         );
         assert_eq!(h.recommendation.suggested, h.recommendation.current);
         assert_eq!(h.recommendation.current, cur);
@@ -1404,7 +1412,7 @@ mod tests {
         assert!(h.adjusted.is_none());
         assert!(h.adjusted_cost.is_none());
         assert_eq!(h.severity, HeadroomSeverity::Pressure);
-        assert!(matches!(h.reason, Some(AdjustmentReason::StorageCritical)));
+        assert!(matches!(h.reason, Some(AdjustmentReason::SourcePoolLow { .. })));
     }
 
     #[test]
@@ -1415,7 +1423,7 @@ mod tests {
             &cur,
             ShapeRole::Local,
             HeadroomSeverity::Healthy,
-            AdjustmentReason::StorageCritical,
+            AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
         );
     }
 
@@ -1427,7 +1435,7 @@ mod tests {
             &cur,
             ShapeRole::Local,
             HeadroomSeverity::Caution,
-            AdjustmentReason::StorageCritical,
+            AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
         );
     }
 }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -879,6 +879,7 @@ mod tests {
             advisories: vec![],
             redundancy_advisories: vec![],
             errors: vec![],
+            storage_posture: None,
         }
     }
 
@@ -915,6 +916,7 @@ mod tests {
             advisories: vec![],
             redundancy_advisories: vec![],
             errors: vec![],
+            storage_posture: None,
         }
     }
 
@@ -1536,6 +1538,7 @@ mod tests {
             advisories: vec![],
             redundancy_advisories: vec![],
             errors: vec![],
+            storage_posture: None,
         }
     }
 

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -383,7 +383,16 @@ impl SentinelRunner {
             btrfs: &assess_btrfs,
         };
 
-        let mut assessments = awareness::assess(&self.config, now, &observation);
+        // The sentinel is deliberately blind to storage posture (D6 — it reacts
+        // to the heartbeat, which carries no posture). Pass an empty signal map
+        // so `assess()` computes no posture on this path; on-demand `status` and
+        // `backup` runs are where posture is gathered and surfaced.
+        let mut assessments = awareness::assess(
+            &self.config,
+            now,
+            &observation,
+            &awareness::StorageSignalMap::new(),
+        );
         advice::overlay_offsite_freshness(&mut assessments, &self.config);
 
         // Emit promise-transition events when the originating event was
@@ -967,6 +976,7 @@ mod tests {
             advisories: vec![],
             redundancy_advisories: vec![],
             errors: vec![],
+            storage_posture: None,
         }
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -209,7 +209,13 @@ impl StateDb {
                 );
 
                 CREATE INDEX IF NOT EXISTS drift_samples_by_subvolume_time
-                    ON drift_samples(subvolume, sampled_at DESC);",
+                    ON drift_samples(subvolume, sampled_at DESC);
+
+                CREATE TABLE IF NOT EXISTS pool_armed_tier (
+                    pool_uuid  TEXT PRIMARY KEY,
+                    armed_tier TEXT NOT NULL,
+                    since      TEXT NOT NULL
+                );",
             )
             .map_err(|e| UrdError::State(format!("failed to create schema: {e}")))?;
 
@@ -1139,6 +1145,143 @@ impl StateDb {
             source_free_bytes: row.source_free_bytes,
             send_kind: row.send_kind,
         }
+    }
+
+    // ── Pool armed-tier methods (UPI 031-a, ADR-113) ────────────────
+    //
+    // Per-pool operational-adaptation state: the hysteresis-stabilized
+    // armed tier and when it last changed. One upserted row per pool.
+    // Best-effort (ADR-102) — never blocks a backup; if lost, Urd
+    // re-derives the current tier statelessly (degraded, never unsafe).
+
+    /// Read the armed tier + `since` for one pool. `None` when the pool has
+    /// no row (never tracked) or the stored tier string is unparseable
+    /// (skip, do not guess — fail toward stateless).
+    ///
+    /// The single-pool granular accessor; 031-a's hot path reads the batched
+    /// `all_armed_tiers` instead. Kept as the per-query primitive (CLAUDE.md
+    /// `state.rs` guidance) and the 032/033 single-pool read hook — exercised
+    /// by tests, no 031-a production caller yet.
+    #[allow(dead_code)]
+    pub fn armed_tier_for_pool(
+        &self,
+        pool_uuid: &str,
+    ) -> crate::error::Result<
+        Option<(crate::storage_critical::TightnessTier, chrono::NaiveDateTime)>,
+    > {
+        let row = self
+            .conn
+            .query_row(
+                "SELECT armed_tier, since FROM pool_armed_tier WHERE pool_uuid = ?1",
+                rusqlite::params![pool_uuid],
+                |row| {
+                    let tier_s: String = row.get(0)?;
+                    let since_s: String = row.get(1)?;
+                    Ok((tier_s, since_s))
+                },
+            )
+            .ok();
+
+        let Some((tier_s, since_s)) = row else {
+            return Ok(None);
+        };
+        Ok(Self::parse_armed_tier_row(&tier_s, &since_s))
+    }
+
+    /// Batched read of every tracked pool's armed tier (for `gather()`).
+    /// Unparseable rows are skipped (logged), not surfaced.
+    pub fn all_armed_tiers(
+        &self,
+    ) -> crate::error::Result<
+        std::collections::HashMap<
+            String,
+            (crate::storage_critical::TightnessTier, chrono::NaiveDateTime),
+        >,
+    > {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT pool_uuid, armed_tier, since FROM pool_armed_tier")
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let pool_uuid: String = row.get(0)?;
+                let tier_s: String = row.get(1)?;
+                let since_s: String = row.get(2)?;
+                Ok((pool_uuid, tier_s, since_s))
+            })
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut out = std::collections::HashMap::new();
+        for row in rows {
+            let (pool_uuid, tier_s, since_s) =
+                row.map_err(|e| UrdError::State(format!("read armed-tier row: {e}")))?;
+            if let Some(parsed) = Self::parse_armed_tier_row(&tier_s, &since_s) {
+                out.insert(pool_uuid, parsed);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Parse a `(armed_tier, since)` row pair. `None` (skip) when either the
+    /// tier string is unknown or the timestamp is unparseable.
+    fn parse_armed_tier_row(
+        tier_s: &str,
+        since_s: &str,
+    ) -> Option<(crate::storage_critical::TightnessTier, chrono::NaiveDateTime)>
+    {
+        let Some(tier) = crate::storage_critical::TightnessTier::from_db_str(tier_s)
+        else {
+            log::warn!("skipping armed-tier row with unknown tier {tier_s:?}");
+            return None;
+        };
+        match chrono::NaiveDateTime::parse_from_str(since_s, "%Y-%m-%dT%H:%M:%S") {
+            Ok(since) => Some((tier, since)),
+            Err(e) => {
+                log::warn!("skipping armed-tier row with unparseable since {since_s:?}: {e}");
+                None
+            }
+        }
+    }
+
+    /// Upsert a pool's armed tier. Best-effort per ADR-102 (operational
+    /// state must never block a backup): failures are logged and swallowed.
+    /// `since` is the caller's responsibility — pass `now` only when the tier
+    /// changed, else the prior `since` (stable "flagged since" timestamp).
+    pub fn upsert_armed_tier_best_effort(
+        &self,
+        pool_uuid: &str,
+        tier: crate::storage_critical::TightnessTier,
+        since: chrono::NaiveDateTime,
+    ) {
+        if let Err(e) = self.upsert_armed_tier_inner(pool_uuid, tier, since) {
+            log::warn!(
+                "armed-tier write failed (best-effort, continuing): {e}"
+            );
+        }
+    }
+
+    fn upsert_armed_tier_inner(
+        &self,
+        pool_uuid: &str,
+        tier: crate::storage_critical::TightnessTier,
+        since: chrono::NaiveDateTime,
+    ) -> crate::error::Result<()> {
+        self.conn
+            .execute(
+                "INSERT INTO pool_armed_tier (pool_uuid, armed_tier, since)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(pool_uuid) DO UPDATE SET
+                     armed_tier = excluded.armed_tier,
+                     since = excluded.since",
+                rusqlite::params![
+                    pool_uuid,
+                    tier.as_db_str(),
+                    since.format("%Y-%m-%dT%H:%M:%S").to_string(),
+                ],
+            )
+            .map_err(|e| UrdError::State(format!("failed to upsert armed tier: {e}")))?;
+        Ok(())
     }
 
     fn map_operation_row(row: &rusqlite::Row) -> rusqlite::Result<OperationRow> {
@@ -3166,5 +3309,106 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM drift_samples", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count_after_second, 1);
+    }
+
+    // ── UPI 031-a: pool_armed_tier ───────────────────────────────────
+
+    #[test]
+    fn pool_armed_tier_table_created_on_open() {
+        let db = StateDb::open_memory().unwrap();
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM pool_armed_tier", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn armed_tier_upsert_then_read_round_trips() {
+        use crate::storage_critical::TightnessTier;
+        let db = StateDb::open_memory().unwrap();
+        let since = drift_dt("2026-05-20T04:00:00");
+        db.upsert_armed_tier_best_effort("pool-A", TightnessTier::Tight, since);
+
+        let got = db.armed_tier_for_pool("pool-A").unwrap();
+        assert_eq!(got, Some((TightnessTier::Tight, since)));
+    }
+
+    #[test]
+    fn armed_tier_update_keeps_single_row() {
+        use crate::storage_critical::TightnessTier;
+        let db = StateDb::open_memory().unwrap();
+        db.upsert_armed_tier_best_effort(
+            "pool-A",
+            TightnessTier::Tight,
+            drift_dt("2026-05-20T04:00:00"),
+        );
+        let bumped = drift_dt("2026-05-21T04:00:00");
+        db.upsert_armed_tier_best_effort("pool-A", TightnessTier::Critical, bumped);
+
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM pool_armed_tier", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+        assert_eq!(
+            db.armed_tier_for_pool("pool-A").unwrap(),
+            Some((TightnessTier::Critical, bumped))
+        );
+    }
+
+    #[test]
+    fn armed_tier_unknown_pool_is_none() {
+        let db = StateDb::open_memory().unwrap();
+        assert_eq!(db.armed_tier_for_pool("nope").unwrap(), None);
+    }
+
+    #[test]
+    fn all_armed_tiers_returns_union() {
+        use crate::storage_critical::TightnessTier;
+        let db = StateDb::open_memory().unwrap();
+        db.upsert_armed_tier_best_effort(
+            "pool-A",
+            TightnessTier::Tight,
+            drift_dt("2026-05-20T04:00:00"),
+        );
+        db.upsert_armed_tier_best_effort(
+            "pool-B",
+            TightnessTier::Critical,
+            drift_dt("2026-05-19T04:00:00"),
+        );
+
+        let all = db.all_armed_tiers().unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all.get("pool-A").unwrap().0, TightnessTier::Tight);
+        assert_eq!(all.get("pool-B").unwrap().0, TightnessTier::Critical);
+    }
+
+    #[test]
+    fn upsert_armed_tier_swallows_errors_on_dropped_table() {
+        use crate::storage_critical::TightnessTier;
+        let db = StateDb::open_memory().unwrap();
+        db.conn.execute("DROP TABLE pool_armed_tier", []).unwrap();
+        // Best-effort: must not panic even though the table is gone.
+        db.upsert_armed_tier_best_effort(
+            "pool-A",
+            TightnessTier::Tight,
+            drift_dt("2026-05-20T04:00:00"),
+        );
+    }
+
+    #[test]
+    fn armed_tier_unparseable_tier_string_is_skipped() {
+        let db = StateDb::open_memory().unwrap();
+        // Hand-write a row with a bogus tier string.
+        db.conn
+            .execute(
+                "INSERT INTO pool_armed_tier (pool_uuid, armed_tier, since)
+                 VALUES ('pool-A', 'bananas', '2026-05-20T04:00:00')",
+                [],
+            )
+            .unwrap();
+        assert_eq!(db.armed_tier_for_pool("pool-A").unwrap(), None);
+        assert!(db.all_armed_tiers().unwrap().is_empty());
     }
 }

--- a/src/storage_critical.rs
+++ b/src/storage_critical.rs
@@ -1,159 +1,503 @@
-//! Storage-critical predicate (ADR-113 Layer 1, UPI 044 stub → UPI 031 rule).
+//! Storage-state detection (ADR-113 Layer 1, UPI 031-a).
 //!
-//! UPI 044 shipped this as a stub returning `false`. UPI 031 retires the stub
-//! and replaces it with a **pure structural rule**: a subvolume is
-//! storage-critical when its source lives on the host's root-filesystem pool
-//! (UUID match), an *enabled* subvolume entrusts `/` itself to Urd, *and* that
-//! pool is genuinely tight right now (free-ratio ≥ Pressure).
+//! UPI 044 shipped a stub `is_storage_critical` returning `false`. UPI 031
+//! replaced it with a single conjunction (`host_root && tier >= Pressure`)
+//! whose only surface was a dimmed `doctor --thorough` footnote — which
+//! *inverted* the severity/response ladder (the most dangerous state produced
+//! the quietest surface) and delivered no told-not-silent state in
+//! `urd status`. UPI 031-a un-conflates that predicate into the two orthogonal
+//! axes the Do-No-Harm arc needs:
 //!
-//! This is distinct from momentary headroom pressure: headroom answers "is this
-//! pool tight now?"; `storage_critical` adds the structural dimension — pressure
-//! here threatens the *host*, not just retention. Only the intersection
-//! (structurally fragile **and** tight) is critical.
+//! - **Tightness tier** — `TightnessTier { Roomy, Tight, Critical }`, derived
+//!   from the source pool's free-ratio alone (via
+//!   `recommendation::classify_free_ratio_value`, the single source of truth
+//!   for the boundaries). Drives the response tier for *any* tight pool Urd
+//!   snapshots to.
+//! - **Host-root flag** — `host_root()`: the source lives on the pool hosting
+//!   `/` *and* an enabled subvolume entrusts `/` itself to Urd. Escalates the
+//!   voice/stakes orthogonally (pressure here risks the host, not just
+//!   retention).
 //!
-//! Purity (ADR-108): this module takes resolved inputs and performs no I/O. The
-//! doctor wiring (`src/commands/doctor.rs`) resolves the one I/O-bound input
-//! (`root_pool_uuid`, one `findmnt /`) at the boundary and feeds it in; the
-//! per-subvolume pool UUID, the `root_subvol_configured` gate, and the
-//! free-ratio severity are all computed there from already-available data.
+//! A persisted per-pool **armed tier** (`state.rs`) plus the pure hysteresis in
+//! `resolve_armed_tier` give told-not-silent *transitions* and anti-flap
+//! stability. The posture (`StoragePosture`) is the per-subvolume cell the
+//! awareness surface carries; transitions are computed **only** at the backup
+//! boundary (never on read paths — there is no transition in the posture to
+//! fire).
 //!
-//! The behavioral half (ephemeral lifecycle, conservative intervals) is
-//! deliberately *not* shipped here — per ADR-113's increment-2 sequencing it
-//! belongs with UPIs 032/033 where the safety scaffolding lands.
+//! Purity (ADR-108): every fn here takes resolved inputs and performs no I/O.
+//! The command layer resolves the I/O-bound signals (pool free-ratio, `findmnt
+//! /`, persisted prior tier) at the boundary and feeds them in.
+//!
+//! The behavioral half (ephemeral lifecycle, conservative intervals, the
+//! `constrained` arming signal that adds `urd_writes_to_pool`) is deliberately
+//! *not* shipped here — it belongs with UPIs 032/033 where the safety
+//! scaffolding lands and has a consumer.
 
-use crate::recommendation::HeadroomSeverity;
+use serde::Serialize;
 
-/// Resolved inputs to the storage-critical structural rule (UPI 031). All
-/// fields are pre-resolved by the doctor wiring; the rule itself is pure.
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct StorageCriticalInput<'a> {
-    /// The BTRFS pool UUID hosting this subvolume's source, if resolvable.
-    pub subvol_pool_uuid: Option<&'a str>,
-    /// The BTRFS pool UUID hosting `/`, if resolvable.
-    pub root_pool_uuid: Option<&'a str>,
-    /// True when an **enabled** configured subvolume has `source == "/"`,
-    /// i.e. the user has actively entrusted the root filesystem to Urd.
-    pub root_subvol_configured: bool,
-    /// Tightness of the source pool by free-ratio only (Branch E): reuses
-    /// `recommendation::classify_free_ratio`, no trend/metadata, no new
-    /// constant. `Pressure` (or the dormant `Critical`) means genuinely tight.
-    pub source_free_ratio_severity: HeadroomSeverity,
+use crate::recommendation::{
+    self, FREE_RATIO_CAUTION, FREE_RATIO_PRESSURE, HeadroomSeverity,
+};
+
+/// Hysteresis level-band (UPI 031-a, D4). A pool de-escalates only once free
+/// recovers to its arm threshold **plus** this band, so a pool hovering at a
+/// tier boundary does not re-notify every run. Crude/load-bearing — revisited
+/// at the ADR-113 30-day checkpoint. Arm thresholds reuse
+/// `FREE_RATIO_PRESSURE` / `FREE_RATIO_CAUTION`; this is the only new constant.
+pub const HYSTERESIS_BAND_PP: f64 = 0.05;
+
+/// Source-pool tightness, free-ratio only (UPI 031-a). Distinct from
+/// `recommendation::HeadroomSeverity` (a *composite* of free-ratio + trend +
+/// destination metadata): the tier is the imperative-bundle axis that drives
+/// Do-No-Harm response. Ordering is load-bearing (`Roomy < Tight < Critical`):
+/// hysteresis and aggregation compare and `.max()` tiers.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum TightnessTier {
+    /// Roomy enough that Urd says nothing.
+    #[default]
+    Roomy,
+    /// "tight" — below the caution threshold (< 25% free). Watch it.
+    Tight,
+    /// "critical" — below the pressure threshold (< 15% free).
+    Critical,
 }
 
-/// True iff the subvolume is storage-critical under the structural rule.
+impl TightnessTier {
+    /// Canonical string form persisted in `pool_armed_tier.armed_tier`.
+    /// Parallels `SendKind::as_db_str`.
+    #[must_use]
+    pub const fn as_db_str(self) -> &'static str {
+        match self {
+            TightnessTier::Roomy => "roomy",
+            TightnessTier::Tight => "tight",
+            TightnessTier::Critical => "critical",
+        }
+    }
+
+    /// Parse the canonical DB form. Returns `None` for any string that does
+    /// not match `as_db_str()` exactly (an unparseable row is skipped, not
+    /// guessed — best-effort, fail toward stateless).
+    #[must_use]
+    pub fn from_db_str(s: &str) -> Option<Self> {
+        match s {
+            "roomy" => Some(TightnessTier::Roomy),
+            "tight" => Some(TightnessTier::Tight),
+            "critical" => Some(TightnessTier::Critical),
+            _ => None,
+        }
+    }
+}
+
+impl From<HeadroomSeverity> for TightnessTier {
+    /// `Healthy → Roomy`, `Caution → Tight`, `Pressure`/`Critical → Critical`.
+    /// The composite severity collapses to the free-ratio-only tier; the
+    /// dormant composite `Critical` maps to the tier `Critical`.
+    fn from(sev: HeadroomSeverity) -> Self {
+        match sev {
+            HeadroomSeverity::Healthy => TightnessTier::Roomy,
+            HeadroomSeverity::Caution => TightnessTier::Tight,
+            HeadroomSeverity::Pressure | HeadroomSeverity::Critical => {
+                TightnessTier::Critical
+            }
+        }
+    }
+}
+
+/// Per-subvolume storage posture (UPI 031-a). Carried on `SubvolAssessment`
+/// and surfaced told-not-silent. Constructed **only** when `tier >= Tight`
+/// (a Roomy pool has no posture — Urd stays silent). No `transition` field:
+/// read paths reflect the stabilized tier and cannot fire a "just noticed"
+/// (that prose lives in the backup-boundary notification).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct StoragePosture {
+    pub tier: TightnessTier,
+    /// True when this subvolume's source is on the host-root pool and an
+    /// enabled subvolume entrusts `/` — escalates the voice/stakes.
+    pub host_root: bool,
+}
+
+/// A change in armed tier (UPI 031-a). Computed only at the backup boundary
+/// (`advance_and_writeback`); consumed only by the notify path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct Transition {
+    pub from: TightnessTier,
+    pub to: TightnessTier,
+}
+
+impl Transition {
+    /// True when the tier worsened (`to > from`). Only escalations notify;
+    /// de-escalation is silent (status reflects recovery).
+    #[must_use]
+    pub fn is_escalation(self) -> bool {
+        self.to > self.from
+    }
+}
+
+/// Host-root structural flag (UPI 031-a — the structural half of the retired
+/// `is_storage_critical`, with the `>= Pressure` tightness check removed).
 ///
-/// ```text
-/// storage_critical =
-///       subvol_pool_uuid == root_pool_uuid     // on the pool hosting "/"
-///   AND root_subvol_configured                  // an ENABLED subvol has source == "/"
-///   AND source_free_ratio_severity >= Pressure  // genuinely tight NOW (<15% free)
-/// ```
-///
-/// Fails toward *not*-critical for every unmeasurable input (unresolved pool
-/// UUID, unmeasurable free-ratio → `Healthy`) — this is an advisory surface.
+/// True iff this subvolume's source pool is the pool hosting `/` (UUID match)
+/// **and** an enabled configured subvolume has `source == "/"`. Fails toward
+/// `false` for every unresolved UUID — pressure on a pool Urd cannot tie to
+/// `/` makes no host-stakes claim.
 #[must_use]
-pub fn is_storage_critical(input: StorageCriticalInput<'_>) -> bool {
+pub fn host_root(
+    subvol_pool_uuid: Option<&str>,
+    root_pool_uuid: Option<&str>,
+    root_subvol_configured: bool,
+) -> bool {
     let on_root_pool = matches!(
-        (input.subvol_pool_uuid, input.root_pool_uuid),
+        (subvol_pool_uuid, root_pool_uuid),
         (Some(a), Some(b)) if a == b
     );
-    on_root_pool
-        && input.root_subvol_configured
-        && input.source_free_ratio_severity >= HeadroomSeverity::Pressure
+    on_root_pool && root_subvol_configured
+}
+
+/// Resolve the new armed tier from the prior armed tier and the current
+/// free-ratio (UPI 031-a hysteresis, D4). Pure — no I/O, no clock.
+///
+/// - **Escalate immediately** when the current free-ratio classifies worse
+///   than the armed tier (no hysteresis on the way up — danger is surfaced
+///   at once). The escalation target comes from
+///   `classify_free_ratio_value` (single source of truth for boundaries — M2).
+/// - **De-escalate stickily**: drop one level at a time, each gated by that
+///   level's arm threshold **+ `HYSTERESIS_BAND_PP`** (Critical→Tight at free
+///   `> 0.20`, Tight→Roomy at free `> 0.30`). A pool can fall two levels in
+///   one run when free recovers past both bands.
+/// - **Unmeasurable** free-ratio (`None`) holds the prior armed tier unchanged.
+#[must_use]
+pub fn resolve_armed_tier(
+    prior_armed: TightnessTier,
+    free_ratio: Option<f64>,
+) -> TightnessTier {
+    let Some(ratio) = free_ratio else {
+        // Cannot measure → hold the prior state (never silently disarms).
+        return prior_armed;
+    };
+
+    let current = TightnessTier::from(
+        recommendation::classify_free_ratio_value(ratio),
+    );
+    if current > prior_armed {
+        // Worse than armed → escalate immediately to the classified tier.
+        return current;
+    }
+
+    // current <= prior_armed: sticky de-escalation, one level at a time, each
+    // gated by `arm_threshold + band`. Strict `>` so exactly-at-band holds.
+    let mut armed = prior_armed;
+    if armed == TightnessTier::Critical
+        && ratio > FREE_RATIO_PRESSURE + HYSTERESIS_BAND_PP
+    {
+        armed = TightnessTier::Tight;
+    }
+    if armed == TightnessTier::Tight
+        && ratio > FREE_RATIO_CAUTION + HYSTERESIS_BAND_PP
+    {
+        armed = TightnessTier::Roomy;
+    }
+    armed
+}
+
+/// The transition between a prior and new armed tier, if any (UPI 031-a).
+/// `None` when the tier is unchanged.
+#[must_use]
+pub fn transition(
+    prior: TightnessTier,
+    new: TightnessTier,
+) -> Option<Transition> {
+    if prior == new {
+        None
+    } else {
+        Some(Transition {
+            from: prior,
+            to: new,
+        })
+    }
+}
+
+/// Derive the per-subvolume posture from the armed tier and host-root flag
+/// (UPI 031-a). `Some` iff `armed >= Tight` — a Roomy pool has no posture, so
+/// Urd stays silent on it.
+#[must_use]
+pub fn derive_posture(
+    armed: TightnessTier,
+    host_root: bool,
+) -> Option<StoragePosture> {
+    (armed >= TightnessTier::Tight).then_some(StoragePosture {
+        tier: armed,
+        host_root,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// Build an input with the structural gate satisfied; callers override
-    /// the field under test.
-    fn on_root(severity: HeadroomSeverity) -> StorageCriticalInput<'static> {
-        StorageCriticalInput {
-            subvol_pool_uuid: Some("root-pool"),
-            root_pool_uuid: Some("root-pool"),
-            root_subvol_configured: true,
-            source_free_ratio_severity: severity,
+    // ── From<HeadroomSeverity> matrix ────────────────────────────────────
+
+    #[test]
+    fn tier_from_severity_matrix() {
+        assert_eq!(
+            TightnessTier::from(HeadroomSeverity::Healthy),
+            TightnessTier::Roomy
+        );
+        assert_eq!(
+            TightnessTier::from(HeadroomSeverity::Caution),
+            TightnessTier::Tight
+        );
+        assert_eq!(
+            TightnessTier::from(HeadroomSeverity::Pressure),
+            TightnessTier::Critical
+        );
+        assert_eq!(
+            TightnessTier::from(HeadroomSeverity::Critical),
+            TightnessTier::Critical
+        );
+    }
+
+    #[test]
+    fn tier_ordering_is_roomy_tight_critical() {
+        assert!(TightnessTier::Roomy < TightnessTier::Tight);
+        assert!(TightnessTier::Tight < TightnessTier::Critical);
+    }
+
+    #[test]
+    fn tier_db_str_round_trip() {
+        for tier in [
+            TightnessTier::Roomy,
+            TightnessTier::Tight,
+            TightnessTier::Critical,
+        ] {
+            assert_eq!(TightnessTier::from_db_str(tier.as_db_str()), Some(tier));
         }
+        assert_eq!(TightnessTier::from_db_str("garbage"), None);
+        assert_eq!(TightnessTier::from_db_str(""), None);
+    }
+
+    // ── host_root gates ──────────────────────────────────────────────────
+
+    #[test]
+    fn host_root_uuid_match_and_configured() {
+        assert!(host_root(Some("root-pool"), Some("root-pool"), true));
     }
 
     #[test]
-    fn root_pool_match_configured_and_pressure_is_critical() {
-        assert!(is_storage_critical(on_root(HeadroomSeverity::Pressure)));
+    fn host_root_uuid_mismatch_is_false() {
+        assert!(!host_root(Some("other-pool"), Some("root-pool"), true));
     }
 
     #[test]
-    fn htpc_root_archetype_is_critical() {
-        // Source `/` on a tight root NVMe (~6% free → Pressure), `/` entrusted.
-        let input = StorageCriticalInput {
-            subvol_pool_uuid: Some("nvme-root"),
-            root_pool_uuid: Some("nvme-root"),
-            root_subvol_configured: true,
-            source_free_ratio_severity: HeadroomSeverity::Pressure,
-        };
-        assert!(is_storage_critical(input));
+    fn host_root_subvol_uuid_none_is_false() {
+        assert!(!host_root(None, Some("root-pool"), true));
     }
 
     #[test]
-    fn caution_is_not_critical() {
-        // Branch E: only Pressure+ qualifies; Caution is below the gate.
-        assert!(!is_storage_critical(on_root(HeadroomSeverity::Caution)));
+    fn host_root_root_uuid_none_is_false() {
+        assert!(!host_root(Some("root-pool"), None, true));
     }
 
     #[test]
-    fn healthy_is_not_critical() {
-        assert!(!is_storage_critical(on_root(HeadroomSeverity::Healthy)));
+    fn host_root_not_configured_is_false() {
+        // UUID match but no enabled `source == "/"` subvolume.
+        assert!(!host_root(Some("root-pool"), Some("root-pool"), false));
+    }
+
+    // ── resolve_armed_tier: escalate / hold / disarm ─────────────────────
+
+    #[test]
+    fn escalate_immediate_roomy_to_tight() {
+        // 0.20 free → Caution → Tight; jumps up at once.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Roomy, Some(0.20)),
+            TightnessTier::Tight
+        );
     }
 
     #[test]
-    fn critical_severity_is_critical() {
-        // Defensive: `>=` accepts the dormant Critical tier.
-        assert!(is_storage_critical(on_root(HeadroomSeverity::Critical)));
+    fn escalate_immediate_two_step_to_critical() {
+        // 0.05 free → Pressure → Critical; two-step jump up, no hysteresis.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Roomy, Some(0.05)),
+            TightnessTier::Critical
+        );
     }
 
     #[test]
-    fn not_configured_is_not_critical() {
-        // Gate: no enabled `source == "/"` subvolume entrusts `/`.
-        let mut input = on_root(HeadroomSeverity::Pressure);
-        input.root_subvol_configured = false;
-        assert!(!is_storage_critical(input));
+    fn sticky_hold_critical_below_disarm_band() {
+        // Armed Critical, free recovered to 0.18 (classifies Tight) but not
+        // past 0.20 → holds Critical (anti-flap).
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Critical, Some(0.18)),
+            TightnessTier::Critical
+        );
     }
 
     #[test]
-    fn uuid_mismatch_is_not_critical() {
-        // Tight + configured, but this subvol is on a different pool.
-        let input = StorageCriticalInput {
-            subvol_pool_uuid: Some("other-pool"),
-            root_pool_uuid: Some("root-pool"),
-            root_subvol_configured: true,
-            source_free_ratio_severity: HeadroomSeverity::Pressure,
-        };
-        assert!(!is_storage_critical(input));
+    fn disarm_critical_to_tight_above_band() {
+        // Free recovered to 0.22 (> 0.20) → Critical disarms to Tight, but
+        // 0.22 < 0.30 so it stays Tight.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Critical, Some(0.22)),
+            TightnessTier::Tight
+        );
     }
 
     #[test]
-    fn subvol_pool_uuid_none_is_not_critical() {
-        let mut input = on_root(HeadroomSeverity::Pressure);
-        input.subvol_pool_uuid = None;
-        assert!(!is_storage_critical(input));
+    fn sticky_hold_tight_below_disarm_band() {
+        // Armed Tight, free recovered to 0.28 (classifies Roomy) but not past
+        // 0.30 → holds Tight.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Tight, Some(0.28)),
+            TightnessTier::Tight
+        );
     }
 
     #[test]
-    fn root_pool_uuid_none_is_not_critical() {
-        // Root not btrfs / unresolved findmnt → no structural claim.
-        let mut input = on_root(HeadroomSeverity::Pressure);
-        input.root_pool_uuid = None;
-        assert!(!is_storage_critical(input));
+    fn disarm_tight_to_roomy_above_band() {
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Tight, Some(0.31)),
+            TightnessTier::Roomy
+        );
     }
 
     #[test]
-    fn both_uuids_none_is_not_critical() {
-        let input = StorageCriticalInput {
-            subvol_pool_uuid: None,
-            root_pool_uuid: None,
-            root_subvol_configured: true,
-            source_free_ratio_severity: HeadroomSeverity::Pressure,
-        };
-        assert!(!is_storage_critical(input));
+    fn two_step_disarm_at_high_ratio() {
+        // Armed Critical, free recovered well past both bands (0.35) → drops
+        // two levels to Roomy in one run.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Critical, Some(0.35)),
+            TightnessTier::Roomy
+        );
+    }
+
+    #[test]
+    fn unmeasurable_ratio_holds_prior() {
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Critical, None),
+            TightnessTier::Critical
+        );
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Tight, None),
+            TightnessTier::Tight
+        );
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Roomy, None),
+            TightnessTier::Roomy
+        );
+    }
+
+    // ── exact boundaries: 0.15 / 0.20 / 0.25 / 0.30 (M2) ─────────────────
+
+    #[test]
+    fn boundary_0_15_classifies_tight_not_critical() {
+        // classify_free_ratio_value is strict `<`: 0.15 is NOT < 0.15, so it
+        // lands in Caution → Tight. Just inside (0.149) is Critical.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Roomy, Some(0.15)),
+            TightnessTier::Tight
+        );
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Roomy, Some(0.149)),
+            TightnessTier::Critical
+        );
+    }
+
+    #[test]
+    fn boundary_0_20_critical_disarm_is_strict() {
+        // Exactly 0.20 does NOT clear the Critical→Tight band (strict `>`).
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Critical, Some(0.20)),
+            TightnessTier::Critical
+        );
+        // Just past it disarms.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Critical, Some(0.2001)),
+            TightnessTier::Tight
+        );
+    }
+
+    #[test]
+    fn boundary_0_25_classifies_roomy() {
+        // Escalation classifier is strict `<`: 0.25 is NOT < 0.25 → Roomy.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Roomy, Some(0.25)),
+            TightnessTier::Roomy
+        );
+        // Just inside is Tight.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Roomy, Some(0.249)),
+            TightnessTier::Tight
+        );
+    }
+
+    #[test]
+    fn boundary_0_30_tight_disarm_is_strict() {
+        // Exactly 0.30 does NOT clear the Tight→Roomy band (strict `>`).
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Tight, Some(0.30)),
+            TightnessTier::Tight
+        );
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Tight, Some(0.3001)),
+            TightnessTier::Roomy
+        );
+    }
+
+    // ── transition + is_escalation ───────────────────────────────────────
+
+    #[test]
+    fn transition_some_on_change_none_on_steady() {
+        assert_eq!(
+            transition(TightnessTier::Roomy, TightnessTier::Tight),
+            Some(Transition {
+                from: TightnessTier::Roomy,
+                to: TightnessTier::Tight,
+            })
+        );
+        assert_eq!(transition(TightnessTier::Tight, TightnessTier::Tight), None);
+    }
+
+    #[test]
+    fn is_escalation_distinguishes_direction() {
+        assert!(
+            transition(TightnessTier::Roomy, TightnessTier::Critical)
+                .unwrap()
+                .is_escalation()
+        );
+        assert!(
+            !transition(TightnessTier::Critical, TightnessTier::Roomy)
+                .unwrap()
+                .is_escalation()
+        );
+    }
+
+    // ── derive_posture ───────────────────────────────────────────────────
+
+    #[test]
+    fn derive_posture_none_below_tight() {
+        assert_eq!(derive_posture(TightnessTier::Roomy, true), None);
+    }
+
+    #[test]
+    fn derive_posture_some_at_tight_and_critical() {
+        assert_eq!(
+            derive_posture(TightnessTier::Tight, false),
+            Some(StoragePosture {
+                tier: TightnessTier::Tight,
+                host_root: false,
+            })
+        );
+        assert_eq!(
+            derive_posture(TightnessTier::Critical, true),
+            Some(StoragePosture {
+                tier: TightnessTier::Critical,
+                host_root: true,
+            })
+        );
     }
 }

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -14,6 +14,7 @@ use colored::Colorize;
 use crate::awareness::PromiseStatus;
 use crate::output::{DoctorCheck, DoctorCheckStatus, DoctorOutput, DoctorVerdictStatus, OutputMode};
 use crate::plan::format_duration_short;
+use crate::storage_critical::TightnessTier;
 
 use super::{SuggestionContext, append_suggestion, classify_verify_checks, pluralize};
 
@@ -119,6 +120,20 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
                 if let Some(ref reason) = ds.reason {
                     writeln!(out, "      {}", reason.dimmed()).ok();
                 }
+            }
+            // UPI 031-a: diagnostic storage-posture line. Renders for any tight
+            // pool independent of promise issues (a Protected subvolume can still
+            // sit on a tight pool); `urd status` remains the primary surface.
+            if let Some(posture) = ds.storage_posture {
+                let state = match posture.tier {
+                    TightnessTier::Critical => "critically tight",
+                    _ => "runs tight",
+                };
+                let mut line = format!("{} \u{2014} source pool {state}", ds.name);
+                if posture.host_root {
+                    line.push_str("; host root, so pressure here risks the machine itself");
+                }
+                writeln!(out, "    {}", line.dimmed()).ok();
             }
         }
     }
@@ -429,7 +444,6 @@ pub(super) fn render_reason_line(
                 _ => String::new(),
             }
         }
-        StorageCritical => String::new(), // pointer line handled at row level
     }
 }
 
@@ -518,22 +532,9 @@ pub(super) fn format_recommendation_row(row: &crate::output::DoctorRecommendatio
     if let Some(ref rec) = row.external {
         role_line("external:", rec);
     }
-    // UPI 031: row-level storage-critical advisory. STAKES, NOT ACTION — it
-    // names the structural fact (the source lives on the host root
-    // filesystem, so pressure here threatens the host, not just retention)
-    // and carries no action verb. The action ("expand storage / reduce
-    // subvolumes") stays on the role reason line, so this complements rather
-    // than duplicates the at-MIN tail. Never reached when severity is
-    // Critical (the R9 pointer path returns first).
-    if row.storage_critical {
-        writeln!(
-            out,
-            "      {}",
-            "storage critical — source is on the host root filesystem; pressure here risks the host itself"
-                .dimmed()
-        )
-        .ok();
-    }
+    // UPI 031-a relocated the host-root stakes advisory out of this row and
+    // into the `urd status` posture surface + the `doctor` data-safety
+    // section; the recommendation row is once again pure retention-shape advice.
     if matches!(row.note, Some(crate::recommendation::RecommendationNote::BurstyPattern)) {
         writeln!(out, "      {}", "bursty pattern — frequent full sends".dimmed()).ok();
     }

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -538,6 +538,7 @@ pub(crate) mod test_fixtures {
                     retention_summary: None,
                     external_only: false,
                     errors: vec![],
+                    storage_posture: None,
                 },
                 StatusAssessment {
                     name: "htpc-docs".to_string(),
@@ -565,6 +566,7 @@ pub(crate) mod test_fixtures {
                     retention_summary: None,
                     external_only: false,
                     errors: vec![],
+                    storage_posture: None,
                 },
             ],
             chain_health: vec![
@@ -601,6 +603,7 @@ pub(crate) mod test_fixtures {
             total_pins: 3,
             redundancy_advisories: vec![],
             advice: vec![],
+            storage_postures: Vec::new(),
         }
     }
 
@@ -660,6 +663,7 @@ pub(crate) mod test_fixtures {
                 retention_summary: None,
                 external_only: false,
                 errors: vec![],
+                storage_posture: None,
             }],
             transitions: vec![],
             warnings: vec![],
@@ -698,6 +702,7 @@ pub(crate) mod test_fixtures {
                     issue: None,
                     suggestion: None,
                     reason: None,
+                    storage_posture: None,
                 },
                 DoctorDataSafety {
                     name: "htpc-docs".to_string(),
@@ -706,6 +711,7 @@ pub(crate) mod test_fixtures {
                     issue: None,
                     suggestion: None,
                     reason: None,
+                    storage_posture: None,
                 },
             ],
             sentinel: DoctorSentinelStatus {
@@ -737,6 +743,7 @@ pub(crate) mod test_fixtures {
             last_run_age_secs: Some(25200), // 7 hours
             best_advice: None,
             total_needing_attention: 0,
+            storage_posture: None,
         }
     }
 
@@ -820,6 +827,104 @@ mod tests {
         let output = render_status(&test_status_output(), OutputMode::Interactive);
         assert!(output.contains("htpc-home"), "missing htpc-home");
         assert!(output.contains("htpc-docs"), "missing htpc-docs");
+    }
+
+    // ── UPI 031-a: storage-posture rendering ────────────────────────
+
+    fn posture(
+        label: &str,
+        tier: crate::storage_critical::TightnessTier,
+        host_root: bool,
+        affected: usize,
+        since: Option<i64>,
+    ) -> crate::output::PoolPostureSummary {
+        crate::output::PoolPostureSummary {
+            pool_label: label.to_string(),
+            tier,
+            host_root,
+            affected_count: affected,
+            since_secs: since,
+        }
+    }
+
+    #[test]
+    fn storage_posture_tight_line_present() {
+        use crate::storage_critical::TightnessTier;
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.storage_postures = vec![posture("/data", TightnessTier::Tight, false, 2, None)];
+        let out = render_status(&data, OutputMode::Interactive);
+        assert!(out.contains("runs tight"), "tight state missing: {out}");
+        assert!(out.contains("/data"), "pool label missing: {out}");
+        assert!(out.contains("2 subvolumes"), "affected count missing: {out}");
+    }
+
+    #[test]
+    fn storage_posture_critical_host_root_escalation() {
+        use crate::storage_critical::TightnessTier;
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.storage_postures = vec![posture("/", TightnessTier::Critical, true, 1, None)];
+        let out = render_status(&data, OutputMode::Interactive);
+        assert!(out.contains("critically tight"), "critical state missing: {out}");
+        assert!(
+            out.contains("machine itself"),
+            "host-root escalation missing: {out}"
+        );
+    }
+
+    #[test]
+    fn storage_posture_flagged_since_present() {
+        use crate::storage_critical::TightnessTier;
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.storage_postures =
+            vec![posture("/data", TightnessTier::Tight, false, 1, Some(7200))];
+        let out = render_status(&data, OutputMode::Interactive);
+        assert!(out.contains("flagged"), "flagged-since clause missing: {out}");
+    }
+
+    #[test]
+    fn storage_posture_silent_when_roomy() {
+        let _color = color_guard(false);
+        // test_status_output has empty storage_postures (all Roomy).
+        let out = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(!out.contains("runs tight"), "must be silent when roomy: {out}");
+        assert!(
+            !out.contains("critically tight"),
+            "must be silent when roomy: {out}"
+        );
+    }
+
+    #[test]
+    fn default_status_worst_pool_clause() {
+        use crate::storage_critical::TightnessTier;
+        let _color = color_guard(false);
+        let mut data = test_default_status_output();
+        data.storage_posture = Some(posture("/data", TightnessTier::Tight, false, 3, None));
+        let out = render_default_status(&data, OutputMode::Interactive);
+        assert!(out.contains("tight"), "bare-`urd` tight clause missing: {out}");
+        assert!(out.contains("/data"), "bare-`urd` pool label missing: {out}");
+    }
+
+    #[test]
+    fn status_2am_golden_shows_tight_state_and_safety() {
+        // The 031-a half of the 2am golden test: the first lines of `urd status`
+        // surface the tight state alongside the "is my data safe?" summary.
+        use crate::storage_critical::TightnessTier;
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.storage_postures = vec![posture("/", TightnessTier::Critical, true, 1, Some(3600))];
+        let out = render_status(&data, OutputMode::Interactive);
+        let head = out.lines().take(4).collect::<Vec<_>>().join("\n");
+        assert!(
+            head.contains("sealed"),
+            "safety summary not in first lines: {head}"
+        );
+        assert!(
+            head.contains("critically tight"),
+            "tight state not in first lines: {head}"
+        );
     }
 
     #[test]
@@ -968,6 +1073,7 @@ mod tests {
             total_pins: 0,
             redundancy_advisories: vec![],
             advice: vec![],
+            storage_postures: Vec::new(),
         };
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
@@ -1042,6 +1148,7 @@ mod tests {
             total_pins: 0,
             redundancy_advisories: vec![],
             advice: vec![],
+            storage_postures: Vec::new(),
         };
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
@@ -3189,6 +3296,7 @@ mod tests {
             last_run_age_secs: None,
             best_advice: None,
             total_needing_attention: 0,
+            storage_posture: None,
         };
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
@@ -3222,6 +3330,7 @@ mod tests {
             last_run_age_secs: None,
             best_advice: None,
             total_needing_attention: 0,
+            storage_posture: None,
         };
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
@@ -3277,6 +3386,7 @@ mod tests {
             last_run_age_secs: None,
             best_advice: None,
             total_needing_attention: 0,
+            storage_posture: None,
         };
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
@@ -3297,6 +3407,7 @@ mod tests {
             last_run_age_secs: None,
             best_advice: None,
             total_needing_attention: 0,
+            storage_posture: None,
         };
         let output = render_default_status(&data, OutputMode::Daemon);
         let parsed: serde_json::Value =
@@ -3420,6 +3531,7 @@ mod tests {
             issue: Some("exposed — data may not be recoverable".to_string()),
             suggestion: Some("Run `urd backup` or connect a drive.".to_string()),
             reason: None,
+            storage_posture: None,
         };
         data.verdict = DoctorVerdict::issues(1);
         let output = render_doctor(&data, OutputMode::Interactive);
@@ -3792,6 +3904,7 @@ mod tests {
             issue: Some("waning — last backup 48 hours ago".to_string()),
             suggestion: Some("Run `urd backup --force-full --subvolume htpc-home`.".to_string()),
             reason: Some("thread to WD-18TB broken (pin missing locally)".to_string()),
+            storage_posture: None,
         };
         data.verdict = DoctorVerdict::warnings(1);
         let output = render_doctor(&data, OutputMode::Interactive);
@@ -3816,6 +3929,7 @@ mod tests {
             issue: Some("exposed — all drives disconnected".to_string()),
             suggestion: None,
             reason: Some("Connect WD-18TB to restore protection".to_string()),
+            storage_posture: None,
         };
         data.verdict = DoctorVerdict::issues(1);
         let output = render_doctor(&data, OutputMode::Interactive);
@@ -4021,6 +4135,7 @@ mod tests {
             retention_summary: None,
             external_only: false,
             errors: vec![],
+            storage_posture: None,
         }
     }
 
@@ -5185,7 +5300,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5225,7 +5339,6 @@ mod tests {
                 )),
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5255,7 +5368,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5286,7 +5398,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5318,7 +5429,6 @@ mod tests {
                 )),
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let days_out = render_doctor(
@@ -5345,7 +5455,6 @@ mod tests {
                 )),
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let weeks_out = render_doctor(
@@ -5372,7 +5481,6 @@ mod tests {
                 )),
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let years_out = render_doctor(
@@ -5403,7 +5511,6 @@ mod tests {
                 external: None,
                 note: Some(crate::recommendation::RecommendationNote::BurstyPattern),
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let output = render_doctor(
@@ -5433,7 +5540,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: Some(crate::types::ProtectionLevel::Sheltered),
-                storage_critical: false,
             }],
         };
         let with_level = render_doctor(
@@ -5461,7 +5567,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let no_level = render_doctor(
@@ -5491,7 +5596,6 @@ mod tests {
                 external: None,
                 note: Some(crate::recommendation::RecommendationNote::BurstyPattern),
                 was_named_level: Some(crate::types::ProtectionLevel::Sheltered),
-                storage_critical: false,
             }],
         };
         let output = render_doctor(&recommendations_doctor_output(view), OutputMode::Daemon);
@@ -5611,7 +5715,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5642,7 +5745,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5676,7 +5778,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5710,7 +5811,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5747,7 +5847,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5769,7 +5868,7 @@ mod tests {
             &cur,
             crate::recommendation::ShapeRole::Local,
             crate::recommendation::HeadroomSeverity::Critical,
-            crate::recommendation::AdjustmentReason::StorageCritical,
+            crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
         );
         let view = crate::output::DoctorRecommendationView {
             header: "h".to_string(),
@@ -5779,7 +5878,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5800,7 +5898,7 @@ mod tests {
             &cur,
             crate::recommendation::ShapeRole::Local,
             crate::recommendation::HeadroomSeverity::Critical,
-            crate::recommendation::AdjustmentReason::StorageCritical,
+            crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
         );
         let view = crate::output::DoctorRecommendationView {
             header: "h".to_string(),
@@ -5810,7 +5908,6 @@ mod tests {
                 external: None,
                 note: Some(crate::recommendation::RecommendationNote::BurstyPattern),
                 was_named_level: Some(crate::types::ProtectionLevel::Sheltered),
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5858,7 +5955,6 @@ mod tests {
                 external: Some(external_pressure),
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5888,7 +5984,6 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
@@ -5904,7 +5999,7 @@ mod tests {
             &cur,
             crate::recommendation::ShapeRole::Local,
             crate::recommendation::HeadroomSeverity::Critical,
-            crate::recommendation::AdjustmentReason::StorageCritical,
+            crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
         );
         let view = crate::output::DoctorRecommendationView {
             header: "h".to_string(),
@@ -5914,159 +6009,11 @@ mod tests {
                 external: None,
                 note: None,
                 was_named_level: None,
-                storage_critical: false,
             }],
         };
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
         assert!(out.contains("storage critical"), "pointer line missing: {out}");
         assert!(!out.contains("daily="), "no shape: {out}");
-    }
-
-    // ── UPI 031 — storage-critical advisory ─────────────────────────
-
-    #[test]
-    fn storage_critical_advisory_rendered_and_complements_shape() {
-        // A tightenable Pressure row that is also storage_critical renders the
-        // tightened shape, the tightening reason, AND the host-stakes advisory
-        // — the advisory is purely additive (stakes, not action).
-        let _color = color_guard(false);
-        let h = ha_rec(
-            crate::recommendation::ShapeRole::Local,
-            shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
-            shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0),
-            200_000_000_000,
-            50_000_000_000,
-            crate::recommendation::HeadroomSeverity::Pressure,
-            Some(crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.10 }),
-            Some(shape(16, 42, 36, crate::types::MonthlyCount::Count(16), 0)),
-            Some(25_000_000_000),
-        );
-        let view = crate::output::DoctorRecommendationView {
-            header: "h".to_string(),
-            rows: vec![crate::output::DoctorRecommendationRow {
-                name: "root".to_string(),
-                local: Some(h),
-                external: None,
-                note: None,
-                was_named_level: None,
-                storage_critical: true,
-            }],
-        };
-        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
-        assert!(out.contains("daily=42"), "tightened shape missing: {out}");
-        assert!(out.contains("shape tightened"), "tightening reason missing: {out}");
-        assert!(
-            out.contains("risks the host itself"),
-            "storage-critical advisory missing: {out}"
-        );
-    }
-
-    #[test]
-    fn storage_critical_at_min_combined_render_no_double_action() {
-        // M3: an at-MIN Pressure row (synth, no adjusted) that is also
-        // storage_critical. The action ("expanding storage") must appear at
-        // most once — on the at-MIN reason line, not duplicated by the
-        // advisory, which supplies only the host stakes.
-        let _color = color_guard(false);
-        let cur = shape(0, 3, 0, crate::types::MonthlyCount::Count(0), 0);
-        let h = crate::recommendation::headroom_aware_pointer_only(
-            &cur,
-            crate::recommendation::ShapeRole::Local,
-            crate::recommendation::HeadroomSeverity::Pressure,
-            crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.10 },
-        );
-        let view = crate::output::DoctorRecommendationView {
-            header: "h".to_string(),
-            rows: vec![crate::output::DoctorRecommendationRow {
-                name: "root".to_string(),
-                local: Some(h),
-                external: None,
-                note: None,
-                was_named_level: None,
-                storage_critical: true,
-            }],
-        };
-        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
-        assert!(
-            out.contains("shape already at minimum"),
-            "at-MIN guidance missing: {out}"
-        );
-        assert!(
-            out.contains("risks the host itself"),
-            "storage-critical advisory missing: {out}"
-        );
-        assert!(
-            out.matches("expanding storage").count() <= 1,
-            "action verb must not be duplicated (action + stakes, not two exhortations): {out}"
-        );
-    }
-
-    #[test]
-    fn storage_critical_advisory_absent_when_flag_false() {
-        // A Pressure row without the flag renders no host-stakes advisory.
-        let _color = color_guard(false);
-        let h = ha_rec(
-            crate::recommendation::ShapeRole::Local,
-            shape(24, 30, 26, crate::types::MonthlyCount::Count(12), 0),
-            shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0),
-            200_000_000_000,
-            50_000_000_000,
-            crate::recommendation::HeadroomSeverity::Pressure,
-            Some(crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.10 }),
-            Some(shape(16, 42, 36, crate::types::MonthlyCount::Count(16), 0)),
-            Some(25_000_000_000),
-        );
-        let view = crate::output::DoctorRecommendationView {
-            header: "h".to_string(),
-            rows: vec![crate::output::DoctorRecommendationRow {
-                name: "containers".to_string(),
-                local: Some(h),
-                external: None,
-                note: None,
-                was_named_level: None,
-                storage_critical: false,
-            }],
-        };
-        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
-        assert!(
-            !out.contains("risks the host itself"),
-            "advisory must be absent when flag false: {out}"
-        );
-    }
-
-    #[test]
-    fn storage_critical_advisory_not_emitted_on_dormant_critical_path() {
-        // Dormant-path guard: a Critical-severity row (032/033 hook) takes the
-        // R9 pointer-only early return, so the additive advisory is NOT also
-        // emitted — only the single pointer line.
-        let _color = color_guard(false);
-        let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
-        let h = crate::recommendation::headroom_aware_pointer_only(
-            &cur,
-            crate::recommendation::ShapeRole::Local,
-            crate::recommendation::HeadroomSeverity::Critical,
-            crate::recommendation::AdjustmentReason::StorageCritical,
-        );
-        let view = crate::output::DoctorRecommendationView {
-            header: "h".to_string(),
-            rows: vec![crate::output::DoctorRecommendationRow {
-                name: "root".to_string(),
-                local: Some(h),
-                external: None,
-                note: None,
-                was_named_level: None,
-                storage_critical: true,
-            }],
-        };
-        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
-        assert!(
-            out.contains("see `urd doctor`"),
-            "R9 pointer line expected: {out}"
-        );
-        assert!(
-            !out.contains("risks the host itself"),
-            "additive advisory must not also fire on the Critical path: {out}"
-        );
     }
 
     // ── UPI 042 — MonthlyCount + yearly rendering ───────────────────

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -11,12 +11,15 @@ use colored::Colorize;
 
 use crate::advice::RedundancyAdvisoryKind;
 use crate::awareness::PromiseStatus;
-use crate::output::{ChainHealth, DefaultStatusOutput, OutputMode, StatusOutput};
+use crate::output::{
+    ChainHealth, DefaultStatusOutput, OutputMode, PoolPostureSummary, StatusOutput,
+};
+use crate::storage_critical::TightnessTier;
 use crate::types::{ByteSize, DriveRole};
 
 use super::{
     SuggestionContext, aggregate_drive_info, append_suggestion, color_result, exposure_label,
-    format_status_table, humanize_duration, unmounted_drive_label,
+    format_status_table, humanize_duration, pluralize, unmounted_drive_label,
 };
 
 // ── Status ──────────────────────────────────────────────────────────────
@@ -39,6 +42,11 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
 
     // ── Summary line ────────────────────────────────────────────────
     render_summary_line(data, &mut out);
+
+    // ── Storage posture (UPI 031-a) ─────────────────────────────────
+    // Told-not-silent: a tight pool is surfaced high, right under the safety
+    // summary. Silent when every pool is Roomy.
+    render_storage_postures(data, &mut out);
 
     // ── Per-subvolume table ──────────────────────────────────────────
     render_subvolume_table(data, &mut out);
@@ -166,6 +174,47 @@ pub(super) fn render_summary_line(data: &StatusOutput, out: &mut String) {
     };
 
     writeln!(out, "{safety_part}{health_part}").ok();
+}
+
+/// Render the per-pool storage-posture lines (UPI 031-a). One line per tight
+/// pool: the state ("runs tight" / "critically tight"), the affected-subvolume
+/// count, the host-root stakes escalation, and "flagged ... ago" when known.
+/// Silent when no pool is tight (a Roomy system says nothing here).
+pub(super) fn render_storage_postures(data: &StatusOutput, out: &mut String) {
+    if data.storage_postures.is_empty() {
+        return;
+    }
+    for p in &data.storage_postures {
+        writeln!(out, "{}", storage_posture_line(p)).ok();
+    }
+}
+
+/// Compose a single posture line. Extracted (pure, `String`-returning) so both
+/// the full `status` surface and the compact bare-`urd` clause can reuse the
+/// state wording.
+fn storage_posture_line(p: &PoolPostureSummary) -> colored::ColoredString {
+    let state = match p.tier {
+        TightnessTier::Critical => "critically tight",
+        // Roomy never reaches here (aggregate emits Tight+ only).
+        _ => "runs tight",
+    };
+    let mut line = format!(
+        "Watching {}: {state} \u{2014} {} affected",
+        p.pool_label,
+        pluralize(p.affected_count, "subvolume", "subvolumes"),
+    );
+    if p.host_root {
+        line.push_str(
+            " \u{2014} this is your host root, so pressure here risks the machine itself",
+        );
+    }
+    if let Some(secs) = p.since_secs.filter(|s| *s >= 0) {
+        write!(line, " (flagged {} ago)", humanize_duration(secs)).ok();
+    }
+    match p.tier {
+        TightnessTier::Critical => line.red(),
+        _ => line.yellow(),
+    }
 }
 
 pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
@@ -478,6 +527,24 @@ fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
             parts.push(format!("{} degraded", data.degraded_count));
         }
         write!(out, " {}.", parts.join(", ")).ok();
+    }
+
+    // Storage posture (UPI 031-a): compact worst-pool clause.
+    if let Some(ref posture) = data.storage_posture {
+        let state = match posture.tier {
+            TightnessTier::Critical => "critically tight",
+            _ => "tight",
+        };
+        let clause = if posture.host_root {
+            format!(" Storage on {} is {state} (host root).", posture.pool_label)
+        } else {
+            format!(" Storage on {} is {state}.", posture.pool_label)
+        };
+        let colored = match posture.tier {
+            TightnessTier::Critical => clause.red(),
+            _ => clause.yellow(),
+        };
+        write!(out, "{colored}").ok();
     }
 
     // Last backup age (pre-computed by command handler to keep voice pure)

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -1009,7 +1009,6 @@ mod contract {
             external: None,
             note: None,
             was_named_level: None,
-            storage_critical: false,
         }
     }
 
@@ -1105,7 +1104,7 @@ mod contract {
             &cur,
             ShapeRole::Local,
             HeadroomSeverity::Critical,
-            AdjustmentReason::StorageCritical,
+            AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
         );
         crate::output::DoctorRecommendationRow {
             name: name.to_string(),
@@ -1113,7 +1112,6 @@ mod contract {
             external: None,
             note: None,
             was_named_level: None,
-            storage_critical: false,
         }
     }
 
@@ -1163,7 +1161,6 @@ mod contract {
             external: None,
             note: None,
             was_named_level: None,
-            storage_critical: false,
         }
     }
 
@@ -1374,7 +1371,6 @@ mod contract {
             external: None,
             note: None,
             was_named_level: None,
-            storage_critical: false,
         };
         let view = crate::output::DoctorRecommendationView {
             header: "header".to_string(),


### PR DESCRIPTION
## Summary

- **Reworks the unreleased UPI 031 storage-critical sliver** into the detection + state + awareness foundation for the ADR-113 Do-No-Harm increment-2 bundle (031-a + 032 + 033). Splits the single `is_storage_critical` predicate — which conflated host-root-ness with current pressure and inverted the severity/response ladder — into two orthogonal axes: a **tightness tier** (`Roomy / Tight / Critical`, free-ratio only on the source pool) and a **host-root** escalation flag.
- **Surfaces the tier told-not-silent** in `urd status` and bare `urd`, backed by a persisted, best-effort, hysteresis-stabilized per-pool armed tier (`pool_armed_tier` SQLite table) that survives runs and does not flap. Backup runs dispatch a best-effort `notify.rs` notification on escalation; de-escalation is silent. Posture is gathered at the command boundary (`commands/storage_signals.rs`) and threaded into `assess()` as a pure `StorageSignalMap`.
- **Removes the inverted `doctor --thorough` row advisory** and its `storage_critical` field; the posture now renders in the `doctor` data-safety section, and the recommendation row returns to pure retention-shape advice. Drops the dead `AdjustmentReason::StorageCritical`; switches the synth-path fallback reason to `SourcePoolLow`.
- **Follow-up `/tidy` pass** (second commit): single-owner `PoolSpace::free_ratio`, a typed `PoolKey` enum replacing stringly-typed pool keys, and a one-pass `gather_with`. Quality-only, no behavior change.

No metric / heartbeat schema change (Cross-Repo Impact: None); no on-disk or config-schema change.

## Testing

- cargo clippy --all-targets -- -D warnings: pass (clean)
- cargo test: 1497 passed, 0 failed, 3 ignored
- cargo build --release: pass
- Integration tests: not run (no drives in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)