### PR TITLE
feat: rotation voice — forecast, hibernating, offsite drive-row ladder (UPI 056 PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Rotation voice: forecast, "hibernating," and the offsite drive-row ladder** (UPI 056 PR2,
+  cites ADR-116). `urd status` now *speaks the rhythm* instead of reporting bald absence. An
+  offsite drive away on schedule reads **hibernating** with a *due home in ~Nd* forecast (shown
+  only while the homecoming is still ahead); past the cadence midpoint but still protected it
+  reads **due home — cycle it on your next trip** — both calm and uncoloured. Only a genuinely
+  overdue/stale copy crosses to **absent**, its offsite thread **fraying** (amber) → **worn
+  thin** (red). Gravity comes solely from the per-copy promise status — the rotation words only
+  enrich the wording within each band, so a `source_unchanged` away offsite never reddens
+  regardless of its data-age. The `OffsiteDriveStale` advisory is now **cadence-relative** ("…
+  overdue — 11 days past its usual ~45d cycle"). After a clean offsite send, `urd backup` adds a
+  *safe to take {drive} back offsite* cue. The `--json` status surface gains an additive,
+  offsite-only `rotation` block (`cadence_secs`, `last_home`, `forecast_secs`, `source`) for
+  Spindle — no `schema_version` bump (additive `--json` evolution, ADR-114 precedent), no
+  metric/heartbeat change.
 - **Role-aware offsite freshness model + rotation view** (UPI 055, ADR-116). Urd's strongest
   tier (multi-drive + offsite) no longer reads chronically degraded while an offsite drive is
   away on its normal rotation rhythm. An offsite drive's absence is now judged against its

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -175,6 +175,22 @@ real redundancy peer (a non-`test` drive) is currently mounted — an offsite dr
 is the *second* line behind a continuously-present primary (ADR-116). A subvolume
 whose only external drive is an away offsite keeps the send-interval judgment.
 
+**The rotation voice register (UPI 056).** The `urd status` drive row speaks a calm
+seasonal register *layered over* those engine tiers. Gravity still comes solely
+from the per-copy `PromiseStatus` (S1) — the words only enrich it within each band:
+
+| Voice word | When | Register / colour |
+|------------|------|-------------------|
+| `hibernating` | offsite away *on schedule* — data-age within the calm half of its window; pairs with a `due home in ~Nd` forecast | dim, no colour (`on_schedule` → PROTECTED) |
+| `due home` | the same PROTECTED band but past the cadence midpoint ("due home — cycle it on your next trip"), and the forecast line itself | dim — a *voice-only* projection, not an engine tier |
+| `absent` | reserved for the degraded bands (the drive is away **and** its data has aged past the window) | amber → red (`overdue`/`stale`) |
+
+"due" is computed in `voice/` from the carried cadence + data-age; `RotationTier`
+stays three-valued (no `Due` variant — gravity has one source). The forecast
+(`due home in ~Nd`) renders only while the next homecoming is still ahead; once
+past due, the seasonal word carries it (no "in ~-3d" falsehood). See the Thread
+cluster's `fraying`/`worn thin` for the matching offsite-freshness weave.
+
 ## Cluster: Thread
 
 A **thread** is the lineage of incremental sends connecting a subvolume to a drive.
@@ -203,6 +219,14 @@ send (`voice.rs::render_transitions`).
 drive. `intact` = the steady-state assertion at the end of a clean run. The verb
 `hold` ("All threads hold") appears in shorter status output for the same
 condition.
+
+**Offsite-freshness weave (UPI 056).** A register describing how the *offsite*
+thread wears as its copy ages past the rotation window — distinct from the chain
+breakage above (this is about freshness, not the incremental lineage). It escalates
+`holds` (fresh, on schedule) → `fraying` (overdue, amber) → `worn thin` (stale, red),
+mapping directly onto the per-copy PROTECTED → AT RISK → UNPROTECTED gravity and
+coining no new status. `fraying`/`worn thin` ride the drive row's `absent` bands and
+the `OffsiteDriveStale` advisory's cadence-relative detail.
 
 ## Cluster: Retention tiers
 

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -381,15 +381,31 @@ pub fn compute_redundancy_advisories(
                     && da.status != PromiseStatus::Protected
                     && let Some(age) = da.last_send_age
                 {
-                    let days = age.num_days();
+                    // Cadence-relative detail (UPI 056, RD10): instead of a bare
+                    // "last sent N days ago", express how far past the drive's
+                    // own rotation cycle the copy has drifted. `tier` reads the
+                    // window-aware `status` (engine terms `overdue`/`stale`, not
+                    // mythic — voice words stay in voice/); the "~Md cycle" reads
+                    // the carried cadence, omitted when there is no rhythm
+                    // (Default window). One advisory kind covers both bands.
+                    let tier = if da.status == PromiseStatus::Unprotected {
+                        "stale"
+                    } else {
+                        "overdue"
+                    };
+                    let cadence_days = da.rotation.and_then(|r| r.cadence).map(|c| c.num_days());
+                    let detail = match cadence_days {
+                        Some(cycle) if cycle > 0 => {
+                            let past = (age.num_days() - cycle).max(0);
+                            format!("{tier} \u{2014} {past} days past its usual ~{cycle}d cycle")
+                        }
+                        _ => format!("{tier} \u{2014} last refreshed {} days ago", age.num_days()),
+                    };
                     advisories.push(RedundancyAdvisory {
                         kind: RedundancyAdvisoryKind::OffsiteDriveStale,
                         subvolume: assessment.name.clone(),
                         drive: Some(da.drive_label.clone()),
-                        detail: format!(
-                            "offsite drive {} last sent {} days ago",
-                            da.drive_label, days,
-                        ),
+                        detail,
                     });
                 }
             }
@@ -551,6 +567,7 @@ drives = ["primary-drive", "offsite-drive"]
             role: DriveRole::Offsite,
             absent_duration_secs: None,
             last_activity_age_secs: None,
+            rotation: None,
         }
     }
 
@@ -566,6 +583,7 @@ drives = ["primary-drive", "offsite-drive"]
             role: DriveRole::Primary,
             absent_duration_secs: None,
             last_activity_age_secs: None,
+            rotation: None,
         }
     }
 
@@ -712,6 +730,7 @@ drives = ["primary-drive", "offsite-drive"]
             role: DriveRole::Offsite,
             absent_duration_secs: None,
             last_activity_age_secs: None,
+            rotation: None,
         };
         let fresh_offsite = offsite_drive_assessment(PromiseStatus::Protected, true);
         let drives = vec![primary_drive_assessment(), stale_offsite, fresh_offsite];
@@ -1398,6 +1417,7 @@ local_retention = "transient"
             role: DriveRole::Primary,
             absent_duration_secs: None,
             last_activity_age_secs: None,
+            rotation: None,
         }
     }
 

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -361,6 +361,45 @@ pub struct LocalAssessment {
     pub configured_interval: Interval,
 }
 
