### PR TITLE
feat: orphan-pin retention warning in `urd doctor --thorough` (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`urd doctor --thorough` now warns about orphan pin files** (#125). A pin file
+  whose drive label is not in `[[drives]]` — e.g. left behind when a drive is
+  removed from config — silently anchors local retention: the planner protects
+  every snapshot newer than the *oldest* pin, so one orphan pin from a retired
+  drive can hold weeks of dailies against the configured shape with no surface to
+  catch it. The new Retention section names the subvolume, pin file, drive label,
+  and the snapshot the pin points to, explains the consequence, and gives the
+  remediation (delete the pin once the drive is retired, or re-add it to
+  `[[drives]]`). Advisory only — nothing is deleted. Renders only when an orphan
+  is found (no false gravity). Doctor JSON schema → v3 (the optional
+  `retention_checks` array; absent when empty).
+
 ## [0.27.1] - 2026-06-26
 
 ### Fixed

--- a/docs/20-reference/cli.md
+++ b/docs/20-reference/cli.md
@@ -316,7 +316,7 @@ an operator runs when something feels off.
 
 | Flag | Semantics |
 |------|-----------|
-| `--thorough` | Add thread-verification (`urd verify`) to the battery. Slower; reads every pin file. |
+| `--thorough` | Add thread-verification (`urd verify`), churn, retention-shape recommendations, and the orphan-pin retention scan to the battery. Slower; reads every pin file. |
 
 **Output.** Interactive — voice-rendered diagnostic block with severity
 icons and suggested next steps. Daemon — JSON.

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::config::Config;
 use crate::error::UrdError;
@@ -90,6 +90,73 @@ pub fn find_pinned_snapshots(
     }
 
     pinned
+}
+
+/// A drive-specific pin file discovered on disk: the drive label parsed from
+/// its `.last-external-parent-{LABEL}` filename and the snapshot it names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredPin {
+    pub label: String,
+    pub snapshot: SnapshotName,
+    /// Full path to the pin file — supplied by the scan so callers never
+    /// reconstruct the `.last-external-parent-{LABEL}` filename themselves.
+    pub path: PathBuf,
+}
+
+const PIN_PREFIX: &str = ".last-external-parent-";
+
+/// List every drive-specific pin file in a local snapshot directory, parsing the
+/// drive label from each `.last-external-parent-{LABEL}` filename.
+///
+/// Advisory scan only (#125 doctor surface), not a safety gate: the legacy
+/// unlabeled `.last-external-parent` is skipped (it carries no label), `.tmp`
+/// atomic-write leftovers are skipped, and an unreadable/empty/malformed pin is
+/// skipped rather than erroring. A missing or unreadable directory yields an
+/// empty list. Ordered by label for stable output.
+#[must_use]
+pub fn discover_pin_files(local_snapshot_dir: &Path) -> Vec<DiscoveredPin> {
+    let Ok(entries) = std::fs::read_dir(local_snapshot_dir) else {
+        return Vec::new();
+    };
+
+    let mut pins = Vec::new();
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let name = file_name.to_string_lossy();
+        let Some(label) = name.strip_prefix(PIN_PREFIX) else {
+            continue; // not a drive-specific pin (legacy `.last-external-parent`, snapshots, …)
+        };
+        if label.ends_with(".tmp") || label.is_empty() {
+            continue; // atomic-write leftover, or a stray `.last-external-parent-`
+        }
+        // Empty/missing/malformed pins are skipped — nothing actionable to
+        // report in an advisory scan.
+        let path = entry.path();
+        if let Ok(Some(snapshot)) = try_read_pin(&path) {
+            pins.push(DiscoveredPin {
+                label: label.to_string(),
+                snapshot,
+                path,
+            });
+        }
+    }
+    pins.sort_by(|a, b| a.label.cmp(&b.label));
+    pins
+}
+
+/// Pure: which discovered pins name a drive label not in the configured set.
+///
+/// An orphan pin anchors local retention (the planner protects everything newer
+/// than the *oldest* pin) for a drive that no longer exists in `[[drives]]`, so
+/// the configured shape is silently overridden (#125). Comparison is
+/// case-sensitive, matching the exact pin-file label form.
+#[must_use]
+pub fn orphan_pins(discovered: &[DiscoveredPin], configured_labels: &[String]) -> Vec<DiscoveredPin> {
+    discovered
+        .iter()
+        .filter(|p| !configured_labels.iter().any(|l| l == &p.label))
+        .cloned()
+        .collect()
 }
 
 /// Defense-in-depth (ADR-106 layer 3): re-check pin status immediately before
