### PR TITLE
refactor: hygiene cuts from the repo-wide ponytail audit (findings 5-10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Internal hygiene sweep from the 2026-07-01 repo-wide over-engineering audit**
+  (findings 5–10): the two heartbeat builders merged into one `heartbeat::build`
+  taking an optional run result; the `NamedSnapshot` trait replaced by plain
+  closure-parameterized change detection; a dead SQLite reader
+  (`run_operations`) deleted; stale `#[allow(dead_code)]` attributes stripped so
+  the dead-code lint regains its value (which surfaced and removed two dead
+  `DriveConnectionRecord` fields); duplicate string-truncation helpers unified.
+  No user-visible behavior change except truncated cells in `urd events` now use
+  `...` (matching every other table) instead of `…`.
+
 ## [0.28.0] - 2026-06-29
 
 ### Added

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -499,7 +499,7 @@ pub struct DriveAssessment {
 ///
 /// Pure function. Empty `previous` returns an empty Vec (suppresses
 /// noise on first run, matching the precedent in
-/// `sentinel::has_changes`). Subvolumes present in `previous` but
+/// `sentinel::has_promise_changes`). Subvolumes present in `previous` but
 /// missing from `current` are silent (deletion is not a transition we
 /// log). Subvolumes new in `current` (not in `previous`) are also
 /// silent — appearance is not a transition either.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -157,7 +157,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         // Empty plan: no operations to execute. This includes plans where all subvolumes
         // were skipped (drives disconnected, space guard, etc.). Previously this case fell
         // through to the executor which ran zero operations and reported run_result "success".
-        // Now it uses build_empty() with run_result "empty" — more accurate for monitoring.
+        // Now it uses heartbeat::build with no result — run_result "empty" is more accurate for monitoring.
         if !args.auto && !backup_plan.skipped.is_empty() {
             let explanation = build_empty_plan_explanation(&backup_plan, &filters);
             print!("{}", crate::voice::render_empty_plan(&explanation));
@@ -184,9 +184,10 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         // have freed space, desyncing this heartbeat from the plan's tier).
         let assessments =
             advice::assess_view(&config, heartbeat_now, &observation, &signals.by_subvol);
-        let hb = heartbeat::build_empty(
+        let hb = heartbeat::build(
             &config,
             heartbeat_now,
+            None,
             &assessments,
             &churn_views,
             observability.pools_heartbeat,
@@ -562,10 +563,10 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // surfaces escalation transitions for the notification path (D6).
     let assessments =
         advice::assess_view(&config, heartbeat_now, &observation, &signals.by_subvol);
-    let hb = heartbeat::build_from_run(
+    let hb = heartbeat::build(
         &config,
         heartbeat_now,
-        &result,
+        Some(&result),
         &assessments,
         &churn_views,
         observability.pools_heartbeat,
@@ -1544,7 +1545,7 @@ fn build_churn_views(
 /// UPI 043: bundled outputs from a single pool-observability pass. Threaded
 /// into both metrics emission (`write_metrics_after_execution` /
 /// `write_metrics_for_skipped`) and heartbeat construction
-/// (`heartbeat::build_from_run` / `heartbeat::build_empty`).
+/// (`heartbeat::build`).
 struct PoolObservability {
     pools_heartbeat: Vec<PoolHeartbeat>,
     drives_heartbeat: Vec<DriveHeartbeat>,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -280,7 +280,6 @@ struct SubvolumeContext {
 }
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct ExecutionResult {
     pub overall: RunResult,
     pub subvolume_results: Vec<SubvolumeResult>,

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -126,24 +126,24 @@ pub struct SubvolumeHeartbeat {
 
 // ── Builder ─────────────────────────────────────────────────────────────
 
-/// Build a heartbeat from a completed backup run with awareness assessments.
+/// Build a heartbeat with awareness assessments. `result` is the completed
+/// backup run, or `None` for an empty/skipped run (`run_result: "empty"`).
 ///
 /// If a future addition pushes this past 8 args, refactor to a
 /// `HeartbeatInputs { ... }` struct instead of growing the positional list.
 #[must_use]
 #[allow(clippy::too_many_arguments)]
-pub fn build_from_run(
+pub fn build(
     config: &Config,
     now: NaiveDateTime,
-    result: &ExecutionResult,
+    result: Option<&ExecutionResult>,
     assessments: &[SubvolAssessment],
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
     pools: Vec<PoolHeartbeat>,
     drives: Vec<DriveHeartbeat>,
     subvol_extras: &HashMap<String, SubvolumeExtras>,
 ) -> Heartbeat {
-    let subvolumes =
-        build_subvolume_entries(Some(result), assessments, churn_views, subvol_extras);
+    let subvolumes = build_subvolume_entries(result, assessments, churn_views, subvol_extras);
 
     Heartbeat {
         schema_version: SCHEMA_VERSION,
@@ -151,40 +151,9 @@ pub fn build_from_run(
         stale_after: compute_stale_after(config, now)
             .format("%Y-%m-%dT%H:%M:%S")
             .to_string(),
-        run_result: result.overall.as_str().to_string(),
-        run_id: result.run_id,
-        subvolumes,
-        notifications_dispatched: false,
-        pools,
-        drives,
-    }
-}
-
-/// Build a heartbeat for an empty/skipped run (no execution result).
-///
-/// If a future addition pushes this past 8 args, refactor to a
-/// `HeartbeatInputs { ... }` struct instead of growing the positional list.
-#[must_use]
-#[allow(clippy::too_many_arguments)]
-pub fn build_empty(
-    config: &Config,
-    now: NaiveDateTime,
-    assessments: &[SubvolAssessment],
-    churn_views: &HashMap<String, ChurnHeartbeatFields>,
-    pools: Vec<PoolHeartbeat>,
-    drives: Vec<DriveHeartbeat>,
-    subvol_extras: &HashMap<String, SubvolumeExtras>,
-) -> Heartbeat {
-    let subvolumes = build_subvolume_entries(None, assessments, churn_views, subvol_extras);
-
-    Heartbeat {
-        schema_version: SCHEMA_VERSION,
-        timestamp: now.format("%Y-%m-%dT%H:%M:%S").to_string(),
-        stale_after: compute_stale_after(config, now)
-            .format("%Y-%m-%dT%H:%M:%S")
-            .to_string(),
-        run_result: "empty".to_string(),
-        run_id: None,
+        run_result: result
+            .map_or_else(|| "empty".to_string(), |r| r.overall.as_str().to_string()),
+        run_id: result.and_then(|r| r.run_id),
         subvolumes,
         notifications_dispatched: false,
         pools,
@@ -478,10 +447,10 @@ mod tests {
         let assessments = test_assessments();
         let result = test_execution_result();
 
-        let heartbeat = build_from_run(
+        let heartbeat = build(
             &config,
             now,
-            &result,
+            Some(&result),
             &assessments,
             &HashMap::new(),
             Vec::new(),
@@ -531,10 +500,10 @@ mod tests {
         });
         let result = test_execution_result();
 
-        let heartbeat = build_from_run(
+        let heartbeat = build(
             &config,
             now,
-            &result,
+            Some(&result),
             &assessments,
             &HashMap::new(),
             Vec::new(),
@@ -583,9 +552,10 @@ mod tests {
             NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let assessments = test_assessments();
 
-        let heartbeat = build_empty(
+        let heartbeat = build(
             &config,
             now,
+            None,
             &assessments,
             &HashMap::new(),
             Vec::new(),
@@ -616,9 +586,10 @@ mod tests {
             NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
         let assessments = test_assessments();
 
-        let heartbeat = build_empty(
+        let heartbeat = build(
             &config,
             now,
+            None,
             &assessments,
             &HashMap::new(),
             Vec::new(),
@@ -643,9 +614,10 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-03-24T02:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let heartbeat = build_empty(
+        let heartbeat = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             Vec::new(),
@@ -664,9 +636,10 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let heartbeat = build_empty(
+        let heartbeat = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             Vec::new(),
@@ -693,9 +666,10 @@ mod tests {
             },
         );
 
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &churn,
             Vec::new(),
@@ -724,9 +698,10 @@ mod tests {
             },
         );
 
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &churn,
             Vec::new(),
@@ -771,9 +746,10 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             Vec::new(),
@@ -792,9 +768,10 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-04-30T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             Vec::new(),
@@ -885,10 +862,10 @@ mod tests {
             run_id: Some(1),
         };
 
-        let hb = build_from_run(
+        let hb = build(
             &config,
             now,
-            &result,
+            Some(&result),
             &assessments,
             &HashMap::new(),
             Vec::new(),
@@ -923,10 +900,10 @@ mod tests {
             run_id: Some(1),
         };
 
-        let hb = build_from_run(
+        let hb = build(
             &config,
             now,
-            &result,
+            Some(&result),
             &assessments,
             &HashMap::new(),
             Vec::new(),
@@ -961,10 +938,10 @@ mod tests {
             run_id: Some(1),
         };
 
-        let hb = build_from_run(
+        let hb = build(
             &config,
             now,
-            &result,
+            Some(&result),
             &assessments,
             &HashMap::new(),
             Vec::new(),
@@ -1058,9 +1035,10 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-05-15T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             Vec::new(),
@@ -1086,9 +1064,10 @@ mod tests {
             free_bytes: Some(42),
             metadata_utilization_ratio: Some(0.5),
         }];
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             pools,
@@ -1110,9 +1089,10 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-05-15T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             Vec::new(),
@@ -1137,9 +1117,10 @@ mod tests {
                 estimated_local_pinned_delta_bytes: Some(1_000_000),
             },
         );
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             Vec::new(),
@@ -1166,9 +1147,10 @@ mod tests {
             mounted: true,
             pool_uuid: Some("uuid-x".to_string()),
         }];
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             Vec::new(),
@@ -1195,9 +1177,10 @@ mod tests {
         let config = test_config(&[("home", "1h")]);
         let now =
             NaiveDateTime::parse_from_str("2026-05-15T03:00:00", "%Y-%m-%dT%H:%M:%S").unwrap();
-        let hb = build_empty(
+        let hb = build(
             &config,
             now,
+            None,
             &test_assessments(),
             &HashMap::new(),
             Vec::new(),

--- a/src/output.rs
+++ b/src/output.rs
@@ -682,7 +682,7 @@ pub fn render_churn(estimate: &crate::drift::ChurnEstimate) -> ChurnRender {
 
 /// Heartbeat / metrics projection of a single subvolume's churn state.
 /// `commands/backup.rs` builds a `HashMap<String, ChurnHeartbeatFields>` and
-/// passes it to both `heartbeat::build_from_run` and
+/// passes it to both `heartbeat::build` and
 /// `metrics::write_metrics_after_execution` so both surfaces share the same
 /// policy: incremental → `churn_bytes_per_second`; full-only →
 /// `last_full_send_bytes`. Cold-start subvolumes have both `None`.
@@ -696,7 +696,7 @@ pub struct ChurnHeartbeatFields {
 }
 
 /// Per-subvolume "extras" populated by `gather_pool_observability` and threaded
-/// to both `heartbeat::build_from_run` and `metrics::write_metrics_after_execution`
+/// to both `heartbeat::build` and `metrics::write_metrics_after_execution`
 /// so both surfaces share the same `pool_uuid`, `local_snapshot_count`, and
 /// `estimated_local_pinned_delta_bytes` values for a given run (UPI 043).
 #[derive(Debug, Clone, Default)]

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -1317,7 +1317,10 @@ fn plan_external_send(
     } else if !is_incremental {
         // Tier 3: Calibrated size from `urd calibrate` (only for full sends)
         if let Some((cal_bytes, measured_at)) = obs.history.calibrated_size(&subvol.name) {
-            let age_days = calibration_age_days(&measured_at);
+            let now_ts = chrono::Local::now().naive_local();
+            let age_days = chrono::NaiveDateTime::parse_from_str(&measured_at, "%Y-%m-%dT%H:%M:%S")
+                .map(|ts| (now_ts - ts).num_days())
+                .unwrap_or(365); // corrupt timestamp → treat as stale, not fresh
             let staleness = if age_days > 30 {
                 format!(
                     " (calibrated {} days ago — run `urd calibrate` to refresh)",
@@ -1495,13 +1498,6 @@ fn exceeds_available_space(
     } else {
         None
     }
-}
-
-fn calibration_age_days(measured_at: &str) -> i64 {
-    let now = chrono::Local::now().naive_local();
-    chrono::NaiveDateTime::parse_from_str(measured_at, "%Y-%m-%dT%H:%M:%S")
-        .map(|ts| (now - ts).num_days())
-        .unwrap_or(365) // corrupt timestamp → treat as stale, not fresh
 }
 
 // ── RealFileSystemState ─────────────────────────────────────────────────

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -563,55 +563,33 @@ pub fn evaluate_trigger_result(
 
 // ── Snapshot change detection ──────────────────────────────────────────
 
-/// Trait for snapshot types that can be compared against assessments.
-/// Enables generic change detection across promise and health axes.
-pub trait NamedSnapshot {
-    fn name(&self) -> &str;
-    fn changed(&self, assessment: &SubvolAssessment) -> bool;
-}
-
-impl NamedSnapshot for PromiseSnapshot {
-    fn name(&self) -> &str {
-        &self.name
-    }
-    fn changed(&self, assessment: &SubvolAssessment) -> bool {
-        self.status != assessment.status
-    }
-}
-
-impl NamedSnapshot for HealthSnapshot {
-    fn name(&self) -> &str {
-        &self.name
-    }
-    fn changed(&self, assessment: &SubvolAssessment) -> bool {
-        self.health != assessment.health
-    }
-}
-
 /// Determine whether snapshot state transitions warrant notifications.
-/// Returns true if any subvolume's tracked state changed, appeared, or disappeared.
+/// Returns true if any subvolume's tracked state changed, appeared, or
+/// disappeared. `name` and `changed` project the per-axis snapshot type
+/// (promise status / health).
 ///
 /// Special case: when `previous` is empty (first assessment after startup),
 /// returns false to suppress spurious notifications (review item M3).
-#[must_use]
-pub fn has_changes<T: NamedSnapshot>(
+fn has_changes<T>(
     previous: &[T],
     current: &[SubvolAssessment],
+    name: impl Fn(&T) -> &str,
+    changed: impl Fn(&T, &SubvolAssessment) -> bool,
 ) -> bool {
     if previous.is_empty() {
         return false;
     }
 
     for assess in current {
-        match previous.iter().find(|p| p.name() == assess.name) {
-            Some(prev) if prev.changed(assess) => return true,
+        match previous.iter().find(|p| name(p) == assess.name) {
+            Some(prev) if changed(prev, assess) => return true,
             None => return true,
             _ => {}
         }
     }
 
     for prev in previous {
-        if !current.iter().any(|a| a.name == prev.name()) {
+        if !current.iter().any(|a| a.name == name(prev)) {
             return true;
         }
     }
@@ -619,22 +597,22 @@ pub fn has_changes<T: NamedSnapshot>(
     false
 }
 
-/// Convenience alias: detect promise state changes.
+/// Detect promise state changes.
 #[must_use]
 pub fn has_promise_changes(
     previous: &[PromiseSnapshot],
     current: &[SubvolAssessment],
 ) -> bool {
-    has_changes(previous, current)
+    has_changes(previous, current, |p| &p.name, |p, a| p.status != a.status)
 }
 
-/// Convenience alias: detect health state changes.
+/// Detect health state changes.
 #[must_use]
 pub fn has_health_changes(
     previous: &[HealthSnapshot],
     current: &[SubvolAssessment],
 ) -> bool {
-    has_changes(previous, current)
+    has_changes(previous, current, |p| &p.name, |p, a| p.health != a.health)
 }
 
 /// Should this assess record promise-transition events? (UPI 063)

--- a/src/state.rs
+++ b/src/state.rs
@@ -66,12 +66,12 @@ impl DriveEventSource {
 
 /// A drive connection event returned from database queries.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct DriveConnectionRecord {
-    pub id: i64,
-    pub drive_label: String,
     pub event_type: String,
     pub timestamp: String,
+    /// Read only by migration tests — verifies the legacy projection
+    /// preserves sentinel/backup attribution (UPI 036).
+    #[allow(dead_code)]
     pub detected_by: String,
 }
 
@@ -489,25 +489,6 @@ impl StateDb {
             .map_err(|e| UrdError::State(format!("failed to read runs: {e}")))
     }
 
-    /// Get all operations for a specific run.
-    #[allow(dead_code)]
-    pub fn run_operations(&self, run_id: i64) -> crate::error::Result<Vec<OperationRow>> {
-        let mut stmt = self
-            .conn
-            .prepare(
-                "SELECT id, run_id, subvolume, operation, drive_label, duration_secs, result, error_message, bytes_transferred
-                 FROM operations WHERE run_id = ?1 ORDER BY id",
-            )
-            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
-
-        let rows = stmt
-            .query_map([run_id], Self::map_operation_row)
-            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
-
-        rows.collect::<Result<Vec<_>, _>>()
-            .map_err(|e| UrdError::State(format!("failed to read operations: {e}")))
-    }
-
     /// Get recent operations for a specific subvolume.
     pub fn subvolume_history(
         &self,
@@ -617,7 +598,6 @@ impl StateDb {
 
     /// Get the timestamp of the most recent successful send (full or incremental)
     /// for a subvolume to a specific drive. Returns the run's started_at timestamp.
-    #[allow(dead_code)]
     pub fn last_successful_send_time(
         &self,
         subvol: &str,
@@ -981,8 +961,6 @@ impl StateDb {
                     }
                 };
                 Ok(Some(DriveConnectionRecord {
-                    id,
-                    drive_label: drive_label.to_string(),
                     event_type,
                     timestamp,
                     detected_by,
@@ -1050,8 +1028,6 @@ impl StateDb {
                 }
             };
             records.push(DriveConnectionRecord {
-                id,
-                drive_label: drive_label.to_string(),
                 event_type,
                 timestamp,
                 detected_by,
@@ -1403,7 +1379,6 @@ impl StateDb {
     }
 
     /// Query events with optional filters, newest first.
-    #[allow(dead_code)]
     pub fn query_events(
         &self,
         filter: &EventQueryFilter,
@@ -1479,7 +1454,6 @@ impl StateDb {
     // ── Counter helpers for Prometheus metrics ──────────────────────
 
     /// Total number of `SentinelCircuitBreak` events whose `to` is `open`.
-    #[allow(dead_code)]
     pub fn count_circuit_breaker_trips(&self) -> crate::error::Result<u64> {
         let n: i64 = self
             .conn
@@ -1496,7 +1470,6 @@ impl StateDb {
     }
 
     /// `PlannerSendChoice` counts grouped by `reason` (full-send reason).
-    #[allow(dead_code)]
     pub fn count_full_sends_by_reason(
         &self,
     ) -> crate::error::Result<Vec<(String, u64)>> {
@@ -1504,13 +1477,11 @@ impl StateDb {
     }
 
     /// `PlannerDefer` counts grouped by `scope`.
-    #[allow(dead_code)]
     pub fn count_defers_by_scope(&self) -> crate::error::Result<Vec<(String, u64)>> {
         self.count_grouped("planner", "PlannerDefer", "scope")
     }
 
     /// `RetentionPrune` counts grouped by `rule`.
-    #[allow(dead_code)]
     pub fn count_prunes_by_rule(&self) -> crate::error::Result<Vec<(String, u64)>> {
         self.count_grouped("retention", "RetentionPrune", "rule")
     }
@@ -1548,7 +1519,6 @@ impl StateDb {
 
 /// Filter parameters for `StateDb::query_events`.
 #[derive(Debug, Clone, Default)]
-#[allow(dead_code)]
 pub struct EventQueryFilter {
     pub since: Option<chrono::NaiveDateTime>,
     pub kind: Option<EventKind>,
@@ -1801,21 +1771,6 @@ mod tests {
 
         let one = db.recent_runs(1).unwrap();
         assert_eq!(one.len(), 1);
-    }
-
-    #[test]
-    fn run_operations_returns_ops_for_run() {
-        let db = StateDb::open_memory().unwrap();
-        let (r1, r2) = seed_db(&db);
-
-        let ops1 = db.run_operations(r1).unwrap();
-        assert_eq!(ops1.len(), 2);
-        assert_eq!(ops1[0].operation, "snapshot");
-        assert_eq!(ops1[1].operation, "send_incremental");
-
-        let ops2 = db.run_operations(r2).unwrap();
-        assert_eq!(ops2.len(), 1);
-        assert_eq!(ops2[0].result, "failure");
     }
 
     #[test]
@@ -2260,7 +2215,6 @@ mod tests {
             .unwrap();
 
         let record = db.last_drive_connection("WD-18TB").unwrap().unwrap();
-        assert_eq!(record.drive_label, "WD-18TB");
         assert_eq!(record.event_type, "mounted");
         assert_eq!(record.detected_by, "sentinel");
         assert!(!record.timestamp.is_empty());

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -330,8 +330,9 @@ pub(super) fn format_history_table(headers: &[String], rows: &[Vec<String>], out
 /// Truncate a string to a maximum visible length, appending an ellipsis when
 /// trimmed. Char-boundary-safe.
 ///
-/// `pub(super)` for sibling voice/* sub-modules (history.rs, verify.rs).
-pub(super) fn truncate_str(s: &str, max_len: usize) -> String {
+/// `pub(crate)` for the voice/* sub-modules (history.rs, verify.rs) and
+/// `voice_events.rs`.
+pub(crate) fn truncate_str(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         return s.to_string();
     }
@@ -753,6 +754,17 @@ mod tests {
         TransitionEvent, VerifyCheck, VerifyDrive,
         VerifyOutput, VerifySubvolume,
     };
+
+    // ── Table primitive tests ───────────────────────────────────────
+
+    #[test]
+    fn truncate_str_is_char_boundary_safe() {
+        // Multibyte char near the boundary must not panic.
+        let s = "café-café-café";
+        let _ = truncate_str(s, 6);
+        assert_eq!(truncate_str("short", 10), "short");
+        assert!(truncate_str("a-much-longer-string", 10).ends_with("..."));
+    }
 
     // ── Backup summary tests ────────────────────────────────────────
 

--- a/src/voice_events.rs
+++ b/src/voice_events.rs
@@ -12,6 +12,7 @@ use colored::Colorize;
 use crate::events::{EventPayload, Severity};
 use crate::output::{EventRow, EventsView};
 use crate::types::ByteSize;
+use crate::voice::truncate_str;
 
 /// Render the events view as a columnar listing for interactive use.
 #[must_use]
@@ -70,9 +71,9 @@ fn format_row(row: &EventRow) -> String {
     let painted = colorize_severity(&row.payload, &summary);
     format!(
         "{:<19}  {:<9}  {:<14}  {painted}",
-        truncate(&row.occurred_at, 19),
+        truncate_str(&row.occurred_at, 19),
         row.kind.as_str(),
-        truncate(&scope, 14),
+        truncate_str(&scope, 14),
     )
 }
 
@@ -243,18 +244,6 @@ fn trigger_phrase(trigger: crate::events::TransitionTrigger) -> &'static str {
         Tick => "tick",
         DriveMounted => "drive mounted",
         ConfigChanged => "config changed",
-    }
-}
-
-fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        let mut end = max.saturating_sub(1);
-        while !s.is_char_boundary(end) && end > 0 {
-            end -= 1;
-        }
-        format!("{}…", &s[..end])
     }
 }
 
@@ -573,14 +562,6 @@ mod tests {
             Some("planner")
         );
         assert!(parsed.get("payload").is_some());
-    }
-
-    #[test]
-    fn truncate_is_char_boundary_safe() {
-        let _color = setup();
-        // Multibyte char near the boundary should not panic.
-        let s = "café-café-café";
-        let _ = truncate(s, 6);
     }
 
     fn _unused_event() -> Event {


### PR DESCRIPTION
## Summary

- Applies the small end of the 2026-07-01 repo-wide ponytail-audit docket (findings 5–10, ~-100 net lines), one mechanical cut per finding.
- `heartbeat::build_from_run`/`build_empty` merged into one `build()` taking `Option<&ExecutionResult>`; `NamedSnapshot` trait replaced by a closure-parameterized private helper; dead `state::run_operations()` deleted.
- Stale `#[allow(dead_code)]` attributes stripped so the lint regains its value — which immediately surfaced two genuinely dead `DriveConnectionRecord` fields (`id`, `drive_label`), now deleted. `detected_by` keeps a field-level allow: only migration tests read it, and they verify the UPI-036 legacy projection preserves sentinel/backup attribution. Documented forward-hook allows (sentinel Session 4, rotation UPI 056, notify dispatch hooks) untouched.
- Duplicate truncation helpers unified on `voice::truncate_str`; the only user-visible change is `urd events` truncated cells now render `...` (matching every other table) instead of `…`.
- Two audit corrections found during verification: `stamp_context` has **two** callers (audit said one) — kept, not inlined; `DriveConnectionRecord`'s allow was **not** fully stale (see above).

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 1837 passed, 0 failed
- cargo build --release: pass
- Integration tests: not applicable (no btrfs-facing behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)