+/// Per-offsite-drive rotation context, carried alongside the per-copy
+/// `status` for UPI 056's forecast voice. **Forecast/cadence context only —
+/// deliberately no `tier`.** Gravity has exactly one source, the per-copy
+/// `PromiseStatus`; the rotation voice only enriches wording *within* each
+/// gravity band (RD6, S1). Carrying an engine `RotationTier` here would
+/// reintroduce a second freshness representation that could disagree with
+/// `status` (e.g. render red on a `source_unchanged` away offsite whose
+/// effective status is Protected) — the plan's worst defect, closed
+/// structurally by not carrying it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DriveRotation {
+    /// Per-drive cadence: the declared `rotation_interval` (PRIMARY) or the
+    /// observed `median_gap` (fallback). `None` for the Default window — there
+    /// is no rhythm to forecast against.
+    pub cadence: Option<Duration>,
+    /// The drive's last homecoming (`rotation::last_homecoming`). `None` if it
+    /// has never been seen home.
+    pub last_home: Option<NaiveDateTime>,
+    /// Window provenance, kept for Spindle's JSON ("declared vs observed
+    /// rhythm"). The MVP voice branches only on `cadence.is_some()`.
+    pub source: crate::rotation::WindowSource,
+    /// Pre-computed seconds until the next expected homecoming
+    /// (`last_home + cadence − now`); `None` when either input is missing.
+    /// Pre-computed here because `voice/` has no `now` (same pattern as
+    /// `output::StatusOutput::last_run_age_secs`). Negative = past due.
+    pub forecast_secs: Option<i64>,
+}
+
+/// Per-offsite-drive precompute, built once at the top of `assess()`: the
+/// freshness `window` (consumed by the per-copy relaxation and the away-nag in
+/// `compute_health`) bundled with the `rotation` carrier (cadence/last_home/
+/// forecast) that 056's voice surfaces. Both derive from the same single
+/// `drive_mount_history` read, so they share one map.
+#[derive(Debug, Clone, Copy)]
+struct OffsiteContext {
+    window: crate::rotation::OffsiteWindow,
+    rotation: DriveRotation,
+}
+
 /// External drive send freshness assessment.
 #[derive(Debug)]
 pub struct DriveAssessment {
@@ -391,6 +430,12 @@ pub struct DriveAssessment {
     /// `absent_duration_secs`.
     #[allow(dead_code)] // consumed via StatusDriveAssessment by voice.rs
     pub last_activity_age_secs: Option<i64>,
+    /// Rotation context for an offsite drive (UPI 056): cadence, last
+    /// homecoming, and the pre-computed homecoming forecast. `None` for
+    /// non-offsite drives — only offsite drives have a rotation rhythm. The
+    /// voice reads this to enrich the drive-row wording *within* the gravity
+    /// band set by `status`; it never sets gravity itself (S1).
+    pub rotation: Option<DriveRotation>,
 }
 
 // ── Core function ──────────────────────────────────────────────────────
@@ -476,20 +521,43 @@ pub fn assess(
         })
         .collect();
 
-    // Per-offsite-drive freshness window (UPI 055, ADR-116), computed once.
-    // An offsite drive's absence is expected — judged against its rotation
-    // cadence (declared `rotation_interval` PRIMARY, observed cadence fallback,
-    // 30d default), not the send interval. This is the only new `obs.history`
-    // call in `assess()`; the function stays pure (ADR-108).
-    let offsite_windows: std::collections::HashMap<String, crate::rotation::OffsiteWindow> = config
+    // Per-offsite-drive freshness window + rotation forecast (UPI 055/056,
+    // ADR-116), computed once. An offsite drive's absence is expected — judged
+    // against its rotation cadence (declared `rotation_interval` PRIMARY,
+    // observed cadence fallback, 30d default), not the send interval. The
+    // forecast context (cadence/last_home/forecast_secs) rides alongside the
+    // window from the same single `drive_mount_history` read; `voice/` has no
+    // `now`, so the homecoming forecast is pre-computed here (the
+    // `last_run_age_secs` precedent). This is the only new `obs.history` call in
+    // `assess()`; the function stays pure (ADR-108).
+    let offsite_ctx: std::collections::HashMap<String, OffsiteContext> = config
         .drives
         .iter()
         .filter(|d| d.role == DriveRole::Offsite)
         .map(|d| {
-            let observed =
-                crate::rotation::observed_cadence(&obs.history.drive_mount_history(&d.label), now);
+            let history = obs.history.drive_mount_history(&d.label);
+            let observed = crate::rotation::observed_cadence(&history, now);
             let window = crate::rotation::resolve_offsite_window(d.rotation_interval, observed);
-            (d.label.clone(), window)
+            // Cadence for the forecast, in window-source priority order:
+            // declared (PRIMARY) → observed median → None (Default — no rhythm).
+            let cadence = d
+                .rotation_interval
+                .map(|i| Duration::seconds(i.as_secs()))
+                .or_else(|| observed.map(|o| o.median_gap));
+            // Last homecoming independent of the ≥3-gap cadence floor (M4): a
+            // declared-window drive with a single homecoming still forecasts.
+            let last_home = crate::rotation::last_homecoming(&history);
+            let forecast_secs = match (last_home, cadence) {
+                (Some(home), Some(cadence)) => Some((home + cadence - now).num_seconds()),
+                _ => None,
+            };
+            let rotation = DriveRotation {
+                cadence,
+                last_home,
+                source: window.source,
+                forecast_secs,
+            };
+            (d.label.clone(), OffsiteContext { window, rotation })
         })
         .collect();
 
@@ -698,18 +766,24 @@ pub fn assess(
                 // Unprotected). Using data-age — not presence-age — keeps a
                 // drive that was briefly home but never refreshed honestly stale
                 // (R3). `source_unchanged` / mounted / never-sent are untouched.
+                let offsite_ctx_for_drive = offsite_ctx.get(&drive.label);
                 if drive.role == DriveRole::Offsite
                     && !mounted
                     && !source_unchanged
                     && any_peer_mounted
-                    && let Some(window) = offsite_windows.get(&drive.label)
+                    && let Some(ctx) = offsite_ctx_for_drive
                     && let Some(age) = last_send_age
                 {
-                    status = crate::rotation::classify(age, window).to_promise_status();
+                    status = crate::rotation::classify(age, &ctx.window).to_promise_status();
                 }
 
                 let (absent_duration_secs, last_activity_age_secs) =
                     drive_absence.get(&drive.label).copied().unwrap_or((None, None));
+
+                // Forecast context rides on every offsite drive (presence-based,
+                // applies whether or not the per-copy relaxation above fired);
+                // `None` for non-offsite drives — they have no rotation rhythm.
+                let rotation = offsite_ctx_for_drive.map(|ctx| ctx.rotation);
 
                 drive_assessments.push(DriveAssessment {
                     drive_label: drive.label.clone(),
@@ -722,6 +796,7 @@ pub fn assess(
                     role: drive.role,
                     absent_duration_secs,
                     last_activity_age_secs,
+                    rotation,
                 });
             }
         }
@@ -779,7 +854,7 @@ pub fn assess(
             &subvol.name,
             local_space_tight.is_some(),
             subvol.local_retention.is_transient(),
-            &offsite_windows,
+            &offsite_ctx,
         );
 
         // ── Storage posture (UPI 031-a) ──────────────────────────────
@@ -1106,7 +1181,7 @@ fn compute_health(
     subvol_name: &str,
     local_space_tight: bool,
     is_transient: bool,
-    offsite_windows: &std::collections::HashMap<String, crate::rotation::OffsiteWindow>,
+    offsite_ctx: &std::collections::HashMap<String, OffsiteContext>,
 ) -> (OperationalHealth, Vec<String>) {
     let mut reasons: Vec<String> = Vec::new();
     let mut worst = OperationalHealth::Healthy;
@@ -1249,9 +1324,9 @@ fn compute_health(
             let threshold = if da.role == DriveRole::Offsite {
                 // Every offsite drive is in the map (built from the same
                 // config.drives); the 30-day default is dead-defensive.
-                offsite_windows
+                offsite_ctx
                     .get(&da.drive_label)
-                    .map(|w| w.overdue_days())
+                    .map(|c| c.window.overdue_days())
                     .unwrap_or(30)
             } else {
                 DRIVE_AWAY_DEGRADED_DAYS

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -3686,6 +3686,7 @@ source = "/data/beta"
             role: DriveRole::Primary,
             absent_duration_secs: None,
             last_activity_age_secs: None,
+            rotation: None,
         }
     }
 

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -406,6 +406,7 @@ mod tests {
                     role: DriveRole::Primary,
                     absent_duration_secs: None,
                     last_activity_age_secs: None,
+                    rotation: None,
                 }],
                 chain_health: vec![],
                 advisories: vec![],

