### PR TITLE
feat: role-aware offsite freshness model + rotation view (UPI 055)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Role-aware offsite freshness model + rotation view** (UPI 055, ADR-116). Urd's strongest
+  tier (multi-drive + offsite) no longer reads chronically degraded while an offsite drive is
+  away on its normal rotation rhythm. An offsite drive's absence is now judged against its
+  **rotation cadence** — declared via a new optional `rotation_interval` on the drive block
+  (e.g. `"3mo"`; PRIMARY), the observed median homecoming gap (fallback, ≥3 homecomings), or a
+  30-day default — instead of the send interval. Away **on schedule** → PROTECTED and silent;
+  only a genuinely **overdue** copy degrades health and re-arms the `OffsiteDriveStale`
+  advisory. Introduces the two-clocks distinction: the per-copy promise keys on **data-age**
+  (time since last send), while the health "away" nag keys on **presence-age** (time since the
+  drive was here). The relaxation fires only when a real redundancy peer is currently mounted —
+  a subvolume whose only external drive is an away offsite keeps the honest send-interval
+  judgment, so a missing sole copy is never falsely reported PROTECTED. `Interval` gains `mo`
+  (30d) and `y` (365d) units. No metric/heartbeat field changes, but existing promise/advisory
+  *values* shift (the intended flattened sawtooth) — verify against the homelab's ADR-021 if any
+  alert is calibrated to the old offsite-away-degrades behavior.
+
 ## [0.23.0] - 2026-06-02
 
 ### Added

--- a/config/urd.toml.v2.example
+++ b/config/urd.toml.v2.example
@@ -47,6 +47,11 @@ snapshot_root = ".snapshots"
 role = "offsite"
 max_usage_percent = 90
 min_free_bytes = "500GB"
+# rotation_interval = "3mo"                      # How often this drive comes home
+#   (offsite only). Urd judges its freshness against this cadence, not the send
+#   interval — so a drive away on its normal rhythm reads on-schedule, not
+#   "exposed". Accepts m/h/d/w/mo/y. Omit to use the observed cadence (≥3
+#   homecomings) or a 30-day default.
 
 # ── Protection Promises ──────────────────────────────────────────────────
 #

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -152,9 +152,28 @@ defends against **site loss** and is **intermittently present by design** — it
 absence is the *normal* operating state, not a fault. This duty distinction (ADR-116
 "Offsite rotation is expected absence") is why, under storage pressure, Urd sheds
 an *away* drive's pin before it breaks a *connected* drive's chain (see `shed`),
-and why offsite freshness will be judged against rotation cadence (UPI 055/056).
-The mechanical pressure decision keys on **presence** (here now?), not role
-directly; role governs *expectation and voice*.
+and why offsite freshness is judged against its rotation cadence (UPI 055; the
+richer forecast voice is 056). The mechanical pressure decision keys on
+**presence** (here now?), not role directly; role governs *expectation and voice*.
+
+**The two clocks and the offsite window (UPI 055, ADR-116).** Every external
+copy carries two independent ages; an offsite drive's freshness is judged on its
+cadence, not the send interval.
+
+| Term | Meaning | Source of truth |
+|------|---------|-----------------|
+| **presence-age** | Time since the drive was last physically here (the `away` duration). The health "away" nag keys on this. | `events` drive history — last `Unmount` |
+| **data-age** | Time since the last successful send to the drive (`last_send_age`). The per-copy promise keys on this. | `events`/operations — last successful send |
+| **rotation cadence** | How often an offsite drive comes home. Declared via `rotation_interval` (PRIMARY) or observed as the median completed inter-arrival gap over ≥3 homecomings. | `config` / `rotation::observed_cadence` |
+| **offsite window** | How long an offsite drive may be away before its absence escalates. Resolved per-drive: declared (`×1.25` overdue, `×2.5` stale) → observed (median `×2`, then `×2`) → 30d/60d default. | `rotation::resolve_offsite_window` |
+| `on_schedule` | Age ≤ overdue threshold — the offsite drive is away on its normal rhythm. Per-copy promise → PROTECTED. | `rotation::classify` |
+| `overdue` | Age past overdue but ≤ stale — worth attention. → AT RISK. | `rotation::classify` |
+| `stale` | Age past the stale threshold — genuinely too long. → UNPROTECTED. | `rotation::classify` |
+
+The relaxation that lets an *away* offsite copy read PROTECTED fires only when a
+real redundancy peer (a non-`test` drive) is currently mounted — an offsite drive
+is the *second* line behind a continuously-present primary (ADR-116). A subvolume
+whose only external drive is an away offsite keeps the send-interval judgment.
 
 ## Cluster: Thread
 

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -308,11 +308,6 @@ fn compute_offsite_freshness(drives: &[DriveAssessment]) -> PromiseStatus {
 
 // ── Redundancy advisory computation ────────────────────────────────────
 
-/// Threshold (days) beyond which an offsite drive is considered stale.
-/// Aligned with OFFSITE_AT_RISK_DAYS (enforcement). The old 7-day threshold
-/// was too aggressive for monthly offsite rotation patterns.
-const OFFSITE_STALE_ADVISORY_DAYS: i64 = 30;
-
 /// Compute redundancy advisories from config and assessment state.
 ///
 /// Pure function: config + assessments + now in, advisories out. No I/O.
@@ -372,25 +367,31 @@ pub fn compute_redundancy_advisories(
         };
 
         // ── OffsiteDriveStale ──────────────────────────────────────────
-        // Offsite drive unmounted with last send older than 30-day threshold.
+        // Offsite drive unmounted whose per-copy promise has slipped past
+        // on-schedule. Keyed on the now window-aware `status` (UPI 055, RD4),
+        // not a fixed day threshold: the advisory fires once the copy is overdue
+        // (AtRisk) or stale (Unprotected) relative to its rotation window, and
+        // stays silent for an on-schedule offsite drive. Inherits F1 for free —
+        // `status` already carries the present-peer guard from `assess()`, so a
+        // single-offsite (no peer) away copy reaches this branch via its
+        // send-interval status, and an on-schedule fortified copy does not.
         if subvol.send_enabled {
             for da in &effective_drives {
                 if da.role == DriveRole::Offsite
                     && !da.mounted
+                    && da.status != PromiseStatus::Protected
                     && let Some(age) = da.last_send_age
                 {
                     let days = age.num_days();
-                    if days > OFFSITE_STALE_ADVISORY_DAYS {
-                        advisories.push(RedundancyAdvisory {
-                            kind: RedundancyAdvisoryKind::OffsiteDriveStale,
-                            subvolume: assessment.name.clone(),
-                            drive: Some(da.drive_label.clone()),
-                            detail: format!(
-                                "offsite drive {} last sent {} days ago",
-                                da.drive_label, days,
-                            ),
-                        });
-                    }
+                    advisories.push(RedundancyAdvisory {
+                        kind: RedundancyAdvisoryKind::OffsiteDriveStale,
+                        subvolume: assessment.name.clone(),
+                        drive: Some(da.drive_label.clone()),
+                        detail: format!(
+                            "offsite drive {} last sent {} days ago",
+                            da.drive_label, days,
+                        ),
+                    });
                 }
             }
         }
@@ -800,8 +801,10 @@ drives = ["drive-a", "drive-b"]
 
     #[test]
     fn redundancy_offsite_stale_at_31_days() {
-        
-
+        // Single-offsite (no peer) away + aging: with no present peer the
+        // rotation relaxation is suppressed (F1), so the copy keeps its
+        // send-interval status (Unprotected) and the advisory still fires —
+        // an aging sole offsite copy is genuinely worth surfacing (UPI 055).
         let config = offsite_test_config();
         let now = dt(2026, 4, 1, 12, 0);
         let mut fs = MockFileSystemState::new();
@@ -823,13 +826,23 @@ drives = ["drive-a", "drive-b"]
     }
 
     #[test]
-    fn redundancy_offsite_not_stale_at_29_days() {
-        let config = offsite_test_config();
+    fn redundancy_offsite_within_window_with_peer_no_advisory() {
+        // UPI 055 (re-anchored from `redundancy_offsite_not_stale_at_29_days`).
+        // The advisory now keys on the window-aware per-copy status, not a fixed
+        // 30-day threshold. An offsite drive away *within* its rotation window
+        // with a present primary peer reads on-schedule (Protected) → silent.
+        let config = fortified_config(); // primary-drive (peer) + offsite-drive
         let now = dt(2026, 4, 1, 12, 0);
         let mut fs = MockFileSystemState::new();
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
-        // Offsite drive: last sent 29 days ago, unmounted
+        // Primary peer present and fresh.
+        fs.mounted_drives.insert("primary-drive".to_string());
+        fs.send_times.insert(
+            ("sv1".to_string(), "primary-drive".to_string()),
+            dt(2026, 4, 1, 10, 0),
+        );
+        // Offsite away 29 days — within the 30-day default window.
         fs.send_times.insert(
             ("sv1".to_string(), "offsite-drive".to_string()),
             dt(2026, 3, 3, 12, 0),
@@ -839,8 +852,78 @@ drives = ["drive-a", "drive-b"]
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
-            advisories.is_empty(),
-            "29 days should not trigger offsite stale advisory: {advisories:?}"
+            !advisories
+                .iter()
+                .any(|a| a.kind == RedundancyAdvisoryKind::OffsiteDriveStale),
+            "on-schedule offsite (peer present) must not fire OffsiteDriveStale: {advisories:?}"
+        );
+    }
+
+    #[test]
+    fn redundancy_offsite_source_unchanged_no_advisory() {
+        // UPI 055: a source_unchanged offsite copy reads Protected at any age
+        // (status short-circuit), so `status != Protected` is false → silent.
+        let config = offsite_test_config();
+        let now = dt(2026, 6, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        let pin_snap = snap(dt(2026, 1, 1, 0, 0), "sv1");
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![pin_snap.clone()]);
+        fs.send_times.insert(
+            ("sv1".to_string(), "offsite-drive".to_string()),
+            dt(2026, 1, 2, 0, 0), // 150 days ago
+        );
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "offsite-drive".to_string()),
+            pin_snap.clone(),
+        );
+        let mb = MockBtrfs::new();
+        mb.generations
+            .borrow_mut()
+            .insert(std::path::PathBuf::from("/data/sv1"), 42);
+        mb.generations.borrow_mut().insert(
+            std::path::PathBuf::from(format!("/snap/sv1/{}", pin_snap.as_str())),
+            42,
+        );
+
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new());
+        let advisories = compute_redundancy_advisories(&config, &assessments);
+
+        assert!(
+            !advisories
+                .iter()
+                .any(|a| a.kind == RedundancyAdvisoryKind::OffsiteDriveStale),
+            "source_unchanged offsite must not fire OffsiteDriveStale: {advisories:?}"
+        );
+    }
+
+    #[test]
+    fn redundancy_offsite_overdue_with_peer_fires_advisory() {
+        // UPI 055: an offsite drive *past* its window (overdue → AtRisk) fires
+        // the advisory even with a present peer.
+        let config = fortified_config();
+        let now = dt(2026, 5, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 5, 1, 11, 0), "sv1")]);
+        fs.mounted_drives.insert("primary-drive".to_string());
+        fs.send_times.insert(
+            ("sv1".to_string(), "primary-drive".to_string()),
+            dt(2026, 5, 1, 10, 0),
+        );
+        // Offsite away 45 days — past the 30-day default window.
+        fs.send_times.insert(
+            ("sv1".to_string(), "offsite-drive".to_string()),
+            dt(2026, 3, 17, 12, 0),
+        );
+
+        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let advisories = compute_redundancy_advisories(&config, &assessments);
+
+        assert!(
+            advisories.iter().any(|a| a.kind == RedundancyAdvisoryKind::OffsiteDriveStale
+                && a.drive.as_deref() == Some("offsite-drive")),
+            "overdue offsite must fire OffsiteDriveStale: {advisories:?}"
         );
     }
 

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -476,6 +476,23 @@ pub fn assess(
         })
         .collect();
 
