### PR TITLE
release: v0.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-06-11
+
 ### Fixed
 - **One tongue: every assessment site judges promises with the same storage posture**
   (UPI 063, #193). Three sites — the sentinel's assessment tick, the backup's
@@ -26,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lock (notifications and its own baseline are unaffected), and a coalesced completion
   suppresses the tick's trigger — the backup stays canonical for in-run transitions
   (trigger=Run).
-
 - **`urd init` greets a missing config instead of erroring.** The bare-`urd` greeting
   advertises `urd init` as the first command, but init sat behind the mandatory config
   load and answered a first-time user with a raw I/O error ("No such file or directory").
@@ -1045,7 +1046,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.25.1...HEAD
+[0.25.1]: https://github.com/vonrobak/urd/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/vonrobak/urd/compare/v0.24.2...v0.25.0
 [0.24.2]: https://github.com/vonrobak/urd/compare/v0.24.1...v0.24.2
 [0.24.1]: https://github.com/vonrobak/urd/compare/v0.24.0...v0.24.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.25.1**. Patch release carrying UPI 063 ("One Tongue", #197): posture parity across all assessment sites (sentinel/CLI promise split-brain, #193) and single-recording of promise transitions when a sentinel tick races a backup run (#194 — both issues close on the day-7 field validation, not here). Also includes the `urd init` missing-config greeting fix (#192).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1768 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)