### PR TITLE
tidy: verify check helpers return checks instead of mut accumulators (#175)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,17 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
-name = "filetime"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -526,10 +515,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall",
 ]
 
 [[package]]
@@ -622,12 +608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -675,15 +655,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags",
-]
 
 [[package]]
 name = "redox_users"
@@ -964,7 +935,6 @@ dependencies = [
  "ctrlc",
  "dirs",
  "env_logger",
- "filetime",
  "log",
  "nix",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ log = "0.4"
 env_logger = "0.11"
 
 [dev-dependencies]
-filetime = "0.2.27"
 tempfile = "3"
 
 [profile.release]

--- a/src/commands/verify.rs
+++ b/src/commands/verify.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::time::SystemTime;
 
 use crate::chain;
 use crate::cli::VerifyArgs;
@@ -6,6 +7,7 @@ use crate::config::Config;
 use crate::drives;
 use crate::output::{OutputMode, VerifyCheck, VerifyDrive, VerifyOutput, VerifySubvolume};
 use crate::plan::{FilesystemQuery, RealFileSystemState};
+use crate::types::SnapshotName;
 use crate::voice;
 
 pub fn run(config: Config, args: VerifyArgs, mode: OutputMode) -> anyhow::Result<()> {
@@ -185,27 +187,22 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
                         total_fail += 1;
                     }
 
-                    // 4. Orphan detection
-                    collect_orphan_checks(
-                        &fs_state,
-                        drive,
-                        &subvol.name,
-                        pin,
-                        &mut checks,
-                        &mut total_ok,
-                        &mut total_warn,
-                    );
+                    // 4. Orphan detection — fetch (I/O), then the pure factory.
+                    let ext_snaps = fs_state
+                        .external_snapshots(drive, &subvol.name)
+                        .unwrap_or_default();
+                    let orphan = orphan_checks(pin, &ext_snaps);
+                    tally(&orphan, &mut total_ok, &mut total_warn);
+                    checks.extend(orphan);
 
                     // 5. Stale pin detection (only meaningful for drive-specific pins)
-                    if !is_legacy {
-                        collect_stale_pin_check(
-                            &local_dir,
-                            &drive.label,
-                            &subvol.send_interval,
-                            &mut checks,
-                            &mut total_ok,
-                            &mut total_warn,
-                        );
+                    if !is_legacy
+                        && let Some(mtime) = pin_file_mtime(&local_dir, &drive.label)
+                    {
+                        let stale =
+                            stale_pin_checks(mtime, &subvol.send_interval, SystemTime::now());
+                        tally(&stale, &mut total_ok, &mut total_warn);
+                        checks.extend(stale);
                     }
                 }
                 Ok(None) => {
@@ -276,83 +273,83 @@ pub(crate) fn collect_verify_output(config: &Config, args: &VerifyArgs) -> Verif
     }
 }
 
