### PR TITLE
docs: slim CLAUDE.md to its load-bearing core; architecture.md authoritative

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,94 +2,75 @@
 
 ## Vision
 
-**Urd** (Old Norse: Urðr) — a BTRFS Time Machine for Linux, written in Rust.
+**Urd** (Old Norse: Urðr) — a BTRFS Time Machine for Linux, written in Rust. Urd
+preserves filesystem history silently and faithfully.
 
-Urd preserves filesystem history silently and faithfully. When invoked, the encounter
-should be pleasant and clear. When Urd demands attention, the user should be glad it did.
+**Design north star.** Every feature must pass three tests: (1) does it make the user's
+data safer? (2) does it reduce the attention the user must spend on backups? (3) does Urd
+do no harm to the host she protects? A backup tool that causes storage pressure or I/O
+contention on the system it protects has failed its promise. When Urd and the host
+conflict, the host wins. Features that add complexity the user must manage need very
+strong justification (ADR-113).
 
-**Design north star:** Every feature must pass three tests: (1) does it make the user's
-data safer? (2) does it reduce the attention the user needs to spend on backups? (3) does
-Urd do no harm to the host she protects? A backup tool that causes storage pressure, I/O
-contention, or other burden on the system it's supposed to protect has failed both its
-job and its promise. When Urd and the host are in conflict, the host wins. If a feature
-adds complexity the user must manage, it needs a very strong justification. See ADR-113.
+**Two modes.** *The invisible worker* runs autonomously (systemd timer ~04:00 + the
+Sentinel daemon for sub-hourly monitoring, drive detection, overdue alerts) — silence
+means data is safe. *The invoked norn* (`urd status`, `urd get`, `urd restore`) speaks
+with authority and clarity, surfacing problems only when they matter.
 
-**Two modes of existence:**
-- **The invisible worker.** Runs autonomously via systemd timer (nightly at ~04:00) and
-  Sentinel daemon (sub-hourly monitoring, drive detection, backup overdue alerts).
-  Silence means data is safe.
-- **The invoked norn.** `urd status`, `urd get`, `urd restore` — the user is consulting Urd.
-  Speaks with authority and clarity. Surfaces problems only when they matter.
-
-**The mythic voice.** Urd's presentation layer carries the character of the norn — evocative
-and grounding. Not cosplay, but a consistent tone. The voice belongs entirely in the
-presentation layer (`voice.rs`), never in config or data structures. Technical details
-remain precise; the framing is mythic.
-
-**Protection promises.** Urd thinks in promises, not operations. The user declares what
-matters; Urd derives the operations. Promise states (PROTECTED / AT RISK / UNPROTECTED)
-are the universal language. Current taxonomy (guarded/protected/resilient) is provisional
-and needs rework — see ADR-110 maturity model.
+**Voice and promises.** The mythic voice (the character of the norn) belongs entirely in
+the presentation layer (`voice/`), never in config or data structures. Urd thinks in
+*promises*, not operations: the user declares what matters; Urd derives the operations.
+Promise states (PROTECTED / AT RISK / UNPROTECTED) are the universal language. Taxonomy
+and full vocabulary: `docs/00-foundation/glossary.md`.
 
 ## Orient Yourself
 
-Read `docs/96-project-supervisor/status.md` first — short current-state document (~50 lines).
-Follow links to `roadmap.md` for priorities and feature tracking.
-See `docs/contributing-internal.md` for documentation structure and conventions.
-
-For controlled vocabulary (promise states, voice labels, protection levels, retention
-tiers, identifier conventions) see `docs/00-foundation/glossary.md`. For a one-screen
-flow diagram of how the modules below connect, see `docs/00-foundation/architecture.md`.
+Read `docs/96-project-supervisor/status.md` first (short current-state doc), then follow
+links: `roadmap.md` (priorities), `registry.md` (UPI → artifacts). For the architecture
+diagram and the authoritative module-responsibility table, see
+`docs/00-foundation/architecture.md`. For controlled vocabulary, see
+`docs/00-foundation/glossary.md`. For documentation structure and conventions, see
+`docs/contributing-internal.md`.
 
 ## Architecture
 
 ### Core Flow
 
 ```
-config  -->  plan (pure function)  -->  execute (I/O)
-                                           |
-                                      btrfs (sudo)
+config  -->  plan (pure function)  -->  execute (I/O)  -->  btrfs (sudo)
 ```
 
-All backup logic flows through: config -> plan -> execute. No exceptions.
+All backup logic flows through config -> plan -> execute. No exceptions.
 
-### Module Responsibilities
+### Modules (compact)
 