--- a/src/output.rs
+++ b/src/output.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::advice::{ActionableAdvice, RedundancyAdvisory, RedundancyAdvisoryKind};
 use crate::awareness::{DriveAssessment, PromiseStatus, SubvolAssessment};
+use crate::rotation::WindowSource;
 use crate::storage_critical::{StoragePosture, TightnessTier};
 use crate::types::{ByteSize, DriveRole};
 
@@ -257,6 +258,44 @@ pub struct StatusDriveAssessment {
     /// exist for this drive at all (ops-log fallback).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_activity_age_secs: Option<i64>,
+    /// Rotation context for an offsite drive (UPI 056): cadence, last
+    /// homecoming, and the pre-computed homecoming forecast. Additive,
+    /// offsite-only — omitted entirely for non-offsite drives (`None`) and
+    /// from JSON when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rotation: Option<DriveRotation>,
+}
+
+/// Serializable mirror of `awareness::DriveRotation` — the offsite rotation
+/// forecast block. Additive `--json` evolution (no `schema_version` bump):
+/// `--json` is documented as not-a-stable-contract (cli.md). Deliberately no
+/// `tier` (gravity is the sibling `status` field; S1).
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct DriveRotation {
+    /// Per-drive cadence in seconds — declared interval or observed median gap.
+    /// Absent for the Default window (no rhythm).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cadence_secs: Option<i64>,
+    /// The drive's last homecoming timestamp, if it has ever been seen home.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_home: Option<chrono::NaiveDateTime>,
+    /// Seconds until the next expected homecoming (`last_home + cadence − now`);
+    /// negative when past due. Absent when cadence or last_home is missing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub forecast_secs: Option<i64>,
+    /// Window provenance: `declared` / `observed` / `default`.
+    pub source: WindowSource,
+}
+
+impl DriveRotation {
+    fn from_engine(r: &crate::awareness::DriveRotation) -> Self {
+        Self {
+            cadence_secs: r.cadence.map(|c| c.num_seconds()),
+            last_home: r.last_home,
+            forecast_secs: r.forecast_secs,
+            source: r.source,
+        }
+    }
 }
 
 impl StatusDriveAssessment {
@@ -271,6 +310,7 @@ impl StatusDriveAssessment {
             role: a.role,
             absent_duration_secs: a.absent_duration_secs,
             last_activity_age_secs: a.last_activity_age_secs,
+            rotation: a.rotation.as_ref().map(DriveRotation::from_engine),
         }
     }
 }
@@ -1695,6 +1735,83 @@ mod tests {
         let sa = StatusAssessment::from_assessment(&assessment);
         assert_eq!(sa.redundancy_advisories.len(), 1);
         assert_eq!(sa.redundancy_advisories[0], advisory);
+    }
+
+    // ── UPI 056: additive rotation JSON block ──────────────────────────
+
+    /// A `DriveAssessment` carrying a rotation forecast, for the additive-JSON
+    /// projection tests. Offsite, away, declared/observed cadence present.
+    fn rotation_drive_assessment(
+        rotation: Option<crate::awareness::DriveRotation>,
+    ) -> DriveAssessment {
+        use crate::types::Interval;
+        DriveAssessment {
+            drive_label: "Offsite-4TB".to_string(),
+            status: PromiseStatus::Protected,
+            mounted: false,
+            snapshot_count: Some(3),
+            last_send_age: Some(chrono::Duration::days(18)),
+            source_unchanged: false,
+            configured_interval: Interval::hours(1),
+            role: DriveRole::Offsite,
+            absent_duration_secs: Some(18 * 86400),
+            last_activity_age_secs: None,
+            rotation,
+        }
+    }
+
+    #[test]
+    fn rotation_block_serializes_additively_when_present() {
+        let last_home = chrono::NaiveDate::from_ymd_opt(2026, 5, 14)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap();
+        let da = rotation_drive_assessment(Some(crate::awareness::DriveRotation {
+            cadence: Some(chrono::Duration::days(15)),
+            last_home: Some(last_home),
+            source: crate::rotation::WindowSource::Observed,
+            forecast_secs: Some(-3 * 86400), // past due
+        }));
+        let sa = StatusDriveAssessment::from_assessment(&da);
+        let value = serde_json::to_value(&sa).unwrap();
+
+        let rot = value.get("rotation").expect("rotation block present when Some");
+        assert_eq!(rot.get("cadence_secs"), Some(&serde_json::Value::from(15 * 86400)));
+        assert_eq!(rot.get("forecast_secs"), Some(&serde_json::Value::from(-3 * 86400)));
+        assert_eq!(rot.get("source"), Some(&serde_json::Value::from("observed")));
+        assert!(rot.get("last_home").is_some(), "last_home serialized: {rot}");
+        // S1: gravity is the sibling `status` field — the rotation block carries
+        // no `tier`. This pins the dropped-tier design at the JSON boundary.
+        assert!(rot.get("tier").is_none(), "rotation block must not carry a tier: {rot}");
+    }
+
+    #[test]
+    fn rotation_block_absent_from_json_when_none() {
+        let da = rotation_drive_assessment(None);
+        let sa = StatusDriveAssessment::from_assessment(&da);
+        let value = serde_json::to_value(&sa).unwrap();
+        assert!(
+            value.get("rotation").is_none(),
+            "rotation key must be omitted when None (additive): {value}"
+        );
+    }
+
+    #[test]
+    fn rotation_block_omits_cadence_for_default_window() {
+        // Default window (no declared, <3 observed gaps): cadence/forecast
+        // absent, but `source` still serializes — Spindle can tell "no rhythm".
+        let da = rotation_drive_assessment(Some(crate::awareness::DriveRotation {
+            cadence: None,
+            last_home: None,
+            source: crate::rotation::WindowSource::Default,
+            forecast_secs: None,
+        }));
+        let sa = StatusDriveAssessment::from_assessment(&da);
+        let value = serde_json::to_value(&sa).unwrap();
+        let rot = value.get("rotation").expect("rotation block present");
+        assert!(rot.get("cadence_secs").is_none(), "no cadence on Default: {rot}");
+        assert!(rot.get("forecast_secs").is_none(), "no forecast on Default: {rot}");
+        assert_eq!(rot.get("source"), Some(&serde_json::Value::from("default")));
     }
 
     #[test]

--- a/src/rotation.rs
+++ b/src/rotation.rs
@@ -64,8 +64,11 @@ pub struct RotationObservation {
 }
 
 /// Where an `OffsiteWindow` came from. Carried for UPI 056 provenance
-/// (forecast/voice); resolved but not yet read by 055's behavior.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// (forecast/voice). Serializes `snake_case` ("declared"/"observed"/"default")
+/// onto the additive `rotation` JSON block so Spindle can distinguish a
+/// declared rhythm from an observed one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum WindowSource {
     Declared,
     Observed,
@@ -97,9 +100,13 @@ impl OffsiteWindow {
     }
 }
 
