### PR TITLE
release: v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-06-29
+
 ### Added
 - **`urd doctor --thorough` now warns about orphan pin files** (#125). A pin file
   whose drive label is not in `[[drives]]` — e.g. left behind when a drive is
@@ -1254,7 +1256,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.27.1...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/vonrobak/urd/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/vonrobak/urd/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/vonrobak/urd/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/vonrobak/urd/compare/v0.25.2...v0.26.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.27.1"
+version = "0.28.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.28.0** — *retention integrity and an honest voice*. One feature and six fixes from the #133→#180 batch (PRs #221–230).

**Added**
- `urd doctor --thorough` now warns about **orphan pin files** (#125) — pin files for drives no longer in `[[drives]]` that silently anchor local retention. Doctor JSON schema → **v3** (optional `retention_checks`, absent when empty).

**Fixed**
- Legacy unlabeled pin no longer over-retains when every drive has a specific pin (#133)
- Backup no longer prints contradictory "thread mended" + "first thread established" (#211)
- Bare `urd` no longer recommends reconnecting a just-rotated offsite drive (#120)
- Tight-pool reassurance line no longer lies for local-only subvolumes; honest cadence rendering (#195)
- Send-size estimate no longer inherits a failed/aborted send's partial bytes — also closes a do-no-harm fit-gate gap (#210)
- Interrupted runs are reaped instead of lingering as zombie `running` records (#213)

Also internal (not changelogged): the `--subvolume` validation integration test (#136) and two tidy refactors (#175, #180).

The one contract change is the doctor JSON schema bump (v2 → v3); no on-disk, metric, or heartbeat contract changed.

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: 1838 passed, 0 failed (4 ignored)
- `cargo build --release`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)