### PR TITLE
fix: remove 6h wall-clock guillotine from backup systemd unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A long backup run can no longer be killed by a wall-clock timeout.** The
+  packaged systemd unit (`urd-backup.service`) set `TimeoutStartSec=6h`, so systemd
+  SIGTERM'd a healthy, still-progressing run at the 6-hour mark — silently
+  cancelling multi-TB first/full sends that legitimately need longer over USB
+  (observed killing two consecutive nightly runs mid-send). The start timeout is now
+  `infinity`: only a real emergency (the storage watchdog, ADR-113) or a genuine
+  failure may stop a send, never a clock. Existing installs must reinstall the unit
+  (or set `TimeoutStartSec=infinity`) and run `systemctl --user daemon-reload`.
+
 ## [0.27.0] - 2026-06-17
 
 ### Added

--- a/systemd/urd-backup.service
+++ b/systemd/urd-backup.service
@@ -6,8 +6,12 @@ Type=oneshot
 ExecStart=%h/.cargo/bin/urd backup --auto --confirm-retention-change
 Environment=RUST_LOG=info
 
-# Allow long backup runs (large btrfs sends can take hours)
-TimeoutStartSec=6h
+# Never time-limit a backup run. A first full multi-TB send can legitimately
+# take many hours (longer than a day on a large subvolume over USB), and a
+# wall-clock guillotine would SIGTERM a healthy, progressing send. Only a real
+# emergency — the storage watchdog (ADR-113) — or a genuine failure may stop a
+# send. systemd's oneshot default would otherwise kill ExecStart far too soon.
+TimeoutStartSec=infinity
 # Allow 5 minutes for graceful shutdown (cleanup partial snapshots)
 TimeoutStopSec=300
 


### PR DESCRIPTION
## Summary

- The packaged `urd-backup.service` set `TimeoutStartSec=6h`. On a `Type=oneshot` service that bounds the **entire** `ExecStart`, so systemd SIGTERM'd any backup run still in progress at the 6-hour mark — cancelling healthy, progressing multi-TB first/full sends over USB with no regard for progress.
- This killed two consecutive nightly runs (#111, #112) at exactly the 6h boundary (confirmed in the journal: `start operation timed out. Terminating.`). Run #112 was the run the user noticed cancelled; it was attempting a 3.4 TB full re-send of `subvol3-opptak`. **Not** the v0.27.0 watchdog bug — no `WatchdogAbort` event fired; the killer was external systemd, not Urd's code.
- The cap was never a deliberate design decision — it rode in as systemd boilerplate in `62f73c5` (Phase 3.5 hardening), framed as generous headroom, not a limiter.
- Changed to `TimeoutStartSec=infinity`. A backup send must never be stopped by a clock; the only legitimate internal abort is the storage watchdog (ADR-113), reserved for real emergencies. `TimeoutStopSec=300` is retained (applies only on deliberate stop/shutdown, bounding partial-snapshot cleanup).

**Existing installs:** reinstall the unit (or set `TimeoutStartSec=infinity`) and run `systemctl --user daemon-reload`. Already applied to the live unit on `fedora-htpc`.

## Testing

- cargo clippy / cargo test: not applicable — deployment unit + CHANGELOG only, no Rust changed
- Live unit verified: `systemctl --user show urd-backup.service -p TimeoutStartUSec` → `TimeoutStartUSec=infinity`
- Failed state cleared; timer armed for next run (Thu 04:02)

🤖 Generated with [Claude Code](https://claude.com/claude-code)