### PR TITLE
release: v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-07-03
+
 ### Changed
 - **`urd status` speaks in facts, not rows.** The first status after onboarding
   now reads like one voice: subvolumes sharing one overdue offsite drive, one
@@ -16,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   says "All sealed."); the SUBVOLUME column shows the short name; and the
   internal "Pinned snapshots" line is gone. `--json` gains an additive
   `storage_adaptations` array and a per-assessment `short_name` field.
+
+## [0.30.0] - 2026-07-03
 
 ### Added
 - **The post-plan orphan invariant now guards every lifecycle.** The planner
@@ -1317,7 +1321,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.30.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.31.0...HEAD
+[0.31.0]: https://github.com/vonrobak/urd/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/vonrobak/urd/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/vonrobak/urd/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/vonrobak/urd/compare/v0.27.1...v0.28.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.30.0"
+version = "0.31.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.31.0** — facts-not-rows reconciliation for `urd status` (UPI 079-a, #243). The first status after onboarding now reads like one voice: grouped REDUNDANCY / NOTE / tight-pool adaptation lines, a distinct-cause footer count, a gated EXPOSURE column on all-sealed tables, short names in the SUBVOLUME cell, and the internal pins line removed. `--json` stays backward-compatible (additive `storage_adaptations` array + per-assessment `short_name`).

Also restores the `## [0.30.0]` CHANGELOG header that was accidentally dropped in #243 (its entry had been absorbed into `[Unreleased]`); the v0.30.0 tag and code are unaffected.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1870 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)