### PR TITLE
release: v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-07-03
+
 ### Added
 - **The post-plan orphan invariant now guards every lifecycle.** The planner
   self-checks the finished plan: a planned snapshot whose send planning
@@ -1307,7 +1309,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.30.0...HEAD
+[0.30.0]: https://github.com/vonrobak/urd/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/vonrobak/urd/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/vonrobak/urd/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/vonrobak/urd/compare/v0.27.0...v0.27.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.30.0**. Contains the lifecycle-agnostic post-plan orphan invariant (UPI 069, #241): a structured nothing-new-to-send marker on planner defers, a pure post-plan self-check that turns the 2026-05-02 stranded-snapshots contradiction into a loud planner-bug tripwire, and the augmentation hoist that removes the bug class's breeding ground.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1848 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)