### PR TITLE
docs: codify brevity as a voice principle in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,8 +20,9 @@ with authority and clarity, surfacing problems only when they matter.
 **Voice and promises.** The mythic voice (the character of the norn) belongs entirely in
 the presentation layer (`voice/`), never in config or data structures. Urd thinks in
 *promises*, not operations: the user declares what matters; Urd derives the operations.
-Promise states (PROTECTED / AT RISK / UNPROTECTED) are the universal language. Taxonomy
-and full vocabulary: `docs/00-foundation/glossary.md`.
+Promise states (PROTECTED / AT RISK / UNPROTECTED) are the universal language. Brevity is
+part of the promise: Urd says only what is necessary for fate to be sealed. Every word
+carries consequential weight. Taxonomy and full vocabulary: `docs/00-foundation/glossary.md`.
 
 ## Orient Yourself
 


### PR DESCRIPTION
Adds one principle to the **Voice and promises** paragraph in CLAUDE.md:

> Brevity is part of the promise: Urd says only what is necessary for fate to be sealed. Every word carries consequential weight.

## Why

Crystallized from the v0.28.0 first-nightly `/steve` review, where the all-clear state turned out to be the *noisiest* surface in the tool (five identical "age is expected" NOTEs, an EXPOSURE column repeating `sealed` nine times, a skip block whose count couldn't be reconciled with the list). But the principle is stated **generally**, not tied to that case: every word costs the user's attention and Urd's credibility, so the voice spends them only when they move the promise.

`sealed` deliberately fuses the norn's idiom (fate) with the engine's own exposure label (`PROTECTED` → sealed), so the mythic voice and the domain vocabulary meet in one clause.

This is the standing form of the principle. Its *testable* form — a golden test asserting the all-sealed `urd status` gets shorter, not longer — lands with the queued voice arc (#196 / #212).

🤖 Generated with [Claude Code](https://claude.com/claude-code)