@@ -281,6 +348,80 @@ mod tests {
         assert_eq!(pinned.len(), 2);
         assert!(pinned.iter().any(|s| s.as_str() == "20260322-opptak"));
         assert!(pinned.iter().any(|s| s.as_str() == "20260321-opptak"));
+    }
+
+    #[test]
+    fn discover_pin_files_parses_labels_skips_legacy_and_tmp() {
+        let dir = TempDir::new().unwrap();
+        fs::write(
+            dir.path().join(".last-external-parent-WD-18TB"),
+            "20260516-0401-containers",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join(".last-external-parent-2TB-backup"),
+            "20260402-1925-containers",
+        )
+        .unwrap();
+        // Skipped: legacy unlabeled, atomic-write leftover, a real snapshot dir.
+        fs::write(dir.path().join(".last-external-parent"), "20260324-containers").unwrap();
+        fs::write(dir.path().join(".last-external-parent-WD-18TB.tmp"), "x").unwrap();
+        fs::create_dir(dir.path().join("20260516-0401-containers")).unwrap();
+
+        let pins = discover_pin_files(dir.path());
+        assert_eq!(pins.len(), 2);
+        // Sorted by label: "2TB-backup" < "WD-18TB".
+        assert_eq!(pins[0].label, "2TB-backup");
+        assert_eq!(pins[0].snapshot.as_str(), "20260402-1925-containers");
+        assert_eq!(pins[1].label, "WD-18TB");
+        assert_eq!(pins[1].snapshot.as_str(), "20260516-0401-containers");
+    }
+
+    #[test]
+    fn discover_pin_files_missing_dir_is_empty() {
+        let dir = TempDir::new().unwrap();
+        let missing = dir.path().join("does-not-exist");
+        assert!(discover_pin_files(&missing).is_empty());
+    }
+
+    #[test]
+    fn discover_pin_files_skips_malformed() {
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join(".last-external-parent-D1"), "not-a-snapshot").unwrap();
+        fs::write(dir.path().join(".last-external-parent-D2"), "   \n").unwrap();
+        assert!(discover_pin_files(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn orphan_pins_flags_unconfigured_labels() {
+        let discovered = vec![
+            DiscoveredPin {
+                label: "WD-18TB".to_string(),
+                snapshot: SnapshotName::parse("20260516-0401-containers").unwrap(),
+                path: PathBuf::from(".last-external-parent-WD-18TB"),
+            },
+            DiscoveredPin {
+                label: "2TB-backup".to_string(),
+                snapshot: SnapshotName::parse("20260402-1925-containers").unwrap(),
+                path: PathBuf::from(".last-external-parent-2TB-backup"),
+            },
+        ];
+        let configured = vec!["WD-18TB".to_string(), "WD-18TB1".to_string()];
+
+        let orphans = orphan_pins(&discovered, &configured);
+        assert_eq!(orphans.len(), 1);
+        assert_eq!(orphans[0].label, "2TB-backup");
+    }
+
+    #[test]
+    fn orphan_pins_empty_when_all_configured() {
+        let discovered = vec![DiscoveredPin {
+            label: "WD-18TB".to_string(),
+            snapshot: SnapshotName::parse("20260516-0401-containers").unwrap(),
+            path: PathBuf::from(".last-external-parent-WD-18TB"),
+        }];
+        let configured = vec!["WD-18TB".to_string()];
+        assert!(orphan_pins(&discovered, &configured).is_empty());
     }
 
     #[test]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -290,6 +290,14 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         None
     };
 
+    // ── 5.7 Retention: orphan pin files (#125 — only with --thorough) ──
+    let retention_checks = if args.thorough {
+        build_retention_checks(&config)
+    } else {
+        Vec::new()
+    };
+    warn_count += retention_checks.len();
+
     // ── 6. Verdict ────────────────────────────────────────────────
     let degraded_count = data_safety
         .iter()
@@ -332,12 +340,52 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         verify: verify_output,
         churn: churn_view,
         recommendations: recommendation_view,
+        retention_checks,
         verdict,
     };
 
     print!("{}", voice::render_doctor(&output, output_mode));
 
     Ok(())
