### PR TITLE
feat: 079-b/-c — honest skip counts, plan disclosure, doctor/sentinel polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   disconnected-drives count is pluralized properly and scoped to absent-drive
   sends; actionable skips sit under their own "Needs attention:" heading instead
   of borrowing the other block's number (#212).
+- **`urd doctor` collapses passing infrastructure checks** to one line
+  ("✓ All 4 checks passed.") outside `--thorough`; any failure expands the full
+  section. Remediation guidance now always renders behind the `→` arrow — the
+  drive-absent row no longer hides its "what do I do" in dimmed context text.
+- **`urd sentinel status` shows the last assessment as a relative age** ("5m ago")
+  instead of an ISO timestamp; the JSON surface keeps the raw stamp.
 
 ## [0.31.0] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   purely because a Critical source pool made Urd slow its cadence — with the backup
   chain otherwise healthy — now renders its EXPOSURE cell dim instead of the alarming
   yellow a genuine problem gets, so a deliberate adaptation reads as calm, not failure.
+- **`urd plan` leads with the summary and hides the operations wall behind
+  `--verbose`.** The default output is verdict → summary → skip reasons, with a
+  pointer line naming the door (`urd plan --verbose lists every operation`); the
+  full per-operation list renders only when asked. In the verbose list, DELETE
+  lines are tagged `[local]` or `[<drive>]` so identical snapshot names deleted
+  from two places no longer read as a duplicate.
+
+### Fixed
+- **A caught-up subvolume no longer appears twice in the skip list.** The planner's
+  `unchanged` record and its per-drive "already on <drive>" records collapse to one
+  line — "unchanged — no changes since last snapshot (3d ago); already on WD-18TB" —
+  and the summary counts collapsed records, in `urd plan`, `urd backup --dry-run`,
+  and the post-backup summary (#212).
+- **The backup summary's skip count now covers only its own list.** The
+  disconnected-drives count is pluralized properly and scoped to absent-drive
+  sends; actionable skips sit under their own "Needs attention:" heading instead
+  of borrowing the other block's number (#212).
 
 ## [0.31.0] - 2026-07-03
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -170,6 +170,10 @@ pub struct PlanArgs {
     /// Create snapshots even for unchanged subvolumes
     #[arg(long)]
     pub force_snapshot: bool,
+
+    /// List every planned operation (default output is summary-first)
+    #[arg(long, short = 'v')]
+    pub verbose: bool,
 }
 
 #[derive(clap::Args, Debug)]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -128,7 +128,9 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
             &config,
         );
         let mode = crate::output::OutputMode::detect();
-        print!("{}", crate::voice::render_plan(&plan_output, mode));
+        // Summary-first like `urd plan` (028-R5); the pointer line in the
+        // rendered output redirects detail-seekers to `urd plan --verbose`.
+        print!("{}", crate::voice::render_plan(&plan_output, mode, false));
         return Ok(());
     }
 
@@ -1256,16 +1258,9 @@ fn build_backup_summary(
         })
         .collect();
 
-    let skipped: Vec<SkippedSubvolume> = plan
-        .skipped
-        .iter()
-        .map(|skip| SkippedSubvolume {
-            name: skip.name.clone(),
-            category: SkipCategory::from_reason(&skip.reason),
-            reason: skip.reason.clone(),
-            next_due_minutes: skip.next_due_minutes,
-        })
-        .collect();
+    // Collapsed like the plan surfaces (#212): one record per conclusion,
+    // not one per drive — see plan_cmd::collapse_skipped.
+    let skipped: Vec<SkippedSubvolume> = crate::commands::plan_cmd::collapse_skipped(&plan.skipped);
 
     // Synthesize deferred entries for subvolumes that needed sends but had no snapshots.
     // Works from the skip list outward: adds to existing SubvolumeSummary or creates synthetic.

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -177,22 +177,14 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
             let advice = advice::compute_advice(a, send_enabled, external_only);
 
             // Extract structured advice into doctor display fields.