+    // Per-offsite-drive freshness window (UPI 055, ADR-116), computed once.
+    // An offsite drive's absence is expected — judged against its rotation
+    // cadence (declared `rotation_interval` PRIMARY, observed cadence fallback,
+    // 30d default), not the send interval. This is the only new `obs.history`
+    // call in `assess()`; the function stays pure (ADR-108).
+    let offsite_windows: std::collections::HashMap<String, crate::rotation::OffsiteWindow> = config
+        .drives
+        .iter()
+        .filter(|d| d.role == DriveRole::Offsite)
+        .map(|d| {
+            let observed =
+                crate::rotation::observed_cadence(&obs.history.drive_mount_history(&d.label), now);
+            let window = crate::rotation::resolve_offsite_window(d.rotation_interval, observed);
+            (d.label.clone(), window)
+        })
+        .collect();
+
     for subvol in &resolved {
         if !subvol.enabled {
             continue;
@@ -594,6 +611,19 @@ pub fn assess(
                 None => config.drives.iter().collect(),
             };
 
+            // Present-peer guard for the offsite rotation relaxation (F1, UPI
+            // 055). The relaxation that lets an away offsite copy read PROTECTED
+            // is a property of the redundancy *strategy* (ADR-116: offsite is
+            // the second line behind a continuously-present primary), so it
+            // fires only when some other real copy is accessible right now.
+            // Exclude Test drives — a mounted test drive is not a real copy
+            // (matches advice's `role != Test` redundancy filter). Since the
+            // override only fires on a `!mounted` offsite drive, "any non-test
+            // drive in the set mounted" == "a redundancy peer is present".
+            let any_peer_mounted = effective_drives
+                .iter()
+                .any(|d| d.role != DriveRole::Test && obs.fs.is_drive_mounted(d));
+
             for drive in &effective_drives {
                 let mounted = obs.fs.is_drive_mounted(drive);
 
@@ -637,7 +667,7 @@ pub fn assess(
                 // Judge staleness against the EFFECTIVE interval (031-b): a
                 // Critical subvol on a weekly cadence must not read AT RISK at
                 // day 2. eff.send_interval == declared at Roomy (no change).
-                let status =
+                let mut status =
                     assess_external_status(last_send_age, eff.send_interval, source_unchanged);
 
                 if source_unchanged
@@ -656,6 +686,26 @@ pub fn assess(
                         "{}: source unchanged since last send — {coarse} age is expected",
                         drive.label,
                     ));
+                }
+
+                // Offsite rotation relaxation (UPI 055, ADR-116). An offsite
+                // drive away on its normal rhythm is expected absence — judge
+                // its copy against the rotation window on the **data-age** clock
+                // (`last_send_age`, G3), not the send interval. Gated on a
+                // present redundancy peer (F1, R6): without one this offsite is
+                // the only external copy and its absence is genuinely exposing,
+                // so it keeps today's send-interval judgment (→ eventually
+                // Unprotected). Using data-age — not presence-age — keeps a
+                // drive that was briefly home but never refreshed honestly stale
+                // (R3). `source_unchanged` / mounted / never-sent are untouched.
+                if drive.role == DriveRole::Offsite
+                    && !mounted
+                    && !source_unchanged
+                    && any_peer_mounted
+                    && let Some(window) = offsite_windows.get(&drive.label)
+                    && let Some(age) = last_send_age
+                {
+                    status = crate::rotation::classify(age, window).to_promise_status();
                 }
 
                 let (absent_duration_secs, last_activity_age_secs) =
@@ -729,6 +779,7 @@ pub fn assess(
             &subvol.name,
             local_space_tight.is_some(),
             subvol.local_retention.is_transient(),
+            &offsite_windows,
         );
 
         // ── Storage posture (UPI 031-a) ──────────────────────────────
@@ -1055,6 +1106,7 @@ fn compute_health(
     subvol_name: &str,
     local_space_tight: bool,
     is_transient: bool,
+    offsite_windows: &std::collections::HashMap<String, crate::rotation::OffsiteWindow>,
 ) -> (OperationalHealth, Vec<String>) {
     let mut reasons: Vec<String> = Vec::new();
     let mut worst = OperationalHealth::Healthy;
@@ -1167,11 +1219,24 @@ fn compute_health(
         }
     }
 
-    // ── Degraded: configured drive unmounted >7 days ───────────────
+    // ── Degraded: configured drive unmounted too long ──────────────
     // Suppressed when `source_unchanged` for the drive: if the pin generation
     // matches the live source, there is nothing pending to send and the
     // drive's absence is not an operational concern. Mirrors the planner's
     // skip-when-source-unchanged behavior (see issue #120, defect 1).
+    //
+    // The threshold is role-aware (UPI 055, ADR-116): a primary/test drive
+    // still nags after the fixed 7-day wall, but an offsite drive is judged
+    // against its rotation window's overdue threshold — its absence is
+    // expected, not a degradation, until it is genuinely overdue. The nag is
+    // NOT gated on a present peer: an away offsite past *its* window is a
+    // legitimate health signal regardless of redundancy.
+    //
+    // F6 — clock caveat: `cascade_age_source` returns presence-age only when an
+    // `Unmount` event exists, and falls back to data-age (`last_send_age`)
+    // otherwise (an offsite drive carried off without a recorded unmount). The
+    // generous offsite window keeps that fallback safe; the "presence-age for
+    // the nag" framing is the common case, not an absolute.
     for da in drive_assessments {
         if !da.mounted
             && !da.source_unchanged
@@ -1181,7 +1246,17 @@ fn compute_health(
             )
         {
             let age_days = age_secs / 86400;
-            if age_days > DRIVE_AWAY_DEGRADED_DAYS {
+            let threshold = if da.role == DriveRole::Offsite {
+                // Every offsite drive is in the map (built from the same
+                // config.drives); the 30-day default is dead-defensive.
+                offsite_windows
+                    .get(&da.drive_label)
+                    .map(|w| w.overdue_days())
+                    .unwrap_or(30)
+            } else {
+                DRIVE_AWAY_DEGRADED_DAYS
+            };
+            if age_days > threshold {
                 reasons.push(format!(
                     "{} {source_word} for {age_days} days",
                     da.drive_label,
@@ -1830,10 +1905,16 @@ send_enabled = false
         assert_eq!(results[0].external[0].snapshot_count, None);
     }
 
-    // ── Test 10: Multiple drives, best wins ────────────────────────
+    // ── Test 10: Multiple drives, away offsite on schedule (UPI 055) ──
+    // Re-anchored from the pre-055 `multiple_drives_best_wins`: an offsite
+    // drive away 8 days with a present primary peer now reads on-schedule
+    // PROTECTED (within the default 30-day window), not UNPROTECTED. The
+    // max()-across-drives "best wins" reduction is proven by the overdue/stale
+    // siblings below, where the offsite is AtRisk/Unprotected yet overall stays
+    // PROTECTED via the present primary.
 
     #[test]
-    fn multiple_drives_best_wins() {
+    fn offsite_away_within_window_with_peer_reads_protected() {
         let toml_str = r#"
 [general]
 state_db = "/tmp/urd.db"
@@ -1883,7 +1964,7 @@ source = "/data/sv1"
             ("sv1".to_string(), "primary".to_string()),
             dt(2026, 3, 23, 8, 0),
         );
-        // Offsite: old send → UNPROTECTED
+        // Offsite: send 8 days ago — within the default 30-day rotation window.
         fs.send_times.insert(
             ("sv1".to_string(), "offsite".to_string()),
             dt(2026, 3, 15, 8, 0),
@@ -1901,17 +1982,333 @@ source = "/data/sv1"
             .unwrap();
         assert_eq!(primary.status, PromiseStatus::Protected);
 
-        // Offsite is UNPROTECTED
+        // Offsite away 8d with a present peer → on-schedule → PROTECTED
+        // (pre-055 this read UNPROTECTED on the send interval).
         let offsite = &results[0]
             .external
             .iter()
             .find(|d| d.drive_label == "offsite")
             .unwrap();
-        assert_eq!(offsite.status, PromiseStatus::Unprotected);
+        assert_eq!(offsite.status, PromiseStatus::Protected);
 
-        // Overall: max(PROTECTED, UNPROTECTED) = PROTECTED for external,
+        // Overall: max(PROTECTED, PROTECTED) = PROTECTED for external,
         // then min(local=PROTECTED, external=PROTECTED) = PROTECTED
         assert_eq!(results[0].status, PromiseStatus::Protected);
+    }
+
+    // ── UPI 055: role-aware offsite rotation model ─────────────────────
+
+    /// Primary ("primary") + offsite ("offsite") config; the offsite drive
+    /// carries `rotation_interval` when `offsite_rotation` is Some.
+    fn primary_plus_offsite_config(offsite_rotation: Option<&str>) -> Config {
+        let ri = offsite_rotation
+            .map(|r| format!("rotation_interval = \"{r}\"\n"))
+            .unwrap_or_default();
+        let toml_str = format!(
+            r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [{{ path = "/snap", subvolumes = ["sv1"] }}]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "primary"
+mount_path = "/mnt/primary"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[drives]]
+label = "offsite"
+mount_path = "/mnt/offsite"
+snapshot_root = ".snapshots"
+role = "offsite"
+{ri}
+[[subvolumes]]
+name = "sv1"
+short_name = "sv1"
+source = "/data/sv1"
+"#
+        );
+        toml::from_str(&toml_str).expect("primary+offsite config parses")
+    }
+
+    #[test]
+    fn offsite_away_overdue_with_peer_at_risk_overall_protected() {
+        // Offsite away 45 days (past the 30d default overdue, within 60d stale)
+        // with a present primary peer → AtRisk per-copy, but overall stays
+        // PROTECTED via the fresh primary — the max()-across-drives best-wins
+        // reduction is preserved.
+        let config = primary_plus_offsite_config(None);
+        let now = dt(2026, 5, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 5, 1, 11, 30), "sv1")]);
+        fs.mounted_drives.insert("primary".to_string());
+        fs.send_times
+            .insert(("sv1".to_string(), "primary".to_string()), dt(2026, 5, 1, 8, 0));
+        fs.send_times.insert(
+            ("sv1".to_string(), "offsite".to_string()),
+            dt(2026, 3, 17, 12, 0), // 45 days before now
+        );
+
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let offsite = results[0].external.iter().find(|d| d.drive_label == "offsite").unwrap();
+        assert_eq!(offsite.status, PromiseStatus::AtRisk);
+        assert_eq!(results[0].status, PromiseStatus::Protected);
+    }
+
+    #[test]
+    fn offsite_away_stale_with_peer_unprotected_overall_protected() {
+        // Offsite away 90 days (past the 60d stale) → Unprotected per-copy;
+        // overall still PROTECTED via the present primary (best wins).
+        let config = primary_plus_offsite_config(None);
+        let now = dt(2026, 6, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 6, 1, 11, 30), "sv1")]);
+        fs.mounted_drives.insert("primary".to_string());
+        fs.send_times
+            .insert(("sv1".to_string(), "primary".to_string()), dt(2026, 6, 1, 8, 0));
+        fs.send_times.insert(
+            ("sv1".to_string(), "offsite".to_string()),
+            dt(2026, 3, 3, 12, 0), // 90 days before now
+        );
+
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let offsite = results[0].external.iter().find(|d| d.drive_label == "offsite").unwrap();
+        assert_eq!(offsite.status, PromiseStatus::Unprotected);
+        assert_eq!(results[0].status, PromiseStatus::Protected);
+    }
+
+    #[test]
+    fn single_offsite_away_changed_source_not_protected() {
+        // F1/R6 — the catastrophic-mode guard. A subvolume whose ONLY external
+        // drive is an away offsite, with a changed source, must NOT read
+        // PROTECTED: no present peer → the rotation relaxation is suppressed and
+        // the copy keeps today's send-interval judgment (UNPROTECTED). Contrast
+        // with `offsite_away_within_window_with_peer_reads_protected`, where the
+        // identical 8-day absence reads PROTECTED *because* a primary is present.
+        let config = offsite_test_config(); // single offsite drive "offsite-drive"
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        // Offsite away (not mounted), sent 8 days ago — inside a rotation
+        // window, but with no peer present there is no relaxation.
+        fs.send_times.insert(
+            ("sv1".to_string(), "offsite-drive".to_string()),
+            dt(2026, 3, 15, 8, 0),
+        );
+
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let offsite = results[0].external.iter().find(|d| d.drive_label == "offsite-drive").unwrap();
+        assert_ne!(offsite.status, PromiseStatus::Protected);
+        assert_eq!(offsite.status, PromiseStatus::Unprotected);
+        // The only external copy is exposed → overall UNPROTECTED.
+        assert_eq!(results[0].status, PromiseStatus::Unprotected);
+    }
+
+    #[test]
+    fn source_unchanged_offsite_protected_at_any_age_even_without_peer() {
+        // Regression guard: the source_unchanged override is load-bearing and
+        // untouched. An unchanged offsite copy reads PROTECTED at any age, even
+        // with no present peer (the subvol5-music case) — the rotation override
+        // carries !source_unchanged, so it never overrides this.
+        let config = offsite_test_config();
+        let now = dt(2026, 6, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        let pin_snap = snap(dt(2026, 1, 1, 0, 0), "sv1");
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![pin_snap.clone()]);
+        // Offsite away, last send 150 days ago — but the source is unchanged.
+        fs.send_times.insert(
+            ("sv1".to_string(), "offsite-drive".to_string()),
+            dt(2026, 1, 2, 0, 0),
+        );
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "offsite-drive".to_string()),
+            pin_snap.clone(),
+        );
+        let mb = MockBtrfs::new();
+        mb.generations
+            .borrow_mut()
+            .insert(std::path::PathBuf::from("/data/sv1"), 42);
+        mb.generations.borrow_mut().insert(
+            std::path::PathBuf::from(format!("/snap/sv1/{}", pin_snap.as_str())),
+            42,
+        );
+
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new());
+        let offsite = results[0].external.iter().find(|d| d.drive_label == "offsite-drive").unwrap();
+        assert!(offsite.source_unchanged, "pin generation matches source");
+        assert_eq!(offsite.status, PromiseStatus::Protected);
+    }
+
+    #[test]
+    fn never_sent_offsite_unprotected_even_with_peer() {
+        // Regression guard: a never-sent offsite copy stays UNPROTECTED — the
+        // override requires last_send_age.is_some(), so it cannot manufacture a
+        // PROTECTED for a copy that was never created, even with a peer present.
+        let config = primary_plus_offsite_config(None);
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 3, 23, 13, 30), "sv1")]);
+        fs.mounted_drives.insert("primary".to_string());
+        fs.send_times
+            .insert(("sv1".to_string(), "primary".to_string()), dt(2026, 3, 23, 8, 0));
+        // No send to offsite ever.
+
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let offsite = results[0].external.iter().find(|d| d.drive_label == "offsite").unwrap();
+        assert_eq!(offsite.status, PromiseStatus::Unprotected);
+    }
+
+    #[test]
+    fn failed_home_window_uses_data_age_not_presence_age() {
+        // R3/G3 — per-copy status keys on DATA-age, not presence-age. An offsite
+        // drive physically here as recently as 1h ago (tiny presence-age) but
+        // whose copy was last refreshed 90 days ago (large data-age) must read
+        // UNPROTECTED: the override classifies on last_send_age.
+        use crate::types::{DriveEvent, DriveEventKind};
+        let config = primary_plus_offsite_config(None);
+        let now = dt(2026, 6, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 6, 1, 11, 30), "sv1")]);
+        fs.mounted_drives.insert("primary".to_string());
+        fs.send_times
+            .insert(("sv1".to_string(), "primary".to_string()), dt(2026, 6, 1, 8, 0));
+        // Offsite unmounted 1h ago (presence-age tiny) but last send 90d ago.
+        fs.drive_events.insert(
+            "offsite".to_string(),
+            DriveEvent { kind: DriveEventKind::Unmount, at: dt(2026, 6, 1, 11, 0) },
+        );
+        fs.send_times.insert(
+            ("sv1".to_string(), "offsite".to_string()),
+            dt(2026, 3, 3, 12, 0), // 90 days
+        );
+
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let offsite = results[0].external.iter().find(|d| d.drive_label == "offsite").unwrap();
+        assert_eq!(
+            offsite.status,
+            PromiseStatus::Unprotected,
+            "data-age (90d) must govern the per-copy status, not the 1h presence-age"
+        );
+    }
+
+    #[test]
+    fn offsite_away_within_window_health_stays_healthy() {
+        // compute_health: an offsite drive away *within* its window does NOT
+        // degrade health — this is the collapse of the 7-subvolume "degraded —
+        // away" wall. Models `health_drive_away_recent_other_mounted` but pushes
+        // D2 (offsite) to 20 days, still inside the 30-day default window.
+        let config = test_config_two_drives(); // D1 primary, D2 offsite
+        let now = dt(2026, 3, 23, 14, 0);
+        let mut fs = MockFileSystemState::new();
+        let pin_snap = snap(dt(2026, 3, 23, 12, 0), "sv1");
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![pin_snap.clone(), snap(dt(2026, 3, 23, 13, 30), "sv1")],
+        );
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![pin_snap.clone()]);
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "D1".to_string()),
+            pin_snap,
+        );
+        fs.send_times
+            .insert(("sv1".to_string(), "D1".to_string()), dt(2026, 3, 23, 12, 0));
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/d1"), 1_000_000_000_000);
+        // D2 offsite, away 20 days (< 30d default window).
+        fs.send_times
+            .insert(("sv1".to_string(), "D2".to_string()), dt(2026, 3, 3, 12, 0));
+
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        assert_eq!(
+            results[0].health,
+            OperationalHealth::Healthy,
+            "reasons: {:?}",
+            results[0].health_reasons
+        );
+        assert!(!results[0].health_reasons.iter().any(|r| r.contains("D2")));
+    }
+
+    #[test]
+    fn offsite_away_past_window_health_degrades() {
+        // compute_health: an offsite drive away *past* its window degrades
+        // health (just later than the 7-day primary wall). D2 (offsite) at 45
+        // days exceeds the 30-day default → "away" reason fires.
+        let config = test_config_two_drives();
+        let now = dt(2026, 5, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        let pin_snap = snap(dt(2026, 5, 1, 10, 0), "sv1");
+        fs.local_snapshots.insert(
+            "sv1".to_string(),
+            vec![pin_snap.clone(), snap(dt(2026, 5, 1, 11, 30), "sv1")],
+        );
+        fs.mounted_drives.insert("D1".to_string());
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![pin_snap.clone()]);
+        fs.pin_files.insert(
+            (std::path::PathBuf::from("/snap/sv1"), "D1".to_string()),
+            pin_snap,
+        );
+        fs.send_times
+            .insert(("sv1".to_string(), "D1".to_string()), dt(2026, 5, 1, 10, 0));
+        fs.free_bytes
+            .insert(std::path::PathBuf::from("/mnt/d1"), 1_000_000_000_000);
+        // D2 offsite, away 45 days (> 30d default window).
+        fs.send_times
+            .insert(("sv1".to_string(), "D2".to_string()), dt(2026, 3, 17, 12, 0));
+
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        assert_eq!(results[0].health, OperationalHealth::Degraded);
+        assert!(
+            results[0].health_reasons.iter().any(|r| r.contains("D2") && r.contains("45 days")),
+            "expected a D2 away-45-days reason, got: {:?}",
+            results[0].health_reasons
+        );
+    }
+
+    #[test]
+    fn declared_rotation_interval_widens_window() {
+        // The declared rotation_interval governs (RD1): a quarterly drive away
+        // 100 days is still on-schedule (overdue ≈ 112d) → PROTECTED, where the
+        // 30-day default would have read it Unprotected.
+        let config = primary_plus_offsite_config(Some("3mo"));
+        let now = dt(2026, 6, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 6, 1, 11, 30), "sv1")]);
+        fs.mounted_drives.insert("primary".to_string());
+        fs.send_times
+            .insert(("sv1".to_string(), "primary".to_string()), dt(2026, 6, 1, 8, 0));
+        // Offsite last sent 100 days ago — past the 30d default, but inside the
+        // declared quarterly window (overdue ≈ 112d).
+        fs.send_times.insert(
+            ("sv1".to_string(), "offsite".to_string()),
+            dt(2026, 2, 21, 12, 0), // 100 days before now
+        );
+
+        let results = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let offsite = results[0].external.iter().find(|d| d.drive_label == "offsite").unwrap();
+        assert_eq!(offsite.status, PromiseStatus::Protected);
     }
 
     // ── Test 11: Overall min of local and best external ────────────
