### PR TITLE
release: v0.27.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.1] - 2026-06-26
+
 ### Fixed
 - **The storage watchdog no longer aborts a healthy send on a transient write-rate
   spike, and no longer pre-allocates disk to do so** (UPI 067, ADR-113 amendment).
@@ -1173,7 +1175,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.27.1...HEAD
+[0.27.1]: https://github.com/vonrobak/urd/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/vonrobak/urd/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/vonrobak/urd/compare/v0.25.2...v0.26.0
 [0.25.2]: https://github.com/vonrobak/urd/compare/v0.25.1...v0.25.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.27.0"
+version = "0.27.1"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.27.1** — three storage-watchdog do-no-harm fixes (all ADR-113):

- **UPI 067 (#215)** — revert Layer 2 to floor-only: delete the write-rate *cliff* trigger and the `.urd-emergency-reserve` bridge, whose entire production firing record was destructive false-positives.
- **UPI 066 (#214)** — gate the abort-reclaim on confirmed sub-floor pressure.
- **#209** — remove the 6h wall-clock guillotine from the backup systemd unit.

Patch release: all three are fixes; no config, on-disk, metric, or heartbeat contract changed, and the `WatchdogAbort` event stays read-compatible.

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: 1814 passed, 0 failed (4 ignored)
- `cargo build --release`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)