+}
+
+/// Build the `--thorough` Retention-section advisories (#125): one `DoctorCheck`
+/// per pin file whose drive label is not in `[[drives]]`. Such an orphan pin
+/// silently anchors local retention (the planner protects everything newer than
+/// the oldest pin) for a drive that no longer exists in config, overriding the
+/// configured shape with no other surface to catch it.
+///
+/// Pure decision (`chain::orphan_pins`) over filesystem-scanned input
+/// (`chain::discover_pin_files`); advisory only — nothing is deleted.
+fn build_retention_checks(config: &Config) -> Vec<DoctorCheck> {
+    let configured = config.drive_labels();
+    let mut checks = Vec::new();
+
+    for sv in config.resolved_subvolumes() {
+        let Some(local_dir) = config.local_snapshot_dir(&sv.name) else {
+            continue;
+        };
+        let discovered = crate::chain::discover_pin_files(&local_dir);
+        for orphan in crate::chain::orphan_pins(&discovered, &configured) {
+            checks.push(DoctorCheck {
+                name: format!("orphan pin: {} · {}", sv.name, orphan.label),
+                status: DoctorCheckStatus::Warn,
+                detail: Some(format!(
+                    "{} names {}, but no configured drive has label \"{}\". \
+                     Retention will not delete that snapshot or any newer one on the chain.",
+                    orphan.path.display(),
+                    orphan.snapshot.as_str(),
+                    orphan.label,
+                )),
+                suggestion: Some(format!(
+                    "Delete the pin file after confirming {} is permanently retired, \
+                     or re-add it to [[drives]].",
+                    orphan.label,
+                )),
+            });
+        }
+    }
+    checks
 }
 
 /// Build the `--thorough` Churn-section view from `drift_samples` history.
@@ -752,6 +800,74 @@ source = "/data/gamma"
             view.rows[1].state,
             crate::output::ChurnRender::FirstMeasurement { .. }
         ));
+    }
+
+    // ── #125 Retention: orphan-pin advisories ──────────────────────
+
+    fn drive(label: &str) -> crate::config::DriveConfig {
+        crate::config::DriveConfig {
+            label: label.to_string(),
+            uuid: None,
+            mount_path: std::path::PathBuf::from(format!("/mnt/{label}")),
+            snapshot_root: ".snapshots".to_string(),
+            role: crate::types::DriveRole::Offsite,
+            max_usage_percent: None,
+            min_free_bytes: None,
+            rotation_interval: None,
+        }
+    }
+
+    #[test]
+    fn retention_checks_flags_orphan_pin() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut config = cfg();
+        config.local_snapshots.roots[0].path = dir.path().to_path_buf();
+        config.drives.push(drive("WD-18TB"));
+
+        let alpha = dir.path().join("alpha");
+        std::fs::create_dir_all(&alpha).unwrap();
+        // One configured pin (fine) + one orphan from a removed drive.
+        std::fs::write(
+            alpha.join(".last-external-parent-WD-18TB"),
+            "20260516-0401-alpha\n",
+        )
+        .unwrap();
+        std::fs::write(
+            alpha.join(".last-external-parent-2TB-backup"),
+            "20260402-1925-alpha\n",
+        )
+        .unwrap();
+
+        let checks = build_retention_checks(&config);
+        assert_eq!(checks.len(), 1, "only the orphan pin should warn");
+        assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
+        assert!(checks[0].name.contains("alpha"));
+        assert!(checks[0].name.contains("2TB-backup"));
+        let detail = checks[0].detail.as_ref().unwrap();
+        assert!(detail.contains("20260402-1925-alpha"));
+        assert!(detail.contains("2TB-backup"));
+        assert!(checks[0].suggestion.is_some());
+    }
+
+    #[test]
+    fn retention_checks_empty_when_all_pins_configured() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut config = cfg();
+        config.local_snapshots.roots[0].path = dir.path().to_path_buf();
+        config.drives.push(drive("WD-18TB"));
+
+        let alpha = dir.path().join("alpha");
+        std::fs::create_dir_all(&alpha).unwrap();
+        std::fs::write(
+            alpha.join(".last-external-parent-WD-18TB"),
+            "20260516-0401-alpha\n",
+        )
+        .unwrap();
+
+        assert!(
+            build_retention_checks(&config).is_empty(),
+            "no orphan pins → no false gravity"
+        );
     }
 
     // ── UPI 041 Recommendations builder ────────────────────────────