-fn collect_orphan_checks(
-    fs_state: &dyn FilesystemQuery,
-    drive: &crate::config::DriveConfig,
-    subvol_name: &str,
-    pin: &crate::types::SnapshotName,
-    checks: &mut Vec<VerifyCheck>,
-    total_ok: &mut u32,
-    total_warn: &mut u32,
-) {
-    let ext_snaps = fs_state
-        .external_snapshots(drive, subvol_name)
-        .unwrap_or_default();
-
-    let orphans: Vec<_> = ext_snaps.iter().filter(|s| *s > pin).collect();
+/// Pure: orphan checks given the pin and the drive's external snapshots
+/// (already fetched). An "orphan" is an external snapshot newer than the pin —
+/// possibly from an interrupted send. Returns one `ok` check when there are
+/// none, or one `warn` per orphan.
+fn orphan_checks(pin: &crate::types::SnapshotName, external: &[SnapshotName]) -> Vec<VerifyCheck> {
+    let orphans: Vec<&SnapshotName> = external.iter().filter(|s| *s > pin).collect();
     if orphans.is_empty() {
-        checks.push(VerifyCheck {
+        return vec![VerifyCheck {
             name: "orphans".to_string(),
             status: "ok".to_string(),
             detail: Some("No orphaned snapshots on drive".to_string()),
             suggestion: None,
-        });
-        *total_ok += 1;
-    } else {
-        for orphan in &orphans {
-            checks.push(VerifyCheck {
-                name: "orphans".to_string(),
-                status: "warn".to_string(),
-                detail: Some(format!(
-                    "Orphaned snapshot on drive: {orphan} (newer than pin, possibly from interrupted send)"
-                )),
-                suggestion: None,
-            });
-        }
-        *total_warn += orphans.len() as u32;
+        }];
     }
+    orphans
+        .iter()
+        .map(|orphan| VerifyCheck {
+            name: "orphans".to_string(),
+            status: "warn".to_string(),
+            detail: Some(format!(
+                "Orphaned snapshot on drive: {orphan} (newer than pin, possibly from interrupted send)"
+            )),
+            suggestion: None,
+        })
+        .collect()
 }
 
-fn collect_stale_pin_check(
-    local_dir: &Path,
-    drive_label: &str,
+/// Pure: stale-pin check given the pin file's mtime, the send interval, and
+/// "now". A pin older than the staleness threshold (`2× send_interval`, min 1
+/// day) warns; otherwise `ok`. The I/O (reading the pin mtime) lives at the call
+/// site so the decision is testable without a filesystem.
+fn stale_pin_checks(
+    pin_mtime: SystemTime,
     send_interval: &crate::types::Interval,
-    checks: &mut Vec<VerifyCheck>,
-    total_ok: &mut u32,
-    total_warn: &mut u32,
-) {
-    let pin_path = local_dir.join(format!(".last-external-parent-{drive_label}"));
-    let Ok(metadata) = std::fs::metadata(&pin_path) else {
-        return;
-    };
-    let Ok(modified) = metadata.modified() else {
-        return;
-    };
-    let age = std::time::SystemTime::now()
-        .duration_since(modified)
-        .unwrap_or_default();
-
+    now: SystemTime,
+) -> Vec<VerifyCheck> {
+    let age = now.duration_since(pin_mtime).unwrap_or_default();
     let threshold_secs = stale_threshold_secs(send_interval);
     if age.as_secs() > threshold_secs as u64 {
         let days = age.as_secs() / 86400;
         let threshold_str = format_threshold(threshold_secs);
-        checks.push(VerifyCheck {
+        vec![VerifyCheck {
             name: "stale-pin".to_string(),
             status: "warn".to_string(),
             detail: Some(format!(
                 "Pin file is {days} day(s) old (threshold: {threshold_str}) \u{2014} last successful send was {days} day(s) ago"
             )),
             suggestion: None,
-        });
-        *total_warn += 1;
+        }]
     } else {
-        checks.push(VerifyCheck {
+        vec![VerifyCheck {
             name: "stale-pin".to_string(),
             status: "ok".to_string(),
             detail: Some("Pin file age OK".to_string()),
             suggestion: None,
-        });
-        *total_ok += 1;
+        }]
+    }
+}
+
+/// Read a drive-specific pin file's mtime, if present and readable. The I/O half
+/// of the stale-pin check, kept separate from the pure decision in
+/// `stale_pin_checks`. Returns `None` when the pin is absent or its mtime can't
+/// be read (the check is then simply skipped, as before).
+fn pin_file_mtime(local_dir: &Path, drive_label: &str) -> Option<SystemTime> {
+    let pin_path = local_dir.join(format!(".last-external-parent-{drive_label}"));
+    std::fs::metadata(&pin_path).and_then(|m| m.modified()).ok()
+}
+
+/// Tally `ok` / `warn` statuses from a batch of checks, folding the running
+/// totals from the returned checks rather than mutating them in each factory.
+fn tally(checks: &[VerifyCheck], total_ok: &mut u32, total_warn: &mut u32) {
+    for c in checks {
+        match c.status.as_str() {
+            "ok" => *total_ok += 1,
+            "warn" => *total_warn += 1,
+            _ => {}
+        }
     }
 }
 
@@ -402,59 +399,62 @@ mod tests {
         assert_eq!(format_threshold(3600), "1h");
     }
 
-    #[test]
-    fn stale_pin_check_with_fresh_file() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let name = SnapshotName::parse("20260322-1430-opptak").unwrap();
-        crate::chain::write_pin_file(dir.path(), "WD-18TB", &name).unwrap();
+    // ── orphan_checks (pure) ───────────────────────────────────────────
 
-        let mut checks = Vec::new();
-        let mut ok = 0;
-        let mut warn = 0;
-        let interval = Interval::hours(4);
-        collect_stale_pin_check(
-            dir.path(),
-            "WD-18TB",
-            &interval,
-            &mut checks,
-            &mut ok,
-            &mut warn,
-        );
-        assert_eq!(ok, 1);
-        assert_eq!(warn, 0);
+    fn snap(s: &str) -> SnapshotName {
+        SnapshotName::parse(s).unwrap()
+    }
+
+    #[test]
+    fn orphan_checks_none_when_pin_is_newest() {
+        let pin = snap("20260322-1430-opptak");
+        let external = vec![snap("20260321-1430-opptak"), snap("20260322-1430-opptak")];
+        let checks = orphan_checks(&pin, &external);
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].status, "ok");
     }
 
     #[test]
