### PR TITLE
feat: facts-not-rows reconciliation for urd status (UPI 079-a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.30.0] - 2026-07-03
+### Changed
+- **`urd status` speaks in facts, not rows.** The first status after onboarding
+  now reads like one voice: subvolumes sharing one overdue offsite drive, one
+  tight pool, or one advisory collapse to a single line naming those affected;
+  the footer counts distinct root causes ("2 issues need attention"), not rows;
+  an all-sealed table drops the redundant EXPOSURE column (the summary already
+  says "All sealed."); the SUBVOLUME column shows the short name; and the
+  internal "Pinned snapshots" line is gone. `--json` gains an additive
+  `storage_adaptations` array and a per-assessment `short_name` field.
 
 ### Added
 - **The post-plan orphan invariant now guards every lifecycle.** The planner

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -167,6 +167,31 @@ pub fn compute_advice(
     None
 }
 
+/// Count the distinct *causes* across a set of actionable advice (UPI 079-a §3).
+///
+/// The footer counts root causes, not rows: N subvolumes stranded by one absent
+/// drive are one thing to fix, not N. A cause is a distinct `Some(reason)` value
+/// (reasons embed the *drive* label, not the subvolume name — see
+/// [`chain_break_reason_text`] and branches 3/5/8 of [`compute_advice`] — so
+/// two subvolumes waiting on the same drive collapse to one cause); each
+/// `None`-reason item counts individually, as those are genuinely per-subvolume
+/// local-staleness singletons (the `!send_enabled`-AtRisk branch and branch 6).
+/// Pure: a slice of advice in, a count out.
+#[must_use]
+pub fn count_distinct_causes(advice: &[ActionableAdvice]) -> usize {
+    let mut distinct_reasons: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut none_reason_count = 0usize;
+    for a in advice {
+        match &a.reason {
+            Some(reason) => {
+                distinct_reasons.insert(reason.as_str());
+            }
+            None => none_reason_count += 1,
+        }
+    }
+    distinct_reasons.len() + none_reason_count
+}
+
 /// True when `drive_label`'s absence is the documented cause of degradation —
 /// i.e. it leads one of `compute_health`'s reasons ("{label} away/overdue for N
 /// days"). The leading-token (`"{label} "`) match is deliberate: it excludes the
@@ -575,6 +600,7 @@ drives = ["primary-drive", "offsite-drive"]
     ) -> SubvolAssessment {
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],
@@ -1452,6 +1478,7 @@ local_retention = "transient"
     ) -> SubvolAssessment {
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status,
             health,
             health_reasons: vec![],
@@ -1636,5 +1663,61 @@ local_retention = "transient"
             "should not say 'last backup' when external_only: {}",
             advice.issue
         );