-/// A copy's freshness tier relative to its offsite window. 055 ships three
-/// variants; UPI 056 adds `Due` by splitting `OnSchedule` (a compiler-checked
-/// enum extension — every match site is then forced to handle it).
+/// A copy's freshness tier relative to its offsite window — three variants,
+/// shared by 055 and 056. UPI 056's "due" register (an offsite away on schedule
+/// but past its cadence midpoint) is a **voice-only projection**, computed in
+/// `voice/` from the carried `cadence` + data-age — it does *not* split
+/// `OnSchedule` here. Gravity has one source, the per-copy `PromiseStatus`
+/// (RD9, S1); the tier stays 3-valued so the engine never grows a second
+/// freshness representation that could diverge from `status`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RotationTier {
     OnSchedule,
@@ -181,6 +188,21 @@ fn median_duration(sorted_gaps: &[Duration]) -> Duration {
         let b = sorted_gaps[n / 2];
         (a + b) / 2
     }
+}
+
+/// The drive's last homecoming — its most recent `Mount` event — regardless of
+/// how many completed cadence cycles exist. Unlike `observed_cadence` (which
+/// stays silent below `MIN_CYCLES_FOR_CADENCE` gaps), this needs only a single
+/// Mount, so a declared-window drive with one homecoming still gets a forecast
+/// (UPI 056, M4). `max` over the timestamps is clock-skew-safe — insertion
+/// order can't pick a stale arrival.
+#[must_use]
+pub fn last_homecoming(events: &[DriveEvent]) -> Option<NaiveDateTime> {
+    events
+        .iter()
+        .filter(|e| e.kind == DriveEventKind::Mount)
+        .map(|e| e.at)
+        .max()
 }
 
 /// Resolve the offsite window from the two cadence sources in priority order:
@@ -403,6 +425,39 @@ mod tests {
         let obs = observed_cadence(&events, now()).expect("3 positive gaps");
         assert_eq!(obs.gaps_observed, 3);
         assert_eq!(obs.median_gap, Duration::days(15));
+    }
+
+    // ── last_homecoming ────────────────────────────────────────────────
+
+    #[test]
+    fn last_homecoming_none_without_mounts() {
+        assert_eq!(last_homecoming(&[]), None);
+        let only_unmounts = [unmount(dt(2026, 3, 1)), unmount(dt(2026, 3, 10))];
+        assert_eq!(last_homecoming(&only_unmounts), None);
+    }
+
+    #[test]
+    fn last_homecoming_single_mount_below_cadence_floor() {
+        // One Mount is below MIN_CYCLES_FOR_CADENCE (so observed_cadence is
+        // None), but last_homecoming still reports it — the forecast must not
+        // wait for three cycles (M4).
+        let events = [mount(dt(2026, 5, 14))];
+        assert_eq!(observed_cadence(&events, now()), None);
+        assert_eq!(last_homecoming(&events), Some(dt(2026, 5, 14)));
+    }
+
+    #[test]
+    fn last_homecoming_picks_latest_ignoring_unmounts_and_order() {
+        // Mounts delivered out of order, interleaved with unmounts. The latest
+        // Mount wins regardless of insertion order (clock-skew safety).
+        let events = [
+            unmount(dt(2026, 4, 30)),
+            mount(dt(2026, 4, 1)),
+            mount(dt(2026, 5, 14)),
+            mount(dt(2026, 4, 21)),
+            unmount(dt(2026, 6, 1)),
+        ];
+        assert_eq!(last_homecoming(&events), Some(dt(2026, 5, 14)));
     }
 
     // ── resolve_offsite_window ─────────────────────────────────────────

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -913,6 +913,7 @@ mod tests {
                 role: DriveRole::Primary,
                 absent_duration_secs: None,
                 last_activity_age_secs: None,
+                rotation: None,
             }],
             chain_health: vec![],
             advisories: vec![],

--- a/src/voice/backup.rs
+++ b/src/voice/backup.rs
@@ -162,11 +162,69 @@ fn render_backup_interactive(data: &BackupSummary) -> String {
     // ── Transitions (mythic voice on events) ─────────────────────────
     render_transitions(&data.transitions, &mut out);
 
+    // ── "Safe to remove" offsite cue (UPI 056, RD2) ──────────────────
+    render_safe_to_remove(data, &mut out);
+
     // ── Next-action suggestion ──────────────────────────────────────
     let has_failures = data.subvolumes.iter().any(|sv| !sv.success);
     append_suggestion(&SuggestionContext::Backup { has_failures }, &mut out);
 
     out
+}
+
+/// After a clean offsite send, tell the user it is safe to take the drive back
+/// offsite — the one retained reconnect sliver of UPI 056 (RD2). Conservative,
+/// data-safety-first: a drive earns the cue only when it is offsite, still
+/// mounted (here now, so the user can act), received at least one **clean**
+/// successful send this run, and had **no** failed/deferred/errored work that
+/// touched it. Any ambiguity suppresses the cue (data-safety > completeness).
+fn render_safe_to_remove(data: &BackupSummary, out: &mut String) {
+    // Offsite drives that are physically present right now (role + mount come
+    // from the post-run assessments — `BackupSummary` has no `Config`).
+    let mut offsite_mounted: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    for a in &data.assessments {
+        for e in &a.external {
+            if e.role == DriveRole::Offsite && e.mounted {
+                offsite_mounted.insert(e.drive_label.as_str());
+            }
+        }
+    }
+
+    for drive in offsite_mounted {
+        let mut clean_success = false;
+        let mut troubled = false;
+        for sv in &data.subvolumes {
+            let sent_here = sv.sends.iter().any(|s| s.drive == drive);
+            let errored_here = sv
+                .structured_errors
+                .iter()
+                .any(|e| e.drive.as_deref() == Some(drive));
+            if !sent_here && !errored_here {
+                continue; // this subvolume did not touch the drive
+            }
+            // A subvolume that touched the drive must be wholly clean to count;
+            // any failure, deferral, or error on it taints the drive's cue.
+            let sv_clean = sv.success
+                && sv.deferred.is_empty()
+                && sv.structured_errors.is_empty()
+                && sv.errors.is_empty();
+            if sent_here && sv_clean {
+                clean_success = true;
+            }
+            if !sv_clean {
+                troubled = true;
+            }
+        }
+        if clean_success && !troubled {
+            writeln!(
+                out,
+                "  {} {}",
+                "·".dimmed(),
+                format!("offsite copy refreshed — safe to take {drive} back offsite").dimmed(),
+            )
+            .ok();
+        }
+    }
 }
 
 /// Render transition events as brief mythic voice lines.
