### PR TITLE
release: v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-06-03
+
 ### Added
 - **Rotation voice: forecast, "hibernating," and the offsite drive-row ladder** (UPI 056 PR2,
   cites ADR-116). `urd status` now *speaks the rhythm* instead of reporting bald absence. An
@@ -893,7 +895,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/vonrobak/urd/compare/v0.23.0...v0.24.0
+[0.23.0]: https://github.com/vonrobak/urd/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/vonrobak/urd/compare/v0.21.2...v0.22.0
 [0.21.2]: https://github.com/vonrobak/urd/compare/v0.21.1...v0.21.2
 [0.21.1]: https://github.com/vonrobak/urd/compare/v0.21.0...v0.21.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Cuts **v0.24.0** (minor) — the rotation-voice half of the offsite-rotation arc.

- **UPI 055** — role-aware offsite freshness model + rotation view (`rotation.rs`, two-clocks split, `rotation_interval`).
- **UPI 056** — rotation voice: window-aware Fortified overlay capped at AT RISK (PR1 #165), plus the drive-row **hibernating / due / absent** ladder, *due home* forecast, cadence-relative `OffsiteDriveStale`, "safe to remove" backup cue, and the additive `--json` `rotation` block (PR2 #166).

Both cite ADR-116; no new ADR, no metric/heartbeat/on-disk/config-schema change. Also backfills the `[0.23.0]` comparison link the previous release skipped and re-points `[Unreleased]`.

(058 already shipped in v0.23.0 — not part of this release.)

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1669 passed, 4 ignored
- cargo check: Cargo.lock bumped to 0.24.0

## After merge

Tag `v0.24.0` on the squash-merged master commit and push the tag (`git push origin master --tags`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)