-            let unpack = |adv: &advice::ActionableAdvice| {
-                (
-                    Some(adv.issue.clone()),
-                    adv.command.as_ref().map(|c| format!("Run `{c}`.")),
-                    adv.reason.clone(),
-                )
-            };
-
             let (issue, suggestion, reason) = match a.status {
                 PromiseStatus::Protected if a.health == awareness::OperationalHealth::Healthy => {
                     (None, None, None)
                 }
-                PromiseStatus::Protected => advice.as_ref().map(unpack).unwrap_or_default(),
+                PromiseStatus::Protected => advice.as_ref().map(unpack_advice).unwrap_or_default(),
                 PromiseStatus::Unprotected => {
                     error_count += 1;
-                    advice.as_ref().map(unpack).unwrap_or_else(|| {
+                    advice.as_ref().map(unpack_advice).unwrap_or_else(|| {
                         (
                             Some("exposed — data may not be recoverable".to_string()),
                             Some("Run `urd backup` or connect a drive.".to_string()),
@@ -202,7 +194,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
                 }
                 PromiseStatus::AtRisk => {
                     warn_count += 1;
-                    advice.as_ref().map(unpack).unwrap_or_else(|| {
+                    advice.as_ref().map(unpack_advice).unwrap_or_else(|| {
                         (
                             Some("waning".to_string()),
                             Some("Run `urd backup` to refresh.".to_string()),
@@ -713,9 +705,67 @@ fn build_doctor_churn_view_inner(
     }
 }
 
+/// Map an `ActionableAdvice` onto doctor's `(issue, suggestion, reason)`
+/// display fields. UPI 029 (via 079-c): remediation always renders behind
+/// the → arrow — `compute_advice` puts machine-runnable fixes in `command`
+/// and human-actionable guidance in `reason` ("Connect WD-18TB1 and run
+/// `urd backup`", branch 5); with no command the reason IS the suggestion,
+/// so promote it rather than leaving the drive-absent row as the one row
+/// without a "what do I do" handle.
+fn unpack_advice(
+    adv: &advice::ActionableAdvice,
+) -> (Option<String>, Option<String>, Option<String>) {
+    match adv.command.as_ref() {
+        Some(c) => (
+            Some(adv.issue.clone()),
+            Some(format!("Run `{c}`.")),
+            adv.reason.clone(),
+        ),
+        None => (Some(adv.issue.clone()), adv.reason.clone(), None),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── unpack_advice (UPI 029 Change 4, via 079-c) ───────────────────
+
+    #[test]
+    fn unpack_advice_keeps_command_as_suggestion_with_reason_context() {
+        let adv = advice::ActionableAdvice {
+            subvolume: "music".to_string(),
+            issue: "waning — last external send 43h ago".to_string(),
+            command: Some("urd backup --subvolume music".to_string()),
+            reason: Some("Drive is mounted; a send closes the gap.".to_string()),
+        };
+        let (issue, suggestion, reason) = unpack_advice(&adv);
+        assert_eq!(issue.as_deref(), Some("waning — last external send 43h ago"));
+        assert_eq!(
+            suggestion.as_deref(),
+            Some("Run `urd backup --subvolume music`.")
+        );
+        assert_eq!(reason.as_deref(), Some("Drive is mounted; a send closes the gap."));
+    }
+
+    #[test]
+    fn unpack_advice_promotes_reason_when_no_command() {
+        // Branch 5 (drive absent): the guidance lives in `reason` — it must
+        // reach the → suggestion slot, not render as dimmed context.
+        let adv = advice::ActionableAdvice {
+            subvolume: "music".to_string(),
+            issue: "waning — last external send 3d ago".to_string(),
+            command: None,
+            reason: Some("Connect WD-18TB1 and run `urd backup`".to_string()),
+        };
+        let (_, suggestion, reason) = unpack_advice(&adv);
+        assert_eq!(
+            suggestion.as_deref(),
+            Some("Connect WD-18TB1 and run `urd backup`"),
+            "reason promotes to the arrowed suggestion slot"
+        );
+        assert_eq!(reason, None, "promoted guidance must not render twice");
+    }
 
     fn cfg() -> Config {
         let toml_str = r#"

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use crate::cli::PlanArgs;
 use crate::commands::storage_signals;
-use crate::config::Config;
+use crate::config::{Config, DriveConfig};
 use crate::drives;
 use crate::output::{
     OutputMode, PlanOperationEntry, PlanOutput, PlanSummaryOutput, SkipCategory,
@@ -8,7 +10,7 @@ use crate::output::{
 };
 use crate::plan::{self, HistoryQuery, Observation, PlanFilters, RealFileSystemState};
 use crate::state::StateDb;
-use crate::types::PlannedOperation;
+use crate::types::{PlannedOperation, PlannedSkip};
 use crate::voice;
 
 pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<()> {
@@ -46,7 +48,7 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
 
     let mut output = build_plan_output(&backup_plan, &fs_state, &config);
     populate_token_warnings(&mut output, state_db.as_ref(), &config);
-    print!("{}", voice::render_plan(&output, mode));
+    print!("{}", voice::render_plan(&output, mode, args.verbose));
 
     Ok(())
 }
@@ -63,19 +65,13 @@ pub fn build_plan_output(
     let operations: Vec<PlanOperationEntry> = backup_plan
         .operations
         .iter()
-        .map(|op| build_operation_entry(op, fs_state))
+        .map(|op| build_operation_entry(op, fs_state, &config.drives))
         .collect();
 
-    let skipped: Vec<SkippedSubvolume> = backup_plan
-        .skipped
-        .iter()
-        .map(|skip| SkippedSubvolume {
-            name: skip.name.clone(),
-            category: SkipCategory::from_reason(&skip.reason),
-            reason: skip.reason.clone(),
-            next_due_minutes: skip.next_due_minutes,
-        })
-        .collect();
+    let skipped = collapse_skipped(&backup_plan.skipped);
+    // Post-collapse count: the summary must agree with the list the user
+    // reads, not with the planner's raw per-branch emissions.
+    let skipped_count = skipped.len();
 
     // Aggregate estimated bytes across all sends with estimates.
     let estimated_total: u64 = operations
@@ -102,12 +98,53 @@ pub fn build_plan_output(
             snapshots: summary.snapshots,
             sends: summary.sends,
             deletions: summary.deletions,
-            skipped: summary.skipped,
+            skipped: skipped_count,
             estimated_total_bytes,
             configured_subvolumes,
         },
         warnings: Vec::new(),
     }
+}
+
+/// Map planner skips to display records, collapsing each subvolume's
+/// `unchanged` local skip with its `already on <drive>` send skips (#212).
+/// The planner rightly emits one record per branch (ADR-100), but they state
+/// one conclusion — nothing new to store or send — and the user should read
+/// it once, not once per configured drive. Collapsing here at the output
+/// boundary leaves the raw list intact for the post-plan orphan invariant
+/// (which runs inside `plan::plan()`) and for metrics.
+///
+/// Shared by `urd plan` / `urd backup --dry-run` (via [`build_plan_output`])
+/// and the post-run backup summary.
+#[must_use]
+pub(crate) fn collapse_skipped(skipped: &[PlannedSkip]) -> Vec<SkippedSubvolume> {
+    let mut out: Vec<SkippedSubvolume> = Vec::new();
+    let mut unchanged_idx: HashMap<&str, usize> = HashMap::new();
+    for skip in skipped {
+        let category = SkipCategory::from_reason(&skip.reason);
+        if category == SkipCategory::Unchanged {
+            unchanged_idx.insert(skip.name.as_str(), out.len());
+        } else if skip.nothing_new_to_send
+            && let Some((_, drive)) = skip.reason.split_once(" already on ")
+            && let Some(&idx) = unchanged_idx.get(skip.name.as_str())
+        {
+            let merged = &mut out[idx];
+            merged.reason.push_str(if merged.reason.contains("; already on ") {
+                ", "
+            } else {
+                "; already on "
+            });
+            merged.reason.push_str(drive);
+            continue;
+        }
+        out.push(SkippedSubvolume {
+            name: skip.name.clone(),
+            category,
+            reason: skip.reason.clone(),
+            next_due_minutes: skip.next_due_minutes,
+        });
+    }
+    out
 }
 
 /// Post-plan token verification — planner is pure (ADR-100/108) and has no
@@ -142,6 +179,7 @@ pub fn populate_token_warnings(
 fn build_operation_entry(
     op: &PlannedOperation,
     fs_state: &dyn HistoryQuery,
+    drives: &[DriveConfig],
 ) -> PlanOperationEntry {
     match op {
         PlannedOperation::CreateSnapshot {
@@ -225,11 +263,18 @@ fn build_operation_entry(
             kind: _,
         } => {
             let snap_name = path.file_name().unwrap_or_default().to_string_lossy();
+            // Local and external retention can delete the same snapshot name
+            // in one plan (UPI 028); the drive label disambiguates. A path
+            // under no configured mount is local by elimination.
+            let drive_label = drives
+                .iter()
+                .find(|d| path.starts_with(&d.mount_path))
+                .map(|d| d.label.clone());
             PlanOperationEntry {
                 subvolume: subvolume_name.clone(),
                 operation: "delete".to_string(),
                 detail: format!("{snap_name} ({reason})"),
-                drive_label: None,
+                drive_label,
                 estimated_bytes: None,
                 is_full_send: None,
                 full_send_reason: None,
@@ -333,7 +378,7 @@ source = "/data/htpc-docs"
             ("htpc-home".into(), "WD-18TB".into(), SendKind::Full),
             53_000_000_000,
         );
-        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs, &[]);
         assert_eq!(entry.estimated_bytes, Some(53_000_000_000));
         assert_eq!(entry.is_full_send, Some(true));
         // Size is NOT in detail — voice.rs renders it from estimated_bytes.
@@ -349,7 +394,7 @@ source = "/data/htpc-docs"
             ("htpc-home".into(), "OTHER-DRIVE".into(), SendKind::Full),
             50_000_000_000,
         );
-        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs, &[]);
         assert_eq!(entry.estimated_bytes, Some(50_000_000_000));
     }
 
@@ -360,7 +405,7 @@ source = "/data/htpc-docs"
             "htpc-home".into(),
             (45_000_000_000, "2026-03-28".into()),
         );
-        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs, &[]);
         assert_eq!(entry.estimated_bytes, Some(45_000_000_000));
     }
 
@@ -379,14 +424,14 @@ source = "/data/htpc-docs"
             "htpc-home".into(),
             (45_000_000_000, "2026-03-28".into()),
         );
-        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs, &[]);
         assert_eq!(entry.estimated_bytes, Some(53_000_000_000));
     }
 
     #[test]
     fn full_send_no_data() {
         let fs = MockFileSystemState::new();
-        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs);
+        let entry = build_operation_entry(&mock_send_full("htpc-home", "WD-18TB"), &fs, &[]);
         assert_eq!(entry.estimated_bytes, None);
         assert!(entry.detail.contains("(full"), "detail: {}", entry.detail);
         assert!(!entry.detail.contains('~'), "should not have size annotation");
@@ -399,7 +444,7 @@ source = "/data/htpc-docs"
             ("htpc-home".into(), "WD-18TB".into(), SendKind::Incremental),
             5_500_000,
         );
-        let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs);
+        let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs, &[]);
         assert_eq!(entry.estimated_bytes, Some(5_500_000));
         assert_eq!(entry.is_full_send, Some(false));
         // Size is NOT in detail — voice.rs renders it from estimated_bytes.
@@ -413,7 +458,7 @@ source = "/data/htpc-docs"
             ("htpc-home".into(), "OTHER".into(), SendKind::Incremental),
             3_000_000,
         );
-        let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs);
+        let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs, &[]);
         assert_eq!(entry.estimated_bytes, Some(3_000_000));
     }
 
@@ -425,7 +470,7 @@ source = "/data/htpc-docs"
             "htpc-home".into(),
             (45_000_000_000, "2026-03-28".into()),
         );
-        let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs);
+        let entry = build_operation_entry(&mock_send_incremental("htpc-home", "WD-18TB"), &fs, &[]);
         assert_eq!(entry.estimated_bytes, None);
     }
 