@@ -463,7 +521,181 @@ fn format_list(items: &[&str]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::output::SkippedSubvolume;
+    use crate::output::{
+        DeferredInfo, SendSummary, SkippedSubvolume, StatusAssessment, StatusDriveAssessment,
+        StructuredError, SubvolumeSummary,
+    };
+    use crate::voice::test_fixtures::color_guard;
+
+    // ── "Safe to remove" cue (UPI 056, RD2) ────────────────────────────
+
+    fn offsite_entry(drive: &str, mounted: bool) -> StatusDriveAssessment {
+        StatusDriveAssessment {
+            drive_label: drive.to_string(),
+            status: PromiseStatus::Protected,
+            mounted,
+            snapshot_count: Some(3),
+            last_send_age_secs: Some(60),
+            role: DriveRole::Offsite,
+            absent_duration_secs: None,
+            last_activity_age_secs: None,
+            rotation: None,
+        }
+    }
+
+    fn assessment_with(drive: &str, mounted: bool) -> StatusAssessment {
+        StatusAssessment {
+            name: "sv".to_string(),
+            status: PromiseStatus::Protected,
+            health: "healthy".to_string(),
+            health_reasons: vec![],
+            promise_level: None,
+            local_snapshot_count: 1,
+            local_newest_age_secs: None,
+            local_status: PromiseStatus::Protected,
+            external: vec![offsite_entry(drive, mounted)],
+            advisories: vec![],
+            redundancy_advisories: vec![],
+            retention_summary: None,
+            external_only: false,
+            errors: vec![],
+            storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval_secs: None,
+        }
+    }
+
+    fn send_to(drive: &str) -> SendSummary {
+        SendSummary {
+            drive: drive.to_string(),
+            send_type: "incremental".to_string(),
+            bytes_transferred: Some(1_000_000),
+        }
+    }
+
+    fn subvol(name: &str, success: bool, sends: Vec<SendSummary>) -> SubvolumeSummary {
+        SubvolumeSummary {
+            name: name.to_string(),
+            success,
+            duration_secs: 1.0,
+            sends,
+            errors: vec![],
+            structured_errors: vec![],
+            deferred: vec![],
+        }
+    }
+
+    fn backup_with(
+        subvolumes: Vec<SubvolumeSummary>,
+        assessments: Vec<StatusAssessment>,
+    ) -> BackupSummary {
+        BackupSummary {
+            result: "success".to_string(),
+            run_id: Some(1),
+            duration_secs: 1.0,
+            subvolumes,
+            skipped: vec![],
+            assessments,
+            transitions: vec![],
+            warnings: vec![],
+            notes: vec![],
+        }
+    }
+
+    fn safe_to_remove_text(data: &BackupSummary) -> String {
+        let mut out = String::new();
+        render_safe_to_remove(data, &mut out);
+        out
+    }
+
+    #[test]
+    fn safe_to_remove_fires_once_for_clean_offsite_send() {
+        let _c = color_guard(false);
+        let data = backup_with(
+            vec![subvol("sv", true, vec![send_to("Offsite-4TB")])],
+            vec![assessment_with("Offsite-4TB", true)],
+        );
+        let out = safe_to_remove_text(&data);
+        assert_eq!(
+            out.matches("safe to take Offsite-4TB back offsite").count(),
+            1,
+            "clean single offsite send should fire exactly once: {out}"
+        );
+    }
+
+    #[test]
+    fn safe_to_remove_suppressed_when_drive_unmounted() {
+        let _c = color_guard(false);
+        // A send completed, but the drive is no longer mounted — can't act on it.
+        let data = backup_with(
+            vec![subvol("sv", true, vec![send_to("Offsite-4TB")])],
+            vec![assessment_with("Offsite-4TB", false)],
+        );
+        assert!(
+            !safe_to_remove_text(&data).contains("safe to take"),
+            "unmounted offsite drive must not get the cue"
+        );
+    }
+
+    #[test]
+    fn safe_to_remove_suppressed_when_no_offsite_send() {
+        let _c = color_guard(false);
+        // Offsite mounted, but the only send went to a different (primary) drive.
+        let mut data = backup_with(
+            vec![subvol("sv", true, vec![send_to("WD-18TB")])],
+            vec![assessment_with("Offsite-4TB", true)],
+        );
+        // Make the primary appear in assessments too (not offsite) — irrelevant.
+        data.assessments[0].external.push(StatusDriveAssessment {
+            role: DriveRole::Primary,
+            ..offsite_entry("WD-18TB", true)
+        });
+        assert!(
+            !safe_to_remove_text(&data).contains("safe to take"),
+            "no offsite send this run → no cue"
+        );
+    }
+
+    #[test]
+    fn safe_to_remove_suppressed_when_a_subvol_failed_to_that_drive() {
+        let _c = color_guard(false);
+        // Multi-subvol: sv-a sent cleanly to the offsite, sv-b failed a send to
+        // the same drive (structured error names it) → suppress (conservative).
+        let mut failed = subvol("sv-b", false, vec![]);
+        failed.structured_errors.push(StructuredError {
+            operation: "send".to_string(),
+            summary: "send failed".to_string(),
+            cause: "pipe broke".to_string(),
+            remediation: vec![],
+            drive: Some("Offsite-4TB".to_string()),
+            bytes_transferred: None,
+        });
+        let data = backup_with(
+            vec![subvol("sv-a", true, vec![send_to("Offsite-4TB")]), failed],
+            vec![assessment_with("Offsite-4TB", true)],
+        );
+        assert!(
+            !safe_to_remove_text(&data).contains("safe to take"),
+            "a failed send to the drive must suppress the cue"
+        );
+    }
+
+    #[test]
+    fn safe_to_remove_suppressed_when_sending_subvol_deferred() {
+        let _c = color_guard(false);
+        // The subvolume that sent to the offsite also deferred work — not wholly
+        // clean, so the drive does not earn the cue.
+        let mut sv = subvol("sv", true, vec![send_to("Offsite-4TB")]);
+        sv.deferred.push(DeferredInfo {
+            reason: "retention deferred".to_string(),
+            suggestion: "run calibrate".to_string(),
+        });
+        let data = backup_with(vec![sv], vec![assessment_with("Offsite-4TB", true)]);
+        assert!(
+            !safe_to_remove_text(&data).contains("safe to take"),
+            "a deferral on the sending subvolume must suppress the cue"
+        );
+    }
 
     #[test]
     fn backup_summary_suppresses_unchanged() {

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -327,6 +327,13 @@ pub(super) struct DriveAggregate {
     worst_status: PromiseStatus,
     absent_duration_secs: Option<i64>,
     last_activity_age_secs: Option<i64>,
+    /// Rotation context for an offsite drive (UPI 056), paired with the
+    /// `data_age_secs` it forecasts against. Per-drive and invariant across
+    /// subvolumes, so we take the first entry that carries it.
+    rotation: Option<crate::output::DriveRotation>,
+    /// Data-age (`last_send_age_secs`) of the entry that supplied `rotation` —
+    /// the clock the hibernating/due split reads (G3: data-age, not presence).
+    data_age_secs: Option<i64>,
 }
 
 pub(super) fn aggregate_drive_info(
@@ -339,6 +346,8 @@ pub(super) fn aggregate_drive_info(
     let mut worst = PromiseStatus::Protected;
     let mut absent_duration_secs: Option<i64> = None;
     let mut last_activity_age_secs: Option<i64> = None;
+    let mut rotation: Option<crate::output::DriveRotation> = None;
+    let mut data_age_secs: Option<i64> = None;
 
     for assessment in assessments {
         for ext in &assessment.external {
@@ -352,6 +361,15 @@ pub(super) fn aggregate_drive_info(
                 if last_activity_age_secs.is_none() {
                     last_activity_age_secs = ext.last_activity_age_secs;
                 }
+                // Take rotation + its paired data-age together from the first
+                // entry that carries it (offsite drives only), so the forecast
+                // and the age it forecasts against never come from split rows.
+                if rotation.is_none()
+                    && let Some(rot) = ext.rotation
+                {
+                    rotation = Some(rot);
+                    data_age_secs = ext.last_send_age_secs;
+                }
             }
         }
     }
@@ -360,6 +378,8 @@ pub(super) fn aggregate_drive_info(
         worst_status: worst,
         absent_duration_secs,
         last_activity_age_secs,
+        rotation,
+        data_age_secs,
     }
 }
 
@@ -417,6 +437,114 @@ pub(super) fn format_drive_age_label(
             format!("{} {phrase} — {}", drive_label.bold(), age_str.dimmed())
         }
     }
+}
+
+// ── Offsite rotation voice (UPI 056) ──────────────────────────────────
+
+/// The homecoming-forecast fragment for a hibernating offsite drive (M3).
+/// Returns `Some("due home in ~5d")` only when the next homecoming is still in
+/// the future (`forecast_secs > 0`); `None` once the drive is past its
+/// projected return (`≤ 0`) — there the seasonal wording carries the meaning
+/// and a "due home in ~-3d" line would be a falsehood (Voice Contract Rule 1).
+pub(super) fn format_due_home(forecast_secs: i64) -> Option<String> {
+    (forecast_secs > 0).then(|| format!("due home in ~{}", humanize_duration(forecast_secs)))
+}
+
+/// Drive-row label for an unmounted **offsite** drive carrying rotation context
+/// — the centerpiece of the rotation voice (UPI 056). Gravity is the
+/// `worst_status` band (S1): rotation context only enriches the wording
+/// *within* the band, it never sets color.
+///
+/// - **PROTECTED** (away on its rhythm) speaks the calm seasonal register:
+///   *hibernating* (on schedule — data-age within the calm half of the window,
+///   with a homecoming forecast) or *due home* (past the cadence midpoint but
+///   still inside the overdue window). Dim, no color. With no cadence (Default
+///   window) or no data-age there is "no rhythm to speak of" → the plain dim
+///   "away" form.
+/// - **AT RISK / UNPROTECTED** (genuinely overdue/stale against its own window):
+///   the word *absent* is earned (glossary: away *and* data aged), the offsite
+///   thread is *fraying* (amber) / *worn thin* (red), and the gravity shows.
+pub(super) fn offsite_drive_label(
+    drive_label: &str,
+    worst_status: PromiseStatus,
+    rotation: &crate::output::DriveRotation,
+    data_age_secs: Option<i64>,
+    absent_duration_secs: Option<i64>,
+    last_activity_age_secs: Option<i64>,
+) -> String {
+    match worst_status {
+        PromiseStatus::Protected => match (rotation.cadence_secs, data_age_secs) {
+            // On schedule — away within the calm half of its window. Append the
+            // homecoming forecast while it is still ahead.
+            (Some(cadence), Some(age)) if age <= cadence => {
+                match rotation.forecast_secs.and_then(format_due_home) {
+                    Some(forecast) => format!(
+                        "{} {} — {}",
+                        drive_label.bold(),
+                        "hibernating".dimmed(),
+                        forecast.dimmed(),
+                    ),
+                    None => format!("{} {}", drive_label.bold(), "hibernating".dimmed()),
+                }
+            }
+            // Past the cadence midpoint but still PROTECTED — due, but calm.
+            (Some(_), Some(_)) => format!(
+                "{} {}",
+                drive_label.bold(),
+                "due home — cycle it on your next trip".dimmed(),
+            ),
+            // Default window (no rhythm) or missing data-age → plain dim away.
+            _ => unmounted_drive_label(
+                drive_label,
+                absent_duration_secs,
+                last_activity_age_secs,
+                PromiseStatus::Protected,
+            ),
+        },
+        // Degraded bands — gravity is earned. "absent" is reserved for these
+        // (glossary: away *and* data aged); the weave word escalates with it.
+        PromiseStatus::AtRisk => offsite_absent_label(
+            drive_label,
+            worst_status,
+            absent_duration_secs,
+            last_activity_age_secs,
+            "fraying; bring it home",
+        ),
+        PromiseStatus::Unprotected => offsite_absent_label(
+            drive_label,
+            worst_status,
+            absent_duration_secs,
+            last_activity_age_secs,
+            "worn thin; bring it home",
+        ),
+    }
+}
+
+/// "{label} absent {age} — {suffix}" for the degraded offsite bands. The age
+/// comes from the same cascade as the calm form (Rule 1: the shown age matches
+/// its source) and reddens with the band — amber at AT RISK, red at
+/// UNPROTECTED, so colour and weave word escalate together. When no
+/// presence/activity signal exists, render "absent" without an age claim rather
+/// than invent one.
+fn offsite_absent_label(
+    drive_label: &str,
+    band: PromiseStatus,
+    absent_duration_secs: Option<i64>,
+    last_activity_age_secs: Option<i64>,
+    suffix: &str,
+) -> String {
+    let Some((age_secs, _phrase)) =
+        crate::awareness::cascade_age_source(absent_duration_secs, last_activity_age_secs)
+    else {
+        return format!("{} absent — {suffix}", drive_label.bold());
+    };
+    let age = humanize_duration(age_secs);
+    let age = if band == PromiseStatus::Unprotected {
+        age.red().to_string()
+    } else {
+        age.yellow().to_string()
+    };
+    format!("{} absent {age} — {suffix}", drive_label.bold())
 }
 
 // ── Next-Action Suggestions (4b) ──────────────────────────────────────
@@ -532,6 +660,7 @@ pub(crate) mod test_fixtures {
                         role: DriveRole::Primary,
                         absent_duration_secs: None,
                         last_activity_age_secs: None,
+                        rotation: None,
                     }],
                     advisories: vec![],
                     redundancy_advisories: vec![],
