### PR TITLE
release: v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] - 2026-07-02
+
 ### Added
 - **Emergency retention now notifies when it runs.** The pre-backup emergency
   pre-flight (critical space on a snapshot root) dispatches a Warning
@@ -20,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so a cell carrying ANSI color codes inflated its column and shifted every
   later column. Both table formatters now share one core that measures visible
   (ANSI-stripped) width.
+- **Voice polish from the v0.28.0 first-nightly review.** Plan-summary counts
+  pluralize correctly, bare `urd` says `All sealed.` consistently with
+  `urd status`, and status/history tables no longer carry trailing whitespace.
 
 ### Changed
 - **Interval-skip "next due" now flows structured from planner to renderer.**
@@ -1293,7 +1298,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.28.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.29.0...HEAD
+[0.29.0]: https://github.com/vonrobak/urd/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/vonrobak/urd/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/vonrobak/urd/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/vonrobak/urd/compare/v0.26.0...v0.27.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.29.0** — the 2026-07-01 repo-wide ponytail-audit follow-through. Headline: the `cleanup_budget` config knob is retired (UPI 068, #238) with an ADR-111 field-retirement amendment and `urd migrate` warn-and-drop. Also: emergency-retention notifications (#237), structured next-due minutes (#236), visible-width table formatting (#235), the hygiene sweep (#234), and post-v0.28.0 voice polish (#232).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1835 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)