### PR TITLE
refactor: localize drift + send-size composition to the read-side adapter (deepening 03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Drift + send-size composition localized to the read-side adapter** (deepening 03;
+  no behavior change). The "fetch drift rows → map to `DriftSample` → ADR-102 fail-open"
+  sequence had been re-typed at three command sites (`backup.rs`, `doctor.rs` ×2), all
+  bypassing the `RealFileSystemState` read-side seam the rest of history goes through;
+  the "freshest send size = max(success, failure)" rule was written twice in adjacent
+  adapter methods. Both now live once: `RealFileSystemState::{drift_samples, drift_samples_multi}`
+  (mirroring `drive_mount_history`) and a `freshest_send_size` helper. The documented
+  "`state.rs` stays granular" decision is preserved — composition moved *to* the adapter,
+  not into `state.rs` (no ADR change). Fallback is provably identical: empty samples feed
+  the pure aggregators to the same `ChurnEstimate::default()` / `None` the explicit
+  fallbacks produced.
 - **`voice/` drive-row helpers extracted into a dedicated submodule** (deepening 02;
   no behavior change). The status-only drive-row presentation cluster (the away /
   last-backup / disconnected cascade and the offsite hibernating / due-home / absent

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -1244,18 +1244,14 @@ fn build_churn_views(
         return out;
     }
     let window = crate::drift::default_window();
+    let fs = RealFileSystemState { state: state_db };
     for sv in config.subvolumes.iter() {
-        // ADR-102 best-effort: a failed drift_samples query yields the safe-empty
-        // estimate so heartbeat fields stay populated (with `None` placeholders)
-        // and a backup never fails because state observability didn't.
-        let estimate = state_db
-            .and_then(|db| db.drift_samples_for_subvolume(&sv.name, now - window).ok())
-            .map(|rows| {
-                let samples: Vec<crate::drift::DriftSample> =
-                    rows.into_iter().map(StateDb::drift_row_to_sample).collect();
-                crate::drift::compute_rolling_churn(&samples, window, now)
-            })
-            .unwrap_or_default();
+        // ADR-102 best-effort: a failed/absent drift query yields empty samples,
+        // and `compute_rolling_churn(&[])` is `ChurnEstimate::default()` — so
+        // heartbeat fields stay populated (with `None` placeholders) and a backup
+        // never fails because state observability didn't.
+        let samples = fs.drift_samples(&sv.name, now - window);
+        let estimate = crate::drift::compute_rolling_churn(&samples, window, now);
         let mean_incremental_bytes = estimate.mean_incremental_bytes;
         let fields = match crate::output::render_churn(&estimate) {
             ChurnRender::NotMeasured => ChurnHeartbeatFields {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -379,12 +379,11 @@ fn build_doctor_recommendation_view(
         |mp: &Path| pools::pool_space(mp).ok(),
         |uuid: &str| pools::metadata_utilization_ratio(uuid),
         |uuid: &str| {
-            let state_db = state_db?;
             let names = pools_by_uuid.get(uuid)?;
-            let rows = state_db
-                .drift_samples_for_subvolumes(names, since)
-                .ok()?;
-            let samples: Vec<_> = rows.into_iter().map(StateDb::drift_row_to_sample).collect();
+            // Fail-open per ADR-102: absent db / query error → empty samples →
+            // `compute_pool_free_bytes_trend(&[], …)` is `None` (same as the
+            // prior `?`-on-error behavior).
+            let samples = RealFileSystemState { state: state_db }.drift_samples_multi(names, since);
             crate::drift::compute_pool_free_bytes_trend(&samples, window, now, MIN_SAMPLE_DAYS)
         },
     )
@@ -631,16 +630,10 @@ fn compute_churn_for(
     window: chrono::Duration,
     now: chrono::NaiveDateTime,
 ) -> crate::drift::ChurnEstimate {
-    // ADR-102 best-effort: a missing db or a failed query yields a safe-empty
-    // estimate, never an error that could propagate into a backup decision.
-    let Some(db) = state_db else {
-        return crate::drift::ChurnEstimate::default();
-    };
-    let Ok(rows) = db.drift_samples_for_subvolume(name, now - window) else {
-        return crate::drift::ChurnEstimate::default();
-    };
-    let samples: Vec<crate::drift::DriftSample> =
-        rows.into_iter().map(StateDb::drift_row_to_sample).collect();
+    // ADR-102 best-effort: a missing db or a failed query yields empty samples,
+    // and `compute_rolling_churn(&[])` is `ChurnEstimate::default()` — never an
+    // error that could propagate into a backup decision.
+    let samples = RealFileSystemState { state: state_db }.drift_samples(name, now - window);
     crate::drift::compute_rolling_churn(&samples, window, now)
 }
 

--- a/src/drift.rs
+++ b/src/drift.rs
@@ -43,10 +43,11 @@ pub struct DriftSample {
 /// Raw aggregates over an in-window slice of drift samples.
 /// No presentation labels — `output::render_churn` maps this to `ChurnRender`.
 ///
-/// `Default` yields the safe-empty estimate (all-`None`, counts `0`) — used by
-/// callers that compose `StateDb::drift_samples_for_subvolume` +
-/// `compute_rolling_churn` and need an ADR-102-style fallback when the db is
-/// absent or the query fails.
+/// `Default` yields the safe-empty estimate (all-`None`, counts `0`) and is
+/// exactly `compute_rolling_churn(&[])`. The drift read path composes
+/// fetch + map + ADR-102 fail-open once in `RealFileSystemState::drift_samples`,
+/// which returns empty samples when the db is absent or the query fails — so
+/// feeding that result here reproduces this `Default` with no separate fallback.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct ChurnEstimate {
     /// Time-weighted mean over in-window incrementals: `sum(bytes) / sum(intervals)`.

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1440,6 +1440,17 @@ impl FilesystemQuery for RealFileSystemState<'_> {
     }
 }
 
+/// The freshest send size is the newer of the last success and the last
+/// failure — when both exist, the larger byte count; otherwise whichever is
+/// present. The domain rule shared by `last_send_size` and
+/// `last_send_size_any_drive` so it lives in exactly one place.
+fn freshest_send_size(successful: Option<u64>, failed: Option<u64>) -> Option<u64> {
+    match (successful, failed) {
+        (Some(s), Some(f)) => Some(s.max(f)),
+        (s, f) => s.or(f),
+    }
+}
+
 impl HistoryQuery for RealFileSystemState<'_> {
     fn last_send_size(
         &self,
@@ -1457,10 +1468,7 @@ impl HistoryQuery for RealFileSystemState<'_> {
                 .last_failed_send_size(subvol_name, drive_label, send_type)
                 .ok()
                 .flatten();
-            match (successful, failed) {
-                (Some(s), Some(f)) => Some(s.max(f)),
-                (s, f) => s.or(f),
-            }
+            freshest_send_size(successful, failed)
         })
     }
 
@@ -1475,10 +1483,7 @@ impl HistoryQuery for RealFileSystemState<'_> {
                 .last_failed_send_size_any_drive(subvol_name, send_type)
                 .ok()
                 .flatten();
-            match (successful, failed) {
-                (Some(s), Some(f)) => Some(s.max(f)),
-                (s, f) => s.or(f),
-            }
+            freshest_send_size(successful, failed)
         })
     }
 
