### PR TITLE
release: v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-06-15
+
 ### Added
 - **A constrained pool now holds its offsite chain at Tight and says so out loud
   when it sheds at Critical** (UPI 064-b, ADR-116 compliance). Tight gains a new
@@ -1102,7 +1104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.25.2...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/vonrobak/urd/compare/v0.25.2...v0.26.0
 [0.25.2]: https://github.com/vonrobak/urd/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/vonrobak/urd/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/vonrobak/urd/compare/v0.24.2...v0.25.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.25.2"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.25.2"
+version = "0.26.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.26.0** — Do-No-Harm tier realignment (UPI 064).

- **064-a (#203, fix):** an absolute-headroom downgrade gate on tier arming, so large absolutely-roomy pools stop arming Tight and silently over-thinning retention (closes #202).
- **064-b (#204, feat):** a new `retain-parents` lifecycle rung holds the offsite chain at Tight, and the Critical shed is now told-not-silent — `OffsiteChainReleased` + `StorageTierTransition` events plus a Warning notification.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1820 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)