### PR TITLE
fix: tight-pool reassurance line no longer lies for local-only subvolumes (#195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The tight-pool reassurance line no longer lies for local-only subvolumes**
+  (#195). A subvolume with no external drive was told "full history is on the
+  drive; backing up every 1d to spare it" — but there is no drive and no send.
+  Local-only subvolumes now get a true sentence ("source pool is tight — keeping
+  less local history to protect the host"). Separately, a tight-stretched cadence
+  (e.g. daily × 1.5 = 36h) used `humanize_duration`, which floored it to "1d" —
+  identical to the declared daily, making the sparing invisible. A new
+  `humanize_cadence` renders it honestly ("every 36h"), so the slowdown the voice
+  narrates is actually visible. Voice Contract Rule 1 (every claim verifiable).
+
 ## [0.27.1] - 2026-06-26
 
 ### Fixed

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -124,6 +124,26 @@ pub(super) fn humanize_duration(secs: i64) -> String {
     }
 }
 
+/// Humanize a *cadence* without `humanize_duration`'s lossy day-flooring. The
+/// tight-tier stretch multiplies the declared interval (e.g. daily × 1.5 = 36h);
+/// flooring that to "1d" makes the slowed cadence read identically to the
+/// declared one, hiding the very adaptation the voice is trying to narrate
+/// (#195). Whole numbers of days stay "Nd"; a sub-two-day cadence that isn't a
+/// whole day shows hours ("36h"); anything else with a fractional day shows one
+/// decimal ("2.5d"). Sub-day cadences fall back to `humanize_duration`.
+pub(super) fn humanize_cadence(secs: i64) -> String {
+    // Sub-day (incl. zero/negative) → the plain humanizer handles it.
+    if secs < 86400 {
+        return humanize_duration(secs);
+    }
+    if secs % 86400 == 0 {
+        return format!("{}d", secs / 86400);
+    }
+    if secs < 2 * 86400 && secs % 3600 == 0 {
+        return format!("{}h", secs / 3600);
+    }
+    format!("{:.1}d", secs as f64 / 86400.0)
+}
 
 // ── Table formatter ─────────────────────────────────────────────────────
 
@@ -3763,6 +3783,21 @@ mod tests {
     fn humanize_duration_zero_returns_less_than_one() {
         assert_eq!(humanize_duration(0), "<1s");
         assert_eq!(humanize_duration(-1), "<1s");
+    }
+
+    #[test]
+    fn humanize_cadence_does_not_floor_sub_two_day_stretch() {
+        // #195: the lossy floor that hid the tight-stretch.
+        assert_eq!(humanize_cadence(129600), "36h"); // daily × 1.5
+        assert_eq!(humanize_duration(129600), "1d"); // the old, misleading form
+        // Whole days stay clean.
+        assert_eq!(humanize_cadence(86400), "1d");
+        assert_eq!(humanize_cadence(7 * 86400), "7d");
+        // Beyond two days, a non-whole cadence shows one decimal.
+        assert_eq!(humanize_cadence(216000), "2.5d");
+        // Sub-day falls back to the plain humanizer.
+        assert_eq!(humanize_cadence(3600), "1h");
+        assert_eq!(humanize_cadence(0), "<1s");
     }
 
     // ── UPI 030 Churn section ──────────────────────────────────────

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -20,7 +20,7 @@ use crate::types::{ByteSize, DriveRole};
 use super::drive_row::{aggregate_drive_info, offsite_drive_label, unmounted_drive_label};
 use super::{
     SuggestionContext, append_suggestion, color_result, exposure_label, format_status_table,
-    humanize_duration, pluralize,
+    humanize_cadence, humanize_duration, pluralize,
 };
 
 // ── Status ──────────────────────────────────────────────────────────────
@@ -204,14 +204,6 @@ pub(super) fn render_storage_adaptations(data: &StatusOutput, out: &mut String) 
         let Some(secs) = a.effective_send_interval_secs else {
             continue; // Roomy — declared cadence, nothing to explain.
         };
-        let cadence = humanize_duration(secs);
-        // Declared-Graduated subvols had graduated local history; the tier
-        // reduced it to retain-one (Tight) or cleared it (Critical).
-        let history = if a.external_only {
-            ""
-        } else {
-            " local history reduced \u{2014} full history is on the drive;"
-        };
         // Capped-by-design (Critical) appends an explicit "by design"
         // reassurance; honest Tight (still Protected) gets the bare note; a
         // genuine failure / UNPROTECTED says nothing here and leads via the
@@ -223,16 +215,34 @@ pub(super) fn render_storage_adaptations(data: &StatusOutput, out: &mut String) 
         } else {
             continue;
         };
-        writeln!(
-            out,
-            "{}",
+
+        // A local-only subvolume (no external drive) has no drive to "spare" and
+        // no full history living "on the drive" — the old line was a flat lie for
+        // it (#195). Say only what's true: the source pool is tight, so Urd keeps
+        // less local history to protect the host.
+        let line = if a.external.is_empty() {
+            format!(
+                "  {}: source pool is tight \u{2014} keeping less local history to protect the host.{suffix}",
+                a.name,
+            )
+        } else {
+            // `humanize_cadence`, not `humanize_duration`: a 36h tight-stretch
+            // must not floor to "1d" (identical to the declared daily), which
+            // would make the sparing invisible (#195).
+            let cadence = humanize_cadence(secs);
+            // Declared-Graduated subvols had graduated local history; the tier
+            // reduced it to retain-one (Tight) or cleared it (Critical).
+            let history = if a.external_only {
+                ""
+            } else {
+                " local history reduced \u{2014} full history is on the drive;"
+            };
             format!(
                 "  {}: tight drive \u{2014}{history} backing up every {cadence} to spare it.{suffix}",
                 a.name,
             )
-            .yellow()
-        )
-        .ok();
+        };
+        writeln!(out, "{}", line.yellow()).ok();
     }
 }
 
