### PR TITLE
release: v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-06-02
+
 ### Added
 - **Presence-aware graduated pin shedding** (UPI 058, new ADR-116 "Offsite rotation is
   expected absence"). Under storage pressure Urd now sheds an **away** offsite drive's pin

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Cuts **v0.23.0** (minor — feature). Bundles UPI 058: **presence-aware graduated pin shedding** + new **ADR-116 "Offsite rotation is expected absence."**

- Critical `clear-all` is now **presence-conditional** — with an away-only pin, Urd retains-one for the connected chain and sheds the away pin in-run (stateless escalation; byte-identical to v0.22.0 when no away pin exists).
- `emergency_reclaim_pool` (watchdog abort-reclaim / idle eject) is now **two-tier** — away pins first, re-measure against the host-survival floor, blanket only if still demanded.
- Amends 031-b's unconditional Critical clear-all; all ADR-106/107 data-loss gates preserved. No metric/heartbeat/on-disk/config-schema change.

Release diff is the version bump only (Cargo.toml/Cargo.lock/CHANGELOG) — the UPI 058 code merged in #161.

## Testing

- cargo clippy --all-targets -- -D warnings: pass (clean)
- cargo test: 1611 passed, 0 failed, 4 ignored
- cargo check: builds at v0.23.0

After merge: tag `v0.23.0` on the master merge commit, then push the tag (matches v0.22.0 / #160).

🤖 Generated with [Claude Code](https://claude.com/claude-code)