### PR TITLE
docs: retire /sequence from the Full workflow tier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,7 @@ discoveries; skipping them should be the exception.
 - **Standard** (medium features, clear scope, no new modules):
   `/design → /grill-me → /prepare → arch-adversary → /post-review → build → /tidy → /check → /commit-push-pr → /session-close`
 - **Full** (new modules, architectural changes, ADR gates):
-  `/brainstorm → /design → /grill-me → [/sequence] → /prepare → arch-adversary → /post-review → build → /tidy → /check → /commit-push-pr → /session-close`
+  `/brainstorm → /design → /grill-me → /prepare → arch-adversary → /post-review → build → /tidy → /check → /commit-push-pr → /session-close`
 
 Available skills and their descriptions are injected into each session — invoke `/<name>`
 to use one. For a multi-UPI arc, run an arc-level `/grill-me` before per-UPI design so


### PR DESCRIPTION
## Summary

- Removes `[/sequence]` from the Full tier in CLAUDE.md's Development Workflow — the command is retired per finding F6 / Package Q of the 2026-07-02 skill ecosystem review (used ~3 times ever; UPI sequencing belongs to the user per lessons §8.6)
- Its one distinct idea (ADR-change-as-prerequisite-gate, surfaced in sequencing) was folded into `/design`'s architectural-gates step

## Testing

- cargo clippy: not applicable (docs-only)
- cargo test: not applicable (docs-only)
- PII scan of the diff: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)