### PR TITLE
fix: legacy unlabeled pin no longer anchors local retention (#133)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A legacy unlabeled `.last-external-parent` pin no longer anchors local
+  retention when every configured drive already has its own drive-specific pin**
+  (#133, sibling class to #125). `find_pinned_snapshots` used to read the legacy
+  pin unconditionally and add it to the protected set on top of the per-drive
+  pins. Because the planner anchors "protect everything newer" to the *oldest*
+  pin, a stale legacy pin left over from the bash→Urd cutover (late March 2026)
+  became the anchor on every pre-cutover subvolume — silently overriding the
+  configured retention shape (e.g. 60 local snapshots against a cap of ~11). The
+  legacy pin is now consulted only as a *per-drive* fallback for a drive that
+  lacks its own pin (a mid-cutover host); once every drive has a specific pin the
+  legacy file is by construction stale and is ignored. No on-disk change — the
+  legacy file is left in place; retiring it is tracked as #133 Phase 2.
+
 ## [0.27.1] - 2026-06-26
 
 ### Fixed

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -53,6 +53,14 @@ pub fn read_pin_file(
 
 /// Collect all pinned snapshot names across all drives.
 /// Errors are logged but do not propagate — returns whatever was found.
+///
+/// The legacy unlabeled `.last-external-parent` pin is consulted only as a
+/// *per-drive* fallback inside `read_pin_file`, for a drive that has no
+/// drive-specific pin yet (a mid-cutover host). Once every configured drive has
+/// its own `.last-external-parent-{LABEL}` pin, the legacy file is by
+/// construction stale — it can only name a pre-cutover snapshot — and is
+/// ignored here. Reading it unconditionally used to anchor retention to that
+/// stale snapshot, silently overriding the configured shape (#133).
 #[must_use]
 pub fn find_pinned_snapshots(
     local_snapshot_dir: &Path,
@@ -72,20 +80,6 @@ pub fn find_pinned_snapshots(
                     local_snapshot_dir.display()
                 );
             }
-        }
-    }
-
-    // Also check legacy pin file directly (might reference a snapshot not in any drive-specific file)
-    match try_read_pin(&local_snapshot_dir.join(".last-external-parent")) {
-        Ok(Some(name)) => {
-            pinned.insert(name);
-        }
-        Ok(None) => {}
-        Err(e) => {
-            log::warn!(
-                "Failed to read legacy pin file in {}: {e}",
-                local_snapshot_dir.display()
-            );
         }
     }
 
@@ -281,6 +275,58 @@ mod tests {
         assert_eq!(pinned.len(), 2);
         assert!(pinned.iter().any(|s| s.as_str() == "20260322-opptak"));
         assert!(pinned.iter().any(|s| s.as_str() == "20260321-opptak"));
+    }
+
+    #[test]
+    fn legacy_ignored_when_all_drives_have_specific_pins() {
+        // Every configured drive has its own pin; a stale legacy pin points at an
+        // older snapshot. The legacy pin must NOT join the pinned set — otherwise
+        // it becomes the oldest-pin retention anchor and over-retains (#133).
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(".last-external-parent-WD-18TB"),
+            "20260516-0401-opptak",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join(".last-external-parent-WD-18TB1"),
+            "20260514-1546-opptak",
+        )
+        .unwrap();
+        // Stale legacy pin from the bash→Urd cutover, older than both.
+        fs::write(dir.path().join(".last-external-parent"), "20260324-opptak").unwrap();
+
+        let labels = vec!["WD-18TB".to_string(), "WD-18TB1".to_string()];
+        let pinned = find_pinned_snapshots(dir.path(), &labels);
+
+        assert_eq!(pinned.len(), 2);
+        assert!(pinned.iter().any(|s| s.as_str() == "20260516-0401-opptak"));
+        assert!(pinned.iter().any(|s| s.as_str() == "20260514-1546-opptak"));
+        assert!(
+            !pinned.iter().any(|s| s.as_str() == "20260324-opptak"),
+            "stale legacy pin must not anchor retention when every drive has a specific pin"
+        );
+    }
+
+    #[test]
+    fn legacy_still_used_when_drive_lacks_specific_pin() {
+        // Mid-cutover host: a drive with no drive-specific pin must still fall back
+        // to the legacy pin (via read_pin_file), so the chain stays protected.
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(".last-external-parent-WD-18TB"),
+            "20260516-0401-opptak",
+        )
+        .unwrap();
+        fs::write(dir.path().join(".last-external-parent"), "20260324-opptak").unwrap();
+
+        // WD-18TB1 has no drive-specific pin → falls back to legacy.
+        let labels = vec!["WD-18TB".to_string(), "WD-18TB1".to_string()];
+        let pinned = find_pinned_snapshots(dir.path(), &labels);
+
+        assert_eq!(pinned.len(), 2);
+        assert!(pinned.iter().any(|s| s.as_str() == "20260516-0401-opptak"));
+        assert!(pinned.iter().any(|s| s.as_str() == "20260324-opptak"));
     }
 
     #[test]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -3145,11 +3145,26 @@ source = "/data/beta"
         let dir = tempfile::TempDir::new().unwrap();
         let alpha = dir.path().join("alpha");
         make_snap_dirs(&alpha, &THREE_SNAPS);
