### PR TITLE
release: v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-07-03
+
 ### Added
 - **`urd status` de-emphasises a slowdown that is by design.** A row that is AT RISK
   purely because a Critical source pool made Urd slow its cadence — with the backup
@@ -1350,7 +1352,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.31.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.32.0...HEAD
+[0.32.0]: https://github.com/vonrobak/urd/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/vonrobak/urd/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/vonrobak/urd/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/vonrobak/urd/compare/v0.28.0...v0.29.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.32.0**. Completes the Voice Arc's remainder: plan progressive disclosure + honest skip counts (UPI 079-b, closes the #212 remainder, PR #246), doctor/sentinel polish (UPI 079-c, PR #246), and the by-design AT RISK de-emphasis (UPI 080, PR #245).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 1893 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)