### PR TITLE
feat: tier-graded ephemeral footprint-cap (UPI 031-b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Tier-graded ephemeral footprint-cap** (UPI 031-b, ADR-113 increment 2). Makes the
+  storage tightness tier from 031-a *act* on Urd's own footprint instead of merely
+  reporting it. The armed tier is now resolved once pre-plan and threaded into the
+  planner, executor, and awareness, so a tight source pool automatically sheds Urd's
+  local footprint: **Tight** → retain-one parent (incremental sends) plus a modest 1.5×
+  send-interval stretch; **Critical** → clear-all (drop the pin, full sends, ≈0 steady
+  footprint) plus a weekly send-interval floor so the forced full sends stay rare.
+  Awareness judges staleness against the *effective* (adapted) interval and caps the
+  promise at AT RISK while Critical — surfaced told-not-silent in `urd status` as
+  deliberate care ("tight drive — backing up every 7d to spare it. Reads AT RISK by
+  design, not a failure."), not a failure. The clear-all deletion path routes through the
+  existing executor gate (all-sends-succeeded + no-pin-failure + fail-closed re-read,
+  ADR-106/107), removing the pin before the re-read so the just-sent snapshot can be
+  cleared; a pin-removal failure fails open (skips the clear, retries next run). Both
+  `urd plan` and `backup --dry-run` now gather signals and show the storage-adapted plan.
+  Carries two in-place ADR amendments — ADR-113 (four→three defensive layers, predictive
+  guards retired) and ADR-110 (the AT-RISK cap overturns arc decision R4) — and deletes
+  the now-confirmed-dead `HeadroomSeverity::Critical` machinery (AB5). No metric,
+  heartbeat, on-disk, or config-schema change (Cross-Repo Impact: None).
 - **Storage-pressure state in `urd status`** (UPI 031-a, reworks the unreleased UPI 031).
   Splits 031's single `is_storage_critical` predicate — which conflated host-root-ness
   with current pressure and inverted the severity/response ladder — into two orthogonal

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,7 +174,7 @@ produce the same internal `Config` struct — v1/v2 synthesize `LocalSnapshotsCo
 - Test retention logic exhaustively — it protects against data loss
 - When building features, use vertical slicing: write one test, implement to pass, repeat. Never write all tests first then all implementation.
 - **Symmetric fixes need symmetric reviews.** When a bug is rooted in a shared planning or rendering pattern (e.g. "augment local_snaps with planned_snap" in plan.rs), grep for the pattern in adjacent code paths before closing the fix. The May 2 stranded-snapshots incident: commit `0f52555` correctly fixed the transient planner branch in April; the symmetric bug in the non-transient branch went unnoticed for nearly a month. See [2026-05-02-stranded-snapshots-non-transient-planner.md](docs/98-journals/2026-05-02-stranded-snapshots-non-transient-planner.md).
-- 521+ tests, all passing, clippy clean
+- 1520+ tests, all passing, clippy clean
 
 ## Backward Compatibility (ADR-105)
 
@@ -238,7 +238,7 @@ Consult when working on code that directly uses these APIs (especially `state.rs
 ```bash
 cargo build                          # Debug
 cargo build --release                # Release
-cargo test                           # Unit tests (931+ tests)
+cargo test                           # Unit tests (1520+ tests)
 cargo test -- --ignored              # Integration tests (needs drives)
 cargo clippy --all-targets -- -D warnings   # Lint (covers test code too)
 cargo check --all-targets            # Fast type-check after mass edits (covers test code; bare `cargo check` does not)

--- a/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
+++ b/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
@@ -6,8 +6,8 @@
 > earn opaque status through operational track record. Current taxonomy:
 > recorded/sheltered/fortified (renamed 2026-04-03 from guarded/protected/resilient).
 
-**Date:** 2026-03-26 (revised 2026-03-27, addendum 2026-03-31, vocabulary 2026-04-03, amendment 2026-05-09)
-**Status:** Accepted (taxonomy renamed 2026-04-03 — see Maturity Model; recommendation-layer amendment 2026-05-09 — see [Amendment 2026-05-09](#amendment-2026-05-09-recommendation-layer-as-graduation-evidence-path-adr-115))
+**Date:** 2026-03-26 (revised 2026-03-27, addendum 2026-03-31, vocabulary 2026-04-03, amendments 2026-05-09 / 2026-05-15 / 2026-05-30)
+**Status:** Accepted (taxonomy renamed 2026-04-03 — see Maturity Model; recommendation-layer amendment 2026-05-09 — see [Amendment 2026-05-09](#amendment-2026-05-09-recommendation-layer-as-graduation-evidence-path-adr-115); AT-RISK cap at Critical overturns R4 2026-05-30 — see [Amendment 2026-05-30](#amendment-2026-05-30-at-risk-cap-at-the-critical-tier-upi-031-b--overturns-r4))
 **Depends on:** ADR-100 (planner/executor separation), ADR-108 (pure function modules),
 ADR-109 (config boundary validation), ADR-111 (config system architecture)
 **Amended by:** ADR-115 (Retention shape symmetry and the recommendation layer)
@@ -428,6 +428,36 @@ re-litigating it later under pressure.
 The only user-visible surface affected is `urd doctor --thorough`'s display of a Recorded
 subvolume's external policy shape: it now reads "no monthly" instead of "unlimited monthly."
 Display-only; no retention behavior changes.
+
+## Amendment 2026-05-30: AT-RISK cap at the Critical tier (UPI 031-b — overturns R4)
+
+The Do-No-Harm arc decision **R4** (recorded in the 031-a journal and the arc-regrill
+doc) held that *"the promise degrades only via honest staleness"* — i.e. storage posture
+(`TightnessTier`) was a presentation axis strictly **separate** from `PromiseStatus`, and
+a tight pool could never, by itself, move the promise. UPI 031-b **overturns R4,
+eyes-open.**
+
+**The change.** At the **Critical** tier, the tier-graded ephemeral spine deliberately
+slows Urd's send cadence (clear-all + a weekly interval floor) to bound Urd's local
+footprint on a dangerously tight pool. Judged honestly, the subvolume *is* less protected
+than its declared cadence promised — a fresh-but-weekly external copy is genuinely a
+weaker guarantee than a fresh-but-daily one. So `awareness::assess` now **caps the promise
+at AT RISK while the pool is Critical**: `overall = overall.min(AtRisk)` (never PROTECTED
+at Critical; AT RISK / UNPROTECTED are unchanged).
+
+**Why this is honest, not synthetic.** The cap is not an alarm bolted onto a healthy
+subvolume. It records a real reduction in protection that Urd chose on the host's behalf.
+The distinction between *this deliberate cap* and a *genuine failure* is carried by a new
+`cadence_adapted` signal (`true` only when the pre-cap status was PROTECTED), which the
+voice layer reads to lead with adaptation prose ("tight drive — backing up weekly to spare
+it … reads AT RISK by design, not a failure") rather than a failure line. The status **word
+stays `AT RISK`** — no new sub-state token (AB3.1), preserving the R4-era trim of promise
+proliferation.
+
+**Scope.** The cap fires **only at Critical**. **Tight** lengthens the cadence but does
+**not** cap the promise (it is lengthened-but-honest). Roomy is unchanged. This is a
+one-notch, bounded, recorded override of R4 — "less protected than declared," surfaced in
+plain language, not a synthetic alarm.
 
 ## Related
 

--- a/docs/00-foundation/decisions/2026-04-18-ADR-113-do-no-harm-invariant.md
+++ b/docs/00-foundation/decisions/2026-04-18-ADR-113-do-no-harm-invariant.md
@@ -10,8 +10,33 @@
 > it prefers host survival over backup-chain continuity.
 
 **Date:** 2026-04-18
-**Status:** Accepted
+**Status:** Accepted (amended 2026-05-30, UPI 031-b)
 **Supersedes:** UPI 011 (hard-cap of 1 local snapshot for transient subvolumes)
+
+> **Amendment — 2026-05-30 (UPI 031-b, the tier-graded ephemeral spine).**
+> The probabilistic defense stack goes from **four layers to three**, and Layer 1
+> is refined:
+>
+> - **Layer 2 (predictive guards) is retired.** UPI 032 collapsed in the
+>   2026-05-30 arc re-grill: with an ephemeral-by-default footprint-cap actually
+>   acting on the armed tier, a proactive *defer* was redundant in the case it
+>   could catch and **net-negative** in the common case — HELDing a run while
+>   ambient host churn fills the disk anyway is the inaction-is-harm trap
+>   (`[[project_adr113_realignment_flagged]]`). The arc's real protection is the
+>   ephemeral lifecycle *itself*, not a guard in front of it.
+> - **Layer 1 is refined from unconditional ephemeral to tier-graded**:
+>   retain-one @ **Tight**, clear-all (zero steady local footprint) @ **Critical**,
+>   keyed on the per-pool armed `TightnessTier` (031-a detection, 031-b action).
+>   The behavioral half lands here, not via the doctor severity ladder — so the
+>   dormant `HeadroomSeverity::Critical` machinery was deleted (AB5).
+>
+> **Amended stack:** (1) reactive host-survival floor (`min_free` space guard +
+> emergency retention, no config override) → (2) **tier-graded ephemeral
+> footprint-cap** (this spine, 031-b) → (3) in-flight watchdog (033) →
+> (4) emergency eject (034). The **invariant and the probabilistic contract are
+> unchanged** — only the layer *mechanism* evolves (matching the in-place-amendment
+> precedent of ADR-104/105/110/111). See the layer table below for the per-layer
+> detail.
 
 ## Context
 
@@ -57,14 +82,19 @@ extends naturally to the other burden categories when they arise.
 Urd applies **multiple independent mechanisms**, each with a distinct failure mode,
 such that the probability of all layers failing together is vanishingly small.
 
-For storage pressure, the four layers are:
+For storage pressure, the three layers are (amended 2026-05-30, UPI 031-b —
+predictive guards retired; see the amendment block above):
 
 | Layer | Prevents | Failure mode | Caught by |
 |-------|----------|--------------|-----------|
-| 1. Ephemeral lifecycle (snapshot → send → delete) on storage_critical subvolumes | Steady-state delta drift in the 24h pin window | N/A (structural) | — |
-| 2. Predictive guards (drift projection + defer) | Sends starting in risky conditions | Prediction too optimistic | Layer 3 |
-| 3. Mid-op watchdog (free-space polling + write-rate sensing during send) | Sends that went bad in-flight | Watchdog loses the race | Layer 4 |
-| 4. Emergency eject (sentinel drops Urd-owned snapshots to reclaim space) | Residual pressure after prediction and watchdog both failed | BTRFS itself failed (ENOSPC mid-transaction, read-only FS) | Outside Urd's domain |
+| 1. **Tier-graded ephemeral footprint-cap** — retain-one @ Tight / clear-all @ Critical, keyed on the per-pool armed `TightnessTier` (031-a/031-b) | Steady-state delta drift in the pin window; at Critical, *any* steady local footprint | N/A (structural) | — |
+| 2. Mid-op watchdog (free-space polling + write-rate sensing during send) | Sends that went bad in-flight | Watchdog loses the race | Layer 3 |
+| 3. Emergency eject (sentinel drops Urd-owned snapshots to reclaim space) | Residual pressure after the footprint-cap and watchdog both failed | BTRFS itself failed (ENOSPC mid-transaction, read-only FS) | Outside Urd's domain |
+
+*Retired (2026-05-30):* **Predictive guards (drift projection + defer).** UPI 032
+collapsed — a proactive defer was redundant where the footprint-cap already acts
+and net-negative otherwise (inaction-is-harm). The `min_free` space guard +
+emergency retention remain as the reactive host-survival floor beneath Layer 1.
 
 Each layer's failure is caught by the next. Each layer has a distinct probabilistic
 profile — they fail under different conditions, so their combined failure probability
@@ -136,9 +166,10 @@ prefer host survival under catastrophic conditions.
 
 ### Negative
 
-- **More moving parts.** Four defensive layers plus telemetry is substantially more
-  machinery than the current reactive guard. Each layer has test surface, tuning
-  parameters, and failure modes of its own.
+- **More moving parts.** Three defensive layers plus telemetry (was four before the
+  2026-05-30 amendment retired predictive guards) is substantially more machinery than
+  the current reactive guard. Each layer has test surface, tuning parameters, and
+  failure modes of its own.
 - **Performance cost.** Watchdog polling during sends adds overhead. Reserve file
   consumes disk space. Telemetry writes to the state DB on every run.
 - **Full sends on storage_critical subvolumes.** Ephemeral lifecycle means no
@@ -170,26 +201,26 @@ prefer host survival under catastrophic conditions.
 
 ## Implementation
 
-The Do-No-Harm arc spans 5 UPIs (030-034), sequenced as dependencies require:
+The Do-No-Harm arc (amended 2026-05-30 — UPI 032 retired, see the amendment block):
 
 1. **UPI 030 — Drift Telemetry.** Foundation. Per-subvolume write-rate history in
-   `state.rs`, surfaced in `awareness.rs` and heartbeat. Blocks everything else.
-2. **UPI 031 — storage_critical Bundle.** New config concept with auto-detection
-   (`source = "/"`, FS usage ≥ 70%, known heavy-write paths). Ephemeral lifecycle
-   for critical subvolumes. Conservative interval defaults. Supersedes UPI 011.
-3. **UPI 032 — Predictive Guards.** Pre-flight drift projection. Defers sends when
-   projected drift would cross threshold. Uses telemetry from UPI 030.
-4. **UPI 033 — Mid-op Watchdog + Reserve File.** Trigger-with-cleanup-budget + reserve
-   file + write-rate sensing during sends. Runs inside `executor.rs` or extracted into
-   a `guard.rs` module.
-5. **UPI 034 — Emergency Eject.** Sentinel extension. Drops Urd-owned snapshots when
-   pressure crosses catastrophic floor outside of an active send.
+   `state.rs`, surfaced in `awareness.rs` and heartbeat. Blocks everything else. *(Shipped.)*
+2. **UPI 031-a — Tightness detection.** Split the storage-critical predicate into a
+   per-pool armed `TightnessTier` (Roomy/Tight/Critical, free-ratio only) + a host-root
+   flag, surfaced told-not-silent in `urd status`. Persisted, hysteresis-stabilized.
+   Supersedes UPI 011. *(Shipped.)*
+3. **UPI 031-b — Tier-graded ephemeral spine.** Threads the armed tier into the planner,
+   executor, and awareness: Tight → retain-one + modest interval stretch; Critical →
+   clear-all (executor-gated) + weekly interval floor; awareness caps the promise at
+   AT RISK while Critical. This is the behavioral Layer 1. *(This UPI.)*
+4. ~~**UPI 032 — Predictive Guards.**~~ **Retired** (2026-05-30 re-grill): redundant where
+   the footprint-cap acts, net-negative otherwise (inaction-is-harm).
+5. **UPI 033 — Mid-op Watchdog + Reserve File.** Trigger-with-cleanup-budget + reserve
+   file + write-rate sensing during sends. Runs inside `executor.rs` or a `guard.rs` module.
+6. **UPI 034 — Emergency Eject.** Sentinel extension. Drops Urd-owned snapshots when
+   pressure crosses the catastrophic floor outside of an active send.
 
-Shippable increments:
-- **Increment 1:** UPI 030 alone (observability, no behavior change).
-- **Increment 2:** UPIs 031+032+033 together (the safety harness — coherent behavior
-  change).
-- **Increment 3:** UPI 034 (last-ditch layer).
+Arc sequence beyond this UPI: **031-b → 033 → 034**.
 
 Each increment is independently testable and independently deployable. `/design` is
 run per UPI. Adversary review and post-review apply to each.

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -248,7 +248,7 @@ runs in the backup hot path.
 | `outer-edge span` | The time span from the *outer* edge of a tier's window back to its inner edge — the only thing that changes total data cost as the shape changes. Slot density inside a window does not. |
 | `drift signal` | The rolling churn rate computed by `drift.rs` (UPI 030) from `drift_samples`. The input the recommendation engine projects cost against. |
 | `symmetric data-cost model` | ADR-115's claim: two shapes with the same outer-edge span over the same drift signal cost the same in retained data bytes, regardless of how many slots populate the interior. Metadata cost is separate and is not modelled by X1. |
-| `headroom` | Destination free-space context (`HeadroomContext`) used to scale the recommended shape. `HeadroomSeverity` is one of `Healthy / Caution / Pressure / Critical` (recommendation.rs). The classifier emits `Healthy / Caution / Pressure`; Pressure produces a tightened companion shape under `HEADROOM_TIGHTEN_MULTIPLIER`. (`Critical` is dormant in production since UPI 031 — kept for the UPI 032/033 bundle.) |
+| `headroom` | Destination free-space context (`HeadroomContext`) used to scale the recommended shape. `HeadroomSeverity` is one of `Healthy / Caution / Pressure` (recommendation.rs) — the classifier emits all three, and Pressure produces a tightened companion shape under `HEADROOM_TIGHTEN_MULTIPLIER`. (The dormant `Critical` variant and its dead voice/recommendation paths were deleted in UPI 031-b, AB5 — the behavioral bundle keys on `TightnessTier`, not this severity ladder.) |
 | `recommended shape` | The shape returned by `recommend_shape*()` — a `ResolvedGraduatedRetention`-shaped suggestion paired with a `CostProjection` and the `AdjustmentReason`s that explain why it differs from what the user has today. |
 
 Source: `recommendation.rs`, ADR-115.
@@ -289,18 +289,25 @@ persisted, hysteresis-stabilized state. Lives in `storage_critical.rs` (pure der
 with I/O at the command boundary (`commands/storage_signals.rs`). It surfaces
 **told-not-silent** in `urd status` and bare `urd`, notifies on backup escalations, and
 appears as a diagnostic line in `doctor --thorough`'s data-safety section. The
-**behavioral** half (defer, ephemeral lifecycle, mid-op watchdog) is deferred to the UPI
-032/033 bundle (ADR-113 increment 2).
+**behavioral** half — the tier-graded ephemeral lifecycle (retain-one @ Tight, clear-all
+@ Critical) plus the AT-RISK cap — shipped in **UPI 031-b** (ADR-113 Layer 1). The mid-op
+watchdog (033) and emergency eject (034) remain ahead; predictive guards (the old UPI 032)
+were retired in the 2026-05-30 re-grill.
 
 | Term | Meaning |
 |------|---------|
 | `tightness tier` | Source-pool free-space tier, **free-ratio only**: `TightnessTier { Roomy, Tight, Critical }` (`storage_critical.rs`). Boundaries reuse `recommendation::classify_free_ratio_value` (`< 0.25` → Tight, `< 0.15` → Critical) — the single source of truth, **no new threshold**. The imperative-bundle axis the Do-No-Harm response climbs with. |
 | `tight` / `critical` | User-facing names for the `Tight` / `Critical` tiers (state vocabulary). `Roomy` is silent — Urd says nothing about a roomy pool. |
 | `host-root axis` | The structural escalation flag (`storage_critical::host_root`): the subvolume's source is on the pool hosting `/` (UUID match) **and** an *enabled* subvolume entrusts `/` itself (`source == "/"`). Orthogonal to the tier — pressure on the host-root pool risks the **machine itself**, not just retention. This is the relocated home of UPI 031's stakes-not-action advisory prose. |
-| `storage posture` | The per-subvolume `StoragePosture { tier, host_root }` carried on `SubvolAssessment` — `Some` only when `tier >= Tight`. A separate presentation axis from the data-safety `PromiseStatus` (ADR-110 R4): "Urd is watching a tight pool," not "your data is unsafe." |
+| `storage posture` | The per-subvolume `StoragePosture { tier, host_root }` carried on `SubvolAssessment` — `Some` only when `tier >= Tight`. A presentation axis distinct from the data-safety `PromiseStatus`: "Urd is watching a tight pool." **Mostly** separate (ADR-110 R4) — **but** UPI 031-b's AT-RISK cap is the one recorded coupling: at **Critical**, the deliberate clear-all cadence is an honest reduction in protection, so the promise is capped at AT RISK (ADR-110 amendment 2026-05-30, overturning R4 at Critical only). Tight/Roomy stay fully separate. |
 | `watching` | The posture verb: Urd is *watching* a tight pool (told-not-silent), as distinct from a data-safety promise degradation. |
 | `armed tier` / `operational-adaptation state` | The persisted, hysteresis-stabilized tier per pool (`pool_armed_tier` table: `pool_uuid → (armed_tier, since)`). Best-effort SQLite (ADR-102) — never blocks a run; if lost, Urd re-derives statelessly (degraded, never unsafe). The seed of the future managed-config/autonomy layer; lives in Urd's state, **never** in `urd.toml`. |
-| `hysteresis band` | `HYSTERESIS_BAND_PP = 0.05` — escalate immediately when the current ratio classifies worse than the armed tier; de-escalate only once free recovers to `arm_threshold + 5pp` (Critical→Tight at `> 0.20`, Tight→Roomy at `> 0.30`). Anti-flap: stops a pool hovering at a boundary from re-notifying every run. 031-a's one new constant; revisited at the ADR-113 30-day checkpoint. |
+| `hysteresis band` | Escalate immediately when the current ratio classifies worse than the armed tier; de-escalate stickily. Tight→Roomy uses `HYSTERESIS_BAND_PP = 0.05` (free `> 0.30`). Critical→Tight uses the **wider** `CRITICAL_DEESCALATION_BAND_PP = 0.10` (free `> 0.25`, the Caution line — UPI 031-b S1): clear-all moves the controlled variable, so a pool must recover to where the classifier stops calling it tight at all before shedding the footprint-cap, damping a Critical↔Tight limit cycle toward the safe (capped) state. Anti-flap; revisited at the ADR-113 30-day checkpoint. |
+| `tier-graded ephemeral lifecycle` | The UPI 031-b behavioral spine (ADR-113 Layer 1): the armed `TightnessTier` selects how much local footprint Urd sheds. **Roomy** → declared policy. **Tight** → `retain-one` + a modest interval stretch (`TIGHT_INTERVAL_FACTOR = 1.5`). **Critical** → `clear-all` + a weekly interval floor (`CRITICAL_INTERVAL_FLOOR = 7d`). Derived purely by `storage_critical::derive_effective_policy`. |
+| `retain-one` | The Tight lifecycle: keep exactly **one** local snapshot (the pin parent) for incremental sends; the executor deletes the *old* parent after the send advances the pin. It is the `Transient` retention policy — there is no separate variant. |
+| `clear-all` | The Critical lifecycle: keep **zero** local snapshots between runs. The planner writes no pin (`pin_on_success: None`); after confirming all sends succeeded, the executor (gated, ADR-107) removes the pin and deletes the just-sent snapshot. Steady-state Critical is therefore full sends. Modeled as `Transient` + the executor `clear_all` signal — **not** a new `LocalRetentionPolicy` variant. |
+| `effective policy` / `declared intent` | `declared intent` = what the user's config says (`ResolvedSubvolume.local_retention` / `send_interval`). `effective policy` = `EffectivePolicy { local_retention, send_interval, clear_all }`, the tier-adapted operational policy the planner, executor, **and** awareness all act on. The planner and awareness MUST derive the same effective policy from the **same** armed tier (the single pre-plan gather, `backup.rs`) or a correctly-adapting subvolume shows false AT RISK. |
+| `cadence_adapted` | The signal (`SubvolAssessment.cadence_adapted`) that distinguishes a **deliberate** AT-RISK cap (the pre-cap status was PROTECTED; a slowed Critical cadence — "less protected than declared") from a **genuine** failure (drive absent, chain broken, stale beyond the effective interval). `true` only in the deliberate case. Voice reads it to lead with adaptation prose rather than a failure line. Never serialized as a status token — the word stays `AT RISK` (AB3.1). |
 | `transition` | A change in armed tier, computed **only** at the backup boundary (`advance_and_writeback`). Escalations dispatch a best-effort `notify.rs` notification; de-escalation is silent (status reflects recovery). Read paths (`status`, bare `urd`, `doctor`) reflect the stabilized tier and **never** fire a transition (S1). |
 
 **`headroom` vs `tightness tier` (do not confuse).** `headroom` (recommendation.rs) is a
@@ -310,8 +317,9 @@ on the *source* pool: trend is handled separately in 032's projection, destinati
 is irrelevant to source-pool tightness. Same free-ratio boundaries, different composites and
 different jobs.
 
-> **Note.** `constrained` (`tier >= Tight && Urd writes to that pool`) is a **UPI 032**
-> term — deferred, not part of 031-a. 031-a's surface gates inline on `tier >= Tight`.
+> **Note.** `constrained` (`tier >= Tight && Urd writes to that pool`) was a **UPI 032**
+> term. UPI 032 (predictive guards) was **retired** in the 2026-05-30 re-grill, so
+> `constrained` did not ship. Urd's lifecycle gates directly on the armed `tier` (031-b).
 
 Source: `storage_critical.rs`, `commands/storage_signals.rs`, `state.rs` (`pool_armed_tier`),
 ADR-113. See also the user-facing rename `drift` → "churn" on the Recommendation cluster's

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -532,6 +532,8 @@ drives = ["primary-drive", "offsite-drive"]
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }
     }
 
@@ -1153,6 +1155,8 @@ local_retention = "transient"
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }
     }
 

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -262,6 +262,18 @@ pub struct SubvolAssessment {
     /// A separate presentation axis from `status`/`health` (ADR-110 R4): it
     /// reflects Urd's posture toward a tight pool, not the data-safety promise.
     pub storage_posture: Option<crate::storage_critical::StoragePosture>,
+    /// UPI 031-b (AB3.1): `true` only when the promise was capped to AT RISK
+    /// *solely* because the pool is Critical — i.e. the pre-cap status was
+    /// Protected. A deliberate slowed cadence ("less protected than declared"),
+    /// NOT a failure. Voice reads it to render adaptation prose ahead of any
+    /// routine staleness line; it is never serialized as a status token (the
+    /// word stays `AT RISK` — ADR-110 amendment overturning R4).
+    pub cadence_adapted: bool,
+    /// UPI 031-b: the *effective* send interval the planner timed against and
+    /// awareness judged staleness against, when adapted (`armed != Roomy`).
+    /// `None` at Roomy (the declared interval governs). Lets voice name the
+    /// cadence ("backing up weekly to spare it").
+    pub effective_send_interval: Option<Interval>,
 }
 
 /// Per-subvolume raw storage signal fed into `assess()` (UPI 031-a). Resolved
@@ -490,12 +502,34 @@ pub fn assess(
                     subvol.name
                 )],
                 storage_posture: None,
+                cadence_adapted: false,
+                effective_send_interval: None,
             });
             continue;
         };
 
         let mut errors = Vec::new();
         let local_dir = snapshot_root.join(&subvol.name);
+
+        // ── Tier-adapted effective policy (UPI 031-b) ────────────────
+        // Resolve the armed tier once (Roomy default when no signal), then
+        // derive the effective policy. The SAME armed tier feeds the planner
+        // (via backup.rs's single pre-plan gather), so the effective send
+        // interval awareness judges staleness against agrees with what the
+        // planner timed against — no false AT RISK for a correctly-adapting
+        // subvolume. `armed` also drives the posture and the AT-RISK cap below.
+        let armed = storage_signals
+            .get(&subvol.name)
+            .map(|sig| {
+                crate::storage_critical::resolve_armed_tier(sig.prior_armed_tier, sig.free_ratio)
+            })
+            .unwrap_or_default();
+        let eff = crate::storage_critical::derive_effective_policy(
+            &subvol.local_retention,
+            subvol.send_interval,
+            subvol.send_enabled,
+            armed,
+        );
 
         // ── Local assessment ────────────────────────────────────────
         let mut advisories = Vec::new();
@@ -595,14 +629,17 @@ pub fn assess(
                     &drive.label,
                     ext_snaps.as_deref(),
                 );
+                // Judge staleness against the EFFECTIVE interval (031-b): a
+                // Critical subvol on a weekly cadence must not read AT RISK at
+                // day 2. eff.send_interval == declared at Roomy (no change).
                 let status =
-                    assess_external_status(last_send_age, subvol.send_interval, source_unchanged);
+                    assess_external_status(last_send_age, eff.send_interval, source_unchanged);
 
                 if source_unchanged
                     && let Some(age) = last_send_age
                     && status == PromiseStatus::Protected
                     && age.num_seconds() as f64
-                        > subvol.send_interval.as_secs() as f64 * EXTERNAL_AT_RISK_MULTIPLIER
+                        > eff.send_interval.as_secs() as f64 * EXTERNAL_AT_RISK_MULTIPLIER
                 {
                     let secs = age.num_seconds();
                     let coarse = if secs >= 86400 {
@@ -644,6 +681,23 @@ pub fn assess(
             overall = PromiseStatus::Unprotected;
         }
 
+        // ── AT-RISK cap at Critical (UPI 031-b AB3, overturns R4) ────
+        // A Critical pool's lifecycle is the deliberately slowed clear-all
+        // cadence; the honest promise is "less protected than declared". Cap at
+        // AT RISK — `PromiseStatus` is worst-to-best so `.min(AtRisk)` is exactly
+        // "never Protected at Critical" (leaves AtRisk/Unprotected unchanged).
+        // `cadence_adapted` distinguishes this deliberate cap (pre-cap was
+        // Protected) from a genuine failure (pre-cap already AtRisk/Unprotected)
+        // — the signal voice reads to lead with adaptation prose vs a failure line.
+        let pre_cap = overall;
+        if armed == crate::storage_critical::TightnessTier::Critical {
+            overall = overall.min(PromiseStatus::AtRisk);
+        }
+        let cadence_adapted = pre_cap == PromiseStatus::Protected
+            && armed == crate::storage_critical::TightnessTier::Critical;
+        let effective_send_interval =
+            (armed != crate::storage_critical::TightnessTier::Roomy).then_some(eff.send_interval);
+
         // ── Operational health ─────────────────────────────────────
         // Pre-compute local space pressure (needs config access not available in compute_health)
         let local_space_tight = subvol
@@ -673,17 +727,13 @@ pub fn assess(
         );
 
         // ── Storage posture (UPI 031-a) ──────────────────────────────
-        // Pure: resolve the hysteresis-stabilized armed tier from the
-        // command-supplied signal, then derive the posture. No I/O, no
-        // write-back (the backup boundary advances state — read paths
-        // only reflect). Subvolumes with no signal get no posture.
-        let storage_posture = storage_signals.get(&subvol.name).and_then(|sig| {
-            let armed = crate::storage_critical::resolve_armed_tier(
-                sig.prior_armed_tier,
-                sig.free_ratio,
-            );
-            crate::storage_critical::derive_posture(armed, sig.host_root)
-        });
+        // Pure: derive the posture from the SAME armed tier resolved at the top
+        // of the loop (single source of truth) + the signal's host-root flag.
+        // No I/O, no write-back (the backup boundary advances state — read paths
+        // only reflect). Subvolumes with no signal get no posture (Roomy).
+        let storage_posture = storage_signals
+            .get(&subvol.name)
+            .and_then(|sig| crate::storage_critical::derive_posture(armed, sig.host_root));
 
         assessments.push(SubvolAssessment {
             name: subvol.name.clone(),
@@ -697,6 +747,8 @@ pub fn assess(
             redundancy_advisories: Vec::new(),
             errors,
             storage_posture,
+            cadence_adapted,
+            effective_send_interval,
         });
     }
 
@@ -1442,6 +1494,134 @@ source = "/data/sv1"
         );
         let posture = posture_of(&results, "sv1").expect("sv1 should have posture");
         assert_eq!(posture.tier, TightnessTier::Tight);
+    }
+
+    // ── UPI 031-b: effective interval + AT-RISK cap (AB3/AB3.1) ──────
+
+    /// A fully-Protected `sv1`: fresh local + a send `send_ago` before `now`,
+    /// plus a `free_ratio` signal. `test_config` declares `send_interval = 1d`.
+    fn capped_fixture(
+        send_at: NaiveDateTime,
+        free_ratio: f64,
+    ) -> (Config, NaiveDateTime, MockFileSystemState, StorageSignalMap) {
+        use crate::storage_critical::TightnessTier;
+        let config = test_config();
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        fs.send_times
+            .insert(("sv1".to_string(), "WD-18TB".to_string()), send_at);
+        fs.mounted_drives.insert("WD-18TB".to_string());
+        let mut signals = StorageSignalMap::new();
+        signals.insert(
+            "sv1".to_string(),
+            ResolvedStorageSignal {
+                free_ratio: Some(free_ratio),
+                host_root: false,
+                prior_armed_tier: TightnessTier::Roomy,
+                prior_since: None,
+            },
+        );
+        (config, now, fs, signals)
+    }
+
+    #[test]
+    fn critical_caps_protected_to_at_risk_with_adapted_flag() {
+        // Critical, last send 3 days ago, declared DAILY. Judged against the
+        // EFFECTIVE weekly interval, 3d is fresh → pre-cap Protected. The
+        // Critical cap drops it to AT RISK with cadence_adapted=true. (Against
+        // the declared 1d, pre-cap would be AtRisk and cadence_adapted false —
+        // so this also proves the effective interval is what's judged.)
+        let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 20, 14, 0), 0.05);
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let sv1 = results.iter().find(|a| a.name == "sv1").unwrap();
+        assert_eq!(sv1.status, PromiseStatus::AtRisk, "Critical caps Protected → AT RISK");
+        assert!(sv1.cadence_adapted, "deliberate cadence, not a failure");
+        assert_eq!(sv1.effective_send_interval, Some(Interval::days(7)));
+    }
+
+    #[test]
+    fn critical_genuinely_stale_is_at_risk_not_adapted() {
+        // Last send 14 days ago — beyond even the weekly effective AT-RISK
+        // threshold (7d × 1.5). Genuine staleness: AT RISK, but cadence_adapted
+        // is FALSE so voice leads with the failure, not adaptation prose.
+        let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 9, 14, 0), 0.05);
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let sv1 = results.iter().find(|a| a.name == "sv1").unwrap();
+        assert_eq!(sv1.status, PromiseStatus::AtRisk);
+        assert!(!sv1.cadence_adapted, "genuine staleness is not a deliberate cadence");
+    }
+
+    #[test]
+    fn tight_is_lengthened_but_not_capped() {
+        // Tight lengthens the cadence (declared 1d → 36h) but never caps the
+        // promise — Tight is honest, not deliberately degraded.
+        let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 23, 8, 0), 0.20);
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let sv1 = results.iter().find(|a| a.name == "sv1").unwrap();
+        assert_eq!(sv1.status, PromiseStatus::Protected, "Tight does not cap");
+        assert!(!sv1.cadence_adapted);
+        assert_eq!(sv1.effective_send_interval, Some(Interval::hours(36)));
+    }
+
+    #[test]
+    fn roomy_subvol_has_no_cap_and_no_effective_interval() {
+        let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 23, 8, 0), 0.50);
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let sv1 = results.iter().find(|a| a.name == "sv1").unwrap();
+        assert_eq!(sv1.status, PromiseStatus::Protected);
+        assert!(!sv1.cadence_adapted);
+        assert_eq!(sv1.effective_send_interval, None, "Roomy uses the declared interval");
+    }
+
+    #[test]
+    fn coherence_awareness_and_planner_share_effective_interval() {
+        // S2 coherence: the interval awareness judges staleness against MUST
+        // equal the one the planner times against, for the same armed tier —
+        // both route through `derive_effective_policy`. A future re-gather that
+        // desynced the tier would break this (false AT RISK).
+        let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 22, 14, 0), 0.05);
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let sv1 = results.iter().find(|a| a.name == "sv1").unwrap();
+        let resolved = config.resolved_subvolumes();
+        let sv = resolved.iter().find(|s| s.name == "sv1").unwrap();
+        let planner_eff = crate::storage_critical::derive_effective_policy(
+            &sv.local_retention,
+            sv.send_interval,
+            sv.send_enabled,
+            crate::storage_critical::TightnessTier::Critical,
+        );
+        assert_eq!(
+            sv1.effective_send_interval,
+            Some(planner_eff.send_interval),
+            "awareness and planner judge the SAME effective interval"
+        );
     }
 
     // ── Test 2: Local stale → AT_RISK ──────────────────────────────
@@ -4300,6 +4480,8 @@ source = "/data/sv1"
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }
     }
 

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -147,6 +147,24 @@ pub fn write_pin_file(
     Ok(())
 }
 
+/// Remove a drive's pin file, if present. Idempotent — a missing pin file is
+/// success (`NotFound` → `Ok`). Used by the executor's clear-all cleanup
+/// (UPI 031-b): the pin is dropped *before* the fail-closed re-read so the
+/// just-sent snapshot (and any surviving Tight-era parent) can then be deleted,
+/// leaving zero local snapshots between runs. Owns the same
+/// `.last-external-parent-{label}` filename format as `write_pin_file`.
+pub fn remove_pin_file(
+    local_snapshot_dir: &Path,
+    drive_label: &str,
+) -> crate::error::Result<()> {
+    let path = local_snapshot_dir.join(format!(".last-external-parent-{drive_label}"));
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(UrdError::Io { path, source: e }),
+    }
+}
+
 fn try_read_pin(path: &Path) -> crate::error::Result<Option<SnapshotName>> {
     match std::fs::read_to_string(path) {
         Ok(content) => {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -77,7 +77,23 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         history: &fs_state,
         btrfs: &plan_btrfs,
     };
-    let mut backup_plan = plan::plan(&config, now, &filters, &observation)?;
+
+    // ── Single pre-plan storage gather (UPI 031-b AB1/S2 — INVARIANT) ──
+    // ONE gather of storage signals, resolved ONCE here pre-plan, feeds the
+    // planner (and the emergency re-plan), the executor's clear-all gate, the
+    // post-exec awareness assess, and the armed-tier writeback. Do NOT add a
+    // second gather for the post-exec assess: clear-all frees space mid-run, so
+    // a re-gather would see a higher free-ratio and falsely de-escalate
+    // Critical→Tight — desyncing the effective send interval the planner timed
+    // against from the one awareness judges staleness against, surfacing a
+    // correctly-adapting subvolume as false AT RISK. The coherence guard is
+    // THIS single gather (Risk 4 / S2), enforced by the awareness coherence
+    // test, not by `derive_effective_policy` alone.
+    let signals = storage_signals::gather(&config, state_db.as_ref());
+    let resolved = storage_signals::resolve_armed_tiers(&signals);
+
+    let mut backup_plan =
+        plan::plan(&config, now, &filters, &observation, &resolved.armed_tier_map)?;
 
     // ADR-107: fail-closed for retention on promise-level subvolumes.
     // If a subvolume has a protection_level, skip retention deletions unless
@@ -113,9 +129,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // Runs under the lock because it performs destructive btrfs deletions.
     let emergency_ran = run_emergency_preflight(&config, state_db.as_ref())?;
 
-    // Re-plan if emergency freed space — plan may have different space_pressure decisions
+    // Re-plan if emergency freed space — plan may have different space_pressure
+    // decisions. Reuses the SAME pre-plan `resolved` armed tiers (AB1: never
+    // re-resolve mid-run, even though emergency just freed space).
     if emergency_ran {
-        backup_plan = plan::plan(&config, now, &filters, &observation)?;
+        backup_plan =
+            plan::plan(&config, now, &filters, &observation, &resolved.armed_tier_map)?;
         if !args.confirm_retention_change {
             filter_promise_retention(&config, &mut backup_plan);
         }
@@ -207,6 +226,11 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let btrfs = RealBtrfs::new(&config.general.btrfs_path, bytes_counter.clone(), sys.supports_compressed_data);
 
     let mut executor = Executor::new(&btrfs, state_db.as_ref(), &config, &shutdown);
+
+    // Thread the pre-plan armed tiers (031-b) so the executor's clear-all gate
+    // derives the SAME effective lifecycle the planner used (the single-gather
+    // invariant). Critical subvolumes clear the just-sent snapshot + pin.
+    executor.set_armed_tiers(resolved.armed_tier_map.clone());
 
     // In autonomous mode (systemd), gate chain-break full sends unless --force-full.
     if !args.force_full && std::env::var("INVOCATION_ID").is_ok() {
@@ -359,10 +383,11 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     )?;
 
     // Write heartbeat (fresh timestamp — `now` is from before execution).
-    // Gather storage signals once: the post-execution assess reflects the
-    // current tier, then `advance_and_writeback` persists it and surfaces
-    // escalation transitions for the notification path (D6).
-    let signals = storage_signals::gather(&config, state_db.as_ref());
+    // Reuse the SINGLE pre-plan `signals`/`resolved` (the AB1/S2 invariant
+    // above) — do NOT re-gather. The post-execution assess reflects the
+    // pre-plan tier (so the effective send interval matches what the planner
+    // used), then `advance_and_writeback` persists the pre-resolved tier and
+    // surfaces escalation transitions for the notification path (D6).
     let mut assessments =
         awareness::assess(&config, heartbeat_now, &observation, &signals.by_subvol);
     advice::overlay_offsite_freshness(&mut assessments, &config);
@@ -387,7 +412,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // from the heartbeat-driven promise notifications below and runs regardless
     // of whether the sentinel is up. Best-effort throughout: never blocks a run.
     if let Some(ref db) = state_db {
-        let escalations = storage_signals::advance_and_writeback(db, heartbeat_now, &signals);
+        let escalations = storage_signals::advance_and_writeback(db, heartbeat_now, &resolved);
         let notes: Vec<notify::Notification> = escalations
             .iter()
             .map(|e| {
@@ -1883,6 +1908,8 @@ mod tests {
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }]
     }
 
@@ -2865,6 +2892,8 @@ mod tests {
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }
     }
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -546,8 +546,7 @@ fn build_doctor_recommendation_view_inner(
 
         let local = match (local_rec, severity_local, local_current_shape) {
             (Some(r), _, _) => Some(r),
-            (None, HeadroomSeverity::Pressure, Some(cur))
-            | (None, HeadroomSeverity::Critical, Some(cur)) => {
+            (None, HeadroomSeverity::Pressure, Some(cur)) => {
                 let reason = recommendation::pick_reason(ctx_local, severity_local, None)
                     .unwrap_or(AdjustmentReason::SourcePoolLow {
                         free_ratio: source_free_ratio,
@@ -563,8 +562,7 @@ fn build_doctor_recommendation_view_inner(
         };
         let external = match (external_rec, severity_external, external_current_shape) {
             (Some(r), _, _) => Some(r),
-            (None, HeadroomSeverity::Pressure, Some(cur))
-            | (None, HeadroomSeverity::Critical, Some(cur)) => {
+            (None, HeadroomSeverity::Pressure, Some(cur)) => {
                 let reason = recommendation::pick_reason(
                     ctx_external,
                     severity_external,

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -1,4 +1,5 @@
 use crate::cli::PlanArgs;
+use crate::commands::storage_signals;
 use crate::config::Config;
 use crate::drives;
 use crate::output::{
@@ -33,7 +34,15 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
         history: &fs_state,
         btrfs: &plan_btrfs,
     };
-    let backup_plan = plan::plan(&config, now, &filters, &observation)?;
+    // Storage-adapted preview (031-b M5): gather the same read-only signals the
+    // backup path uses and resolve the armed tier, so `urd plan` shows the
+    // truth of what `urd backup` will do (transient route / no pin at Critical)
+    // rather than declared policy. Degrades gracefully — an unmounted/unmeasurable
+    // pool yields free_ratio None → Roomy → declared behavior.
+    let signals = storage_signals::gather(&config, state_db.as_ref());
+    let resolved = storage_signals::resolve_armed_tiers(&signals);
+    let backup_plan =
+        plan::plan(&config, now, &filters, &observation, &resolved.armed_tier_map)?;
 
     let mut output = build_plan_output(&backup_plan, &fs_state, &config);
     populate_token_warnings(&mut output, state_db.as_ref(), &config);

--- a/src/commands/storage_signals.rs
+++ b/src/commands/storage_signals.rs
@@ -24,7 +24,7 @@ use crate::config::Config;
 use crate::output::PoolPostureSummary;
 use crate::pools::{self, PoolSpace};
 use crate::state::StateDb;
-use crate::storage_critical::{self, TightnessTier, Transition};
+use crate::storage_critical::{self, ArmedTierMap, TightnessTier, Transition};
 
 /// Per-pool resolved signal (UPI 031-a). The command-layer view that backs
 /// both `aggregate()` (display) and `advance_and_writeback()` (persistence).
@@ -182,27 +182,86 @@ fn gather_with(
     StorageSignals { by_subvol, pools }
 }
 
-/// Re-run the hysteresis per UUID-resolvable pool, persist `(armed_tier,
-/// since)` best-effort, and return the **escalation** transitions (backup
-/// path only — read paths must never call this). `since` advances to `now`
-/// only when the tier changes; otherwise the prior `since` is preserved so
-/// the "flagged since" timestamp stays stable. UUID-less pools are skipped
+/// A pool's armed tier resolved once, pre-plan (UPI 031-b AB1). Carries
+/// everything `advance_and_writeback` needs to persist the transition without
+/// re-resolving from a (possibly clear-all-freed) post-exec free-ratio.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedPoolTier {
+    /// Pool UUID when resolvable; `None` for a pool keyed only by mount/name —
+    /// surfaced status-only, never persisted (S5).
+    pub uuid: Option<String>,
+    pub label: String,
+    pub host_root: bool,
+    pub prior_armed_tier: TightnessTier,
+    pub prior_since: Option<NaiveDateTime>,
+    /// The tier resolved from `(prior_armed_tier, free_ratio)` at gather time.
+    pub new_tier: TightnessTier,
+}
+
+/// The armed tier resolved once for the backup run (UPI 031-b AB1). Carries the
+/// planner/executor/awareness-facing `armed_tier_map` (subvol → tier) AND the
+/// per-pool rows the post-exec writeback persists — one resolution, two
+/// consumers, so "resolve once" stays literal.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedArmedTiers {
+    pub armed_tier_map: ArmedTierMap,
+    pub pools: Vec<ResolvedPoolTier>,
+}
+
+/// Resolve each pool's armed tier from the gathered signals exactly once,
+/// pre-plan (UPI 031-b AB1). Fans the per-pool tier out to every subvolume on
+/// the pool to build the `armed_tier_map`, and carries the per-pool rows the
+/// writeback needs. The SAME values are persisted post-exec — never
+/// re-resolved: clear-all frees space mid-run, and a re-resolve would see the
+/// higher free-ratio and falsely de-escalate Critical→Tight, defeating the
+/// hysteresis that stops lifecycle flapping.
+#[must_use]
+pub fn resolve_armed_tiers(signals: &StorageSignals) -> ResolvedArmedTiers {
+    let mut armed_tier_map = ArmedTierMap::new();
+    let mut pools = Vec::with_capacity(signals.pools.len());
+    for pool in &signals.pools {
+        let new_tier = storage_critical::resolve_armed_tier(
+            pool.prior_armed_tier,
+            pool.free_ratio,
+        );
+        for name in &pool.subvol_names {
+            armed_tier_map.insert(name.clone(), new_tier);
+        }
+        pools.push(ResolvedPoolTier {
+            uuid: pool.uuid.clone(),
+            label: pool.label.clone(),
+            host_root: pool.host_root,
+            prior_armed_tier: pool.prior_armed_tier,
+            prior_since: pool.prior_since,
+            new_tier,
+        });
+    }
+    ResolvedArmedTiers {
+        armed_tier_map,
+        pools,
+    }
+}
+
+/// Persist the pre-resolved armed tier per UUID-resolvable pool best-effort and
+/// return the **escalation** transitions (backup path only — read paths must
+/// never call this). Consumes the `ResolvedArmedTiers` from
+/// [`resolve_armed_tiers`]: it does **not** re-resolve (AB1 — clear-all frees
+/// space mid-run; a re-resolve would falsely de-escalate). `since` advances to
+/// `now` only when the tier changes; otherwise the prior `since` is preserved
+/// so the "flagged since" timestamp stays stable. UUID-less pools are skipped
 /// (S5) — no persist, no notification, status-only degrade.
 #[must_use]
 pub fn advance_and_writeback(
     state_db: &StateDb,
     now: NaiveDateTime,
-    signals: &StorageSignals,
+    resolved: &ResolvedArmedTiers,
 ) -> Vec<PostureEscalation> {
     let mut escalations = Vec::new();
-    for pool in &signals.pools {
+    for pool in &resolved.pools {
         let Some(uuid) = pool.uuid.as_deref() else {
             continue; // UUID-less: status-only (S5)
         };
-        let new = storage_critical::resolve_armed_tier(
-            pool.prior_armed_tier,
-            pool.free_ratio,
-        );
+        let new = pool.new_tier; // pre-resolved (AB1: never re-resolve)
         let since = if new == pool.prior_armed_tier {
             pool.prior_since.unwrap_or(now)
         } else {
@@ -413,7 +472,7 @@ source = "/"
         let signals =
             gather_with(&cfg(), &HashMap::new(), Some("root-uuid"), resolver, space_tight);
 
-        let transitions = advance_and_writeback(&db, now, &signals);
+        let transitions = advance_and_writeback(&db, now, &resolve_armed_tiers(&signals));
         // Both pools start Roomy; data escalates to Tight, root stays Roomy.
         assert_eq!(transitions.len(), 1);
         assert_eq!(transitions[0].pool_label, "/data");
@@ -421,7 +480,7 @@ source = "/"
         assert!(!transitions[0].host_root);
 
         // Persisted.
-        let stored = db.armed_tier_for_pool("data-uuid").unwrap();
+        let stored = db.all_armed_tiers().unwrap().get("data-uuid").copied();
         assert_eq!(stored.map(|(t, _)| t), Some(TightnessTier::Tight));
         // `since` was set to `now` (tier changed).
         assert_eq!(stored.map(|(_, s)| s), Some(now));
@@ -438,9 +497,9 @@ source = "/"
             gather_with(&cfg(), &prior, Some("root-uuid"), resolver, space_tight);
         let now = dt("2026-05-30T04:00:00");
 
-        let transitions = advance_and_writeback(&db, now, &signals);
+        let transitions = advance_and_writeback(&db, now, &resolve_armed_tiers(&signals));
         assert!(transitions.is_empty()); // no escalation on steady state
-        let stored = db.armed_tier_for_pool("data-uuid").unwrap();
+        let stored = db.all_armed_tiers().unwrap().get("data-uuid").copied();
         assert_eq!(stored, Some((TightnessTier::Tight, prior_since)));
     }
 
@@ -457,11 +516,11 @@ source = "/"
             gather_with(&cfg(), &prior, Some("root-uuid"), resolver, space_full);
         let now = dt("2026-05-30T04:00:00");
 
-        let escalations = advance_and_writeback(&db, now, &signals);
+        let escalations = advance_and_writeback(&db, now, &resolve_armed_tiers(&signals));
         // De-escalation is silent — no notification.
         assert!(escalations.is_empty());
         // But the recovery IS persisted, with `since` advanced to now.
-        let stored = db.armed_tier_for_pool("data-uuid").unwrap();
+        let stored = db.all_armed_tiers().unwrap().get("data-uuid").copied();
         assert_eq!(stored, Some((TightnessTier::Roomy, now)));
     }
 
@@ -477,7 +536,8 @@ source = "/"
             resolver_no_uuid,
             space_tight,
         );
-        let transitions = advance_and_writeback(&db, dt("2026-05-30T04:00:00"), &signals);
+        let transitions =
+            advance_and_writeback(&db, dt("2026-05-30T04:00:00"), &resolve_armed_tiers(&signals));
         assert!(transitions.is_empty());
         // Nothing written.
         assert!(db.all_armed_tiers().unwrap().is_empty());
@@ -519,6 +579,56 @@ source = "/"
         assert_eq!(s.since_secs, Some(86_400)); // one day
     }
 
+    // ── resolve_armed_tiers (UPI 031-b AB1) ──────────────────────────────
+
+    #[test]
+    fn resolve_armed_tiers_fans_pool_tier_to_subvols() {
+        // /data is Tight (20% free) → both subvols on it get Tight; root (50%
+        // free) gets Roomy. One resolution per pool, fanned to subvolumes.
+        let signals =
+            gather_with(&cfg(), &HashMap::new(), Some("root-uuid"), resolver, space_tight);
+        let resolved = resolve_armed_tiers(&signals);
+        assert_eq!(resolved.armed_tier_map.get("alpha"), Some(&TightnessTier::Tight));
+        assert_eq!(resolved.armed_tier_map.get("beta"), Some(&TightnessTier::Tight));
+        assert_eq!(resolved.armed_tier_map.get("root"), Some(&TightnessTier::Roomy));
+    }
+
+    #[test]
+    fn persisted_tier_is_pre_resolved_never_re_resolved() {
+        // AB1 de-escalation-defeat guard. Resolve the tier ONCE pre-plan from a
+        // Critical free-ratio, then persist. advance_and_writeback consumes the
+        // pre-resolved tier and must NOT re-resolve — a re-resolve from the
+        // higher free-ratio clear-all produces mid-run would falsely
+        // de-escalate Critical→Tight. Critical must persist as Critical.
+        let db = StateDb::open_memory().unwrap();
+        let now = dt("2026-05-30T04:00:00");
+        let space_critical = |mp: &Path| {
+            if mp == Path::new("/data") {
+                Some(PoolSpace { free_bytes: 5, capacity_bytes: 100 }) // 5% → Critical
+            } else {
+                Some(PoolSpace { free_bytes: 50, capacity_bytes: 100 })
+            }
+        };
+        let signals = gather_with(
+            &cfg(),
+            &HashMap::new(),
+            Some("root-uuid"),
+            resolver,
+            space_critical,
+        );
+        let resolved = resolve_armed_tiers(&signals);
+        let data = resolved
+            .pools
+            .iter()
+            .find(|p| p.uuid.as_deref() == Some("data-uuid"))
+            .unwrap();
+        assert_eq!(data.new_tier, TightnessTier::Critical);
+
+        let _ = advance_and_writeback(&db, now, &resolved);
+        let stored = db.all_armed_tiers().unwrap().get("data-uuid").copied();
+        assert_eq!(stored.map(|(t, _)| t), Some(TightnessTier::Critical));
+    }
+
     fn mk_assess(name: &str, posture: Option<StoragePosture>) -> SubvolAssessment {
         use crate::awareness::{LocalAssessment, OperationalHealth, PromiseStatus};
         use crate::types::Interval;
@@ -539,6 +649,8 @@ source = "/"
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: posture,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }
     }
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -13,6 +13,7 @@ use crate::config::Config;
 use crate::drives;
 use crate::error::BtrfsOperation;
 use crate::state::{DriftSampleRow, OperationRecord, StateDb};
