### PR TITLE
fix: send-size estimate never lets a failed partial outrank a real signal (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The send-size estimate no longer inherits a failed/aborted send's partial
+  bytes** (#210). A failed send's `bytes_transferred` is an under-count (the send
+  aborted), but the estimate blended successful and failed sizes with `max()` and
+  short-circuited on the first hit — so a watchdog-killed 2.67TB partial on the
+  target drive shadowed a genuine 7.58TB full send recorded on another drive
+  (run #114 showed a ~3.8TB header for an ~8.7TB run). `last_send_size` /
+  `last_send_size_any_drive` are now **successful-only**; the preference order is
+  successful (this drive) → successful (any drive) → calibrated (full) → a
+  failed partial as a last-resort *floor*. This also closes a do-no-harm gap: the
+  same value feeds the planner's space-fit gate, where a falsely-low partial
+  estimate could green-light a send onto a drive that cannot hold it (ADR-113).
+
 ## [0.27.1] - 2026-06-26
 
 ### Fixed

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -80,6 +80,18 @@ pub trait HistoryQuery {
     /// across **all** drives. Cross-drive fallback for drive swap scenarios.
     fn last_send_size_any_drive(&self, subvol_name: &str, send_kind: SendKind) -> Option<u64>;
 
+    /// A last-resort *floor* from a failed/aborted send (this drive preferred,
+    /// then any drive). A failed send's `bytes_transferred` is an under-count —
+    /// the send aborted — so it must never outrank a successful or calibrated
+    /// signal; it is consulted only after both and treated as a lower bound, not
+    /// a confident estimate (#210). Returns None when no failed send is on record.
+    fn last_failed_send_floor(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+        send_kind: SendKind,
+    ) -> Option<u64>;
+
     /// Get a calibrated size estimate for a subvolume (from `urd calibrate`).
     /// Returns `(estimated_bytes, measured_at)` or None if not calibrated.
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)>;

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -123,6 +123,11 @@ pub fn estimated_send_size(
     } else {
         SendKind::Incremental
     };
+    // Preference order, strongest signal first (#210): a successful send to this
+    // drive, then a successful send to any drive, then the calibrated size (full
+    // only), and — only when no confident signal exists — a failed/aborted send's
+    // bytes as a last-resort floor. A failed partial must never outrank a real
+    // measurement, which is the bug this order fixes.
     history
         .last_send_size(subvol_name, drive_label, send_kind)
         .or_else(|| history.last_send_size_any_drive(subvol_name, send_kind))
@@ -133,6 +138,7 @@ pub fn estimated_send_size(
                 None
             }
         })
+        .or_else(|| history.last_failed_send_floor(subvol_name, drive_label, send_kind))
 }
 
 // ── PlanFilters ─────────────────────────────────────────────────────────
@@ -1549,17 +1555,6 @@ impl FilesystemQuery for RealFileSystemState<'_> {
     }
 }
 
-/// The freshest send size is the newer of the last success and the last
-/// failure — when both exist, the larger byte count; otherwise whichever is
-/// present. The domain rule shared by `last_send_size` and
-/// `last_send_size_any_drive` so it lives in exactly one place.
-fn freshest_send_size(successful: Option<u64>, failed: Option<u64>) -> Option<u64> {
-    match (successful, failed) {
-        (Some(s), Some(f)) => Some(s.max(f)),
-        (s, f) => s.or(f),
-    }
-}
-
 impl HistoryQuery for RealFileSystemState<'_> {
     fn last_send_size(
         &self,
@@ -1567,32 +1562,40 @@ impl HistoryQuery for RealFileSystemState<'_> {
         drive_label: &str,
         send_kind: SendKind,
     ) -> Option<u64> {
+        // Successful sends only. A failed/aborted send's bytes are an under-count
+        // and must never stand in for a real measurement — they are consulted
+        // separately as a last-resort floor (#210).
         self.state.and_then(|db| {
-            let send_type = send_kind.as_db_str();
-            let successful = db
-                .last_successful_send_size(subvol_name, drive_label, send_type)
+            db.last_successful_send_size(subvol_name, drive_label, send_kind.as_db_str())
                 .ok()
-                .flatten();
-            let failed = db
-                .last_failed_send_size(subvol_name, drive_label, send_type)
-                .ok()
-                .flatten();
-            freshest_send_size(successful, failed)
+                .flatten()
         })
     }
 
     fn last_send_size_any_drive(&self, subvol_name: &str, send_kind: SendKind) -> Option<u64> {
         self.state.and_then(|db| {
+            db.last_successful_send_size_any_drive(subvol_name, send_kind.as_db_str())
+                .ok()
+                .flatten()
+        })
+    }
+
+    fn last_failed_send_floor(
+        &self,
+        subvol_name: &str,
+        drive_label: &str,
+        send_kind: SendKind,
+    ) -> Option<u64> {
+        self.state.and_then(|db| {
             let send_type = send_kind.as_db_str();
-            let successful = db
-                .last_successful_send_size_any_drive(subvol_name, send_type)
+            db.last_failed_send_size(subvol_name, drive_label, send_type)
                 .ok()
-                .flatten();
-            let failed = db
-                .last_failed_send_size_any_drive(subvol_name, send_type)
-                .ok()
-                .flatten();
-            freshest_send_size(successful, failed)
+                .flatten()
+                .or_else(|| {
+                    db.last_failed_send_size_any_drive(subvol_name, send_type)
+                        .ok()
+                        .flatten()
+                })
         })
     }
 
