### PR TITLE
fix: urd init greets a missing config instead of erroring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`urd init` greets a missing config instead of erroring.** The bare-`urd` greeting
+  advertises `urd init` as the first command, but init sat behind the mandatory config
+  load and answered a first-time user with a raw I/O error ("No such file or directory").
+  It now uses the same fallible-load discrimination as bare `urd`: a missing config gets
+  guidance (where the config lives, where the annotated example is, what to run next);
+  any other load error still surfaces. Daemon mode reports `{"status":"not_configured"}`,
+  matching the bare-`urd` contract.
+
 ## [0.25.0] - 2026-06-10
 
 ### Added

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,15 +1,39 @@
 use std::io::Write as _;
+use std::path::Path;
 
 use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::chain;
 use crate::config::Config;
 use crate::drives;
+use crate::error::UrdError;
 use crate::output::{
     InitCheck, InitDriveStatus, InitIncomplete, InitOutput, InitPinFile, InitSnapshotCount,
     InitStatus, OutputMode,
 };
 use crate::plan::{FilesystemQuery, RealFileSystemState};
 use crate::state::StateDb;
+
+/// CLI entry with fallible config load and first-time discrimination,
+/// mirroring `commands::default::run`: file-not-found → first-time guidance;
+/// all other errors → surface. The bare-`urd` greeting advertises `urd init`
+/// as the first command — a missing config must greet, not error.
+pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<()> {
+    let config = match Config::load(config_path) {
+        Ok(c) => c,
+        Err(UrdError::Io {
+            ref path,
+            ref source,
+        }) if source.kind() == std::io::ErrorKind::NotFound => {
+            print!(
+                "{}",
+                crate::voice::render_init_first_time(path, output_mode)
+            );
+            return Ok(());
+        }
+        Err(e) => return Err(e.into()),
+    };
+    run(config)
+}
 
 pub fn run(config: Config) -> anyhow::Result<()> {
     let fs_state = RealFileSystemState { state: None };

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,11 @@ fn main() -> anyhow::Result<()> {
     if cli.command.is_none() {
         return commands::default::run(cli.config.as_deref(), output_mode);
     }
+    // `urd init` also loads fallibly: the bare-`urd` greeting points first-time
+    // users at it, so a missing config gets guidance, not an I/O error.
+    if let Some(Commands::Init) = cli.command {
+        return commands::init::run_cli(cli.config.as_deref(), output_mode);
+    }
 
     // Strategy C: mandatory config load (all existing commands)
     let config = config::Config::load(cli.config.as_deref())?;
@@ -88,7 +93,6 @@ fn main() -> anyhow::Result<()> {
     match cli.command.unwrap() {
         Commands::Plan(args) => commands::plan_cmd::run(config, args, output_mode),
         Commands::Backup(args) => commands::backup::run(config, args),
-        Commands::Init => commands::init::run(config),
         Commands::Calibrate(args) => commands::calibrate::run(config, args, output_mode),
         Commands::Status => commands::status::run(config, output_mode),
         Commands::History(args) => commands::history::run(config, args, output_mode),
@@ -110,6 +114,8 @@ fn main() -> anyhow::Result<()> {
             commands::retention_preview::run(config, args, output_mode)
         }
         Commands::Events(args) => commands::events::run(config, args, output_mode),
-        Commands::Completions(_) | Commands::Migrate(_) => unreachable!("handled above"),
+        Commands::Completions(_) | Commands::Migrate(_) | Commands::Init => {
+            unreachable!("handled above")
+        }
     }
 }

--- a/src/voice/init.rs
+++ b/src/voice/init.rs
@@ -4,11 +4,31 @@
 //! mode.
 
 use std::fmt::Write;
+use std::path::Path;
 
 use colored::Colorize;
 
 use crate::output::{InitOutput, InitStatus, OutputMode};
 use crate::types::{ByteSize, DriveRole};
+
+/// First-run guidance when `urd init` finds no config. The bare-`urd`
+/// greeting points new users here, so a missing config is the expected
+/// starting state — greet and guide, never error.
+#[must_use]
+pub fn render_init_first_time(config_path: &Path, mode: OutputMode) -> String {
+    match mode {
+        OutputMode::Interactive => format!(
+            "Urd is not configured yet — nothing to verify.\n\
+             \n\
+             To begin, create a config at {}.\n\
+             Start from the annotated example (config/urd.toml.example in the\n\
+             Urd repository, walked through in the README's Configuration\n\
+             section), then run `urd init` again to check your setup.\n",
+            config_path.display()
+        ),
+        OutputMode::Daemon => r#"{"status":"not_configured"}"#.to_string(),
+    }
+}
 
 /// Render init output according to the given mode.
 #[must_use]

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -51,7 +51,7 @@ pub use drives::{render_drives_adopt, render_drives_list};
 pub use emergency::{render_emergency, render_emergency_result};
 pub use get::render_get;
 pub use history::{render_events, render_history, render_subvolume_history};
-pub use init::render_init;
+pub use init::{render_init, render_init_first_time};
 pub use plan::{render_empty_plan, render_plan};
 pub use retention::render_retention_preview;
 pub use sentinel::render_sentinel_status;
@@ -2298,6 +2298,36 @@ mod tests {
         };
         let output = render_init(&data, OutputMode::Daemon);
         let _: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+    }
+
+    #[test]
+    fn init_first_time_interactive_guides_without_erroring() {
+        let path = std::path::Path::new("/home/user/.config/urd/urd.toml");
+        let output = render_init_first_time(path, OutputMode::Interactive);
+        assert!(
+            output.contains("/home/user/.config/urd/urd.toml"),
+            "must name the path where the config belongs"
+        );
+        assert!(
+            output.contains("urd.toml.example"),
+            "must point at the annotated example"
+        );
+        assert!(
+            output.contains("`urd init`"),
+            "must close the loop back to init"
+        );
+        assert!(
+            !output.to_lowercase().contains("error"),
+            "a missing config is a starting state, not an error"
+        );
+    }
+
+    #[test]
+    fn init_first_time_daemon_reports_not_configured() {
+        let path = std::path::Path::new("/home/user/.config/urd/urd.toml");
+        let output = render_init_first_time(path, OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
+        assert_eq!(parsed["status"], "not_configured");
     }
 
     // ── Sentinel status tests ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `urd init` is the command the bare-`urd` greeting points first-time users at, yet it sat behind the mandatory config load — a missing config answered with `Error: I/O error ... No such file or directory (os error 2)` as the user's literal first step.
- Init now dispatches before the mandatory load and reuses the fallible-load discrimination from `commands::default::run`: file-not-found renders first-time guidance (config path, annotated example, loop back to `urd init`); all other load errors surface unchanged.
- Daemon mode emits `{"status":"not_configured"}`, matching the bare-`urd` contract.
- Found by the 2026-06-11 vision review's first-encounter walk; first item of its Ask #4.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 1756 tests, pass (2 new: interactive guidance, daemon JSON)
- Manual: missing config greets in pty + pipe modes; invalid TOML still errors with exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)