+use crate::storage_critical::{self, ArmedTierMap};
 use crate::types::{BackupPlan, DeleteKind, FullSendReason, PlannedOperation, SendKind};
 
 // ── Types ───────────────────────────────────────────────────────────────
@@ -116,16 +117,24 @@ pub enum TransientCleanupOutcome {
     SkippedPartialSends,
     /// Cleanup skipped: pin write failure made chain state ambiguous.
     SkippedPinFailure,
+    /// Clear-all skipped (UPI 031-b m2): removing the pin file failed, so the
+    /// run refused to delete anything — never leave a half-cleared state
+    /// (snapshot gone, pin lingering). Fail-open: next run retries the whole
+    /// clear-all. No data loss — the data is on the drive.
+    SkippedPinRemovalFailure,
     /// Attempted but delete failed (non-fatal, next run handles it).
     DeleteFailed { path: String, error: String },
 }
 
 /// Context about a subvolume passed to the per-subvolume executor.
-/// Constructed from config lookup in `execute()`.
+/// Constructed from config lookup + the armed tier in `execute()`.
 #[derive(Debug)]
 struct SubvolumeContext {
     name: String,
     is_transient: bool,
+    /// Critical tier (UPI 031-b): after the gated cleanup, also delete the
+    /// just-sent snapshot(s) and remove the pin, leaving zero local snapshots.
+    clear_all: bool,
 }
 
 #[derive(Debug)]
