### PR TITLE
release: v0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2] - 2026-06-06
+
 ### Changed
 - **Emergency-preflight reclaim given a dependency-injection seam** (UPI 059-a; no behavior
   change). The one destructive helper on the nightly backup path — `run_emergency_preflight`,
@@ -953,7 +955,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.24.1...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.24.2...HEAD
+[0.24.2]: https://github.com/vonrobak/urd/compare/v0.24.1...v0.24.2
 [0.24.1]: https://github.com/vonrobak/urd/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/vonrobak/urd/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/vonrobak/urd/compare/v0.22.0...v0.23.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.24.2** — a quality-and-testability release, all changes behavior-preserving.

- **UPI 059 backup-orchestration arc:** emergency-preflight given a DI seam (#176) and the token-gating decision extracted into pure, tested functions (#178).
- **Deepenings 01–03:** armed-tier coherence hardened from convention to structure (#171), `voice/` drive-row helpers extracted into a focused submodule (#172), and drift + send-size composition localized to the read-side adapter (#173).

No new features, no breaking changes, no on-disk/metric/heartbeat/event-contract change (zero homelab ADR-021 impact).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1693 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)