@@ -562,6 +691,7 @@ pub(crate) mod test_fixtures {
                         role: DriveRole::Primary,
                         absent_duration_secs: None,
                         last_activity_age_secs: None,
+                        rotation: None,
                     }],
                     advisories: vec![],
                     redundancy_advisories: vec![],
@@ -1065,6 +1195,7 @@ mod tests {
             role: DriveRole::Primary,
             absent_duration_secs: Some(604800), // 7 days — drives the "away" label
             last_activity_age_secs: None,
+            rotation: None,
         });
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
@@ -3170,6 +3301,7 @@ mod tests {
             role: DriveRole::Primary,
             absent_duration_secs: Some(86400),
             last_activity_age_secs: None,
+            rotation: None,
         });
         data.drives.push(DriveInfo {
             label: "Test-Drive".to_string(),
@@ -3239,6 +3371,7 @@ mod tests {
             role: DriveRole::Offsite,
             absent_duration_secs: Some(172800),
             last_activity_age_secs: None,
+            rotation: None,
         });
         let output = render_status(&data, OutputMode::Interactive);
         assert!(output.contains("away"), "unmounted drive with history should show 'away': {output}");
@@ -4185,6 +4318,7 @@ mod tests {
                 role: DriveRole::Primary,
                 absent_duration_secs: absent,
                 last_activity_age_secs: last_activity,
+                rotation: None,
             }],
             advisories: vec![],
             redundancy_advisories: vec![],
@@ -4357,6 +4491,69 @@ mod tests {
             !label.contains("last backup"),
             "must not use ops-log label when event exists: {label}"
         );