@@ -146,6 +155,11 @@ pub struct Executor<'a> {
     progress_context: Option<Arc<Mutex<ProgressContext>>>,
     size_estimates: Option<SizeEstimates>,
     full_send_policy: FullSendPolicy,
+    /// Per-subvolume armed tier (UPI 031-b). Default empty → every subvolume
+    /// resolves to its declared policy (Roomy), so existing `.execute()` test
+    /// sites need no change (mirrors `full_send_policy`). The backup path sets
+    /// the real map via `set_armed_tiers` before `execute`.
+    armed_tiers: ArmedTierMap,
 }
 
 impl<'a> Executor<'a> {
@@ -164,12 +178,20 @@ impl<'a> Executor<'a> {
             progress_context: None,
             size_estimates: None,
             full_send_policy: FullSendPolicy::Allow,
+            armed_tiers: ArmedTierMap::new(),
         }
     }
 
     /// Set the full-send policy for chain-break gating.
     pub fn set_full_send_policy(&mut self, policy: FullSendPolicy) {
         self.full_send_policy = policy;
+    }
+
+    /// Set the per-subvolume armed tier map (UPI 031-b). The executor derives
+    /// each subvolume's effective lifecycle (`is_transient`) and clear-all
+    /// signal from this + the declared config. Default empty → declared policy.
+    pub fn set_armed_tiers(&mut self, armed_tiers: ArmedTierMap) {
+        self.armed_tiers = armed_tiers;
     }
 
     /// Set progress context for rich progress display.