@@ -3443,7 +3840,11 @@ send_enabled = false
         // Space tight: 105GB free, 100GB min
         fs.free_bytes
             .insert(std::path::PathBuf::from("/mnt/d1"), 105_000_000_000);
-        // D2 unmounted, >7 days
+        // D2 (offsite) unmounted, last send 13 days ago. Post-UPI-055 this is
+        // *within* the 30-day default rotation window, so it no longer
+        // contributes an "away" reason — the >= 2 reasons below come from the
+        // chain-broken + space-tight conditions on D1, which is what this test
+        // is really about (multiple reasons collected, not the away nag).
         fs.send_times.insert(
             ("sv1".to_string(), "D2".to_string()),
             dt(2026, 3, 10, 12, 0),
@@ -3453,7 +3854,8 @@ send_enabled = false
         assert_eq!(results[0].health, OperationalHealth::Degraded);
         assert!(results[0].health_reasons.len() >= 2, "expected multiple reasons, got: {:?}", results[0].health_reasons);
         assert!(results[0].health_reasons.iter().any(|r| r.contains("chain broken")));
-        // Either space tight or drive away, depending on config
+        // The two reasons are chain-broken on D1 and space-tight on D1 (the
+        // D2-away reason no longer fires at 13 days < 30-day window).
     }
 
     #[test]

