### PR TITLE
docs: add rotation.rs to the module-responsibility table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ live in `docs/00-foundation/architecture.md`.
 - `awareness.rs` — promise state ("is my data safe?"); `advice.rs` — what to do about it
 - `recommendation.rs` — headroom-aware retention-shape advice (ADR-115)
 - `storage_critical.rs` — storage-state tiers for the Do-No-Harm arc (ADR-113)
-- `drift.rs` — churn aggregation; `preflight.rs` — achievability advisories
+- `drift.rs` — churn aggregation; `rotation.rs` — offsite rotation cadence + freshness window; `preflight.rs` — achievability advisories
 - `chain.rs` — pin files; `state.rs` — SQLite history (granular wrappers)
 - `drives.rs` / `pools.rs` — drive + BTRFS-pool detection
 - `output.rs` / `voice/` — structured output types / mythic-voice rendering

--- a/docs/00-foundation/architecture.md
+++ b/docs/00-foundation/architecture.md
@@ -171,6 +171,7 @@ the documentation convention in `contributing-internal.md`).
 | `metrics.rs` | Write Prometheus `.prom` files | Read metrics |
 | `notify.rs` | Compute and dispatch notifications (consumes awareness) | Decide promise states |
 | `drift.rs` | Pure: rolling time-windowed churn aggregation from `drift_samples` | Perform I/O or persist |
+| `rotation.rs` | Pure: infer offsite rotation cadence (median homecoming gap) and resolve the offsite freshness window from drive-mount history | Perform I/O or persist |
 | `drives.rs` | Detect mounted drives, UUID fingerprinting, check space | Mount/unmount drives |
 | `pools.rs` | Detect BTRFS pools, group subvolumes by pool UUID, read sysfs/statvfs utilization | Know about retention, plans, drive lifecycle, or notification policy |
 | `output.rs` | Define structured output types | Render text (`voice/` does that) |


### PR DESCRIPTION
## Summary

- UPI 055 added `src/rotation.rs` (pure offsite-cadence observer, mirrors `drift.rs`) but the authoritative module-responsibility table in `architecture.md` and the compact module list in `CLAUDE.md` weren't updated in the feature PR.
- Adds the one-line role to both, closing the reference-doc drift before it ages (the FileSystemState→Observation lesson).

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)