### PR TITLE
fix: advice Branch 8 only recommends the drive whose absence degraded (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Bare `urd` no longer recommends connecting an offsite drive whose absence
+  isn't the problem** (#120, defect 2). `compute_advice` Branch 8 recommended
+  connecting *any* unmounted drive on a Protected+Degraded subvolume, without
+  confirming that drive's absence was the cause — so after rotating an offsite
+  drive in, running a backup, and rotating it back out, Urd's headline could be
+  "Consider connecting {the drive you just used}". It now recommends connecting a
+  drive only when its absence is the documented cause (its label leads a health
+  reason). The upstream half (#103 / `compute_health` mislabeling send-age as
+  physical-away, and ignoring `source_unchanged`) was already fixed; this closes
+  the residual in the advice surface and future-proofs it against other
+  miscaused-degradation paths.
+
 ## [0.27.1] - 2026-06-26
 
 ### Fixed

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -144,8 +144,17 @@ pub fn compute_advice(
             });
         }
 
-        // Branch 8: Protected + Degraded + drive away long
-        if let Some(absent) = assessment.external.iter().find(|d| !d.mounted) {
+        // Branch 8: Protected + Degraded because a specific drive's absence is
+        // the documented cause. Only recommend connecting a drive whose absence
+        // `compute_health` actually flagged — its label leads a health reason
+        // ("{label} away/overdue for N days"). Recommending *any* unmounted drive
+        // would point at an offsite that is legitimately away on its rotation,
+        // telling the user to redo what they just did (#120 defect 2). The
+        // leading-token match also avoids the `WD-18TB`/`WD-18TB1` substring trap
+        // and the unrelated "space tight on {label}" reason.
+        if let Some(absent) = assessment.external.iter().find(|d| {
+            !d.mounted && drive_absence_is_health_cause(&d.drive_label, &assessment.health_reasons)
+        }) {
             return Some(ActionableAdvice {
                 subvolume: name.clone(),
                 issue: format!("degraded — {} away", absent.drive_label),
@@ -156,6 +165,16 @@ pub fn compute_advice(
     }
 
     None
+}
+
+/// True when `drive_label`'s absence is the documented cause of degradation —
+/// i.e. it leads one of `compute_health`'s reasons ("{label} away/overdue for N
+/// days"). The leading-token (`"{label} "`) match is deliberate: it excludes the
+/// "space tight on {label}" reason (label not leading) and never confuses a
+/// label that is a prefix of another (`WD-18TB` vs `WD-18TB1`). See #120.
+fn drive_absence_is_health_cause(drive_label: &str, health_reasons: &[String]) -> bool {
+    let prefix = format!("{drive_label} ");
+    health_reasons.iter().any(|r| r.starts_with(&prefix))
 }
 
 /// Find the first chain break on a mounted drive.
@@ -1544,6 +1563,52 @@ local_retention = "transient"
         assert!(advice.issue.contains("degraded"));
         assert!(advice.command.as_ref().unwrap().contains("--force-full"));
         assert!(advice.reason.as_ref().unwrap().contains("full send"));
+    }
+
+    #[test]
+    fn advice_branch8_fires_when_absence_is_the_cause() {
+        // Offsite genuinely overdue: its label leads a health reason, so
+        // recommending we bring it home is correct.
+        let mut a =
+            test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB1", false, Some(48))];
+        a.health_reasons = vec!["WD-18TB1 overdue for 45 days".to_string()];
+        let advice = compute_advice(&a, true, false).unwrap();
+        assert_eq!(advice.issue, "degraded — WD-18TB1 away");
+        assert!(advice.reason.as_ref().unwrap().contains("Consider connecting WD-18TB1"));
+    }
+
+    #[test]
+    fn advice_branch8_silent_for_legitimately_away_offsite() {
+        // The #120 case: degradation is caused by something else (space tight on
+        // a present drive); the absent offsite is within its rotation window and
+        // is NOT in health_reasons. Branch 8 must not tell the user to reconnect
+        // the drive they just rotated out.
+        let mut a =
+            test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Degraded);
+        a.external = vec![
+            drive_assessment("WD-18TB", true, Some(2)),
+            drive_assessment("WD-18TB1", false, Some(48)),
+        ];
+        a.health_reasons = vec!["space tight on WD-18TB".to_string()];
+        assert!(
+            compute_advice(&a, true, false).is_none(),
+            "must not recommend connecting an offsite whose absence is not the cause"
+        );
+    }
+
+    #[test]
+    fn advice_branch8_substring_label_not_confused() {
+        // "WD-18TB" is a prefix of "WD-18TB1". A reason about WD-18TB1 must not
+        // make the present-but-prefixed drive look like the cause, and vice versa.
+        let mut a =
+            test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", false, Some(48))];
+        a.health_reasons = vec!["WD-18TB1 overdue for 45 days".to_string()];
+        assert!(
+            compute_advice(&a, true, false).is_none(),
+            "a reason about WD-18TB1 must not flag WD-18TB as the cause"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

After swapping an offsite drive in, running `urd backup`, and swapping it back out, bare `urd` could render:

```
All connected drives are sealed. 1 degraded. Last backup 1h ago.
Consider connecting WD-18TB1
```

— recommending the drive that was *just connected and just used*. The headline next-action was the inverse of what's appropriate.

## Verify-first

#120's root cause #1 (#103 — `compute_health` mislabeling `last_send_age` as physical-away) is **closed**, and `compute_health` now also suppresses the away-degradation when `source_unchanged` (the comment at `awareness.rs` even cites "issue #120, defect 1") and uses role-aware thresholds. So the **original music manifestation no longer reproduces** — a `source_unchanged` offsite never reaches Protected+Degraded, so Branch 8 isn't entered for it.

This PR closes the **residual** defect 2 (the issue: *"Either fix on its own breaks this manifestation; both together also future-proof Branch 8 against other miscaused-degradation paths"*).

## The residual

`compute_advice` Branch 8 still picked *any* unmounted drive:

```rust
if let Some(absent) = assessment.external.iter().find(|d| !d.mounted) { ... }
```

It didn't read `health_reasons`, didn't filter by role, and didn't confirm the recommended drive's absence was the cause. So a Protected+Degraded subvolume degraded by, say, "space tight on {present drive}" with an offsite legitimately away within its rotation window would still produce "Consider connecting {offsite}".

## Fix

Branch 8 now fires only when the absent drive's absence is the **documented cause** — its label leads a `compute_health` reason (`"{label} away/overdue for N days"`), via a new `drive_absence_is_health_cause` helper. The leading-token (`"{label} "`) match:
- excludes the unrelated "space tight on {label}" reason (label not leading);
- never confuses a label that prefixes another (`WD-18TB` vs `WD-18TB1`).

This is correct under ADR-116: an offsite genuinely *overdue* leads a health reason, so recommending we bring it home still fires — that's the desired nag. An offsite away *within* its window is not in `health_reasons`, so no spurious recommendation.

## Tests

- `advice_branch8_fires_when_absence_is_the_cause` — overdue offsite → recommends connecting it.
- `advice_branch8_silent_for_legitimately_away_offsite` — the #120 case (degradation from "space tight" elsewhere; offsite within window) → no advice.
- `advice_branch8_substring_label_not_confused` — a reason about `WD-18TB1` must not flag `WD-18TB`.

All 1817 tests pass; `cargo clippy --all-targets -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)