### PR TITLE
fix: reap orphaned 'running' run records at backup startup (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Interrupted runs no longer leave orphaned `running` records in the runs
+  table** (#213). A run whose process died before `finish_run` (watchdog abort,
+  drive-away kill, reboot, crash) left its row `result='running'`,
+  `finished_at=NULL` forever, and nothing reaped it — so a zombie row could hold
+  the max id and make `urd status` report a long-dead run as "(running)"
+  indefinitely. Backup startup now reaps stale `running` rows, marking each
+  `interrupted` with a best-effort `finished_at`. This is safe by construction:
+  the advisory lock admits one backup at a time, so any `running` row present when
+  a new run begins belongs to a dead prior run. The reap is best-effort and never
+  blocks a backup (ADR-102). `interrupted` renders dimmed (past history, not an
+  alarm).
+
 ## [0.27.1] - 2026-06-26
 
 ### Fixed

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1929,6 +1929,15 @@ impl<'a> Executor<'a> {
 
     fn begin_run(&self, mode: &str) -> Option<i64> {
         if let Some(state) = self.state {
+            // Reap any orphaned `running` rows from a prior crashed run before
+            // starting this one. Safe under the backup lock (one run at a time),
+            // so any surviving `running` row is a zombie (#213). Best-effort —
+            // a reap failure must never block the backup (ADR-102).
+            match state.reap_stale_runs() {
+                Ok(0) => {}
+                Ok(n) => log::warn!("Reaped {n} orphaned 'running' run record(s) from a prior interrupted run"),
+                Err(e) => log::warn!("Failed to reap stale run records: {e}"),
+            }
             match state.begin_run(mode) {
                 Ok(id) => Some(id),
                 Err(e) => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -380,6 +380,28 @@ impl StateDb {
         Ok(())
     }
 
+    /// Reap orphaned `running` run rows — rows whose process died before
+    /// `finish_run` (watchdog abort, drive-away kill, reboot, crash). Marks each
+    /// `result = 'interrupted'` with a best-effort `finished_at = now`, and
+    /// returns the count reaped.
+    ///
+    /// Called at backup startup, where it is safe by construction: the advisory
+    /// lock (`lock.rs`) admits one backup at a time, so any `running` row present
+    /// when a new run begins belongs to a dead prior run — never a live one.
+    /// Without this, a zombie row stays `running`/`finished_at = NULL` forever and
+    /// can hold the max id, so `last_run` reports a long-dead run as "(running)".
+    pub fn reap_stale_runs(&self) -> crate::error::Result<usize> {
+        let now = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+        let reaped = self
+            .conn
+            .execute(
+                "UPDATE runs SET finished_at = ?1, result = 'interrupted' WHERE result = 'running'",
+                rusqlite::params![now],
+            )
+            .map_err(|e| UrdError::State(format!("failed to reap stale runs: {e}")))?;
+        Ok(reaped)
+    }
+
     /// Finish a run with the given result ("success", "partial", "failure").
     pub fn finish_run(&self, run_id: i64, result: &str) -> crate::error::Result<()> {
         let now = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
@@ -1603,6 +1625,32 @@ mod tests {
             .unwrap();
         assert_eq!(result, "success");
         assert!(!finished.is_empty());
+    }
+
+    #[test]
+    fn reap_stale_runs_marks_unfinished_as_interrupted() {
+        let db = StateDb::open_memory().unwrap();
+        // Two orphaned runs (never finished) and one that completed normally.
+        let r1 = db.begin_run("full").unwrap();
+        let r2 = db.begin_run("full").unwrap();
+        let r3 = db.begin_run("full").unwrap();
+        db.finish_run(r3, "success").unwrap();
+
+        let reaped = db.reap_stale_runs().unwrap();
+        assert_eq!(reaped, 2, "only the two unfinished runs are reaped");
+
+        let recent = db.recent_runs(10).unwrap();
+        let find = |id: i64| recent.iter().find(|r| r.id == id).unwrap();
+        assert_eq!(find(r1).result, "interrupted");
+        assert!(find(r1).finished_at.is_some(), "reaped run gets a finished_at");
+        assert_eq!(find(r2).result, "interrupted");
+        assert_eq!(find(r3).result, "success", "a completed run is untouched");
+
+        // The latest run is no longer a zombie 'running' record.
+        assert_eq!(db.last_run().unwrap().unwrap().result, "success");
+
+        // Idempotent — a second reap finds nothing to do.
+        assert_eq!(db.reap_stale_runs().unwrap(), 0);
     }
 
     #[test]

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -229,6 +229,9 @@ pub(super) fn color_result(result: &str) -> String {
         "success" => "success".green().to_string(),
         "partial" => "partial".yellow().to_string(),
         "failure" => "failure".red().to_string(),
+        // A run whose process died before finalizing, reaped at the next backup
+        // startup (#213). Dimmed — past history, not an active alarm.
+        "interrupted" => "interrupted".dimmed().to_string(),
         other => other.to_string(),
     }
 }


### PR DESCRIPTION
## Summary

The `runs` table accumulated **3 orphaned `running` records** that never finalized — each recorded one operation, then the process died (watchdog abort, drive-away, reboot) before `finish_run`. Nothing reaped them, so they stayed `result='running'`, `finished_at=NULL` forever.

`latest_run` (`ORDER BY id DESC LIMIT 1`) and `render_last_run` have no defense: if a zombie row ever holds the max id, `urd status` reports a long-dead run as "(running)" indefinitely — corrosive for a tool whose proposition is "silence means your data is safe."

## Policy decision

Reap **at backup startup**, with a new terminal `interrupted` state:

- `StateDb::reap_stale_runs()` marks every `running` row `result='interrupted'` with a best-effort `finished_at = now`, returning the count.
- Wired into the executor's `begin_run` wrapper, **before** the new run row is inserted.
- **Safe by construction:** the advisory lock (`lock.rs`) admits one backup at a time, so any `running` row present when a new run begins belongs to a dead prior run — never a live one.
- **Best-effort:** a reap failure logs a warning and never blocks the backup (ADR-102).

`interrupted` renders **dimmed** (past history, not an active alarm).

## Change

- `state.rs`: `reap_stale_runs` + unit test (two zombies → `interrupted`, a completed run untouched, `last_run` no longer reports `running`, idempotent).
- `executor.rs`: reap in `begin_run` before `state.begin_run`.
- `voice/mod.rs`: `color_result` handles `interrupted`.

All 1815 tests pass; `cargo clippy --all-targets -- -D warnings` clean.

## Deliberately scoped out

Full **real-time** live-vs-stale detection in `urd status` (probing the advisory lock / PID before annotating "(running)") is left as a follow-up. The reaper already converts the reported failure mode from *permanent* ("(running)" forever) to *transient* (cleared on the next backup, and shown as `interrupted` thereafter), which resolves the accumulation the issue reported. Adding a lock-probe to the read path is a larger change (plumbing lock state through the status command) and the issue itself de-emphasized the specific status line ("plausibly accurate … this issue is the latent orphan-record problem, not that specific line").

🤖 Generated with [Claude Code](https://claude.com/claude-code)