### PR TITLE
release: v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-06-17
+
 ### Added
 - **The mid-op watchdog no longer kills a healthy long send over a momentary
   write spike** (UPI 065-a). Its cliff trigger (free-space drop rate) now fires on
@@ -32,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reading" provable. The `WatchdogAbort` event gains a `send_aborted` discriminator
   (`urd events --kind watchdog`); historical rows read back as same-filesystem
   aborts. No config knob; no metric or heartbeat changes.
+
+## [0.26.0] - 2026-06-15
 
 ### Added
 - **A constrained pool now holds its offsite chain at Tight and says so out loud
@@ -1128,7 +1132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.27.0...HEAD
+[0.27.0]: https://github.com/vonrobak/urd/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/vonrobak/urd/compare/v0.25.2...v0.26.0
 [0.25.2]: https://github.com/vonrobak/urd/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/vonrobak/urd/compare/v0.25.0...v0.25.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.27.0** — watchdog hardening for field incident run #110 (UPI 065).

- **065-a** ([#206](https://github.com/vonrobak/urd/pull/206)): cliff trigger fires on a windowed average over a ~2 s window, not a single 250 ms sample — transient bursts no longer signal-kill a healthy long send.
- **065-b** ([#207](https://github.com/vonrobak/urd/pull/207)): the watchdog's response is **scoped to the in-flight send's source filesystem** (ADR-113 amendment) — pressure on one independent pool no longer aborts a backup reading a different pool.

Also backfills the previously-missing `## [0.26.0]` changelog section (UPI 064, [#202](https://github.com/vonrobak/urd/issues/202)) so the changelog matches what each tag shipped.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1838 passed, 0 failed (5 ignored)
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)