@@ -486,6 +531,160 @@ source = "/data/htpc-docs"
         };
         let output = build_plan_output(&plan, &fs, &test_config());
         assert_eq!(output.summary.estimated_total_bytes, None);
+    }
+
+    // ── Skip-collapse tests (#212 / 079-b §6) ─────────────────────────
+
+    fn unchanged_skip(name: &str) -> PlannedSkip {
+        PlannedSkip {
+            name: name.to_string(),
+            reason: "unchanged \u{2014} no changes since last snapshot (3d ago)".to_string(),
+            next_due_minutes: None,
+            nothing_new_to_send: false,
+        }
+    }
+
+    fn already_on_skip(name: &str, drive: &str) -> PlannedSkip {
+        PlannedSkip {
+            name: name.to_string(),
+            reason: format!("20260329-0404-{name} already on {drive}"),
+            next_due_minutes: None,
+            nothing_new_to_send: true,
+        }
+    }
+
+    #[test]
+    fn collapse_merges_unchanged_with_already_on() {
+        let skips = vec![
+            unchanged_skip("htpc-home"),
+            already_on_skip("htpc-home", "WD-18TB"),
+        ];
+        let collapsed = collapse_skipped(&skips);
+        assert_eq!(collapsed.len(), 1, "one conclusion, one record");
+        assert_eq!(collapsed[0].category, SkipCategory::Unchanged);
+        assert_eq!(
+            collapsed[0].reason,
+            "unchanged \u{2014} no changes since last snapshot (3d ago); already on WD-18TB",
+            "keeps the age, names the drive"
+        );
+    }
+
+    #[test]
+    fn collapse_folds_multiple_drives_into_one_record() {
+        let skips = vec![
+            unchanged_skip("htpc-home"),
+            already_on_skip("htpc-home", "WD-18TB"),
+            already_on_skip("htpc-home", "WD-18TB1"),
+        ];
+        let collapsed = collapse_skipped(&skips);
+        assert_eq!(collapsed.len(), 1);
+        assert!(
+            collapsed[0].reason.ends_with("already on WD-18TB, WD-18TB1"),
+            "drives fold into one list: {}",
+            collapsed[0].reason
+        );
+    }
+
+    #[test]
+    fn collapse_leaves_lone_already_on_untouched() {
+        // Under --auto a subvolume can be caught up on a drive while its
+        // snapshot interval hasn't elapsed — two distinct facts, no merge.
+        let skips = vec![
+            PlannedSkip {
+                name: "htpc-home".to_string(),
+                reason: "interval not elapsed (next in ~2h)".to_string(),
+                next_due_minutes: Some(120),
+                nothing_new_to_send: false,
+            },
+            already_on_skip("htpc-home", "WD-18TB"),
+        ];
+        let collapsed = collapse_skipped(&skips);
+        assert_eq!(collapsed.len(), 2, "no unchanged record, no merge");
+        assert_eq!(collapsed[1].reason, "20260329-0404-htpc-home already on WD-18TB");
+    }
+
+    #[test]
+    fn collapse_scopes_merge_per_subvolume() {
+        let skips = vec![
+            unchanged_skip("htpc-home"),
+            already_on_skip("htpc-home", "WD-18TB"),
+            unchanged_skip("htpc-docs"),
+            already_on_skip("htpc-docs", "WD-18TB"),
+        ];
+        let collapsed = collapse_skipped(&skips);
+        assert_eq!(collapsed.len(), 2);
+        assert_eq!(collapsed[0].name, "htpc-home");
+        assert_eq!(collapsed[1].name, "htpc-docs");
+        assert!(collapsed[0].reason.contains("already on WD-18TB"));
+        assert!(collapsed[1].reason.contains("already on WD-18TB"));
+    }
+
+    #[test]
+    fn collapse_keeps_unrelated_skips_separate() {
+        let skips = vec![
+            unchanged_skip("htpc-home"),
+            already_on_skip("htpc-home", "WD-18TB"),
+            PlannedSkip {
+                name: "htpc-home".to_string(),
+                reason: "send to WD-18TB1 not due (next in ~4h)".to_string(),
+                next_due_minutes: Some(240),
+                nothing_new_to_send: false,
+            },
+        ];
+        let collapsed = collapse_skipped(&skips);
+        assert_eq!(collapsed.len(), 2, "the send-interval deferral is its own fact");
+        assert_eq!(collapsed[1].category, SkipCategory::IntervalNotElapsed);
+    }
+
+    #[test]
+    fn summary_skipped_counts_collapsed_records() {
+        let fs = MockFileSystemState::new();
+        let plan = BackupPlan {
+            timestamp: chrono::NaiveDateTime::default(),
+            operations: vec![],
+            skipped: vec![
+                unchanged_skip("htpc-home"),
+                already_on_skip("htpc-home", "WD-18TB"),
+                already_on_skip("htpc-home", "WD-18TB1"),
+            ],
+            events: Vec::new(),
+        };
+        let output = build_plan_output(&plan, &fs, &test_config());
+        assert_eq!(output.skipped.len(), 1);
+        assert_eq!(
+            output.summary.skipped, 1,
+            "displayed count must match the collapsed list, not raw planner emissions"
+        );
+    }
+
+    // ── Delete-location tests (UPI 028 Change 2, folded via 079-b) ────
+
+    #[test]
+    fn delete_entry_under_drive_mount_carries_its_label() {
+        let fs = MockFileSystemState::new();
+        let config = test_config();
+        let op = PlannedOperation::DeleteSnapshot {
+            path: PathBuf::from("/mnt/wd/htpc-home/20260322-1430-htpc-home"),
+            reason: "beyond retention window".to_string(),
+            subvolume_name: "htpc-home".to_string(),
+            kind: crate::types::DeleteKind::Policy,
+        };
+        let entry = build_operation_entry(&op, &fs, &config.drives);
+        assert_eq!(entry.drive_label.as_deref(), Some("WD-18TB"));
+    }
+
+    #[test]
+    fn delete_entry_outside_drive_mounts_is_local() {
+        let fs = MockFileSystemState::new();
+        let config = test_config();
+        let op = PlannedOperation::DeleteSnapshot {
+            path: PathBuf::from("/snap/htpc-home/20260322-1430-htpc-home"),
+            reason: "graduated: daily thinning".to_string(),
+            subvolume_name: "htpc-home".to_string(),
+            kind: crate::types::DeleteKind::Policy,
+        };
+        let entry = build_operation_entry(&op, &fs, &config.drives);
+        assert_eq!(entry.drive_label, None, "local delete carries no drive label");
     }
 
     #[test]

