### PR TITLE
feat: dispatch EmergencyRetentionRan notification from the pre-flight path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Emergency retention now notifies when it runs.** The pre-backup emergency
+  pre-flight (critical space on a snapshot root) dispatches a Warning
+  notification per reclaimed root with the deletion count and the measured
+  freed space — emergency deletions are never silent. The freed size is
+  omitted (never guessed) when the post-delete free-space probe fails.
+
 ### Fixed
 - **History and verify tables no longer mis-align rows containing pre-colored
   cells.** The history-table formatter computed column widths from byte length,

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -2255,16 +2255,45 @@ fn run_emergency_preflight(
     if let Some(db) = state_db {
         db.record_events_best_effort(&outcome.emitted_events);
     }
+    // Told-not-silent: emergency deletions before a backup must never be
+    // silent. Best-effort — dispatch failure never blocks the run.
+    if !outcome.root_summaries.is_empty() {
+        let notes: Vec<notify::Notification> = outcome
+            .root_summaries
+            .iter()
+            .map(|s| {
+                notify::build_emergency_retention_notification(
+                    &s.root,
+                    s.freed_bytes,
+                    s.deleted_count,
+                )
+            })
+            .collect();
+        notify::dispatch(&notes, &config.notifications);
+    }
     Ok(outcome.any_deleted)
 }
 
 /// Structured outcome of an emergency-preflight pass. The injectable core
 /// ([`run_emergency_preflight_with`]) accumulates the prune events it would
 /// persist and returns them here instead of writing them, so the wrapper owns
-/// the SQLite write and the tests stay free of a `StateDb`.
+/// the SQLite write and notification dispatch, and the tests stay free of a
+/// `StateDb`.
 struct EmergencyPreflightOutcome {
     any_deleted: bool,
     emitted_events: Vec<crate::events::Event>,
+    /// One entry per root that had at least one successful emergency delete;
+    /// the wrapper turns these into `EmergencyRetentionRan` notifications.
+    root_summaries: Vec<EmergencyRootReclaim>,
+}
+
+/// Per-root reclaim summary from the emergency pre-flight. `freed_bytes` is
+/// the post-sync free-space delta, `None` when the re-probe failed (never
+/// report a made-up size).
+struct EmergencyRootReclaim {
+    root: String,
+    freed_bytes: Option<u64>,
+    deleted_count: usize,
 }
 
 /// Testable core of [`run_emergency_preflight`]: the free-space probe and the