-| Module | Does | Does NOT |
-|--------|------|----------|
-| `config.rs` | Parse TOML, validate, expand paths, resolve subvolumes | Touch filesystem beyond path checks |
-| `types.rs` | Domain types, parsing, Display, `derive_policy()` | Contain business logic |
-| `plan.rs` | Decide what operations to run (pure function) | Execute anything or call btrfs |
-| `executor.rs` | Execute planned operations, error isolation | Decide what to do (planner's job) |
-| `btrfs.rs` | Wrap `sudo btrfs` subprocess calls via `BtrfsOps` trait. Read-only generation reads go through the `BtrfsRead` supertrait (`BtrfsOps: BtrfsRead`) so pure planners get a non-mutating seam (ADR-100/101) | Know about retention, plans, config |
-| `observation.rs` | Read-side query seams (UPI 052): `FilesystemQuery` (filesystem of truth), `HistoryQuery` (SQLite history), and `Observation` — the `{ fs, history, btrfs }` bundle threaded through `plan::plan` and `awareness::assess`. Each command-layer caller depends on exactly the query half it uses (UPI 052 complete; the `FileSystemState` bridge is retired) | Perform I/O (defines traits only); decide anything |
-| `retention.rs` | Compute which snapshots to keep/delete (pure) | Delete anything (returns lists) |
-| `awareness.rs` | Pure: observe promise state (PROTECTED / AT RISK / UNPROTECTED) from config + filesystem + history. The "is my data safe right now?" surface | Perform I/O; translate observations into advice (`advice.rs` does that); recommend retention shapes (`recommendation.rs` does that) |
-| `advice.rs` | Pure: translate `SubvolAssessment` into actionable advice (issue/command/reason) and structured redundancy advisories. The "what should the user do?" surface — rule-based, the volatile layer where product refinements land | Perform I/O; assess promise state (`awareness.rs` does that) |
-| `recommendation.rs` | Pure: head-room-aware retention-shape recommendations and cost projections — the advisory layer that translates drift signals + headroom into a recommended shape with reasons (ADR-115, UPI 041) | Perform I/O; assess promise state (`awareness.rs` does that); mutate config; run in the backup hot path |
-| `chain.rs` | Track incremental chain parents (pin files) | Send snapshots |
-| `state.rs` | Record history in SQLite — granular SQL wrappers (one method per query). Also hosts `drift_row_to_sample` (row → `drift::DriftSample` conversion) as a small, shared boundary helper. | Influence backup decisions; compose domain-shaped answers (callers compose primitives inline — see `commands/doctor.rs::compute_churn_for` and `commands/backup.rs::build_churn_views`) |
-| `preflight.rs` | Validate config achievability (pure) | Block backups (advisory only) |
-| `heartbeat.rs` | Write JSON health signal after each run | Block backups on failure |
-| `metrics.rs` | Write Prometheus `.prom` files | Read metrics |
-| `notify.rs` | Compute and dispatch notifications | Decide promise states (uses awareness) |
-| `drift.rs` | Pure: rolling time-windowed churn aggregation from `drift_samples` (UPI 030) | Perform I/O or persist |
-| `drives.rs` | Detect mounted drives, UUID fingerprinting, check space | Mount/unmount drives |
-| `pools.rs` | Detect BTRFS pools (source + destination), group subvolumes by pool UUID, read sysfs metadata utilization and statvfs free bytes | Know about retention, plans, drive lifecycle, or notification policy |
-| `output.rs` | Define structured output types | Render text (voice.rs does that) |
-| `voice/` | Render structured output as text (mythic voice). Per-command sub-modules under `voice/` (`backup.rs`, `calibrate.rs`, `chooser.rs`, `doctor.rs`, `drives.rs`, `emergency.rs`, `get.rs`, `history.rs`, `init.rs`, `plan.rs`, `retention.rs`, `sentinel.rs`, `status.rs`, `verify.rs`) — the UPI 050 per-command split is now complete. Cross-renderer helpers (`humanize_duration`, `exposure_label`, `color_*`, `pluralize`, `classify_verify_checks`, `append_suggestion`/`SuggestionContext`, `format_history_table`, `truncate_str`, `skip_tag`, `aggregate_drive_info`, `unmounted_drive_label`, `format_drive_age_label`, `status_severity`) live in `voice/mod.rs` and are `pub(super)` so sub-modules can use them. Public surface preserved via re-exports — callers continue to use `voice::render_*` unchanged | Perform I/O or compute state |
-| `voice_events.rs` | Per-variant `EventPayload` renderer (columnar + NDJSON) | Perform I/O or query state |
-| `events.rs` | Pure: `Event`, `EventKind`, `EventPayload`, `Severity`, typed payload enums (UPI 036) | Perform I/O |
-| `lock.rs` | Shared advisory lock with metadata (PID, trigger source) | Decide whether to proceed (caller's job) |
-| `sentinel.rs` | Pure state machine for Sentinel daemon (events, actions, circuit breaker) | Perform I/O (sentinel_runner.rs does that) |
-| `storage_critical.rs` | Stub predicate `is_storage_critical(subvolume)` — false in UPI 044; replaced by UPI 031 with its chosen truth source (ADR-115 amendment 2026-05-16) | Decide on critical state (UPI 031's job) |
-| `error.rs` | Error types, `translate_btrfs_error()` for actionable messages | Recovery logic |
-| `commands/` | CLI subcommand handlers (wire pure modules to I/O) | Core logic (delegate to above) |
+One clause each. Full responsibilities table (`Does` / `Does NOT`) and the flow diagram
+live in `docs/00-foundation/architecture.md`.
+
+- `config.rs` — parse/validate TOML, resolve subvolumes
+- `cli.rs` / `cli_validation.rs` — clap command surface / pre-planner input guards
+- `types.rs` — domain types, parsing, `derive_policy()`
+- `plan.rs` — decide operations (pure); `executor.rs` — run them, isolate failures
+- `btrfs.rs` — sole path to `sudo btrfs` (`BtrfsOps: BtrfsRead`)
+- `observation.rs` — read-side query traits (`FilesystemQuery` + `HistoryQuery`)
+- `retention.rs` — which snapshots to keep/delete (pure)
+- `awareness.rs` — promise state ("is my data safe?"); `advice.rs` — what to do about it
+- `recommendation.rs` — headroom-aware retention-shape advice (ADR-115)
+- `storage_critical.rs` — storage-state tiers for the Do-No-Harm arc (ADR-113)
+- `drift.rs` — churn aggregation; `preflight.rs` — achievability advisories
+- `chain.rs` — pin files; `state.rs` — SQLite history (granular wrappers)
+- `drives.rs` / `pools.rs` — drive + BTRFS-pool detection
+- `output.rs` / `voice/` — structured output types / mythic-voice rendering
+- `events.rs` / `voice_events.rs` — typed event payloads / their renderer
+- `notify.rs`, `heartbeat.rs`, `metrics.rs` — notification + health surfaces
+- `lock.rs` — shared advisory lock; `error.rs` — error types + `translate_btrfs_error()`
+- `sentinel.rs` / `sentinel_runner.rs` — daemon state machine (pure) / its I/O wrapper
+- `commands/` — CLI handlers that wire pure modules to I/O
 
 ### Architectural Invariants
 
 These rules are load-bearing. Violating them causes architectural damage that compounds.
-Each references an ADR in `docs/00-foundation/decisions/` with full rationale.
+Each references an ADR in `docs/00-foundation/decisions/`.
 
 1. **The planner never modifies anything.** Pure function: config + state in, plan out. (ADR-100)
 2. **All btrfs calls go through `BtrfsOps`.** No other module spawns btrfs subprocesses. (ADR-101)
@@ -98,250 +79,130 @@ Each references an ADR in `docs/00-foundation/decisions/` with full rationale.
 5. **Retention never deletes pinned snapshots.** Three independent layers: unsent protection, planner exclusion, executor re-check. (ADR-106)
 6. **Backups fail open; deletions fail closed.** Proceed on missing data, never delete what can't be confirmed safe. (ADR-107)
 7. **Core logic modules are pure functions.** Planner, awareness, retention, voice — inputs in, outputs out, no I/O. (ADR-108)
-8. **Validate structure at load time; isolate failures at runtime.** Structural config errors refuse to start. Runtime conditions (unmounted drive, full filesystem) skip per-unit and report. (ADR-109, ADR-111)
-9. **Backward compatibility contracts are sacred.** Snapshot names, pin files, Prometheus metrics — on-disk data format changes require an ADR with migration plan. Config schema changes use `urd migrate`. (ADR-105, ADR-111)
-10. **Named protection levels are opaque or they don't exist.** No per-field overrides on named levels. Custom is first-class. Named levels must earn opaque status through operational track record. (ADR-110, ADR-111)
-
-### Config System (ADR-111)
-
-Tri-parser architecture supporting **legacy**, **v1**, and **v2** schemas. `Config::load()`
-pre-parses `config_version` from `[general]`, then dispatches to `parse_legacy()` (absent),
-`parse_v1()` (`config_version = 1`), or `parse_v2()` (`config_version = 2`). All three
-produce the same internal `Config` struct — v1/v2 synthesize `LocalSnapshotsConfig` and
-`DefaultsConfig` so downstream code is schema-agnostic.
-
-- **Legacy:** `[defaults]`, `[local_snapshots]`, `protection_level`, `short_name` required.
-- **v1:** Self-describing `[[subvolumes]]` with inline `snapshot_root`/`min_free_bytes`,
-  `protection` field (renamed), `short_name` optional (defaults to `name`), no `[defaults]`
-  or `[local_snapshots]`. Named levels are opaque — no operational overrides.
-  `monthly = 0` means "unlimited monthly retention" (v1 contract preserved indefinitely).
-- **v2:** As v1, plus explicit `monthly = "unlimited"` (string) for unbounded monthly
-  retention; new optional `yearly: u32` retention tier. `monthly = 0` is a parse error
-  (v2 closes the v1 footgun at the parse boundary).
-- **`urd migrate`:** Auto-targets latest version. Today: legacy → v2 or v1 → v2 (single
-  hop). Reads raw TOML, builds v2 as string output. Saves backup to `{path}.legacy` or
-  `{path}.v1`. Comments and original formatting are not preserved (`.v1` / `.legacy`
-  backup is the verbatim source of truth).
-- **Example configs:** `config/urd.toml.example` (legacy), `config/urd.toml.v1.example`
-  (v1), `config/urd.toml.v2.example` (v2).
+8. **Validate structure at load time; isolate failures at runtime.** Structural config errors refuse to start; runtime conditions (unmounted drive, full filesystem) skip per-unit and report. (ADR-109, ADR-111)
+9. **Backward-compatibility contracts are sacred.** On-disk data format changes require an ADR with a migration plan; config schema changes use `urd migrate`. (ADR-105, ADR-111)
+10. **Named protection levels are opaque or they don't exist.** No per-field overrides on named levels; custom is first-class. (ADR-110, ADR-111)
 
 ### Error Handling
 
-- `thiserror` for types in `error.rs`; `anyhow` in `main.rs` / CLI layer
-- Individual subvolume failures must NOT abort the entire backup run
-- Failed sends must clean up partial snapshots at the destination
-- SQLite failures must NOT prevent backups (log warning, continue)
-- `translate_btrfs_error()` converts btrfs stderr into actionable `BtrfsErrorDetail`
-
-### UX Principles
-
-- **Invisible worker, invoked norn.** Autonomous operation is silent; invoked interaction
-  is rich and guided. Failures are always impossible to miss.
-- **Answer "is my data safe?"** Every surface should answer this in promise states and
-  plain language — not subvolume IDs.
-- **Guide through affordances, not error messages.** Lead users toward correct choices.
-  Fewer errors, not better errors.
-- **Precision in config, voice in presentation.** Config layer is mechanical and explicit.
-  Mythic voice belongs entirely in `voice.rs` and notifications.
-- **The Sentinel is the integration layer.** Event-driven state machine that reacts to
-  drive events, updates promise states, and drives notifications. Deployed as a systemd
-  user service.
-- **Capture real CLI output during drive operations.** Snapshot, send, swap, fail — saved
-  transcripts of what the user actually sees are the highest-value input to `/steve` and
-  to product-level critique generally. Reviewing strings the user encountered beats
-  reviewing strings the designer hopes the user will encounter.
+- `thiserror` for types in `error.rs`; `anyhow` in `main.rs` / the CLI layer.
+- Subvolume failures must not abort the run; failed sends clean up partial snapshots at
+  the destination; SQLite failures log a warning and continue.
+- `translate_btrfs_error()` converts btrfs stderr into an actionable `BtrfsErrorDetail`.
 
 ## Coding Conventions
 
-- Standard Rust: `snake_case` functions, `CamelCase` types
-- `cargo clippy --all-targets -- -D warnings` (all warnings are errors; `--all-targets` includes test code, which bare clippy skips)
-- `rustfmt` before committing
-- Strong types over primitives: `SnapshotName` not `String`, `Tier` not `u8`
-- `#[must_use]` on functions whose return values matter
-- Derive `Debug` on all types; `Clone`, `PartialEq`, `Eq` where sensible
-- No `unsafe` — no need for it in this project
-- No `unwrap()` / `expect()` in library code — only in tests and `main.rs`
-- Fallback values must be *safe*, not just *convenient*. `unwrap_or(0)` is wrong when 0 is in-range but semantically meaningless (e.g., bytes transferred, age in days). Use `Option` to represent absence.
-- Daemon code (sentinel): lifecycle events use `warn!()` to be visible at default log levels
-- Doc filenames: lowercase kebab-case (exceptions: CLAUDE.md, README.md, CONTRIBUTING.md)
+- Standard Rust: `snake_case` functions, `CamelCase` types.
+- `cargo clippy --all-targets -- -D warnings` (all warnings are errors; `--all-targets` covers test code).
+- `rustfmt` before committing — but do **not** run `cargo fmt` repo-wide (see Project State).
+- Strong types over primitives: `SnapshotName` not `String`, `Tier` not `u8`.
+- `#[must_use]` where return values matter; derive `Debug` everywhere, `Clone`/`PartialEq`/`Eq` where sensible.
+- No `unsafe`. No `unwrap()`/`expect()` in library code (tests and `main.rs` only).
+- Fallback values must be *safe*, not just *convenient*. `unwrap_or(0)` is wrong when 0 is in-range but semantically meaningless (bytes transferred, age in days) — use `Option` for absence.
+- Daemon (sentinel) lifecycle events use `warn!()` to be visible at default log levels.
+- Doc filenames: lowercase kebab-case (exceptions: CLAUDE.md, README.md, CONTRIBUTING.md).
 
 ## Testing
 
-- Unit tests: `#[cfg(test)] mod tests` in same file. Run: `cargo test`
-- Integration tests: `tests/integration/`, `#[ignore]` by default. Run: `cargo test -- --ignored`
-- Use `MockBtrfs` and `MockFileSystemState` for anything that would call btrfs or read filesystem
-- Code using path-constructing functions (`external_snapshot_dir()`, `local_snapshot_dir()`) should also have `tempfile::TempDir` tests — mocks are blind to filesystem preconditions like missing parent directories
-- Test retention logic exhaustively — it protects against data loss
-- When building features, use vertical slicing: write one test, implement to pass, repeat. Never write all tests first then all implementation.
-- **Symmetric fixes need symmetric reviews.** When a bug is rooted in a shared planning or rendering pattern (e.g. "augment local_snaps with planned_snap" in plan.rs), grep for the pattern in adjacent code paths before closing the fix. The May 2 stranded-snapshots incident: commit `0f52555` correctly fixed the transient planner branch in April; the symmetric bug in the non-transient branch went unnoticed for nearly a month. See [2026-05-02-stranded-snapshots-non-transient-planner.md](docs/98-journals/2026-05-02-stranded-snapshots-non-transient-planner.md).
-- 1520+ tests, all passing, clippy clean
+- Unit tests: `#[cfg(test)] mod tests` in-file (`cargo test`). Integration tests in
+  `tests/integration/`, `#[ignore]` by default (`cargo test -- --ignored`).
+- Use `MockBtrfs` / `MockFileSystemState` for anything that would call btrfs or read the
+  filesystem. Path-constructing code should also have `tempfile::TempDir` tests — mocks are
+  blind to filesystem preconditions like missing parent directories.
+- Test retention logic exhaustively — it protects against data loss.
+- Vertical slicing: one test, implement to pass, repeat. Never all tests then all impl.
+- **Symmetric fixes need symmetric reviews.** When a bug is rooted in a shared planning or
+  rendering pattern, grep for the pattern in adjacent code paths before closing the fix
+  (see `docs/98-journals/2026-05-02-stranded-snapshots-non-transient-planner.md`).
+- Comprehensive suite, all passing, clippy clean. (Exact count lives in status.md.)
 
-## Backward Compatibility (ADR-105)
+## Config & Backward Compatibility
 
-These **on-disk data formats** are load-bearing — existing snapshots, monitoring, and pin
-files depend on them. Config schema has separate versioning (ADR-111).
+- **Config (ADR-111):** a tri-parser — legacy (no `config_version`), v1, and v2 — all
+  producing one internal `Config`, so downstream code is schema-agnostic. `urd migrate`
+  auto-targets the latest schema (v2). Mechanics and rationale: ADR-111. Examples:
+  `config/urd.toml.{example,v1.example,v2.example}`.
+- **On-disk contracts (ADR-105) — changes require an ADR + migration plan:** snapshot names
+  (`YYYYMMDD-HHMM-{short_name}`; legacy `YYYYMMDD-{short_name}` parsed as midnight; ordered by
+  datetime), snapshot dirs (`{snapshot_root}/{name}/`), pin files
+  (`.last-external-parent-{DRIVE_LABEL}`), and Prometheus metric names/labels/semantics.
+  Field-level detail: `docs/20-reference/` (cli, metrics, heartbeat-schema).
+- **External interface:** a homelab monitoring stack consumes Urd's metrics + heartbeat.
+  Changes to metric names/labels, the heartbeat schema, systemd unit names, or `.prom` format
+  require a matching update to the homelab's ADR-021. Keep observability monitoring-agnostic —
+  standard Prometheus textfile to a user-configured path, no assumptions about any stack.
+- **Versioning (ADR-112):** SemVer; single source of truth is `Cargo.toml`. `/release` bumps
+  the version, updates CHANGELOG, and tags (user pushes). Pre-1.0: MINOR for features/breaking
+  changes, PATCH for fixes. `schema_version` (output/heartbeat) and `config_version` version
+  their data contracts independently of the app.
 
-1. **Snapshot names:** Legacy `YYYYMMDD-{short_name}` (read-only, parsed as midnight) and
-   current `YYYYMMDD-HHMM-{short_name}` (all new snapshots). Ordering by datetime, not string.
-2. **Snapshot dirs:** `{snapshot_root}/{name}/` — `name` is the directory, `short_name` is
-   in the snapshot name. Both are on-disk contracts.
-3. **Pin files:** `.last-external-parent-{DRIVE_LABEL}` in local snapshot dir
-4. **Prometheus metrics:** exact names, labels, and value semantics must be preserved
+## BTRFS
 
-**Downstream consumer.** A homelab monitoring stack consumes Urd's metrics and heartbeat.
-Changes to the external interface (metric names/labels, heartbeat schema, systemd unit
-names, `.prom` file format) require a corresponding update to the homelab's ADR-021 at
-`~/containers/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md`.
-
-**Public release boundary.** Urd targets general-purpose use on any Linux system with BTRFS.
-Metrics, notifications, and observability features must remain monitoring-agnostic. Urd writes
-standard Prometheus textfile exposition format to a user-configured path — it must not assume
-any specific monitoring stack, alert system, or notification service. Keep homelab-specific
-concerns (specific dashboards, webhooks, alert rules) out of Urd's code and defaults.
-
-## Versioning (ADR-112)
-
-Standard SemVer (`MAJOR.MINOR.PATCH`). Single source of truth: `Cargo.toml` version field.
-
-- **Pre-1.0:** MINOR for features/breaking changes, PATCH for fixes
-- **Post-1.0:** MAJOR for breaking changes (CLI, config, on-disk contracts), MINOR for
-  features, PATCH for fixes
-- **CHANGELOG.md:** Keep a Changelog format. `/commit-push-pr` adds entries to `[Unreleased]`
-  for feat/fix/refactor commits. `/release` moves them to a dated version section.
-- **Git tags:** Annotated tags (`v0.3.0`) on release commits. Dates go in tag annotations.
-- **Release workflow:** `/release patch|minor|major` — bumps Cargo.toml, updates changelog,
-  runs quality gate, commits, and tags. User pushes manually.
-- **Data format versions are independent.** `schema_version` in heartbeat/output and
-  `config_version` (ADR-111) version their data contracts, not the application.
-
-## BTRFS Commands
-
-All operations require `sudo` (scoped via sudoers). The `BtrfsOps` trait wraps:
-
-```
-snapshot -r, send [-p parent], receive, subvolume delete, subvolume show, filesystem show
-```
-
-The send|receive pipeline captures stderr from both sides, checks both exit codes, and
-cleans up partial snapshots on failure. Paths passed as `&Path` to `Command::arg()`, never
-stringified — prevents shell injection and preserves non-UTF-8 paths.
-
-## Dependency Reference
-
-Docs in `docs/00-foundation/source-documentation/` cover current API patterns and migration
-notes for rusqlite 0.39, toml 1.x, nix 0.31, colored 3.x, Rust 2024 edition, and BTRFS.
-Consult when working on code that directly uses these APIs (especially `state.rs`, `config.rs`,
-`lock.rs`). Not needed for domain-level work (retention, awareness, voice, planning).
+All operations require `sudo` (scoped via sudoers). `BtrfsOps` wraps: create read-only
+snapshot, send|receive (optional parent), delete subvolume, check existence, read free
+bytes, sync. The send|receive pipeline captures both sides' stderr, checks both exit codes,
+and cleans up partial snapshots on failure. Paths pass as `&Path` to `Command::arg()`, never
+stringified — prevents shell injection and preserves non-UTF-8 paths. API patterns:
+`docs/00-foundation/source-documentation/btrfs-reference.md`.
 
 ## Build & Run
 
 ```bash
-cargo build                          # Debug
-cargo build --release                # Release
-cargo test                           # Unit tests (1520+ tests)
-cargo test -- --ignored              # Integration tests (needs drives)
-cargo clippy --all-targets -- -D warnings   # Lint (covers test code too)
-cargo check --all-targets            # Fast type-check after mass edits (covers test code; bare `cargo check` does not)
-cargo run -- plan                    # Preview backup plan
-cargo run -- backup --dry-run        # Dry-run
-cargo run -- status                  # Current promise states
-cargo run -- get FILE --at DATE      # Restore file from snapshot
-cargo run -- migrate --dry-run       # Preview legacy → v1 migration
-cargo run -- migrate                 # Migrate config to v1 schema
+cargo build [--release]                      # build
+cargo test [-- --ignored]                    # unit / integration tests
+cargo clippy --all-targets -- -D warnings    # lint (covers test code)
+cargo check --all-targets                    # fast type-check after mass edits
+cargo run -- plan                            # preview backup plan
+cargo run -- backup --dry-run                # dry-run a backup
+cargo run -- status                          # current promise states
+cargo run -- get FILE --at DATE              # restore a file from a snapshot
+cargo run -- migrate [--dry-run]             # migrate config to the latest schema (v2)
 ```
+
+Other subcommands: `history`, `verify`, `init`, `calibrate`, `sentinel`, `drives`,
+`doctor`, `emergency`, `retention-preview`, `events`, `completions`.
 
 ## Configuration
 
 - Config: `~/.config/urd/urd.toml` (override: `--config`)
 - State DB: `~/.local/share/urd/urd.db`
 - Heartbeat: `~/.local/share/urd/heartbeat.json`
-- Example (legacy): `config/urd.toml.example`
-- Example (v1): `config/urd.toml.v1.example`
-- Example (v2): `config/urd.toml.v2.example`
+- Dependency API references (rusqlite, toml, nix, colored, Rust 2024 edition, BTRFS):
+  `docs/00-foundation/source-documentation/` — consult for `state.rs` / `config.rs` /
+  `lock.rs` work; not needed for domain-level work.
 
-## ADR Index
+## ADRs
 
-| ADR | Title | Scope |
-|-----|-------|-------|
-| 100 | Planner/executor separation | Core architecture |
-| 101 | BtrfsOps trait | Btrfs abstraction |
-| 102 | Filesystem truth, SQLite history | State management |
-| 103 | Interval-based scheduling | Snapshot/send timing |
-| 104 | Graduated retention (amended 2026-05-15) | Snapshot lifecycle |
-| 105 | Backward compatibility contracts (amended 2026-05-15) | On-disk data formats |
-| 106 | Defense-in-depth data integrity | Pin protection layers |
-| 107 | Fail-open backups, fail-closed deletions | Error philosophy |
-| 108 | Pure-function module pattern | Module design |
-| 109 | Config-boundary validation | Security/correctness |
-| 110 | Protection promises (amended 2026-05-15) | Promise semantics, maturity model |
-| 111 | Config system architecture (amended 2026-05-15) | Config structure, versioning (target, not yet implemented) |
-| 112 | SemVer and release workflow | Versioning, CHANGELOG, git tags, /release skill |
-| 113 | The Do-No-Harm invariant | Layered, probabilistic defense against Urd-induced host burden |
-| 114 | Structured event log | Typed change-and-decision history; complement to Prometheus gauges and UPI 030 drift_samples |
-| 115 | Retention shape symmetry and the recommendation layer | Symmetric data-cost model + advisory recommendation surface; amends ADR-110 |
+The `docs/00-foundation/decisions/` directory is the index — filenames carry the number and
+title. ADRs are immutable; they evolve by amendment or supersession. The architectural
+invariants above each cite their ADR.
 
-**ADR gating criteria.** An entry earns ADR status when all three of these hold:
-(1) the decision is hard to reverse, (2) the rationale would surprise a reader without
-context, (3) it is the result of a real trade-off among considered alternatives. If a
-decision fails any of the three, it belongs in CLAUDE.md, the design doc, or a journal —
-not in the ADR series. (Adopted from Matt Pocock's `ADR-FORMAT.md`; see
-`docs/99-reports/2026-05-16-skill-ecosystem-review.md` §5 and Doc-1.)
+**ADR gating criteria.** A decision earns ADR status only when all three hold: (1) it is
+hard to reverse, (2) the rationale would surprise a reader without context, (3) it is the
+result of a real trade-off among considered alternatives. If it fails any of the three, it
+belongs in CLAUDE.md, a design doc, or a journal — not the ADR series.
 
 ## Development Workflow
 
-Three tiers based on scope. Use the lightest tier that fits — but when in doubt, tier up.
-The review and stress-test phases (`/grill-me`, `arch-adversary`) consistently surface
-valuable discoveries. Skipping them should be the exception, not the default.
+Three tiers by scope. Use the lightest tier that fits — when in doubt, tier up. The review
+and stress-test phases (`/grill-me`, `arch-adversary`) consistently surface valuable
+discoveries; skipping them should be the exception.
 
-### Patch — bug fixes, small changes, <3 files
+- **Patch** (bug fixes, small changes, <3 files):
+  `systematic-debugging → build → /check → /commit-push-pr → /session-close`
+- **Standard** (medium features, clear scope, no new modules):
+  `/design → /grill-me → /prepare → arch-adversary → /post-review → build → /tidy → /check → /commit-push-pr → /session-close`
+- **Full** (new modules, architectural changes, ADR gates):
+  `/brainstorm → /design → /grill-me → [/sequence] → /prepare → arch-adversary → /post-review → build → /tidy → /check → /commit-push-pr → /session-close`
 
-```
-systematic-debugging → build → /check → /commit-push-pr → /session-close
-```
-
-### Standard — medium features, clear scope, no new modules
-
-```
-/design → /grill-me → /prepare → arch-adversary → /post-review → build → /tidy → /check → /commit-push-pr → /session-close
-```
-
-### Full — new modules, architectural changes, ADR gates
-
-```
-/brainstorm → /design → /grill-me → [/sequence] → /prepare → arch-adversary → /post-review → build → /tidy → /check → /commit-push-pr → /session-close
-```
-
-### Tool reference
-
-| Tool | Phase | What it does |
-|------|-------|--------------|
-| `/brainstorm` | Ideation | Divergent thinking, no scoring. Output: `docs/95-ideas/` |
-| `/design` | Design | Module decomposition, UPI assignment, ADR gate identification |
-| `/grill-me` | Stress-test | Socratic interview, resolve decisions, update design doc |
-| `/sequence` | Sequencing | (Optional) Order reviewed designs by dependencies when multiple are queued |
-| `/prepare` | Planning | Read design + codebase, produce implementation plan in `docs/97-plans/`. No code. |
-| `arch-adversary` | Plan review | Severity-ranked findings on the implementation plan |
-| `/post-review` | Plan revision | Revise the plan to address adversary findings |
-| `build` | Implementation | Execute the reviewed plan |
-| `/tidy` | Post-build | Rust simplification pass: module boundaries, strong types, idiom, control flow (renamed from `/simplify` to avoid the built-in skill) |
-| `test-team` | Testing | Risk-proportional coverage analysis and gap identification |
-| `systematic-debugging` | Diagnosis | Four-phase root cause investigation (any tier, especially patch) |
-| `/check` | Quality gate | `cargo clippy` + `cargo test` + `cargo build --release` |
-| `/commit-push-pr` | Integration | PII scan, CHANGELOG, branch, commit, PR |
-| `/journal` | Any time | Focused journal entry about a specific topic or lesson learned |
-| `/session-close` | Session close | Comprehensive journal + status.md + registry.md updates (always last) |
-| `/release` | Release | SemVer bump, CHANGELOG, tag (user pushes manually) |
-
-**Arc-level grilling for multi-UPI work.** For an arc that will be implemented across
-several UPIs, run a `/grill-me` session against the arc *before* per-UPI design work
-begins. The arc-level grill pins format, naming, and cross-UPI sequencing once;
-subsequent per-UPI grills go faster because the cross-cutting decisions are already
-resolved. Use letters or descriptive names (Branch A, "drive-detection step") for
-to-be-designed pieces — UPI numbers belong to `/design`, not to the grill (lessons §8.6, §8.7).
+Available skills and their descriptions are injected into each session — invoke `/<name>`
+to use one. For a multi-UPI arc, run an arc-level `/grill-me` before per-UPI design so
+format, naming, and cross-UPI sequencing are pinned once.
 
 ## Project State
 
-See `docs/96-project-supervisor/status.md` for current state and what to build next.
-See `docs/96-project-supervisor/roadmap.md` for strategy, sequencing, and horizon.
-See `docs/96-project-supervisor/registry.md` for UPI lookup (work items → artifacts).
-See `docs/contributing-internal.md` for documentation structure, conventions, and privacy rules.
+- `docs/96-project-supervisor/status.md` — current state and what to build next.
+- `docs/96-project-supervisor/roadmap.md` — strategy, sequencing, horizon.
+- `docs/96-project-supervisor/registry.md` — UPI lookup (work items → artifacts).
+- **Do NOT run `cargo fmt` repo-wide** — HEAD was formatted with an older rustfmt; the
+  current version mass-reformats many files. Hand-match the surrounding style instead.

--- a/docs/00-foundation/architecture.md
+++ b/docs/00-foundation/architecture.md
@@ -1,14 +1,14 @@
 # Architecture at a Glance
 
 > **TL;DR:** Urd is a strict pipeline — *config → plan → execute → btrfs* — with a
-> ring of read-only observers (awareness, retention, drift, preflight) and a small
-> set of surfaces (voice, heartbeat, Prometheus, notifications). The planner is
-> pure; the executor is the only place state mutates; every btrfs call funnels
-> through one trait. This page is the orientation diagram and short prose; the
-> module-responsibility table in `CLAUDE.md` and the ADRs in `decisions/` are
-> authoritative for the why.
+> ring of read-only observers (awareness, retention, drift, preflight,
+> recommendation) and a small set of surfaces (voice, heartbeat, Prometheus,
+> notifications). The planner is pure; the executor is the only place state
+> mutates; every btrfs call funnels through one trait. This page is the
+> orientation diagram, the prose that explains it, and the **authoritative
+> module-responsibility table**. The ADRs in `decisions/` are authoritative for
+> the *why*; the ten architectural invariants live in `CLAUDE.md`.
 
-**Date:** 2026-05-02
 **Audience:** Both human readers and Claude sessions. One screen of orientation
 before reading specific modules or ADRs.
 
@@ -18,7 +18,7 @@ before reading specific modules or ADRs.
 flowchart LR
     %% Sources
     cfg["config.rs<br/>parse + validate TOML"]
-    fsstate["FileSystemState<br/>(snapshots, free space, mounts)"]
+    obs["observation.rs<br/>FilesystemQuery + HistoryQuery<br/>(bundled as Observation)"]
     db[("state.rs<br/>SQLite history")]
 
     %% Pure core
@@ -26,10 +26,14 @@ flowchart LR
         direction TB
         plan["plan.rs<br/>decide operations"]
         awareness["awareness.rs<br/>compute promise states"]
+        advice["advice.rs<br/>assessment → advice"]
         retention["retention.rs<br/>which snapshots to drop"]
+        recommendation["recommendation.rs<br/>retention-shape advice"]
         drift["drift.rs<br/>churn aggregation"]
         preflight["preflight.rs<br/>achievability advisories"]
+        storagecrit["storage_critical.rs<br/>storage-state / tier"]
         evpure["events.rs<br/>typed event payloads"]
+        output["output.rs<br/>structured output types"]
     end
 
     %% I/O boundary
@@ -44,7 +48,7 @@ flowchart LR
     %% Surfaces
     subgraph surfaces["Surfaces"]
         direction TB
-        voice["voice.rs<br/>render text (mythic)"]
+        voice["voice/<br/>render text (mythic)"]
         notify["notify.rs<br/>dispatch alerts"]
         heartbeat["heartbeat.rs<br/>JSON health"]
         metrics["metrics.rs<br/>Prometheus .prom"]
@@ -60,7 +64,7 @@ flowchart LR
 
     %% Edges — main pipeline
     cfg --> plan
-    fsstate --> plan
+    obs --> plan
     db --> plan
     plan --> executor
     retention -.consult.-> executor
@@ -71,11 +75,17 @@ flowchart LR
     evpure --> db
 
     %% Edges — observers
-    fsstate --> awareness
+    obs --> awareness
     db --> awareness
     drift --> awareness
     db --> drift
-    awareness --> voice
+    storagecrit --> awareness
+    awareness --> advice
+    awareness --> recommendation
+    advice --> output
+    recommendation --> output
+    awareness --> output
+    output --> voice
     awareness --> notify
     awareness --> heartbeat
     awareness --> metrics
@@ -92,37 +102,87 @@ flowchart LR
 ## How to read it
 
 The diagram is shaped by three architectural rules. Each is load-bearing — the
-ADR in parentheses is the canonical statement.
+ADR in parentheses is the canonical statement (full list of invariants in
+`CLAUDE.md`).
 
-1. **The planner never modifies anything (ADR-100).** `plan.rs` is a pure function
-   from `(config, FileSystemState, history)` to `Vec<PlannedOperation>`. Every
-   skip/proceed decision lives there. The executor trusts the plan — it does not
-   reconsider, only acts. This is why retention, drift, awareness, and preflight
-   sit in the pure box: they feed the planner or the surfaces, but never mutate.
+1. **The planner never modifies anything (ADR-100).** `plan.rs` is a pure
+   function from `(config, Observation)` to `Vec<PlannedOperation>`, where
+   `Observation` bundles the filesystem-of-truth and SQLite-history query traits.
+   Every skip/proceed decision lives there. The executor trusts the plan — it
+   does not reconsider, only acts. This is why retention, drift, awareness,
+   preflight, recommendation, and storage_critical sit in the pure box: they feed
+   the planner or the surfaces, but never mutate.
 
 2. **Every btrfs call goes through one trait (ADR-101).** `BtrfsOps` is the only
-   path to `sudo btrfs`. No other module spawns subprocesses. Tests inject
-   `MockBtrfs`; production injects the real wrapper. The trait is a hard boundary
-   — it makes the executor's blast radius auditable in one file.
+   path to `sudo btrfs`. No other module spawns subprocesses. Read-only
+   generation reads go through the `BtrfsRead` supertrait (`BtrfsOps: BtrfsRead`)
+   so pure planners get a non-mutating seam. Tests inject `MockBtrfs`; production
+   injects the real wrapper. The trait is a hard boundary — it makes the
+   executor's blast radius auditable in one file.
 
 3. **Filesystem is truth, SQLite is history (ADR-102).** Pin files and snapshot
    directories are authoritative for "what exists." The state DB records what
    happened, but a SQLite failure never blocks a backup. This is why `state.rs`
    appears as both an input and an output of the pipeline: callers persist
    best-effort records, and readers (awareness, drift, sentinel) consult them
-   knowing the data may be incomplete.
+   knowing the data may be incomplete. The read-side split lives in
+   `observation.rs`: `FilesystemQuery` for the filesystem-of-truth surface,
+   `HistoryQuery` for the SQLite-history surface.
 
 The ring of pure observers feeds the surfaces without ever touching btrfs.
-`awareness.rs` answers "is my data safe?"; `drift.rs` (UPI 030) aggregates churn
-for the Do-No-Harm arc (ADR-113); `preflight.rs` issues advisories for
+`awareness.rs` answers "is my data safe?"; `advice.rs` answers "what should I do?";
+`recommendation.rs` answers "what retention shape fits my headroom?"; `drift.rs`
+aggregates churn for the Do-No-Harm arc (ADR-113); `storage_critical.rs` derives
+storage-state tiers for the same arc; `preflight.rs` issues advisories for
 unachievable promises. None of them block — they describe.
 
 The sentinel runs as a separate user-space systemd service. Its state machine is
-pure; the runner around it is the only I/O surface. Sentinel does not race with
-the timer-driven backup — the executor takes a shared advisory lock with metadata
-(`lock.rs`) and the sentinel honors it.
+pure (`sentinel.rs`); the runner around it (`sentinel_runner.rs`) is the only I/O
+surface. Sentinel does not race with the timer-driven backup — the executor takes
+a shared advisory lock with metadata (`lock.rs`) and the sentinel honors it.
 
-## What the events table is for (UPI 036, ADR-114)
+## Module responsibilities
+
+The authoritative one-line-per-module reference. Describes each module's *role
+and boundaries* — the code is the source of truth for its function inventory (see
+the documentation convention in `contributing-internal.md`).
+
+| Module | Does | Does NOT |
+|--------|------|----------|
+| `config.rs` | Parse TOML, validate, expand paths, resolve subvolumes | Touch filesystem beyond path checks |
+| `cli.rs` | Define the `clap` command surface (argument parsing) | Contain command logic (`commands/` does that) |
+| `cli_validation.rs` | CLI-boundary guards: resolve a user string to a known config name before the planner, or refuse with help | Run core logic; let unvalidated input reach the planner |
+| `types.rs` | Domain types, parsing, `Display`, `derive_policy()` | Contain business logic |
+| `plan.rs` | Decide what operations to run (pure function) | Execute anything or call btrfs |
+| `executor.rs` | Execute planned operations, isolate errors per subvolume | Decide what to do (the planner's job) |
+| `btrfs.rs` | Wrap `sudo btrfs` calls via `BtrfsOps`; read-only reads via the `BtrfsRead` supertrait (`BtrfsOps: BtrfsRead`) | Know about retention, plans, config |
+| `observation.rs` | Define read-side query traits on the ADR-102 axis: `FilesystemQuery` (filesystem of truth) + `HistoryQuery` (SQLite history), bundled as `Observation` | Perform I/O (traits only); decide anything |
+| `retention.rs` | Compute which snapshots to keep/delete (pure) | Delete anything (returns lists) |
+| `awareness.rs` | Pure: observe promise state (PROTECTED / AT RISK / UNPROTECTED) — the "is my data safe right now?" surface | Perform I/O; translate to advice (`advice.rs`) or recommend shapes (`recommendation.rs`) |
+| `advice.rs` | Pure: translate an assessment into actionable advice (issue/command/reason) and redundancy advisories — the "what should the user do?" surface; the volatile product layer | Perform I/O; assess promise state |
+| `recommendation.rs` | Pure: headroom-aware retention-shape recommendations and cost projections (ADR-115) | Perform I/O; assess promise state; mutate config; run in the backup hot path |
+| `storage_critical.rs` | Pure: storage-state detection for the Do-No-Harm arc (ADR-113) — tightness tier, host-root flag, hysteresis tier resolution, per-subvolume posture, effective-policy derivation | Perform I/O (the command layer resolves the signals at the boundary) |
+| `chain.rs` | Track incremental chain parents (pin files) | Send snapshots |
+| `state.rs` | Record history in SQLite — granular SQL wrappers (one method per query) | Influence backup decisions; compose domain-shaped answers (callers compose primitives) |
+| `preflight.rs` | Validate config achievability (pure, advisory) | Block backups |
+| `heartbeat.rs` | Write JSON health signal after each run | Block backups on failure |
+| `metrics.rs` | Write Prometheus `.prom` files | Read metrics |
+| `notify.rs` | Compute and dispatch notifications (consumes awareness) | Decide promise states |
+| `drift.rs` | Pure: rolling time-windowed churn aggregation from `drift_samples` | Perform I/O or persist |
+| `drives.rs` | Detect mounted drives, UUID fingerprinting, check space | Mount/unmount drives |
+| `pools.rs` | Detect BTRFS pools, group subvolumes by pool UUID, read sysfs/statvfs utilization | Know about retention, plans, drive lifecycle, or notification policy |
+| `output.rs` | Define structured output types | Render text (`voice/` does that) |
+| `voice/` | Render structured output as mythic-voice text; per-command sub-modules, with cross-renderer helpers in `voice/mod.rs` exposed `pub(super)` | Perform I/O or compute state |
+| `voice_events.rs` | Per-variant `EventPayload` renderer (columnar + NDJSON) | Perform I/O or query state |
+| `voice_contract.rs` | Encode the seven-rule voice contract as in-tree tests | Render or compute (test-only) |
+| `events.rs` | Pure: `Event`, `EventKind`, `EventPayload`, `Severity`, typed payload enums | Perform I/O |
+| `lock.rs` | Shared advisory lock with metadata (PID, trigger source) | Decide whether to proceed (the caller's job) |
+| `sentinel.rs` | Pure state machine for the Sentinel daemon (events, actions, circuit breaker) | Perform I/O (`sentinel_runner.rs` does that) |
+| `sentinel_runner.rs` | I/O wrapper around the Sentinel state machine — the daemon's only I/O surface | Make state-machine decisions (`sentinel.rs` does that) |
+| `error.rs` | Error types; `translate_btrfs_error()` for actionable messages | Recovery logic |
+| `commands/` | CLI subcommand handlers (wire pure modules to I/O) | Core logic (delegate to the modules above) |
+
+## What the events table is for (ADR-114)
 
 Prometheus owns gauges (current state over time). The `events` table in SQLite
 owns typed state changes and decisions with rationale: *"retention pruned snapshot
@@ -139,15 +199,13 @@ schema changes never break older readers.
 - **Error translation** (`error.rs::translate_btrfs_error`): turns btrfs stderr
   into actionable `BtrfsErrorDetail`. Sits between btrfs.rs and the surfaces.
 - **Migration** (`urd migrate`): a separate strategy that runs *before* config
-  load (ADR-111). It transforms legacy TOML to v1 TOML; downstream code remains
+  load (ADR-111). It transforms legacy/v1 TOML to v2 TOML; downstream code remains
   schema-agnostic.
 
 ## See also
 
-- **Module responsibilities table:** `CLAUDE.md` "Module Responsibilities" — the
-  authoritative one-line-per-module reference.
-- **Architectural invariants:** `CLAUDE.md` "Architectural Invariants" — the
-  ten load-bearing rules with ADR references.
+- **Architectural invariants:** `CLAUDE.md` "Architectural Invariants" — the ten
+  load-bearing rules with ADR references.
 - **Glossary:** `glossary.md` (this directory) — promise states, voice labels,
   protection levels, retention tiers, identifiers.
-- **ADRs:** `decisions/ADR-100..ADR-114` — the why behind every box and edge.
+- **ADRs:** `decisions/` — the why behind every box and edge.

--- a/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
+++ b/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
@@ -9,8 +9,9 @@
 **Date:** 2026-03-27
 **Revised:** 2026-04-03 (v1 schema specification, vocabulary alignment, field tables,
 migration spec, validation messages)
-**Status:** Accepted — sessions 1-2 implemented (P6a rename, P6b serialize), sessions 3-4
-pending (v1 parser, `urd migrate`)
+**Status:** Accepted — fully implemented. The tri-parser (`parse_legacy` / `parse_v1` /
+`parse_v2` in `config.rs`) and `urd migrate` all ship; see the 2026-05-15 amendment for v2
+(`config_version = 2`).
 **Depends on:** ADR-108 (pure function modules), ADR-109 (config boundary validation)
 **Partially supersedes:** ADR-110 (override semantics replaced; see ADR-110 revision)
 **Modifies:** ADR-103 (defaults inheritance removed), ADR-104 (defaults inheritance removed)


### PR DESCRIPTION
## Summary

- **Slim CLAUDE.md** (reloaded in full every session) from **347 → 208 lines, ~6.1k → ~3.1k tokens (~49% lighter)**. Kept the guardrails (10 invariants), north-star, high-frequency conventions, and tier pipelines; replaced reference blocks with pointers. Dropped the ADR-index table (the `decisions/` dir is the index) and the per-tool table (skill descriptions are injected into every session).
- **Make `architecture.md` the authoritative module reference.** Received the module-responsibility table, rewritten at role+boundary altitude (no helper-function or UPI-history enumerations — the accretion that caused both bloat and staleness). Inverted the See-also so it no longer points back at CLAUDE.md for the table.
- **Fixed staleness surfaced by an audit:** `FileSystemState` → `Observation` (UPI 052) in the diagram and prose; the `storage_critical.rs` row (no longer a stub); omitted modules added; the `BtrfsOps` surface; migrate examples (→ v2); de-hardcoded test count; and ADR-111's stale "sessions 3-4 pending" status (the tri-parser and `urd migrate` are fully implemented).

Rationale and the full section-by-section review live in the (local-only) `docs/99-reports/2026-05-31-claude-md-context-budget-review.md`. A follow-up to realign skill/command doc-instructions that still cite "CLAUDE.md's module table" is tracked locally for a future session.

## Testing

- Docs-only change — no Rust touched; build-inert (no `include_str!` of docs).
- cargo clippy / cargo test: not applicable (skipped per docs workflow).
- Verified every doc path referenced by CLAUDE.md resolves on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)