@@ -1530,10 +1535,69 @@ impl HistoryQuery for RealFileSystemState<'_> {
     }
 }
 
+/// Drift-history composition — the single home for the "fetch rows → map to
+/// `DriftSample` → fail-open (ADR-102)" sequence that command callers used to
+/// re-assemble inline. Mirrors `drive_mount_history`/`drive_record_to_event`:
+/// granular `state.rs` wrappers, with the domain shape localized once at the
+/// adapter. Inherent (not on `HistoryQuery`) because every drift consumer is a
+/// command-layer path holding `Option<&StateDb>`; no pure function reaches drift
+/// through `Observation`. Empty results feed the pure aggregators unchanged —
+/// `drift::compute_rolling_churn(&[])` is `ChurnEstimate::default()` and
+/// `compute_pool_free_bytes_trend(&[], …)` is `None`.
+impl RealFileSystemState<'_> {
+    /// Drift samples for one subvolume since `since`, newest-first. DB absent
+    /// or query error → empty, never an error that could block a backup
+    /// (ADR-102). Feeds `drift::compute_rolling_churn`.
+    #[must_use]
+    pub fn drift_samples(&self, subvol_name: &str, since: NaiveDateTime) -> Vec<crate::drift::DriftSample> {
+        let Some(db) = self.state else {
+            return Vec::new();
+        };
+        match db.drift_samples_for_subvolume(subvol_name, since) {
+            Ok(rows) => rows
+                .into_iter()
+                .map(crate::state::StateDb::drift_row_to_sample)
+                .collect(),
+            Err(e) => {
+                log::warn!("drift_samples_for_subvolume failed for {subvol_name}: {e}");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Batched variant across a set of subvolumes (the pool-trend path, UPI
+    /// 044). Same fail-open contract as `drift_samples`. Feeds
+    /// `drift::compute_pool_free_bytes_trend`.
+    #[must_use]
+    pub fn drift_samples_multi(
+        &self,
+        subvol_names: &[String],
+        since: NaiveDateTime,
+    ) -> Vec<crate::drift::DriftSample> {
+        let Some(db) = self.state else {
+            return Vec::new();
+        };
+        match db.drift_samples_for_subvolumes(subvol_names, since) {
+            Ok(rows) => rows
+                .into_iter()
+                .map(crate::state::StateDb::drift_row_to_sample)
+                .collect(),
+            Err(e) => {
+                log::warn!("drift_samples_for_subvolumes failed: {e}");
+                Vec::new()
+            }
+        }
+    }
+}
+
 /// Map a persisted `DriveConnectionRecord` to a `DriveEvent`, or `None` for an
 /// unknown event type / unparseable timestamp (logged). Shared by
 /// `last_drive_event` (one row) and `drive_mount_history` (all rows). The parse
 /// format matches the sentinel's write format (`%Y-%m-%dT%H:%M:%S`).
+///
+/// This is the read-side composition pattern: granular `state.rs` wrappers, with
+/// the domain shaping localized once at the adapter (see also `drift_samples`).
+/// Keep `state.rs` itself one-method-per-query — composition lives here.
 fn drive_record_to_event(record: &crate::state::DriveConnectionRecord) -> Option<DriveEvent> {
     let kind = match record.event_type.as_str() {
         "mounted" => DriveEventKind::Mount,
@@ -4874,6 +4938,64 @@ local_retention = "transient"
 
         // Unknown drive → empty (never blocks).
         assert!(fs.drive_mount_history("nope").is_empty());
+    }
+
+    // ── Read-side composition: freshest_send_size + drift_samples ───────
+
+    #[test]
+    fn freshest_send_size_picks_larger_when_both_present() {
+        assert_eq!(freshest_send_size(Some(100), Some(250)), Some(250));
+        assert_eq!(freshest_send_size(Some(900), Some(250)), Some(900));
+    }
+
+    #[test]
+    fn freshest_send_size_falls_back_to_whichever_exists() {
+        assert_eq!(freshest_send_size(Some(100), None), Some(100));
+        assert_eq!(freshest_send_size(None, Some(250)), Some(250));
+        assert_eq!(freshest_send_size(None, None), None);
+    }
+
+    fn drift_at(s: &str) -> NaiveDateTime {
+        NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").unwrap()
+    }
+
+    #[test]
+    fn drift_samples_fail_open_when_db_absent() {
+        // ADR-102: no state DB → empty samples, never an error. This locks the
+        // command-site fallback — `compute_rolling_churn(&[])` is
+        // `ChurnEstimate::default()` and `compute_pool_free_bytes_trend(&[], …)`
+        // is `None`, so empty here reproduces the prior explicit fallbacks.
+        let fs = RealFileSystemState { state: None };
+        let since = drift_at("2026-05-01T00:00:00");
+        assert!(fs.drift_samples("home", since).is_empty());
+        assert!(fs.drift_samples_multi(&["home".to_string()], since).is_empty());
+    }
+
+    #[test]
+    fn drift_samples_round_trips_through_the_adapter() {
+        use crate::state::{DriftSampleRow, StateDb};
+        use tempfile::TempDir;
+
+        let dir = TempDir::new().unwrap();
+        let db = StateDb::open(&dir.path().join("urd.db")).unwrap();
+        db.record_drift_sample_best_effort(&DriftSampleRow {
+            run_id: None,
+            subvolume: "home".to_string(),
+            sampled_at: drift_at("2026-05-02T04:00:00"),
+            seconds_since_prev_send: Some(86_400),
+            bytes_transferred: 4_096,
+            source_free_bytes: None,
+            send_kind: SendKind::Incremental,
+        });
+
+        let fs = RealFileSystemState { state: Some(&db) };
+        let since = drift_at("2026-05-01T00:00:00");
+        let one = fs.drift_samples("home", since);
+        assert_eq!(one.len(), 1);
+        assert_eq!(one[0].bytes_transferred, 4_096);
+        // Batched variant sees the same row; unrelated names stay empty.
+        assert_eq!(fs.drift_samples_multi(&["home".to_string()], since).len(), 1);
+        assert!(fs.drift_samples("photos", since).is_empty());
     }
 
     // ── Planner event-emission tests ───────────────────────────────────


### PR DESCRIPTION
## Summary

- **One home for drift composition.** The "fetch drift rows → map to `DriftSample` → ADR-102 fail-open" sequence was re-typed at three command sites (`backup.rs`, `doctor.rs` ×2), all calling `StateDb` directly and *bypassing* the `RealFileSystemState` read-side seam the rest of the history path uses. It now lives once as `RealFileSystemState::{drift_samples, drift_samples_multi}`, modeled on `drive_mount_history`'s fail-open shape.
- **One home for the send-size rule.** "freshest send size = `max(last success, last failure)`" was duplicated byte-for-byte across `last_send_size` / `last_send_size_any_drive`; extracted to a `freshest_send_size` helper called by both.
- **Concrete, not trait.** The drift methods are inherent on the adapter (not on `HistoryQuery`) because every drift consumer is a command-layer path holding `Option<&StateDb>` — no pure function reaches drift via `Observation` (verified by grep).
- **Preserves the documented decision.** Composition moved *to* the adapter, **not** into `state.rs`, which keeps its one-method-per-query SQL wrappers + `drift_row_to_sample`. No ADR change; no on-disk/metric/btrfs change.
- **Provably behavior-preserving.** Empty samples feed the pure aggregators to the same fallback the explicit code produced: `compute_rolling_churn(&[]) == ChurnEstimate::default()` and `compute_pool_free_bytes_trend(&[], …) == None`. Locked by a fail-open test.

Implements `docs/99-reports/2026-06-05-deepening-03-state-composition-locality.md` (Path A). **Path B** (a shared read-side fail-open convention) deferred — but noted: the five `.ok().flatten()` history methods swallow SQLite errors *silently* while `drive_mount_history` and the new drift methods `warn!`. That observability inconsistency is worth a future pass.

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass (clean)
- `cargo test`: 1677 passed, 0 failed, 4 ignored (baseline 1673 + 4 new: `freshest_send_size` ×2, drift fail-open lock, adapter round-trip)
- `cargo build --release`: pass
- Invariant check: `drift_samples_for_subvolume(s)` / `drift_row_to_sample` now appear only in `plan.rs` (the adapter) — no fourth composition remains
- `doctor --thorough` drift output: unchanged (covered analytically + by existing doctor view tests; a live run needs the protected btrfs host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)