### PR TITLE
fix: gate post-upgrade acknowledgment preamble on OutputMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Post-upgrade acknowledgment preamble now gated on output mode** (#168). The one-time
+  v0.13.0 "trust repair" notice could be prepended ahead of the JSON document on a single
+  Daemon (non-TTY) run, making that one output non-parseable as JSON. The preamble is now
+  suppressed in Daemon mode and, crucially, a daemon run no longer consumes the one-shot
+  marker — so the user still sees the reassurance on their next interactive invocation.
+  Closes the latent pattern where any future acknowledgment reusing `preamble_for` would
+  inherit the same JSON-corruption window.
+
 ## [0.24.0] - 2026-06-03
 
 ### Added

--- a/src/commands/acknowledgment.rs
+++ b/src/commands/acknowledgment.rs
@@ -1,3 +1,4 @@
+use crate::output::OutputMode;
 use crate::state::StateDb;
 use colored::Colorize;
 use std::path::Path;
@@ -20,7 +21,16 @@ const MESSAGE: &str = "Urd's self-check is now more accurate. Some subvolumes pr
 /// `state_db` path and returns the preamble string (empty if not applicable).
 /// Call sites that already hold a `StateDb` and the `Config` use this to
 /// avoid duplicating the `state_db.parent()` plumbing.
-pub fn preamble_for(state_db_path: &Path, db: Option<&StateDb>) -> String {
+///
+/// The acknowledgment is a user-facing reassurance, so it is suppressed in
+/// Daemon (non-TTY) mode — never prepended ahead of machine-readable JSON.
+/// A daemon run returns early *before* consuming the one-shot, so the marker
+/// stays unwritten and the user still sees the line on their next interactive
+/// invocation.
+pub fn preamble_for(state_db_path: &Path, db: Option<&StateDb>, mode: OutputMode) -> String {
+    if mode != OutputMode::Interactive {
+        return String::new();
+    }
     db.and_then(|db| state_db_path.parent().and_then(|dir| take_post_upgrade_preamble(dir, db)))
         .unwrap_or_default()
 }
@@ -116,5 +126,32 @@ mod tests {
 
         let marker = tmp.path().join(".acknowledgments").join(MARKER_NAME);
         assert!(!marker.exists());
+    }
+
+    #[test]
+    fn daemon_mode_suppresses_and_preserves_one_shot() {
+        let tmp = TempDir::new().unwrap();
+        let db = open_db(&tmp);
+        record_completed_run(&db);
+        let state_db_path = tmp.path().join("urd.db");
+        let marker = tmp.path().join(".acknowledgments").join(MARKER_NAME);
+
+        // Daemon run: returning user, no marker → emits nothing and must NOT
+        // consume the one-shot (the marker stays unwritten).
+        let daemon = preamble_for(&state_db_path, Some(&db), OutputMode::Daemon);
+        assert!(daemon.is_empty());
+        assert!(!marker.exists());
+
+        // The user still sees the line on their next interactive invocation.
+        let interactive = preamble_for(&state_db_path, Some(&db), OutputMode::Interactive);
+        assert!(interactive.contains("self-check is now more accurate"));
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn interactive_mode_returns_none_without_db() {
+        let tmp = TempDir::new().unwrap();
+        let state_db_path = tmp.path().join("urd.db");
+        assert!(preamble_for(&state_db_path, None, OutputMode::Interactive).is_empty());
     }
 }

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -574,6 +574,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let preamble = crate::commands::acknowledgment::preamble_for(
         &config.general.state_db,
         state_db.as_ref(),
+        output_mode,
     );
     println!("{preamble}{rendered}");
 

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -102,6 +102,7 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
     let preamble = crate::commands::acknowledgment::preamble_for(
         &config.general.state_db,
         state_db.as_ref(),
+        output_mode,
     );
     print!("{preamble}{rendered}");
     Ok(())

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -147,6 +147,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     let preamble = crate::commands::acknowledgment::preamble_for(
         &config.general.state_db,
         state_db.as_ref(),
+        output_mode,
     );
     print!("{preamble}{rendered}");
 


### PR DESCRIPTION
## Summary

Fixes #168.

- The one-time v0.13.0 "trust repair" acknowledgment line was prepended to command output **without gating on `OutputMode`**. On the single run it fires, a Daemon (non-TTY) invocation emitted the plain-text message ahead of the JSON document on stdout — making that one output non-parseable as JSON.
- Threaded the already-detected `OutputMode` into `preamble_for`, which now **early-returns an empty string in non-Interactive mode** — *before* `take_post_upgrade_preamble` runs, so a daemon run does **not** consume the one-shot marker.
- Because the acknowledgment is a user-facing reassurance, "skip don't consume" is the intended behavior: the user still sees the line on their next interactive invocation.
- Updated all three call sites (`backup`, `status`, default) to pass `output_mode`.

Largely inert today (any install past v0.13.0 has consumed the marker; the homelab consumer parses heartbeat/metrics, not CLI JSON per ADR-021). The value is **closing the latent pattern**: a future acknowledgment reusing `preamble_for` would inherit the same JSON-corruption window.

## Acceptance criteria

- [x] No acknowledgment text is ever emitted in Daemon mode from `backup` / `status` / default.
- [x] A Daemon-mode run does **not** consume the one-shot marker.
- [x] Regression test: Daemon mode with a returning user and no marker → no preamble, marker not created, then interactive run still emits the line.
- [x] Existing interactive behavior and tests remain green.

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: 1671 passed, 0 failed (incl. 2 new acknowledgment tests)
- `cargo build --release`: pass
- Integration tests: not applicable (no btrfs/drive interaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)