@@ -2287,6 +2316,7 @@ fn run_emergency_preflight_with(
     let drive_labels = config.drive_labels();
     let mut any_deleted = false;
     let mut emitted_events: Vec<crate::events::Event> = Vec::new();
+    let mut root_summaries: Vec<EmergencyRootReclaim> = Vec::new();
 
     for root in &config.local_snapshots.roots {
         // Skip roots without min_free_bytes configured
@@ -2308,6 +2338,8 @@ fn run_emergency_preflight_with(
             crate::types::ByteSize(free),
             crate::types::ByteSize(min_free),
         );
+
+        let mut root_deleted: usize = 0;
 
         for subvol_name in &root.subvolumes {
             // Skip transient subvolumes — already delete aggressively
@@ -2365,6 +2397,7 @@ fn run_emergency_preflight_with(
                 match btrfs.delete_subvolume(&snap_path) {
                     Ok(()) => {
                         any_deleted = true;
+                        root_deleted += 1;
                         log::info!("Emergency: deleted {}", snap_path.display());
                         // Stamp the matching emitted event with the
                         // subvolume name and stash for persistence.
@@ -2403,6 +2436,17 @@ fn run_emergency_preflight_with(
                 root.path.display()
             );
         }
+
+        if root_deleted > 0 {
+            // Post-sync free-space delta; `free` is a real probe here (a
+            // failed initial probe reads as u64::MAX and skips the root).
+            let freed = free_bytes(&root.path).map(|after| after.saturating_sub(free));
+            root_summaries.push(EmergencyRootReclaim {
+                root: root.path.display().to_string(),
+                freed_bytes: freed,
+                deleted_count: root_deleted,
+            });
+        }
     }
 
     if any_deleted {
@@ -2412,6 +2456,7 @@ fn run_emergency_preflight_with(
     Ok(EmergencyPreflightOutcome {
         any_deleted,
         emitted_events,
+        root_summaries,
     })
 }
 
@@ -3157,6 +3202,31 @@ source = "/data/beta"
             "latest must survive"
         );
         assert!(out.any_deleted);
+    }
+
+    #[test]
+    fn emergency_reclaim_summary_carries_root_count_and_freed_delta() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let alpha = dir.path().join("alpha");
+        make_snap_dirs(&alpha, &THREE_SNAPS);
+        let config = emergency_config(dir.path());
+        let mock = crate::btrfs::MockBtrfs::new();
+
+        // First probe (criticality check) reads 400 MB; the post-delete
+        // re-probe reads 900 MB — a 500 MB freed delta.
+        let calls = std::cell::Cell::new(0u32);
+        let probe = |_: &std::path::Path| {
+            let n = calls.get();
+            calls.set(n + 1);
+            Some(if n == 0 { 400_000_000u64 } else { 900_000_000u64 })
+        };
+        let out = run_emergency_preflight_with(&config, pass_now(), &mock, probe).unwrap();
+
+        assert_eq!(out.root_summaries.len(), 1, "one root reclaimed");
+        let s = &out.root_summaries[0];
+        assert_eq!(s.deleted_count, 2, "two older snaps deleted");
+        assert_eq!(s.freed_bytes, Some(500_000_000));
+        assert_eq!(s.root, dir.path().display().to_string());
     }
 
     #[test]

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -87,10 +87,10 @@ pub enum NotificationEvent {
     },
     /// Emergency retention ran before a backup to recover critical space.
     /// Dispatched by the backup command's emergency pre-flight path.
-    #[allow(dead_code)] // Constructed by backup pre-flight, not yet wired to dispatch
+    /// `freed_bytes` is `None` when the post-delete free-space probe failed.
     EmergencyRetentionRan {
         root: String,
-        freed_bytes: u64,
+        freed_bytes: Option<u64>,
         deleted_count: usize,
     },
     /// A source pool's tightness tier escalated (UPI 031-a). Dispatched
@@ -577,14 +577,23 @@ pub fn build_drive_needs_adoption_notification(label: &str) -> Notification {
 }
 
 /// Build a notification for emergency retention that ran before a backup.
+/// `freed_bytes` is `None` when the post-delete free-space probe failed —
+/// the body then reports only the deletion count, never a made-up size.
 #[must_use]
-#[allow(dead_code)] // Will be wired to backup dispatch path
 pub fn build_emergency_retention_notification(
     root: &str,
-    freed_bytes: u64,
+    freed_bytes: Option<u64>,
     deleted_count: usize,
 ) -> Notification {
-    let freed = crate::types::ByteSize(freed_bytes);
+    let body = match freed_bytes {
+        Some(bytes) => format!(
+            "Freed {} from {root} by deleting {deleted_count} snapshots before backup.",
+            crate::types::ByteSize(bytes)
+        ),
+        None => format!(
+            "Deleted {deleted_count} snapshots from {root} to recover critical space before backup."
+        ),
+    };
     Notification {
         event: NotificationEvent::EmergencyRetentionRan {
             root: root.to_string(),
@@ -593,9 +602,7 @@ pub fn build_emergency_retention_notification(
         },
         urgency: Urgency::Warning,
         title: "Emergency retention ran".to_string(),
-        body: format!(
-            "Freed {freed} from {root} by deleting {deleted_count} snapshots before backup."
-        ),
+        body,
     }
 }
 
@@ -1334,9 +1341,10 @@ mod tests {
 
     #[test]
     fn emergency_retention_notification_format() {
-        let n = build_emergency_retention_notification("/snap/home", 8_200_000_000, 39);
+        let n = build_emergency_retention_notification("/snap/home", Some(8_200_000_000), 39);
         assert_eq!(n.urgency, Urgency::Warning);
         assert_eq!(n.title, "Emergency retention ran");
+        assert!(n.body.contains("Freed"), "body: {}", n.body);
         assert!(n.body.contains("39 snapshots"), "body: {}", n.body);
         assert!(n.body.contains("/snap/home"), "body: {}", n.body);
         assert!(
@@ -1350,6 +1358,17 @@ mod tests {
             "event: {:?}",
             n.event
         );
+    }
+
+    #[test]
+    fn emergency_retention_notification_unknown_freed_reports_count_only() {
+        let n = build_emergency_retention_notification("/snap/home", None, 3);
+        assert!(
+            !n.body.contains("Freed"),
+            "must not claim a freed size when the probe failed: {}",
+            n.body
+        );
+        assert!(n.body.contains("3 snapshots"), "body: {}", n.body);
     }
 
     // ── UPI 031-a: storage-pressure notifications ───────────────────


### PR DESCRIPTION
## Summary

- Audit finding 4, resolved per the wire-vs-delete decision: **wire it** (told-not-silent doctrine — emergency deletions before a backup must never be silent).
- The emergency pre-flight core now returns per-root reclaim summaries (deletion count + freed space measured as the post-sync free-probe delta); the wrapper dispatches one Warning notification per reclaimed root, best-effort.
- `freed_bytes` becomes `Option<u64>` — when the post-delete probe fails, the notification reports only the count instead of claiming a made-up size (the project's safe-fallback rule).
- Both `#[allow(dead_code)]` markers removed; new tests cover the summary math (count + delta) and the unknown-freed wording.

**Stacked on #236** — merge order: #234 → #235 → #236 → this.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 1834 passed, 0 failed
- cargo build --release: pass
- Integration tests: not applicable (mock-covered btrfs path; no live-drive behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)