### PR TITLE
fix: one tongue — promise coherence across assessors (UPI 063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **One tongue: every assessment site judges promises with the same storage posture**
+  (UPI 063, #193). Three sites — the sentinel's assessment tick, the backup's
+  pre-execution snapshot, and the empty-plan heartbeat — assessed with an empty signal
+  map, judging freshness against *declared* intervals while `urd status` judged against
+  *effective* tight-tier intervals. On a tight pool the 1.5× stretch guarantees sends
+  age into the 36–54h window every other day, so the sentinel flipped promises AT RISK
+  mid-afternoon while status said sealed — a daily split-brain feeding the heartbeat,
+  notifications, the event log (~5–9 phantom transitions/day), and the run output's
+  transition acknowledgments. All sites now consume the gathered signals (reflect-only;
+  the backup's post-exec writeback remains the only place the armed tier advances).
+- **Promise transitions are recorded once when a sentinel tick races a backup run**
+  (UPI 063, #194). A tick landing inside a run window diffed mid-run state against the
+  sentinel's private baseline and recorded flips the run recorded again at completion;
+  a tick coalescing with the completion event in the same poll cycle could do the same
+  after the fact. The sentinel now skips event recording while a live backup holds the
+  lock (notifications and its own baseline are unaffected), and a coalesced completion
+  suppresses the tick's trigger — the backup stays canonical for in-run transitions
+  (trigger=Run).
+
 - **`urd init` greets a missing config instead of erroring.** The bare-`urd` greeting
   advertises `urd init` as the first command, but init sat behind the mandatory config
   load and answered a first-time user with a raw I/O error ("No such file or directory").

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -251,8 +251,10 @@ pub struct RedundancyAdvisory {
 /// The assessment view: the awareness assessment plus every product overlay.
 ///
 /// The only input from which surfaces render promise state. Callers supply
-/// gathered signals or an empty map (sentinel D6 / backup S4 paths); this
-/// function never gathers (backup's 031-b single-gather invariant).
+/// gathered signals — since UPI 063 every production assessment site (status,
+/// doctor, bare `urd`, sentinel, backup pre/post/empty-plan) judges with
+/// gathered signals, so all tongues speak one verdict. This function never
+/// gathers itself (backup's 031-b single-gather invariant).
 #[must_use]
 pub fn assess_view(
     config: &Config,
@@ -910,9 +912,11 @@ drives = ["primary-drive", "offsite-drive"]
 
     #[test]
     fn assess_view_empty_signals_flows_through() {
-        // Pins the sentinel (D6) / backup (S4) empty-map contract: callers may
-        // pass an empty StorageSignalMap and still get assessments — with no
-        // storage posture computed on those paths.
+        // assess_view is signal-agnostic: an empty StorageSignalMap still
+        // yields assessments, with no storage posture computed. No production
+        // path passes an empty map since UPI 063 (posture parity), but the
+        // function must not require signals — gather failures degrade to
+        // absent signals, never to a refusal to assess.
         let config = fortified_rotation_config();
         let now = dt(2026, 4, 1, 12, 0);
         let mut fs = MockFileSystemState::new();

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -1821,13 +1821,9 @@ source = "/data/sv1"
         // therefore consume the gathered signals, or Urd speaks with two
         // tongues in the 36–54h window the Tight stretch itself guarantees.
         let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 21, 22, 0), 0.20);
+        let obs = Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() };
 
-        let with_signals = assess(
-            &config,
-            now,
-            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
-            &signals,
-        );
+        let with_signals = assess(&config, now, &obs, &signals);
         let sv1 = with_signals.iter().find(|a| a.name == "sv1").unwrap();
         assert_eq!(
             sv1.status,
@@ -1835,12 +1831,7 @@ source = "/data/sv1"
             "40h is fresh against the effective 36h interval (threshold 54h)"
         );
 
-        let posture_blind = assess(
-            &config,
-            now,
-            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
-            &StorageSignalMap::new(),
-        );
+        let posture_blind = assess(&config, now, &obs, &StorageSignalMap::new());
         let sv1_blind = posture_blind.iter().find(|a| a.name == "sv1").unwrap();
         assert_eq!(
             sv1_blind.status,

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -1812,6 +1812,93 @@ source = "/data/sv1"
     }
 
     #[test]
+    fn tight_stretch_window_verdict_depends_on_signal_map() {
+        // UPI 063 — the split-brain mechanism, pinned. Send age 40h, declared
+        // 1d, pool Tight. Judged WITH the signal: effective interval 36h,
+        // AT-RISK threshold 54h → PROTECTED. Judged with an EMPTY map (the old
+        // posture-blind D6/S4 paths): declared 24h, threshold 36h → AT RISK.
+        // Same filesystem state, opposite verdicts — every assessment site must
+        // therefore consume the gathered signals, or Urd speaks with two
+        // tongues in the 36–54h window the Tight stretch itself guarantees.
+        let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 21, 22, 0), 0.20);
+
+        let with_signals = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &signals,
+        );
+        let sv1 = with_signals.iter().find(|a| a.name == "sv1").unwrap();
+        assert_eq!(
+            sv1.status,
+            PromiseStatus::Protected,
+            "40h is fresh against the effective 36h interval (threshold 54h)"
+        );
+
+        let posture_blind = assess(
+            &config,
+            now,
+            &Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() },
+            &StorageSignalMap::new(),
+        );
+        let sv1_blind = posture_blind.iter().find(|a| a.name == "sv1").unwrap();
+        assert_eq!(
+            sv1_blind.status,
+            PromiseStatus::AtRisk,
+            "40h is stale against the declared 1d interval (threshold 36h)"
+        );
+    }
+
+    #[test]
+    fn pre_post_diff_under_one_judgment_is_empty() {
+        // UPI 063 — the phantom-transition reproducer, fixed half. Pre and
+        // post snapshots judged under the SAME signal map with no underlying
+        // change produce no transitions. This is what backup.rs's pre/post
+        // diff does after posture parity.
+        let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 21, 22, 0), 0.20);
+        let obs = Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() };
+
+        let pre = assess(&config, now, &obs, &signals);
+        let post = assess(&config, now, &obs, &signals);
+
+        let prev_snapshots = crate::sentinel::snapshot_promises(&pre);
+        let events = diff_promise_states(
+            &prev_snapshots,
+            &post,
+            now,
+            crate::events::TransitionTrigger::Run,
+        );
+        assert!(events.is_empty(), "same judgment, same state → no transitions");
+    }
+
+    #[test]
+    fn pre_post_diff_across_judgments_fabricates_transitions() {
+        // UPI 063 — the phantom-transition reproducer, broken half. A
+        // posture-blind pre against a posture-judged post fabricates a
+        // transition from the judgment mismatch alone (40h send age, Tight
+        // pool: blind says AT RISK, judged says PROTECTED — no filesystem
+        // change between the two). This is what backup.rs's diff did before
+        // posture parity.
+        let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 21, 22, 0), 0.20);
+        let obs = Observation { fs: &fs, history: &fs, btrfs: &MockBtrfs::new() };
+
+        let blind_pre = assess(&config, now, &obs, &StorageSignalMap::new());
+        let judged_post = assess(&config, now, &obs, &signals);
+
+        let prev_snapshots = crate::sentinel::snapshot_promises(&blind_pre);
+        let events = diff_promise_states(
+            &prev_snapshots,
+            &judged_post,
+            now,
+            crate::events::TransitionTrigger::Run,
+        );
+        assert!(
+            !events.is_empty(),
+            "split judgment fabricates a transition with no state change"
+        );
+    }
+
+    #[test]
     fn roomy_subvol_has_no_cap_and_no_effective_interval() {
         let (config, now, fs, signals) = capped_fixture(dt(2026, 3, 23, 8, 0), 0.50);
         let results = assess(

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -173,15 +173,14 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
             &observability,
         )?;
         let previous_hb = heartbeat::read(&config.general.heartbeat_file);
-        // Empty-plan path: storage posture is not surfaced here (the heartbeat
-        // projection carries no posture — S4), so skip the findmnt sweep and
-        // pass an empty signal map.
-        let assessments = advice::assess_view(
-            &config,
-            heartbeat_now,
-            &observation,
-            &awareness::StorageSignalMap::new(),
-        );
+        // Posture parity (UPI 063): the empty-plan heartbeat embeds promise
+        // verdicts, and verdicts are posture-sensitive — S4's "the projection
+        // carries no posture" conflated fields with judgment. Reuse the
+        // pre-plan `signals` (AB1: still exactly one gather on the run path;
+        // re-gathering here would be judged after the emergency preflight may
+        // have freed space, desyncing this heartbeat from the plan's tier).
+        let assessments =
+            advice::assess_view(&config, heartbeat_now, &observation, &signals.by_subvol);
         let hb = heartbeat::build_empty(
             &config,
             heartbeat_now,
@@ -311,14 +310,14 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // (thread restored, promise recovered, etc.) by diffing with post-backup state.
     let pre_assessments = {
         let pre_now = chrono::Local::now().naive_local();
-        // Pre-execution snapshot is used only to diff promise-state transitions;
-        // posture is not a promise state, so an empty signal map suffices.
-        advice::assess_view(
-            &config,
-            pre_now,
-            &observation,
-            &awareness::StorageSignalMap::new(),
-        )
+        // Posture parity (UPI 063): judge the pre-snapshot under the SAME
+        // pre-plan signals as the post-exec assess, so the run's transition
+        // diff (events at trigger=Run, and the run output's transition
+        // acknowledgments via `detect_transitions`) records only flips the run
+        // actually caused. An empty map here judged the pre against declared
+        // intervals while the post was judged against effective tight-tier
+        // intervals — fabricating transitions out of the judgment mismatch.
+        advice::assess_view(&config, pre_now, &observation, &signals.by_subvol)
     };
 
     // Build progress context after token filtering so counters reflect actual work.

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -637,6 +637,25 @@ pub fn has_health_changes(
     has_changes(previous, current)
 }
 
+/// Should this assess record promise-transition events? (UPI 063)
+///
+/// Encodes the ownership rule backup.rs states ("Backup is canonical for
+/// in-run promise transitions, trigger=Run") for the window the trigger
+/// suppression alone misses: a sentinel tick landing INSIDE a backup run
+/// would diff mid-run state against the sentinel's private baseline and
+/// record flips the run records again at completion. While a backup holds
+/// the lock (`backup_active`), the sentinel observes but does not record —
+/// its baseline still absorbs the flip (one notification, no duplicate
+/// event), and the run's own pre/post diff is the honest attribution.
+#[must_use]
+pub fn should_record_transitions(
+    has_initial_assessment: bool,
+    trigger: Option<crate::events::TransitionTrigger>,
+    backup_active: bool,
+) -> bool {
+    has_initial_assessment && trigger.is_some() && !backup_active
+}
+
 // ── Snapshot extractors ───────────────────────────────────────────────
 
 /// Extract promise snapshots from assessments for state storage.
@@ -1094,6 +1113,52 @@ mod tests {
     #[test]
     fn tick_empty_assessments_is_2_minutes() {
         assert_eq!(compute_next_tick(&[]), Duration::from_secs(2 * 60));
+    }
+
+    // ── should_record_transitions (UPI 063) ─────────────────────────────
+
+    #[test]
+    fn records_on_tick_when_initialized_and_no_backup() {
+        use crate::events::TransitionTrigger;
+        assert!(should_record_transitions(
+            true,
+            Some(TransitionTrigger::Tick),
+            false
+        ));
+    }
+
+    #[test]
+    fn never_records_before_initial_assessment() {
+        use crate::events::TransitionTrigger;
+        for trigger in [None, Some(TransitionTrigger::Tick)] {
+            for backup_active in [false, true] {
+                assert!(!should_record_transitions(false, trigger, backup_active));
+            }
+        }
+    }
+
+    #[test]
+    fn never_records_without_a_trigger() {
+        // BackupCompleted-only cycles arrive as trigger=None — the backup
+        // already recorded with trigger=Run.
+        for backup_active in [false, true] {
+            assert!(!should_record_transitions(true, None, backup_active));
+        }
+    }
+
+    #[test]
+    fn never_records_while_a_backup_run_is_active() {
+        // The tick-inside-run window: the run's own pre/post diff is the
+        // canonical recorder (trigger=Run); a concurrent tick must not
+        // double-record.
+        use crate::events::TransitionTrigger;
+        for trigger in [
+            TransitionTrigger::Tick,
+            TransitionTrigger::DriveMounted,
+            TransitionTrigger::ConfigChanged,
+        ] {
+            assert!(!should_record_transitions(true, Some(trigger), true));
+        }
     }
 
     // ── Circuit breaker ─────────────────────────────────────────────────

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -18,6 +18,7 @@ use chrono::NaiveDateTime;
 
 use crate::advice;
 use crate::awareness::{self, PromiseStatus, SubvolAssessment};
+use crate::commands::storage_signals;
 use crate::config::Config;
 use crate::drives::{self, DriveAvailability};
 use crate::heartbeat;
@@ -377,6 +378,12 @@ impl SentinelRunner {
 
     // ── Action execution ────────────────────────────────────────────────
 
+    /// True when a foreign live process holds the backup lock (UPI 063).
+    fn backup_run_active(&self) -> bool {
+        let lock_path = self.config.general.state_db.with_extension("lock");
+        backup_run_active_at(&lock_path)
+    }
+
     fn execute_assess(
         &mut self,
         trigger: Option<crate::events::TransitionTrigger>,
@@ -398,23 +405,34 @@ impl SentinelRunner {
             btrfs: &assess_btrfs,
         };
 
-        // The sentinel is deliberately blind to storage posture (D6 — it reacts
-        // to the heartbeat, which carries no posture). Pass an empty signal map
-        // so `assess()` computes no posture on this path; on-demand `status` and
-        // `backup` runs are where posture is gathered and surfaced.
+        // Posture parity (UPI 063): the sentinel judges with the same gathered
+        // signals as `urd status`, so both tongues speak one verdict. D6's
+        // premise ("posture is presentation, not promise") was falsified by
+        // 031-b — the armed tier changes the effective send interval and thus
+        // the verdict, so a posture-blind assess flips promises AT RISK in the
+        // 36–54h window the Tight stretch itself guarantees. `gather()` is
+        // reflect-only (S1: reads never advance hysteresis); the backup's
+        // post-exec writeback remains the only place the armed tier advances.
+        let signals = storage_signals::gather(&self.config, state_db.as_ref());
         let assessments = advice::assess_view(
             &self.config,
             now,
             &observation,
-            &awareness::StorageSignalMap::new(),
+            &signals.by_subvol,
         );
 
         // Emit promise-transition events when the originating event was
         // Tick/DriveMounted/ConfigChanged. On BackupCompleted the backup
         // itself emitted these with trigger=Run; sentinel just refreshes
-        // its baseline.
-        if self.state.has_initial_assessment
-            && let Some(t) = trigger
+        // its baseline. While a backup run holds the lock, recording is
+        // suppressed (UPI 063) — ONLY this statement: the baseline update
+        // below still absorbs the flip (so the next tick doesn't re-detect
+        // it) and notifications keep their timing (grill D).
+        if sentinel::should_record_transitions(
+            self.state.has_initial_assessment,
+            trigger,
+            self.backup_run_active(),
+        ) && let Some(t) = trigger
         {
             audit_events.extend(awareness::diff_promise_states(
                 &self.state.last_promise_states,
@@ -892,16 +910,26 @@ impl SentinelRunner {
 /// This is a separate path from `notify::compute_notifications()`, which operates
 /// on heartbeat data. The two paths converge at `notify::dispatch()`.
 /// Pick the originating `TransitionTrigger` for promise-transition events
-/// emitted during this cycle. Returns `None` when only `BackupCompleted`
-/// fired — in that case the backup itself emitted promise transitions
-/// with `trigger=Run` and the sentinel must not duplicate them.
+/// emitted during this cycle. Returns `None` when `BackupCompleted` fired
+/// without an explicit trigger event — the backup itself emitted promise
+/// transitions with `trigger=Run` and the sentinel must not duplicate them.
+///
+/// `BackupCompleted` suppresses a coalesced routine Tick too (UPI 063): the
+/// run's pid is already dead when the completion is detected, so the
+/// backup-lock probe cannot see this window — a Tick landing in the same
+/// poll cycle would diff against the pre-run baseline and re-record the
+/// run's transitions. The baseline refresh absorbs the post-run state
+/// instead.
 ///
 /// Precedence (when multiple events fire in the same cycle): an explicit
-/// trigger event (DriveMounted, ConfigChanged) wins over a routine Tick.
+/// trigger event (DriveMounted, ConfigChanged) wins over everything — a
+/// drive event coalesced with a completion is a real external change and
+/// keeps its trigger.
 fn pick_transition_trigger(
     events: &[SentinelEvent],
 ) -> Option<crate::events::TransitionTrigger> {
-    let mut chosen = None;
+    let mut saw_tick = false;
+    let mut saw_backup_completed = false;
     for event in events {
         match event {
             SentinelEvent::DriveMounted { .. } => {
@@ -910,14 +938,13 @@ fn pick_transition_trigger(
             SentinelEvent::ConfigChanged => {
                 return Some(crate::events::TransitionTrigger::ConfigChanged);
             }
-            SentinelEvent::AssessmentTick => {
-                chosen.get_or_insert(crate::events::TransitionTrigger::Tick);
-            }
-            // BackupCompleted, DriveUnmounted, Shutdown — no diff trigger.
+            SentinelEvent::AssessmentTick => saw_tick = true,
+            SentinelEvent::BackupCompleted => saw_backup_completed = true,
+            // DriveUnmounted, Shutdown — no diff trigger.
             _ => {}
         }
     }
-    chosen
+    (saw_tick && !saw_backup_completed).then_some(crate::events::TransitionTrigger::Tick)
 }
 
 pub fn build_notifications(
@@ -1172,6 +1199,29 @@ pub fn sentinel_is_running(config: &Config) -> bool {
         return false;
     };
     is_pid_alive(state.pid)
+}
+
+/// True when a foreign live process holds the backup lock metadata (UPI 063).
+///
+/// `read_lock_info` reads metadata only — the lock FILE persists after release
+/// (flock drops on close), so a readable LockInfo proves nothing by itself.
+/// Two checks turn it into evidence of an active run:
+/// - **pid-aliveness**: a dead recorded pid means a finished or crashed run
+///   left the file behind (normal).
+/// - **self-pid exclusion**: the sentinel's own emergency eject (UPI 034)
+///   writes OUR always-alive pid into the metadata; the runner loop is
+///   single-threaded, so we cannot be mid-eject while assessing — our own
+///   pid in the file is always a stale record.
+///
+/// Polarity is fail-open toward recording: the holder's metadata write is
+/// ftruncate-then-write, so a probe racing it may read empty/partial JSON →
+/// `None` → record (worst case one status-quo duplicate event, never lost
+/// monitoring). Do not "fix" this toward suppression.
+fn backup_run_active_at(lock_path: &std::path::Path) -> bool {
+    match crate::lock::read_lock_info(lock_path) {
+        Some(info) => info.pid != std::process::id() && is_pid_alive(info.pid),
+        None => false,
+    }
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -1451,6 +1501,67 @@ mod tests {
     #[test]
     fn pid_alive_dead_process() {
         assert!(!is_pid_alive(99_999_999));
+    }
+
+    // ── backup_run_active_at (UPI 063) ───────────────────────────────
+
+    fn write_lock_info(path: &std::path::Path, pid: u32) {
+        let info = crate::lock::LockInfo {
+            pid,
+            started: "2026-06-11T04:00:00".to_string(),
+            trigger: "auto".to_string(),
+        };
+        std::fs::write(path, serde_json::to_string(&info).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn probe_false_on_missing_lock_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!backup_run_active_at(&dir.path().join("urd.lock")));
+    }
+
+    #[test]
+    fn probe_false_on_dead_pid() {
+        // A finished/crashed run leaves the file behind — flock released,
+        // metadata stale. Not an active run.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("urd.lock");
+        write_lock_info(&path, 99_999_999);
+        assert!(!backup_run_active_at(&path));
+    }
+
+    #[test]
+    fn probe_false_on_own_pid() {
+        // The post-eject case: emergency eject wrote OUR pid, which is alive
+        // for the daemon's whole life. Must read as stale, not active —
+        // otherwise the gate wedges shut forever after the first eject.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("urd.lock");
+        write_lock_info(&path, std::process::id());
+        assert!(!backup_run_active_at(&path));
+    }
+
+    #[test]
+    fn probe_true_on_live_foreign_pid() {
+        // pid 1 is alive on any Linux and is never the test process.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("urd.lock");
+        write_lock_info(&path, 1);
+        assert!(backup_run_active_at(&path));
+    }
+
+    #[test]
+    fn probe_false_on_corrupt_or_empty_lock_file() {
+        // Fail-open toward recording: unreadable metadata is not evidence of
+        // an active run.
+        let dir = tempfile::tempdir().unwrap();
+        let corrupt = dir.path().join("corrupt.lock");
+        std::fs::write(&corrupt, b"not json {{{").unwrap();
+        assert!(!backup_run_active_at(&corrupt));
+
+        let empty = dir.path().join("empty.lock");
+        std::fs::write(&empty, b"").unwrap();
+        assert!(!backup_run_active_at(&empty));
     }
 
     // ── build_notifications ─────────────────────────────────────────
@@ -1878,6 +1989,42 @@ protection = "recorded"
             label: "WD-18TB".into(),
         }];
         assert_eq!(pick_transition_trigger(&events), None);
+    }
+
+    #[test]
+    fn trigger_backup_completed_suppresses_coalesced_tick() {
+        // UPI 063: a Tick in the same poll cycle as the completion would diff
+        // against the pre-run baseline and re-record the run's transitions —
+        // the run's pid is already dead, so the lock probe can't catch it.
+        // Order must not matter.
+        for events in [
+            vec![SentinelEvent::BackupCompleted, SentinelEvent::AssessmentTick],
+            vec![SentinelEvent::AssessmentTick, SentinelEvent::BackupCompleted],
+        ] {
+            assert_eq!(pick_transition_trigger(&events), None);
+        }
+    }
+
+    #[test]
+    fn trigger_explicit_events_survive_backup_completed() {
+        // A drive event coalesced with a completion is a real external change
+        // and keeps its trigger.
+        let events = vec![
+            SentinelEvent::BackupCompleted,
+            SentinelEvent::DriveMounted {
+                label: "WD-18TB".into(),
+            },
+        ];
+        assert_eq!(
+            pick_transition_trigger(&events),
+            Some(crate::events::TransitionTrigger::DriveMounted)
+        );
+
+        let events = vec![SentinelEvent::BackupCompleted, SentinelEvent::ConfigChanged];
+        assert_eq!(
+            pick_transition_trigger(&events),
+            Some(crate::events::TransitionTrigger::ConfigChanged)
+        );
     }
 
     // ── Emergency eject: sample gathering (UPI 034) ────────────────────

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -428,11 +428,12 @@ impl SentinelRunner {
         // suppressed (UPI 063) — ONLY this statement: the baseline update
         // below still absorbs the flip (so the next tick doesn't re-detect
         // it) and notifications keep their timing (grill D).
-        if sentinel::should_record_transitions(
-            self.state.has_initial_assessment,
-            trigger,
-            self.backup_run_active(),
-        ) && let Some(t) = trigger
+        if let Some(t) = trigger
+            && sentinel::should_record_transitions(
+                self.state.has_initial_assessment,
+                trigger,
+                self.backup_run_active(),
+            )
         {
             audit_events.extend(awareness::diff_promise_states(
                 &self.state.last_promise_states,


### PR DESCRIPTION
## Summary

- **Posture parity (#193):** the sentinel's assess path, the backup's pre-execution snapshot, and the empty-plan heartbeat judged promises against *declared* intervals (empty signal map) while `urd status` judged against *effective* tight-tier intervals — flipping promises AT RISK every other afternoon while status said sealed. All three sites now consume gathered storage signals; gathering stays reflect-only (S1), and the backup's pre-snapshot/empty-plan paths **reuse** the run's single pre-plan gather (AB1: no second gather — an empty-plan re-gather would be judged after the emergency preflight may have freed space, desyncing the heartbeat from the plan's tier; this corrects the design doc's "one gather() call" wording).
- **One recorder in the run window (#194):** new pure `sentinel::should_record_transitions` gates *only* the event-recording statement on a backup-lock probe (`read_lock_info` + pid-aliveness + **self-pid exclusion** — the lock file persists after release, and the sentinel's own emergency eject writes its always-alive pid into it; without the exclusion the gate would wedge shut forever after the first eject). Fail-open toward recording: unreadable metadata → record (worst case one status-quo duplicate, never lost monitoring).
- **Post-completion coalescing window (adversary F2):** `BackupCompleted` coalesced with a routine tick in the same 5 s poll cycle now suppresses the tick's trigger — the run's pid is already dead there, so the lock probe cannot see that duplicate path. Explicit DriveMounted/ConfigChanged precedence is unchanged.
- Baseline updates and notification timing are untouched (grill D); first post-upgrade sentinel assess silently re-baselines (`has_initial_assessment` is not restored across restarts) — no notification/event burst on upgrade day.

**`StorageSignalMap::new()` survivors** after the sweep: all remaining call sites are test fixtures plus `gather_with`'s own constructor — no production assessment path passes an empty map. Two stale doc comments citing D6/S4 were updated (`advice.rs`).

**Not closing #193/#194 by keyword:** per the design's resolved decision E, they close on a green day-7 field validation (duplicate query + tick-cause query), not on merge.

Design: `docs/95-ideas/2026-06-11-design-063-one-tongue-promise-coherence.md` (grilled; adversary-reviewed plan, all findings folded in).

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 1768 passed, 0 failed (14 new: parity-window mechanism test, phantom-diff reproducer pair, `should_record_transitions` truth table, lock-probe matrix incl. dead-pid/own-pid/corrupt-file, trigger-coalescing table)
- cargo build --release: pass
- Integration tests: not applicable (no btrfs surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)