-    fn stale_pin_warns_with_neutral_message() {
-        let dir = tempfile::TempDir::new().unwrap();
-        let name = SnapshotName::parse("20260322-1430-opptak").unwrap();
-        crate::chain::write_pin_file(dir.path(), "WD-18TB", &name).unwrap();
+    fn orphan_checks_one_warn_per_newer_snapshot() {
+        let pin = snap("20260320-0000-opptak");
+        let external = vec![
+            snap("20260320-0000-opptak"),
+            snap("20260321-0000-opptak"),
+            snap("20260322-0000-opptak"),
+        ];
+        let checks = orphan_checks(&pin, &external);
+        assert_eq!(checks.len(), 2, "two snapshots are newer than the pin");
+        assert!(checks.iter().all(|c| c.status == "warn"));
+        assert!(checks[0].detail.as_ref().unwrap().contains("Orphaned snapshot"));
+    }
 
-        // Backdate the pin file to 3 days ago
-        let pin_path = dir.path().join(".last-external-parent-WD-18TB");
-        let three_days_ago = std::time::SystemTime::now()
-            - std::time::Duration::from_secs(3 * 86400);
-        filetime::set_file_mtime(
-            &pin_path,
-            filetime::FileTime::from_system_time(three_days_ago),
-        )
-        .unwrap();
+    #[test]
+    fn orphan_checks_empty_external_is_ok() {
+        let pin = snap("20260322-1430-opptak");
+        let checks = orphan_checks(&pin, &[]);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, "ok");
+    }
 
-        let mut checks = Vec::new();
-        let mut ok = 0;
-        let mut warn = 0;
-        let interval = Interval::hours(4); // threshold = max(2*4h, 1d) = 1d, pin is 3d old
-        collect_stale_pin_check(
-            dir.path(),
-            "WD-18TB",
-            &interval,
-            &mut checks,
-            &mut ok,
-            &mut warn,
-        );
-        assert_eq!(warn, 1);
+    // ── stale_pin_checks (pure) ────────────────────────────────────────
+
+    #[test]
+    fn stale_pin_ok_at_threshold_boundary() {
+        // age == threshold → ok (the check warns only when age > threshold).
+        let interval = Interval::hours(4); // threshold = max(2*4h, 1d) = 1d
+        let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(10 * 86400);
+        let mtime = now - std::time::Duration::from_secs(86400);
+        let checks = stale_pin_checks(mtime, &interval, now);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, "ok");
+    }
+
+    #[test]
+    fn stale_pin_warns_one_second_past_threshold_with_neutral_message() {
+        let interval = Interval::hours(4); // threshold = 1d
+        let now = SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(10 * 86400);
+        let mtime = now - std::time::Duration::from_secs(86400 + 1);
+        let checks = stale_pin_checks(mtime, &interval, now);
         assert_eq!(checks.len(), 1);
         assert_eq!(checks[0].status, "warn");
         let detail = checks[0].detail.as_ref().unwrap();
@@ -466,5 +466,18 @@ mod tests {
             !detail.contains("sends may be failing"),
             "should not use accusatory message, got: {detail}"
         );
+    }
+
+    #[test]
+    fn tally_counts_ok_and_warn() {
+        let checks = vec![
+            VerifyCheck { name: "a".into(), status: "ok".into(), detail: None, suggestion: None },
+            VerifyCheck { name: "b".into(), status: "warn".into(), detail: None, suggestion: None },
+            VerifyCheck { name: "c".into(), status: "warn".into(), detail: None, suggestion: None },
+            VerifyCheck { name: "d".into(), status: "fail".into(), detail: None, suggestion: None },
+        ];
+        let (mut ok, mut warn) = (0, 0);
+        tally(&checks, &mut ok, &mut warn);
+        assert_eq!((ok, warn), (1, 2));
     }
 }


### PR DESCRIPTION
## Summary

Tidy-grade cleanup surfaced in the 2026-06-06 architecture-deepening review. `verify`'s two check-collecting helpers threaded `&mut Vec<VerifyCheck>` plus two `&mut u32` running totals, interleaving the *decision* (what counts as an orphan; when a pin is stale) with I/O and out-parameter mutation — so the decision couldn't be unit-tested without a `MockFileSystemState` and a tempfile.

## Change

Split each helper into a **pure check factory** that returns `Vec<VerifyCheck>`:

- `orphan_checks(pin, external)` — takes already-fetched external snapshots.
- `stale_pin_checks(pin_mtime, send_interval, now)` — takes the pin mtime + now.

The I/O moves to the call site (`external_snapshots` fetch; a small `pin_file_mtime` reader), and totals are folded from the returned checks via a `tally` helper — the `&mut u32` out-params are gone.

**Behaviour-preserving:** identical `VerifyCheck` names/statuses/details and identical totals. No change to `urd verify` output. No on-disk/contract change.

## Tests

- The decisions are now unit-tested with synthetic inputs, **no filesystem/mocks**: orphan none/some/empty; stale-pin at-threshold (ok) vs one-second-past (warn) with the neutral message; `tally` counting.
- The old tempfile + `filetime`-backdating tests are replaced by these pure ones. `filetime` was their only user, so it's dropped from dev-dependencies.

`cargo test` + `cargo clippy --all-targets -- -D warnings` clean (1818 tests).

Suggested tier per the issue: Patch (`/tidy`). `src/commands/verify.rs` + a dev-dep removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)