+    }
+
+    // ── UPI 056: offsite rotation voice helpers ───────────────────────
+
+    #[test]
+    fn format_due_home_only_when_ahead() {
+        // M3: a future homecoming forecasts; a past-due one suppresses.
+        assert_eq!(format_due_home(5 * 86400), Some("due home in ~5d".to_string()));
+        assert_eq!(format_due_home(1), Some("due home in ~1s".to_string()));
+        assert_eq!(format_due_home(0), None, "≤ 0 suppresses the forecast");
+        assert_eq!(format_due_home(-3 * 86400), None, "past due suppresses");
+    }
+
+    fn rot(cadence_secs: Option<i64>, forecast_secs: Option<i64>) -> crate::output::DriveRotation {
+        crate::output::DriveRotation {
+            cadence_secs,
+            last_home: None,
+            forecast_secs,
+            source: crate::rotation::WindowSource::Observed,
+        }
+    }
+
+    #[test]
+    fn offsite_label_protected_hibernating_and_due_split() {
+        let _color = color_guard(false);
+        let cadence = 15 * 86400;
+        // a ≤ cadence → hibernating + forecast.
+        let r = rot(Some(cadence), Some(5 * 86400));
+        let h = offsite_drive_label("Off", PromiseStatus::Protected, &r, Some(cadence), Some(cadence), None);
+        assert!(h.contains("hibernating"), "a == cadence → hibernating: {h}");
+        assert!(h.contains("due home in ~5d"), "forecast appended: {h}");
+        // a > cadence → due.
+        let r2 = rot(Some(cadence), None);
+        let d = offsite_drive_label("Off", PromiseStatus::Protected, &r2, Some(cadence + 1), Some(cadence + 1), None);
+        assert!(d.contains("due home") && !d.contains("hibernating"), "past midpoint → due: {d}");
+    }
+
+    #[test]
+    fn offsite_label_default_window_falls_back_to_away() {
+        let _color = color_guard(false);
+        let r = rot(None, None); // no cadence
+        let label =
+            offsite_drive_label("Off", PromiseStatus::Protected, &r, Some(5 * 86400), Some(5 * 86400), None);
+        assert!(label.contains("away"), "no rhythm → plain away: {label}");
+        assert!(!label.contains("hibernating") && !label.contains("due home"), "no split: {label}");
+    }
+
+    #[test]
+    fn offsite_label_degraded_bands_use_absent_and_weave() {
+        let _color = color_guard(false);
+        let r = rot(Some(15 * 86400), None);
+        let at_risk =
+            offsite_drive_label("Off", PromiseStatus::AtRisk, &r, Some(40 * 86400), Some(40 * 86400), None);
+        assert!(at_risk.contains("absent") && at_risk.contains("fraying"), "AtRisk: {at_risk}");
+        let unprot = offsite_drive_label(
+            "Off",
+            PromiseStatus::Unprotected,
+            &r,
+            Some(80 * 86400),
+            Some(80 * 86400),
+            None,
+        );
+        assert!(unprot.contains("absent") && unprot.contains("worn thin"), "Unprotected: {unprot}");
     }
 
     // ── 4b: Next-Action Suggestion Tests ──────────────────────────────

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -19,7 +19,7 @@ use crate::types::{ByteSize, DriveRole};
 
 use super::{
     SuggestionContext, aggregate_drive_info, append_suggestion, color_result, exposure_label,
-    format_status_table, humanize_duration, pluralize, unmounted_drive_label,
+    format_status_table, humanize_duration, offsite_drive_label, pluralize, unmounted_drive_label,
 };
 
 // ── Status ──────────────────────────────────────────────────────────────
@@ -449,14 +449,15 @@ pub(super) fn render_redundancy_advisories(data: &StatusOutput, out: &mut String
                 "Consider designating a drive as offsite to protect against site loss.".to_string(),
             ),
             RedundancyAdvisoryKind::OffsiteDriveStale => (
+                // The cadence-relative predicate comes from the engine `detail`
+                // (UPI 056, RD10) — e.g. "overdue — 11 days past its usual ~45d
+                // cycle"; voice supplies only the framing.
                 format!(
-                    "The offsite copy on {} has aged.",
-                    advisory
-                        .drive
-                        .as_deref()
-                        .unwrap_or("unknown"),
+                    "The offsite copy on {} is {}.",
+                    advisory.drive.as_deref().unwrap_or("unknown"),
+                    advisory.detail,
                 ),
-                "Cycle the offsite drive to refresh your off-site copy.".to_string(),
+                "Cycle the offsite drive on your next trip to refresh the copy.".to_string(),
             ),
             RedundancyAdvisoryKind::SinglePointOfFailure => (
                 format!(
@@ -507,12 +508,25 @@ pub(super) fn render_drive_summary(data: &StatusOutput, out: &mut String) {
             .ok();
         } else {
             let agg = aggregate_drive_info(&data.assessments, &drive.label);
-            let line = unmounted_drive_label(
-                &drive.label,
-                agg.absent_duration_secs,
-                agg.last_activity_age_secs,
-                agg.worst_status,
-            );
+            // Offsite drives carry rotation context → the seasonal ladder
+            // (hibernating / due / absent); everything else falls through to the
+            // shared away/last-backup cascade (UPI 056, S1: gravity from status).
+            let line = match agg.rotation.as_ref() {
+                Some(rotation) => offsite_drive_label(
+                    &drive.label,
+                    agg.worst_status,
+                    rotation,
+                    agg.data_age_secs,
+                    agg.absent_duration_secs,
+                    agg.last_activity_age_secs,
+                ),
+                None => unmounted_drive_label(
+                    &drive.label,
+                    agg.absent_duration_secs,
+                    agg.last_activity_age_secs,
+                    agg.worst_status,
+                ),
+            };
             writeln!(out, "Drives: {line}").ok();
         }
     }

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -457,6 +457,7 @@ mod contract {
                 role: crate::types::DriveRole::Offsite,
                 absent_duration_secs: Some(18 * 86400),
                 last_activity_age_secs: None,
+                rotation: None,
             });
         }
 
