### PR TITLE
refactor: one home for the protection-level contract (UPI 062, PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **One home for the protection-level contract** (UPI 062, PR 1; no acceptance-behavior
+  change). The ADR-110 opacity rules — enforced until now as two near-identical validators in
+  the v1 and v2 config parsers — live once: `validate_protection_contract()` in `types.rs`,
+  next to `derive_policy()`. Each parser projects its subvolumes into a schema-agnostic
+  `ProtectionContractView`; rejection messages stay byte-identical (the dense v1 fixture suite
+  passes untouched, and the v2 side gains its own one-test-per-rule fixture suite it never
+  had). The fortified-requires-offsite rule stays v1-only by design — preflight's
+  `fortified-without-offsite` advisory is the all-schema achievability home. The two
+  field-identical synthesized-`[defaults]` blocks fold into one `parser_fallback_defaults()`,
+  equality-tested against `derive_policy()` on every field.
 - **Structural home for the Prometheus wire contract** (UPI 061; output byte-identical for
   every realistic config, proven by a write-once golden-file test). Every metric name now has
   exactly one definition (`metrics.rs::names`, guard-tested) and every sample line is emitted

--- a/docs/00-foundation/architecture.md
+++ b/docs/00-foundation/architecture.md
@@ -152,7 +152,7 @@ the documentation convention in `contributing-internal.md`).
 | `config.rs` | Parse TOML, validate, expand paths, resolve subvolumes | Touch filesystem beyond path checks |
 | `cli.rs` | Define the `clap` command surface (argument parsing) | Contain command logic (`commands/` does that) |
 | `cli_validation.rs` | CLI-boundary guards: resolve a user string to a known config name before the planner, or refuse with help | Run core logic; let unvalidated input reach the planner |
