### PR TITLE
release: v0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-06-04
+
 ### Fixed
 - **Post-upgrade acknowledgment preamble now gated on output mode** (#168). The one-time
   v0.13.0 "trust repair" notice could be prepended ahead of the JSON document on a single
@@ -904,7 +906,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.24.1...HEAD
+[0.24.1]: https://github.com/vonrobak/urd/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/vonrobak/urd/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/vonrobak/urd/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/vonrobak/urd/compare/v0.21.2...v0.22.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Patch release **v0.24.1**.

- Fixes #168: the post-upgrade acknowledgment preamble is now gated on `OutputMode` — never prepended ahead of machine-readable JSON in Daemon mode, and a daemon run no longer consumes the one-shot marker (the user still sees the reassurance on their next interactive run).
- Bumps `Cargo.toml` / `Cargo.lock` to 0.24.1 and moves the CHANGELOG `[Unreleased]` entry into `[0.24.1] - 2026-06-04`.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1671 passed, 0 failed
- Integration tests: not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)