@@ -822,6 +832,64 @@ mod tests {
         );
         let head = out.lines().take(4).collect::<Vec<_>>().join("\n");
         assert!(head.contains("chain broken"), "failure reason must lead: {head}");
+    }
+
+    #[test]
+    fn tight_local_only_reassurance_states_only_truths() {
+        // #195: a local-only subvolume (no external drive) must not be told its
+        // "full history is on the drive" or that Urd is "backing up to spare it"
+        // — there is no drive and no send. Say only what's true.
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.assessments.truncate(1);
+        let a = &mut data.assessments[0];
+        a.name = "subvol6-tmp".to_string();
+        a.external = vec![]; // local-only
+        a.status = PromiseStatus::Protected;
+        a.cadence_adapted = false;
+        a.effective_send_interval_secs = Some(86400);
+
+        let mut out = String::new();
+        render_storage_adaptations(&data, &mut out);
+
+        assert!(out.contains("source pool is tight"), "missing true statement: {out}");
+        assert!(out.contains("protect the host"), "missing true statement: {out}");
+        assert!(
+            !out.contains("full history is on the drive"),
+            "phantom-drive claim for local-only: {out}"
+        );
+        assert!(
+            !out.contains("to spare it"),
+            "phantom send-cadence claim for local-only: {out}"
+        );
+        assert!(
+            !out.contains("tight drive"),
+            "local-only has no drive — must not say 'tight drive': {out}"
+        );
+    }
+
+    #[test]
+    fn tight_stretched_cadence_shows_hours_not_floored_day() {
+        // #195 sibling defect: a 36h tight-stretch (daily × 1.5) must render as
+        // "36h", not floor to "1d" (identical to the declared daily — which makes
+        // the sparing invisible).
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.assessments.truncate(1);
+        let a = &mut data.assessments[0]; // htpc-home, has external WD-18TB
+        a.status = PromiseStatus::Protected;
+        a.cadence_adapted = false;
+        a.effective_send_interval_secs = Some(129600); // 36h
+
+        let mut out = String::new();
+        render_storage_adaptations(&data, &mut out);
+
+        assert!(out.contains("every 36h"), "stretched cadence must show 36h: {out}");
+        assert!(!out.contains("every 1d"), "36h must not floor to 1d: {out}");
+        assert!(
+            out.contains("to spare it"),
+            "an external subvol keeps the spare-the-drive prose: {out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Live `urd status` on a tight pool rendered, for a local-only subvolume:

```
subvol6-tmp: tight drive — local history reduced — full history is on the drive; backing up every 1d to spare it.
```

`subvol6-tmp` has no external drive (table row shows `—`). Two falsehoods in one calm line (Voice Contract Rule 1 — every claim must be verifiable):

1. **"full history is on the drive"** — there is no drive.
2. **"backing up every 1d to spare it"** — there is no send; nothing is being spared.

Plus the sibling defect from the 2026-06-02 review: for send-enabled subvolumes a stretched cadence (`129600s` = 36h) renders through `humanize_duration` as "1d" — identical to the declared daily, so the claimed sparing is invisible.

## Fix

- **Condition on external presence.** `render_storage_adaptations` now branches on `external.is_empty()`. A local-only subvolume gets a true sentence: *"source pool is tight — keeping less local history to protect the host"* (no phantom drive, no phantom send cadence). Subvolumes with a drive keep the existing spare-the-drive prose.
- **Honest cadence.** New `humanize_cadence` does not floor sub-two-day stretches: whole days → "Nd", a sub-two-day non-whole cadence → "36h", otherwise one-decimal days ("2.5d"). The adaptation prose uses it so a 36h stretch reads as "every 36h".

## Tests

- `tight_local_only_reassurance_states_only_truths` — local-only output asserts the true statement and the absence of "full history is on the drive" / "to spare it" / "tight drive".
- `tight_stretched_cadence_shows_hours_not_floored_day` — 36h renders as "every 36h", not "every 1d"; external subvol keeps the spare prose.
- `humanize_cadence_does_not_floor_sub_two_day_stretch` — unit coverage incl. the contrast with the old `humanize_duration` flooring.
- The three `status_2am_golden_*` tests (weekly = 7d, whole days) still pass — `htpc-home` has a drive, so it stays on the external branch.

All 1817 tests pass; `cargo clippy --all-targets -- -D warnings` clean.

Tracked separately from the facts-not-rows voice arc (#196) because this is a factual lie, not a style issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)