--- a/src/commands/drives.rs
+++ b/src/commands/drives.rs
@@ -210,6 +210,7 @@ mod tests {
             role: DriveRole::Test,
             max_usage_percent: None,
             min_free_bytes: None,
+            rotation_interval: None,
         }
     }
 
@@ -368,6 +369,7 @@ mod tests {
             role: DriveRole::Test,
             max_usage_percent: None,
             min_free_bytes: None,
+            rotation_interval: None,
         };
 
         let availability = drive_availability(&drive);

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,6 +91,14 @@ pub struct DriveConfig {
     pub max_usage_percent: Option<u8>,
     #[serde(default)]
     pub min_free_bytes: Option<ByteSize>,
+    /// How often this offsite drive comes home (UPI 055, ADR-116). The
+    /// declared rotation cadence — judged against, not the send interval — so
+    /// an offsite drive away on its normal rhythm reads on-schedule, not
+    /// "exposed". Additive-optional (no `urd migrate`): legacy/v1/v2 all accept
+    /// its absence, mirroring `min_free_bytes`. Meaningful only for
+    /// `role = "offsite"`; on other roles preflight warns and it is ignored.
+    #[serde(default)]
+    pub rotation_interval: Option<Interval>,
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
@@ -1401,6 +1409,56 @@ mod tests {
     fn expand_tilde_absolute() {
         let expanded = expand_tilde(Path::new("/usr/bin/btrfs"));
         assert_eq!(expanded, PathBuf::from("/usr/bin/btrfs"));
+    }
+
+    // ── rotation_interval (UPI 055) ──────────────────────────────────────
+
+    /// `DriveConfig` is the single struct shared by the legacy, V1, and V2
+    /// parsers (`Config.drives`, `V1Config.drives`, `V2Config.drives` are all
+    /// `Vec<DriveConfig>`), so a `#[serde(default)]` optional field is accepted
+    /// — present or absent — across every schema. This test exercises both the
+    /// parsed-value and the absent-defaults-to-None paths on a legacy config.
+    #[test]
+    fn rotation_interval_parses_when_present_and_defaults_to_none() {
+        let with_field = r#"
+[general]
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = [{ path = "/snap", subvolumes = ["sv1"] }]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[drives]]
+label = "offsite"
+mount_path = "/mnt/offsite"
+snapshot_root = ".snapshots"
+role = "offsite"
+rotation_interval = "3mo"
+
+[[subvolumes]]
+name = "sv1"
+short_name = "sv1"
+source = "/data/sv1"
+"#;
+        let config: Config = toml::from_str(with_field).expect("parse with field");
+        assert_eq!(
+            config.drives[0].rotation_interval,
+            Some("3mo".parse().unwrap())
+        );
+
+        // Same config without the field → None (additive-optional default).
+        let without_field = with_field.replace("rotation_interval = \"3mo\"\n", "");
+        let config: Config = toml::from_str(&without_field).expect("parse without field");
+        assert_eq!(config.drives[0].rotation_interval, None);
     }
 
     #[test]

--- a/src/drives.rs
+++ b/src/drives.rs
@@ -395,6 +395,7 @@ mod tests {
             role: DriveRole::Primary,
             max_usage_percent: Some(90),
             min_free_bytes: None,
+            rotation_interval: None,
         }
     }
 
@@ -436,6 +437,7 @@ mod tests {
             role: DriveRole::Test,
             max_usage_percent: None,
             min_free_bytes: None,
+            rotation_interval: None,
         };
         assert_eq!(drive_availability(&drive), DriveAvailability::Available);
     }
@@ -451,6 +453,7 @@ mod tests {
             role: DriveRole::Test,
             max_usage_percent: None,
             min_free_bytes: None,
+            rotation_interval: None,
         };
         match drive_availability(&drive) {
             DriveAvailability::UuidMismatch { expected, found } => {
@@ -474,6 +477,7 @@ mod tests {
                 role: DriveRole::Test,
                 max_usage_percent: None,
                 min_free_bytes: None,
+                rotation_interval: None,
             };
             assert_eq!(drive_availability(&drive), DriveAvailability::Available);
         }
@@ -492,6 +496,7 @@ mod tests {
                 role: DriveRole::Test,
                 max_usage_percent: None,
                 min_free_bytes: None,
+                rotation_interval: None,
             };
             assert_eq!(drive_availability(&drive), DriveAvailability::Available);
         }
@@ -511,6 +516,7 @@ mod tests {
             role: DriveRole::Test,
             max_usage_percent: None,
             min_free_bytes: None,
+            rotation_interval: None,
         }
     }
 
@@ -570,6 +576,7 @@ mod tests {
             role: DriveRole::Test,
             max_usage_percent: None,
             min_free_bytes: None,
+            rotation_interval: None,
         };
 
         write_drive_token(&drive, "tok-123").unwrap();
@@ -667,6 +674,7 @@ mod tests {
                 role: DriveRole::Primary,
                 max_usage_percent: None,
                 min_free_bytes: None,
+                rotation_interval: None,
             },
             DriveConfig {
                 label: "WD-18TB1".to_string(),
@@ -676,6 +684,7 @@ mod tests {
                 role: DriveRole::Primary,
                 max_usage_percent: None,
                 min_free_bytes: None,
+                rotation_interval: None,
             },
         ];
 
@@ -699,6 +708,7 @@ mod tests {
                 role: DriveRole::Primary,
                 max_usage_percent: None,
                 min_free_bytes: None,
+                rotation_interval: None,
             },
             DriveConfig {
                 label: "2TB-backup".to_string(),
@@ -708,6 +718,7 @@ mod tests {
                 role: DriveRole::Primary,
                 max_usage_percent: None,
                 min_free_bytes: None,
+                rotation_interval: None,
             },
         ];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod preflight;
 mod recommendation;
 mod reserve;
 mod retention;
+mod rotation;
 mod sentinel;
 mod sentinel_runner;
 mod state;

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -91,6 +91,12 @@ pub trait HistoryQuery {
     /// None if no event recorded (drive never seen by sentinel).
     fn last_drive_event(&self, drive_label: &str) -> Option<DriveEvent>;
 
+    /// Full ordered (oldest-first) mount/unmount history for a drive, from the
+    /// `events` table (`kind='drive'`). The rotation view (UPI 055) derives the
+    /// observed cadence from this stream. Empty when no events exist or the
+    /// query fails — never blocks assessment (ADR-102).
+    fn drive_mount_history(&self, drive_label: &str) -> Vec<DriveEvent>;
+
     /// Most recent successful send timestamp for this drive (any subvolume).
     /// None when no successful send has ever completed for this drive.
     fn last_successful_operation_at(&self, drive_label: &str) -> Option<NaiveDateTime>;

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1503,23 +1503,22 @@ impl HistoryQuery for RealFileSystemState<'_> {
         let record = self
             .state
             .and_then(|db| db.last_drive_connection(drive_label).ok().flatten())?;
-        let kind = match record.event_type.as_str() {
-            "mounted" => DriveEventKind::Mount,
-            "unmounted" => DriveEventKind::Unmount,
-            other => {
-                log::warn!("unknown drive_connections.event_type {other:?} — ignoring");
-                return None;
-            }
+        drive_record_to_event(&record)
+    }
+
+    fn drive_mount_history(&self, drive_label: &str) -> Vec<DriveEvent> {
+        // No state DB (e.g. SQLite open failed) → empty history, never blocks
+        // (ADR-102). Unparseable rows are dropped by `drive_record_to_event`.
+        let Some(db) = self.state else {
+            return Vec::new();
         };
-        let at = chrono::NaiveDateTime::parse_from_str(&record.timestamp, "%Y-%m-%dT%H:%M:%S")
-            .inspect_err(|e| {
-                log::warn!(
-                    "failed to parse drive_connections.timestamp {:?}: {e}",
-                    record.timestamp
-                );
-            })
-            .ok()?;
-        Some(DriveEvent { kind, at })
+        match db.drive_connection_history(drive_label) {
+            Ok(records) => records.iter().filter_map(drive_record_to_event).collect(),
+            Err(e) => {
+                log::warn!("drive_connection_history failed for {drive_label}: {e}");
+                Vec::new()
+            }
+        }
     }
 
     fn last_successful_operation_at(&self, drive_label: &str) -> Option<NaiveDateTime> {
@@ -1529,6 +1528,30 @@ impl HistoryQuery for RealFileSystemState<'_> {
                 .flatten()
         })
     }