-        // Legacy unlabeled pin → read unconditionally (chain.rs:78–90),
-        // independent of the empty `drives`. Pins the oldest snapshot, so this
-        // exercises the *primary* ADR-107 layer by construction (F3).
-        std::fs::write(alpha.join(".last-external-parent"), "20260101-1200-alpha\n").unwrap();
-        let config = emergency_config(dir.path());
+        let mut config = emergency_config(dir.path());
+        // A configured drive with its own drive-specific pin on the oldest
+        // snapshot. This exercises the *primary* ADR-107 pin layer by
+        // construction (F3) through the canonical drive-scoped path — the legacy
+        // unlabeled pin no longer anchors retention on its own (#133).
+        config.drives.push(crate::config::DriveConfig {
+            label: "D1".to_string(),
+            uuid: None,
+            mount_path: std::path::PathBuf::from("/mnt/d1"),
+            snapshot_root: ".snapshots".to_string(),
+            role: crate::types::DriveRole::Offsite,
+            max_usage_percent: None,
+            min_free_bytes: None,
+            rotation_interval: None,
+        });
+        std::fs::write(
+            alpha.join(".last-external-parent-D1"),
+            "20260101-1200-alpha\n",
+        )
+        .unwrap();
 
         // Test-setup insurance: the loop dir (`root.path.join(subvol)`) and the
         // defence-in-depth dir (`config.local_snapshot_dir`) must agree, else the


### PR DESCRIPTION
## Summary

Phase 1 of the three-phase plan in #133. `find_pinned_snapshots` read the legacy unlabeled `.last-external-parent` pin **unconditionally** and added it to the protected set on top of the per-drive pins. Because the planner anchors "protect everything newer" to the **oldest** pin, a stale legacy pin left over from the bash→Urd cutover (late March 2026) became the anchor on every pre-cutover subvolume — silently overriding the configured retention shape (the field host showed 60 local snapshots against a configured cap of ~11).

This is the sibling class to #125 (orphan-by-removed-drive); #125's check does not cover the unlabeled legacy case, and this fix does not cover the orphan-with-different-label case.

## Change

- **`chain.rs`**: drop the trailing unconditional legacy read in `find_pinned_snapshots`. The legacy pin is still honored as a *per-drive* fallback inside `read_pin_file` for a drive that lacks its own pin (a mid-cutover host); once every configured drive has a drive-specific pin, the legacy file is by construction stale and is ignored. Documented the semantics on the function.
- **No on-disk change** — the legacy file is left in place. Retiring it (rename to `.retired-*` + event + doctor surface) is Phase 2; removing legacy code paths is Phase 3.

## Tests

- `legacy_ignored_when_all_drives_have_specific_pins` — the bug, now asserted away.
- `legacy_still_used_when_drive_lacks_specific_pin` — mid-cutover fallback preserved.
- Rerouted `emergency_pin_gating_keeps_pinned_oldest` through a configured drive + drive-specific pin (it previously leaned on the removed legacy path), so emergency-reclaim pin-gating stays covered through the canonical path.

All 1816 tests pass; `cargo clippy --all-targets -- -D warnings` clean; build clean.

## Invariants

ADR-106 (three pin-protection layers) preserved — `is_pinned_at_delete_time` reuses `find_pinned_snapshots`, so the executor re-check inherits the corrected set. ADR-105 (on-disk contract) untouched — no pin file is created, moved, or deleted by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)