@@ -485,6 +486,197 @@ mod contract {
             helpers::count_red(&output),
             0,
             "on-schedule fortified status must have zero red SGR escapes; got:\n{output}"
+        );
+    }
+
+    // ── UPI 056 — Rotation voice (forecast / hibernating-due / weave) ───
+    //
+    // Gravity is the per-copy `worst_status` band (S1); rotation context only
+    // enriches wording within it. These tests pin that contract: the dropped
+    // engine `tier` can never redden a PROTECTED row, the hibernating/due split
+    // and forecast obey their boundaries (M5/M3), and only the genuinely
+    // degraded bands earn `absent` + the weave words.
+
+    /// Push an unmounted Offsite-4TB copy carrying rotation context onto every
+    /// subvolume of an all-sealed status. `worst_status` for the drive row then
+    /// comes solely from `status`; the rotation block only colours the wording.
+    fn status_with_offsite_rotation(
+        status: PromiseStatus,
+        data_age_secs: i64,
+        rotation: Option<crate::output::DriveRotation>,
+    ) -> crate::output::StatusOutput {
+        let mut data = all_sealed_status();
+        for a in &mut data.assessments {
+            a.external.push(crate::output::StatusDriveAssessment {
+                drive_label: "Offsite-4TB".to_string(),
+                status,
+                mounted: false,
+                snapshot_count: None,
+                last_send_age_secs: Some(data_age_secs),
+                role: crate::types::DriveRole::Offsite,
+                absent_duration_secs: Some(data_age_secs),
+                last_activity_age_secs: None,
+                rotation,
+            });
+        }
+        data
+    }
+
+    fn offsite_line(output: &str) -> String {
+        helpers::strip_ansi(output)
+            .lines()
+            .find(|l| l.starts_with("Drives:") && l.contains("Offsite-4TB"))
+            .map(str::to_string)
+            .unwrap_or_else(|| panic!("no Offsite-4TB drive line in:\n{output}"))
+    }
+
+    fn observed_rotation(
+        cadence_secs: Option<i64>,
+        forecast_secs: Option<i64>,
+    ) -> crate::output::DriveRotation {
+        crate::output::DriveRotation {
+            cadence_secs,
+            last_home: None,
+            forecast_secs,
+            source: crate::rotation::WindowSource::Observed,
+        }
+    }
+
+    /// S1 — the headline guard. A `source_unchanged` away offsite stays
+    /// PROTECTED at *any* data-age; the drive row must read that band (dim
+    /// "due home"), never a raw `classify` on the huge age (which would say
+    /// stale → red "worn thin"). This is the regression the dropped-tier
+    /// design prevents.
+    #[test]
+    fn rule1_source_unchanged_offsite_huge_age_stays_dim() {
+        let _color = color_guard(true);
+        let rotation = observed_rotation(Some(15 * 86400), None); // past due → no forecast
+        let data = status_with_offsite_rotation(
+            PromiseStatus::Protected,
+            200 * 86400, // 200d data-age, yet still PROTECTED (source_unchanged)
+            Some(rotation),
+        );
+        let output = render_status(&data, OutputMode::Interactive);
+        let line = offsite_line(&output);
+        assert!(line.contains("due home"), "past-cadence PROTECTED → due home: {line}");
+        assert!(
+            !line.contains("fraying") && !line.contains("worn thin"),
+            "PROTECTED band must not surface weave-degradation words: {line}"
+        );
+        assert!(
+            !line.contains("absent"),
+            "'absent' is reserved for degraded bands; PROTECTED is 'away'/'due': {line}"
+        );
+        assert_eq!(
+            helpers::count_red(&output),
+            0,
+            "source_unchanged PROTECTED offsite must render zero red: {output}"
+        );
+    }
+
+    /// M5 — the hibernating/due boundary is inclusive of hibernating, plus the
+    /// forecast renders only while the homecoming is still ahead.
+    #[test]
+    fn rule1_hibernating_due_boundary_no_color() {
+        let _color = color_guard(true);
+        let cadence = 15 * 86400;
+        // a == cadence → still hibernating; forecast (ahead) renders.
+        let data = status_with_offsite_rotation(
+            PromiseStatus::Protected,
+            cadence,
+            Some(observed_rotation(Some(cadence), Some(5 * 86400))),
+        );
+        let out = render_status(&data, OutputMode::Interactive);
+        let line = offsite_line(&out);
+        assert!(line.contains("hibernating"), "a == cadence → hibernating: {line}");
+        assert!(line.contains("due home in ~5d"), "forecast shows when ahead: {line}");
+        assert_eq!(helpers::count_red(&out), 0, "hibernating is colourless: {out}");
+
+        // a == cadence + 1s → due, not hibernating.
+        let data2 = status_with_offsite_rotation(
+            PromiseStatus::Protected,
+            cadence + 1,
+            Some(observed_rotation(Some(cadence), None)),
+        );
+        let out2 = render_status(&data2, OutputMode::Interactive);
+        let line2 = offsite_line(&out2);
+        assert!(line2.contains("due home"), "a == cadence+1s → due: {line2}");
+        assert!(!line2.contains("hibernating"), "past midpoint is not hibernating: {line2}");
+        assert_eq!(helpers::count_red(&out2), 0, "due is colourless: {out2}");
+    }
+
+    /// M3 — a past-due forecast (`forecast_secs ≤ 0`) is suppressed: no
+    /// "due home in ~-3d" falsehood; the seasonal word carries it.
+    #[test]
+    fn rule1_forecast_suppressed_when_past_due() {
+        let _color = color_guard(true);
+        let data = status_with_offsite_rotation(
+            PromiseStatus::Protected,
+            10 * 86400, // a ≤ cadence → hibernating
+            Some(observed_rotation(Some(15 * 86400), Some(-3 * 86400))),
+        );
+        let out = render_status(&data, OutputMode::Interactive);
+        let line = offsite_line(&out);
+        assert!(line.contains("hibernating"), "still on schedule: {line}");
+        assert!(
+            !line.contains("due home in"),
+            "past-due forecast must be suppressed (no 'due home in ~-3d'): {line}"
+        );
+    }
+
+    /// Default window (no cadence) → no seasonal split; the plain dim "away"
+    /// form, "no rhythm to speak of".
+    #[test]
+    fn rule1_default_window_falls_back_to_away() {
+        let _color = color_guard(true);
+        let data = status_with_offsite_rotation(
+            PromiseStatus::Protected,
+            5 * 86400,
+            Some(observed_rotation(None, None)),
+        );
+        let out = render_status(&data, OutputMode::Interactive);
+        let line = offsite_line(&out);
+        assert!(line.contains("away"), "Default window → plain dim away: {line}");
+        assert!(
+            !line.contains("hibernating") && !line.contains("due home"),
+            "no rhythm → no seasonal split: {line}"
+        );
+        assert_eq!(helpers::count_red(&out), 0, "calm away form is colourless: {out}");
+    }
+
+    /// The degraded bands earn `absent` + the weave words, and gravity escalates
+    /// amber (AT RISK) → red (UNPROTECTED). Also guards the sole-offsite-no-peer
+    /// case: an AtRisk offsite (its honest send-interval status) is NOT falsely
+    /// dimmed to hibernating just because it carries cadence context.
+    #[test]
+    fn offsite_degraded_bands_earn_absent_and_weave_words() {
+        let _color = color_guard(true);
+        let rotation = observed_rotation(Some(15 * 86400), None);
+
+        let at_risk =
+            status_with_offsite_rotation(PromiseStatus::AtRisk, 40 * 86400, Some(rotation));
+        let out = render_status(&at_risk, OutputMode::Interactive);
+        let line = offsite_line(&out);
+        assert!(
+            line.contains("absent") && line.contains("fraying"),
+            "AtRisk offsite → absent + fraying: {line}"
+        );
+        assert!(
+            !line.contains("hibernating"),
+            "an AtRisk offsite must not be falsely dimmed to hibernating: {line}"
+        );
+
+        let unprot =
+            status_with_offsite_rotation(PromiseStatus::Unprotected, 80 * 86400, Some(rotation));
+        let out2 = render_status(&unprot, OutputMode::Interactive);
+        let line2 = offsite_line(&out2);
+        assert!(
+            line2.contains("absent") && line2.contains("worn thin"),
+            "Unprotected offsite → absent + worn thin: {line2}"
+        );
+        assert!(
+            helpers::count_red(&out2) >= 1,
+            "Unprotected offsite drive row reddens (E2 composition): {out2}"
         );
     }
 


### PR DESCRIPTION
## Summary

Completes UPI 056. PR1 (#165) made the Fortified offsite-freshness overlay window-aware (the truth); this PR gives the rotation rhythm a **voice** (the presentation). `urd status` now speaks an offsite drive's cadence instead of reporting bald absence.

- **Carrier (no tier — S1).** New `awareness::DriveRotation` (cadence / last_home / source / pre-computed homecoming forecast) rides on every offsite `DriveAssessment`, built once in `assess()` from a single mount-history read. Gravity has exactly one source — the per-copy `PromiseStatus` — so a `source_unchanged` away offsite never falsely reddens regardless of data-age. New pure `rotation::last_homecoming()` (independent of the ≥3-gap cadence floor) feeds the forecast.
- **Drive-row ladder.** PROTECTED → *hibernating* + *due home in ~Nd* (forecast suppressed once past due) / *due home — cycle it on your next trip*; AT RISK / UNPROTECTED → *absent* + thread *fraying* (amber) / *worn thin* (red). Rotation words only enrich wording within the gravity band.
- **Advisory + cue.** `OffsiteDriveStale` reworded cadence-relative ("overdue — N days past its usual ~Md cycle"); `urd backup` adds a conservative *safe to take {drive} back offsite* cue after a clean offsite send.
- **JSON.** Additive, offsite-only `rotation` block on `urd status --json` for Spindle (`cadence_secs` / `last_home` / `forecast_secs` / `source` — no `tier`). No `schema_version` bump (additive `--json` evolution, ADR-114 precedent); no metric/heartbeat change. Cites ADR-116.

Live-verified read-only: the real offsite drive at 58d data-age stays PROTECTED (source_unchanged) and renders the calm "due home", never a false red — S1 holding in the field.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1669 passed, 4 ignored
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)