+}
+
+/// Map a persisted `DriveConnectionRecord` to a `DriveEvent`, or `None` for an
+/// unknown event type / unparseable timestamp (logged). Shared by
+/// `last_drive_event` (one row) and `drive_mount_history` (all rows). The parse
+/// format matches the sentinel's write format (`%Y-%m-%dT%H:%M:%S`).
+fn drive_record_to_event(record: &crate::state::DriveConnectionRecord) -> Option<DriveEvent> {
+    let kind = match record.event_type.as_str() {
+        "mounted" => DriveEventKind::Mount,
+        "unmounted" => DriveEventKind::Unmount,
+        other => {
+            log::warn!("unknown drive_connections.event_type {other:?} — ignoring");
+            return None;
+        }
+    };
+    let at = chrono::NaiveDateTime::parse_from_str(&record.timestamp, "%Y-%m-%dT%H:%M:%S")
+        .inspect_err(|e| {
+            log::warn!(
+                "failed to parse drive_connections.timestamp {:?}: {e}",
+                record.timestamp
+            );
+        })
+        .ok()?;
+    Some(DriveEvent { kind, at })
 }
 
 pub(crate) fn read_snapshot_dir(dir: &Path) -> crate::error::Result<Vec<SnapshotName>> {
@@ -1579,6 +1602,10 @@ pub struct MockFileSystemState {
     pub calibrated_sizes: std::collections::HashMap<String, (u64, String)>,
     pub send_times: std::collections::HashMap<(String, String), NaiveDateTime>,
     pub drive_events: std::collections::HashMap<String, DriveEvent>,
+    /// Full ordered mount/unmount history per drive (UPI 055). Additive
+    /// alongside the single-event `drive_events` so existing `last_drive_event`
+    /// tests are untouched; injected only by rotation-aware tests.
+    pub drive_event_history: std::collections::HashMap<String, Vec<DriveEvent>>,
     pub last_successful_ops: std::collections::HashMap<String, NaiveDateTime>,
     /// Subvolume names for which local_snapshots() should return an error.
     pub fail_local_snapshots: HashSet<String>,
@@ -1600,6 +1627,7 @@ impl MockFileSystemState {
             calibrated_sizes: std::collections::HashMap::new(),
             send_times: std::collections::HashMap::new(),
             drive_events: std::collections::HashMap::new(),
+            drive_event_history: std::collections::HashMap::new(),
             last_successful_ops: std::collections::HashMap::new(),
             fail_local_snapshots: HashSet::new(),
             fail_pin_reads: HashSet::new(),
@@ -1735,6 +1763,13 @@ impl HistoryQuery for MockFileSystemState {
 
     fn last_drive_event(&self, drive_label: &str) -> Option<DriveEvent> {
         self.drive_events.get(drive_label).cloned()
+    }
+
+    fn drive_mount_history(&self, drive_label: &str) -> Vec<DriveEvent> {
+        self.drive_event_history
+            .get(drive_label)
+            .cloned()
+            .unwrap_or_default()
     }
 
     fn last_successful_operation_at(&self, drive_label: &str) -> Option<NaiveDateTime> {
@@ -4805,6 +4840,40 @@ local_retention = "transient"
             .last_drive_event("D1")
             .expect("round-trip must yield an event — guards schema/parser drift");
         assert!(matches!(event.kind, DriveEventKind::Unmount));
+    }
+
+    #[test]
+    fn real_file_system_state_drive_mount_history_full_ordered_round_trip() {
+        // UPI 055: the rotation view consumes the full ordered stream. This
+        // round-trips real sentinel-written rows (whose timestamps the parser
+        // must accept) through `drive_mount_history`, oldest-first.
+        use crate::state::{DriveEventSource, DriveEventType, StateDb};
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let db = StateDb::open(&dir.path().join("urd.db")).unwrap();
+        db.record_drive_event("D1", DriveEventType::Mounted, DriveEventSource::Sentinel)
+            .unwrap();
+        db.record_drive_event("D1", DriveEventType::Unmounted, DriveEventSource::Sentinel)
+            .unwrap();
+        db.record_drive_event("D1", DriveEventType::Mounted, DriveEventSource::Sentinel)
+            .unwrap();
+
+        let fs = RealFileSystemState { state: Some(&db) };
+        let history = fs.drive_mount_history("D1");
+        let kinds: Vec<DriveEventKind> = history.iter().map(|e| e.kind).collect();
+        assert_eq!(
+            kinds,
+            vec![
+                DriveEventKind::Mount,
+                DriveEventKind::Unmount,
+                DriveEventKind::Mount,
+            ],
+            "history must be oldest-first (ORDER BY id ASC) and complete"
+        );
+
+        // Unknown drive → empty (never blocks).
+        assert!(fs.drive_mount_history("nope").is_empty());
     }
 
     // ── Planner event-emission tests ───────────────────────────────────

--- a/src/preflight.rs
+++ b/src/preflight.rs
@@ -33,6 +33,7 @@ pub fn preflight_checks(config: &Config) -> Vec<PreflightCheck> {
 
     // Global checks (not per-subvolume)
     check_send_without_drives(&resolved, config, &mut checks);
+    check_rotation_interval_on_offsite(config, &mut checks);
 
     // Per-subvolume checks
     for subvol in &resolved {
@@ -326,6 +327,29 @@ fn check_redundant_yearly(
     }
 }
 
+// ── Rotation-interval-on-non-offsite check ─────────────────────────────
+//
+// `rotation_interval` (UPI 055) declares an offsite drive's homecoming
+// cadence — meaningful only for `role = "offsite"`. On a primary or test
+// drive it has nothing to govern and is ignored downstream, so surface the
+// likely misconfiguration as an advisory. Per ADR-109, refusal is reserved
+// for structural errors; this is a warning, not a hard error. Mirrors
+// `check_redundant_yearly`'s "harmless-but-probably-unintended" stance.
+fn check_rotation_interval_on_offsite(config: &Config, checks: &mut Vec<PreflightCheck>) {
+    for drive in &config.drives {
+        if drive.rotation_interval.is_some() && drive.role != DriveRole::Offsite {
+            checks.push(PreflightCheck {
+                name: "rotation-interval-non-offsite",
+                message: format!(
+                    "drive {}: rotation_interval is only meaningful for offsite drives \
+                     (role is {:?}) — it will be ignored",
+                    drive.label, drive.role,
+                ),
+            });
+        }
+    }
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────
 
 /// Format hours into a human-readable duration string.
@@ -412,6 +436,7 @@ mod tests {
             role: DriveRole::Primary,
             max_usage_percent: Some(90),
             min_free_bytes: None,
+            rotation_interval: None,
         }
     }
 
@@ -1052,6 +1077,7 @@ mod tests {
             role: DriveRole::Offsite,
             max_usage_percent: Some(90),
             min_free_bytes: None,
+            rotation_interval: None,
         }
     }
 
@@ -1107,6 +1133,36 @@ mod tests {
         let results: Vec<_> = preflight_checks(&config)
             .into_iter()
             .filter(|c| c.name == "fortified-without-offsite")
+            .collect();
+
+        assert!(results.is_empty());
+    }
+
+    // ── rotation_interval-on-non-offsite (UPI 055) ───────────────────────
+
+    #[test]
+    fn rotation_interval_on_primary_warns() {
+        // A rotation_interval on a primary drive has nothing to govern.
+        let mut primary = test_drive(); // role = Primary
+        primary.rotation_interval = Some("3mo".parse().unwrap());
+        let config = test_config(vec![test_subvolume("docs")], vec![primary]);
+        let results: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "rotation-interval-non-offsite")
+            .collect();
+
+        assert_eq!(results.len(), 1);
+        assert!(results[0].message.contains("test-drive"));
+    }
+
+    #[test]
+    fn rotation_interval_on_offsite_silent() {
+        let mut offsite = offsite_drive(); // role = Offsite
+        offsite.rotation_interval = Some("3mo".parse().unwrap());
+        let config = test_config(vec![test_subvolume("docs")], vec![test_drive(), offsite]);
+        let results: Vec<_> = preflight_checks(&config)
+            .into_iter()
+            .filter(|c| c.name == "rotation-interval-non-offsite")
             .collect();
 
         assert!(results.is_empty());

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -1,0 +1,492 @@
+// Rotation view — pure observer of an offsite drive's homecoming rhythm.
+//
+// Mirrors `drift.rs`: rolling aggregation over a history stream, no I/O
+// (ADR-108). Given the drive-mount event stream, it infers the *observed
+// cadence* (median inter-arrival gap) and resolves the *offsite window* — how
+// long an offsite drive may be away before its absence is worth surfacing —
+// from the declared `rotation_interval` (PRIMARY), the observed cadence
+// (fallback), or a conservative default. `classify` then maps a copy's age
+// against that window to a `RotationTier`.
+//
+// Cites ADR-116 ("Offsite rotation is expected absence"): an offsite drive's
+// absence is the normal state, judged against its rotation cadence — not the
+// send interval (UPI 055). The richer voice (forecast, "resting", `Due`) is
+// UPI 056; the `WindowSource`/`RotationObservation` provenance carried here is
+// for that follow-up.
+
+use chrono::{Duration, NaiveDateTime};
+
+use crate::awareness::PromiseStatus;
+use crate::types::{DriveEvent, DriveEventKind, Interval};
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+/// Completed gaps required before an observed cadence may govern the window.
+/// Below this floor, fall back to the Default window: a median over 1–2 gaps
+/// is too noisy to drive an alarm (one outlier skews it ≥50 %). Three is the
+/// smallest count that has a genuine middle value.
+const MIN_CYCLES_FOR_CADENCE: usize = 3;
+
+/// Observed window: `overdue = median_gap × 2`. An observed median from few
+/// samples underestimates the true spread, so the slack is generous (×2.0)
+/// relative to the declared case.
+const OBSERVED_OVERDUE_FACTOR: i32 = 2;
+
+/// Declared window: `overdue = declared × 1.25`, expressed as ×5/4 so the
+/// integer-second arithmetic is exact. A declared cadence is deliberate
+/// intent, so the slack is tighter than the observed factor.
+const DECLARED_OVERDUE_SLACK_NUM: i64 = 5;
+const DECLARED_OVERDUE_SLACK_DEN: i64 = 4;
+
+/// `stale = overdue × 2`, shared by the declared and observed windows.
+const STALE_FACTOR: i32 = 2;
+
+/// Default overdue window when neither declared nor observed is available.
+/// Matches today's offsite advisory default (30 days), so cold-start behavior
+/// is unchanged.
+const DEFAULT_OVERDUE_DAYS: i64 = 30;
+
+/// Default stale window (60 days).
+const DEFAULT_STALE_DAYS: i64 = 60;
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+/// Observed homecoming rhythm of an offsite drive, derived from its mount
+/// history. `median_gap` is the median *completed* inter-arrival gap; the
+/// in-progress absence since `last_home` is deliberately not a completed gap
+/// (RD3). `last_home`/`gaps_observed` are carried for UPI 056's forecast.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)] // last_home / gaps_observed feed UPI 056's forecast.
+pub struct RotationObservation {
+    pub last_home: NaiveDateTime,
+    pub median_gap: Duration,
+    pub gaps_observed: usize,
+}
+
+/// Where an `OffsiteWindow` came from. Carried for UPI 056 provenance
+/// (forecast/voice); resolved but not yet read by 055's behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WindowSource {
+    Declared,
+    Observed,
+    Default,
+}
+
+/// The resolved freshness window for an offsite drive: how long it may be away
+/// before its absence escalates on-schedule → overdue → stale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OffsiteWindow {
+    pub overdue_after: Duration,
+    pub stale_after: Duration,
+    /// Provenance, for UPI 056. Resolved here but unread by 055.
+    #[allow(dead_code)]
+    pub source: WindowSource,
+}
+
+impl OffsiteWindow {
+    /// Overdue threshold in whole days, for `compute_health`'s integer-day
+    /// away-nag.
+    ///
+    /// F8: the per-copy classifier uses `classify` over the full `Duration`,
+    /// while this truncates to whole days, so the nag and the per-copy promise
+    /// can disagree by up to one day at the boundary — a deliberate
+    /// granularity difference layered on the two-clocks split (G3), not a bug.
+    #[must_use]
+    pub fn overdue_days(&self) -> i64 {
+        self.overdue_after.num_days()
+    }
+}
+
+/// A copy's freshness tier relative to its offsite window. 055 ships three
+/// variants; UPI 056 adds `Due` by splitting `OnSchedule` (a compiler-checked
+/// enum extension — every match site is then forced to handle it).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RotationTier {
+    OnSchedule,
+    Overdue,
+    Stale,
+}
+
+impl RotationTier {
+    /// Map the tier onto the per-copy promise: on-schedule keeps the promise,
+    /// overdue is at risk, stale is exposed.
+    #[must_use]
+    pub fn to_promise_status(self) -> PromiseStatus {
+        match self {
+            RotationTier::OnSchedule => PromiseStatus::Protected,
+            RotationTier::Overdue => PromiseStatus::AtRisk,
+            RotationTier::Stale => PromiseStatus::Unprotected,
+        }
+    }
+}
+
+// ── Functions ──────────────────────────────────────────────────────────
+
+/// Infer the observed cadence from a drive's mount history. Returns `None`
+/// below `MIN_CYCLES_FOR_CADENCE` completed gaps (the noise floor) so a
+/// 1–2-sample estimate never governs an alarm.
+///
+/// `_now` is unused in 055 — kept in the signature for UPI 056's forecast,
+/// which projects the next homecoming from `now` and the cadence.
+#[must_use]
+pub fn observed_cadence(events: &[DriveEvent], _now: NaiveDateTime) -> Option<RotationObservation> {
+    // Mount events only, sorted by time (clock-skew safety) so the consecutive
+    // gaps below are derived from the true arrival order, not insertion order.
+    let mut mounts: Vec<NaiveDateTime> = events
+        .iter()
+        .filter(|e| e.kind == DriveEventKind::Mount)
+        .map(|e| e.at)
+        .collect();
+    mounts.sort_unstable();
+
+    // Consecutive inter-arrival gaps. Drop non-positive (zero-duration /
+    // duplicate-stamp) gaps so a duplicate arrival can't deflate the median;
+    // post-sort, a gap can only be zero or positive.
+    let mut gaps: Vec<Duration> = mounts
+        .windows(2)
+        .map(|w| w[1] - w[0])
+        .filter(|g| *g > Duration::zero())
+        .collect();
+
+    if gaps.len() < MIN_CYCLES_FOR_CADENCE {
+        return None;
+    }
+
+    // mounts is non-empty here (gaps.len() ≥ 3 ⇒ ≥ 4 mounts).
+    let last_home = *mounts.last()?;
+
+    // Median over the GAP SET sorted by magnitude (F4) — NOT the temporal
+    // middle. Consecutive gaps from time-ordered events do not arrive in
+    // magnitude order, so the gap set must be sorted before the median is
+    // taken; the "middle gap in time order" is a different (wrong) number.
+    gaps.sort_unstable();
+    let median_gap = median_duration(&gaps);
+
+    Some(RotationObservation {
+        last_home,
+        median_gap,
+        gaps_observed: gaps.len(),
+    })
+}
+
+/// Median of a slice of durations that is **already sorted ascending**.
+/// For an even count, averages the two middle gaps (whole-second precision is
+/// ample — sub-second cadence is meaningless for rotation).
+fn median_duration(sorted_gaps: &[Duration]) -> Duration {
+    let n = sorted_gaps.len();
+    if n % 2 == 1 {
+        sorted_gaps[n / 2]
+    } else {
+        let a = sorted_gaps[n / 2 - 1];
+        let b = sorted_gaps[n / 2];
+        (a + b) / 2
+    }
+}
+
+/// Resolve the offsite window from the two cadence sources in priority order:
+/// declared (PRIMARY, RD1) → observed (fallback, RD3) → default constant.
+#[must_use]
+pub fn resolve_offsite_window(
+    declared: Option<Interval>,
+    observed: Option<RotationObservation>,
+) -> OffsiteWindow {
+    if let Some(declared) = declared {
+        // overdue = declared × 1.25 (= ×5/4); stale = overdue × 2.
+        let overdue = Duration::seconds(
+            declared.as_secs() * DECLARED_OVERDUE_SLACK_NUM / DECLARED_OVERDUE_SLACK_DEN,
+        );
+        return OffsiteWindow {
+            overdue_after: overdue,
+            stale_after: overdue * STALE_FACTOR,
+            source: WindowSource::Declared,
+        };
+    }
+    if let Some(obs) = observed {
+        let overdue = obs.median_gap * OBSERVED_OVERDUE_FACTOR;
+        return OffsiteWindow {
+            overdue_after: overdue,
+            stale_after: overdue * STALE_FACTOR,
+            source: WindowSource::Observed,
+        };
+    }
+    OffsiteWindow {
+        overdue_after: Duration::days(DEFAULT_OVERDUE_DAYS),
+        stale_after: Duration::days(DEFAULT_STALE_DAYS),
+        source: WindowSource::Default,
+    }
+}
+
+/// Classify a copy's age against its window. Boundaries are inclusive of the
+/// lower tier: `age == overdue_after` is still OnSchedule, `age == stale_after`
+/// is still Overdue.
+#[must_use]
+pub fn classify(age: Duration, w: &OffsiteWindow) -> RotationTier {
+    if age <= w.overdue_after {
+        RotationTier::OnSchedule
+    } else if age <= w.stale_after {
+        RotationTier::Overdue
+    } else {
+        RotationTier::Stale
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn dt(year: i32, month: u32, day: u32) -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(year, month, day)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+    }
+
+    fn mount(at: NaiveDateTime) -> DriveEvent {
+        DriveEvent {
+            kind: DriveEventKind::Mount,
+            at,
+        }
+    }
+
+    fn unmount(at: NaiveDateTime) -> DriveEvent {
+        DriveEvent {
+            kind: DriveEventKind::Unmount,
+            at,
+        }
+    }
+
+    // A fixed "now" — `observed_cadence` ignores it in 055.
+    fn now() -> NaiveDateTime {
+        dt(2026, 6, 1)
+    }
+
+    // ── observed_cadence: the noise floor ──────────────────────────────
+
+    #[test]
+    fn no_events_is_none() {
+        assert_eq!(observed_cadence(&[], now()), None);
+    }
+
+    #[test]
+    fn one_mount_zero_gaps_is_none() {
+        let events = [mount(dt(2026, 3, 1))];
+        assert_eq!(observed_cadence(&events, now()), None);
+    }
+
+    #[test]
+    fn two_mounts_one_gap_is_none() {
+        let events = [mount(dt(2026, 3, 1)), mount(dt(2026, 3, 10))];
+        assert_eq!(observed_cadence(&events, now()), None);
+    }
+
+    #[test]
+    fn three_mounts_two_gaps_below_floor_is_none() {
+        // 3 mounts = 2 gaps < MIN_CYCLES_FOR_CADENCE(3) → None.
+        let events = [
+            mount(dt(2026, 3, 1)),
+            mount(dt(2026, 3, 11)),
+            mount(dt(2026, 3, 21)),
+        ];
+        assert_eq!(observed_cadence(&events, now()), None);
+    }
+
+    #[test]
+    fn only_unmount_events_is_none() {
+        let events = [unmount(dt(2026, 3, 1)), unmount(dt(2026, 3, 10))];
+        assert_eq!(observed_cadence(&events, now()), None);
+    }
+
+    // ── observed_cadence: the median ───────────────────────────────────
+
+    #[test]
+    fn three_regular_gaps_median() {
+        // Gaps 10/10/10 → median 10. (4 mounts = 3 gaps = the floor.)
+        let events = [
+            mount(dt(2026, 3, 1)),
+            mount(dt(2026, 3, 11)),
+            mount(dt(2026, 3, 21)),
+            mount(dt(2026, 3, 31)),
+        ];
+        let obs = observed_cadence(&events, now()).expect("at the floor");
+        assert_eq!(obs.median_gap, Duration::days(10));
+        assert_eq!(obs.gaps_observed, 3);
+        assert_eq!(obs.last_home, dt(2026, 3, 31));
+    }
+
+    #[test]
+    fn four_gaps_even_count_median_averages_middles() {
+        // 5 mounts → gaps 10/20/30/40 (already magnitude-sorted) →
+        // median = (20+30)/2 = 25.
+        let events = [
+            mount(dt(2026, 1, 1)),
+            mount(dt(2026, 1, 11)), // +10
+            mount(dt(2026, 1, 31)), // +20
+            mount(dt(2026, 3, 2)),  // +30
+            mount(dt(2026, 4, 11)), // +40
+        ];
+        let obs = observed_cadence(&events, now()).expect("4 gaps");
+        assert_eq!(obs.gaps_observed, 4);
+        assert_eq!(obs.median_gap, Duration::days(25));
+    }
+
+    #[test]
+    fn median_needs_magnitude_sort_not_temporal_middle() {
+        // F4: consecutive gaps 23, 8, 15 in TIME order. Sorted by magnitude:
+        // 8, 15, 23 → median 15. A "middle gap in time order" bug returns the
+        // 2nd arrival gap (8) and fails this test.
+        let events = [
+            mount(dt(2026, 1, 1)),
+            mount(dt(2026, 1, 24)), // +23
+            mount(dt(2026, 2, 1)),  // +8
+            mount(dt(2026, 2, 16)), // +15
+        ];
+        let obs = observed_cadence(&events, now()).expect("3 gaps");
+        assert_eq!(
+            obs.median_gap,
+            Duration::days(15),
+            "median must be over the magnitude-sorted gap set, not the temporal middle"
+        );
+    }
+
+    #[test]
+    fn live_data_regression_18_days_on_schedule() {
+        // The motivating live data: arrivals 03-29, 04-06, 04-21, 05-14 →
+        // gaps 8/15/23 → median 15 → observed overdue 30d, stale 60d.
+        // An 18-day-old copy then classifies OnSchedule (18 ≤ 30).
+        let events = [
+            mount(dt(2026, 3, 29)),
+            mount(dt(2026, 4, 6)),  // +8
+            mount(dt(2026, 4, 21)), // +15
+            mount(dt(2026, 5, 14)), // +23
+        ];
+        let obs = observed_cadence(&events, now()).expect("3 gaps");
+        assert_eq!(obs.median_gap, Duration::days(15));
+
+        let window = resolve_offsite_window(None, Some(obs));
+        assert_eq!(window.source, WindowSource::Observed);
+        assert_eq!(window.overdue_after, Duration::days(30));
+        assert_eq!(window.stale_after, Duration::days(60));
+        assert_eq!(classify(Duration::days(18), &window), RotationTier::OnSchedule);
+    }
+
+    #[test]
+    fn clock_skew_unsorted_events_sorted_before_gaps() {
+        // Same arrivals as a regular run, but delivered out of time order.
+        // After the internal sort: days 0,10,25,40 → gaps 10,15,15 →
+        // median 15. Without the event sort, gaps would be garbage.
+        let events = [
+            mount(dt(2026, 2, 10)), // day 40
+            mount(dt(2026, 1, 1)),  // day 0
+            mount(dt(2026, 1, 26)), // day 25
+            mount(dt(2026, 1, 11)), // day 10
+        ];
+        let obs = observed_cadence(&events, now()).expect("3 gaps after sort");
+        assert_eq!(obs.median_gap, Duration::days(15));
+        assert_eq!(obs.last_home, dt(2026, 2, 10));
+    }
+
+    #[test]
+    fn duplicate_arrival_zero_gap_dropped() {
+        // A duplicate Mount stamp yields a zero gap that must be dropped, not
+        // counted as a tiny cadence. Arrivals 0,0,10,25,40 → gaps (after the
+        // zero is dropped) 10,15,15 → median 15, 3 gaps.
+        let events = [
+            mount(dt(2026, 1, 1)),
+            mount(dt(2026, 1, 1)), // duplicate → zero gap, dropped
+            mount(dt(2026, 1, 11)),
+            mount(dt(2026, 1, 26)),
+            mount(dt(2026, 2, 10)),
+        ];
+        let obs = observed_cadence(&events, now()).expect("3 positive gaps");
+        assert_eq!(obs.gaps_observed, 3);
+        assert_eq!(obs.median_gap, Duration::days(15));
+    }
+
+    // ── resolve_offsite_window ─────────────────────────────────────────
+
+    #[test]
+    fn resolve_declared_quarterly() {
+        // "3mo" = 90d → overdue = 90 × 1.25 = 112.5d (112 whole days),
+        // stale = overdue × 2 = 225d.
+        let declared: Interval = "3mo".parse().unwrap();
+        let window = resolve_offsite_window(Some(declared), None);
+        assert_eq!(window.source, WindowSource::Declared);
+        assert_eq!(window.overdue_after, Duration::seconds(90 * 86400 * 5 / 4));
+        assert_eq!(window.overdue_days(), 112);
+        assert_eq!(window.stale_after, window.overdue_after * 2);
+        assert_eq!(window.stale_after.num_days(), 225);
+    }
+
+    #[test]
+    fn resolve_declared_wins_over_observed() {
+        // Declared is PRIMARY (RD1): present declared interval governs even
+        // when an observed cadence also exists.
+        let declared: Interval = "4w".parse().unwrap(); // 28d
+        let events = [
+            mount(dt(2026, 3, 1)),
+            mount(dt(2026, 3, 11)),
+            mount(dt(2026, 3, 21)),
+            mount(dt(2026, 3, 31)),
+        ];
+        let obs = observed_cadence(&events, now());
+        let window = resolve_offsite_window(Some(declared), obs);
+        assert_eq!(window.source, WindowSource::Declared);
+        assert_eq!(window.overdue_after, Duration::seconds(28 * 86400 * 5 / 4));
+    }
+
+    #[test]
+    fn resolve_default_when_neither() {
+        let window = resolve_offsite_window(None, None);
+        assert_eq!(window.source, WindowSource::Default);
+        assert_eq!(window.overdue_after, Duration::days(30));
+        assert_eq!(window.stale_after, Duration::days(60));
+    }
+
+    // ── classify: boundary cases ───────────────────────────────────────
+
+    #[test]
+    fn classify_boundaries_are_inclusive_of_lower_tier() {
+        let window = resolve_offsite_window(None, None); // 30d / 60d
+        // Exactly at overdue_after → still OnSchedule.
+        assert_eq!(classify(Duration::days(30), &window), RotationTier::OnSchedule);
+        // One second past → Overdue.
+        assert_eq!(
+            classify(Duration::days(30) + Duration::seconds(1), &window),
+            RotationTier::Overdue
+        );
+        // Exactly at stale_after → still Overdue.
+        assert_eq!(classify(Duration::days(60), &window), RotationTier::Overdue);
+        // One second past → Stale.
+        assert_eq!(
+            classify(Duration::days(60) + Duration::seconds(1), &window),
+            RotationTier::Stale
+        );
+    }
+
+    #[test]
+    fn classify_zero_age_is_on_schedule() {
+        let window = resolve_offsite_window(None, None);
+        assert_eq!(classify(Duration::zero(), &window), RotationTier::OnSchedule);
+    }
+
+    // ── to_promise_status ──────────────────────────────────────────────
+
+    #[test]
+    fn tier_to_promise_status_mapping() {
+        assert_eq!(
+            RotationTier::OnSchedule.to_promise_status(),
+            PromiseStatus::Protected
+        );
+        assert_eq!(
+            RotationTier::Overdue.to_promise_status(),
+            PromiseStatus::AtRisk
+        );
+        assert_eq!(
+            RotationTier::Stale.to_promise_status(),
+            PromiseStatus::Unprotected
+        );
+    }
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -970,6 +970,74 @@ impl StateDb {
         }
     }
 
+    /// Full ordered (oldest-first) mount/unmount history for a drive, from the
+    /// `events` table (`kind='drive'`). The clone of `last_drive_connection`
+    /// without the `LIMIT 1`, collecting every row — the rotation view (UPI
+    /// 055) needs the whole arrival stream, not just the latest event. Rows
+    /// whose payload is not a drive event are logged and skipped, not fatal
+    /// (ADR-102: history must never block a read).
+    ///
+    /// F9: no `LIMIT`. Bounded in practice — an offsite drive logs ~2
+    /// mount/unmount transitions per cycle and this runs only for offsite
+    /// drives — but unbounded in principle over years. Revisit with a
+    /// `LIMIT`/time-window only if a flapping drive ever bloats the row count.
+    pub fn drive_connection_history(
+        &self,
+        drive_label: &str,
+    ) -> crate::error::Result<Vec<DriveConnectionRecord>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT id, occurred_at, payload
+                 FROM events
+                 WHERE kind = 'drive' AND drive_label = ?1
+                 ORDER BY id ASC",
+            )
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut rows = stmt
+            .query(rusqlite::params![drive_label])
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
+
+        let mut records = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .map_err(|e| UrdError::State(format!("query failed: {e}")))?
+        {
+            let id: i64 = row
+                .get(0)
+                .map_err(|e| UrdError::State(format!("read id: {e}")))?;
+            let timestamp: String = row
+                .get(1)
+                .map_err(|e| UrdError::State(format!("read occurred_at: {e}")))?;
+            let payload_json: String = row
+                .get(2)
+                .map_err(|e| UrdError::State(format!("read payload: {e}")))?;
+            let payload: EventPayload = serde_json::from_str(&payload_json)
+                .map_err(|e| UrdError::State(format!("decode drive event payload: {e}")))?;
+            let (event_type, detected_by) = match payload {
+                EventPayload::DriveMounted { detected_by } => {
+                    ("mounted".to_string(), detected_by.as_str().to_string())
+                }
+                EventPayload::DriveUnmounted { detected_by } => {
+                    ("unmounted".to_string(), detected_by.as_str().to_string())
+                }
+                other => {
+                    log::warn!("drive event row #{id} has non-drive payload, skipping: {other:?}");
+                    continue;
+                }
+            };
+            records.push(DriveConnectionRecord {
+                id,
+                drive_label: drive_label.to_string(),
+                event_type,
+                timestamp,
+                detected_by,
+            });
+        }
+        Ok(records)
+    }
+
     // ── Drift-sample methods ────────────────────────────────────────
 
     /// Persist a drift sample. Best-effort per ADR-102 (telemetry must