--- a/src/output.rs
+++ b/src/output.rs
@@ -528,9 +528,10 @@ pub struct EmergencyResult {
 /// Started at 2 with UPI 044 (which retroactively names the pre-UPI-044
 /// shape v1). v1 had row-level `local: Option<ShapeRecommendation>`;
 /// v2 has `local: Option<HeadroomAwareRecommendation>` (nested
-/// `.recommendation` plus headroom fields). Bump for any future
-/// breaking JSON shape change; document in CHANGELOG and ADR-115.
-pub const DOCTOR_OUTPUT_SCHEMA_VERSION: u32 = 2;
+/// `.recommendation` plus headroom fields). v3 (#125) adds the optional
+/// `retention_checks` array (orphan/legacy pin advisories; absent when empty).
+/// Bump for any future breaking JSON shape change; document in CHANGELOG.
+pub const DOCTOR_OUTPUT_SCHEMA_VERSION: u32 = 3;
 
 /// Full output for the `urd doctor` command.
 #[derive(Debug, Serialize)]
@@ -557,6 +558,12 @@ pub struct DoctorOutput {
     /// `urd doctor --thorough` (UPI 041, ADR-115). Advisory only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recommendations: Option<DoctorRecommendationView>,
+    /// Orphan/legacy pin-file advisories under `urd doctor --thorough` (#125):
+    /// pin files whose drive label is not in `[[drives]]`, which silently anchor
+    /// local retention against the configured shape. Empty when none found (no
+    /// false gravity); omitted from JSON when empty. Schema v3.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub retention_checks: Vec<DoctorCheck>,
     pub verdict: DoctorVerdict,
 }
 
@@ -2365,6 +2372,7 @@ source = "/data/sv2"
             verify: None,
             churn: None,
             recommendations: None,
+            retention_checks: Vec::new(),
             verdict: DoctorVerdict::healthy(),
         };
         let json = serde_json::to_string(&output).unwrap();
@@ -2389,10 +2397,13 @@ source = "/data/sv2"
             verify: None,
             churn: None,
             recommendations: None,
+            retention_checks: Vec::new(),
             verdict: DoctorVerdict::healthy(),
         };
         let value = serde_json::to_value(&output).unwrap();
-        assert_eq!(value.get("schema_version"), Some(&serde_json::Value::from(2)));
+        assert_eq!(value.get("schema_version"), Some(&serde_json::Value::from(3)));
+        // Empty retention_checks is omitted from JSON (no false gravity, #125).
+        assert_eq!(value.get("retention_checks"), None);
     }
 
     #[test]

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -267,6 +267,21 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
         }
     }
 
+    // Retention section (--thorough only). #125 orphan/legacy pin advisories.
+    // Rendered only when something is wrong — no header, no false gravity, on a
+    // clean scan (Voice Contract Rule 5).
+    if !data.retention_checks.is_empty() {
+        writeln!(out).ok();
+        writeln!(out, "  {}", "Retention".bold()).ok();
+        for check in &data.retention_checks {
+            let detail = check.detail.as_deref().unwrap_or(&check.name);
+            writeln!(out, "    {} {}", "\u{26a0}".yellow(), detail).ok();
+            if let Some(ref suggestion) = check.suggestion {
+                writeln!(out, "      \u{2192} {suggestion}").ok();
+            }
+        }
+    }
+
     // Doctor verdict already provides guidance (rendered at the top now);
     // suggestion is always None.
     append_suggestion(&SuggestionContext::Doctor, &mut out);

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -627,6 +627,7 @@ pub(crate) mod test_fixtures {
             verify: None,
             churn: None,
             recommendations: None,
+            retention_checks: Vec::new(),
             verdict: DoctorVerdict::healthy(),
         }
     }