--- a/src/voice/backup.rs
+++ b/src/voice/backup.rs
@@ -15,7 +15,7 @@ use crate::types::{ByteSize, DriveRole};
 
 use super::{
     SuggestionContext, append_suggestion, color_result, exposure_label, format_status_table,
-    skip_tag,
+    pluralize, skip_tag,
 };
 
 /// Render post-backup summary according to the given mode.
@@ -328,9 +328,19 @@ fn render_skipped_block(skipped: &[crate::output::SkippedSubvolume], out: &mut S
             not_mounted_drives.join(", "),
         )
         .ok();
-        writeln!(out, "    {} send(s) skipped", not_mounted_count).ok();
+        writeln!(
+            out,
+            "    {} skipped",
+            pluralize(not_mounted_count, "send", "sends")
+        )
+        .ok();
     }
 
+    // #212: label the actionable population so it can't be misread as the
+    // list behind the disconnected-drives count above.
+    if !actionable_skips.is_empty() {
+        writeln!(out, "  Needs attention:").ok();
+    }
     for skip in &actionable_skips {
         writeln!(
             out,
@@ -694,6 +704,59 @@ mod tests {
         assert!(
             !safe_to_remove_text(&data).contains("safe to take"),
             "a deferral on the sending subvolume must suppress the cue"
+        );
+    }
+
+    /// #212: the actionable-skip lines used to render directly under the
+    /// disconnected-drives count line, reading as if enumerated by it — two
+    /// populations sharing one number. Each block now labels itself.
+    #[test]
+    fn skipped_block_actionable_skips_get_own_heading() {
+        let skipped = vec![
+            SkippedSubvolume {
+                next_due_minutes: None,
+                name: "sv1".to_string(),
+                reason: "drive WD-18TB not mounted".to_string(),
+                category: SkipCategory::DriveNotMounted,
+            },
+            SkippedSubvolume {
+                next_due_minutes: None,
+                name: "sv2".to_string(),
+                reason: "estimated send exceeds free space".to_string(),
+                category: SkipCategory::SpaceExceeded,
+            },
+        ];
+        let mut out = String::new();
+        render_skipped_block(&skipped, &mut out);
+        assert!(
+            out.contains("1 send skipped"),
+            "disconnected count covers only its own population: {out}"
+        );
+        assert!(
+            out.contains("Needs attention:"),
+            "actionable skips need their own heading: {out}"
+        );
+        let heading_pos = out.find("Needs attention:").unwrap();
+        let skip_pos = out.find("sv2").unwrap();
+        assert!(
+            heading_pos < skip_pos,
+            "heading must precede the actionable list: {out}"
+        );
+    }
+
+    #[test]
+    fn skipped_block_no_heading_without_actionable_skips() {
+        let skipped = vec![SkippedSubvolume {
+            next_due_minutes: None,
+            name: "sv1".to_string(),
+            reason: "drive WD-18TB not mounted".to_string(),
+            category: SkipCategory::DriveNotMounted,
+        }];
+        let mut out = String::new();
+        render_skipped_block(&skipped, &mut out);
+        assert!(
+            !out.contains("Needs attention:"),
+            "no actionable skips, no heading: {out}"
         );
     }
 

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -76,9 +76,28 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
     // Config section
     render_doctor_check_section(&mut out, "Config", &data.config_checks);
 
-    // Infrastructure section
+    // Infrastructure section. UPI 029 (via 079-c): four green checkmarks
+    // carry no information after first setup — when everything passes,
+    // collapse to one line. `--thorough` (verify present) expands, and any
+    // failure renders the full section so the red has its green context.
     writeln!(out).ok();
-    render_doctor_check_section(&mut out, "Infrastructure", &data.infra_checks);
+    let all_infra_ok = !data.infra_checks.is_empty()
+        && data
+            .infra_checks
+            .iter()
+            .all(|c| c.status == DoctorCheckStatus::Ok);
+    if all_infra_ok && data.verify.is_none() {
+        writeln!(out, "  {}", "Infrastructure".bold()).ok();
+        writeln!(
+            out,
+            "    {} All {} checks passed.",
+            "\u{2713}".green(),
+            data.infra_checks.len()
+        )
+        .ok();
+    } else {
+        render_doctor_check_section(&mut out, "Infrastructure", &data.infra_checks);
+    }
 
     // Data safety section
     writeln!(out).ok();

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -2730,6 +2730,101 @@ mod tests {
         assert!(output.contains("2026-03-27T10:00:00"), "missing last seen timestamp");
     }
 
+    // ── Doctor infra collapse + sentinel relative age (UPI 029 via 079-c) ──
+
+    #[test]
+    fn doctor_collapses_all_passing_infra_checks() {
+        let _color = color_guard(false);
+        let output = render_doctor(&test_doctor_output(), OutputMode::Interactive);
+        assert!(
+            output.contains("All 2 checks passed."),
+            "passing infra collapses to one counted line: {output}"
+        );
+        assert!(
+            !output.contains("sudo btrfs"),
+            "individual passing checks stay collapsed: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_expands_infra_when_a_check_fails() {
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
+        data.infra_checks[1] = DoctorCheck {
+            name: "sudo btrfs".to_string(),
+            status: DoctorCheckStatus::Error,
+            detail: Some("permission denied".to_string()),
+            suggestion: Some("Add btrfs to sudoers".to_string()),
+        };
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("checks passed."),
+            "a failure expands the section: {output}"
+        );
+        assert!(
+            output.contains("sudo btrfs") && output.contains("permission denied"),
+            "the failed check renders with its detail: {output}"
+        );
+        assert!(
+            output.contains("Verifying state database"),
+            "passing checks give the red its green context: {output}"
+        );
+    }
+
+    #[test]
+    fn doctor_expands_infra_under_thorough() {
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
+        data.verify = Some(test_verify_output());
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(
+            !output.contains("checks passed."),
+            "--thorough means show everything: {output}"
+        );
+        assert!(
+            output.contains("sudo btrfs"),
+            "thorough renders every infra check: {output}"
+        );
+    }
+
+    #[test]
+    fn sentinel_assessment_age_is_relative() {
+        let _color = color_guard(false);
+        let five_min_ago = (chrono::Local::now().naive_local()
+            - chrono::Duration::minutes(5))
+        .format("%Y-%m-%dT%H:%M:%S")
+        .to_string();
+        let mut data = test_sentinel_running();
+        let SentinelStatusOutput::Running { ref mut state, .. } = data else {
+            unreachable!()
+        };
+        state.last_assessment = Some(five_min_ago.clone());
+        let output = render_sentinel_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("5m ago"),
+            "assessment age must be relative: {output}"
+        );
+        assert!(
+            !output.contains(&five_min_ago),
+            "the raw ISO stamp belongs to JSON mode only: {output}"
+        );
+    }
+
+    #[test]
+    fn sentinel_assessment_age_falls_back_to_raw_string() {
+        let _color = color_guard(false);
+        let mut data = test_sentinel_running();
+        let SentinelStatusOutput::Running { ref mut state, .. } = data else {
+            unreachable!()
+        };
+        state.last_assessment = Some("not-a-timestamp".to_string());
+        let output = render_sentinel_status(&data, OutputMode::Interactive);
+        assert!(
+            output.contains("not-a-timestamp"),
+            "unparseable stamp renders raw, never panics: {output}"
+        );
+    }
+
     #[test]
     fn sentinel_daemon_produces_valid_json() {
         let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Daemon);

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -939,7 +939,7 @@ mod tests {
             output.contains("2TB-backup"),
             "missing drive name in grouped skip"
         );
-        assert!(output.contains("2 send(s) skipped"), "missing skip count");
+        assert!(output.contains("2 sends skipped"), "missing skip count");
     }
 
     #[test]
