### PR TITLE
refactor: advice::assess_view — one home for the assessment view (UPI 060, PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **One home for the read-side assessment view** (UPI 060, PR 2; no behavior change).
+  The assess-then-overlay composition every surface must perform now lives once:
+  `advice::assess_view` — the assessment view, the only input from which surfaces render
+  promise state. All seven call sites (status, default summary, doctor, backup ×3, sentinel)
+  switched; a clippy `disallowed-methods` guard makes the rule structural, so the doctor-style
+  coherence gap (one surface skipping an overlay) can no longer be written. Glossary gains
+  *assessment view* and backfills *rotation view* (UPI 055).
+
 ### Fixed
 - **`urd doctor` now applies the offsite-freshness overlay** (UPI 060, PR 1). Doctor was the
   only one of seven assessment surfaces that skipped `advice::overlay_offsite_freshness`, so a

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+  { path = "urd::awareness::assess", reason = "call advice::assess_view — surfaces render the assessment view, never raw assessments" },
+]

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -49,6 +49,14 @@ heartbeat JSON, NDJSON event payloads, Prometheus labels, SQLite rows. The
 voice labels (next cluster) only render in `urd status` and similar interactive
 output.
 
+**assessment view (UPI 060).** The awareness assessment plus every product
+overlay (today: the offsite-freshness overlay); the only input from which
+surfaces render promise state (`advice::assess_view`). Raw `awareness::assess`
+output is a half-built picture — awareness stays protection-level-blind
+(ADR-110), so a surface reading it directly misses the Fortified
+stale-offsite degradation. A clippy `disallowed-methods` guard enforces the
+rule: surfaces call `assess_view`, never `assess`.
+
 ## Cluster: Voice labels (presentation)
 
 The CLI surface renders the promise states with the mythic voice labels below. The
@@ -169,6 +177,13 @@ cadence, not the send interval.
 | `on_schedule` | Age ≤ overdue threshold — the offsite drive is away on its normal rhythm. Per-copy promise → PROTECTED. | `rotation::classify` |
 | `overdue` | Age past overdue but ≤ stale — worth attention. → AT RISK. | `rotation::classify` |
 | `stale` | Age past the stale threshold — genuinely too long. → UNPROTECTED. | `rotation::classify` |
+
+**rotation view (UPI 055).** The pure projection over drive-mount history
+(`rotation.rs` over `HistoryQuery::drive_mount_history`) that derives an offsite
+drive's rotation cadence and resolves its freshness window. Derives live — no
+new table (RD2). Window sources in priority order: declared `rotation_interval`
+primary, observed median cadence fallback (≥2 completed gaps), conservative
+30d/60d default otherwise (RD1).
 
 The relaxation that lets an *away* offsite copy read PROTECTED fires only when a
 real redundancy peer (a non-`test` drive) is currently mounted — an offsite drive

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -5,14 +5,15 @@
 //! Sibling to [`crate::awareness`], which observes promise state. This
 //! module turns observations into prescriptions.
 
-use chrono::Duration;
+use chrono::{Duration, NaiveDateTime};
 use serde::{Deserialize, Serialize};
 
 use crate::awareness::{
     ChainStatus, DriveAssessment, DriveChainHealth, OperationalHealth, PromiseStatus,
-    SubvolAssessment,
+    StorageSignalMap, SubvolAssessment,
 };
 use crate::config::Config;
+use crate::observation::Observation;
 use crate::types::{DriveRole, ProtectionLevel};
 
 // ── Actionable Advice ─────────────────────────────────────────────────
@@ -245,12 +246,34 @@ pub struct RedundancyAdvisory {
     pub detail: String,
 }
 
+// ── Assessment view ────────────────────────────────────────────────────
+
+/// The assessment view: the awareness assessment plus every product overlay.
+///
+/// The only input from which surfaces render promise state. Callers supply
+/// gathered signals or an empty map (sentinel D6 / backup S4 paths); this
+/// function never gathers (backup's 031-b single-gather invariant).
+#[must_use]
+pub fn assess_view(
+    config: &Config,
+    now: NaiveDateTime,
+    obs: &Observation,
+    storage_signals: &StorageSignalMap,
+) -> Vec<SubvolAssessment> {
+    // The one sanctioned caller of the raw assess (clippy disallowed-methods guard).
+    #[allow(clippy::disallowed_methods)]
+    let mut assessments = crate::awareness::assess(config, now, obs, storage_signals);
+    overlay_offsite_freshness(&mut assessments, config);
+    assessments
+}
+
 // ── Offsite freshness overlay ──────────────────────────────────────────
 
 /// Post-processing overlay: degrade fortified subvolumes with stale offsite copies.
 ///
 /// This is NOT part of `assess()` — awareness remains protection-level-blind per