-| `types.rs` | Domain types, parsing, `Display`, `derive_policy()` | Contain business logic |
+| `types.rs` | Domain types, parsing, `Display`, `derive_policy()`, `validate_protection_contract()` (the ADR-110 opacity contract) | Contain business logic |
 | `plan.rs` | Decide what operations to run (pure function) | Execute anything or call btrfs |
 | `executor.rs` | Execute planned operations, isolate errors per subvolume; host the gated clear-all and the `emergency_reclaim_pool` never-the-only-copy reclaim that both the watchdog abort (ADR-113 Layer 2) and the idle eject (Layer 3) reuse | Decide what to do (the planner's job) |
 | `btrfs.rs` | Wrap `sudo btrfs` calls via `BtrfsOps`; read-only reads via the `BtrfsRead` supertrait (`BtrfsOps: BtrfsRead`) | Know about retention, plans, config |

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -128,6 +128,11 @@ local_retention = { daily = 3, weekly = 2 }
 The level names describe what the data *becomes* (recorded / sheltered / fortified),
 not the mechanism used to get there. Mechanism is the planner's concern.
 
+**Protection-level contract** — the schema-agnostic rule set that enforces the
+opacity rule at config load: `validate_protection_contract()` in `types.rs`
+(next to `derive_policy()`). Every config schema projects its subvolumes into
+one `ProtectionContractView` and gets the same rejections, byte-for-byte.
+
 ## Cluster: Drive states
 
 | State | Meaning | Source of truth |

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,9 @@ use serde::{Deserialize, Serialize};
 use crate::error::UrdError;
 use crate::notify::NotificationConfig;
 use crate::types::{
-    ByteSize, DriveRole, GraduatedRetention, Interval, LocalRetentionConfig, LocalRetentionPolicy,
-    MonthlyCount, ProtectionLevel, ResolvedGraduatedRetention, RunFrequency,
+    ByteSize, DriveRole, GraduatedRetention, Interval, LocalRetentionConfig, LocalRetentionKind,
+    LocalRetentionPolicy, MonthlyCount, ProtectionContractView, ProtectionLevel,
+    ResolvedGraduatedRetention, RunFrequency, validate_protection_contract,
 };
 
 // ── Top-level config ────────────────────────────────────────────────────
@@ -653,6 +654,32 @@ struct V1SubvolumeConfig {
     external_retention: Option<GraduatedRetention>,
 }
 
+/// Fallback `[defaults]` synthesized for v1/v2 Custom or unset protection
+/// levels. Values match full_retention / full_external_retention from
+/// `derive_policy()` in types.rs (`yearly: None` ↔ resolved 0).
+fn parser_fallback_defaults() -> DefaultsConfig {
+    DefaultsConfig {
+        snapshot_interval: Interval::days(1),
+        send_interval: Interval::days(1),
+        send_enabled: true,
+        enabled: true,
+        local_retention: GraduatedRetention {
+            hourly: Some(24),
+            daily: Some(30),
+            weekly: Some(26),
+            monthly: Some(MonthlyCount::Count(12)),
+            yearly: None,
+        },
+        external_retention: GraduatedRetention {
+            hourly: None,
+            daily: Some(30),
+            weekly: Some(26),
+            monthly: Some(MonthlyCount::Unlimited),
+            yearly: None,
+        },
+    }
+}
+
 impl V1Config {
     /// Convert v1 config into the internal Config representation.
     ///
@@ -687,28 +714,7 @@ impl V1Config {
             })
             .collect();
 
-        // Fallback defaults for v1 Custom/unset protection levels.
-        // Values match full_retention from derive_policy() in types.rs.
-        let defaults = DefaultsConfig {
-            snapshot_interval: Interval::days(1),
-            send_interval: Interval::days(1),
-            send_enabled: true,
-            enabled: true,
-            local_retention: GraduatedRetention {
-                hourly: Some(24),
-                daily: Some(30),
-                weekly: Some(26),
-                monthly: Some(MonthlyCount::Count(12)),
-                yearly: None,
-            },
-            external_retention: GraduatedRetention {
-                hourly: None,
-                daily: Some(30),
-                weekly: Some(26),
-                monthly: Some(MonthlyCount::Unlimited),
-                yearly: None,
-            },
-        };
+        let defaults = parser_fallback_defaults();
 
         // Convert V1SubvolumeConfig → SubvolumeConfig
         let subvolumes: Vec<SubvolumeConfig> = self
@@ -767,104 +773,32 @@ impl V1Config {
             // compatibility. `urd migrate` will rename them to canonical v1 names.
             let level = sv.protection.unwrap_or(ProtectionLevel::Custom);
 
-            // Rule 1: Reject local_retention = "transient" universally in v1
-            // (applies to both named and custom — use local_snapshots = false instead)
-            if matches!(sv.local_retention, Some(LocalRetentionConfig::Transient)) {
-                return Err(format!(
-                    "subvolume {:?}: local_retention = \"transient\" is not supported in v1 \
-                     — use local_snapshots = false instead.",
-                    sv.name
-                ));
-            }
-
-            // Rule 2: Mutual exclusion — local_snapshots = false + local_retention
-            if sv.local_snapshots == Some(false) && sv.local_retention.is_some() {
-                return Err(format!(
-                    "subvolume {:?}: local_snapshots = false and local_retention are mutually \
-                     exclusive — when local_snapshots is disabled, there is nothing to retain.",
-                    sv.name
-                ));
-            }
-
-            // Named levels must not have operational overrides
-            if level != ProtectionLevel::Custom {
-                let forbidden = [
-                    ("snapshot_interval", sv.snapshot_interval.is_some()),
-                    ("send_interval", sv.send_interval.is_some()),
-                    ("send_enabled", sv.send_enabled.is_some()),
-                    ("external_retention", sv.external_retention.is_some()),
-                ];
-                for (field, is_set) in &forbidden {
-                    if *is_set {
-                        return Err(format!(
-                            "subvolume {:?}: {field} cannot be set alongside \
-                             protection = \"{level}\" — the protection level controls this field. \
-                             Use protection = \"custom\" for manual control.",
-                            sv.name
-                        ));
-                    }
-                }
-
-                // Rule 3a: local_snapshots = false is incompatible with named levels
-                if sv.local_snapshots == Some(false) {
-                    return Err(format!(
-                        "subvolume {:?}: local_snapshots = false is incompatible with \
-                         protection = \"{level}\" — named levels require local snapshots. \
-                         Remove the protection field for custom configuration.",
-                        sv.name
-                    ));
-                }
-
-                // Rule 3b: ANY local_retention alongside named level is rejected
-                // (transient already caught by Rule 1 above)
-                if sv.local_retention.is_some() {
-                    return Err(format!(
-                        "subvolume {:?}: local_retention cannot be set alongside \
-                         protection = \"{level}\" — the protection level controls this field. \
-                         Use protection = \"custom\" for manual control.",
-                        sv.name
-                    ));
-                }
-            }
-
-            // Rule 4: local_snapshots = false requires at least one drive
             let has_any_drives = match sv.drives {
                 Some(ref d) => !d.is_empty(),
                 None => !self.drives.is_empty(),
             };
-            if sv.local_snapshots == Some(false) && !has_any_drives {
-                return Err(format!(
-                    "subvolume {:?}: local_snapshots = false requires at least one drive \
-                     — without local snapshots or external sends, nothing is being backed up.",
-                    sv.name
-                ));
-            }
+            let view = ProtectionContractView {
+                name: &sv.name,
+                level,
+                local_retention: match sv.local_retention {
+                    None => LocalRetentionKind::None,
+                    Some(LocalRetentionConfig::Transient) => LocalRetentionKind::Transient,
+                    Some(LocalRetentionConfig::Graduated(_)) => LocalRetentionKind::Graduated,
+                },
+                local_snapshots: sv.local_snapshots,
+                has_snapshot_interval: sv.snapshot_interval.is_some(),
+                has_send_interval: sv.send_interval.is_some(),
+                has_send_enabled: sv.send_enabled.is_some(),
+                has_external_retention: sv.external_retention.is_some(),
+                has_any_drives,
+                has_empty_drive_list: matches!(sv.drives, Some(ref d) if d.is_empty()),
+            };
+            validate_protection_contract(&view, "v1")?;
 
-            // Reject empty drives list on any level that requires external sends
-            if let Some(ref d) = sv.drives
-                && d.is_empty()
-                && matches!(
-                    level,
-                    ProtectionLevel::Sheltered | ProtectionLevel::Fortified
-                )
-            {
-                return Err(format!(
-                    "subvolume {:?}: protection = \"{level}\" requires drives for \
-                     external backups, but drives is an empty list.",
-                    sv.name
-                ));
-            }
-
-            // Sheltered requires at least one drive (global or assigned)
-            if level == ProtectionLevel::Sheltered && !has_any_drives {
-                return Err(format!(
-                    "subvolume {:?}: protection = \"sheltered\" requires at least one \
-                     configured drive for external backups.",
-                    sv.name
-                ));
-            }
-
-            // Fortified requires at least one offsite drive
+            // Fortified requires at least one offsite drive — a v1-only rule,
+            // kept outside the shared contract: v2 deliberately lacks it; the
+            // all-schema achievability home is preflight's
+            // fortified-without-offsite advisory (preflight.rs).
             if level == ProtectionLevel::Fortified {
                 let has_offsite = if let Some(ref sv_drives) = sv.drives {
                     sv_drives.iter().any(|label| {
@@ -1156,28 +1090,7 @@ impl V2Config {
             })
             .collect();
 
-        // Fallback defaults for v2 Custom/unset protection levels. Values
-        // mirror full_retention / full_external_retention from derive_policy.
-        let defaults = DefaultsConfig {
-            snapshot_interval: Interval::days(1),
-            send_interval: Interval::days(1),
-            send_enabled: true,
-            enabled: true,
-            local_retention: GraduatedRetention {
-                hourly: Some(24),
-                daily: Some(30),
-                weekly: Some(26),
-                monthly: Some(MonthlyCount::Count(12)),
-                yearly: None,
-            },
-            external_retention: GraduatedRetention {
-                hourly: None,
-                daily: Some(30),
-                weekly: Some(26),
-                monthly: Some(MonthlyCount::Unlimited),
-                yearly: None,
-            },
-        };
+        let defaults = parser_fallback_defaults();
 
         let subvolumes: Vec<SubvolumeConfig> = self
             .subvolumes
@@ -1232,95 +1145,27 @@ impl V2Config {
         for sv in &self.subvolumes {
             let level = sv.protection.unwrap_or(ProtectionLevel::Custom);
 
-            // Rule 1: Reject local_retention = "transient" universally
-            if matches!(sv.local_retention, Some(V2LocalRetentionConfig::Transient)) {
-                return Err(format!(
-                    "subvolume {:?}: local_retention = \"transient\" is not supported in v2 \
-                     — use local_snapshots = false instead.",
-                    sv.name
-                ));
-            }
-
-            // Rule 2: Mutual exclusion — local_snapshots = false + local_retention
-            if sv.local_snapshots == Some(false) && sv.local_retention.is_some() {
-                return Err(format!(
-                    "subvolume {:?}: local_snapshots = false and local_retention are mutually \
-                     exclusive — when local_snapshots is disabled, there is nothing to retain.",
-                    sv.name
-                ));
-            }
-
-            // Named levels must not have operational overrides
-            if level != ProtectionLevel::Custom {
-                let forbidden = [
-                    ("snapshot_interval", sv.snapshot_interval.is_some()),
-                    ("send_interval", sv.send_interval.is_some()),
-                    ("send_enabled", sv.send_enabled.is_some()),
-                    ("external_retention", sv.external_retention.is_some()),
-                ];
-                for (field, is_set) in &forbidden {
-                    if *is_set {
-                        return Err(format!(
-                            "subvolume {:?}: {field} cannot be set alongside \
-                             protection = \"{level}\" — the protection level controls this field. \
-                             Use protection = \"custom\" for manual control.",
-                            sv.name
-                        ));
-                    }
-                }
-
-                if sv.local_snapshots == Some(false) {
-                    return Err(format!(
-                        "subvolume {:?}: local_snapshots = false is incompatible with \
-                         protection = \"{level}\" — named levels require local snapshots. \
-                         Remove the protection field for custom configuration.",
-                        sv.name
-                    ));
-                }
-
-                if sv.local_retention.is_some() {
-                    return Err(format!(
-                        "subvolume {:?}: local_retention cannot be set alongside \
-                         protection = \"{level}\" — the protection level controls this field. \
-                         Use protection = \"custom\" for manual control.",
-                        sv.name
-                    ));
-                }
-            }
-
             let has_any_drives = match sv.drives {
                 Some(ref d) => !d.is_empty(),
                 None => !self.drives.is_empty(),
             };
-            if sv.local_snapshots == Some(false) && !has_any_drives {
-                return Err(format!(
-                    "subvolume {:?}: local_snapshots = false requires at least one drive \
-                     — without local snapshots or external sends, nothing is being backed up.",
-                    sv.name
-                ));
-            }
-
-            if let Some(ref d) = sv.drives
-                && d.is_empty()
-                && matches!(
-                    level,
-                    ProtectionLevel::Sheltered | ProtectionLevel::Fortified
-                )
-            {
-                return Err(format!(
-                    "subvolume {:?}: protection = \"{level}\" requires drives for \
-                     external backups, but drives is an empty list.",
-                    sv.name
-                ));
-            }
-
-            if level == ProtectionLevel::Sheltered && !has_any_drives {
-                return Err(format!(
-                    "subvolume {:?}: protection = \"sheltered\" requires at least one \
-                     configured drive for external backups.",
-                    sv.name
-                ));
-            }
+            let view = ProtectionContractView {
+                name: &sv.name,
+                level,
+                local_retention: match sv.local_retention {
+                    None => LocalRetentionKind::None,
+                    Some(V2LocalRetentionConfig::Transient) => LocalRetentionKind::Transient,
+                    Some(V2LocalRetentionConfig::Graduated(_)) => LocalRetentionKind::Graduated,
+                },
+                local_snapshots: sv.local_snapshots,
+                has_snapshot_interval: sv.snapshot_interval.is_some(),
+                has_send_interval: sv.send_interval.is_some(),
+                has_send_enabled: sv.send_enabled.is_some(),
+                has_external_retention: sv.external_retention.is_some(),
+                has_any_drives,
+                has_empty_drive_list: matches!(sv.drives, Some(ref d) if d.is_empty()),
+            };
+            validate_protection_contract(&view, "v2")?;
         }
         Ok(())
     }
@@ -2754,6 +2599,132 @@ snapshot_interval = "6h"
         assert!(err.contains("custom"));
     }
 
+    // ── UPI 062 — v2 contract fixtures (one per shared rule) ───────────
+    // Mirrors the dense v1 suite so the v2 projection refactor has its own
+    // no-behaviour-change guard.
+
+    #[test]
+    fn v2_rejects_transient_spelling() {
+        let raw = format!(
+            "{}local_retention = \"transient\"\n",
+            v2_minimal_config_str()
+        );
+        let err = parse_v2(&raw).unwrap_err();
+        assert!(
+            err.contains("not supported in v2"),
+            "expected transient-spelling rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn v2_rejects_local_snapshots_false_with_local_retention() {
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[drives]]
+label = "D1"
+mount_path = "/mnt/d1"
+snapshot_root = ".snap"
+role = "primary"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+protection = "custom"
+local_snapshots = false
+local_retention = { daily = 7 }
+"#;
+        let err = parse_v2(raw).unwrap_err();
+        assert!(
+            err.contains("mutually exclusive"),
+            "expected mutual-exclusion rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn v2_rejects_local_snapshots_false_on_named_level() {
+        let raw = format!("{}local_snapshots = false\n", v2_minimal_config_str());
+        let err = parse_v2(&raw).unwrap_err();
+        assert!(
+            err.contains("local_snapshots = false is incompatible with"),
+            "expected named-level incompatibility, got: {err}"
+        );
+        assert!(err.contains("sheltered"));
+    }
+
+    #[test]
+    fn v2_rejects_graduated_local_retention_on_named_level() {
+        let raw = format!(
+            "{}local_retention = {{ daily = 7 }}\n",
+            v2_minimal_config_str()
+        );
+        let err = parse_v2(&raw).unwrap_err();
+        assert!(
+            err.contains("local_retention cannot be set alongside"),
+            "expected named-level local_retention rejection, got: {err}"
+        );
+        assert!(err.contains("sheltered"));
+    }
+
+    #[test]
+    fn v2_rejects_local_snapshots_false_without_drives() {
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+local_snapshots = false
+"#;
+        let err = parse_v2(raw).unwrap_err();
+        assert!(
+            err.contains("requires at least one drive"),
+            "expected no-drives rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn v2_rejects_empty_drives_list_on_sheltered() {
+        let raw = format!("{}drives = []\n", v2_minimal_config_str());
+        let err = parse_v2(&raw).unwrap_err();
+        assert!(
+            err.contains("drives is an empty list"),
+            "expected empty-drive-list rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn v2_rejects_sheltered_without_drives() {
+        let raw = r#"
+[general]
+config_version = 2
+state_db = "/tmp/urd.db"
+metrics_file = "/tmp/backup.prom"
+log_dir = "/tmp"
+
+[[subvolumes]]
+name = "sv"
+source = "/data/sv"
+snapshot_root = "/snap"
+protection = "sheltered"
+"#;
+        let err = parse_v2(raw).unwrap_err();
+        assert!(
+            err.contains("requires at least one configured drive"),
+            "expected sheltered-without-drives rejection, got: {err}"
+        );
+    }
+
     #[test]
     fn dispatcher_rejects_v3() {
         let raw = r#"
@@ -4038,6 +4009,16 @@ min_free_bytes = "10GB"
             "local monthly diverged"
         );
         assert_eq!(
+            defaults.local_retention.resolved().yearly,
+            policy.local_retention.yearly,
+            "local yearly diverged"
+        );
+        assert_eq!(
+            defaults.external_retention.resolved().hourly,
+            policy.external_retention.hourly,
+            "external hourly diverged"
+        );
+        assert_eq!(
             defaults.external_retention.resolved().daily,
             policy.external_retention.daily,
             "external daily diverged"
@@ -4051,6 +4032,37 @@ min_free_bytes = "10GB"
             defaults.external_retention.resolved().monthly,
             policy.external_retention.monthly,
             "external monthly diverged"
+        );
+        assert_eq!(
+            defaults.external_retention.resolved().yearly,
+            policy.external_retention.yearly,
+            "external yearly diverged"
+        );
+    }
+
+    #[test]
+    fn parser_fallback_defaults_match_derive_policy_all_fields() {
+        use crate::types::{derive_policy, RunFrequency};
+
+        // Both into_configs synthesize their [defaults] from this one fn, so
+        // this covers v1 and v2. yearly: None ↔ 0 maps via resolved().
+        let policy = derive_policy(
+            ProtectionLevel::Sheltered,
+            RunFrequency::Timer {
+                interval: Interval::days(1),
+            },
+        )
+        .expect("sheltered should produce a policy");
+
+        let defaults = parser_fallback_defaults();
+        assert_eq!(defaults.snapshot_interval, policy.snapshot_interval);
+        assert_eq!(defaults.send_interval, policy.send_interval);
+        assert_eq!(defaults.send_enabled, policy.send_enabled);
+        assert!(defaults.enabled);
+        assert_eq!(defaults.local_retention.resolved(), policy.local_retention);
+        assert_eq!(
+            defaults.external_retention.resolved(),
+            policy.external_retention
         );
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -542,6 +542,142 @@ pub fn derive_policy(level: ProtectionLevel, freq: RunFrequency) -> Option<Deriv
     }
 }
 
+// ── Protection-level contract (ADR-110) ─────────────────────────────────
+
+/// How a subvolume's `local_retention` field is set, schema-agnostically.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LocalRetentionKind {
+    None,
+    Transient,
+    Graduated,
+}
+
+/// Schema-agnostic projection of one subvolume's protection-relevant
+/// fields. Each config parser builds this view and calls
+/// [`validate_protection_contract`] — the single home for architectural
+/// invariant #10 (named protection levels are opaque, ADR-110).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ProtectionContractView<'a> {
+    pub(crate) name: &'a str,
+    pub(crate) level: ProtectionLevel,
+    pub(crate) local_retention: LocalRetentionKind,
+    pub(crate) local_snapshots: Option<bool>,
+    pub(crate) has_snapshot_interval: bool,
+    pub(crate) has_send_interval: bool,
+    pub(crate) has_send_enabled: bool,
+    pub(crate) has_external_retention: bool,
+    pub(crate) has_any_drives: bool,
+    pub(crate) has_empty_drive_list: bool,
+}
+
+/// The operational fields a named level controls, in rule order. Returns
+/// the names of those set on the view. Shared by the validator and
+/// `opacity_violations` so the field list exists exactly once.
+fn named_level_field_overrides(sv: &ProtectionContractView<'_>) -> Vec<&'static str> {
+    let fields = [
+        ("snapshot_interval", sv.has_snapshot_interval),
+        ("send_interval", sv.has_send_interval),
+        ("send_enabled", sv.has_send_enabled),
+        ("external_retention", sv.has_external_retention),
+    ];
+    fields
+        .iter()
+        .filter(|(_, is_set)| *is_set)
+        .map(|(field, _)| *field)
+        .collect()
+}
+
+/// Validate the protection-level contract for one subvolume view.
+///
+/// The rules and their order are shared by every config schema; only the
+/// transient-spelling message names the schema (via `schema`). Returns the
+/// first violation. Pure function: no I/O (ADR-108).
+pub(crate) fn validate_protection_contract(
+    sv: &ProtectionContractView<'_>,
+    schema: &str,
+) -> Result<(), String> {
+    let name = sv.name;
+    let level = sv.level;
+
+    // Rule 1: Reject local_retention = "transient" universally
+    // (applies to both named and custom — use local_snapshots = false instead)
+    if sv.local_retention == LocalRetentionKind::Transient {
+        return Err(format!(
+            "subvolume {name:?}: local_retention = \"transient\" is not supported in {schema} \
+             — use local_snapshots = false instead."
+        ));
+    }
+
+    // Rule 2: Mutual exclusion — local_snapshots = false + local_retention
+    if sv.local_snapshots == Some(false) && sv.local_retention != LocalRetentionKind::None {
+        return Err(format!(
+            "subvolume {name:?}: local_snapshots = false and local_retention are mutually \
+             exclusive — when local_snapshots is disabled, there is nothing to retain."
+        ));
+    }
+
+    // Named levels must not have operational overrides
+    if level != ProtectionLevel::Custom {
+        if let Some(field) = named_level_field_overrides(sv).first() {
+            return Err(format!(
+                "subvolume {name:?}: {field} cannot be set alongside \
+                 protection = \"{level}\" — the protection level controls this field. \
+                 Use protection = \"custom\" for manual control."
+            ));
+        }
+
+        // local_snapshots = false is incompatible with named levels
+        if sv.local_snapshots == Some(false) {
+            return Err(format!(
+                "subvolume {name:?}: local_snapshots = false is incompatible with \
+                 protection = \"{level}\" — named levels require local snapshots. \
+                 Remove the protection field for custom configuration."
+            ));
+        }
+
+        // ANY local_retention alongside a named level is rejected
+        // (transient already caught by Rule 1 above)
+        if sv.local_retention != LocalRetentionKind::None {
+            return Err(format!(
+                "subvolume {name:?}: local_retention cannot be set alongside \
+                 protection = \"{level}\" — the protection level controls this field. \
+                 Use protection = \"custom\" for manual control."
+            ));
+        }
+    }
+
+    // local_snapshots = false requires at least one drive
+    if sv.local_snapshots == Some(false) && !sv.has_any_drives {
+        return Err(format!(
+            "subvolume {name:?}: local_snapshots = false requires at least one drive \
+             — without local snapshots or external sends, nothing is being backed up."
+        ));
+    }
+
+    // Reject empty drives list on any level that requires external sends
+    if sv.has_empty_drive_list
+        && matches!(
+            level,
+            ProtectionLevel::Sheltered | ProtectionLevel::Fortified
+        )
+    {
+        return Err(format!(
+            "subvolume {name:?}: protection = \"{level}\" requires drives for \
+             external backups, but drives is an empty list."
+        ));
+    }
+
+    // Sheltered requires at least one drive (global or assigned)
+    if level == ProtectionLevel::Sheltered && !sv.has_any_drives {
+        return Err(format!(
+            "subvolume {name:?}: protection = \"sheltered\" requires at least one \
+             configured drive for external backups."
+        ));
+    }
+
+    Ok(())
+}
+
 // ── MonthlyCount ────────────────────────────────────────────────────────
 
 /// Monthly retention quantity: either a bounded count or unlimited.
@@ -1982,5 +2118,276 @@ weekly = 4
             yearly: None,
         };
         assert_eq!(g.resolved().monthly, MonthlyCount::Count(0));
+    }
+
+    // ── protection-level contract tests ────────────────────────────
+
+    /// A view that passes every contract rule; tests flip one field each.
+    fn contract_view(level: ProtectionLevel) -> ProtectionContractView<'static> {
+        ProtectionContractView {
+            name: "home",
+            level,
+            local_retention: LocalRetentionKind::None,
+            local_snapshots: None,
+            has_snapshot_interval: false,
+            has_send_interval: false,
+            has_send_enabled: false,
+            has_external_retention: false,
+            has_any_drives: true,
+            has_empty_drive_list: false,
+        }
+    }
+
+    #[test]
+    fn contract_accepts_clean_views_on_every_level() {
+        for level in [
+            ProtectionLevel::Recorded,
+            ProtectionLevel::Sheltered,
+            ProtectionLevel::Fortified,
+            ProtectionLevel::Custom,
+        ] {
+            let view = contract_view(level);
+            assert!(validate_protection_contract(&view, "v1").is_ok());
+            assert!(validate_protection_contract(&view, "v2").is_ok());
+        }
+    }
+
+    #[test]
+    fn contract_accepts_custom_with_everything_set() {
+        let view = ProtectionContractView {
+            local_retention: LocalRetentionKind::Graduated,
+            local_snapshots: Some(true),
+            has_snapshot_interval: true,
+            has_send_interval: true,
+            has_send_enabled: true,
+            has_external_retention: true,
+            ..contract_view(ProtectionLevel::Custom)
+        };
+        assert!(validate_protection_contract(&view, "v1").is_ok());
+    }
+
+    #[test]
+    fn contract_rejects_transient_spelling_on_named_and_custom() {
+        for level in [ProtectionLevel::Sheltered, ProtectionLevel::Custom] {
+            let view = ProtectionContractView {
+                local_retention: LocalRetentionKind::Transient,
+                ..contract_view(level)
+            };
+            let err = validate_protection_contract(&view, "v1").unwrap_err();
+            assert_eq!(
+                err,
+                "subvolume \"home\": local_retention = \"transient\" is not supported in v1 \
+                 — use local_snapshots = false instead."
+            );
+        }
+    }
+
+    #[test]
+    fn contract_transient_message_carries_the_schema() {
+        let view = ProtectionContractView {
+            local_retention: LocalRetentionKind::Transient,
+            ..contract_view(ProtectionLevel::Custom)
+        };
+        let err = validate_protection_contract(&view, "v2").unwrap_err();
+        assert!(err.contains("not supported in v2"));
+    }
+
+    #[test]
+    fn contract_rejects_local_snapshots_false_with_local_retention() {
+        let view = ProtectionContractView {
+            local_snapshots: Some(false),
+            local_retention: LocalRetentionKind::Graduated,
+            ..contract_view(ProtectionLevel::Custom)
+        };
+        let err = validate_protection_contract(&view, "v1").unwrap_err();
+        assert_eq!(
+            err,
+            "subvolume \"home\": local_snapshots = false and local_retention are mutually \
+             exclusive — when local_snapshots is disabled, there is nothing to retain."
+        );
+    }
+
+    #[test]
+    fn contract_rejects_each_forbidden_field_on_named_level() {
+        let base = contract_view(ProtectionLevel::Sheltered);
+        let cases = [
+            (
+                "snapshot_interval",
+                ProtectionContractView {
+                    has_snapshot_interval: true,
+                    ..base
+                },
+            ),
+            (
+                "send_interval",
+                ProtectionContractView {
+                    has_send_interval: true,
+                    ..base
+                },
+            ),
+            (
+                "send_enabled",
+                ProtectionContractView {
+                    has_send_enabled: true,
+                    ..base
+                },
+            ),
+            (
+                "external_retention",
+                ProtectionContractView {
+                    has_external_retention: true,
+                    ..base
+                },
+            ),
+        ];
+        for (field, view) in cases {
+            let err = validate_protection_contract(&view, "v1").unwrap_err();
+            assert_eq!(
+                err,
+                format!(
+                    "subvolume \"home\": {field} cannot be set alongside \
+                     protection = \"sheltered\" — the protection level controls this field. \
+                     Use protection = \"custom\" for manual control."
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn contract_forbidden_fields_check_in_field_order() {
+        // All four set → snapshot_interval reported first.
+        let view = ProtectionContractView {
+            has_snapshot_interval: true,
+            has_send_interval: true,
+            has_send_enabled: true,
+            has_external_retention: true,
+            ..contract_view(ProtectionLevel::Recorded)
+        };
+        let err = validate_protection_contract(&view, "v1").unwrap_err();
+        assert!(err.contains("snapshot_interval cannot be set"));
+    }
+
+    #[test]
+    fn contract_rejects_local_snapshots_false_on_named_level() {
+        let view = ProtectionContractView {
+            local_snapshots: Some(false),
+            ..contract_view(ProtectionLevel::Sheltered)
+        };
+        let err = validate_protection_contract(&view, "v1").unwrap_err();
+        assert_eq!(
+            err,
+            "subvolume \"home\": local_snapshots = false is incompatible with \
+             protection = \"sheltered\" — named levels require local snapshots. \
+             Remove the protection field for custom configuration."
+        );
+    }
+
+    #[test]
+    fn contract_rejects_graduated_local_retention_on_named_level() {
+        let view = ProtectionContractView {
+            local_retention: LocalRetentionKind::Graduated,
+            ..contract_view(ProtectionLevel::Fortified)
+        };
+        let err = validate_protection_contract(&view, "v1").unwrap_err();
+        assert_eq!(
+            err,
+            "subvolume \"home\": local_retention cannot be set alongside \
+             protection = \"fortified\" — the protection level controls this field. \
+             Use protection = \"custom\" for manual control."
+        );
+    }
+
+    #[test]
+    fn contract_rejects_local_snapshots_false_without_drives() {
+        let view = ProtectionContractView {
+            local_snapshots: Some(false),
+            has_any_drives: false,
+            ..contract_view(ProtectionLevel::Custom)
+        };
+        let err = validate_protection_contract(&view, "v1").unwrap_err();
+        assert_eq!(
+            err,
+            "subvolume \"home\": local_snapshots = false requires at least one drive \
+             — without local snapshots or external sends, nothing is being backed up."
+        );
+    }
+
+    #[test]
+    fn contract_rejects_empty_drive_list_on_external_levels() {
+        for level in [ProtectionLevel::Sheltered, ProtectionLevel::Fortified] {
+            let view = ProtectionContractView {
+                has_empty_drive_list: true,
+                has_any_drives: false,
+                ..contract_view(level)
+            };
+            let err = validate_protection_contract(&view, "v1").unwrap_err();
+            assert_eq!(
+                err,
+                format!(
+                    "subvolume \"home\": protection = \"{level}\" requires drives for \
+                     external backups, but drives is an empty list."
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn contract_accepts_empty_drive_list_on_local_levels() {
+        for level in [ProtectionLevel::Recorded, ProtectionLevel::Custom] {
+            let view = ProtectionContractView {
+                has_empty_drive_list: true,
+                has_any_drives: false,
+                ..contract_view(level)
+            };
+            assert!(validate_protection_contract(&view, "v1").is_ok());
+        }
+    }
+
+    #[test]
+    fn contract_rejects_sheltered_without_drives() {
+        let view = ProtectionContractView {
+            has_any_drives: false,
+            ..contract_view(ProtectionLevel::Sheltered)
+        };
+        let err = validate_protection_contract(&view, "v1").unwrap_err();
+        assert_eq!(
+            err,
+            "subvolume \"home\": protection = \"sheltered\" requires at least one \
+             configured drive for external backups."
+        );
+    }
+
+    #[test]
+    fn contract_accepts_recorded_and_custom_without_drives() {
+        for level in [ProtectionLevel::Recorded, ProtectionLevel::Custom] {
+            let view = ProtectionContractView {
+                has_any_drives: false,
+                ..contract_view(level)
+            };
+            assert!(validate_protection_contract(&view, "v1").is_ok());
+        }
+    }
+
+    #[test]
+    fn contract_first_violation_wins_in_rule_order() {
+        // Mirrors v1_rejects_transient_and_local_snapshots_false: the
+        // transient-spelling rule fires before the mutual-exclusion rule.
+        let view = ProtectionContractView {
+            local_retention: LocalRetentionKind::Transient,
+            local_snapshots: Some(false),
+            ..contract_view(ProtectionLevel::Custom)
+        };
+        let err = validate_protection_contract(&view, "v1").unwrap_err();
+        assert!(err.contains("not supported in v1"));
+
+        // Forbidden operational fields fire before the named-level
+        // local_snapshots = false rule.
+        let view = ProtectionContractView {
+            has_send_interval: true,
+            local_snapshots: Some(false),
+            ..contract_view(ProtectionLevel::Sheltered)
+        };
+        let err = validate_protection_contract(&view, "v1").unwrap_err();
+        assert!(err.contains("send_interval cannot be set"));
     }
 }


### PR DESCRIPTION
## Summary

- Extracts architectural invariant #10 (named protection levels are opaque, ADR-110) from two near-identical validators (`validate_v1`, `validate_v2`) into a single shared `validate_protection_contract()` in `types.rs`, next to `derive_policy()`. Each parser projects its subvolumes into a schema-agnostic `ProtectionContractView` and delegates.
- **No acceptance-behavior change**, evidenced three ways: the dense v1 one-test-per-rule fixture suite passes untouched (byte-identical messages); a new seven-test v2 fixture suite was written green against the *old* `validate_v2` before the refactor (the v2 contract previously had a single fixture test); and the shared validator gains a rule matrix with exact-message and rule-ordering assertions.
- The fortified-requires-offsite rule stays v1-only by design — v2 deliberately lacks it; preflight's `fortified-without-offsite` advisory is the all-schema achievability home.
- The two field-identical synthesized-`[defaults]` blocks fold into one `parser_fallback_defaults()`, equality-tested against `derive_policy()` on every field (including the previously unasserted `yearly` / external-`hourly`).
- `resolved()`'s legacy merge arms are untouched; migration-identity tests re-run green (`migration_identity_no_protection_level`).
- Docs: `architecture.md` `types.rs` row gains the contract; glossary gains a "protection-level contract" entry.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 1742 passed, 0 failed (baseline 1719 + 15 contract-matrix + 7 v2 fixtures + 1 defaults-equality)
- cargo build --release: pass
- Integration tests: not applicable (pure refactor, no btrfs-facing change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)