### PR TITLE
refactor: armed-tier coherence — convention to structure (deepening 01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Armed-tier coherence hardened from convention into structure** (hardens the ADR-113
+  single-gather invariant). The hysteresis-resolved storage tier is now carried on
+  `ResolvedStorageSignal` and derived once by its constructor; awareness reads that stamped
+  tier instead of independently re-resolving it, so the staleness judgement can no longer
+  desync from the tier the planner timed against — closing a latent false-AT-RISK /
+  false-PROTECTED path. Behavior-preserving: the planner/executor map and the post-exec
+  writeback are unchanged.
+
 ## [0.24.1] - 2026-06-04
 
 ### Fixed

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -292,6 +292,49 @@ pub struct ResolvedStorageSignal {
     pub prior_armed_tier: crate::storage_critical::TightnessTier,
     /// When the armed tier last changed (the "flagged since" timestamp).
     pub prior_since: Option<NaiveDateTime>,
+    /// The hysteresis-resolved armed tier for this run, derived ONCE at
+    /// construction from `(prior_armed_tier, free_ratio)`. Private and
+    /// read-only: every consumer (planner via the map, executor, awareness)
+    /// reads back the SAME resolved value instead of re-deriving it, so the
+    /// promise can never desync from the plan. This carries the ADR-113
+    /// single-gather invariant in the type rather than a prose comment. Read
+    /// via [`armed_tier`](ResolvedStorageSignal::armed_tier).
+    armed_tier: crate::storage_critical::TightnessTier,
+}
+
+impl ResolvedStorageSignal {
+    /// Build a signal, deriving the armed tier from `(prior, free_ratio)` via
+    /// the single hysteresis resolver (`storage_critical::resolve_armed_tier`).
+    /// This is the ONLY constructor: a signal whose stamped `armed_tier`
+    /// disagrees with its inputs cannot exist. Stamped once on the single
+    /// pre-plan gather (`commands/storage_signals`); awareness and the
+    /// planner/executor `armed_tier_map` all read it back, never re-resolve.
+    #[must_use]
+    pub fn resolved(
+        free_ratio: Option<f64>,
+        host_root: bool,
+        prior_armed_tier: crate::storage_critical::TightnessTier,
+        prior_since: Option<NaiveDateTime>,
+    ) -> Self {
+        let armed_tier = crate::storage_critical::resolve_armed_tier(
+            prior_armed_tier,
+            free_ratio,
+        );
+        Self {
+            free_ratio,
+            host_root,
+            prior_armed_tier,
+            prior_since,
+            armed_tier,
+        }
+    }
+
+    /// The hysteresis-resolved armed tier for this run (read-only). The single
+    /// value the planner timed against and awareness judges staleness against.
+    #[must_use]
+    pub fn armed_tier(&self) -> crate::storage_critical::TightnessTier {
+        self.armed_tier
+    }
 }
 
 /// Per-subvolume storage signals keyed by subvolume name (UPI 031-a). Built at
@@ -597,17 +640,16 @@ pub fn assess(
         let local_dir = snapshot_root.join(&subvol.name);
 
         // ── Tier-adapted effective policy (UPI 031-b) ────────────────
-        // Resolve the armed tier once (Roomy default when no signal), then
-        // derive the effective policy. The SAME armed tier feeds the planner
-        // (via backup.rs's single pre-plan gather), so the effective send
-        // interval awareness judges staleness against agrees with what the
-        // planner timed against — no false AT RISK for a correctly-adapting
-        // subvolume. `armed` also drives the posture and the AT-RISK cap below.
+        // READ the armed tier stamped once at the single pre-plan gather
+        // (`commands/storage_signals`); awareness never re-resolves. The
+        // planner's `armed_tier_map` carries the SAME stamped value, so the
+        // effective send interval awareness judges staleness against agrees with
+        // what the planner timed against — no false AT RISK for a
+        // correctly-adapting subvolume. Roomy default when a subvolume has no
+        // signal. `armed` also drives the posture and the AT-RISK cap below.
         let armed = storage_signals
             .get(&subvol.name)
-            .map(|sig| {
-                crate::storage_critical::resolve_armed_tier(sig.prior_armed_tier, sig.free_ratio)
-            })
+            .map(|sig| sig.armed_tier())
             .unwrap_or_default();
         let eff = crate::storage_critical::derive_effective_policy(
             &subvol.local_retention,
@@ -1512,12 +1554,12 @@ source = "/data/sv1"
         let mut signals = crate::awareness::StorageSignalMap::new();
         signals.insert(
             "sv1".to_string(),
-            ResolvedStorageSignal {
-                free_ratio: Some(0.20), // < 0.25 → Tight
-                host_root: false,
-                prior_armed_tier: TightnessTier::Roomy,
-                prior_since: None,
-            },
+            ResolvedStorageSignal::resolved(
+                Some(0.20), // < 0.25 → Tight
+                false,
+                TightnessTier::Roomy,
+                None,
+            ),
         );
 
         let results = assess(
@@ -1538,12 +1580,12 @@ source = "/data/sv1"
         let mut signals = crate::awareness::StorageSignalMap::new();
         signals.insert(
             "sv1".to_string(),
-            ResolvedStorageSignal {
-                free_ratio: Some(0.05), // < 0.15 → Critical
-                host_root: true,
-                prior_armed_tier: TightnessTier::Roomy,
-                prior_since: None,
-            },
+            ResolvedStorageSignal::resolved(
+                Some(0.05), // < 0.15 → Critical
+                true,
+                TightnessTier::Roomy,
+                None,
+            ),
         );
 
         let results = assess(
@@ -1564,12 +1606,12 @@ source = "/data/sv1"
         let mut signals = crate::awareness::StorageSignalMap::new();
         signals.insert(
             "sv1".to_string(),
-            ResolvedStorageSignal {
-                free_ratio: Some(0.50), // roomy
-                host_root: true,
-                prior_armed_tier: TightnessTier::Roomy,
-                prior_since: None,
-            },
+            ResolvedStorageSignal::resolved(
+                Some(0.50), // roomy
+                true,
+                TightnessTier::Roomy,
+                None,
+            ),
         );
 
         let results = assess(
@@ -1604,12 +1646,12 @@ source = "/data/sv1"
         // Only sv1 has a signal; sv2 must stay posture-free.
         signals.insert(
             "sv1".to_string(),
-            ResolvedStorageSignal {
-                free_ratio: Some(0.10),
-                host_root: false,
-                prior_armed_tier: TightnessTier::Roomy,
-                prior_since: None,
-            },
+            ResolvedStorageSignal::resolved(
+                Some(0.10),
+                false,
+                TightnessTier::Roomy,
+                None,
+            ),
         );
 
         let results = assess(
@@ -1633,12 +1675,44 @@ source = "/data/sv1"
         let mut signals = crate::awareness::StorageSignalMap::new();
         signals.insert(
             "sv1".to_string(),
-            ResolvedStorageSignal {
-                free_ratio: Some(0.18), // classifies Tight; prior was Roomy
-                host_root: false,
-                prior_armed_tier: TightnessTier::Roomy,
-                prior_since: None,
-            },
+            ResolvedStorageSignal::resolved(
+                Some(0.18), // classifies Tight; prior was Roomy
+                false,
+                TightnessTier::Roomy,
+                None,
+            ),
+        );
+
+        let results = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let posture = posture_of(&results, "sv1").expect("sv1 should have posture");
+        assert_eq!(posture.tier, TightnessTier::Tight);
+    }
+
+    #[test]
+    fn read_path_posture_reflects_stamped_hysteresis_tier() {
+        // Read paths (status/doctor/default) feed assess the gathered signal and
+        // READ the stamped tier — they never re-resolve. Prove assess reflects
+        // the HYSTERESIS-resolved tier, not the prior and not a naive classify:
+        // prior Critical + 0.28 free de-escalates exactly one band to Tight
+        // (Critical→Tight needs free > 0.25; Tight→Roomy needs > 0.30). So
+        // posture must be Tight — Critical (the prior) or Roomy (a bare classify
+        // of 0.28) would both be wrong, and only the stamped tier is right.
+        use crate::storage_critical::TightnessTier;
+        let (config, now, fs) = posture_fixture();
+        let mut signals = crate::awareness::StorageSignalMap::new();
+        signals.insert(
+            "sv1".to_string(),
+            ResolvedStorageSignal::resolved(
+                Some(0.28),
+                false,
+                TightnessTier::Critical,
+                None,
+            ),
         );
 
         let results = assess(
@@ -1671,12 +1745,12 @@ source = "/data/sv1"
         let mut signals = StorageSignalMap::new();
         signals.insert(
             "sv1".to_string(),
-            ResolvedStorageSignal {
-                free_ratio: Some(free_ratio),
-                host_root: false,
-                prior_armed_tier: TightnessTier::Roomy,
-                prior_since: None,
-            },
+            ResolvedStorageSignal::resolved(
+                Some(free_ratio),
+                false,
+                TightnessTier::Roomy,
+                None,
+            ),
         );
         (config, now, fs, signals)
     }
@@ -1751,12 +1825,26 @@ source = "/data/sv1"
     }
 
     #[test]
-    fn coherence_awareness_and_planner_share_effective_interval() {
-        // S2 coherence: the interval awareness judges staleness against MUST
-        // equal the one the planner times against, for the same armed tier —
-        // both route through `derive_effective_policy`. A future re-gather that
-        // desynced the tier would break this (false AT RISK).
+    fn coherence_awareness_judges_against_the_stamped_tier() {
+        // S2 coherence: awareness judges staleness against the SAME armed tier
+        // the planner times against. The planner reads `resolve_armed_tiers`'s
+        // map; awareness reads the stamped `ResolvedStorageSignal::armed_tier` —
+        // and `gather_with` stamps ONE value for both (that the two stamps agree
+        // is locked by `gather_stamps_one_tier_read_by_planner_and_awareness` in
+        // storage_signals). Here: assert awareness's effective interval is the
+        // one derived from the tier ACTUALLY stamped on the signal — not a tier
+        // re-derived inside the test (the old hardcoded-`Critical` tautology,
+        // which proved only that `derive_effective_policy` is deterministic).
         let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 22, 14, 0), 0.05);
+        let sv1_sig = signals.get("sv1").expect("fixture stamps sv1");
+        // Non-vacuous: 0.05 free resolves to Critical, whose effective interval
+        // (the 7d floor) differs from the declared 1d — so this exercises the
+        // adapted path, not a Roomy passthrough.
+        assert_eq!(
+            sv1_sig.armed_tier(),
+            crate::storage_critical::TightnessTier::Critical,
+            "fixture must exercise the adapted (Critical) interval"
+        );
         let results = assess(
             &config,
             now,
@@ -1770,15 +1858,16 @@ source = "/data/sv1"
             &sv.local_retention,
             sv.send_interval,
             sv.send_enabled,
-            crate::storage_critical::TightnessTier::Critical,
-            // send_interval is invariant under has_away_pin, so this coherence
-            // check holds for either value; awareness itself passes false.
+            // The tier the planner's map ALSO carries (same gather, same value).
+            sv1_sig.armed_tier(),
+            // send_interval is invariant under has_away_pin (UPI 058); awareness
+            // passes false, so coherence holds for either value.
             false,
         );
         assert_eq!(
             sv1.effective_send_interval,
             Some(planner_eff.send_interval),
-            "awareness and planner judge the SAME effective interval"
+            "awareness judges against the interval derived from the stamped tier"
         );
     }
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -95,8 +95,10 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // Critical→Tight — desyncing the effective send interval the planner timed
     // against from the one awareness judges staleness against, surfacing a
     // correctly-adapting subvolume as false AT RISK. The coherence guard is
-    // THIS single gather (Risk 4 / S2), enforced by the awareness coherence
-    // test, not by `derive_effective_policy` alone.
+    // THIS single gather (Risk 4 / S2): the tier is resolved once and STAMPED
+    // on the signal (`ResolvedStorageSignal::armed_tier`, derived in its
+    // constructor), so the planner's map, the executor, the writeback, and
+    // awareness all READ the same value rather than each re-deriving it.
     let signals = storage_signals::gather(&config, state_db.as_ref());
     let resolved = storage_signals::resolve_armed_tiers(&signals);
 

--- a/src/commands/storage_signals.rs
+++ b/src/commands/storage_signals.rs
@@ -165,12 +165,12 @@ fn gather_with(
             pool.subvol_names.push(sv.name.clone());
             by_subvol.insert(
                 sv.name.clone(),
-                ResolvedStorageSignal {
-                    free_ratio: pool.free_ratio,
-                    host_root: pool.host_root,
-                    prior_armed_tier: pool.prior_armed_tier,
-                    prior_since: pool.prior_since,
-                },
+                ResolvedStorageSignal::resolved(
+                    pool.free_ratio,
+                    pool.host_root,
+                    pool.prior_armed_tier,
+                    pool.prior_since,
+                ),
             );
         }
     }
@@ -198,10 +198,12 @@ pub struct ResolvedPoolTier {
     pub new_tier: TightnessTier,
 }
 
-/// The armed tier resolved once for the backup run (UPI 031-b AB1). Carries the
-/// planner/executor/awareness-facing `armed_tier_map` (subvol → tier) AND the
-/// per-pool rows the post-exec writeback persists — one resolution, two
-/// consumers, so "resolve once" stays literal.
+/// The armed tier for the backup run (UPI 031-b AB1). Carries the
+/// planner/executor-facing `armed_tier_map` (subvol → tier) AND the per-pool
+/// rows the post-exec writeback persists — both resolved once here, pre-plan,
+/// from the gathered `(prior, free)`. Awareness does not read this map; it reads
+/// the matching per-subvolume `ResolvedStorageSignal::armed_tier`, derived from
+/// the same inputs.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedArmedTiers {
     pub armed_tier_map: ArmedTierMap,
@@ -220,6 +222,14 @@ pub fn resolve_armed_tiers(signals: &StorageSignals) -> ResolvedArmedTiers {
     let mut armed_tier_map = ArmedTierMap::new();
     let mut pools = Vec::with_capacity(signals.pools.len());
     for pool in &signals.pools {
+        // Resolve the per-pool tier from the gathered (prior, free) — the
+        // single pre-plan resolution for the planner/executor map. NEVER
+        // re-resolved post-exec (AB1): clear-all frees space mid-run, and a
+        // re-resolve would see the higher free-ratio and falsely de-escalate
+        // Critical→Tight, defeating the hysteresis. The per-subvolume carrier
+        // awareness reads (`ResolvedStorageSignal::armed_tier`) derives from the
+        // SAME (prior, free), so the two consumers stay coherent by construction
+        // (locked by `gather_stamps_one_tier_read_by_planner_and_awareness`).
         let new_tier = storage_critical::resolve_armed_tier(
             pool.prior_armed_tier,
             pool.free_ratio,
@@ -591,6 +601,27 @@ source = "/"
         assert_eq!(resolved.armed_tier_map.get("alpha"), Some(&TightnessTier::Tight));
         assert_eq!(resolved.armed_tier_map.get("beta"), Some(&TightnessTier::Tight));
         assert_eq!(resolved.armed_tier_map.get("root"), Some(&TightnessTier::Roomy));
+    }
+
+    #[test]
+    fn gather_stamps_one_tier_read_by_planner_and_awareness() {
+        // The coherence the old awareness test could not see: the per-subvolume
+        // tier awareness reads (`ResolvedStorageSignal::armed_tier`) MUST equal
+        // the tier the planner/executor read (`resolve_armed_tiers`'s map),
+        // because both are the SAME value stamped once in `gather_with`. A
+        // desync is the false-AT-RISK failure mode — the planner times against
+        // one tier while awareness judges against another.
+        let signals =
+            gather_with(&cfg(), &HashMap::new(), Some("root-uuid"), resolver, space_tight);
+        let map = resolve_armed_tiers(&signals).armed_tier_map;
+        assert!(!signals.by_subvol.is_empty(), "fixture must exercise subvols");
+        for (name, sig) in &signals.by_subvol {
+            assert_eq!(
+                map.get(name),
+                Some(&sig.armed_tier()),
+                "subvol {name}: awareness tier must equal the planner's map tier"
+            );
+        }
     }
 
     #[test]

--- a/src/storage_critical.rs
+++ b/src/storage_critical.rs
@@ -77,11 +77,13 @@ pub const TIGHT_INTERVAL_FACTOR: f64 = 1.5;
 /// `const fn`).
 pub const CRITICAL_INTERVAL_FLOOR_DAYS: i64 = 7;
 
-/// Planner/executor/awareness-facing map: subvolume name → armed tier (UPI
-/// 031-b). Resolved once pre-plan (`commands/storage_signals::resolve_armed_tiers`)
-/// and threaded into `plan::plan`, the executor, and `awareness::assess`. An
-/// absent key defaults to `Roomy` (`get(..).copied().unwrap_or_default()`) →
-/// declared behavior → zero behavior change (the regression firewall).
+/// Planner/executor-facing map: subvolume name → armed tier (UPI 031-b).
+/// Resolved once pre-plan (`commands/storage_signals::resolve_armed_tiers`) and
+/// threaded into `plan::plan` and the executor. Awareness does not read this
+/// map — it reads the per-subvolume `ResolvedStorageSignal::armed_tier`, derived
+/// from the same gathered inputs. An absent key defaults to `Roomy`
+/// (`get(..).copied().unwrap_or_default()`) → declared behavior → zero behavior
+/// change (the regression firewall).
 pub type ArmedTierMap = HashMap<String, TightnessTier>;
 
 /// Source-pool tightness, free-ratio only (UPI 031-a). Distinct from
@@ -205,8 +207,19 @@ pub fn host_root(
 ///   `FREE_RATIO_CAUTION + HYSTERESIS_BAND_PP` (free `> 0.30`). A pool can fall
 ///   two levels in one run when free recovers past both bands.
 /// - **Unmeasurable** free-ratio (`None`) holds the prior armed tier unchanged.
+///
+/// Resolved at the single pre-plan gather only — never re-derived post-exec
+/// (AB1) and never re-resolved by awareness. The per-subvolume carrier
+/// [`ResolvedStorageSignal::resolved`](crate::awareness::ResolvedStorageSignal::resolved)
+/// derives it in its constructor (awareness reads it back via `armed_tier()`,
+/// never re-resolving); `resolve_armed_tiers` derives the per-pool
+/// `armed_tier_map` for the planner/executor from the same gathered
+/// `(prior, free)`. The two consumers stay coherent because both feed identical
+/// inputs to this deterministic function. `pub(crate)` keeps the resolver
+/// in-crate; the carrier's constructor keeps its stamped tier consistent with
+/// its inputs, so a signal whose tier disagrees with its free-ratio cannot exist.
 #[must_use]
-pub fn resolve_armed_tier(
+pub(crate) fn resolve_armed_tier(
     prior_armed: TightnessTier,
     free_ratio: Option<f64>,
 ) -> TightnessTier {
@@ -278,8 +291,9 @@ pub fn derive_posture(
 /// 031-b, AB2). Carries exactly the three knobs the tier changes (all consumed
 /// this UPI). Paralleling `types::derive_policy`/`DerivedPolicy`, the same tier
 /// in always yields the same policy out — coherence between planner and
-/// awareness rests on both deriving from the *same* armed tier (the single
-/// pre-plan gather, `commands/backup.rs`), not on this function alone.
+/// awareness rests on both reading the *same* armed tier — resolved once at the
+/// single pre-plan gather and stamped on the signal
+/// (`ResolvedStorageSignal::armed_tier`) — not on this function alone.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct EffectivePolicy {
     /// Lifecycle the planner dispatches on. Tight/Critical → `Transient`


### PR DESCRIPTION
## Summary

Implements **deepening 01** (armed-tier coherence). Converts the single most safety-critical *derived* value in Urd — the hysteresis-resolved storage `TightnessTier` — from an invariant carried by prose comments + a tautological test into one carried by the type system.

- **`ResolvedStorageSignal` now carries a private, read-only `armed_tier`**, derived once by its constructor (`resolved(..)`). A signal whose tier disagrees with its `(prior_armed_tier, free_ratio)` cannot be constructed anywhere in the crate.
- **`assess()` reads `sig.armed_tier()`** instead of independently re-resolving — the inline re-resolution is deleted, so awareness can no longer desync from the tier the planner timed against (a latent false-AT-RISK / false-PROTECTED path).
- **Behavior-preserving.** The planner/executor `armed_tier_map` and the post-exec writeback are byte-identical to master (`resolve_armed_tiers` still computes the map inline). `resolve_armed_tier` is now `pub(crate)` with exactly two production callers (the carrier constructor and `resolve_armed_tiers`), both pure; the ~20 exhaustive hysteresis tests stay in `storage_critical`.
- **Tests check wiring, not determinism.** The old hardcoded-`Critical` coherence test is replaced by a cross-consumer lock (carrier tier == planner map tier from one gather) and a de-escalation read-path test.

Hardens the **ADR-113 single-gather invariant**; no ADR change required. Reviewed with `arch-adversary` (one Significant finding — an unsealed `PoolSignal.armed_tier` field on the clear-all path — found and removed before this PR). Prerequisite input to deepening-04.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1673 passed, 0 failed, 4 ignored (pre-existing)
- cargo build --release: pass
- Integration tests: not applicable (pure-logic refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)