@@ -1234,7 +1234,7 @@ mod tests {
             output.contains("2TB-backup"),
             "missing second drive in grouped skips"
         );
-        assert!(output.contains("4 send(s) skipped"), "wrong skip count");
+        assert!(output.contains("4 sends skipped"), "wrong skip count");
     }
 
     // ── Plan tests ──────────────────────────────────────────────────────
@@ -1274,10 +1274,129 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(output.contains("htpc-home"), "missing subvolume name");
         assert!(output.contains("WD-18TB"), "missing drive label");
         assert!(output.contains("1 snapshot,"), "missing summary");
+    }
+
+    // ── Plan progressive disclosure (UPI 028, folded via 079-b) ─────────
+
+    #[test]
+    fn plan_default_hides_operations_and_names_the_door() {
+        let _color = color_guard(false);
+        let data = test_plan_output();
+        let output = render_plan(&data, OutputMode::Interactive, false);
+        assert!(
+            !output.contains("=== Planned operations ==="),
+            "default view must not show the operations wall: {output}"
+        );
+        assert!(
+            !output.contains("[CREATE]"),
+            "default view must not list individual operations: {output}"
+        );
+        assert!(
+            output.contains("urd plan --verbose"),
+            "hiding detail is only honest with a pointer to it: {output}"
+        );
+        assert!(output.contains("Summary:"), "summary must survive: {output}");
+    }
+
+    #[test]
+    fn plan_verbose_shows_operations_without_pointer() {
+        let _color = color_guard(false);
+        let data = test_plan_output();
+        let output = render_plan(&data, OutputMode::Interactive, true);
+        assert!(
+            output.contains("=== Planned operations ==="),
+            "verbose view lists operations: {output}"
+        );
+        assert!(
+            !output.contains("urd plan --verbose"),
+            "no pointer when the detail is already shown: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_summary_renders_before_skips_and_operations() {
+        let _color = color_guard(false);
+        let mut data = test_plan_output();
+        data.skipped = vec![SkippedSubvolume {
+            next_due_minutes: None,
+            name: "htpc-docs".to_string(),
+            reason: "disabled".to_string(),
+            category: SkipCategory::Disabled,
+        }];
+        data.summary.skipped = 1;
+        let output = render_plan(&data, OutputMode::Interactive, true);
+        let summary_pos = output.find("Summary:").expect("summary present");
+        let skipped_pos = output.find("=== Skipped").expect("skips present");
+        let ops_pos = output.find("=== Planned operations").expect("ops present");
+        assert!(
+            summary_pos < skipped_pos && skipped_pos < ops_pos,
+            "order must be summary, skips, operations: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_all_skipped_shows_no_verbose_pointer() {
+        let _color = color_guard(false);
+        let mut data = test_plan_output();
+        data.operations = vec![];
+        data.skipped = vec![SkippedSubvolume {
+            next_due_minutes: None,
+            name: "htpc-docs".to_string(),
+            reason: "disabled".to_string(),
+            category: SkipCategory::Disabled,
+        }];
+        data.summary = PlanSummaryOutput {
+            snapshots: 0,
+            sends: 0,
+            deletions: 0,
+            skipped: 1,
+            estimated_total_bytes: None,
+            configured_subvolumes: 2,
+        };
+        let output = render_plan(&data, OutputMode::Interactive, false);
+        assert!(
+            !output.contains("urd plan --verbose"),
+            "nothing hidden, nothing to point at: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_verbose_delete_lines_carry_location() {
+        let _color = color_guard(false);
+        let mut data = test_plan_output();
+        data.operations = vec![
+            PlanOperationEntry {
+                subvolume: "music".to_string(),
+                operation: "delete".to_string(),
+                detail: "20260402-2147-music (graduated: daily thinning)".to_string(),
+                drive_label: None,
+                estimated_bytes: None,
+                is_full_send: None,
+                full_send_reason: None,
+            },
+            PlanOperationEntry {
+                subvolume: "music".to_string(),
+                operation: "delete".to_string(),
+                detail: "20260402-2147-music (beyond retention window)".to_string(),
+                drive_label: Some("WD-18TB".to_string()),
+                estimated_bytes: None,
+                is_full_send: None,
+                full_send_reason: None,
+            },
+        ];
+        let output = render_plan(&data, OutputMode::Interactive, true);
+        assert!(
+            output.contains("[local]"),
+            "local delete must be tagged: {output}"
+        );
+        assert!(
+            output.contains("[WD-18TB]"),
+            "external delete must carry the drive label: {output}"
+        );
     }
 
     #[test]
@@ -1296,7 +1415,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Daemon);
+        let output = render_plan(&data, OutputMode::Daemon, false);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert!(parsed.get("timestamp").is_some());
     }
@@ -1333,7 +1452,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("=== Planned operations ==="),
             "missing operations heading"
@@ -1363,7 +1482,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         // UPI 045: the ops-empty+skips-non-empty branch now renders the
         // verdict "No backups planned (all skipped — see below)." on line 1
         // and lets the Skipped section carry the detail. The old
@@ -1414,7 +1533,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("Disconnected:"),
             "missing grouped not-mounted line"
@@ -1472,7 +1591,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("Interval not elapsed:"),
             "missing interval group"
@@ -1518,7 +1637,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         // 2h30m (150 min) < 9d (12960 min) — must show 2h30m as shortest, not 9d
         assert!(
             output.contains("(next in ~2h30m)"),
@@ -1562,7 +1681,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("Disabled:"),
             "missing disabled group: {output}"
@@ -1608,7 +1727,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("[SPACE]"),
             "space exceeded should use [SPACE] tag"
@@ -1641,7 +1760,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("[EXT]"),
             "external-only should use [EXT] tag: {output}"
@@ -1713,7 +1832,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         let not_mounted_pos = output.find("Disconnected:").expect("missing Disconnected");
         let interval_pos = output.find("Interval not elapsed:").expect("missing Interval");
         let disabled_pos = output.find("Disabled:").expect("missing Disabled");
@@ -1748,7 +1867,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Daemon);
+        let output = render_plan(&data, OutputMode::Daemon, false);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         let category = parsed["skipped"][0]["category"]
             .as_str()
@@ -1794,7 +1913,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("2 sends (~54.2GB total)"),
             "summary should show total estimate: {output}"
@@ -1831,7 +1950,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("last: ~5.5MB"),
             "should render incremental size with 'last:' prefix: {output}"
@@ -1874,7 +1993,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("2 sends (~53.0GB estimated for 1 of 2)"),
             "partial estimates should be qualified: {output}"
@@ -1906,7 +2025,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("1 send,"),
             "no estimates should just show count: {output}"
@@ -1941,7 +2060,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Daemon);
+        let output = render_plan(&data, OutputMode::Daemon, false);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert_eq!(
             parsed["operations"][0]["estimated_bytes"].as_u64(),
@@ -1977,7 +2096,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Daemon);
+        let output = render_plan(&data, OutputMode::Daemon, false);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert!(
             parsed["operations"][0].get("estimated_bytes").is_none(),
@@ -2014,7 +2133,7 @@ mod tests {
                     .to_string(),
             ],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("[WARNING]"),
             "warnings should render with [WARNING] tag: {output}"
@@ -2041,7 +2160,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Daemon);
+        let output = render_plan(&data, OutputMode::Daemon, false);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert!(
             parsed.get("warnings").is_none(),
@@ -2065,7 +2184,7 @@ mod tests {
             },
             warnings: vec!["Drive X identity suspect".to_string()],
         };
