### PR TITLE
feat: de-emphasise by-design AT RISK rows in urd status (UPI 080)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`urd status` de-emphasises a slowdown that is by design.** A row that is AT RISK
+  purely because a Critical source pool made Urd slow its cadence — with the backup
+  chain otherwise healthy — now renders its EXPOSURE cell dim instead of the alarming
+  yellow a genuine problem gets, so a deliberate adaptation reads as calm, not failure.
+
 ## [0.31.0] - 2026-07-03
 
 ### Changed

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -58,6 +58,34 @@ output is a half-built picture — awareness stays protection-level-blind
 stale-offsite degradation. A clippy `disallowed-methods` guard enforces the
 rule: surfaces call `assess_view`, never `assess`.
 
+**gravity.** The single severity ordering by which Urd decides what is more urgent:
+`PromiseStatus`'s derived `Ord` (worst-to-best, `UNPROTECTED < AT RISK < PROTECTED`) —
+and *nothing else*. Every "worst wins" reduction rides this one ordering: `min()` across
+a subvolume's copies, across subvolumes, and the aggregate summary line. The rule is
+load-bearing and deliberately enforced — a second severity representation that could
+disagree with `status` is the bug UPI 053 shipped a deletion to remove (the hand-rolled
+`status_severity` helper), and the mistake `DriveRotation`/`rotation.rs` cite as the one
+not to repeat (no `RotationTier`/`Due` gravity — `awareness.rs:423`, `rotation.rs:107`).
+Orthogonal axes (operational health, storage posture, the rotation voice register) may
+*layer over* gravity, but never re-order it. A derived display classifier reads gravity;
+it never competes with it, and carries no `Ord` of its own.
+
+**operational health** (`OperationalHealth`, `awareness.rs`). A second, orthogonal axis
+answering *"can the next backup succeed efficiently?"* — distinct from gravity's *"is my
+data safe?"*. Three values, ordered worst-to-best (`min()` yields the worst):
+
+| Health | Meaning |
+|--------|---------|
+| `blocked` | Something will prevent or severely impair the next backup. |
+| `degraded` | The next backup will work, but suboptimally (e.g. a broken chain forcing a full send). |
+| `healthy` | Normal — incremental chains intact, space adequate. |
+
+Mostly separate from `PromiseStatus`: a subvolume can be `PROTECTED` yet `degraded`, or
+`AT RISK` yet `healthy`. The one recorded coupling is the Critical-pool AT-RISK cap (see
+`storage posture`). Unlike promise states, health has **no separate voice label** — the
+lowercase engine word renders directly (`healthy` dimmed, `degraded` yellow, `blocked`
+red), and `urd status` shows the HEALTH column only when some subvolume is non-`healthy`.
+
 ## Cluster: Voice labels (presentation)
 
 The CLI surface renders the promise states with the mythic voice labels below. The

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -285,6 +285,8 @@ fn color_exposure_str(exposure: &str) -> String {
         "sealed" => "sealed".green().to_string(),
         "waning" => "waning".yellow().to_string(),
         "exposed" => "exposed".red().to_string(),
+        // An adapting row's cell arrives already dimmed (UPI 080, `status::exposure_cell`)
+        // and falls here — passed through unchanged so the de-emphasis survives.
         other => other.to_string(),
     }
 }

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -12,7 +12,8 @@ use colored::Colorize;
 use crate::advice::RedundancyAdvisoryKind;
 use crate::awareness::PromiseStatus;
 use crate::output::{
-    ChainHealth, DefaultStatusOutput, OutputMode, PoolPostureSummary, StatusOutput,
+    ChainHealth, DefaultStatusOutput, OutputMode, PoolPostureSummary, StatusAssessment,
+    StatusOutput,
 };
 use crate::storage_critical::TightnessTier;
 use crate::types::{ByteSize, DriveRole};
@@ -287,6 +288,28 @@ fn storage_posture_line(p: &PoolPostureSummary) -> colored::ColoredString {
     }
 }
 
