### PR TITLE
fix: urd doctor skips the offsite-freshness overlay (UPI 060, PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`urd doctor` now applies the offsite-freshness overlay** (UPI 060, PR 1). Doctor was the
+  only one of seven assessment surfaces that skipped `advice::overlay_offsite_freshness`, so a
+  Fortified subvolume with a stale offsite copy showed waning in `urd status` but healthy in
+  `urd doctor`. The two surfaces now agree: Fortified rows with stale offsite copies flip
+  healthy → waning in doctor output (and the corresponding `--json` status/issue values shift;
+  the schema is unchanged).
+
 ## [0.24.2] - 2026-06-06
 
 ### Changed

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -164,8 +164,10 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     let now = chrono::Local::now().naive_local();
     // Read-only gather: thread storage posture into the data-safety section.
     let signals = crate::commands::storage_signals::gather(&config, state_db.as_ref());
-    let assessments =
+    let mut assessments =
         awareness::assess(&config, now, &observation, &signals.by_subvol);
+    // Overlay must follow assess — degrades Fortified rows with stale offsite copies.
+    advice::overlay_offsite_freshness(&mut assessments, &config);
 
     let resolved = config.resolved_subvolumes();
     let data_safety: Vec<DoctorDataSafety> = assessments


### PR DESCRIPTION
## Summary

- `urd doctor` was the only one of seven assess sites that skipped `advice::overlay_offsite_freshness`, so a Fortified subvolume with a stale offsite copy showed **waning in `urd status` and healthy in `urd doctor`**. One overlay call after `assess()` fixes the incoherence.
- The gap is as old as the overlay itself (born at `9ece55f`). Grill ruling: bug, not a design choice.
- **Intended output change:** Fortified-stale doctor rows flip healthy → waning. Doctor `--json` *values* shift accordingly (corrected status/issue fields); the schema is unchanged, and no external consumer is affected (the homelab contract is metrics + heartbeat only).
- No new test (grilled): the wiring has no seam; overlay semantics are covered by advice.rs's 12 overlay tests, and the wiring guarantee lands structurally in PR 2 (clippy `disallowed-methods` guard making `advice::assess_view` the only sanctioned composition point).

First of three PRs for UPI 060 (read-side assessment view). Smallest revert surface: one line.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 1693 tests, pass (no test pinned the old doctor output)
- Integration tests: not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)