-        let output = render_plan(&data, OutputMode::Daemon);
+        let output = render_plan(&data, OutputMode::Daemon, false);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert_eq!(
             parsed["warnings"][0].as_str(),
@@ -2139,7 +2258,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Daemon);
+        let output = render_plan(&data, OutputMode::Daemon, false);
         let parsed: serde_json::Value = serde_json::from_str(&output).expect("valid JSON");
         assert_eq!(
             parsed["skipped"][0]["category"].as_str(),
@@ -3879,7 +3998,7 @@ mod tests {
             },
             warnings: vec![],
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
             output.contains("[SAME]"),
             "plan output should contain [SAME] tag, got: {output}"

--- a/src/voice/plan.rs
+++ b/src/voice/plan.rs
@@ -30,17 +30,21 @@ pub fn render_empty_plan(explanation: &crate::output::EmptyPlanExplanation) -> S
 }
 
 /// Render plan output according to the given mode.
+///
+/// `verbose` gates the per-operation wall (UPI 028): the default output is
+/// summary-first with a pointer to `urd plan --verbose`. Daemon mode ignores
+/// it — JSON always carries the full operations list.
 #[must_use]
-pub fn render_plan(data: &PlanOutput, mode: OutputMode) -> String {
+pub fn render_plan(data: &PlanOutput, mode: OutputMode, verbose: bool) -> String {
     match mode {
-        OutputMode::Interactive => render_plan_interactive(data),
+        OutputMode::Interactive => render_plan_interactive(data, verbose),
         OutputMode::Daemon => {
             serde_json::to_string_pretty(data).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
         }
     }
 }
 
-fn render_plan_interactive(data: &PlanOutput) -> String {
+fn render_plan_interactive(data: &PlanOutput, verbose: bool) -> String {
     let mut out = String::new();
 
     // Verdict line first (UPI 045 Rule 5 — first line is the answer).
@@ -73,49 +77,9 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
         return out;
     }
 
-    // === Planned operations ===
-    if !data.operations.is_empty() {
-        writeln!(out, "{}", "=== Planned operations ===".bold()).ok();
-        let mut current_subvol: Option<&str> = None;
-        for entry in &data.operations {
-            if current_subvol != Some(&entry.subvolume) {
-                if current_subvol.is_some() {
-                    writeln!(out).ok();
-                }
-                writeln!(out, "{}:", entry.subvolume.bold()).ok();
-                current_subvol = Some(&entry.subvolume);
-            }
-
-            let label = match entry.operation.as_str() {
-                "create" => "[CREATE]".green().to_string(),
-                "send" => "[SEND]".blue().to_string(),
-                "delete" => "[DELETE]".yellow().to_string(),
-                other => format!("[{other}]"),
-            };
-            let size_annotation = match (entry.estimated_bytes, entry.is_full_send) {
-                (Some(bytes), Some(true)) => format!(" ~{}", ByteSize(bytes)),
-                (Some(bytes), Some(false)) => format!(" last: ~{}", ByteSize(bytes)),
-                _ => String::new(),
-            };
-            writeln!(out, "  {:<10} {}{}", label, entry.detail, size_annotation.dimmed()).ok();
-        }
-        writeln!(out).ok();
-    }
-
-    // === Skipped (N) ===
-    if !data.skipped.is_empty() {
-        writeln!(
-            out,
-            "{}",
-            format!("=== Skipped ({}) ===", data.skipped.len()).dimmed()
-        )
-        .ok();
-        render_plan_skipped_grouped(&data.skipped, &mut out);
-    }
-
-    writeln!(out).ok();
-
-    // Build sends portion of summary, with estimated total if available.
+    // === Summary (UPI 028: summary-first) ===
+    // The user typed `urd plan` to learn what will happen — quantities lead,
+    // detail follows. Build sends portion with estimated total if available.
     let sends_str = if data.summary.sends == 0 {
         "0 sends".to_string()
     } else if let Some(total) = data.summary.estimated_total_bytes {
@@ -156,6 +120,73 @@ fn render_plan_interactive(data: &PlanOutput) -> String {
         .bold()
     )
     .ok();
+    // Hiding detail is only honest when the output names the door.
+    if !verbose && !ops_empty {
+        writeln!(
+            out,
+            "  {}",
+            "(urd plan --verbose lists every operation)".dimmed()
+        )
+        .ok();
+    }
+    writeln!(out).ok();
+
+    // === Skipped (N) ===
+    if !data.skipped.is_empty() {
+        writeln!(
+            out,
+            "{}",
+            format!("=== Skipped ({}) ===", data.skipped.len()).dimmed()
+        )
+        .ok();
+        render_plan_skipped_grouped(&data.skipped, &mut out);
+    }
+
+    // === Planned operations (--verbose only) ===
+    if verbose && !ops_empty {
+        if !data.skipped.is_empty() {
+            writeln!(out).ok();
+        }
+        writeln!(out, "{}", "=== Planned operations ===".bold()).ok();
+        let mut current_subvol: Option<&str> = None;
+        for entry in &data.operations {
+            if current_subvol != Some(&entry.subvolume) {
+                if current_subvol.is_some() {
+                    writeln!(out).ok();
+                }
+                writeln!(out, "{}:", entry.subvolume.bold()).ok();
+                current_subvol = Some(&entry.subvolume);
+            }
+
+            let label = match entry.operation.as_str() {
+                "create" => "[CREATE]".green().to_string(),
+                "send" => "[SEND]".blue().to_string(),
+                "delete" => "[DELETE]".yellow().to_string(),
+                other => format!("[{other}]"),
+            };
+            let size_annotation = match (entry.estimated_bytes, entry.is_full_send) {
+                (Some(bytes), Some(true)) => format!(" ~{}", ByteSize(bytes)),
+                (Some(bytes), Some(false)) => format!(" last: ~{}", ByteSize(bytes)),
+                _ => String::new(),
+            };
+            // UPI 028: local and external retention can delete the same
+            // snapshot name — the location tag is what tells them apart.
+            let location = if entry.operation == "delete" {
+                format!(" [{}]", entry.drive_label.as_deref().unwrap_or("local"))
+            } else {
+                String::new()
+            };
+            writeln!(
+                out,
+                "  {:<10} {}{}{}",
+                label,
+                entry.detail,
+                size_annotation.dimmed(),
+                location.dimmed()
+            )
+            .ok();
+        }
+    }
 
     // ── Next-action suggestion ──────────────────────────────────────
     let has_space_skip = data

--- a/src/voice/sentinel.rs
+++ b/src/voice/sentinel.rs
@@ -35,10 +35,19 @@ fn render_sentinel_status_interactive(data: &SentinelStatusOutput) -> String {
             )
             .ok();
 
-            // Assessment timing
+            // Assessment timing. UPI 029 (via 079-c): relative age, not an
+            // ISO stamp the user must subtract from "now" themselves — the
+            // JSON surface keeps the raw timestamp for machine consumers.
             if let Some(ref last) = state.last_assessment {
                 let tick_desc = format_tick_description(state.tick_interval_secs, &state.promise_states);
-                writeln!(out, "  {:<14}{} (tick: {})", "Assessment", last, tick_desc).ok();
+                writeln!(
+                    out,
+                    "  {:<14}{} (tick: {})",
+                    "Assessment",
+                    humanize_assessment_age(last),
+                    tick_desc
+                )
+                .ok();
             }
 
             // Mounted drives
@@ -66,6 +75,24 @@ fn render_sentinel_status_interactive(data: &SentinelStatusOutput) -> String {
     }
 
     out
+}
+
+/// Format the sentinel state file's ISO `last_assessment` stamp as a
+/// relative age ("5m ago"). Falls back to the raw string when it doesn't
+/// parse (hand-edited state file) — degraded, never wrong.
+fn humanize_assessment_age(timestamp: &str) -> String {
+    let Ok(ts) = chrono::NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%dT%H:%M:%S") else {
+        return timestamp.to_string();
+    };
+    let mins = chrono::Local::now()
+        .naive_local()
+        .signed_duration_since(ts)
+        .num_minutes();
+    if mins < 1 {
+        "just now".to_string()
+    } else {
+        format!("{} ago", crate::plan::format_duration_short(mins))
+    }
 }
 
 fn format_tick_description(tick_secs: u64, promise_states: &[crate::output::SentinelPromiseState]) -> String {

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -877,7 +877,7 @@ mod contract {
         let _color = color_guard(false);
         // Non-empty plan: lifted fixture has 2 operations, 1 send.
         let non_empty = test_plan_output();
-        let output = render_plan(&non_empty, OutputMode::Interactive);
+        let output = render_plan(&non_empty, OutputMode::Interactive, true);
         let first = helpers::non_blank_lines(&output)
             .into_iter()
             .next()
@@ -901,7 +901,7 @@ mod contract {
             estimated_total_bytes: None,
             configured_subvolumes: 2,
         };
-        let output = render_plan(&empty, OutputMode::Interactive);
+        let output = render_plan(&empty, OutputMode::Interactive, true);
         let first = helpers::non_blank_lines(&output)
             .into_iter()
             .next()
@@ -995,7 +995,7 @@ mod contract {
             estimated_total_bytes: None,
             configured_subvolumes: 2,
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         let first = helpers::non_blank_lines(&output)
             .into_iter()
             .next()
@@ -1024,7 +1024,7 @@ mod contract {
             estimated_total_bytes: None,
             configured_subvolumes: 0,
         };
-        let output = render_plan(&data, OutputMode::Interactive);
+        let output = render_plan(&data, OutputMode::Interactive, true);
         let first = helpers::non_blank_lines(&output)
             .into_iter()
             .next()


### PR DESCRIPTION
## Summary

- **UPI 079-b (commit 1):** closes the #212 remainder at both independent sites and folds UPI 028. A caught-up subvolume's `unchanged` + per-drive "already on" skip records collapse to one line at the output boundary (keyed on the structured `nothing_new_to_send` marker; pure planner and orphan invariant untouched, ADR-100); the backup summary's skip blocks each own their count ("3 sends skipped" / "Needs attention:"); `urd plan` is summary-first with the operations wall behind `--verbose`, a pointer line naming the door, and DELETE lines tagged `[local]`/`[<drive>]`.
- **UPI 079-c (commit 2):** folds UPI 029. `urd doctor` collapses all-passing infrastructure checks to "✓ All 4 checks passed." outside `--thorough`; remediation guidance always renders behind the `→` arrow (drive-absent row included); `urd sentinel status` shows the last assessment as "5m ago" while JSON keeps the ISO stamp.
- Scope was pre-shaped by /ponytail and /steve reviews (local docs/99-reports/): no new `location` output field (reuses `drive_label`), `--verbose` on `plan` only, merged skip line keeps the age and names exact drives, 028's short_name-in-plan and 029's "already exists" changes cut.
- §6 collapse verified live on this host: three caught-up subvolumes each render one skip record instead of two.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 1893 passed, 0 failed, 4 ignored (+18 new tests; each commit verified standalone: 1886 / 1893)
- cargo build --release: pass
- Integration tests: not applicable (presentation/output-boundary changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)