+/// The EXPOSURE cell string for one row (UPI 080, adapting de-emphasis).
+///
+/// Normally the plain voice label (`sealed`/`waning`/`exposed`), coloured
+/// downstream by `color_exposure_str` on the safety column. The one exception:
+/// an *adapting* row — AT RISK purely because the Critical-pool cadence cap
+/// slowed it (`cadence_adapted`), with a healthy chain — is "waning by design",
+/// not a failure, so its cell is pre-dimmed here. De-emphasis only: it is never
+/// brighter than `status`, and the `health == "healthy"` clause is ruling (i) —
+/// a broken-chain (degraded) capped row keeps the alarming yellow, because a
+/// broken chain *is* something to act on. The pre-coloured string passes through
+/// `color_exposure_str`'s fall-through branch untouched.
+fn exposure_cell(a: &StatusAssessment) -> String {
+    let label = exposure_label(a.status);
+    let adapting =
+        a.status == PromiseStatus::AtRisk && a.cadence_adapted && a.health == "healthy";
+    if adapting {
+        label.dimmed().to_string()
+    } else {
+        label
+    }
+}
+
 pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
     if data.assessments.is_empty() {
         writeln!(out, "{}", "No subvolumes configured.".dimmed()).ok();
@@ -356,7 +379,7 @@ pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
         // Safety column — omitted entirely when every subvolume is sealed.
         let mut row: Vec<String> = Vec::new();
         if show_exposure {
-            row.push(exposure_label(assessment.status));
+            row.push(exposure_cell(assessment));
         }
 
         if show_health {
@@ -1068,6 +1091,34 @@ mod tests {
         assert!(
             output.contains("\u{1b}[33mdegraded\u{1b}[0m"),
             "degraded HEALTH cell must stay yellow after the index shift: {output:?}"
+        );
+    }
+
+    #[test]
+    fn adapting_row_exposure_cell_dims_genuine_waning_stays_yellow() {
+        // UPI 080 (adapting de-emphasis): a row that is AT RISK purely because the
+        // Critical-pool cadence cap slowed it (`cadence_adapted`) and whose chain is
+        // healthy is "waning by design", not a failure — its EXPOSURE cell renders
+        // dim, not the alarming yellow a genuine waning gets. De-emphasis only;
+        // ruling (i): a broken-chain (degraded) capped row stays yellow.
+        let _color = color_guard(true);
+        let mut data = test_status_output();
+        // assessments[0] (htpc-home): make it the adapting row.
+        let a = &mut data.assessments[0];
+        a.status = PromiseStatus::AtRisk;
+        a.cadence_adapted = true;
+        a.health = "healthy".to_string();
+        // assessments[1] (htpc-docs) stays AT RISK + degraded (genuine) from the
+        // fixture — the yellow-waning control on the same table.
+
+        let out = render_status(&data, OutputMode::Interactive);
+        assert!(
+            out.contains("\u{1b}[2mwaning\u{1b}[0m"),
+            "an adapting row's EXPOSURE cell must render dim: {out:?}"
+        );
+        assert!(
+            out.contains("\u{1b}[33mwaning\u{1b}[0m"),
+            "a genuine (non-adapting) waning must stay yellow: {out:?}"
         );
     }
 


### PR DESCRIPTION
## Summary

- **The CLI half of UPI 080.** An *adapting* row — AT RISK purely because a Critical source pool capped its cadence (`cadence_adapted`) while the backup chain stays healthy — now renders its EXPOSURE cell **dim** instead of the alarming yellow a genuine waning gets. A deliberate do-no-harm slowdown reads as calm, not failure.
- **De-emphasis only.** The treatment is never brighter than `status` (a sealed/exposed cell can't dim), and a broken-chain (degraded) capped row keeps the yellow — a broken chain *is* something to act on.
- **Implementation:** a small `exposure_cell()` render helper in `voice/status.rs`; the pre-dimmed cell passes through `color_exposure_str`'s fall-through untouched. No new type, no `--json`/schema change, no cross-repo impact.
- **Glossary:** formalises the load-bearing **`gravity`** term (single-source severity ordering) and documents the **operational-health** axis (`healthy`/`degraded`/`blocked`), both previously undocumented.

The four-signal `RowSignal` model and the `VisualIcon`/Spindle-schema retirement are **deferred to Spindle's own design** (per the ponytail + steve reviews): a visual treatment should be judged against the menubar it serves, not built speculatively now.

## Testing

- cargo clippy --all-targets -D warnings: pass (clean)
- cargo test: 1871 passed / 4 ignored (+1 new test: `adapting_row_exposure_cell_dims_genuine_waning_stays_yellow`)
- cargo build --release: pass
- Perceptual check (does dim-vs-yellow read to a human) pending on a real terminal with a Critical-pool subvolume — owned by the maintainer post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)