### PR TITLE
release: v0.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.2] - 2026-06-11
+
 ### Fixed
 - **A wedged `btrfs receive` can no longer hang a backup run past the watchdog's
   cancel** (UPI 054-b). The copy pump blocked in `write_all` against a full pipe
@@ -1072,7 +1074,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.25.1...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.25.2...HEAD
+[0.25.2]: https://github.com/vonrobak/urd/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/vonrobak/urd/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/vonrobak/urd/compare/v0.24.2...v0.25.0
 [0.24.2]: https://github.com/vonrobak/urd/compare/v0.24.1...v0.24.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.25.1"
+version = "0.25.2"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.25.2**. The 033/034 hardening pair (UPI 054): the planner reserves the host-survival floor before any send starts (#199), and the send pipeline stays cancel-responsive against a wedged `btrfs receive` — non-blocking pump, outcome-aware bounded waits, and a fail-closed pre-send sweep of abandoned partial snapshots (#200).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1797 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)