### PR TITLE
fix: pluralize plan summary, unify bare-`urd` "All sealed.", trim table whitespace

### DIFF
--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -171,7 +171,9 @@ fn format_status_table(
         .enumerate()
         .map(|(i, h)| format!("{:<width$}", h, width = widths[i]))
         .collect();
-    writeln!(out, "{}", header_line.join("  ").bold()).ok();
+    // Trim the last column's padding — trailing whitespace aligns nothing.
+    let header_str = header_line.join("  ");
+    writeln!(out, "{}", header_str.trim_end().bold()).ok();
 
     // Rows — color SAFETY and HEALTH columns
     for row in rows {
@@ -194,7 +196,8 @@ fn format_status_table(
                 }
             })
             .collect();
-        writeln!(out, "{}", line.join("  ")).ok();
+        let row_str = line.join("  ");
+        writeln!(out, "{}", row_str.trim_end()).ok();
     }
 }
 
@@ -297,7 +300,9 @@ pub(super) fn format_history_table(headers: &[String], rows: &[Vec<String>], out
         .enumerate()
         .map(|(i, h)| format!("{:<width$}", h, width = widths[i]))
         .collect();
-    writeln!(out, "{}", header_line.join("  ").bold()).ok();
+    // Trim the last column's padding — trailing whitespace aligns nothing.
+    let header_str = header_line.join("  ");
+    writeln!(out, "{}", header_str.trim_end().bold()).ok();
 
     // Rows — color the RESULT column
     let result_col = headers.iter().position(|h| h == "RESULT");
@@ -317,7 +322,8 @@ pub(super) fn format_history_table(headers: &[String], rows: &[Vec<String>], out
                 }
             })
             .collect();
-        writeln!(out, "{}", line.join("  ")).ok();
+        let row_str = line.join("  ");
+        writeln!(out, "{}", row_str.trim_end()).ok();
     }
 }
 
@@ -1122,7 +1128,7 @@ mod tests {
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(output.contains("htpc-home"), "missing subvolume name");
         assert!(output.contains("WD-18TB"), "missing drive label");
-        assert!(output.contains("1 snapshots"), "missing summary");
+        assert!(output.contains("1 snapshot,"), "missing summary");
     }
 
     #[test]
@@ -1733,7 +1739,7 @@ mod tests {
         };
         let output = render_plan(&data, OutputMode::Interactive);
         assert!(
-            output.contains("1 sends,"),
+            output.contains("1 send,"),
             "no estimates should just show count: {output}"
         );
         assert!(

--- a/src/voice/plan.rs
+++ b/src/voice/plan.rs
@@ -16,7 +16,7 @@ use crate::output::{
 use crate::plan::format_duration_short;
 use crate::types::ByteSize;
 
-use super::{SuggestionContext, append_suggestion, skip_tag};
+use super::{SuggestionContext, append_suggestion, pluralize, skip_tag};
 
 /// Render an explanation for why a manual backup produced an empty plan.
 #[must_use]
@@ -127,28 +127,32 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
             .filter(|op| op.operation == "send" && op.estimated_bytes.is_some())
             .count();
         if sends_with_estimates == data.summary.sends {
-            format!("{} sends (~{} total)", data.summary.sends, ByteSize(total))
+            format!(
+                "{} (~{} total)",
+                pluralize(data.summary.sends, "send", "sends"),
+                ByteSize(total)
+            )
         } else {
             format!(
-                "{} sends (~{} estimated for {} of {})",
-                data.summary.sends,
+                "{} (~{} estimated for {} of {})",
+                pluralize(data.summary.sends, "send", "sends"),
                 ByteSize(total),
                 sends_with_estimates,
                 data.summary.sends
             )
         }
     } else {
-        format!("{} sends", data.summary.sends)
+        pluralize(data.summary.sends, "send", "sends")
     };
 
     writeln!(
         out,
         "{}",
         format!(
-            "Summary: {}, {} snapshots, {} deletions, {} skipped",
+            "Summary: {}, {}, {}, {} skipped",
             sends_str,
-            data.summary.snapshots,
-            data.summary.deletions,
+            pluralize(data.summary.snapshots, "snapshot", "snapshots"),
+            pluralize(data.summary.deletions, "deletion", "deletions"),
             data.summary.skipped
         )
         .bold()

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -589,7 +589,7 @@ fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
 
     // Safety line
     if data.sealed_count() == data.total {
-        write!(out, "{}", "All connected drives are sealed.".green()).ok();
+        write!(out, "{}", "All sealed.".green()).ok();
     } else {
         write!(out, "{} of {} sealed.", data.sealed_count(), data.total).ok();
         if !data.exposed_names.is_empty() {
@@ -1555,7 +1555,7 @@ mod tests {
     fn default_all_sealed() {
         let _color = color_guard(false);
         let output = render_default_status(&test_default_status_output(), OutputMode::Interactive);
-        assert!(output.contains("All connected drives are sealed."), "missing sealed message in: {output}");
+        assert!(output.contains("All sealed."), "missing sealed message in: {output}");
         assert!(
             output.contains("urd status"),
             "missing hint to run urd status: {output}"


### PR DESCRIPTION
Three mechanical voice fixes from the 2026-06-29 Steve product review of the v0.28.0 first-nightly-run CLI experience (review report kept local in `docs/99-reports/`, which is gitignored).

## What changed

1. **`urd plan` summary pluralization** — the summary line read `Summary: 1 sends, 1 snapshots, 1 deletions, …`. It now reads `1 send, 1 snapshot, 1 deletion`, routing the count nouns through the existing `pluralize` helper. (`skipped` does not inflect, left as-is.)

2. **bare `urd` says `All sealed.`** — previously `All connected drives are sealed.`, which `urd status` already phrases as `All sealed.`. The old line was the wrong altitude: `sealed` is a *subvolume*’s exposure state (and `sealed_count`/`total` count subvolumes, not drives), and the `connected` hedge invited worry about the deliberately-away drive on the tool’s most-run glance.

3. **Tables trim trailing whitespace** — the last column was left-padded to its width, leaving trailing spaces on every row. Fixed symmetrically in both `format_status_table` (`urd status`) and `format_history_table` (`urd history`), per CLAUDE.md’s "symmetric fixes need symmetric reviews".

## Deferred (not in this PR)

The design-level findings from the same review — silence the all-sealed `NOTE` stutter, make the `EXPOSURE` column conditional, and reshape the `plan` skip section to facts-not-rows — are the substance of the already-queued **voice arc (#196 / #212)**, per `status.md` Next Up #2. This PR is only the unambiguous mechanical subset.

## Verification

- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` — 1838 passed, 0 failed (4 ignored). Two voice tests that asserted the old plural forms (`1 sends,` / `1 snapshots`) were updated to the corrected singular.

🤖 Generated with [Claude Code](https://claude.com/claude-code)