+    }
+
+    // ── count_distinct_causes (UPI 079-a §3) ───────────────────────────
+
+    fn adv(subvol: &str, reason: Option<&str>) -> ActionableAdvice {
+        ActionableAdvice {
+            subvolume: subvol.to_string(),
+            issue: "issue".to_string(),
+            command: None,
+            reason: reason.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn count_distinct_causes_two_rows_one_reason_is_one() {
+        // Two subvolumes waiting on the same drive → one cause, not two rows.
+        let a = vec![
+            adv("sv1", Some("Connect WD-18TB to restore protection")),
+            adv("sv2", Some("Connect WD-18TB to restore protection")),
+        ];
+        assert_eq!(count_distinct_causes(&a), 1);
+    }
+
+    #[test]
+    fn count_distinct_causes_two_reasons_is_two() {
+        let a = vec![
+            adv("sv1", Some("Connect WD-18TB")),
+            adv("sv2", Some("Connect Offsite-4TB")),
+        ];
+        assert_eq!(count_distinct_causes(&a), 2);
+    }
+
+    #[test]
+    fn count_distinct_causes_none_reasons_each_distinct() {
+        // None-reason items are per-subvolume local-staleness singletons.
+        let a = vec![adv("sv1", None), adv("sv2", None)];
+        assert_eq!(count_distinct_causes(&a), 2);
+    }
+
+    #[test]
+    fn count_distinct_causes_same_drive_chain_break_is_one_cause() {
+        // m3: two branch-4 chain breaks to the SAME drive share the reason (it
+        // embeds the drive, not the subvolume) → one cause.
+        let reason = "thread to WD-18TB broken (no pin)";
+        let a = vec![adv("sv1", Some(reason)), adv("sv2", Some(reason))];
+        assert_eq!(count_distinct_causes(&a), 1);
+    }
+
+    #[test]
+    fn count_distinct_causes_mixes_none_and_shared_reason() {
+        let a = vec![
+            adv("sv1", None),                    // singleton
+            adv("sv2", Some("Connect WD-18TB")), // cause A
+            adv("sv3", Some("Connect WD-18TB")), // same cause A
+        ];
+        assert_eq!(count_distinct_causes(&a), 2); // 1 none + 1 distinct reason
     }
 }

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -240,6 +240,10 @@ impl std::fmt::Display for OperationalHealth {
 #[derive(Debug)]
 pub struct SubvolAssessment {
     pub name: String,
+    /// The user-facing short name (UPI 079-a §8a) — rendered in the SUBVOLUME
+    /// display cell. `name` stays the join key for chain health, advisories, and
+    /// errors; only the display cell uses this.
+    pub short_name: String,
     pub status: PromiseStatus,
     /// Operational health — can the next backup succeed efficiently?
     pub health: OperationalHealth,
@@ -622,6 +626,7 @@ pub fn assess(
         let Some(ref snapshot_root) = subvol.snapshot_root else {
             assessments.push(SubvolAssessment {
                 name: subvol.name.clone(),
+                short_name: subvol.short_name.clone(),
                 status: PromiseStatus::Unprotected,
                 health: OperationalHealth::Blocked,
                 health_reasons: vec!["no snapshot root configured".to_string()],
@@ -920,6 +925,7 @@ pub fn assess(
 
         assessments.push(SubvolAssessment {
             name: subvol.name.clone(),
+            short_name: subvol.short_name.clone(),
             status: overall,
             health,
             health_reasons,
@@ -5143,6 +5149,7 @@ source = "/data/sv1"
     fn make_assess(name: &str, status: PromiseStatus) -> SubvolAssessment {
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -3439,6 +3439,7 @@ source = "/data/beta"
     fn sample_assessments() -> Vec<SubvolAssessment> {
         vec![SubvolAssessment {
             name: "htpc-home".to_string(),
+            short_name: "htpc-home".to_string(),
             status: PromiseStatus::Protected,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],
@@ -4430,6 +4431,7 @@ source = "/data/beta"
     ) -> SubvolAssessment {
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -76,7 +76,9 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         })
         .collect();
 
-    let total_needing_attention = advice_items.len();
+    // Distinct root causes, not rows (UPI 079-a §3) — symmetric with the full
+    // `urd status` footer. Borrow before consuming `advice_items` below.
+    let total_needing_attention = advice::count_distinct_causes(&advice_items);
     let best_advice = advice_items.into_iter().next();
 
     // Worst tight pool drives the compact bare-`urd` clause.

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -6,7 +6,7 @@ use crate::chain;
 use crate::config::Config;
 use crate::drives;
 use crate::output::{
-    ChainHealth, ChainHealthEntry, DriveInfo, LastRunInfo, OutputMode,
+    AdaptationSummary, ChainHealth, ChainHealthEntry, DriveInfo, LastRunInfo, OutputMode,
     PoolPostureSummary, StatusAssessment, StatusOutput,
 };
 use crate::plan::{Observation, RealFileSystemState};
@@ -40,6 +40,11 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     let assessments =
         advice::assess_view(&config, now, &observation, &signals.by_subvol);
     let storage_postures = storage_signals::aggregate(&assessments, &signals, now);
+    // §2: collapse per-subvolume adaptations to one line per group (needs
+    // `signals.pools`, which the renderer can't see — so aggregate here where
+    // `signals` is live, like `storage_postures`).
+    let storage_adaptations =
+        storage_signals::aggregate_adaptations(&assessments, &signals, &config);
 
     // ── Drive info ──────────────────────────────────────────────────
     let drive_infos: Vec<DriveInfo> = config
@@ -79,6 +84,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     let status_output = assemble_status_output(
         &assessments,
         storage_postures,
+        storage_adaptations,
         drive_infos,
         last_run,
         total_pins,
@@ -102,9 +108,11 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
 /// chain-health worst-selection, promise-level threading, advice filtering,
 /// redundancy advisories, and last-run age all live here.
 #[must_use]
+#[allow(clippy::too_many_arguments)]
 fn assemble_status_output(
     assessments: &[SubvolAssessment],
     storage_postures: Vec<PoolPostureSummary>,
+    storage_adaptations: Vec<AdaptationSummary>,
     drive_infos: Vec<DriveInfo>,
     last_run: Option<LastRunInfo>,
     total_pins: usize,
@@ -179,6 +187,7 @@ fn assemble_status_output(
         redundancy_advisories,
         advice,
         storage_postures,
+        storage_adaptations,
     }
 }
 
@@ -247,6 +256,7 @@ local_retention = "transient"
     fn assessment(name: &str) -> SubvolAssessment {
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status: PromiseStatus::Protected,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],
@@ -286,6 +296,7 @@ local_retention = "transient"
     fn assemble(assessments: &[SubvolAssessment], config: &Config) -> StatusOutput {
         assemble_status_output(
             assessments,
+            vec![],
             vec![],
             vec![],
             None,
@@ -468,6 +479,7 @@ local_retention = "transient"
         };
         let out = assemble_status_output(
             &[],
+            vec![],
             vec![],
             vec![],
             Some(last_run),

--- a/src/commands/storage_signals.rs
+++ b/src/commands/storage_signals.rs
@@ -5,9 +5,10 @@
 //! the persisted prior armed tier. Pure derivation stays in
 //! `storage_critical.rs`; `assess()` consumes the per-subvolume signal map.
 //!
-//! - **Read paths** (`status`, bare `urd`, `doctor`) call `gather()` +
-//!   `aggregate()` only — they *reflect* the hysteresis-stabilized tier and
-//!   never advance state (S1: a read can never fire a transition).
+//! - **Read paths** (`status`, bare `urd`, `doctor`) call `gather()` plus the
+//!   pure display aggregators (`aggregate()`, and `aggregate_adaptations()` for
+//!   `status`) only — they *reflect* the hysteresis-stabilized tier and never
+//!   advance state (S1: a read can never fire a transition).
 //! - **`backup`** additionally calls `advance_and_writeback()` after its
 //!   post-execution `assess()`: it re-runs the pure hysteresis per
 //!   UUID-resolvable pool, persists `(armed_tier, since)` best-effort, and
@@ -19,10 +20,10 @@ use std::path::{Path, PathBuf};
 
 use chrono::NaiveDateTime;
 
-use crate::awareness::{ResolvedStorageSignal, StorageSignalMap, SubvolAssessment};
+use crate::awareness::{PromiseStatus, ResolvedStorageSignal, StorageSignalMap, SubvolAssessment};
 use crate::config::Config;
 use crate::events::{Event, EventPayload};
-use crate::output::PoolPostureSummary;
+use crate::output::{AdaptationSummary, PoolPostureSummary};
 use crate::pools::{self, PoolSpace};
 use crate::state::StateDb;
 use crate::storage_critical::{self, ArmedTierMap, TightnessTier, Transition};
@@ -430,6 +431,111 @@ pub fn aggregate(
         });
     }
     summaries
+}
+
+/// Aggregate per-subvolume storage *adaptations* into one display line per group
+/// (UPI 079-a §2). Pure. Mirrors the renderer's original per-assessment gate but
+/// collapses subvolumes that share an adaptation into a single
+/// [`AdaptationSummary`], so N subvolumes on one tight pool render one line.
+///
+/// **M1 — iterate assessments, not pools.** The original renderer was
+/// assessment-driven (every adapted subvolume rendered). We iterate `assessments`
+/// and gate each on an effective interval AND either Protected (honest Tight) or
+/// AT-RISK-by-design (Critical cap), skipping Roomy and genuine-failure/Unprotected
+/// — mirroring the renderer's `continue`s. Each gated-in assessment reverse-looks
+/// up its pool label from `signals.pools`; **if none is found, the subvolume's own
+/// name is the group key so the line still renders** (pool-iteration would have
+/// silently dropped a gated-in-but-poolless subvolume).
+///
+/// **S2 — conditional grouping key.** A local-only group keys on
+/// `(pool_label, by_design)` only — its sentence renders neither cadence nor the
+/// external/history clause, so folding those in would split identical lines.
+/// A non-local group additionally keys on `(cadence_secs, external_only)`.
+///
+/// `config` supplies the transient/external-only flag, which `SubvolAssessment`
+/// does not carry (it is config-derived, resolved the same way the status
+/// assembler resolves it).
+#[must_use]
+pub fn aggregate_adaptations(
+    assessments: &[SubvolAssessment],
+    signals: &StorageSignals,
+    config: &Config,
+) -> Vec<AdaptationSummary> {
+    let resolved = config.resolved_subvolumes();
+
+    // Grouping key: (pool_label, local_only, cadence_secs, external_only, by_design)
+    // — the cadence/external_only slots carry the normalized (None/false) values
+    // for a local-only group, so S2's conditional key falls out of one tuple.
+    type AdaptKey = (String, bool, Option<i64>, bool, bool);
+    let mut order: Vec<AdaptKey> = Vec::new();
+    let mut groups: HashMap<AdaptKey, AdaptationSummary> = HashMap::new();
+
+    for a in assessments {
+        // Gate (M1): only adapted subvolumes speak here.
+        let Some(interval) = a.effective_send_interval else {
+            continue; // Roomy — nothing to explain.
+        };
+        let cadence_secs = interval.as_secs();
+        let by_design = if a.status == PromiseStatus::AtRisk && a.cadence_adapted {
+            true
+        } else if a.status == PromiseStatus::Protected {
+            false
+        } else {
+            continue; // genuine failure / Unprotected — the summary leads instead
+        };
+
+        let local_only = a.external.is_empty();
+        let external_only = resolved
+            .iter()
+            .find(|sv| sv.name == a.name)
+            .map(|sv| sv.local_retention.is_transient() && sv.send_enabled)
+            .unwrap_or(false);
+
+        // Reverse-look-up the pool label; fall back to the subvolume's own name
+        // so a gated-in but poolless subvolume still renders.
+        let pool_label = signals
+            .pools
+            .iter()
+            .find(|p| p.subvol_names.iter().any(|n| n == &a.name))
+            .map(|p| p.label.clone())
+            .unwrap_or_else(|| a.name.clone());
+
+        // Normalize the cadence/external_only slots to None/false for a
+        // local-only group so identical local-only lines share one key (S2).
+        let (cadence_field, external_only_field) = if local_only {
+            (None, false)
+        } else {
+            (Some(cadence_secs), external_only)
+        };
+        let key: AdaptKey = (
+            pool_label.clone(),
+            local_only,
+            cadence_field,
+            external_only_field,
+            by_design,
+        );
+
+        groups
+            .entry(key.clone())
+            .or_insert_with(|| {
+                order.push(key.clone());
+                AdaptationSummary {
+                    pool_label,
+                    local_only,
+                    external_only: external_only_field,
+                    cadence_secs: cadence_field,
+                    by_design,
+                    subvolumes: Vec::new(),
+                }
+            })
+            .subvolumes
+            .push(a.name.clone());
+    }
+
+    order
+        .into_iter()
+        .filter_map(|k| groups.remove(&k))
+        .collect()
 }
 
 #[cfg(test)]
@@ -1057,6 +1163,7 @@ source = "/"
         use crate::types::Interval;
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status: PromiseStatus::Protected,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],
@@ -1075,5 +1182,186 @@ source = "/"
             cadence_adapted: false,
             effective_send_interval: None,
         }
+    }
+
+    // ── aggregate_adaptations (UPI 079-a §2) ─────────────────────────────
+
+    /// One pool carrying `subvols`, keyed by mountpoint (UUID-less is fine — the
+    /// aggregator reads only `label` and `subvol_names`).
+    fn signals_with_pool(label: &str, subvols: &[&str]) -> StorageSignals {
+        StorageSignals {
+            by_subvol: StorageSignalMap::new(),
+            pools: vec![PoolSignal {
+                uuid: None,
+                label: label.to_string(),
+                subvol_names: subvols.iter().map(|s| s.to_string()).collect(),
+                free_ratio: None,
+                free_bytes: None,
+                capacity_bytes: None,
+                floor_bytes: None,
+                host_root: false,
+                prior_armed_tier: TightnessTier::Roomy,
+                prior_since: None,
+            }],
+        }
+    }
+
+    fn adapt_assess(
+        name: &str,
+        status: crate::awareness::PromiseStatus,
+        cadence_adapted: bool,
+        effective_secs: Option<i64>,
+        has_external: bool,
+    ) -> SubvolAssessment {
+        use crate::awareness::{DriveAssessment, LocalAssessment, OperationalHealth, PromiseStatus};
+        use crate::types::{DriveRole, Interval};
+        let external = if has_external {
+            vec![DriveAssessment {
+                drive_label: "drive".to_string(),
+                status: PromiseStatus::Protected,
+                mounted: true,
+                snapshot_count: Some(1),
+                last_send_age: None,
+                source_unchanged: false,
+                configured_interval: Interval::hours(24),
+                role: DriveRole::Primary,
+                absent_duration_secs: None,
+                last_activity_age_secs: None,
+                rotation: None,
+            }]
+        } else {
+            vec![]
+        };
+        SubvolAssessment {
+            name: name.to_string(),
+            short_name: name.to_string(),
+            status,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
+            local: LocalAssessment {
+                status: PromiseStatus::Protected,
+                snapshot_count: 1,
+                newest_age: None,
+                configured_interval: Interval::hours(1),
+            },
+            external,
+            chain_health: vec![],
+            advisories: vec![],
+            redundancy_advisories: vec![],
+            errors: vec![],
+            storage_posture: None,
+            cadence_adapted,
+            effective_send_interval: effective_secs
+                .map(|s| Interval::from_chrono(chrono::Duration::seconds(s))),
+        }
+    }
+
+    #[test]
+    fn aggregate_adaptations_single_subvol_one_summary() {
+        use crate::awareness::PromiseStatus;
+        let signals = signals_with_pool("/data", &["alpha"]);
+        let assessments =
+            vec![adapt_assess("alpha", PromiseStatus::Protected, false, Some(86400), true)];
+        let out = aggregate_adaptations(&assessments, &signals, &cfg());
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].subvolumes, vec!["alpha".to_string()]);
+        assert_eq!(out[0].pool_label, "/data");
+        assert!(!out[0].by_design);
+        assert_eq!(out[0].cadence_secs, Some(86400));
+    }
+
+    #[test]
+    fn aggregate_adaptations_same_pool_shape_collapses() {
+        use crate::awareness::PromiseStatus;
+        let signals = signals_with_pool("/data", &["alpha", "beta"]);
+        let assessments = vec![
+            adapt_assess("alpha", PromiseStatus::Protected, false, Some(86400), true),
+            adapt_assess("beta", PromiseStatus::Protected, false, Some(86400), true),
+        ];
+        let out = aggregate_adaptations(&assessments, &signals, &cfg());
+        assert_eq!(out.len(), 1, "same pool+cadence+shape collapses: {out:?}");
+        assert_eq!(
+            out[0].subvolumes,
+            vec!["alpha".to_string(), "beta".to_string()]
+        );
+    }
+
+    #[test]
+    fn aggregate_adaptations_non_local_two_cadences_two_summaries() {
+        use crate::awareness::PromiseStatus;
+        let signals = signals_with_pool("/data", &["alpha", "beta"]);
+        let assessments = vec![
+            adapt_assess("alpha", PromiseStatus::Protected, false, Some(86400), true),
+            adapt_assess("beta", PromiseStatus::Protected, false, Some(2 * 86400), true),
+        ];
+        let out = aggregate_adaptations(&assessments, &signals, &cfg());
+        assert_eq!(out.len(), 2, "distinct cadences on a non-local pool split: {out:?}");
+    }
+
+    #[test]
+    fn aggregate_adaptations_local_only_different_cadence_one_summary() {
+        // S2 regression guard: local-only subvols with DIFFERENT cadence still
+        // collapse — the local-only sentence names no cadence, so cadence must not
+        // split the group.
+        use crate::awareness::PromiseStatus;
+        let signals = signals_with_pool("/data", &["alpha", "beta"]);
+        let assessments = vec![
+            adapt_assess("alpha", PromiseStatus::Protected, false, Some(86400), false),
+            adapt_assess("beta", PromiseStatus::Protected, false, Some(2 * 86400), false),
+        ];
+        let out = aggregate_adaptations(&assessments, &signals, &cfg());
+        assert_eq!(out.len(), 1, "local-only group must not split on cadence: {out:?}");
+        assert!(out[0].local_only);
+        assert_eq!(out[0].cadence_secs, None, "local-only carries no cadence");
+        assert_eq!(out[0].subvolumes.len(), 2);
+    }
+
+    #[test]
+    fn aggregate_adaptations_by_design_splits() {
+        // Same pool + cadence + shape but different by_design → two summaries (one
+        // appends the "by design" reassurance, the other does not).
+        use crate::awareness::PromiseStatus;
+        let signals = signals_with_pool("/data", &["alpha", "beta"]);
+        let assessments = vec![
+            adapt_assess("alpha", PromiseStatus::Protected, false, Some(86400), true),
+            adapt_assess("beta", PromiseStatus::AtRisk, true, Some(86400), true),
+        ];
+        let out = aggregate_adaptations(&assessments, &signals, &cfg());
+        assert_eq!(out.len(), 2, "by_design difference splits the group: {out:?}");
+        assert!(out.iter().any(|s| s.by_design));
+        assert!(out.iter().any(|s| !s.by_design));
+    }
+
+    #[test]
+    fn aggregate_adaptations_skips_roomy_and_genuine_failure() {
+        use crate::awareness::PromiseStatus;
+        let signals = signals_with_pool("/data", &["alpha", "beta", "gamma"]);
+        let assessments = vec![
+            adapt_assess("alpha", PromiseStatus::Protected, false, None, true), // Roomy → skip
+            adapt_assess("beta", PromiseStatus::AtRisk, false, Some(86400), true), // failure → skip
+            adapt_assess("gamma", PromiseStatus::Unprotected, false, Some(86400), true), // unprotected → skip
+        ];
+        let out = aggregate_adaptations(&assessments, &signals, &cfg());
+        assert!(
+            out.is_empty(),
+            "Roomy + genuine-failure + unprotected produce no adaptation lines: {out:?}"
+        );
+    }
+
+    #[test]
+    fn aggregate_adaptations_poolless_subvol_still_renders() {
+        // M1 guard: a gated-in subvolume whose pool is absent from signals.pools
+        // must still render (keyed on its own name), never silently drop.
+        use crate::awareness::PromiseStatus;
+        let signals = StorageSignals {
+            by_subvol: StorageSignalMap::new(),
+            pools: vec![],
+        };
+        let assessments =
+            vec![adapt_assess("orphan", PromiseStatus::Protected, false, Some(86400), true)];
+        let out = aggregate_adaptations(&assessments, &signals, &cfg());
+        assert_eq!(out.len(), 1, "poolless gated-in subvol must still render: {out:?}");
+        assert_eq!(out[0].pool_label, "orphan", "falls back to the subvol's own name");
+        assert_eq!(out[0].subvolumes, vec!["orphan".to_string()]);
     }
 }

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -354,6 +354,7 @@ mod tests {
         vec![
             SubvolAssessment {
                 name: "home".to_string(),
+                short_name: "home".to_string(),
                 status: PromiseStatus::Protected,
                 health: OperationalHealth::Healthy,
                 health_reasons: vec![],
@@ -386,6 +387,7 @@ mod tests {
             },
             SubvolAssessment {
                 name: "docs".to_string(),
+                short_name: "docs".to_string(),
                 status: PromiseStatus::AtRisk,
                 health: OperationalHealth::Healthy,
                 health_reasons: vec![],

--- a/src/output.rs
+++ b/src/output.rs
@@ -131,6 +131,40 @@ pub struct PoolPostureSummary {
     pub since_secs: Option<i64>,
 }
 
+// ── AdaptationSummary ───────────────────────────────────────────────────
+
+/// One per-group storage-adaptation display line (UPI 079-a §2). Mirrors
+/// [`PoolPostureSummary`]: the deliberate-slowdown fact stated once for a set of
+/// subvolumes that share it, so N subvolumes on one tight pool render a single
+/// line instead of N. Aggregated compute-side by
+/// [`crate::commands::storage_signals::aggregate_adaptations`] (it needs
+/// `signals.pools`, which the renderer can't see). These fields fully determine
+/// the rendered sentence — the pool label, whether the pool is local-only, the
+/// external-only (transient) shape, the effective cadence, and whether the AT
+/// RISK reading is by-design.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct AdaptationSummary {
+    /// Display label of the shared source pool (grouping anchor; the sentence
+    /// templates name subvolumes and cadence, not the pool, so this is unread by
+    /// the renderer — carried for `--json`).
+    pub pool_label: String,
+    /// The pool has no external drive for these subvolumes — a different sentence
+    /// (no drive to spare, no history "on the drive").
+    pub local_only: bool,
+    /// Transient local retention (external-only) — suppresses the "local history
+    /// reduced" clause. Unread (carried `false`) for a local-only group.
+    pub external_only: bool,
+    /// The effective send interval in seconds. Unread (carried `None`) for a
+    /// local-only group, whose sentence names no cadence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cadence_secs: Option<i64>,
+    /// The AT RISK reading is a deliberate Critical cap, not a failure — appends
+    /// the "Reads AT RISK by design" reassurance.
+    pub by_design: bool,
+    /// The subvolumes sharing this adaptation (rendered in place of a single name).
+    pub subvolumes: Vec<String>,
+}
+
 // ── StatusOutput ────────────────────────────────────────────────────────
 
 /// Structured output for the `urd status` command.
@@ -159,12 +193,19 @@ pub struct StatusOutput {
     /// pools are Roomy, so roomy systems stay silent.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub storage_postures: Vec<PoolPostureSummary>,
+    /// Per-group storage-adaptation lines (UPI 079-a §2). Omitted from JSON when
+    /// no subvolume is adapting, so a Roomy system stays silent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub storage_adaptations: Vec<AdaptationSummary>,
 }
 
 /// Serializable wrapper around SubvolAssessment data.
 #[derive(Debug, Serialize)]
 pub struct StatusAssessment {
     pub name: String,
+    /// User-facing short name (UPI 079-a §8a) — rendered in the SUBVOLUME cell.
+    /// `name` remains the join key for chain health / advisories / errors.
+    pub short_name: String,
     /// Promise status (serializes SCREAMING: "PROTECTED" / "AT RISK" / "UNPROTECTED").
     pub status: PromiseStatus,
     /// Operational health: "healthy", "degraded", or "blocked".
@@ -212,6 +253,7 @@ impl StatusAssessment {
     pub fn from_assessment(a: &SubvolAssessment) -> Self {
         Self {
             name: a.name.clone(),
+            short_name: a.short_name.clone(),
             status: a.status,
             health: a.health.to_string(),
             health_reasons: a.health_reasons.clone(),
@@ -1690,6 +1732,7 @@ mod tests {
         };
         let assessment = SubvolAssessment {
             name: "sv1".to_string(),
+            short_name: "sv1".to_string(),
             status: PromiseStatus::Protected,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -862,6 +862,7 @@ mod tests {
     fn make_assessment(name: &str, status: PromiseStatus) -> SubvolAssessment {
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],
@@ -890,6 +891,7 @@ mod tests {
     ) -> SubvolAssessment {
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],
@@ -1572,6 +1574,7 @@ mod tests {
             .collect();
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status: PromiseStatus::Protected,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -1244,6 +1244,7 @@ mod tests {
     fn make_assessment(name: &str, status: PromiseStatus) -> SubvolAssessment {
         SubvolAssessment {
             name: name.to_string(),
+            short_name: name.to_string(),
             status,
             health: OperationalHealth::Healthy,
             health_reasons: vec![],

--- a/src/voice/backup.rs
+++ b/src/voice/backup.rs
@@ -387,7 +387,8 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
                     .unwrap_or_else(|| "\u{2014}".to_string()),
             );
         }
-        row.push(assessment.name.clone());
+        // SUBVOLUME cell shows the user-facing short name (§8a).
+        row.push(assessment.short_name.clone());
         row.push(assessment.local_snapshot_count.to_string());
 
         for label in &drive_labels {
@@ -409,21 +410,19 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
 }
 
 /// Render advisories and errors from awareness assessments.
+///
+/// Errors stay per-subvolume; advisory NOTEs group by exact text (UPI 079-a §4)
+/// off the shared `super::group_advisory_notes`. No trailing blank line —
+/// preserving this renderer's current shape (the status caller adds one, keyed
+/// on errors; this one does not).
 fn render_assessment_advisories(data: &BackupSummary, out: &mut String) {
     for assessment in &data.assessments {
         for error in &assessment.errors {
             writeln!(out, "  {} {}: {}", "ERROR".red(), assessment.name, error).ok();
         }
-        for advisory in &assessment.advisories {
-            writeln!(
-                out,
-                "  {} {}: {}",
-                "NOTE".dimmed(),
-                assessment.name,
-                advisory,
-            )
-            .ok();
-        }
+    }
+    for (advisory, subvols) in super::group_advisory_notes(&data.assessments) {
+        writeln!(out, "  {} {}: {}", "NOTE".dimmed(), subvols.join(", "), advisory).ok();
     }
 }
 
@@ -546,6 +545,7 @@ mod tests {
     fn assessment_with(drive: &str, mounted: bool) -> StatusAssessment {
         StatusAssessment {
             name: "sv".to_string(),
+            short_name: "sv".to_string(),
             status: PromiseStatus::Protected,
             health: "healthy".to_string(),
             health_reasons: vec![],

--- a/src/voice/drive_row.rs
+++ b/src/voice/drive_row.rs
@@ -260,6 +260,7 @@ mod tests {
     ) -> StatusAssessment {
         StatusAssessment {
             name: "sv1".to_string(),
+            short_name: "sv1".to_string(),
             status,
             health: "healthy".to_string(),
             health_reasons: vec![],

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -108,6 +108,47 @@ pub(super) fn exposure_label(status: PromiseStatus) -> String {
     }
 }
 
+/// Group per-subvolume advisory NOTE strings for display (UPI 079-a §4).
+///
+/// Collects, for each distinct advisory string (exact equality), the subvolume
+/// names carrying it — in first-appearance order for both the groups and the
+/// names within a group. N subvolumes sharing one advisory collapse to a single
+/// `(advisory, [names…])` group, so a caller emits one NOTE line instead of N
+/// identical ones; a single-subvolume advisory yields a one-name group that
+/// renders byte-identical to the pre-grouping `NOTE name: advisory` line.
+///
+/// Deduping display lines is presentation, not state computation (architecture.md:
+/// voice/ renders), so this lives render-side. Errors are deliberately NOT grouped
+/// — they stay per-subvolume in the callers, which loop `assessment.errors`
+/// directly. Both `render_advisories` (status) and `render_assessment_advisories`
+/// (backup) render their own lines off this shared *grouping* helper because they
+/// differ in trailing-blank-line behavior.
+pub(super) fn group_advisory_notes(
+    assessments: &[crate::output::StatusAssessment],
+) -> Vec<(String, Vec<String>)> {
+    let mut order: Vec<String> = Vec::new();
+    let mut groups: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for a in assessments {
+        for advisory in &a.advisories {
+            groups
+                .entry(advisory.clone())
+                .or_insert_with(|| {
+                    order.push(advisory.clone());
+                    Vec::new()
+                })
+                .push(a.name.clone());
+        }
+    }
+    order
+        .into_iter()
+        .map(|adv| {
+            let names = groups.remove(&adv).unwrap_or_default();
+            (adv, names)
+        })
+        .collect()
+}
+
 
 /// Humanize seconds into a compact duration string. Cross-renderer helper.
 pub(super) fn humanize_duration(secs: i64) -> String {
@@ -418,6 +459,7 @@ pub(crate) mod test_fixtures {
             assessments: vec![
                 StatusAssessment {
                     name: "htpc-home".to_string(),
+                    short_name: "htpc-home".to_string(),
                     status: PromiseStatus::Protected,
                     health: "healthy".to_string(),
                     health_reasons: vec![],
@@ -447,6 +489,7 @@ pub(crate) mod test_fixtures {
                 },
                 StatusAssessment {
                     name: "htpc-docs".to_string(),
+                    short_name: "htpc-docs".to_string(),
                     status: PromiseStatus::AtRisk,
                     health: "degraded".to_string(),
                     health_reasons: vec![
@@ -512,6 +555,7 @@ pub(crate) mod test_fixtures {
             redundancy_advisories: vec![],
             advice: vec![],
             storage_postures: Vec::new(),
+            storage_adaptations: Vec::new(),
         }
     }
 
@@ -560,6 +604,7 @@ pub(crate) mod test_fixtures {
             ],
             assessments: vec![StatusAssessment {
                 name: "htpc-home".to_string(),
+                short_name: "htpc-home".to_string(),
                 status: PromiseStatus::Protected,
                 health: "healthy".to_string(),
                 health_reasons: vec![],
@@ -782,6 +827,72 @@ mod tests {
         let _ = truncate_str(s, 6);
         assert_eq!(truncate_str("short", 10), "short");
         assert!(truncate_str("a-much-longer-string", 10).ends_with("..."));
+    }
+
+    // ── group_advisory_notes (UPI 079-a §4) ─────────────────────────────
+
+    /// Minimal `StatusAssessment` carrying only the fields `group_advisory_notes`
+    /// reads (`name`, `advisories`).
+    fn adv_assessment(name: &str, advisories: &[&str]) -> crate::output::StatusAssessment {
+        crate::output::StatusAssessment {
+            name: name.to_string(),
+            short_name: name.to_string(),
+            status: PromiseStatus::Protected,
+            health: "healthy".to_string(),
+            health_reasons: vec![],
+            promise_level: None,
+            local_snapshot_count: 0,
+            local_newest_age_secs: None,
+            local_status: PromiseStatus::Protected,
+            external: vec![],
+            advisories: advisories.iter().map(|s| s.to_string()).collect(),
+            redundancy_advisories: vec![],
+            retention_summary: None,
+            external_only: false,
+            errors: vec![],
+            storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval_secs: None,
+        }
+    }
+
+    #[test]
+    fn group_advisory_notes_single_subvol_one_group() {
+        let groups = group_advisory_notes(&[adv_assessment("sv1", &["offsite stale"])]);
+        assert_eq!(
+            groups,
+            vec![("offsite stale".to_string(), vec!["sv1".to_string()])]
+        );
+    }
+
+    #[test]
+    fn group_advisory_notes_three_subvols_same_string_one_group() {
+        let assessments = vec![
+            adv_assessment("sv1", &["offsite stale"]),
+            adv_assessment("sv2", &["offsite stale"]),
+            adv_assessment("sv3", &["offsite stale"]),
+        ];
+        let groups = group_advisory_notes(&assessments);
+        assert_eq!(groups.len(), 1, "shared advisory collapses to one group: {groups:?}");
+        assert_eq!(groups[0].0, "offsite stale");
+        assert_eq!(
+            groups[0].1,
+            vec!["sv1".to_string(), "sv2".to_string(), "sv3".to_string()],
+            "names preserved in first-appearance order"
+        );
+    }
+
+    #[test]
+    fn group_advisory_notes_two_distinct_strings_two_groups() {
+        let assessments = vec![
+            adv_assessment("sv1", &["advisory A"]),
+            adv_assessment("sv2", &["advisory B"]),
+        ];
+        let groups = group_advisory_notes(&assessments);
+        assert_eq!(groups.len(), 2);
+        // First-appearance order preserved across distinct strings.
+        assert_eq!(groups[0].0, "advisory A");
+        assert_eq!(groups[1].0, "advisory B");
     }
 
     // ── Backup summary tests ────────────────────────────────────────

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -72,15 +72,9 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
     // ── Last run ────────────────────────────────────────────────────
     render_last_run(data, &mut out);
 
-    // ── Pin summary ─────────────────────────────────────────────────
-    if data.total_pins > 0 {
-        writeln!(
-            out,
-            "Pinned snapshots: {} across subvolumes",
-            data.total_pins
-        )
-        .ok();
-    }
+    // §8b (UPI 079-a): the "Pinned snapshots: N" line is dropped — pin count is
+    // an internal fact, not a promise the user acts on. `total_pins` stays on
+    // `StatusOutput` for `--json`.
 
     // ── Next-action suggestion ──────────────────────────────────────
     if !data.advice.is_empty() {
@@ -93,7 +87,22 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
                 writeln!(out, "{}", format!("{} — {}.", a.subvolume, reason).dimmed()).ok();
             }
         } else {
-            writeln!(out, "{}", format!("{} subvolumes need attention — run `urd doctor` for details.", data.advice.len()).dimmed()).ok();
+            // Footer counts distinct root causes, not rows (UPI 079-a §3): N
+            // subvolumes stranded by one absent drive are one thing to fix. The
+            // cause count can be 1 here even though ≥2 advice rows landed in this
+            // branch (they collapsed to one cause), so agree the verb.
+            let causes = crate::advice::count_distinct_causes(&data.advice);
+            let verb = if causes == 1 { "needs" } else { "need" };
+            writeln!(
+                out,
+                "{}",
+                format!(
+                    "{} {verb} attention — run `urd doctor` for details.",
+                    pluralize(causes, "issue", "issues")
+                )
+                .dimmed()
+            )
+            .ok();
         }
     }
 
@@ -184,62 +193,53 @@ pub(super) fn render_summary_line(data: &StatusOutput, out: &mut String) {
     writeln!(out, "{safety_part}{health_part}").ok();
 }
 
-/// Render per-subvolume storage-adaptation prose (UPI 031-b AB3.1). When a tight
-/// pool has slowed Urd's cadence (`effective_send_interval_secs` set), explain
-/// it told-not-silent so the slowdown reads as deliberate care, not failure:
+/// Render storage-adaptation prose (UPI 031-b AB3.1; grouped per UPI 079-a §2).
+/// When a tight pool has slowed Urd's cadence, explain it told-not-silent so the
+/// slowdown reads as deliberate care, not failure. Reads the pre-aggregated
+/// [`AdaptationSummary`] list (one per group of subvolumes that share the
+/// adaptation) — the gate and grouping live compute-side in
+/// [`crate::commands::storage_signals::aggregate_adaptations`], so a Roomy /
+/// genuine-failure subvolume never reaches here:
 ///
-/// - **Critical capped (`cadence_adapted`)** — the promise was dropped to AT RISK
-///   *by design*; say so explicitly, naming the cadence. This is the user-facing
-///   acceptance criterion for the R4 overturn (the 2am golden test).
-/// - **Honest Tight (still `Protected`)** — an informational lengthened-cadence
-///   note; the promise is untouched.
-/// - **Genuine failure** (AT RISK *without* `cadence_adapted`, or UNPROTECTED) —
-///   say nothing here; the failure is the more urgent truth and leads via the
-///   summary/advisories.
+/// - **Critical capped (`by_design`)** — the promise was dropped to AT RISK *by
+///   design*; say so explicitly, naming the cadence (the R4-overturn 2am golden).
+/// - **Honest Tight (`!by_design`)** — an informational lengthened-cadence note;
+///   the promise is untouched.
 ///
-/// A declared-Graduated subvolume (`!external_only`) additionally notes that its
-/// local history was reduced/cleared — full history lives on the drive.
+/// A local-only group (`local_only`) has no drive to "spare" and no history "on
+/// the drive" (#195). A declared-Graduated group (`!external_only`) additionally
+/// notes that its local history was reduced/cleared.
 pub(super) fn render_storage_adaptations(data: &StatusOutput, out: &mut String) {
-    for a in &data.assessments {
-        let Some(secs) = a.effective_send_interval_secs else {
-            continue; // Roomy — declared cadence, nothing to explain.
-        };
-        // Capped-by-design (Critical) appends an explicit "by design"
-        // reassurance; honest Tight (still Protected) gets the bare note; a
-        // genuine failure / UNPROTECTED says nothing here and leads via the
-        // summary instead.
-        let suffix = if a.status == PromiseStatus::AtRisk && a.cadence_adapted {
+    for s in &data.storage_adaptations {
+        // Capped-by-design (Critical) appends an explicit "by design" reassurance;
+        // honest Tight gets the bare note.
+        let suffix = if s.by_design {
             " Reads AT RISK by design, not a failure."
-        } else if a.status == PromiseStatus::Protected {
-            ""
         } else {
-            continue;
+            ""
         };
-
-        // A local-only subvolume (no external drive) has no drive to "spare" and
-        // no full history living "on the drive" — the old line was a flat lie for
-        // it (#195). Say only what's true: the source pool is tight, so Urd keeps
-        // less local history to protect the host.
-        let line = if a.external.is_empty() {
+        let names = s.subvolumes.join(", ");
+        let line = if s.local_only {
+            // A local-only group has no drive to spare and no full history living
+            // "on the drive" (#195). Say only what's true.
             format!(
-                "  {}: source pool is tight \u{2014} keeping less local history to protect the host.{suffix}",
-                a.name,
+                "  {names}: source pool is tight \u{2014} keeping less local history to protect the host.{suffix}",
             )
         } else {
-            // `humanize_cadence`, not `humanize_duration`: a 36h tight-stretch
-            // must not floor to "1d" (identical to the declared daily), which
-            // would make the sparing invisible (#195).
-            let cadence = humanize_cadence(secs);
+            // `humanize_cadence`, not `humanize_duration`: a 36h tight-stretch must
+            // not floor to "1d" (identical to the declared daily), which would make
+            // the sparing invisible (#195). Non-local groups always carry a cadence.
+            let cadence = s.cadence_secs.map(humanize_cadence).unwrap_or_default();
             // Declared-Graduated subvols had graduated local history; the tier
-            // reduced it to retain-one (Tight) or cleared it (Critical).
-            let history = if a.external_only {
+            // reduced it to retain-one (Tight) or cleared it (Critical). Transient
+            // (external-only) groups have no local history to reduce.
+            let history = if s.external_only {
                 ""
             } else {
                 " local history reduced \u{2014} full history is on the drive;"
             };
             format!(
-                "  {}: tight drive \u{2014}{history} backing up every {cadence} to spare it.{suffix}",
-                a.name,
+                "  {names}: tight drive \u{2014}{history} backing up every {cadence} to spare it.{suffix}",
             )
         };
         writeln!(out, "{}", line.yellow()).ok();
@@ -312,9 +312,22 @@ pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
     });
     // Only show HEALTH column when at least one subvolume is non-healthy
     let show_health = data.assessments.iter().any(|a| a.health != "healthy");
+    // EXPOSURE is hidden when every subvolume is sealed (all Protected) — the
+    // column would be "sealed" repeated down every row, the seven-line wall one
+    // column over (UPI 079-a §9). Load-bearing coupling: this gate is licensed
+    // ONLY because `render_summary_line` already states the aggregate promise
+    // ("All sealed." in green) as the first line of `urd status`. Do not weaken
+    // that summary without revisiting this gate.
+    let show_exposure = data
+        .assessments
+        .iter()
+        .any(|a| a.status != PromiseStatus::Protected);
 
-    // Build headers: EXPOSURE  [HEALTH]  [PROTECTION]  SUBVOLUME  LOCAL  [DRIVES...]  THREAD
-    let mut headers: Vec<String> = vec!["EXPOSURE".to_string()];
+    // Build headers: [EXPOSURE]  [HEALTH]  [PROTECTION]  SUBVOLUME  LOCAL  [DRIVES...]  THREAD
+    let mut headers: Vec<String> = Vec::new();
+    if show_exposure {
+        headers.push("EXPOSURE".to_string());
+    }
     if show_health {
         headers.push("HEALTH".to_string());
     }
@@ -328,16 +341,23 @@ pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
     }
     headers.push("THREAD".to_string());
 
-    // Track which columns need coloring
-    let safety_col = Some(0usize);
-    let health_col = if show_health { Some(1usize) } else { None };
+    // Track which columns need coloring. Indices shift when EXPOSURE is hidden:
+    // HEALTH then leads at index 0 instead of following EXPOSURE at index 1.
+    let safety_col = if show_exposure { Some(0usize) } else { None };
+    let health_col = if show_health {
+        Some(if show_exposure { 1 } else { 0 })
+    } else {
+        None
+    };
 
     // Build rows
     let mut rows: Vec<Vec<String>> = Vec::new();
     for assessment in &data.assessments {
-        // Safety column — new vocabulary
-        let safety = exposure_label(assessment.status);
-        let mut row = vec![safety];
+        // Safety column — omitted entirely when every subvolume is sealed.
+        let mut row: Vec<String> = Vec::new();
+        if show_exposure {
+            row.push(exposure_label(assessment.status));
+        }
 
         if show_health {
             row.push(assessment.health.clone());
@@ -350,7 +370,9 @@ pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
                     .unwrap_or_else(|| "\u{2014}".to_string()),
             );
         }
-        row.push(assessment.name.clone());
+        // SUBVOLUME cell shows the user-facing short name (§8a); the long `name`
+        // stays the key for the THREAD join, advisories, errors, and chain_health.
+        row.push(assessment.short_name.clone());
 
         // LOCAL column with temporal context
         let local_cell = if assessment.external_only {
@@ -421,25 +443,44 @@ pub(super) fn format_count_with_age(count: usize, age_secs: Option<i64>) -> Stri
 
 pub(super) fn render_advisories(data: &StatusOutput, out: &mut String) {
     let mut any = false;
+    // Errors stay per-subvolume (genuinely per-unit); only advisory NOTEs group
+    // (UPI 079-a §4). All ERRORs render first, then the grouped NOTEs — today
+    // they interleave per-assessment; the reorder is cosmetic and `contains`-safe
+    // (m2). The trailing blank line still keys on `any` (errors only), preserving
+    // the pre-grouping behavior where advisories alone add no blank line.
     for assessment in &data.assessments {
         for error in &assessment.errors {
             writeln!(out, "  {} {}: {}", "ERROR".red(), assessment.name, error).ok();
             any = true;
         }
-        for advisory in &assessment.advisories {
-            writeln!(
-                out,
-                "  {} {}: {}",
-                "NOTE".dimmed(),
-                assessment.name,
-                advisory
-            )
-            .ok();
-        }
+    }
+    for (advisory, subvols) in super::group_advisory_notes(&data.assessments) {
+        writeln!(out, "  {} {}: {}", "NOTE".dimmed(), subvols.join(", "), advisory).ok();
     }
     if any {
         writeln!(out).ok();
     }
+}
+
+/// Extract the leading day-count the engine embedded in an `OffsiteDriveStale`
+/// `detail` (UPI 056 RD10 format — `"overdue — 11 days past its usual ~45d
+/// cycle"` or `"stale — last refreshed 40 days ago"`). Used only to pick the
+/// most-overdue detail across a drive group (worst-age-wins, UPI 079-a §1 S1).
+/// A drive group is format-homogeneous — cadence is drive-level, so every
+/// member shares the same detail shape — so the *first* integer is monotonic
+/// with `last_send_age` within the group. Returns 0 when no integer is present
+/// (defensive: the format always carries one). Kept in lockstep with the
+/// `advice.rs` detail format; the §1 regression test pins the coupling.
+fn stale_detail_days(detail: &str) -> i64 {
+    let mut digits = String::new();
+    for ch in detail.chars() {
+        if ch.is_ascii_digit() {
+            digits.push(ch);
+        } else if !digits.is_empty() {
+            break;
+        }
+    }
+    digits.parse().unwrap_or(0)
 }
 
 pub(super) fn render_redundancy_advisories(data: &StatusOutput, out: &mut String) {
@@ -450,7 +491,23 @@ pub(super) fn render_redundancy_advisories(data: &StatusOutput, out: &mut String
     writeln!(out).ok();
     writeln!(out, "{}", "REDUNDANCY".dimmed()).ok();
 
+    // OffsiteDriveStale groups by drive (UPI 079-a §1): N subvolumes on one
+    // overdue offsite drive share a single physical fact, so the drive's copy
+    // staleness renders once — naming the affected subvolumes — not N identical
+    // lines. Every other kind is genuinely per-subvolume (its text names the
+    // subvolume) and renders unchanged. Grouping display lines is presentation
+    // (architecture.md: voice/ renders), so it stays render-side.
+    let mut seen_stale_drives: std::collections::HashSet<Option<String>> =
+        std::collections::HashSet::new();
+
     for advisory in &data.redundancy_advisories {
+        // Emit an OffsiteDriveStale drive group only at its first appearance.
+        if advisory.kind == RedundancyAdvisoryKind::OffsiteDriveStale
+            && !seen_stale_drives.insert(advisory.drive.clone())
+        {
+            continue;
+        }
+
         let (observation, suggestion) = match advisory.kind {
             RedundancyAdvisoryKind::NoOffsiteProtection => (
                 format!(
@@ -459,17 +516,37 @@ pub(super) fn render_redundancy_advisories(data: &StatusOutput, out: &mut String
                 ),
                 "Consider designating a drive as offsite to protect against site loss.".to_string(),
             ),
-            RedundancyAdvisoryKind::OffsiteDriveStale => (
-                // The cadence-relative predicate comes from the engine `detail`
-                // (UPI 056, RD10) — e.g. "overdue — 11 days past its usual ~45d
-                // cycle"; voice supplies only the framing.
-                format!(
-                    "The offsite copy on {} is {}.",
-                    advisory.drive.as_deref().unwrap_or("unknown"),
-                    advisory.detail,
-                ),
-                "Cycle the offsite drive on your next trip to refresh the copy.".to_string(),
-            ),
+            RedundancyAdvisoryKind::OffsiteDriveStale => {
+                // Worst-age-wins across the drive group (S1): `detail` embeds a
+                // per-subvolume day count (the cadence-relative predicate from
+                // advice.rs, UPI 056 RD10), so grouping on the raw detail would
+                // fail to collapse different-age subvolumes. Surface the
+                // most-overdue detail and name the affected subvolumes.
+                let mut worst_detail = advisory.detail.as_str();
+                let mut worst_days = stale_detail_days(&advisory.detail);
+                let mut names: Vec<&str> = Vec::new();
+                for a in &data.redundancy_advisories {
+                    if a.kind == RedundancyAdvisoryKind::OffsiteDriveStale
+                        && a.drive == advisory.drive
+                    {
+                        names.push(a.subvolume.as_str());
+                        let days = stale_detail_days(&a.detail);
+                        if days > worst_days {
+                            worst_days = days;
+                            worst_detail = a.detail.as_str();
+                        }
+                    }
+                }
+                (
+                    format!(
+                        "The offsite copy on {} is {} ({}).",
+                        advisory.drive.as_deref().unwrap_or("unknown"),
+                        worst_detail,
+                        names.join(", "),
+                    ),
+                    "Cycle the offsite drive on your next trip to refresh the copy.".to_string(),
+                )
+            }
             RedundancyAdvisoryKind::SinglePointOfFailure => (
                 format!(
                     "{} rests on a single external drive.",
@@ -640,6 +717,10 @@ fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
 
     // Next-action suggestion
     if let Some(ref advice) = data.best_advice {
+        // `total_needing_attention` is a distinct-cause count (UPI 079-a §3), not
+        // a row count. m1: when N subvolumes share ONE cause it is 1, so this
+        // inline branch fires and names the FIRST subvolume's remediation —
+        // intended (connecting the shared drive fixes all N), not a bug.
         if data.total_needing_attention == 1 {
             if let Some(ref cmd) = advice.command {
                 writeln!(out, "{}", format!("Run `{cmd}`.").dimmed()).ok();
@@ -647,7 +728,16 @@ fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
                 writeln!(out, "{}", reason.dimmed()).ok();
             }
         } else {
-            writeln!(out, "{}", format!("{} subvolumes need attention — run `urd status` for details.", data.total_needing_attention).dimmed()).ok();
+            writeln!(
+                out,
+                "{}",
+                format!(
+                    "{} need attention — run `urd status` for details.",
+                    pluralize(data.total_needing_attention, "issue", "issues")
+                )
+                .dimmed()
+            )
+            .ok();
         }
     } else if data.sealed_count() < data.total || health_issues > 0 {
         append_suggestion(&SuggestionContext::Default { has_issues: true }, &mut out);
@@ -675,7 +765,7 @@ pub fn render_first_time(mode: OutputMode) -> String {
 mod tests {
     use super::*;
     use crate::advice::ActionableAdvice;
-    use crate::output::{DriveInfo, StatusDriveAssessment};
+    use crate::output::{AdaptationSummary, DriveInfo, StatusDriveAssessment};
     use crate::voice::test_fixtures::*;
 
     #[test]
@@ -799,7 +889,16 @@ mod tests {
         h.status = PromiseStatus::AtRisk; // capped from Protected
         h.cadence_adapted = true;
         h.effective_send_interval_secs = Some(7 * 86400); // weekly
-        // declared-Graduated (external_only stays false) → history-reduced clause.
+        // The adaptation line is driven by the pre-aggregated summary (UPI 079-a
+        // §2). declared-Graduated (external_only false) → history-reduced clause.
+        data.storage_adaptations = vec![AdaptationSummary {
+            pool_label: "/".to_string(),
+            local_only: false,
+            external_only: false,
+            cadence_secs: Some(7 * 86400), // weekly
+            by_design: true,
+            subvolumes: vec!["htpc-home".to_string()],
+        }];
 
         let out = render_status(&data, OutputMode::Interactive);
         let head = out.lines().take(4).collect::<Vec<_>>().join("\n");
@@ -836,18 +935,19 @@ mod tests {
 
     #[test]
     fn tight_local_only_reassurance_states_only_truths() {
-        // #195: a local-only subvolume (no external drive) must not be told its
-        // "full history is on the drive" or that Urd is "backing up to spare it"
-        // — there is no drive and no send. Say only what's true.
+        // #195: a local-only group (no external drive) must not be told its "full
+        // history is on the drive" or that Urd is "backing up to spare it" — there
+        // is no drive and no send. Say only what's true.
         let _color = color_guard(false);
         let mut data = test_status_output();
-        data.assessments.truncate(1);
-        let a = &mut data.assessments[0];
-        a.name = "subvol6-tmp".to_string();
-        a.external = vec![]; // local-only
-        a.status = PromiseStatus::Protected;
-        a.cadence_adapted = false;
-        a.effective_send_interval_secs = Some(86400);
+        data.storage_adaptations = vec![AdaptationSummary {
+            pool_label: "/data".to_string(),
+            local_only: true,
+            external_only: false,
+            cadence_secs: None,
+            by_design: false,
+            subvolumes: vec!["subvol6-tmp".to_string()],
+        }];
 
         let mut out = String::new();
         render_storage_adaptations(&data, &mut out);
@@ -875,11 +975,14 @@ mod tests {
         // the sparing invisible).
         let _color = color_guard(false);
         let mut data = test_status_output();
-        data.assessments.truncate(1);
-        let a = &mut data.assessments[0]; // htpc-home, has external WD-18TB
-        a.status = PromiseStatus::Protected;
-        a.cadence_adapted = false;
-        a.effective_send_interval_secs = Some(129600); // 36h
+        data.storage_adaptations = vec![AdaptationSummary {
+            pool_label: "/data".to_string(),
+            local_only: false,
+            external_only: false, // has local history → "full history on the drive"
+            cadence_secs: Some(129600), // 36h
+            by_design: false,
+            subvolumes: vec!["htpc-home".to_string()],
+        }];
 
         let mut out = String::new();
         render_storage_adaptations(&data, &mut out);
@@ -889,6 +992,82 @@ mod tests {
         assert!(
             out.contains("to spare it"),
             "an external subvol keeps the spare-the-drive prose: {out}"
+        );
+    }
+
+    #[test]
+    fn subvolume_cell_shows_short_name_while_thread_resolves_by_long_name() {
+        // §8a: the SUBVOLUME cell renders the user-facing short name, but the
+        // THREAD column (keyed on the long `name` via chain_health) still resolves
+        // — proving the long name stays the join key.
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.assessments[0].short_name = "SHORTHOME".to_string(); // long name stays "htpc-home"
+        let output = render_status(&data, OutputMode::Interactive);
+        let row = output
+            .lines()
+            .find(|l| l.contains("SHORTHOME"))
+            .unwrap_or_else(|| panic!("no SHORTHOME row in:\n{output}"));
+        assert!(
+            row.contains("unbroken"),
+            "THREAD must resolve via the long name (chain_health keyed 'htpc-home'): {row}"
+        );
+        assert!(
+            !row.contains("htpc-home"),
+            "SUBVOLUME cell must show the short name only, not the long name: {row}"
+        );
+    }
+
+    #[test]
+    fn all_sealed_table_omits_exposure_column_mixed_keeps_it() {
+        // §9: an all-sealed table hides the EXPOSURE column (the aggregate promise
+        // already leads via the summary line); a mixed table keeps it.
+        let _color = color_guard(false);
+
+        // Mixed (fixture htpc-docs is AT RISK) → EXPOSURE header present.
+        let mixed = render_status(&test_status_output(), OutputMode::Interactive);
+        assert!(
+            mixed.contains("EXPOSURE"),
+            "a mixed table must keep the EXPOSURE header: {mixed}"
+        );
+
+        // All sealed → EXPOSURE header and per-row exposure cell gone.
+        let mut data = test_status_output();
+        for a in &mut data.assessments {
+            a.status = PromiseStatus::Protected;
+            a.health = "healthy".to_string();
+            a.health_reasons.clear();
+        }
+        let sealed = render_status(&data, OutputMode::Interactive);
+        assert!(
+            !sealed.contains("EXPOSURE"),
+            "an all-sealed table must omit the EXPOSURE header: {sealed}"
+        );
+        // The aggregate promise state still leads via the summary line.
+        assert!(
+            sealed.contains("All sealed."),
+            "the summary must still state the aggregate promise: {sealed}"
+        );
+    }
+
+    #[test]
+    fn all_sealed_table_health_column_leads_when_exposure_hidden() {
+        // When EXPOSURE is hidden but a sealed subvolume is still degraded, HEALTH
+        // takes index 0 — the color index must shift so the HEALTH cell stays
+        // yellow (a stale health_col = 1 would colour the SUBVOLUME cell instead).
+        let _color = color_guard(true);
+        let mut data = test_status_output();
+        for a in &mut data.assessments {
+            a.status = PromiseStatus::Protected; // all sealed → EXPOSURE hidden
+        }
+        // htpc-docs stays health "degraded" (from the fixture) → HEALTH shown.
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(!output.contains("EXPOSURE"), "EXPOSURE hidden when all sealed: {output}");
+        assert!(output.contains("HEALTH"), "HEALTH column still shown for a degraded sealed row");
+        // The degraded HEALTH cell (now at index 0) is still yellow-wrapped.
+        assert!(
+            output.contains("\u{1b}[33mdegraded\u{1b}[0m"),
+            "degraded HEALTH cell must stay yellow after the index shift: {output:?}"
         );
     }
 
@@ -1021,13 +1200,6 @@ mod tests {
     }
 
     #[test]
-    fn interactive_contains_pin_count() {
-        let _color = color_guard(false);
-        let output = render_status(&test_status_output(), OutputMode::Interactive);
-        assert!(output.contains("3"), "missing pin count");
-    }
-
-    #[test]
     fn interactive_no_subvolumes() {
         let _color = color_guard(false);
         let data = StatusOutput {
@@ -1040,6 +1212,7 @@ mod tests {
             redundancy_advisories: vec![],
             advice: vec![],
             storage_postures: Vec::new(),
+            storage_adaptations: Vec::new(),
         };
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
@@ -1115,6 +1288,7 @@ mod tests {
             redundancy_advisories: vec![],
             advice: vec![],
             storage_postures: Vec::new(),
+            storage_adaptations: Vec::new(),
         };
         let output = render_status(&data, OutputMode::Interactive);
         assert!(
@@ -1220,13 +1394,44 @@ mod tests {
             },
         ];
         let output = render_status(&data, OutputMode::Interactive);
+        // Two advice rows, distinct causes (one None-reason waning + one
+        // Connect-drive reason) → "2 issues need attention" (UPI 079-a §3).
         assert!(
-            output.contains("2 subvolumes need attention"),
-            "missing doctor redirect: {output}"
+            output.contains("2 issues need attention"),
+            "missing cause-count doctor redirect: {output}"
         );
         assert!(
             output.contains("urd doctor"),
             "missing doctor command: {output}"
+        );
+    }
+
+    #[test]
+    fn status_two_rows_one_cause_reads_one_issue_singular() {
+        // §3: two advice rows sharing one cause collapse to "1 issue needs
+        // attention" — the row count is 2 but the cause count is 1, and the verb
+        // agrees.
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        let shared = "Connect WD-18TB and run `urd backup`".to_string();
+        data.advice = vec![
+            ActionableAdvice {
+                subvolume: "htpc-home".to_string(),
+                issue: "waning".to_string(),
+                command: None,
+                reason: Some(shared.clone()),
+            },
+            ActionableAdvice {
+                subvolume: "htpc-docs".to_string(),
+                issue: "waning".to_string(),
+                command: None,
+                reason: Some(shared),
+            },
+        ];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("1 issue needs attention"),
+            "two rows, one cause → singular cause count with agreeing verb: {output}"
         );
     }
 
@@ -1287,6 +1492,87 @@ mod tests {
         assert!(
             !output.contains("REDUNDANCY"),
             "REDUNDANCY section should be absent when no advisories"
+        );
+    }
+
+    fn offsite_stale(subvolume: &str, drive: &str, detail: &str) -> crate::advice::RedundancyAdvisory {
+        crate::advice::RedundancyAdvisory {
+            kind: RedundancyAdvisoryKind::OffsiteDriveStale,
+            subvolume: subvolume.to_string(),
+            drive: Some(drive.to_string()),
+            detail: detail.to_string(),
+        }
+    }
+
+    #[test]
+    fn redundancy_offsite_stale_groups_by_drive_names_affected_subvols() {
+        // UPI 079-a §1: N subvolumes on one overdue offsite drive collapse to a
+        // single line naming all affected subvolumes — not N identical lines.
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        let detail = "overdue \u{2014} 10 days past its usual ~30d cycle";
+        data.redundancy_advisories = vec![
+            offsite_stale("htpc-home", "WD-18TB", detail),
+            offsite_stale("htpc-docs", "WD-18TB", detail),
+            offsite_stale("htpc-media", "WD-18TB", detail),
+        ];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert_eq!(
+            output.matches("The offsite copy on WD-18TB").count(),
+            1,
+            "one offsite-stale line per drive, got:\n{output}"
+        );
+        let line = output
+            .lines()
+            .find(|l| l.contains("The offsite copy on WD-18TB"))
+            .unwrap();
+        assert!(
+            line.contains("htpc-home") && line.contains("htpc-docs") && line.contains("htpc-media"),
+            "grouped line must name all affected subvolumes: {line}"
+        );
+        assert_eq!(
+            output.matches("Cycle the offsite drive").count(),
+            1,
+            "one suggestion per drive group, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn redundancy_offsite_stale_group_carries_worst_age() {
+        // S1 regression guard: two subvolumes, same drive, different
+        // last_send_age → one line carrying the OLDER age (worst-age-wins).
+        // Guards the string-identity-vs-fact-identity regression: grouping on the
+        // raw `detail` would fail to collapse the two different-age rows.
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.redundancy_advisories = vec![
+            offsite_stale("htpc-home", "WD-18TB", "overdue \u{2014} 5 days past its usual ~30d cycle"),
+            offsite_stale("htpc-docs", "WD-18TB", "overdue \u{2014} 20 days past its usual ~30d cycle"),
+        ];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert_eq!(output.matches("The offsite copy on WD-18TB").count(), 1);
+        let line = output
+            .lines()
+            .find(|l| l.contains("The offsite copy on WD-18TB"))
+            .unwrap();
+        assert!(line.contains("20 days"), "grouped line must carry the older age: {line}");
+        assert!(!line.contains("5 days"), "must not carry the younger age: {line}");
+    }
+
+    #[test]
+    fn redundancy_offsite_stale_distinct_drives_render_separately() {
+        // Different drives are different facts → two lines, not a false merge.
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        data.redundancy_advisories = vec![
+            offsite_stale("htpc-home", "WD-18TB", "overdue \u{2014} 5 days past its usual ~30d cycle"),
+            offsite_stale("htpc-docs", "Offsite-4TB", "stale \u{2014} last refreshed 90 days ago"),
+        ];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert_eq!(
+            output.matches("The offsite copy on").count(),
+            2,
+            "two distinct drives → two lines: {output}"
         );
     }
 
@@ -1527,6 +1813,31 @@ mod tests {
     }
 
     #[test]
+    fn advisories_collapse_multi_subvol_into_one_note_line() {
+        // UPI 079-a §4: N subvolumes sharing one advisory collapse to a single
+        // NOTE line naming all of them — not N identical lines.
+        let _color = color_guard(false);
+        let mut data = test_status_output();
+        let shared = "offsite copy stale — resilient promise degraded";
+        data.assessments[0].advisories = vec![shared.to_string()];
+        data.assessments[1].advisories = vec![shared.to_string()];
+        let output = render_status(&data, OutputMode::Interactive);
+        assert_eq!(
+            output.matches(shared).count(),
+            1,
+            "shared advisory must render on a single NOTE line, got:\n{output}"
+        );
+        let note_line = output
+            .lines()
+            .find(|l| l.contains("NOTE"))
+            .unwrap_or_else(|| panic!("no NOTE line in:\n{output}"));
+        assert!(
+            note_line.contains("htpc-home") && note_line.contains("htpc-docs"),
+            "grouped NOTE must name both subvolumes: {note_line}"
+        );
+    }
+
+    #[test]
     fn advisory_transient_no_recovery_uses_disabled_vocabulary() {
         let _color = color_guard(false);
         let mut data = test_status_output();
@@ -1756,8 +2067,8 @@ mod tests {
         data.total_needing_attention = 2;
         let output = render_default_status(&data, OutputMode::Interactive);
         assert!(
-            output.contains("2 subvolumes need attention"),
-            "multiple issues should show count: {output}"
+            output.contains("2 issues need attention"),
+            "multiple issues should show cause count: {output}"
         );
         assert!(
             output.contains("urd status"),


### PR DESCRIPTION
## Summary

Reworks the `urd status` surface so the first status after onboarding reads like one voice speaking, not a spreadsheet. Six render-layer collapses plus two additive `--json` shapes (UPI 079-a):

- **§4 NOTE grouping** — N subvolumes sharing one advisory collapse to one NOTE line naming them (errors stay per-subvolume).
- **§1 REDUNDANCY grouping** — `OffsiteDriveStale` groups by drive, surfaces the most-overdue detail (worst-age-wins), and names the affected subvolumes instead of printing one identical line each.
- **§3 footer cause-count** — new pure `advice::count_distinct_causes` counts root causes, not rows, in both the full-status and bare-`urd` footers ("2 issues need attention").
- **§2 tight-pool adaptations** — new `AdaptationSummary` type + compute-side `aggregate_adaptations` (the one new output type — it needs `signals.pools`, invisible to the renderer) collapse per-pool adaptation lines.
- **§8b** — drops the internal "Pinned snapshots: N" line (`total_pins` retained for `--json`).
- **§8a** — threads `short_name` into the SUBVOLUME display cell; the long `name` stays the join key for chain health / advisories / errors.
- **§9** — hides the EXPOSURE column on an all-sealed table (the summary line already states "All sealed.").

Grouping lives render-side (presentation, not state computation); only §2 is a compute-side aggregator. No breaking `--json` change — `storage_adaptations` and `short_name` are additive; `redundancy_advisories` / `advice` / `assessments` shapes are unchanged. Verified end-to-end on a real all-sealed host (no EXPOSURE column, short names, no pins line, additive JSON).

Plan: `docs/97-plans/2026-07-03-plan-079-a-facts-not-rows.md` (design → grill → prepare → arch-adversary → post-review).

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 1870 passed, 0 failed (4+1 ignored) — +23 new characterization/unit tests, -1 obsolete
- cargo build --release: pass
- present-not-journey doc lint: pass
- Integration tests: not applicable (no drive-touching changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)