### PR TITLE
test: integration test for --subvolume bogus across all commands (#136)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,13 @@ env_logger = "0.11"
 filetime = "0.2.27"
 tempfile = "3"
 
+# Integration tests live under tests/integration/ (CLAUDE.md convention) and are
+# #[ignore]'d by default (they build + shell out to the binary). Run with
+# `cargo test -- --ignored`. Each file is declared as its own test target.
+[[test]]
+name = "cli_subvolume_validation"
+path = "tests/integration/cli_subvolume_validation.rs"
+
 [profile.release]
 lto = true
 strip = true

--- a/tests/integration/cli_subvolume_validation.rs
+++ b/tests/integration/cli_subvolume_validation.rs
@@ -1,0 +1,107 @@
+//! Integration test (#136): every `--subvolume`-accepting CLI command must
+//! reject an unknown subvolume name with a non-zero exit and a clear message.
+//!
+//! Guards against the regression class from #134/#135. The fix as shipped relies
+//! on per-handler discipline (`cli_validation::require_known_subvolume` at the
+//! top of each `run`) with no compile-time enforcement — a future command that
+//! forgets the guard would silently reintroduce the empty-set bug (#134). The
+//! canonical list below is the tripwire: a 9th `--subvolume`-accepting command
+//! must be added here (and given the guard) or it ships without coverage.
+//!
+//! `#[ignore]`'d because it builds and shells out to the binary (slow); run in
+//! CI's pre-release gate via `cargo test -- --ignored`.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// Minimal valid config with two subvolumes. Paths are absolute (under `dir`)
+/// and need not exist on disk — config validation checks path *safety*, not
+/// presence, and the subvolume guard fires before any filesystem access.
+fn write_config(dir: &TempDir) -> PathBuf {
+    let base = dir.path().display();
+    let toml = format!(
+        r#"
+drives = []
+
+[general]
+state_db = "{base}/urd.db"
+metrics_file = "{base}/backup.prom"
+log_dir = "{base}"
+
+[local_snapshots]
+roots = [
+  {{ path = "{base}/snap", subvolumes = ["subvol1", "subvol2"] }}
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[subvolumes]]
+name = "subvol1"
+short_name = "s1"
+source = "{base}/data/subvol1"
+
+[[subvolumes]]
+name = "subvol2"
+short_name = "s2"
+source = "{base}/data/subvol2"
+"#
+    );
+    let path = dir.path().join("urd.toml");
+    std::fs::write(&path, toml).expect("write throwaway config");
+    path
+}
+
+/// Every command that accepts a subvolume selector, with the exact arg form it
+/// uses (`--subvolume <name>` for most; a positional for `retention-preview`;
+/// `get` also needs a path + `--at`). Keep this in sync with the handlers that
+/// call `require_known_subvolume`.
+const SUBVOLUME_COMMANDS: &[&[&str]] = &[
+    &["plan", "--subvolume", "bogus"],
+    &["backup", "--dry-run", "--subvolume", "bogus"],
+    &["history", "--subvolume", "bogus"],
+    &["calibrate", "--subvolume", "bogus"],
+    &["verify", "--subvolume", "bogus"],
+    &["events", "--subvolume", "bogus"],
+    &["get", "/some/file", "--at", "2026-01-01", "--subvolume", "bogus"],
+    &["retention-preview", "bogus"], // positional subvolume
+];
+
+#[test]
+#[ignore = "builds + shells out to the binary; run via `cargo test -- --ignored`"]
+fn every_subvolume_command_rejects_unknown_name() {
+    let dir = TempDir::new().expect("tempdir");
+    let config = write_config(&dir);
+    let bin = env!("CARGO_BIN_EXE_urd");
+
+    for argv in SUBVOLUME_COMMANDS {
+        let output = Command::new(bin)
+            .arg("--config")
+            .arg(&config)
+            .args(*argv)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run `urd {}`: {e}", argv.join(" ")));
+
+        assert!(
+            !output.status.success(),
+            "`urd {}` should exit non-zero for an unknown subvolume, but succeeded\nstdout:\n{}\nstderr:\n{}",
+            argv.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(r#"no subvolume named "bogus""#),
+            "`urd {}` stderr should name the unknown subvolume; got:\n{stderr}",
+            argv.join(" "),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR #135 (fix for #134) added `cli_validation::require_known_subvolume` to all 8 commands that accept a subvolume selector. That works, but it's **per-handler discipline with no compile-time check** — when someone later adds `urd inspect --subvolume FOO` and forgets the guard, the silent empty-set bug from #134 returns and nothing in CI catches it. Flagged as Significant Finding S-1 in the #135 adversary review and explicitly deferred.

## What this adds

The first integration test under `tests/integration/` (the CLAUDE.md convention — there was no `tests/` dir yet), wired as its own `[[test]]` target in Cargo.toml. It:

1. Writes a minimal throwaway two-subvolume config to a tempdir (absolute paths; config validation checks path *safety*, not presence, and the guard fires before any FS access).
2. Runs the built binary (`env!("CARGO_BIN_EXE_urd")`) for each command in the canonical list with an unknown subvolume:
   - `--subvolume bogus` for `plan`, `backup`, `history`, `calibrate`, `verify`, `events`
   - positional `bogus` for `retention-preview`
   - `get /some/file --at 2026-01-01 --subvolume bogus`
3. Asserts each exits **non-zero** with stderr containing `no subvolume named "bogus"`.

The `SUBVOLUME_COMMANDS` constant is the regression tripwire: a 9th such command must be added here (and given the guard) or it ships without coverage.

## Notes

- `#[ignore]`'d because it builds and shells out to the binary (slow). Verified passing locally via `cargo test --test cli_subvolume_validation -- --ignored` (1 passed); the default `cargo test` correctly skips it (shows as ignored).
- Per the issue, the optional clap-introspection meta-check was skipped as gold-plating ("the explicit list catches 95% of the regression value with 5% of the code").
- Out of scope (separate issues if confirmed): the symmetric `--drive LABEL` audit; refactoring the guard into a clap `value_parser`.
- No CHANGELOG entry — test-only infra, no user-facing behavior change.

`cargo clippy --all-targets -- -D warnings` clean; main suite green (1814).

🤖 Generated with [Claude Code](https://claude.com/claude-code)