@@ -216,6 +238,14 @@ impl<'a> Executor<'a> {
         // Per-drive space recovery tracking (shared across subvolumes)
         let mut space_recovered: HashMap<String, bool> = HashMap::new();
 
+        // Resolve effective policies once (UPI 031-b). With the default empty
+        // armed-tier map every subvolume resolves to Roomy → its declared
+        // policy, so `is_transient` is byte-identical to the previous raw-config
+        // check (proven by the equivalence test, incl. the named-level +
+        // explicit-transient case). A Tight/Critical send-enabled subvolume
+        // resolves to Transient; Critical additionally sets `clear_all`.
+        let resolved_subvols = self.config.resolved_subvolumes();
+
         let mut subvolume_results = Vec::new();
 
         for (subvol_name, ops) in &groups {
@@ -223,23 +253,28 @@ impl<'a> Executor<'a> {
                 log::warn!("Shutdown signal received, skipping remaining subvolumes");
                 break;
             }
-            // Raw field check: named protection levels never derive transient
-            // retention (derive_policy returns Graduated for all named levels).
-            // If this changes, switch to sv.resolved(...).local_retention.is_transient().
-            let is_transient = self
-                .config
-                .subvolumes
+            let armed = self
+                .armed_tiers
+                .get(subvol_name)
+                .copied()
+                .unwrap_or_default();
+            let (is_transient, clear_all) = resolved_subvols
                 .iter()
-                .find(|sv| sv.name == *subvol_name)
-                .is_some_and(|sv| {
-                    matches!(
-                        sv.local_retention,
-                        Some(crate::types::LocalRetentionConfig::Transient)
-                    )
-                });
+                .find(|sv| &sv.name == subvol_name)
+                .map(|sv| {
+                    let eff = storage_critical::derive_effective_policy(
+                        &sv.local_retention,
+                        sv.send_interval,
+                        sv.send_enabled,
+                        armed,
+                    );
+                    (eff.local_retention.is_transient(), eff.clear_all)
+                })
+                .unwrap_or((false, false));
             let context = SubvolumeContext {
                 name: subvol_name.clone(),
                 is_transient,
+                clear_all,
             };
             let result = self.execute_subvolume(
                 &context,
@@ -304,6 +339,10 @@ impl<'a> Executor<'a> {
 
         // Transient cleanup tracking: old pin parents from incremental sends
         let mut old_pin_parents: HashMap<String, std::path::PathBuf> = HashMap::new();
+        // Clear-all tracking (UPI 031-b): the just-sent snapshot per drive,
+        // deleted after the all-sends-succeeded gate for Critical subvolumes so
+        // zero local snapshots survive between runs.
+        let mut sent_snapshots: HashMap<String, std::path::PathBuf> = HashMap::new();
         let mut sends_succeeded: HashSet<String> = HashSet::new();
         let mut planned_send_drives: HashSet<String> = HashSet::new();
 
@@ -381,6 +420,8 @@ impl<'a> Executor<'a> {
                         sends_succeeded.insert(drive_label.clone());
                         // Track old pin parent for transient cleanup
                         old_pin_parents.insert(drive_label.clone(), parent.clone());
+                        // Track the just-sent snapshot for clear-all (031-b).
+                        sent_snapshots.insert(drive_label.clone(), snapshot.clone());
                     }
                     if pin_failed {
                         pin_failures += 1;
@@ -443,6 +484,8 @@ impl<'a> Executor<'a> {
                         if result.result == OpResult::Success {
                             send_type = SendType::Full;
                             sends_succeeded.insert(drive_label.clone());
+                            // Track the just-sent snapshot for clear-all (031-b).
+                            sent_snapshots.insert(drive_label.clone(), snapshot.clone());
                         }
                         if pin_failed {
                             pin_failures += 1;
@@ -473,6 +516,7 @@ impl<'a> Executor<'a> {
         let transient_cleanup = self.attempt_transient_cleanup(
             context,
             &old_pin_parents,
+            &sent_snapshots,
             &sends_succeeded,
             &planned_send_drives,
             pin_failures,
@@ -1021,13 +1065,25 @@ impl<'a> Executor<'a> {
         self.drive_for_path(path).map(|d| d.label.clone())
     }
 
-    /// Attempt transient immediate cleanup: delete old pin parents after all
-    /// sends succeed for a transient subvolume.
+    /// Attempt transient immediate cleanup after all sends succeed for a
+    /// transient subvolume.
     ///
-    /// This is a timing optimization for an operation the planner would produce
-    /// on the next run. The executor does not make retention decisions — it
-    /// accelerates a deletion the planner has already endorsed by construction
-    /// (transient mode deletes all non-pinned snapshots).
+    /// **Retain-one (Tight / all transient):** delete the *old* pin parent the
+    /// send advanced past — a timing optimization for a deletion the planner
+    /// would produce next run anyway (transient mode deletes all non-pinned
+    /// snapshots). One local snapshot (the new pin) survives.
+    ///
+    /// **Clear-all (Critical, UPI 031-b):** additionally remove the pin file and
+    /// delete the *just-sent* snapshot, leaving **zero** local snapshots between
+    /// runs. This is the footprint-cap the htpc pool needs — but it is also a
+    /// new deletion path on the data-loss axis, so it routes through the SAME
+    /// gate (all-sends-succeeded + no-pin-failure + fail-closed re-read), never
+    /// the planner's unconditional `DeleteSnapshot`. A 3am send failure → gate
+    /// fails → nothing is deleted (ADR-107). Order is load-bearing:
+    /// **remove pin → re-read → delete** (a surviving pin would make the
+    /// fail-closed re-read refuse to delete the old parent). If pin removal
+    /// fails, the whole clear-all is skipped this run (m2) — never a half-cleared
+    /// state.
     ///
     /// Safety: relies on the advisory lock preventing concurrent backup runs.
     /// The TOCTOU window between pin re-read and delete is not independently
@@ -1037,6 +1093,7 @@ impl<'a> Executor<'a> {
         &self,
         context: &SubvolumeContext,
         old_pin_parents: &HashMap<String, std::path::PathBuf>,
+        sent_snapshots: &HashMap<String, std::path::PathBuf>,
         sends_succeeded: &HashSet<String>,
         planned_send_drives: &HashSet<String>,
         pin_failures: u32,
@@ -1046,12 +1103,18 @@ impl<'a> Executor<'a> {
             return TransientCleanupOutcome::NotApplicable;
         }
 
-        // No incremental sends means no old parents to clean up
-        if old_pin_parents.is_empty() {
+        // Is there any cleanup work? Retain-one: an old pin parent to delete.
+        // Clear-all (Critical): additionally the just-sent snapshot(s) + pin —
+        // even in the steady-state full-send case where there is NO old parent.
+        let clear_all = context.clear_all;
+        let has_old_parents = !old_pin_parents.is_empty();
+        let has_sent_to_clear = clear_all && !sent_snapshots.is_empty();
+        if !has_old_parents && !has_sent_to_clear {
             return TransientCleanupOutcome::NotApplicable;
         }
 
-        // Condition 3: no pin write failures
+        // ── The ADR-107 firewall: gate runs BEFORE any deletion ────────
+        // Condition 3: no pin write failures (chain state ambiguous).
         if pin_failures > 0 {
             log::info!(
                 "Transient cleanup skipped for {}: pin write failure makes chain state ambiguous",
@@ -1059,8 +1122,7 @@ impl<'a> Executor<'a> {
             );
             return TransientCleanupOutcome::SkippedPinFailure;
         }
-
-        // Condition 2: all configured drives with planned sends succeeded
+        // Condition 2: all configured drives with planned sends succeeded.
         if sends_succeeded != planned_send_drives {
             log::info!(
                 "Transient cleanup skipped for {}: not all drives succeeded",
@@ -1069,34 +1131,57 @@ impl<'a> Executor<'a> {
             return TransientCleanupOutcome::SkippedPartialSends;
         }
 
-        // Collect unique old parent paths (multiple drives may share the same parent)
-        let unique_parents: HashSet<&std::path::PathBuf> =
-            old_pin_parents.values().collect();
+        let local_dir = self.config.local_snapshot_dir(&context.name);
 
-        // Condition 4 (early): if no old parent still exists, skip pin I/O
-        let existing_parents: Vec<&&std::path::PathBuf> = unique_parents
-            .iter()
-            .filter(|p| p.exists())
-            .collect();
-        if existing_parents.is_empty() {
-            return TransientCleanupOutcome::NotApplicable;
+        // ── Clear-all: drop the pin file(s) FIRST (031-b) ──────────────
+        // The planner wrote no pin for a clear-all subvol; the only pin on disk
+        // is a surviving Tight-era one (first-Critical-run). Removing it before
+        // the fail-closed re-read is what lets the old parent be deleted. m2: if
+        // removal fails, refuse ALL clear-all deletions this run — never leave a
+        // half-cleared state (snapshot gone, pin lingering). Fail-open; next run
+        // retries. `remove_pin_file` is idempotent (absent pin → Ok).
+        if clear_all && let Some(ref dir) = local_dir {
+            for drive_label in sends_succeeded {
+                if let Err(e) = chain::remove_pin_file(dir, drive_label) {
+                    log::warn!(
+                        "Transient clear-all for {}: pin removal failed for {drive_label}: {e} \
+                         — refusing all clear-all deletions this run (next run retries)",
+                        context.name,
+                    );
+                    return TransientCleanupOutcome::SkippedPinRemovalFailure;
+                }
+            }
         }
 
-        // Condition 5: re-read pin files to verify old parents are no longer pinned
+        // Condition 5: re-read pin files AFTER any clear-all removal, so the
+        // fail-closed check below reflects the post-removal pin state.
         let drive_labels = self.config.drive_labels();
-        let local_dir = self.config.local_snapshot_dir(&context.name);
         let current_pinned = local_dir
             .as_ref()
             .map(|dir| chain::find_pinned_snapshots(dir, &drive_labels))
             .unwrap_or_default();
 
+        // Build the deletion set: old pin parents (retain-one + Critical entry),
+        // plus — for clear-all — the just-sent snapshot(s), leaving zero locals.
+        // Unique (drives may share a parent) and existing-on-disk only.
+        let mut targets: HashSet<std::path::PathBuf> =
+            old_pin_parents.values().cloned().collect();
+        if clear_all {
+            targets.extend(sent_snapshots.values().cloned());
+        }
+        let existing: Vec<std::path::PathBuf> =
+            targets.into_iter().filter(|p| p.exists()).collect();
+        if existing.is_empty() {
+            return TransientCleanupOutcome::NotApplicable;
+        }
+
         let mut deleted_count = 0;
         let mut first_failure: Option<(String, String)> = None;
 
-        for parent_path in existing_parents {
-            // Condition 5: fail-closed — only delete if we can verify it's NOT pinned.
-            // Unparseable names default to "don't delete" (ADR-107: fail-closed for deletions).
-            let is_safe_to_delete = parent_path
+        for path in &existing {
+            // Condition 5: fail-closed — only delete if we can verify it's NOT
+            // pinned. Unparseable names default to "don't delete" (ADR-107).
+            let is_safe_to_delete = path
                 .file_name()
                 .and_then(|name| {
                     crate::types::SnapshotName::parse(&name.to_string_lossy()).ok()
@@ -1107,29 +1192,22 @@ impl<'a> Executor<'a> {
             if !is_safe_to_delete {
                 log::warn!(
                     "Transient cleanup: refusing to delete {} (still pinned or unparseable)",
-                    parent_path.display(),
+                    path.display(),
                 );
                 continue;
             }
 
-            // Delete the old parent. Continue through all parents on failure
-            // (consistent with executor error isolation — ADR-100 invariant 4).
-            match self.btrfs.delete_subvolume(parent_path) {
+            // Delete. Continue through all targets on failure (executor error
+            // isolation — ADR-100 invariant 4).
+            match self.btrfs.delete_subvolume(path) {
                 Ok(()) => {
-                    log::info!(
-                        "Transient cleanup: deleted old pin parent {}",
-                        parent_path.display(),
-                    );
+                    log::info!("Transient cleanup: deleted {}", path.display());
                     deleted_count += 1;
                 }
                 Err(e) => {
-                    log::warn!(
-                        "Transient cleanup: failed to delete {}: {e}",
-                        parent_path.display(),
-                    );
+                    log::warn!("Transient cleanup: failed to delete {}: {e}", path.display());
                     if first_failure.is_none() {
-                        first_failure =
-                            Some((parent_path.display().to_string(), e.to_string()));
+                        first_failure = Some((path.display().to_string(), e.to_string()));
                     }
                 }
             }
@@ -3718,5 +3796,424 @@ local_retention = "transient"
             )
             .unwrap();
         assert_eq!(bytes, 2_000_000);
+    }
+
+    // ── UPI 031-b: Critical clear-all gate (the data-loss firewall) ─────
+
+    fn armed_map(tier: storage_critical::TightnessTier) -> ArmedTierMap {
+        let mut m = ArmedTierMap::new();
+        m.insert("sv-t".to_string(), tier);
+        m
+    }
+
+    fn delete_calls(mock: &MockBtrfs) -> Vec<PathBuf> {
+        mock.calls()
+            .iter()
+            .filter_map(|c| match c {
+                MockBtrfsCall::DeleteSubvolume { path } => Some(path.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn clear_all_send_failure_deletes_nothing_3am_gate() {
+        // THE data-loss firewall (write-first). Critical clear-all + a SendFull
+        // that FAILS at 3am → the just-created snapshot is never tracked as sent,
+        // so the executor deletes nothing. The snapshot survives for next run's
+        // retry. To reach data loss you'd have to break this AND the gate AND the
+        // fail-closed re-read (ADR-107).
+        let snap_dir = tempfile::TempDir::new().unwrap();
+        let drive_dir = tempfile::TempDir::new().unwrap();
+        let sv_dir = snap_dir.path().join("sv-t");
+        std::fs::create_dir_all(&sv_dir).unwrap();
+        let snap = sv_dir.join("20260322-1430-t");
+        std::fs::create_dir(&snap).unwrap();
+
+        let config = transient_config_n_drives(
+            snap_dir.path(),
+            &[("DRIVE-A", drive_dir.path(), "primary")],
+        );
+        let mock = MockBtrfs::new();
+        mock.fail_sends.borrow_mut().insert(snap.clone()); // 3am: the send fails
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_armed_tiers(armed_map(storage_critical::TightnessTier::Critical));
+
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::SendFull {
+                snapshot: snap.clone(),
+                dest_dir: drive_dir.path().join(".snapshots/sv-t"),
+                drive_label: "DRIVE-A".to_string(),
+                subvolume_name: "sv-t".to_string(),
+                pin_on_success: None, // Critical writes no pin
+                reason: FullSendReason::FirstSend,
+                token_verified: false,
+            }],
+            timestamp: test_ts(),
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert!(!result.subvolume_results[0].success, "send failed");
+        assert_eq!(
+            result.subvolume_results[0].transient_cleanup,
+            TransientCleanupOutcome::NotApplicable,
+            "nothing tracked as sent → no clear-all work"
+        );
+        assert!(snap.exists(), "unsent snapshot must survive a failed send");
+        assert!(delete_calls(&mock).is_empty(), "no deletions on send failure");
+    }
+
+    #[test]
+    fn clear_all_critical_steady_clears_just_sent_snapshot() {
+        // Steady Critical: full send succeeds, no old parent, no pin → the
+        // just-sent snapshot is deleted, leaving zero local snapshots.
+        let snap_dir = tempfile::TempDir::new().unwrap();
+        let drive_dir = tempfile::TempDir::new().unwrap();
+        let sv_dir = snap_dir.path().join("sv-t");
+        std::fs::create_dir_all(&sv_dir).unwrap();
+        let snap = sv_dir.join("20260322-1430-t");
+        std::fs::create_dir(&snap).unwrap();
+
+        let config = transient_config_n_drives(
+            snap_dir.path(),
+            &[("DRIVE-A", drive_dir.path(), "primary")],
+        );
+        let mock = MockBtrfs::new();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_armed_tiers(armed_map(storage_critical::TightnessTier::Critical));
+
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::SendFull {
+                snapshot: snap.clone(),
+                dest_dir: drive_dir.path().join(".snapshots/sv-t"),
+                drive_label: "DRIVE-A".to_string(),
+                subvolume_name: "sv-t".to_string(),
+                pin_on_success: None,
+                reason: FullSendReason::FirstSend,
+                token_verified: false,
+            }],
+            timestamp: test_ts(),
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert!(result.subvolume_results[0].success);
+        assert_eq!(
+            result.subvolume_results[0].transient_cleanup,
+            TransientCleanupOutcome::Cleaned { deleted_count: 1 },
+        );
+        assert!(delete_calls(&mock).contains(&snap), "sent snapshot cleared");
+        assert!(
+            !sv_dir.join(".last-external-parent-DRIVE-A").exists(),
+            "no pin left behind"
+        );
+    }
+
+    #[test]
+    fn clear_all_critical_entry_clears_parent_and_sent_removes_pin() {
+        // First Critical run: a Tight-era pin + old parent survive. The run takes
+        // one cheap incremental, then clears BOTH the old parent and the sent
+        // snapshot and removes the pin — zero locals. The pin-remove-FIRST order
+        // is what lets the fail-closed re-read approve the old-parent delete.
+        let snap_dir = tempfile::TempDir::new().unwrap();
+        let drive_dir = tempfile::TempDir::new().unwrap();
+        let sv_dir = snap_dir.path().join("sv-t");
+        std::fs::create_dir_all(&sv_dir).unwrap();
+        let old_parent = sv_dir.join("20260321-t");
+        std::fs::create_dir(&old_parent).unwrap();
+        let snap = sv_dir.join("20260322-1430-t");
+        std::fs::create_dir(&snap).unwrap();
+        chain::write_pin_file(&sv_dir, "DRIVE-A", &SnapshotName::parse("20260321-t").unwrap())
+            .unwrap();
+        let pin_path = sv_dir.join(".last-external-parent-DRIVE-A");
+        assert!(pin_path.exists());
+
+        let config = transient_config_n_drives(
+            snap_dir.path(),
+            &[("DRIVE-A", drive_dir.path(), "primary")],
+        );
+        let mock = MockBtrfs::new();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_armed_tiers(armed_map(storage_critical::TightnessTier::Critical));
+
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::SendIncremental {
+                parent: old_parent.clone(),
+                snapshot: snap.clone(),
+                dest_dir: drive_dir.path().join(".snapshots/sv-t"),
+                drive_label: "DRIVE-A".to_string(),
+                subvolume_name: "sv-t".to_string(),
+                pin_on_success: None, // Critical writes no pin
+            }],
+            timestamp: test_ts(),
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert!(result.subvolume_results[0].success);
+        assert_eq!(
+            result.subvolume_results[0].transient_cleanup,
+            TransientCleanupOutcome::Cleaned { deleted_count: 2 },
+        );
+        let deletes = delete_calls(&mock);
+        assert!(deletes.contains(&old_parent), "old Tight-era parent cleared");
+        assert!(deletes.contains(&snap), "just-sent snapshot cleared");
+        assert!(!pin_path.exists(), "pin removed (first) → zero locals");
+    }
+
+    #[test]
+    fn clear_all_pin_removal_failure_skips_all_deletions() {
+        // m2: if removing the pin fails, refuse ALL clear-all deletions this run
+        // (fail-open, next run retries) — never a half-cleared state. Force the
+        // failure by making the pin path a directory (remove_file errors, and the
+        // error is not NotFound).
+        let snap_dir = tempfile::TempDir::new().unwrap();
+        let drive_dir = tempfile::TempDir::new().unwrap();
+        let sv_dir = snap_dir.path().join("sv-t");
+        std::fs::create_dir_all(&sv_dir).unwrap();
+        let old_parent = sv_dir.join("20260321-t");
+        std::fs::create_dir(&old_parent).unwrap();
+        let snap = sv_dir.join("20260322-1430-t");
+        std::fs::create_dir(&snap).unwrap();
+        // Pin path is a DIRECTORY → remove_file fails (not NotFound).
+        std::fs::create_dir(sv_dir.join(".last-external-parent-DRIVE-A")).unwrap();
+
+        let config = transient_config_n_drives(
+            snap_dir.path(),
+            &[("DRIVE-A", drive_dir.path(), "primary")],
+        );
+        let mock = MockBtrfs::new();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_armed_tiers(armed_map(storage_critical::TightnessTier::Critical));
+
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::SendIncremental {
+                parent: old_parent.clone(),
+                snapshot: snap.clone(),
+                dest_dir: drive_dir.path().join(".snapshots/sv-t"),
+                drive_label: "DRIVE-A".to_string(),
+                subvolume_name: "sv-t".to_string(),
+                pin_on_success: None,
+            }],
+            timestamp: test_ts(),
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert_eq!(
+            result.subvolume_results[0].transient_cleanup,
+            TransientCleanupOutcome::SkippedPinRemovalFailure,
+        );
+        assert!(delete_calls(&mock).is_empty(), "fail-open: nothing deleted");
+        assert!(old_parent.exists());
+        assert!(snap.exists());
+    }
+
+    #[test]
+    fn clear_all_multi_drive_partial_keeps_everything() {
+        // Critical clear-all, two drives: A succeeds, B fails. The all-sends-
+        // succeeded gate blocks ALL clear-all deletions — A's sent snapshot and
+        // the old parent survive for next run's retry.
+        let snap_dir = tempfile::TempDir::new().unwrap();
+        let drive_a = tempfile::TempDir::new().unwrap();
+        let drive_b = tempfile::TempDir::new().unwrap();
+        let sv_dir = snap_dir.path().join("sv-t");
+        std::fs::create_dir_all(&sv_dir).unwrap();
+        let old_parent = sv_dir.join("20260321-t");
+        std::fs::create_dir(&old_parent).unwrap();
+        let snap = sv_dir.join("20260322-1430-t");
+        std::fs::create_dir(&snap).unwrap();
+        let snap_b = sv_dir.join("20260322-1430-t-b");
+        std::fs::create_dir(&snap_b).unwrap();
+
+        let config = transient_config_n_drives(
+            snap_dir.path(),
+            &[
+                ("DRIVE-A", drive_a.path(), "primary"),
+                ("DRIVE-B", drive_b.path(), "offsite"),
+            ],
+        );
+        let mock = MockBtrfs::new();
+        mock.fail_sends.borrow_mut().insert(snap_b.clone()); // B fails
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_armed_tiers(armed_map(storage_critical::TightnessTier::Critical));
+
+        let plan = BackupPlan {
+            operations: vec![
+                PlannedOperation::SendIncremental {
+                    parent: old_parent.clone(),
+                    snapshot: snap.clone(),
+                    dest_dir: drive_a.path().join(".snapshots/sv-t"),
+                    drive_label: "DRIVE-A".to_string(),
+                    subvolume_name: "sv-t".to_string(),
+                    pin_on_success: None,
+                },
+                PlannedOperation::SendIncremental {
+                    parent: old_parent.clone(),
+                    snapshot: snap_b.clone(),
+                    dest_dir: drive_b.path().join(".snapshots/sv-t"),
+                    drive_label: "DRIVE-B".to_string(),
+                    subvolume_name: "sv-t".to_string(),
+                    pin_on_success: None,
+                },
+            ],
+            timestamp: test_ts(),
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert_eq!(
+            result.subvolume_results[0].transient_cleanup,
+            TransientCleanupOutcome::SkippedPartialSends,
+        );
+        assert!(delete_calls(&mock).is_empty(), "partial success → no clear-all");
+        assert!(old_parent.exists());
+        assert!(snap.exists());
+    }
+
+    #[test]
+    fn tight_retain_one_keeps_new_pin_clears_old_parent() {
+        // Tight (clear_all = false): retain-one, unchanged. Old parent cleaned,
+        // the just-sent snapshot becomes the new pin and survives.
+        let snap_dir = tempfile::TempDir::new().unwrap();
+        let drive_dir = tempfile::TempDir::new().unwrap();
+        let sv_dir = snap_dir.path().join("sv-t");
+        std::fs::create_dir_all(&sv_dir).unwrap();
+        let old_parent = sv_dir.join("20260321-t");
+        std::fs::create_dir(&old_parent).unwrap();
+        let snap = sv_dir.join("20260322-1430-t");
+        std::fs::create_dir(&snap).unwrap();
+        chain::write_pin_file(&sv_dir, "DRIVE-A", &SnapshotName::parse("20260321-t").unwrap())
+            .unwrap();
+
+        let config = transient_config_n_drives(
+            snap_dir.path(),
+            &[("DRIVE-A", drive_dir.path(), "primary")],
+        );
+        let mock = MockBtrfs::new();
+        let shutdown = no_shutdown();
+        let mut executor = Executor::new(&mock, None, &config, &shutdown);
+        executor.set_armed_tiers(armed_map(storage_critical::TightnessTier::Tight));
+
+        let new_pin_path = sv_dir.join(".last-external-parent-DRIVE-A");
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::SendIncremental {
+                parent: old_parent.clone(),
+                snapshot: snap.clone(),
+                dest_dir: drive_dir.path().join(".snapshots/sv-t"),
+                drive_label: "DRIVE-A".to_string(),
+                subvolume_name: "sv-t".to_string(),
+                pin_on_success: Some((
+                    new_pin_path.clone(),
+                    SnapshotName::parse("20260322-1430-t").unwrap(),
+                )),
+            }],
+            timestamp: test_ts(),
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let result = executor.execute(&plan, "full");
+        assert_eq!(
+            result.subvolume_results[0].transient_cleanup,
+            TransientCleanupOutcome::Cleaned { deleted_count: 1 },
+        );
+        let deletes = delete_calls(&mock);
+        assert!(deletes.contains(&old_parent), "old parent cleaned");
+        assert!(!deletes.contains(&snap), "new pin (retain-one) survives at Tight");
+        let pin = std::fs::read_to_string(&new_pin_path).unwrap();
+        assert_eq!(pin.trim(), "20260322-1430-t", "pin advanced to new snapshot");
+    }
+
+    #[test]
+    fn is_transient_resolution_behavior_neutral_named_level_explicit_transient() {
+        // M3: the executor derives is_transient via derive_effective_policy
+        // (empty map → Roomy → declared) instead of a raw-config check. Prove the
+        // two agree on the non-obvious case — a NAMED level + explicit transient
+        // resolves to Transient (config.rs:182-184), while a named level alone
+        // never does — so the switch is behavior-neutral for every config.
+        use crate::storage_critical::{derive_effective_policy, TightnessTier};
+        let config_str = r#"
+drives = []
+
+[general]
+state_db = "/tmp/urd-test/urd.db"
+metrics_file = "/tmp/urd-test/backup.prom"
+log_dir = "/tmp/urd-test"
+
+[local_snapshots]
+roots = [ { path = "/snap", subvolumes = ["named-transient", "named-graduated"] } ]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+send_enabled = true
+enabled = true
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[subvolumes]]
+name = "named-transient"
+short_name = "nt"
+source = "/data/nt"
+protection_level = "sheltered"
+local_retention = "transient"
+
+[[subvolumes]]
+name = "named-graduated"
+short_name = "ng"
+source = "/data/ng"
+protection_level = "sheltered"
+"#;
+        let config: Config = toml::from_str(config_str).unwrap();
+        let resolved = config.resolved_subvolumes();
+
+        // Named level + explicit transient → resolves Transient; Roomy derive agrees.
+        let nt = resolved.iter().find(|s| s.name == "named-transient").unwrap();
+        assert!(matches!(
+            config.subvolumes.iter().find(|s| s.name == "named-transient").unwrap().local_retention,
+            Some(crate::types::LocalRetentionConfig::Transient)
+        ));
+        assert!(
+            derive_effective_policy(
+                &nt.local_retention,
+                nt.send_interval,
+                nt.send_enabled,
+                TightnessTier::Roomy,
+            )
+            .local_retention
+            .is_transient(),
+            "named-level + explicit transient is_transient at Roomy"
+        );
+
+        // Named level ALONE never resolves to transient.
+        let ng = resolved.iter().find(|s| s.name == "named-graduated").unwrap();
+        assert!(
+            config.subvolumes.iter().find(|s| s.name == "named-graduated").unwrap().local_retention.is_none()
+        );
+        assert!(
+            !derive_effective_policy(
+                &ng.local_retention,
+                ng.send_interval,
+                ng.send_enabled,
+                TightnessTier::Roomy,
+            )
+            .local_retention
+            .is_transient(),
+            "named level alone is NOT transient"
+        );
     }
 }

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -411,6 +411,8 @@ mod tests {
                 redundancy_advisories: vec![],
                 errors: vec![],
                 storage_posture: None,
+                cadence_adapted: false,
+                effective_send_interval: None,
             },
             SubvolAssessment {
                 name: "docs".to_string(),
@@ -429,6 +431,8 @@ mod tests {
                 redundancy_advisories: vec![],
                 errors: vec![],
                 storage_posture: None,
+                cadence_adapted: false,
+                effective_send_interval: None,
             },
         ]
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -195,6 +195,15 @@ pub struct StatusAssessment {
     /// Omitted when the subvolume's pool is Roomy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_posture: Option<StoragePosture>,
+    /// UPI 031-b: `true` when the AT RISK promise reflects a deliberate Critical
+    /// cadence (adaptation), not a failure. The signal voice reads to lead with
+    /// adaptation prose instead of a failure line. Additive to `--json`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub cadence_adapted: bool,
+    /// UPI 031-b: the effective send interval in seconds when adapted
+    /// (`armed != Roomy`); `None` at Roomy. Lets voice name the cadence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_send_interval_secs: Option<i64>,
 }
 
 impl StatusAssessment {
@@ -220,6 +229,8 @@ impl StatusAssessment {
             external_only: false,
             errors: a.errors.clone(),
             storage_posture: a.storage_posture,
+            cadence_adapted: a.cadence_adapted,
+            effective_send_interval_secs: a.effective_send_interval.map(|i| i.as_secs()),
         }
     }
 }
@@ -1677,6 +1688,8 @@ mod tests {
             redundancy_advisories: vec![advisory.clone()],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         };
 
         let sa = StatusAssessment::from_assessment(&assessment);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -10,6 +10,7 @@ use crate::drives::DriveAvailability;
 use crate::error::UrdError;
 use crate::events::{DeferScope, Event, EventPayload};
 use crate::retention;
+use crate::storage_critical::{self, ArmedTierMap, EffectivePolicy};
 use crate::types::{
     BackupPlan, DeleteKind, DriveEvent, DriveEventKind, FullSendReason, LocalRetentionPolicy,
     PlannedOperation, SendKind, SnapshotName,
@@ -223,11 +224,20 @@ fn interval_elapsed(elapsed: chrono::Duration, interval: chrono::Duration) -> bo
 // ── Planner ─────────────────────────────────────────────────────────────
 
 /// Generate a backup plan based on config, current time, filters, and filesystem state.
+///
+/// `armed_tiers` maps subvolume name → its source pool's armed `TightnessTier`
+/// (UPI 031-b). An absent key defaults to `Roomy` → declared behavior, so a
+/// read-only caller without storage signals passes an empty map and gets
+/// byte-identical plans (the regression firewall). The backup path supplies the
+/// real map (resolved once pre-plan, AB1) so a tight pool sheds Urd's footprint:
+/// Tight/Critical send-enabled subvolumes route through the transient lifecycle
+/// and Critical writes no pin (`derive_effective_policy`).
 pub fn plan(
     config: &Config,
     now: NaiveDateTime,
     filters: &PlanFilters,
     obs: &Observation,
+    armed_tiers: &ArmedTierMap,
 ) -> crate::error::Result<BackupPlan> {
     let mut operations = Vec::new();
     // Skip reason strings are classified by output::SkipCategory::from_reason().
@@ -325,10 +335,26 @@ pub fn plan(
             })
             .collect();
 
+        // ── Tier-adapted effective policy (UPI 031-b) ──────────────
+        // Resolve the source pool's armed tier (Roomy default for an absent
+        // key → declared behavior) and derive the effective lifecycle / send
+        // interval / clear-all signal. Planner and awareness both derive from
+        // the SAME armed tier (the single pre-plan gather in backup.rs), so the
+        // effective send interval they judge against agrees.
+        let armed = armed_tiers.get(&subvol.name).copied().unwrap_or_default();
+        let eff = storage_critical::derive_effective_policy(
+            &subvol.local_retention,
+            subvol.send_interval,
+            subvol.send_enabled,
+            armed,
+        );
+
         // ── Transient subvolumes: atomic lifecycle planning ────────
-        if subvol.local_retention.is_transient() && subvol.send_enabled {
+        // Dispatch on the EFFECTIVE lifecycle: a Tight/Critical declared-Graduated
+        // send-enabled subvolume now routes through the transient path.
+        if eff.local_retention.is_transient() && subvol.send_enabled {
             plan_transient_lifecycle(
-                subvol, config, &local_dir, &local_snaps, now, force, filters,
+                subvol, &eff, config, &local_dir, &local_snaps, now, force, filters,
                 &pinned, &mounted_pins, obs, &mut operations, &mut skipped, &mut events,
             );
             continue; // skip the normal two-phase flow
@@ -355,6 +381,7 @@ pub fn plan(
             );
             plan_local_retention(
                 subvol,
+                &eff,
                 &local_dir,
                 &local_snaps,
                 now,
@@ -410,6 +437,7 @@ pub fn plan(
 
                 plan_external_send(
                     subvol,
+                    &eff,
                     drive,
                     &local_dir,
                     effective_local_snaps,
@@ -445,9 +473,18 @@ pub fn plan(
         }
     }
 
-    // Transient invariant: CreateSnapshot without Send is an orphan.
+    // Transient invariant: CreateSnapshot without Send is an orphan. Keyed on
+    // the EFFECTIVE lifecycle (031-b): a Tight/Critical Graduated subvol routed
+    // through the transient path is subject to the same invariant.
     for subvol in &resolved {
-        if !subvol.local_retention.is_transient() || !subvol.send_enabled {
+        let armed = armed_tiers.get(&subvol.name).copied().unwrap_or_default();
+        let eff = storage_critical::derive_effective_policy(
+            &subvol.local_retention,
+            subvol.send_interval,
+            subvol.send_enabled,
+            armed,
+        );
+        if !eff.local_retention.is_transient() || !subvol.send_enabled {
             continue;
         }
         let has_create = operations.iter().any(|op| {
@@ -649,6 +686,7 @@ fn plan_local_snapshot(
 #[allow(clippy::too_many_arguments)]
 fn plan_local_retention(
     subvol: &ResolvedSubvolume,
+    eff: &EffectivePolicy,
     local_dir: &Path,
     local_snaps: &[SnapshotName],
     now: NaiveDateTime,
@@ -668,7 +706,7 @@ fn plan_local_retention(
     // causes space exhaustion on constrained filesystems.
     // For graduated subvolumes, protect ALL pins (conservative default).
     let protected = if subvol.send_enabled {
-        let effective_pinned = if subvol.local_retention.is_transient() {
+        let effective_pinned = if eff.local_retention.is_transient() {
             mounted_pins.clone()
         } else {
             pinned.clone()
@@ -683,7 +721,7 @@ fn plan_local_retention(
                     }
                 }
             }
-            None if subvol.local_retention.is_transient() => {
+            None if eff.local_retention.is_transient() => {
                 // Transient + no mounted pins = nothing to protect.
                 // Full sends when drives return.
             }
@@ -700,7 +738,7 @@ fn plan_local_retention(
         pinned.clone()
     };
 
-    match &subvol.local_retention {
+    match &eff.local_retention {
         LocalRetentionPolicy::Transient => {
             // Transient: delete everything not in the protected set (pins + unsent).
             // Transient lifecycle is policy-driven — always execute.
@@ -759,6 +797,7 @@ fn plan_local_retention(
 #[allow(clippy::too_many_arguments)]
 fn plan_transient_lifecycle(
     subvol: &ResolvedSubvolume,
+    eff: &EffectivePolicy,
     config: &Config,
     local_dir: &Path,
     local_snaps: &[SnapshotName],
@@ -795,7 +834,7 @@ fn plan_transient_lifecycle(
             let send_due = match newest_ext {
                 Some(newest_dt) => {
                     let elapsed = now.signed_duration_since(newest_dt);
-                    interval_elapsed(elapsed, subvol.send_interval.as_chrono())
+                    interval_elapsed(elapsed, eff.send_interval.as_chrono())
                 }
                 None => true, // No external snapshots — first send
             };
@@ -822,6 +861,7 @@ fn plan_transient_lifecycle(
         // Phase 4 only: retention on leftovers
         plan_local_retention(
             subvol,
+            eff,
             local_dir,
             local_snaps,
             now,
@@ -839,7 +879,7 @@ fn plan_transient_lifecycle(
             .iter()
             .filter_map(|(drive, newest_ext)| {
                 let newest_dt = (*newest_ext)?;
-                let next_in = subvol.send_interval.as_chrono()
+                let next_in = eff.send_interval.as_chrono()
                     - now.signed_duration_since(newest_dt);
                 Some(format!(
                     "send to {} not due (next in ~{})",
@@ -865,6 +905,7 @@ fn plan_transient_lifecycle(
         // Phase 4 only: retention on leftovers
         plan_local_retention(
             subvol,
+            eff,
             local_dir,
             local_snaps,
             now,
@@ -878,6 +919,14 @@ fn plan_transient_lifecycle(
     }
 
     // ── Phase 2: Plan snapshot creation (only if a send will happen) ──
+    // LOAD-BEARING INVARIANT (031-b M1): snapshot creation is gated on a send
+    // being due (Phase 1 set `any_send_due`). This is why lengthening
+    // `eff.send_interval` at Critical is sufficient to bound footprint — it
+    // lengthens *creation* too, so clear-all's "≈0 between-run footprint" holds
+    // without accumulation. Do NOT decouple creation from the send-due gate in
+    // the transient path (e.g. "keep a fresher local for restores"): a weekly
+    // Critical send with daily creation would strand 7 unsent snapshots and
+    // reproduce the htpc catastrophe this UPI exists to prevent.
     let planned_snap = if !filters.external_only {
         let min_free = subvol.min_free_bytes.unwrap_or(0);
         plan_local_snapshot(
@@ -892,6 +941,7 @@ fn plan_transient_lifecycle(
         // No planned snapshot and no existing snapshots — nothing to send.
         plan_local_retention(
             subvol,
+            eff,
             local_dir,
             local_snaps,
             now,
@@ -925,7 +975,7 @@ fn plan_transient_lifecycle(
 
     for (drive, _) in &sendable_drives {
         plan_external_send(
-            subvol, drive, local_dir, effective_local_snaps, now, force,
+            subvol, eff, drive, local_dir, effective_local_snaps, now, force,
             filters.skip_intervals, obs, operations, skipped, events,
         );
         plan_external_retention(subvol, drive, now, obs, pinned, operations, events);
@@ -935,6 +985,7 @@ fn plan_transient_lifecycle(
     // Use original local_snaps — retention only operates on existing-on-disk snapshots.
     plan_local_retention(
         subvol,
+        eff,
         local_dir,
         local_snaps,
         now,
@@ -949,6 +1000,7 @@ fn plan_transient_lifecycle(
 #[allow(clippy::too_many_arguments)]
 fn plan_external_send(
     subvol: &ResolvedSubvolume,
+    eff: &EffectivePolicy,
     drive: &DriveConfig,
     local_dir: &Path,
     local_snaps: &[SnapshotName],
@@ -972,13 +1024,13 @@ fn plan_external_send(
         true
     } else if let Some(newest) = newest_ext {
         let elapsed = now.signed_duration_since(newest.datetime());
-        interval_elapsed(elapsed, subvol.send_interval.as_chrono())
+        interval_elapsed(elapsed, eff.send_interval.as_chrono())
     } else {
         true // No external snapshots — send first one
     };
 
     if !should_send {
-        let next_in = subvol.send_interval.as_chrono()
+        let next_in = eff.send_interval.as_chrono()
             - now.signed_duration_since(newest_ext.unwrap().datetime());
         record_defer(
             skipped,
@@ -998,7 +1050,7 @@ fn plan_external_send(
 
     // Find the snapshot to send (newest local)
     let Some(snap_to_send) = local_snaps.iter().max() else {
-        let reason = if subvol.local_retention.is_transient() {
+        let reason = if eff.local_retention.is_transient() {
             "external-only \u{2014} sends on next backup".to_string()
         } else {
             "no local snapshots to send".to_string()
@@ -1119,10 +1171,21 @@ fn plan_external_send(
         }
     }
 
-    let pin_info = Some((
-        local_dir.join(format!(".last-external-parent-{}", drive.label)),
-        snap_to_send.clone(),
-    ));
+    // Critical (clear_all) writes NO pin: the executor deletes the just-sent
+    // snapshot + pin after the gated all-sends-succeeded check (031-b), leaving
+    // zero local snapshots between runs. A surviving pin would make the
+    // fail-closed re-read refuse to clear, so the planner withholds it here.
+    // On the FIRST Critical run a Tight-era pin may still be present on disk,
+    // so this run takes one cheap incremental against it before the executor
+    // clears both; steady-state Critical (no pin) falls through to SendFull.
+    let pin_info = if eff.clear_all {
+        None
+    } else {
+        Some((
+            local_dir.join(format!(".last-external-parent-{}", drive.label)),
+            snap_to_send.clone(),
+        ))
+    };
 
     if is_incremental {
         let parent_name = pin.unwrap();
@@ -1756,7 +1819,7 @@ priority = 2
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1773,7 +1836,7 @@ priority = 2
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260322-1455-one")]);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1847,7 +1910,7 @@ priority = 2
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap("20260321-1502-one")]);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1862,7 +1925,7 @@ priority = 2
         let fs = MockFileSystemState::new();
         // No snapshots exist at all
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1884,7 +1947,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -1903,7 +1966,7 @@ priority = 2
             priority: Some(1),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         // Only sv1 (priority 1), not sv2 (priority 2)
         let creates: Vec<_> = result
             .operations
@@ -1934,7 +1997,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -1955,7 +2018,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -1988,7 +2051,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2021,7 +2084,7 @@ priority = 2
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let send = result
             .operations
             .iter()
@@ -2048,7 +2111,7 @@ priority = 2
             .insert("sv1".to_string(), vec![snap("20260322-1500-one")]);
         // Drive NOT mounted
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         assert!(
             result
                 .skipped
@@ -2106,7 +2169,7 @@ send_enabled = false
             .insert("sv".to_string(), vec![snap("20260322-1400-sv")]);
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         assert!(
             result
                 .skipped
@@ -2125,7 +2188,7 @@ send_enabled = false
             local_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2148,7 +2211,7 @@ send_enabled = false
             external_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -2169,7 +2232,7 @@ send_enabled = false
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends_with_pin: Vec<_> = result
             .operations
             .iter()
@@ -2215,7 +2278,7 @@ send_enabled = false
             local_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         // All snapshots newer than the pin should be protected (not deleted)
         let deletes: Vec<_> = result
             .operations
@@ -2252,7 +2315,7 @@ send_enabled = false
             local_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -2311,7 +2374,7 @@ send_enabled = false
             ],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -2342,7 +2405,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 150_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2378,7 +2441,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 500_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2402,7 +2465,7 @@ send_enabled = false
         // Tiny free space — but no history means we can't estimate, so proceed
         fs.free_bytes.insert(PathBuf::from("/mnt/d1"), 1_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2431,7 +2494,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 500_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2472,7 +2535,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 500_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2495,7 +2558,7 @@ send_enabled = false
         // No send_sizes, no calibrated_sizes — fail open
         fs.free_bytes.insert(PathBuf::from("/mnt/d1"), 1_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2524,7 +2587,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/mnt/d1"), 500_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2554,7 +2617,7 @@ send_enabled = false
             vec![snap("20260322-1600-one")], // now() is 15:00, this is 16:00
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -2590,7 +2653,7 @@ send_enabled = false
             },
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         assert!(
             result
                 .skipped
@@ -2627,7 +2690,7 @@ send_enabled = false
             DriveAvailability::UuidCheckFailed("findmnt not found".to_string()),
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         assert!(
             result
                 .skipped
@@ -2647,7 +2710,7 @@ send_enabled = false
         fs.drive_availability_overrides
             .insert("D1".to_string(), DriveAvailability::Available);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2673,7 +2736,7 @@ send_enabled = false
             .insert("sv1".to_string(), vec![snap("20260322-1300-one")]);
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2706,7 +2769,7 @@ send_enabled = false
             },
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         assert!(
             result
                 .skipped
@@ -2740,7 +2803,7 @@ send_enabled = false
         fs.drive_availability_overrides
             .insert("D1".to_string(), DriveAvailability::TokenMissing);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -2766,7 +2829,7 @@ send_enabled = false
         fs.drive_availability_overrides
             .insert("D1".to_string(), DriveAvailability::TokenExpectedButMissing);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         assert!(
             result
                 .skipped
@@ -2799,7 +2862,7 @@ send_enabled = false
         fs.drive_availability_overrides
             .insert("D1".to_string(), DriveAvailability::TokenExpectedButMissing);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -2823,7 +2886,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/snap/sv1"), 5_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         // No snapshot should be created for sv1
         let creates: Vec<_> = result
@@ -2859,7 +2922,7 @@ send_enabled = false
         fs.free_bytes
             .insert(PathBuf::from("/snap/sv1"), 50_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -2887,7 +2950,7 @@ send_enabled = false
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -2933,7 +2996,7 @@ send_enabled = false
         mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1").join(s1.as_str()), 50);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -2974,7 +3037,7 @@ send_enabled = false
             .insert("sv1".to_string(), vec![snap("20260322-1440-one")]);
         // Note: no fs.free_bytes entry for /snap/sv1
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -3049,7 +3112,7 @@ drives = ["D1"]
         fs.mounted_drives.insert("D1".to_string());
         fs.mounted_drives.insert("D2".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         // Should only have send operations for D1, not D2
         let sends: Vec<_> = result
@@ -3161,7 +3224,7 @@ local_retention = "transient"
             vec![snap("20260320-1000-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3205,7 +3268,7 @@ local_retention = "transient"
             ],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3246,7 +3309,7 @@ local_retention = "transient"
         // No pin files — nothing has ever been sent
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3274,7 +3337,7 @@ local_retention = "transient"
         let fs = MockFileSystemState::new();
         // No local snapshots, no drives mounted
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -3389,7 +3452,7 @@ local_retention = "transient"
             vec![snap("20260320-1000-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3427,7 +3490,7 @@ local_retention = "transient"
         // Drive NOT mounted — transient should skip snapshot creation
         // (no drive to send to, creating a snapshot is pointless)
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -3454,7 +3517,7 @@ local_retention = "transient"
         // No local snapshots, no drives mounted.
         // Transient: no snapshot created — can't be sent, would be orphaned.
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -3495,7 +3558,7 @@ local_retention = "transient"
             vec![snap("20260322-1400-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3534,7 +3597,7 @@ local_retention = "transient"
             snap("20260320-1000-one"),
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3589,7 +3652,7 @@ local_retention = "transient"
             vec![snap("20260320-1000-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3683,7 +3746,7 @@ priority = 1
         fs.mounted_drives.insert("D1".to_string());
         // D2 NOT mounted
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3721,7 +3784,7 @@ priority = 1
         );
         // No pin files, no drives mounted
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3766,7 +3829,7 @@ priority = 1
             vec![snap("20260321-1000-one")],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3802,7 +3865,7 @@ priority = 1
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -3829,7 +3892,7 @@ priority = 1
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sends: Vec<_> = result
             .operations
             .iter()
@@ -3860,7 +3923,7 @@ priority = 1
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -3909,7 +3972,7 @@ priority = 1
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let deletes: Vec<_> = result
             .operations
             .iter()
@@ -3937,7 +4000,7 @@ priority = 1
             local_only: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -3966,7 +4029,7 @@ priority = 1
         let mut fs = MockFileSystemState::new();
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -3989,7 +4052,7 @@ priority = 1
         let config = transient_config();
         let fs = MockFileSystemState::new();
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         assert!(
             result.operations.is_empty(),
@@ -4016,7 +4079,7 @@ priority = 1
             ],
         );
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4055,7 +4118,7 @@ priority = 1
             skip_intervals: false,
             ..Default::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4100,7 +4163,7 @@ priority = 1
         mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1400-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4175,7 +4238,7 @@ local_retention = "transient"
         fs.free_bytes
             .insert(PathBuf::from("/snap/sv1"), 1_000_000_000);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4197,7 +4260,7 @@ local_retention = "transient"
         let mut fs = MockFileSystemState::new();
         fs.mounted_drives.insert("D1".to_string());
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4245,7 +4308,7 @@ local_retention = "transient"
         mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260321-1000-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4281,7 +4344,7 @@ local_retention = "transient"
             skip_intervals: false,
             ..Default::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
 
         let creates: Vec<_> = result
             .operations
@@ -4320,7 +4383,7 @@ local_retention = "transient"
         mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4349,7 +4412,7 @@ local_retention = "transient"
         mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4364,7 +4427,7 @@ local_retention = "transient"
         let fs = MockFileSystemState::new();
         // No existing snapshots → create (no generation to compare)
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4386,7 +4449,7 @@ local_retention = "transient"
         mb.generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"), 500);
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4408,7 +4471,7 @@ local_retention = "transient"
         mb.fail_generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"));
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4430,7 +4493,7 @@ local_retention = "transient"
         mb.fail_generations.borrow_mut()
             .insert(PathBuf::from("/snap/sv1/20260322-1440-one"));
 
-        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4456,7 +4519,7 @@ local_retention = "transient"
             force_snapshot: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4482,7 +4545,7 @@ local_retention = "transient"
             subvolume: Some("sv1".to_string()),
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4508,7 +4571,7 @@ local_retention = "transient"
             skip_intervals: true,
             ..PlanFilters::default()
         };
-        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &mb }).unwrap();
+        let result = plan(&config, now(), &filters, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &ArmedTierMap::new()).unwrap();
         let creates: Vec<_> = result
             .operations
             .iter()
@@ -4567,7 +4630,7 @@ local_retention = "transient"
         fs.external_snapshots
             .insert(("D1".to_string(), "sv1".to_string()), vec![]);
 
-        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let saw_first_send = plan.events.iter().any(|e| {
             matches!(
                 &e.payload,
@@ -4609,7 +4672,7 @@ local_retention = "transient"
         fs.pin_files
             .insert((PathBuf::from("/snap/sv1"), "D1".to_string()), parent.clone());
 
-        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         // Sanity: ensure an incremental was actually chosen (else the test is moot).
         let any_incremental = plan
             .operations
@@ -4630,7 +4693,7 @@ local_retention = "transient"
             }
         }
         let fs = MockFileSystemState::new();
-        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let saw_disabled_defer = plan.events.iter().any(|e| match &e.payload {
             EventPayload::PlannerDefer { reason, scope } => {
                 reason == "disabled" && *scope == DeferScope::Subvolume
@@ -4654,7 +4717,7 @@ local_retention = "transient"
             .insert("sv1".to_string(), vec![snap("20260322-1455-one")]);
         // Drive D1 not mounted.
 
-        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let saw_drive_defer = plan.events.iter().any(|e| match &e.payload {
             EventPayload::PlannerDefer { reason, scope } => {
                 reason.contains("not mounted") && *scope == DeferScope::Drive
@@ -4676,7 +4739,7 @@ local_retention = "transient"
             }
         }
         let fs = MockFileSystemState::new();
-        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }).unwrap();
+        let plan = plan(&config, now(), &PlanFilters::default(), &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &ArmedTierMap::new()).unwrap();
         let sv2_defers: Vec<_> = plan
             .events
             .iter()
@@ -4686,6 +4749,318 @@ local_retention = "transient"
         assert!(
             !sv2_defers.is_empty(),
             "PlannerDefer for sv2 should carry subvolume='sv2'"
+        );
+    }
+
+    // ── UPI 031-b: tier-graded lifecycle in the planner ─────────────────
+
+    /// A send-enabled, declared-GRADUATED subvolume on drive D1 (no
+    /// `local_retention = "transient"`). Used to prove the tier reroutes a
+    /// graduated subvol through the transient path at Tight/Critical.
+    fn graduated_send_config() -> Config {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "test"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "one"
+source = "/data/sv1"
+priority = 1
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    fn armed_map(name: &str, tier: crate::storage_critical::TightnessTier) -> ArmedTierMap {
+        let mut m = ArmedTierMap::new();
+        m.insert(name.to_string(), tier);
+        m
+    }
+
+    fn count_creates(plan: &BackupPlan, subvol: &str) -> usize {
+        plan.operations
+            .iter()
+            .filter(|op| {
+                matches!(op, PlannedOperation::CreateSnapshot { subvolume_name, .. } if subvolume_name == subvol)
+            })
+            .count()
+    }
+
+    fn count_transient_deletes(plan: &BackupPlan) -> usize {
+        plan.operations
+            .iter()
+            .filter(|op| {
+                matches!(op, PlannedOperation::DeleteSnapshot { reason, .. } if reason.contains("transient"))
+            })
+            .count()
+    }
+
+    /// `Some(true)` = a send op with a pin write; `Some(false)` = send op with
+    /// no pin; `None` = no send op for the subvolume.
+    fn send_has_pin(plan: &BackupPlan, subvol: &str) -> Option<bool> {
+        plan.operations.iter().find_map(|op| match op {
+            PlannedOperation::SendFull { subvolume_name, pin_on_success, .. }
+            | PlannedOperation::SendIncremental { subvolume_name, pin_on_success, .. }
+                if subvolume_name == subvol =>
+            {
+                Some(pin_on_success.is_some())
+            }
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn tight_routes_graduated_subvol_to_transient_retention() {
+        use crate::storage_critical::TightnessTier;
+        let config = graduated_send_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![
+                snap("20260320-1000-one"),
+                snap("20260321-1000-one"),
+                snap("20260322-1400-one"),
+            ],
+        );
+        // Pin at the newest; all three already on the drive (send not due).
+        fs.pin_files.insert(
+            (PathBuf::from("/snap/sv1"), "D1".to_string()),
+            snap("20260322-1400-one"),
+        );
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![
+                snap("20260320-1000-one"),
+                snap("20260321-1000-one"),
+                snap("20260322-1400-one"),
+            ],
+        );
+
+        // Roomy (empty map): declared graduated keeps each daily rep → 0 deletes.
+        let roomy = plan(
+            &config,
+            now(),
+            &PlanFilters::default(),
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &ArmedTierMap::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            count_transient_deletes(&roomy),
+            0,
+            "Roomy: graduated retention, no transient deletes"
+        );
+
+        // Tight: routes through the transient path → the two pre-pin snapshots
+        // are pruned to retain-one.
+        let tight = plan(
+            &config,
+            now(),
+            &PlanFilters::default(),
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &armed_map("sv1", TightnessTier::Tight),
+        )
+        .unwrap();
+        assert_eq!(
+            count_transient_deletes(&tight),
+            2,
+            "Tight: graduated subvol routed to transient retention (retain-one)"
+        );
+    }
+
+    #[test]
+    fn empty_map_equals_explicit_roomy() {
+        // The regression firewall in miniature: an absent key and an explicit
+        // Roomy tier produce byte-identical operations (Roomy == declared).
+        use crate::storage_critical::TightnessTier;
+        let config = graduated_send_config();
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1400-one")]);
+        fs.mounted_drives.insert("D1".to_string());
+
+        let empty = plan(
+            &config,
+            now(),
+            &PlanFilters::default(),
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &ArmedTierMap::new(),
+        )
+        .unwrap();
+        let roomy = plan(
+            &config,
+            now(),
+            &PlanFilters::default(),
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &armed_map("sv1", TightnessTier::Roomy),
+        )
+        .unwrap();
+        assert_eq!(empty.operations, roomy.operations);
+    }
+
+    #[test]
+    fn critical_writes_no_pin_tight_does() {
+        // The clear_all flip within one run: Tight writes a pin on the send;
+        // Critical (clear_all) writes none — the executor clears the just-sent
+        // snapshot post-send-success instead.
+        use crate::storage_critical::TightnessTier;
+        let config = graduated_send_config();
+        let mut fs = MockFileSystemState::new();
+        // One recent local snapshot; nothing on the drive yet → first send.
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap("20260322-1400-one")]);
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![]);
+
+        let tight = plan(
+            &config,
+            now(),
+            &PlanFilters::default(),
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &armed_map("sv1", TightnessTier::Tight),
+        )
+        .unwrap();
+        assert_eq!(
+            send_has_pin(&tight, "sv1"),
+            Some(true),
+            "Tight (retain-one) writes a pin on the send"
+        );
+
+        let critical = plan(
+            &config,
+            now(),
+            &PlanFilters::default(),
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &armed_map("sv1", TightnessTier::Critical),
+        )
+        .unwrap();
+        assert_eq!(
+            send_has_pin(&critical, "sv1"),
+            Some(false),
+            "Critical (clear_all) writes no pin"
+        );
+    }
+
+    /// Daily declared snapshot + send intervals — used to show the M1
+    /// send-gated-creation invariant at Critical (floored to weekly).
+    fn m1_daily_config() -> Config {
+        let toml_str = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["sv1"] }
+]
+
+[defaults]
+snapshot_interval = "1d"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+
+[defaults.local_retention]
+hourly = 0
+daily = 30
+weekly = 26
+monthly = 12
+
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snapshots"
+role = "test"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "one"
+source = "/data/sv1"
+priority = 1
+"#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    #[test]
+    fn critical_creation_is_gated_on_send_due_not_snapshot_interval() {
+        // M1 invariant: at Critical the send interval is floored to weekly, and
+        // snapshot CREATION is gated on a send being due (plan.rs Phase 2). With
+        // the last send only ~2 days old (< the weekly floor), NO snapshot is
+        // created this run even though the declared DAILY snapshot_interval has
+        // elapsed — so locals can't accumulate seven-deep between weekly sends.
+        // A Roomy graduated subvol, by contrast, creates regardless of send timing.
+        use crate::storage_critical::TightnessTier;
+        let config = m1_daily_config();
+        let mut fs = MockFileSystemState::new();
+        fs.mounted_drives.insert("D1".to_string());
+        // Steady Critical state: zero local snapshots, last send ~2 days ago.
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![snap("20260320-1400-one")]);
+
+        let critical = plan(
+            &config,
+            now(),
+            &PlanFilters::default(),
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &armed_map("sv1", TightnessTier::Critical),
+        )
+        .unwrap();
+        assert_eq!(
+            count_creates(&critical, "sv1"),
+            0,
+            "Critical: creation suppressed — the weekly send is not due"
+        );
+
+        let roomy = plan(
+            &config,
+            now(),
+            &PlanFilters::default(),
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &ArmedTierMap::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            count_creates(&roomy, "sv1"),
+            1,
+            "Roomy graduated: creates the daily snapshot regardless of send timing"
         );
     }
 }

--- a/src/recommendation.rs
+++ b/src/recommendation.rs
@@ -55,31 +55,25 @@ pub struct HeadroomContext {
 
 /// Per-(subvolume, role) headroom severity (UPI 044). Ordering is
 /// load-bearing: `.iter().max()` yields the dominant tier when multiple
-/// signals fire. Critical is **not** in the classifier's output domain.
+/// signals fire.
 ///
-/// UPI 031 retired the doctor-side Critical *injection* (the old
-/// force-Critical path), so as of this UPI nothing in production constructs
-/// `Critical` — the tier, the voice R9 pointer path, and
-/// `headroom_aware_pointer_only(.., Critical, ..)` are reachable only from
-/// tests. This is the intentional hook for the behavioral bundle (UPIs
-/// 032/033), time-boxed to that horizon; if the bundle slips, reconsider
-/// whether the tier should be deleted rather than maintained unused.
+/// UPI 031 retired the doctor-side Critical *injection*; UPI 031-b's
+/// tier-graded ephemeral spine confirmed the behavioral bundle keys on
+/// `TightnessTier`, not this severity ladder, so the dormant `Critical`
+/// variant (and its dead voice/recommendation paths) were deleted (AB5).
+/// `classify_headroom_severity` emits only `Healthy | Caution | Pressure`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HeadroomSeverity {
     Healthy,
     Caution,
     Pressure,
-    /// Dormant in production since UPI 031 (see the type doc). Kept alive for
-    /// the UPI 032/033 bundle and exercised by tests.
-    #[allow(dead_code)]
-    Critical,
 }
 
-/// Compute the headroom severity from a `HeadroomContext`. Returns only
-/// `Healthy | Caution | Pressure` — Critical is injected externally by
-/// doctor.rs. Three signals (free ratio, time-to-empty, metadata) are
-/// classified independently and the max is returned.
+/// Compute the headroom severity from a `HeadroomContext`. Returns
+/// `Healthy | Caution | Pressure` (the full domain since UPI 031-b deleted the
+/// dormant Critical variant). Three signals (free ratio, time-to-empty,
+/// metadata) are classified independently and the max is returned.
 #[must_use]
 pub fn classify_headroom_severity(ctx: HeadroomContext) -> HeadroomSeverity {
     let free_ratio_sev = classify_free_ratio(
@@ -461,13 +455,13 @@ fn tighten(
 }
 
 /// Synthesize a "pointer-only" recommendation for doctor.rs when severity
-/// is `Pressure` or `Critical` and the churn-fit engine returned `None`
-/// (cold/transient subvolume). The renderer detects the synth shape via
+/// is `Pressure` and the churn-fit engine returned `None` (cold/transient
+/// subvolume). The renderer detects the synth shape via
 /// `suggested == current && both costs zero` and emits only the reason
 /// line — no shape, no recovery tail.
 ///
-/// Severity is restricted to `Pressure | Critical`; Healthy/Caution synth
-/// is meaningless and would represent a doctor.rs bug.
+/// Severity is restricted to `Pressure`; Healthy/Caution synth is meaningless
+/// and would represent a doctor.rs bug.
 #[must_use]
 pub fn headroom_aware_pointer_only(
     current: &ResolvedGraduatedRetention,
@@ -476,8 +470,8 @@ pub fn headroom_aware_pointer_only(
     reason: AdjustmentReason,
 ) -> HeadroomAwareRecommendation {
     debug_assert!(
-        matches!(severity, HeadroomSeverity::Pressure | HeadroomSeverity::Critical),
-        "headroom_aware_pointer_only is only valid for Pressure or Critical severity, got {severity:?}",
+        matches!(severity, HeadroomSeverity::Pressure),
+        "headroom_aware_pointer_only is only valid for Pressure severity, got {severity:?}",
     );
     let zero_cost = CostProjection {
         data_bytes: 0,
@@ -1159,9 +1153,10 @@ mod tests {
     }
 
     #[test]
-    fn classify_never_returns_critical() {
-        // Critical is not in the classifier's output domain. Even with
-        // every signal maxed, the result tops out at Pressure.
+    fn classify_tops_out_at_pressure() {
+        // Pressure is the top of the classifier's output domain. Even with
+        // every signal maxed, the result tops out at Pressure (the dormant
+        // Critical variant was deleted in UPI 031-b, AB5).
         let ctx = HeadroomContext {
             source_pool_free_bytes: Some(1),
             source_pool_capacity_bytes: Some(100),
@@ -1169,18 +1164,16 @@ mod tests {
             destination_metadata_ratio: Some(0.999),
         };
         let sev = classify_headroom_severity(ctx);
-        assert_ne!(sev, HeadroomSeverity::Critical);
         assert_eq!(sev, HeadroomSeverity::Pressure);
     }
 
     #[test]
     fn severity_variant_ordering_is_load_bearing() {
-        // Healthy < Caution < Pressure < Critical via PartialOrd, Ord.
-        // Guards against accidental reorder (alphabetical, etc.) that
-        // would break `.iter().max()` semantics in classify.
+        // Healthy < Caution < Pressure via PartialOrd, Ord. Guards against an
+        // accidental reorder (alphabetical, etc.) that would break
+        // `.iter().max()` semantics in classify.
         assert!(HeadroomSeverity::Healthy < HeadroomSeverity::Caution);
         assert!(HeadroomSeverity::Caution < HeadroomSeverity::Pressure);
-        assert!(HeadroomSeverity::Pressure < HeadroomSeverity::Critical);
     }
 
     // ── UPI 044: recommend_shape_with_headroom + tighten + synth ───

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -880,6 +880,8 @@ mod tests {
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }
     }
 
@@ -917,6 +919,8 @@ mod tests {
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }
     }
 
@@ -1539,6 +1543,8 @@ mod tests {
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }
     }
 

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -977,6 +977,8 @@ mod tests {
             redundancy_advisories: vec![],
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
         }
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -1154,40 +1154,6 @@ impl StateDb {
     // Best-effort (ADR-102) — never blocks a backup; if lost, Urd
     // re-derives the current tier statelessly (degraded, never unsafe).
 
-    /// Read the armed tier + `since` for one pool. `None` when the pool has
-    /// no row (never tracked) or the stored tier string is unparseable
-    /// (skip, do not guess — fail toward stateless).
-    ///
-    /// The single-pool granular accessor; 031-a's hot path reads the batched
-    /// `all_armed_tiers` instead. Kept as the per-query primitive (CLAUDE.md
-    /// `state.rs` guidance) and the 032/033 single-pool read hook — exercised
-    /// by tests, no 031-a production caller yet.
-    #[allow(dead_code)]
-    pub fn armed_tier_for_pool(
-        &self,
-        pool_uuid: &str,
-    ) -> crate::error::Result<
-        Option<(crate::storage_critical::TightnessTier, chrono::NaiveDateTime)>,
-    > {
-        let row = self
-            .conn
-            .query_row(
-                "SELECT armed_tier, since FROM pool_armed_tier WHERE pool_uuid = ?1",
-                rusqlite::params![pool_uuid],
-                |row| {
-                    let tier_s: String = row.get(0)?;
-                    let since_s: String = row.get(1)?;
-                    Ok((tier_s, since_s))
-                },
-            )
-            .ok();
-
-        let Some((tier_s, since_s)) = row else {
-            return Ok(None);
-        };
-        Ok(Self::parse_armed_tier_row(&tier_s, &since_s))
-    }
-
     /// Batched read of every tracked pool's armed tier (for `gather()`).
     /// Unparseable rows are skipped (logged), not surfaced.
     pub fn all_armed_tiers(
@@ -3330,7 +3296,7 @@ mod tests {
         let since = drift_dt("2026-05-20T04:00:00");
         db.upsert_armed_tier_best_effort("pool-A", TightnessTier::Tight, since);
 
-        let got = db.armed_tier_for_pool("pool-A").unwrap();
+        let got = db.all_armed_tiers().unwrap().get("pool-A").copied();
         assert_eq!(got, Some((TightnessTier::Tight, since)));
     }
 
@@ -3352,7 +3318,7 @@ mod tests {
             .unwrap();
         assert_eq!(count, 1);
         assert_eq!(
-            db.armed_tier_for_pool("pool-A").unwrap(),
+            db.all_armed_tiers().unwrap().get("pool-A").copied(),
             Some((TightnessTier::Critical, bumped))
         );
     }
@@ -3360,7 +3326,7 @@ mod tests {
     #[test]
     fn armed_tier_unknown_pool_is_none() {
         let db = StateDb::open_memory().unwrap();
-        assert_eq!(db.armed_tier_for_pool("nope").unwrap(), None);
+        assert_eq!(db.all_armed_tiers().unwrap().get("nope").copied(), None);
     }
 
     #[test]
@@ -3408,7 +3374,7 @@ mod tests {
                 [],
             )
             .unwrap();
-        assert_eq!(db.armed_tier_for_pool("pool-A").unwrap(), None);
+        assert_eq!(db.all_armed_tiers().unwrap().get("pool-A").copied(), None);
         assert!(db.all_armed_tiers().unwrap().is_empty());
     }
 }

--- a/src/storage_critical.rs
+++ b/src/storage_critical.rs
@@ -34,18 +34,55 @@
 //! *not* shipped here — it belongs with UPIs 032/033 where the safety
 //! scaffolding lands and has a consumer.
 
+use std::collections::HashMap;
+
 use serde::Serialize;
 
 use crate::recommendation::{
     self, FREE_RATIO_CAUTION, FREE_RATIO_PRESSURE, HeadroomSeverity,
 };
+use crate::types::{Interval, LocalRetentionPolicy};
 
 /// Hysteresis level-band (UPI 031-a, D4). A pool de-escalates only once free
 /// recovers to its arm threshold **plus** this band, so a pool hovering at a
 /// tier boundary does not re-notify every run. Crude/load-bearing — revisited
 /// at the ADR-113 30-day checkpoint. Arm thresholds reuse
 /// `FREE_RATIO_PRESSURE` / `FREE_RATIO_CAUTION`; this is the only new constant.
+///
+/// Used for the Tight→Roomy de-escalation step; the Critical→Tight step uses
+/// the wider [`CRITICAL_DEESCALATION_BAND_PP`] (UPI 031-b S1).
 pub const HYSTERESIS_BAND_PP: f64 = 0.05;
+
+/// Wider Critical→Tight de-escalation band (UPI 031-b S1, 2026-05-30 amendment
+/// to 031-a's hysteresis). The clear-all control action at Critical *moves the
+/// controlled variable* (it frees Urd's own footprint), so the +0.05 level band
+/// cannot damp a Critical↔Tight limit cycle when Urd's footprint is the swing
+/// factor (the htpc case). A pool therefore leaves Critical only once free
+/// recovers to the **Caution line** (`FREE_RATIO_PRESSURE + 0.10 = 0.25`, where
+/// the classifier stops calling it tight at all) before shedding the
+/// footprint-cap — the conservative "host wins" bias of the north star. The
+/// deeper dwell-time / `cleanup_budget` treatment is 033 scope.
+pub const CRITICAL_DEESCALATION_BAND_PP: f64 = 0.10;
+
+/// Tight send-interval multiplier (UPI 031-b). At Tight the retain-one pin
+/// survives the whole interval, so a longer interval *increases* footprint;
+/// the factor stays modest so the scaled interval does not eat the 18–30 GB
+/// headroom that makes retain-one safe. Declared-daily → ~36h.
+pub const TIGHT_INTERVAL_FACTOR: f64 = 1.5;
+
+/// Critical send-interval floor in days (UPI 031-b). At Critical clear-all
+/// zeroes between-run footprint, so a weekly full send amortizes cheaply; the
+/// floor is `max(declared, 7d)` so it never *shortens* an already-sparse
+/// subvolume. Built via `Interval::days(7)` (the `Interval` ctors are not
+/// `const fn`).
+pub const CRITICAL_INTERVAL_FLOOR_DAYS: i64 = 7;
+
+/// Planner/executor/awareness-facing map: subvolume name → armed tier (UPI
+/// 031-b). Resolved once pre-plan (`commands/storage_signals::resolve_armed_tiers`)
+/// and threaded into `plan::plan`, the executor, and `awareness::assess`. An
+/// absent key defaults to `Roomy` (`get(..).copied().unwrap_or_default()`) →
+/// declared behavior → zero behavior change (the regression firewall).
+pub type ArmedTierMap = HashMap<String, TightnessTier>;
 
 /// Source-pool tightness, free-ratio only (UPI 031-a). Distinct from
 /// `recommendation::HeadroomSeverity` (a *composite* of free-ratio + trend +
@@ -93,16 +130,14 @@ impl TightnessTier {
 }
 
 impl From<HeadroomSeverity> for TightnessTier {
-    /// `Healthy → Roomy`, `Caution → Tight`, `Pressure`/`Critical → Critical`.
-    /// The composite severity collapses to the free-ratio-only tier; the
-    /// dormant composite `Critical` maps to the tier `Critical`.
+    /// `Healthy → Roomy`, `Caution → Tight`, `Pressure → Critical`.
+    /// The composite severity collapses to the free-ratio-only tier. (The
+    /// composite `Critical` variant was deleted in UPI 031-b, AB5.)
     fn from(sev: HeadroomSeverity) -> Self {
         match sev {
             HeadroomSeverity::Healthy => TightnessTier::Roomy,
             HeadroomSeverity::Caution => TightnessTier::Tight,
-            HeadroomSeverity::Pressure | HeadroomSeverity::Critical => {
-                TightnessTier::Critical
-            }
+            HeadroomSeverity::Pressure => TightnessTier::Critical,
         }
     }
 }
@@ -164,10 +199,11 @@ pub fn host_root(
 ///   than the armed tier (no hysteresis on the way up — danger is surfaced
 ///   at once). The escalation target comes from
 ///   `classify_free_ratio_value` (single source of truth for boundaries — M2).
-/// - **De-escalate stickily**: drop one level at a time, each gated by that
-///   level's arm threshold **+ `HYSTERESIS_BAND_PP`** (Critical→Tight at free
-///   `> 0.20`, Tight→Roomy at free `> 0.30`). A pool can fall two levels in
-///   one run when free recovers past both bands.
+/// - **De-escalate stickily**: drop one level at a time. Critical→Tight is
+///   gated by `FREE_RATIO_PRESSURE + CRITICAL_DEESCALATION_BAND_PP` (free
+///   `> 0.25`, the Caution line — UPI 031-b S1); Tight→Roomy by
+///   `FREE_RATIO_CAUTION + HYSTERESIS_BAND_PP` (free `> 0.30`). A pool can fall
+///   two levels in one run when free recovers past both bands.
 /// - **Unmeasurable** free-ratio (`None`) holds the prior armed tier unchanged.
 #[must_use]
 pub fn resolve_armed_tier(
@@ -189,9 +225,12 @@ pub fn resolve_armed_tier(
 
     // current <= prior_armed: sticky de-escalation, one level at a time, each
     // gated by `arm_threshold + band`. Strict `>` so exactly-at-band holds.
+    // Critical→Tight uses the wider band (031-b S1): clear-all moves the
+    // controlled variable, so the pool must recover to the Caution line before
+    // shedding the footprint-cap, damping the limit cycle toward the safe state.
     let mut armed = prior_armed;
     if armed == TightnessTier::Critical
-        && ratio > FREE_RATIO_PRESSURE + HYSTERESIS_BAND_PP
+        && ratio > FREE_RATIO_PRESSURE + CRITICAL_DEESCALATION_BAND_PP
     {
         armed = TightnessTier::Tight;
     }
@@ -234,6 +273,97 @@ pub fn derive_posture(
     })
 }
 
+/// The tier-adapted operational policy the planner, executor, and awareness all
+/// act on, derived from a subvolume's declared intent and the armed tier (UPI
+/// 031-b, AB2). Carries exactly the three knobs the tier changes (all consumed
+/// this UPI). Paralleling `types::derive_policy`/`DerivedPolicy`, the same tier
+/// in always yields the same policy out — coherence between planner and
+/// awareness rests on both deriving from the *same* armed tier (the single
+/// pre-plan gather, `commands/backup.rs`), not on this function alone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EffectivePolicy {
+    /// Lifecycle the planner dispatches on. Tight/Critical → `Transient`
+    /// (retain-one). The clear-all delta (Critical) is the separate `clear_all`
+    /// flag — it is NOT a lifecycle the planner can express alone (clear-all's
+    /// same-run deletion of the just-sent snapshot is executor-gated for
+    /// ADR-107).
+    pub local_retention: LocalRetentionPolicy,
+    /// Send cadence the planner times against AND awareness judges staleness
+    /// against — they MUST agree or a correctly-adapting subvol shows false
+    /// AT RISK.
+    pub send_interval: Interval,
+    /// Critical only: the subvolume keeps zero local snapshots between runs.
+    /// The planner writes no pin (`pin_on_success: None`); the executor deletes
+    /// the just-sent snapshot + pin after confirming the send (gated).
+    pub clear_all: bool,
+}
+
+/// Derive the tier-adapted [`EffectivePolicy`] from a subvolume's *declared*
+/// intent and the armed tier (UPI 031-b, AB2). Pure — no I/O, no clock (ADR-108).
+///
+/// Takes the three declared fields (not the whole `ResolvedSubvolume`) to keep
+/// `storage_critical` a leaf module and honor the scalar precedent of
+/// `types::derive_policy` (M2).
+///
+/// - `!send_enabled` → declared passes through unchanged (a local-only
+///   subvolume has no ephemeral lifecycle — arc R6).
+/// - **Roomy** → declared lifecycle + declared interval + `clear_all: false`.
+/// - **Tight** → `Transient` (retain-one) + interval × [`TIGHT_INTERVAL_FACTOR`]
+///   + `clear_all: false`.
+/// - **Critical** → `Transient` + `max(declared, CRITICAL_INTERVAL_FLOOR)` +
+///   `clear_all: true`. The floor never *shortens* an already-sparse subvolume.
+#[must_use]
+pub fn derive_effective_policy(
+    declared_retention: &LocalRetentionPolicy,
+    declared_send_interval: Interval,
+    send_enabled: bool,
+    armed: TightnessTier,
+) -> EffectivePolicy {
+    // Local-only: no send, no ephemeral lifecycle. Declared passthrough.
+    if !send_enabled {
+        return EffectivePolicy {
+            local_retention: *declared_retention,
+            send_interval: declared_send_interval,
+            clear_all: false,
+        };
+    }
+
+    match armed {
+        TightnessTier::Roomy => EffectivePolicy {
+            local_retention: *declared_retention,
+            send_interval: declared_send_interval,
+            clear_all: false,
+        },
+        TightnessTier::Tight => EffectivePolicy {
+            local_retention: LocalRetentionPolicy::Transient,
+            send_interval: scale_interval(declared_send_interval, TIGHT_INTERVAL_FACTOR),
+            clear_all: false,
+        },
+        TightnessTier::Critical => {
+            let floor = Interval::days(CRITICAL_INTERVAL_FLOOR_DAYS);
+            // max(declared, floor) — never shorten an already-sparse subvol.
+            let send_interval = if declared_send_interval.as_secs() >= floor.as_secs() {
+                declared_send_interval
+            } else {
+                floor
+            };
+            EffectivePolicy {
+                local_retention: LocalRetentionPolicy::Transient,
+                send_interval,
+                clear_all: true,
+            }
+        }
+    }
+}
+
+/// Scale an interval by a factor, rounding to whole seconds. The tuple field is
+/// private to `Interval`, so the scaled duration is built via `from_chrono`.
+fn scale_interval(interval: Interval, factor: f64) -> Interval {
+    #[allow(clippy::cast_possible_truncation)]
+    let scaled_secs = (interval.as_secs() as f64 * factor) as i64;
+    Interval::from_chrono(chrono::Duration::seconds(scaled_secs))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -252,10 +382,6 @@ mod tests {
         );
         assert_eq!(
             TightnessTier::from(HeadroomSeverity::Pressure),
-            TightnessTier::Critical
-        );
-        assert_eq!(
-            TightnessTier::from(HeadroomSeverity::Critical),
             TightnessTier::Critical
         );
     }
@@ -330,19 +456,24 @@ mod tests {
     #[test]
     fn sticky_hold_critical_below_disarm_band() {
         // Armed Critical, free recovered to 0.18 (classifies Tight) but not
-        // past 0.20 → holds Critical (anti-flap).
+        // past the 0.25 Caution-line band (031-b S1) → holds Critical (anti-flap).
         assert_eq!(
             resolve_armed_tier(TightnessTier::Critical, Some(0.18)),
+            TightnessTier::Critical
+        );
+        // Even at 0.22 — past the old 0.20 band but below the new 0.25 — it holds.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Critical, Some(0.22)),
             TightnessTier::Critical
         );
     }
 
     #[test]
     fn disarm_critical_to_tight_above_band() {
-        // Free recovered to 0.22 (> 0.20) → Critical disarms to Tight, but
-        // 0.22 < 0.30 so it stays Tight.
+        // Free recovered to 0.26 (> 0.25 Caution line, 031-b S1) → Critical
+        // disarms to Tight; 0.26 < 0.30 so it stays Tight.
         assert_eq!(
-            resolve_armed_tier(TightnessTier::Critical, Some(0.22)),
+            resolve_armed_tier(TightnessTier::Critical, Some(0.26)),
             TightnessTier::Tight
         );
     }
@@ -408,15 +539,16 @@ mod tests {
     }
 
     #[test]
-    fn boundary_0_20_critical_disarm_is_strict() {
-        // Exactly 0.20 does NOT clear the Critical→Tight band (strict `>`).
+    fn boundary_0_25_critical_disarm_is_strict() {
+        // Exactly 0.25 does NOT clear the Critical→Tight band (strict `>`,
+        // 031-b S1 wider band).
         assert_eq!(
-            resolve_armed_tier(TightnessTier::Critical, Some(0.20)),
+            resolve_armed_tier(TightnessTier::Critical, Some(0.25)),
             TightnessTier::Critical
         );
         // Just past it disarms.
         assert_eq!(
-            resolve_armed_tier(TightnessTier::Critical, Some(0.2001)),
+            resolve_armed_tier(TightnessTier::Critical, Some(0.2501)),
             TightnessTier::Tight
         );
     }
@@ -499,5 +631,100 @@ mod tests {
                 host_root: true,
             })
         );
+    }
+
+    // ── S1: Critical↔Tight limit-cycle regression (031-b) ────────────────
+
+    #[test]
+    fn critical_held_through_clear_all_until_caution_line() {
+        // S1 limit-cycle guard. A pool entered Critical because of Urd's own
+        // retain-one footprint (the htpc case). clear-all frees that footprint,
+        // lifting free-ratio from ~0.14 (Critical) to ~0.21 — PAST the old 0.20
+        // Critical→Tight band but NOT the new 0.25 Caution-line band. It must
+        // HOLD Critical, or de-escalating to Tight/retain-one re-grows the
+        // footprint and re-escalates (the flap), paying a full send each cycle.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Critical, Some(0.21)),
+            TightnessTier::Critical,
+        );
+        // Only once it clears the Caution line (0.25 free) does it shed the cap.
+        assert_eq!(
+            resolve_armed_tier(TightnessTier::Critical, Some(0.26)),
+            TightnessTier::Tight,
+        );
+    }
+
+    // ── derive_effective_policy matrix (031-b AB2) ───────────────────────
+
+    fn grad() -> LocalRetentionPolicy {
+        LocalRetentionPolicy::Graduated(crate::types::ResolvedGraduatedRetention {
+            hourly: 24,
+            daily: 30,
+            weekly: 26,
+            monthly: crate::types::MonthlyCount::Count(12),
+            yearly: 0,
+        })
+    }
+
+    #[test]
+    fn effective_policy_roomy_is_declared_passthrough() {
+        let eff = derive_effective_policy(&grad(), Interval::days(1), true, TightnessTier::Roomy);
+        assert_eq!(eff.local_retention, grad());
+        assert_eq!(eff.send_interval.as_secs(), Interval::days(1).as_secs());
+        assert!(!eff.clear_all);
+    }
+
+    #[test]
+    fn effective_policy_tight_is_transient_with_scaled_interval() {
+        let eff = derive_effective_policy(&grad(), Interval::days(1), true, TightnessTier::Tight);
+        assert!(eff.local_retention.is_transient());
+        // daily × 1.5 = 36h.
+        assert_eq!(eff.send_interval.as_secs(), 36 * 3600);
+        assert_eq!(eff.send_interval.to_string(), "36h");
+        assert!(!eff.clear_all);
+    }
+
+    #[test]
+    fn effective_policy_critical_is_clear_all_with_floor() {
+        let eff = derive_effective_policy(&grad(), Interval::days(1), true, TightnessTier::Critical);
+        assert!(eff.local_retention.is_transient());
+        // declared daily < 7d floor → floored to weekly.
+        assert_eq!(eff.send_interval.as_secs(), Interval::days(7).as_secs());
+        assert!(eff.clear_all);
+    }
+
+    #[test]
+    fn effective_policy_critical_floor_never_shortens() {
+        // A declared-fortnightly subvol at Critical keeps its 2w interval
+        // (max(declared, 7d) = declared), and still clears all.
+        let declared = "2w".parse::<Interval>().unwrap();
+        let eff = derive_effective_policy(&grad(), declared, true, TightnessTier::Critical);
+        assert_eq!(eff.send_interval.as_secs(), declared.as_secs());
+        assert!(eff.clear_all);
+    }
+
+    #[test]
+    fn effective_policy_declared_transient_at_tight_is_lifecycle_noop_but_lengthens() {
+        // A subvol already Transient stays Transient at Tight (lifecycle no-op)
+        // but the interval is still scaled — Tight always lengthens the cadence.
+        let eff = derive_effective_policy(
+            &LocalRetentionPolicy::Transient,
+            Interval::hours(4),
+            true,
+            TightnessTier::Tight,
+        );
+        assert!(eff.local_retention.is_transient());
+        assert_eq!(eff.send_interval.as_secs(), 6 * 3600); // 4h × 1.5
+        assert!(!eff.clear_all);
+    }
+
+    #[test]
+    fn effective_policy_local_only_is_full_noop_at_every_tier() {
+        for tier in [TightnessTier::Roomy, TightnessTier::Tight, TightnessTier::Critical] {
+            let eff = derive_effective_policy(&grad(), Interval::days(1), false, tier);
+            assert_eq!(eff.local_retention, grad());
+            assert_eq!(eff.send_interval.as_secs(), Interval::days(1).as_secs());
+            assert!(!eff.clear_all, "local-only never clears at {tier:?}");
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,6 +38,15 @@ impl Interval {
         self.0
     }
 
+    /// Wrap a `chrono::Duration` directly. Used by `storage_critical` to build
+    /// the tier-scaled Tight send interval (declared × factor), where the
+    /// duration is computed rather than parsed from a unit string. The tuple
+    /// field is private, so this is the only seam for a computed `Interval`.
+    #[must_use]
+    pub fn from_chrono(d: chrono::Duration) -> Self {
+        Self(d)
+    }
+
     #[must_use]
     pub fn as_secs(&self) -> i64 {
         self.0.num_seconds()

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -451,31 +451,15 @@ pub(super) fn render_reason_line(
 /// role lines (`local:` / `external:`) + optional bursty/named-level
 /// hint lines. Per UPI 044, each role carries severity, an optional
 /// adjustment reason, and an optional tightened shape (`adjusted`).
-/// Critical severity (injected by doctor.rs) suppresses the shape and
-/// hint lines in favor of a single pointer (R9).
+///
+/// (UPI 031-b, AB5: the R9 Critical-pointer branch was deleted with the
+/// dormant `HeadroomSeverity::Critical` variant — `Pressure` pointer-only
+/// recommendations still render via the synth path below.)
 pub(super) fn format_recommendation_row(row: &crate::output::DoctorRecommendationRow) -> String {
     use crate::recommendation::HeadroomSeverity;
 
     let mut out = String::new();
     writeln!(out, "    {}", row.name).ok();
-
-    // R9: if either role is Critical, render only the pointer line.
-    let any_critical = matches!(
-        row.local.as_ref().map(|h| h.severity),
-        Some(HeadroomSeverity::Critical)
-    ) || matches!(
-        row.external.as_ref().map(|h| h.severity),
-        Some(HeadroomSeverity::Critical)
-    );
-    if any_critical {
-        writeln!(
-            out,
-            "      {}",
-            "storage critical — see `urd doctor` for current actions".dimmed()
-        )
-        .ok();
-        return out;
-    }
 
     let mut role_line = |label: &str, h: &crate::recommendation::HeadroomAwareRecommendation| {
         let synth = is_synth_pointer(h);

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -539,6 +539,8 @@ pub(crate) mod test_fixtures {
                     external_only: false,
                     errors: vec![],
                     storage_posture: None,
+                    cadence_adapted: false,
+                    effective_send_interval_secs: None,
                 },
                 StatusAssessment {
                     name: "htpc-docs".to_string(),
@@ -567,6 +569,8 @@ pub(crate) mod test_fixtures {
                     external_only: false,
                     errors: vec![],
                     storage_posture: None,
+                    cadence_adapted: false,
+                    effective_send_interval_secs: None,
                 },
             ],
             chain_health: vec![
@@ -664,6 +668,8 @@ pub(crate) mod test_fixtures {
                 external_only: false,
                 errors: vec![],
                 storage_posture: None,
+                cadence_adapted: false,
+                effective_send_interval_secs: None,
             }],
             transitions: vec![],
             warnings: vec![],
@@ -925,6 +931,56 @@ mod tests {
             head.contains("critically tight"),
             "tight state not in first lines: {head}"
         );
+    }
+
+    #[test]
+    fn status_2am_golden_critical_adapted_reads_as_care_not_failure() {
+        // The 031-b half of the 2am golden test (AB3.1, the R4-overturn
+        // acceptance criterion). A Critical pool slowed Urd to a weekly cadence,
+        // capping the promise to AT RISK *by design*. The first lines must read
+        // as deliberate care — naming the cadence — NOT as a broken backup.
+        use crate::storage_critical::TightnessTier;
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.assessments.truncate(1); // keep only htpc-home (healthy, Protected)
+        data.storage_postures = vec![posture("/", TightnessTier::Critical, true, 1, Some(3600))];
+        let h = &mut data.assessments[0];
+        h.status = PromiseStatus::AtRisk; // capped from Protected
+        h.cadence_adapted = true;
+        h.effective_send_interval_secs = Some(7 * 86400); // weekly
+        // declared-Graduated (external_only stays false) → history-reduced clause.
+
+        let out = render_status(&data, OutputMode::Interactive);
+        let head = out.lines().take(4).collect::<Vec<_>>().join("\n");
+        assert!(head.contains("by design"), "adaptation framing missing from head: {head}");
+        assert!(head.contains("7d"), "named cadence missing from head: {head}");
+        assert!(head.contains("to spare"), "spare-the-drive prose missing: {head}");
+        assert!(
+            !head.contains("chain broken"),
+            "an adapted-but-healthy subvol must not read as a failure: {head}"
+        );
+    }
+
+    #[test]
+    fn status_2am_golden_critical_failing_leads_with_failure_not_adaptation() {
+        // Sibling case: a Critical-pool subvolume that is genuinely failing
+        // (cadence_adapted == false) must NOT get the reassuring "by design"
+        // prose — the failure is the more urgent truth and leads.
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        // htpc-docs (assessments[1]) is AT RISK + degraded (chain broken) in the
+        // fixture. Give it an adapted interval but leave cadence_adapted false.
+        let d = &mut data.assessments[1];
+        d.effective_send_interval_secs = Some(7 * 86400);
+        d.cadence_adapted = false;
+
+        let out = render_status(&data, OutputMode::Interactive);
+        assert!(
+            !out.contains("by design"),
+            "a genuine failure must not be reassured as 'by design': {out}"
+        );
+        let head = out.lines().take(4).collect::<Vec<_>>().join("\n");
+        assert!(head.contains("chain broken"), "failure reason must lead: {head}");
     }
 
     #[test]
@@ -4136,6 +4192,8 @@ mod tests {
             external_only: false,
             errors: vec![],
             storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval_secs: None,
         }
     }
 
@@ -5861,67 +5919,6 @@ mod tests {
     }
 
     #[test]
-    fn format_row_critical_renders_pointer_only() {
-        let _color = color_guard(false);
-        let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
-        let h = crate::recommendation::headroom_aware_pointer_only(
-            &cur,
-            crate::recommendation::ShapeRole::Local,
-            crate::recommendation::HeadroomSeverity::Critical,
-            crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
-        );
-        let view = crate::output::DoctorRecommendationView {
-            header: "h".to_string(),
-            rows: vec![crate::output::DoctorRecommendationRow {
-                name: "containers".to_string(),
-                local: Some(h),
-                external: None,
-                note: None,
-                was_named_level: None,
-            }],
-        };
-        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
-        assert!(
-            out.contains("storage critical"),
-            "Critical pointer line missing: {out}"
-        );
-        assert!(!out.contains("daily="), "no shape at Critical: {out}");
-    }
-
-    #[test]
-    fn format_row_critical_suppresses_bursty_and_named_level_hints() {
-        // R9: Critical severity suppresses both bursty pattern and
-        // was_named_level hints.
-        let _color = color_guard(false);
-        let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
-        let h = crate::recommendation::headroom_aware_pointer_only(
-            &cur,
-            crate::recommendation::ShapeRole::Local,
-            crate::recommendation::HeadroomSeverity::Critical,
-            crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
-        );
-        let view = crate::output::DoctorRecommendationView {
-            header: "h".to_string(),
-            rows: vec![crate::output::DoctorRecommendationRow {
-                name: "containers".to_string(),
-                local: Some(h),
-                external: None,
-                note: Some(crate::recommendation::RecommendationNote::BurstyPattern),
-                was_named_level: Some(crate::types::ProtectionLevel::Sheltered),
-            }],
-        };
-        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
-        assert!(
-            !out.contains("bursty pattern"),
-            "bursty hint must be suppressed at Critical: {out}"
-        );
-        assert!(
-            !out.contains("applying switches to custom"),
-            "named-level hint must be suppressed at Critical: {out}"
-        );
-    }
-
-    #[test]
     fn format_row_per_role_independent_severity() {
         // Local Healthy, External Pressure → Local renders bare,
         // External renders the adjustment.
@@ -5989,31 +5986,6 @@ mod tests {
         let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
         assert!(!out.contains("daily="), "synth must omit shape: {out}");
         assert!(out.contains("shape already at minimum"), "at-MIN message missing: {out}");
-    }
-
-    #[test]
-    fn format_row_synth_critical_emits_pointer_only() {
-        let _color = color_guard(false);
-        let cur = shape(0, 3, 0, crate::types::MonthlyCount::Count(0), 0);
-        let h = crate::recommendation::headroom_aware_pointer_only(
-            &cur,
-            crate::recommendation::ShapeRole::Local,
-            crate::recommendation::HeadroomSeverity::Critical,
-            crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
-        );
-        let view = crate::output::DoctorRecommendationView {
-            header: "h".to_string(),
-            rows: vec![crate::output::DoctorRecommendationRow {
-                name: "transient".to_string(),
-                local: Some(h),
-                external: None,
-                note: None,
-                was_named_level: None,
-            }],
-        };
-        let out = render_doctor(&recommendations_doctor_output(view), OutputMode::Interactive);
-        assert!(out.contains("storage critical"), "pointer line missing: {out}");
-        assert!(!out.contains("daily="), "no shape: {out}");
     }
 
     // ── UPI 042 — MonthlyCount + yearly rendering ───────────────────

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -43,6 +43,13 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
     // ── Summary line ────────────────────────────────────────────────
     render_summary_line(data, &mut out);
 
+    // ── Storage adaptation prose (UPI 031-b AB3.1) ──────────────────
+    // Rendered HIGH (right under the summary, ahead of any routine staleness
+    // line) so a deliberately-slowed Critical subvolume does not read as broken
+    // at 2am. Only adaptation (capped-by-design / honest Tight) speaks here; a
+    // genuine failure is left to lead via the summary and advisories.
+    render_storage_adaptations(data, &mut out);
+
     // ── Storage posture (UPI 031-a) ─────────────────────────────────
     // Told-not-silent: a tight pool is surfaced high, right under the safety
     // summary. Silent when every pool is Roomy.
@@ -174,6 +181,58 @@ pub(super) fn render_summary_line(data: &StatusOutput, out: &mut String) {
     };
 
     writeln!(out, "{safety_part}{health_part}").ok();
+}
+
+/// Render per-subvolume storage-adaptation prose (UPI 031-b AB3.1). When a tight
+/// pool has slowed Urd's cadence (`effective_send_interval_secs` set), explain
+/// it told-not-silent so the slowdown reads as deliberate care, not failure:
+///
+/// - **Critical capped (`cadence_adapted`)** — the promise was dropped to AT RISK
+///   *by design*; say so explicitly, naming the cadence. This is the user-facing
+///   acceptance criterion for the R4 overturn (the 2am golden test).
+/// - **Honest Tight (still `Protected`)** — an informational lengthened-cadence
+///   note; the promise is untouched.
+/// - **Genuine failure** (AT RISK *without* `cadence_adapted`, or UNPROTECTED) —
+///   say nothing here; the failure is the more urgent truth and leads via the
+///   summary/advisories.
+///
+/// A declared-Graduated subvolume (`!external_only`) additionally notes that its
+/// local history was reduced/cleared — full history lives on the drive.
+pub(super) fn render_storage_adaptations(data: &StatusOutput, out: &mut String) {
+    for a in &data.assessments {
+        let Some(secs) = a.effective_send_interval_secs else {
+            continue; // Roomy — declared cadence, nothing to explain.
+        };
+        let cadence = humanize_duration(secs);
+        // Declared-Graduated subvols had graduated local history; the tier
+        // reduced it to retain-one (Tight) or cleared it (Critical).
+        let history = if a.external_only {
+            ""
+        } else {
+            " local history reduced \u{2014} full history is on the drive;"
+        };
+        // Capped-by-design (Critical) appends an explicit "by design"
+        // reassurance; honest Tight (still Protected) gets the bare note; a
+        // genuine failure / UNPROTECTED says nothing here and leads via the
+        // summary instead.
+        let suffix = if a.status == PromiseStatus::AtRisk && a.cadence_adapted {
+            " Reads AT RISK by design, not a failure."
+        } else if a.status == PromiseStatus::Protected {
+            ""
+        } else {
+            continue;
+        };
+        writeln!(
+            out,
+            "{}",
+            format!(
+                "  {}: tight drive \u{2014}{history} backing up every {cadence} to spare it.{suffix}",
+                a.name,
+            )
+            .yellow()
+        )
+        .ok();
+    }
 }
 
 /// Render the per-pool storage-posture lines (UPI 031-a). One line per tight

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -1088,33 +1088,6 @@ mod contract {
 
     // ── UPI 044 — Rule 6 (gravity) + Rule 1 (no falsehoods) ──────────
 
-    fn critical_row(name: &str) -> crate::output::DoctorRecommendationRow {
-        use crate::recommendation::{
-            headroom_aware_pointer_only, AdjustmentReason, HeadroomSeverity, ShapeRole,
-        };
-        use crate::types::{MonthlyCount, ResolvedGraduatedRetention};
-        let cur = ResolvedGraduatedRetention {
-            hourly: 24,
-            daily: 60,
-            weekly: 52,
-            monthly: MonthlyCount::Count(24),
-            yearly: 0,
-        };
-        let h = headroom_aware_pointer_only(
-            &cur,
-            ShapeRole::Local,
-            HeadroomSeverity::Critical,
-            AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
-        );
-        crate::output::DoctorRecommendationRow {
-            name: name.to_string(),
-            local: Some(h),
-            external: None,
-            note: None,
-            was_named_level: None,
-        }
-    }
-
     fn caution_row_low_free(name: &str, free_ratio: f64) -> crate::output::DoctorRecommendationRow {
         use crate::recommendation::{
             AdjustmentReason, CostProjection, HeadroomAwareRecommendation, HeadroomSeverity,
@@ -1161,45 +1134,6 @@ mod contract {
             external: None,
             note: None,
             was_named_level: None,
-        }
-    }
-
-    #[test]
-    fn rule6_critical_severity_row_renders_no_shape_and_no_red() {
-        // Rule 6: gravity calibration. A Critical recommendation row is a
-        // pointer to UPI 031's surface — it must not borrow alarm
-        // semantics (red text, ✗ glyphs) since the loud surface lives
-        // elsewhere.
-        let _color = color_guard(false);
-        let view = crate::output::DoctorRecommendationView {
-            header: "header".to_string(),
-            rows: vec![critical_row("crit-sv")],
-        };
-        let output = render_doctor(
-            &recommendations_doctor_output(view),
-            OutputMode::Interactive,
-        );
-        let stripped = helpers::strip_ansi(&output);
-        // No shape line on the row.
-        assert!(!stripped.contains("daily="), "Critical row leaked shape: {stripped}");
-        // No red SGR escapes on the row line.
-        for line in output.lines() {
-            if line.contains("crit-sv") || line.contains("storage critical") {
-                assert_eq!(
-                    helpers::count_red(line),
-                    0,
-                    "Rule 6 violation: Critical row line uses red: {line}"
-                );
-            }
-        }
-        // No ✗ glyph on the row.
-        for line in stripped.lines() {
-            if line.contains("crit-sv") || line.contains("storage critical") {
-                assert!(
-                    !line.contains('✗'),
-                    "Rule 6 violation: Critical row line uses ✗ glyph: {line}"
-                );
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Makes the storage tightness tier from UPI 031-a *act* on Urd's own footprint instead of only reporting it: the armed tier is resolved once pre-plan and threaded into the planner, executor, and awareness.
- A tight source pool now sheds Urd's local footprint automatically — **Tight** → retain-one parent + 1.5× send-interval; **Critical** → clear-all (drop the pin, full sends, ≈0 steady footprint) + a weekly send-interval floor.
- Awareness judges staleness against the *effective* (adapted) interval and caps the promise at AT RISK while Critical, surfaced told-not-silent in `urd status` as deliberate care ("backing up every 7d to spare it. Reads AT RISK by design, not a failure."). Clear-all deletion routes through the gated transient cleanup (all-sends-succeeded + no-pin-failure + fail-closed re-read, ADR-106/107); pin-removal failure fails open.
- Carries two in-place ADR amendments — ADR-113 (four→three defensive layers, predictive guards retired) and ADR-110 (the AT-RISK cap overturns arc decision R4) — and deletes the now-confirmed-dead `HeadroomSeverity::Critical` machinery (AB5). No metric, heartbeat, on-disk, or config-schema change (Cross-Repo Impact: None).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1520 passed, 0 failed, 3 ignored
- Integration tests: not run (require drives)

🤖 Generated with [Claude Code](https://claude.com/claude-code)