### PR TITLE
release: v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-06-10
+
 ### Added
 - **Legacy configs warn when a named protection level is overridden** (UPI 062, PR 2). The
   legacy schema predates the ADR-110 opacity contract and silently honors explicit settings
@@ -1015,7 +1017,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.24.2...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/vonrobak/urd/compare/v0.24.2...v0.25.0
 [0.24.2]: https://github.com/vonrobak/urd/compare/v0.24.1...v0.24.2
 [0.24.1]: https://github.com/vonrobak/urd/compare/v0.24.0...v0.24.1
 [0.24.0]: https://github.com/vonrobak/urd/compare/v0.23.0...v0.24.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.24.2"
+version = "0.25.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.25.0**. Headline: one home for the protection-level contract (UPI 062, #189/#190) — shared ADR-110 opacity validator, legacy opacity warnings, and a migrate output self-check through the full v2 load path. Also includes the UPI 060 assessment-view/status-assembly refactors (#184/#185), the UPI 061 Prometheus wire-contract home (#187), and the `urd doctor` offsite-freshness fix (#182).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1752 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)