@@ -2477,6 +2478,49 @@ mod tests {
         assert!(
             output.contains("1 warning"),
             "missing verdict: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_retention_section_renders_orphan_pin() {
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
+        data.retention_checks = vec![DoctorCheck {
+            name: "orphan pin: subvol7-containers · 2TB-backup".to_string(),
+            status: DoctorCheckStatus::Warn,
+            detail: Some(
+                "/snap/subvol7-containers/.last-external-parent-2TB-backup names \
+                 20260402-1925-containers, but no configured drive has label \"2TB-backup\". \
+                 Retention will not delete that snapshot or any newer one on the chain."
+                    .to_string(),
+            ),
+            suggestion: Some(
+                "Delete the pin file after confirming 2TB-backup is permanently retired, \
+                 or re-add it to [[drives]]."
+                    .to_string(),
+            ),
+        }];
+        data.verdict = DoctorVerdict::warnings(1);
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(output.contains("Retention"), "missing Retention header: {output}");
+        assert!(
+            output.contains("2TB-backup"),
+            "missing orphan pin label: {output}"
+        );
+        assert!(
+            output.contains("re-add it to [[drives]]"),
+            "missing remediation: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_no_retention_section_when_clean() {
+        // No false gravity: an empty retention scan renders no Retention header.
+        let _color = color_guard(false);
+        let output = render_doctor(&test_doctor_output(), OutputMode::Interactive);
+        assert!(
+            !output.contains("Retention"),
+            "Retention section must not render when there are no orphan pins: {output}"
         );
     }
 


### PR DESCRIPTION
## Summary

Option 1 from #125 (the recommended first step). A pin file whose drive label is not in `[[drives]]` — left behind when a drive is removed from config — silently anchors local retention. Because the planner protects every snapshot newer than the **oldest** pin, one orphan pin from a retired drive can hold weeks of dailies against the configured retention shape, with **no surface to catch it** today. `urd doctor --thorough` now warns.

Sibling class to #133 (legacy unlabeled pin). The two share the over-retention symptom but need independent detection: #133's removal does not cover the orphan-with-a-real-label case, and this check does not cover the unlabeled legacy case.

## Change

- **`chain.rs`** — `discover_pin_files(dir)` scans `.last-external-parent-{LABEL}` files (skipping the legacy unlabeled pin and `.tmp` atomic-write leftovers, skipping unreadable/malformed pins — advisory, not a safety gate) + a pure `orphan_pins(discovered, configured)` classifier.
- **`commands/doctor.rs`** — `build_retention_checks` runs under `--thorough`, emitting one `Warn` `DoctorCheck` per orphan (names the subvolume, pin file path, drive label, the snapshot the pin points to, the consequence, and the remediation), contributing to `warn_count`.
- **`output.rs`** — new optional `retention_checks` field; doctor JSON schema → **v3** (the array is omitted when empty, so the common case is byte-identical to v2).
- **`voice/doctor.rs`** — a "Retention" section, rendered **only when non-empty** (Voice Contract Rule 5 — no false gravity on a clean scan).
- **`docs/20-reference/cli.md`** + CHANGELOG updated.

## Tests

- chain: `discover_pin_files_*` (label parsing; skips legacy/tmp; missing dir; malformed) + `orphan_pins_*` (flags unconfigured; empty when all configured).
- doctor: `retention_checks_flags_orphan_pin`, `retention_checks_empty_when_all_pins_configured`.
- voice: `doctor_retention_section_renders_orphan_pin`, `doctor_no_retention_section_when_clean`.
- output: schema-version assertion bumped to 3 + asserts empty `retention_checks` is omitted from JSON.

All 1823 tests pass; `cargo clippy --all-targets -- -D warnings` clean; build clean.

## Notes

- **Deviation from the issue's "tested with MockFileSystemState":** `discover_pin_files` does direct directory I/O and is `TempDir`-tested, consistent with the rest of `chain.rs` (and with CLAUDE.md's guidance that path-constructing code needs `TempDir` tests because mocks are blind to filesystem preconditions). The *decision* (`orphan_pins`) is pure and unit-tested without any FS.
- **No deletion / no on-disk change** — ADR-109 (advisory, doesn't refuse to start) and ADR-107 (fail-open) preserved.
- **Merge note:** touches `chain.rs` alongside #133 (PR #221) but in disjoint regions; expect at most a trivial conflict in the chain.rs test module if both land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)