@@ -1927,6 +1930,17 @@ impl HistoryQuery for MockFileSystemState {
             .filter(|((sv, _, st), _)| sv == subvol_name && *st == send_kind)
             .map(|(_, &bytes)| bytes)
             .max()
+    }
+
+    fn last_failed_send_floor(
+        &self,
+        _subvol_name: &str,
+        _drive_label: &str,
+        _send_kind: SendKind,
+    ) -> Option<u64> {
+        // The mock's `send_sizes` model successful sends only; the failed-floor
+        // path is exercised by the real-DB regression tests (#210).
+        None
     }
 
     fn calibrated_size(&self, subvol_name: &str) -> Option<(u64, String)> {
@@ -5645,19 +5659,92 @@ local_retention = "transient"
         assert!(fs.drive_mount_history("nope").is_empty());
     }
 
-    // ── Read-side composition: freshest_send_size + drift_samples ───────
+    // ── Send-size estimation: failed partials never outrank a real signal ──
 
-    #[test]
-    fn freshest_send_size_picks_larger_when_both_present() {
-        assert_eq!(freshest_send_size(Some(100), Some(250)), Some(250));
-        assert_eq!(freshest_send_size(Some(900), Some(250)), Some(900));
+    /// Seed an operation row for the estimate tests.
+    fn seed_op(
+        db: &crate::state::StateDb,
+        subvol: &str,
+        drive: &str,
+        send_kind: SendKind,
+        result: &str,
+        bytes: i64,
+    ) {
+        let run_id = db.begin_run("full").unwrap();
+        db.record_operation(&crate::state::OperationRecord {
+            run_id,
+            subvolume: subvol.to_string(),
+            operation: send_kind.as_db_str().to_string(),
+            drive_label: Some(drive.to_string()),
+            duration_secs: Some(60.0),
+            result: result.to_string(),
+            error_message: if result == "failure" {
+                Some("aborted".to_string())
+            } else {
+                None
+            },
+            bytes_transferred: Some(bytes),
+        })
+        .unwrap();
     }
 
     #[test]
-    fn freshest_send_size_falls_back_to_whichever_exists() {
-        assert_eq!(freshest_send_size(Some(100), None), Some(100));
-        assert_eq!(freshest_send_size(None, Some(250)), Some(250));
-        assert_eq!(freshest_send_size(None, None), None);
+    fn estimated_send_size_prefers_successful_any_drive_over_failed_partial() {
+        // The #210 field case (run #114): subvol4-multimedia had a failed partial
+        // to WD-18TB1 (2.67TB, watchdog-aborted) and a genuine full success to
+        // WD-18TB (7.58TB). The estimate for WD-18TB1 must resolve to the real
+        // any-drive success, not the failed partial.
+        use crate::state::StateDb;
+        use tempfile::TempDir;
+        let dir = TempDir::new().unwrap();
+        let db = StateDb::open(&dir.path().join("urd.db")).unwrap();
+        seed_op(&db, "multimedia", "WD-18TB", SendKind::Full, "success", 7_577_674_879_444);
+        seed_op(&db, "multimedia", "WD-18TB1", SendKind::Full, "failure", 2_672_831_974_169);
+
+        let fs = RealFileSystemState { state: Some(&db) };
+        assert_eq!(
+            estimated_send_size(&fs, "multimedia", "WD-18TB1", true),
+            Some(7_577_674_879_444),
+            "a failed partial must not outrank a successful any-drive send"
+        );
+    }
+
+    #[test]
+    fn estimated_send_size_uses_failed_partial_only_as_last_resort_floor() {
+        // No successful send and no calibration anywhere → the failed partial is
+        // the only signal, so it is used as a last-resort floor.
+        use crate::state::StateDb;
+        use tempfile::TempDir;
+        let dir = TempDir::new().unwrap();
+        let db = StateDb::open(&dir.path().join("urd.db")).unwrap();
+        seed_op(&db, "multimedia", "WD-18TB1", SendKind::Full, "failure", 2_672_831_974_169);
+
+        let fs = RealFileSystemState { state: Some(&db) };
+        assert_eq!(
+            estimated_send_size(&fs, "multimedia", "WD-18TB1", true),
+            Some(2_672_831_974_169),
+            "with no better signal, the failed partial is the floor"
+        );
+    }
+
+    #[test]
+    fn last_send_size_excludes_failed_sends() {
+        // The trait method itself is successful-only now — a drive with only a
+        // failed send reports no size (the floor lives behind its own method).
+        use crate::state::StateDb;
+        use tempfile::TempDir;
+        let dir = TempDir::new().unwrap();
+        let db = StateDb::open(&dir.path().join("urd.db")).unwrap();
+        seed_op(&db, "multimedia", "WD-18TB1", SendKind::Full, "failure", 2_672_831_974_169);
+
+        let fs = RealFileSystemState { state: Some(&db) };
+        assert_eq!(fs.last_send_size("multimedia", "WD-18TB1", SendKind::Full), None);
+        assert_eq!(fs.last_send_size_any_drive("multimedia", SendKind::Full), None);
+        // But the floor method still surfaces it.
+        assert_eq!(
+            fs.last_failed_send_floor("multimedia", "WD-18TB1", SendKind::Full),
+            Some(2_672_831_974_169)
+        );
     }
 
     fn drift_at(s: &str) -> NaiveDateTime {


### PR DESCRIPTION
## Summary

`urd backup` (run #114) showed a ~3.8TB plan estimate / live denominator for a run that transferred ~8.7TB. The per-send measurements were correct — only the *estimate* was wrong.

## Root cause

A failed/aborted send's `bytes_transferred` is an under-count (the send aborted), but:
- `RealFileSystemState::last_send_size` blended successful and failed sizes via `freshest_send_size` = `max(successful, failed)`.
- `estimated_send_size` short-circuited on the first `Some`.

`subvol4-multimedia` had **no** successful full send to WD-18TB1 (runs #110/#113 failed), so `last_send_size(multimedia, WD-18TB1, Full)` returned the watchdog-killed **2.67TB** partial — and because it was `Some`, the chain never reached `last_send_size_any_drive`, which would have returned run #78's genuine **7.58TB**. The real number was in the DB the whole time.

This feeds two consumers, both in `plan.rs`: the **display** (header + live progress denominator) and the **do-no-harm space-fit gate** (`exceeds_available_space`), where a falsely-low partial estimate can green-light a send onto a drive that cannot hold it → stranded chain (ADR-113).

## Policy decision (floor-only)

The issue left the policy open (exclude / floor-only / TTL-on-success). I chose **floor-only**, which the issue's candidate fix describes and which keeps the failed-size query methods meaningfully used:

- `last_send_size` / `last_send_size_any_drive` are now **successful-only**.
- A failed partial is consulted only as a last-resort **floor** via a new `last_failed_send_floor` (this drive, then any drive).
- Preference order in `estimated_send_size`: successful (this drive) → successful (any drive) → calibrated (full only) → failed floor.

## Change

- `observation.rs`: add `last_failed_send_floor` to `HistoryQuery`.
- `plan.rs`: successful-only `last_send_size`/`any_drive`; delete the `freshest_send_size` blend (and its now-moot unit tests); floor as the final tier in `estimated_send_size`. Mock floor returns `None` (the mock models successful sends only).
- The fit gate keeps its tiered messaging (successful → calibrated); it no longer green-lights on a partial because its estimate is successful-only.

## Tests (real in-memory DB)

- `estimated_send_size_prefers_successful_any_drive_over_failed_partial` — the run-#114 shape resolves to **7.58TB**, not 2.67TB (the issue's acceptance criterion).
- `estimated_send_size_uses_failed_partial_only_as_last_resort_floor` — when a failed partial is the only signal, it's used as the floor.
- `last_send_size_excludes_failed_sends` — the trait method is successful-only; the floor method still surfaces the failure.

All 1815 tests pass; `cargo clippy --all-targets -- -D warnings` clean.

## Notes / deliberately out of scope

- **TTL-on-success** (expiring failed-size rows after a success) is unnecessary under floor-only — the failed size is simply outranked, never consulted when a success exists.
- **Floor in the gate:** the failed floor is display-only. The gate's primary bug (green-lighting on a low partial) is fixed by successful-only semantics; for a subvolume whose *only* signal is a failed partial, the gate fails open (ADR-107) and the floor watchdog (UPI 067) backstops the send. Adding a conservative floor-exceeds skip to the gate is a reasonable future enhancement but kept out to preserve the gate's tiered messaging and scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)