@@ -2643,6 +2711,28 @@ mod tests {
         .unwrap();
         let record = db.last_drive_connection("WD-18TB").unwrap().unwrap();
         assert_eq!(record.event_type, "unmounted"); // most recent wins
+    }
+
+    #[test]
+    fn drive_connection_history_returns_all_ordered_and_empty_for_unknown() {
+        // UPI 055: the rotation view needs the full arrival stream, oldest-first.
+        let db = StateDb::open_memory().unwrap();
+        db.record_drive_event("WD-18TB", DriveEventType::Mounted, DriveEventSource::Sentinel)
+            .unwrap();
+        db.record_drive_event("WD-18TB", DriveEventType::Unmounted, DriveEventSource::Sentinel)
+            .unwrap();
+        db.record_drive_event("WD-18TB", DriveEventType::Mounted, DriveEventSource::Sentinel)
+            .unwrap();
+        // A different drive's events must not bleed into the result.
+        db.record_drive_event("OTHER", DriveEventType::Mounted, DriveEventSource::Sentinel)
+            .unwrap();
+
+        let history = db.drive_connection_history("WD-18TB").unwrap();
+        let kinds: Vec<&str> = history.iter().map(|r| r.event_type.as_str()).collect();
+        assert_eq!(kinds, vec!["mounted", "unmounted", "mounted"]);
+
+        // Unknown drive → empty Vec, not an error.
+        assert!(db.drive_connection_history("never-seen").unwrap().is_empty());
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,10 +58,17 @@ impl FromStr for Interval {
 
     fn from_str(s: &str) -> crate::error::Result<Self> {
         let s = s.trim();
-        if s.len() < 2 {
+        // Split the numeric prefix from the unit suffix. "mo" (months) is the
+        // only multi-char unit, so strip it first; every other unit is a
+        // single trailing char. Order is load-bearing (R1): stripping "mo"
+        // before the single-char split keeps "15m" minutes, not "15" months.
+        let (num_str, unit) = if let Some(num) = s.strip_suffix("mo") {
+            (num, "mo")
+        } else if s.len() >= 2 {
+            s.split_at(s.len() - 1)
+        } else {
             return Err(UrdError::Parse(format!("invalid interval: {s:?}")));
-        }
-        let (num_str, unit) = s.split_at(s.len() - 1);
+        };
         let n: i64 = num_str
             .parse()
             .map_err(|_| UrdError::Parse(format!("invalid interval number: {num_str:?}")))?;
@@ -73,8 +80,14 @@ impl FromStr for Interval {
             "h" => Ok(Self(chrono::Duration::hours(n))),
             "d" => Ok(Self(chrono::Duration::days(n))),
             "w" => Ok(Self(chrono::Duration::weeks(n))),
+            // Calendar-ish units for long offsite cadences (UPI 055):
+            // month = 30d, year = 365d. `Display` deliberately does NOT render
+            // these (it would turn an existing "30d" into "1mo"), so "3mo"/"1y"
+            // round-trip through Serialize as "90d"/"365d" — same Duration.
+            "mo" => Ok(Self(chrono::Duration::days(30 * n))),
+            "y" => Ok(Self(chrono::Duration::days(365 * n))),
             _ => Err(UrdError::Parse(format!(
-                "unknown interval unit {unit:?} in {s:?} (expected m/h/d/w)"
+                "unknown interval unit {unit:?} in {s:?} (expected m/h/d/w/mo/y)"
             ))),
         }
     }
@@ -1212,12 +1225,42 @@ mod tests {
     }
 
     #[test]
+    fn parse_interval_months() {
+        // UPI 055: month = 30 days. Display does not render "mo", so it
+        // round-trips as the equivalent day count.
+        let i: Interval = "3mo".parse().unwrap();
+        assert_eq!(i.as_secs(), 3 * 30 * 86400);
+        assert_eq!(i.to_string(), "90d");
+    }
+
+    #[test]
+    fn parse_interval_years() {
+        // UPI 055: year = 365 days.
+        let i: Interval = "1y".parse().unwrap();
+        assert_eq!(i.as_secs(), 365 * 86400);
+        assert_eq!(i.to_string(), "365d");
+    }
+
+    #[test]
+    fn parse_interval_minutes_not_eaten_by_mo_strip() {
+        // R1: "15m" must stay minutes — the "mo" suffix-strip must not
+        // cannibalize the single "m" unit.
+        let i: Interval = "15m".parse().unwrap();
+        assert_eq!(i.as_secs(), 15 * 60);
+    }
+
+    #[test]
     fn parse_interval_invalid() {
         assert!("0h".parse::<Interval>().is_err());
         assert!("-1h".parse::<Interval>().is_err());
         assert!("5x".parse::<Interval>().is_err());
         assert!("h".parse::<Interval>().is_err());
         assert!("".parse::<Interval>().is_err());
+        // UPI 055 unit edge cases: bare/zero/negative months.
+        assert!("mo".parse::<Interval>().is_err());
+        assert!("0mo".parse::<Interval>().is_err());
+        assert!("-1mo".parse::<Interval>().is_err());
+        assert!("0y".parse::<Interval>().is_err());
     }
 
     // ── SendKind tests ──────────────────────────────────────────────

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -432,6 +432,62 @@ mod contract {
         );
     }
 
+    // ── UPI 055 — Offsite rotation: no false gravity within window ──────
+    //
+    // G6: once `assess()` returns Protected for an on-schedule offsite copy
+    // (away within its rotation window, present peer), the drive row renders
+    // the dimmed PROTECTED form — the "protection aging" / "consider
+    // connecting" gravity and the degraded "away" wall disappear *purely from
+    // the status flip*, with no `voice/` code change. This pins that contract.
+
+    #[test]
+    fn rule1_offsite_on_schedule_within_window_no_false_gravity() {
+        let _color = color_guard(true);
+        let mut data = all_sealed_status();
+        // Simulate the post-055 assess() output: every subvolume has an
+        // on-schedule offsite copy on the (unmounted) Offsite-4TB — away 18
+        // days, within window, per-copy status PROTECTED.
+        for a in &mut data.assessments {
+            a.external.push(crate::output::StatusDriveAssessment {
+                drive_label: "Offsite-4TB".to_string(),
+                status: PromiseStatus::Protected,
+                mounted: false,
+                snapshot_count: None,
+                last_send_age_secs: Some(18 * 86400),
+                role: crate::types::DriveRole::Offsite,
+                absent_duration_secs: Some(18 * 86400),
+                last_activity_age_secs: None,
+            });
+        }
+
+        let output = render_status(&data, OutputMode::Interactive);
+        let stripped = helpers::strip_ansi(&output);
+
+        // The Offsite-4TB drive row renders the dimmed away form — no gravity.
+        let offsite_line = stripped
+            .lines()
+            .find(|l| l.starts_with("Drives:") && l.contains("Offsite-4TB"))
+            .unwrap_or_else(|| panic!("no Offsite-4TB drive line in:\n{stripped}"));
+        assert!(
+            offsite_line.contains("away"),
+            "expected the dimmed 'away …' form for the on-schedule offsite: {offsite_line}"
+        );
+        assert!(
+            !offsite_line.contains("protection aging"),
+            "on-schedule offsite must not render 'protection aging': {offsite_line}"
+        );
+        assert!(
+            !offsite_line.contains("consider connecting"),
+            "on-schedule offsite must not render 'consider connecting': {offsite_line}"
+        );
+        // No earned red anywhere — the 7-row degraded wall is gone.
+        assert_eq!(
+            helpers::count_red(&output),
+            0,
+            "on-schedule fortified status must have zero red SGR escapes; got:\n{output}"
+        );
+    }
+
     // ── Rule 2 — No contradictions (no red on a sealed row) ────────────
 
     /// Split a rendered status-table row into its non-empty cells. ANSI


### PR DESCRIPTION
## Summary

- Teaches `awareness` the difference between an offsite copy's **data-age** (time since last send) and a drive's **presence-age** (time since it was here), and judges an offsite drive's absence against its **rotation cadence** instead of the send interval. An offsite drive away *on schedule* now reads PROTECTED and silent; only a genuinely overdue copy degrades health and re-arms the `OffsiteDriveStale` advisory — collapsing the nightly promise-transition sawtooth.
- New pure `rotation.rs` (mirrors `drift.rs`): observed-cadence inference (median over the magnitude-sorted gap set), window resolution (declared `rotation_interval` → observed → 30/60d default), and tier classification. Folded into `assess()`'s existing once-per-drive precompute — no boundary module, no `DriveAssessment` field.
- **Present-peer guard (catastrophic-mode guard):** the PROTECTED relaxation fires only when a real redundancy peer is currently mounted, so a subvolume whose *only* external drive is an away offsite keeps the honest send-interval judgment — a missing sole copy is never falsely reported PROTECTED. `source_unchanged` and `max()`-across-drives are preserved.
- Config gains additive-optional `DriveConfig.rotation_interval` (no migrate; preflight warns on non-offsite roles); `Interval` gains `mo`/`y` units; new `HistoryQuery::drive_mount_history` seam. Voice suppression falls out of the status flip (one Voice-Contract regression test, no `voice/` code change).

Cites ADR-116 (no new ADR). No metric/heartbeat/on-disk/config-schema **field** changes, but existing promise/advisory **values** shift (the intended flattened sawtooth) — worth a glance at the homelab's ADR-021 alerting (see note below).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1648 passed, 0 failed, 4 ignored (pre-existing deferred voice-contract stubs); 39 new tests
- cargo build --release: pass
- Integration tests: not applicable (read-side change; no btrfs/executor path touched)

## Follow-ups

- `advice::overlay_offsite_freshness` (the ADR-110 Fortified overlay) still uses hardcoded 30/90d thresholds and was deliberately out of scope — it can undercut the rotation window for *named-Fortified* subvolumes past 30d. Harmless today (live drive ~18d); flagged for UPI 056.
- Cross-repo: confirm no homelab alert is calibrated to the old offsite-away-degrades behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)