-/// ADR-110 Invariant 6. Call this after `assess()` returns.
+/// ADR-110 Invariant 6. `assess_view` composes it after `assess()`; surfaces
+/// call `assess_view`, never this overlay directly.
 ///
 /// Pure function: assessments + config in, mutations in place.
 pub fn overlay_offsite_freshness(assessments: &mut [SubvolAssessment], config: &Config) {
@@ -465,9 +488,7 @@ pub fn compute_redundancy_advisories(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::awareness::{
-        ChainBreakReason, DriveChainHealth, LocalAssessment, assess,
-    };
+    use crate::awareness::{ChainBreakReason, DriveChainHealth, LocalAssessment};
     use crate::awareness::test_support::{dt, offsite_test_config, snap, test_config};
     use crate::btrfs::MockBtrfs;
     use crate::observation::Observation;
@@ -840,13 +861,12 @@ drives = ["primary-drive", "offsite-drive"]
             dt(2026, 2, 10, 12, 0),
         );
 
-        let mut assessments = assess(
+        let assessments = assess_view(
             &config,
             now,
             &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
             &crate::awareness::StorageSignalMap::new(),
         );
-        overlay_offsite_freshness(&mut assessments, &config);
 
         let sv1 = assessments.iter().find(|a| a.name == "sv1").expect("sv1 assessed");
         assert_eq!(sv1.status, PromiseStatus::Protected);
@@ -873,19 +893,43 @@ drives = ["primary-drive", "offsite-drive"]
             dt(2026, 1, 1, 12, 0),
         );
 
-        let mut assessments = assess(
+        let assessments = assess_view(
             &config,
             now,
             &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
             &crate::awareness::StorageSignalMap::new(),
         );
-        overlay_offsite_freshness(&mut assessments, &config);
 
         let sv1 = assessments.iter().find(|a| a.name == "sv1").expect("sv1 assessed");
         assert_eq!(
             sv1.status,
             PromiseStatus::AtRisk,
             "stale offsite must cap at AT RISK, never UNPROTECTED (RD8)"
+        );
+    }
+
+    #[test]
+    fn assess_view_empty_signals_flows_through() {
+        // Pins the sentinel (D6) / backup (S4) empty-map contract: callers may
+        // pass an empty StorageSignalMap and still get assessments — with no
+        // storage posture computed on those paths.
+        let config = fortified_rotation_config();
+        let now = dt(2026, 4, 1, 12, 0);
+        let mut fs = MockFileSystemState::new();
+        fs.local_snapshots
+            .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
+
+        let assessments = assess_view(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &crate::awareness::StorageSignalMap::new(),
+        );
+
+        assert_eq!(assessments.len(), 1, "assessment produced despite empty signals");
+        assert!(
+            assessments[0].storage_posture.is_none(),
+            "no posture on the empty-map paths"
         );
     }
 
@@ -952,7 +996,7 @@ drives = ["drive-a", "drive-b"]
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
         fs.mounted_drives.insert("drive-a".to_string());
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert_eq!(advisories.len(), 1);
@@ -978,7 +1022,7 @@ drives = ["drive-a", "drive-b"]
             dt(2026, 3, 1, 12, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert_eq!(advisories.len(), 1);
@@ -1010,7 +1054,7 @@ drives = ["drive-a", "drive-b"]
             dt(2026, 3, 3, 12, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1048,7 +1092,7 @@ drives = ["drive-a", "drive-b"]
             42,
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &mb }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1079,7 +1123,7 @@ drives = ["drive-a", "drive-b"]
             dt(2026, 3, 17, 12, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1098,7 +1142,7 @@ drives = ["drive-a", "drive-b"]
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
         fs.mounted_drives.insert("primary-drive".to_string());
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1165,7 +1209,7 @@ protection_level = "protected"
             dt(2026, 4, 1, 8, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert_eq!(advisories.len(), 1);
@@ -1184,7 +1228,7 @@ protection_level = "protected"
         fs.mounted_drives.insert("drive-a".to_string());
         fs.mounted_drives.insert("drive-b".to_string());
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         // Should have NoOffsiteProtection but NOT SinglePointOfFailure
@@ -1244,7 +1288,7 @@ protection_level = "guarded"
         fs.local_snapshots
             .insert("sv1".to_string(), vec![snap(dt(2026, 4, 1, 11, 0), "sv1")]);
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1310,7 +1354,7 @@ local_retention = "transient"
             dt(2026, 3, 30, 12, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1334,7 +1378,7 @@ local_retention = "transient"
             dt(2026, 4, 1, 8, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         assert!(
@@ -1356,7 +1400,7 @@ local_retention = "transient"
             dt(2026, 3, 30, 12, 0),
         );
 
-        let assessments = assess(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
+        let assessments = assess_view(&config, now, &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() }, &crate::awareness::StorageSignalMap::new());
         let advisories = compute_redundancy_advisories(&config, &assessments);
 
         let advisory = advisories

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -1388,6 +1388,8 @@ fn compute_health(
 
 // ── Tests ──────────────────────────────────────────────────────────────
 
+// Module-under-test calls its own raw assess directly (clippy disallowed-methods guard).
+#[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -176,13 +176,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         // Empty-plan path: storage posture is not surfaced here (the heartbeat
         // projection carries no posture — S4), so skip the findmnt sweep and
         // pass an empty signal map.
-        let mut assessments = awareness::assess(
+        let assessments = advice::assess_view(
             &config,
             heartbeat_now,
             &observation,
             &awareness::StorageSignalMap::new(),
         );
-        advice::overlay_offsite_freshness(&mut assessments, &config);
         let hb = heartbeat::build_empty(
             &config,
             heartbeat_now,
@@ -314,14 +313,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         let pre_now = chrono::Local::now().naive_local();
         // Pre-execution snapshot is used only to diff promise-state transitions;
         // posture is not a promise state, so an empty signal map suffices.
-        let mut pre = awareness::assess(
+        advice::assess_view(
             &config,
             pre_now,
             &observation,
             &awareness::StorageSignalMap::new(),
-        );
-        advice::overlay_offsite_freshness(&mut pre, &config);
-        pre
+        )
     };
 
     // Build progress context after token filtering so counters reflect actual work.
@@ -456,9 +453,8 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // pre-plan tier (so the effective send interval matches what the planner
     // used), then `advance_and_writeback` persists the pre-resolved tier and
     // surfaces escalation transitions for the notification path (D6).
-    let mut assessments =
-        awareness::assess(&config, heartbeat_now, &observation, &signals.by_subvol);
-    advice::overlay_offsite_freshness(&mut assessments, &config);
+    let assessments =
+        advice::assess_view(&config, heartbeat_now, &observation, &signals.by_subvol);
     let hb = heartbeat::build_from_run(
         &config,
         heartbeat_now,

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -40,9 +40,8 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
     // Awareness assessment — lighter than status (no chain health, no drive info, no pins)
     let now = chrono::Local::now().naive_local();
     let signals = storage_signals::gather(&config, state_db.as_ref());
-    let mut assessments =
-        awareness::assess(&config, now, &observation, &signals.by_subvol);
-    advice::overlay_offsite_freshness(&mut assessments, &config);
+    let assessments =
+        advice::assess_view(&config, now, &observation, &signals.by_subvol);
 
     let last_run = state_db.as_ref().and_then(|db| db.last_run_info());
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -164,10 +164,8 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     let now = chrono::Local::now().naive_local();
     // Read-only gather: thread storage posture into the data-safety section.
     let signals = crate::commands::storage_signals::gather(&config, state_db.as_ref());
-    let mut assessments =
-        awareness::assess(&config, now, &observation, &signals.by_subvol);
-    // Overlay must follow assess — degrades Fortified rows with stale offsite copies.
-    advice::overlay_offsite_freshness(&mut assessments, &config);
+    let assessments =
+        advice::assess_view(&config, now, &observation, &signals.by_subvol);
 
     let resolved = config.resolved_subvolumes();
     let data_safety: Vec<DoctorDataSafety> = assessments

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,5 +1,5 @@
 use crate::advice;
-use crate::awareness::{self, ChainBreakReason, ChainStatus};
+use crate::awareness::{ChainBreakReason, ChainStatus};
 use crate::chain;
 use crate::config::Config;
 use crate::drives;
@@ -35,9 +35,8 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     // Gather storage signals (read-only) and thread the per-subvol map into
     // assess(); status reflects the stabilized tier but never advances it (S1).
     let signals = storage_signals::gather(&config, state_db.as_ref());
-    let mut assessments =
-        awareness::assess(&config, now, &observation, &signals.by_subvol);
-    advice::overlay_offsite_freshness(&mut assessments, &config);
+    let assessments =
+        advice::assess_view(&config, now, &observation, &signals.by_subvol);
     let storage_postures = storage_signals::aggregate(&assessments, &signals, now);
 
     // ── Chain health per subvolume (derived from awareness assessment) ──

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -106,7 +106,7 @@ pub trait HistoryQuery {
 
 /// The read-only world a pure decision function observes: the filesystem of
 /// truth, the SQLite history, and the btrfs generation-read seam. Threaded as
-/// `&Observation` through `plan::plan` and `awareness::assess` so those
+/// `&Observation` through `plan::plan` and `advice::assess_view` so those
 /// functions read state through three narrow, non-mutating trait objects
 /// rather than a single wide one (ADR-100, ADR-101, UPI 052).
 pub struct Observation<'a> {

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -768,7 +768,7 @@ pub struct DriveAnomaly {
 /// Extract chain snapshots from assessments for mounted drives only.
 ///
 /// Pure function: reads `SubvolAssessment::chain_health` (populated by
-/// `awareness::assess()`) and filters to chains for drives in
+/// `advice::assess_view()`) and filters to chains for drives in
 /// `mounted_drives`. Unmounted drives are excluded because chain health
 /// cannot be assessed without reading the drive's snapshots.
 #[must_use]

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -402,13 +402,12 @@ impl SentinelRunner {
         // to the heartbeat, which carries no posture). Pass an empty signal map
         // so `assess()` computes no posture on this path; on-demand `status` and
         // `backup` runs are where posture is gathered and surfaced.
-        let mut assessments = awareness::assess(
+        let assessments = advice::assess_view(
             &self.config,
             now,
             &observation,
             &awareness::StorageSignalMap::new(),
         );
-        advice::overlay_offsite_freshness(&mut assessments, &self.config);
 
         // Emit promise-transition events when the originating event was
         // Tick/DriveMounted/ConfigChanged. On BackupCompleted the backup


### PR DESCRIPTION
## Summary

- **New `advice::assess_view`** (`#[must_use]`, pure): raw `awareness::assess` + `overlay_offsite_freshness` — the *assessment view*, the only input from which surfaces render promise state. Callers supply gathered signals or an empty map (sentinel D6 / backup S4 paths); the view never gathers (031-b single-gather invariant).
- **All 7 production call sites switched** (status, default, doctor, backup ×3, sentinel_runner). Each keeps its signal argument and explanatory comment verbatim; every `let mut` drops. No behavior change — every site already composed assess+overlay (doctor since PR 1).
- **Clippy guard** (`clippy.toml` `disallowed-methods` on `urd::awareness::assess`) makes the rule structural — a new surface calling raw `assess` fails the lint gate. Exactly two sanctioned allows: `assess_view`'s body and awareness's own test module. Spike-verified: with the switches absent, the lint fires at all 7 sites.
- **Tests:** the two advice overlay-roundtrip tests convert to `assess_view` (the composition proof), plus new `assess_view_empty_signals_flows_through` pinning the empty-map contract. The 12 redundancy-advisory tests also convert — `compute_redundancy_advisories` reads neither field the overlay mutates, so those are semantics-neutral (the plan had counted only 2 raw advice test callers; the guard surfaced 14).
- **Glossary:** adds *assessment view* (060) and backfills *rotation view* (055 vocabulary, wording sourced from the 055 design RD1/RD2).

Deviation from plan: commits 1+2 (add fn / switch sites) merged into one — `assess_view` with no production caller is dead code under `-D warnings`, so the split couldn't stay green.

**Stacked on #182** (PR 1 — doctor fix) — merge that first; this PR's doctor switch assumes the overlay line exists.

## Testing

- cargo clippy --all-targets -D warnings: pass (guard active)
- cargo test: 1694 tests, pass (net +1)
- Release build: pass; `urd status` and `urd doctor` agree on all 9 promise rows on the live config

🤖 Generated with [Claude Code](https://claude.com/claude-code)