### PR TITLE
chore: encounter staging protocol — lab guide + guarded reset script (UPI 078)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ scripts/*
 !scripts/check-docs.sh
 !scripts/check-registry.sh
 !scripts/check-present-not-journey.sh
+!scripts/staging-reset.sh

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -6,7 +6,7 @@
 > conflicts with this page, this page wins.
 
 **Date:** 2026-05-02 (restructured 2026-05-16 — explicit clusters, in-context
-examples, Flagged Ambiguities section)
+examples, Flagged Ambiguities section; Encounter cluster added 2026-07-03)
 **Audience:** Both human readers and Claude sessions. Read once; refer back when
 language is ambiguous in another doc.
 
@@ -14,7 +14,7 @@ language is ambiguous in another doc.
 
 Terms are grouped into **clusters**: Promise, Voice, Protection, Drive, Thread,
 Retention, Identifier, Recommendation, Storage pressure, Read-side query seams,
-Planner soundness. Each cluster has a canonical definition table
+Planner soundness, Encounter. Each cluster has a canonical definition table
 and a short **In context** example grounded in real CLI output, config, or
 on-disk artifacts. Skim by cluster heading; use the examples when a definition
 alone is too abstract. Terms still in transition are collected at the bottom
@@ -493,6 +493,30 @@ of passing silently.
 Source: `plan.rs` (`orphan_invariant_violations`), `types.rs` (`PlannedSkip`),
 `docs/98-journals/2026-05-02-stranded-snapshots-non-transient-planner.md`, UPI 069.
 
+## Cluster: The Encounter (first meeting)
+
+**The Encounter** is a new user's first meeting with Urd — the journey from the
+GitHub page to the first sealed promise (UPIs 070–078, arc-grilled 2026-07-03).
+The name is internal; the user experiences it as Urd introducing herself, looking
+at what the system has, asking what matters and what they fear, and proposing
+fates — nothing is written without approval. Stages, in order: the doorstep
+(no-config `urd` / `urd init`) → the looking (unprivileged discovery) → the
+conversation → the derivation → the runestone → the carving (config written) →
+the earning (root, via shown sudoers) → the seal.
+
+| Term | Layer | Meaning |
+|------|-------|---------|
+| `runestone` | **voice-layer only** | The rendered strategy proposal at the Encounter's decision point — what the user reads before choosing set-and-forget or delve-deeper. The engine type underneath is `ProposedStrategy` (`strategy.rs`); "runestone" never appears in engine code, config, or data surfaces. |
+| `gap` / `GapKind` | engine | A named disaster a proposed setup cannot survive (e.g. no offsite drive → fire/theft). Derivation attaches gaps instead of refusing or over-promising: the generated config encodes reality (ADR-111), and each gap names the path to more. Extends ADR-116's honest vocabulary for expected absence. |
+| `the seal` | internal + voice | The Encounter's closing stage — the act that makes promises *sealed*: root earned (sudoers shown, installed, `visudo`-verified), drive adoption, systemd units enabled, the first snapshot spun, the first-send offer, handoff to `urd status`. "The seal" is the stage; `sealed` (Voice cluster) remains the per-subvolume promise-state label whose truth the seal establishes. |
+
+Final Encounter wording is deliberately **not** pinned here or in the capsules —
+register rules only, with one full voice rewrite planned post-build. The stage
+names above are the stable internal vocabulary for design docs and code review.
+
+Source: `docs/95-ideas/2026-07-03-arc-proposal-the-encounter.md` (local-only),
+UPIs 070–078.
+
 ## Flagged Ambiguities
 
 Terms in transition, or with a known gap between their canonical definition and
@@ -521,6 +545,14 @@ without re-deriving the context.
   (a drive that is both away *and* whose data has aged past the freshness
   threshold). See `voice.rs::format_drive_age_label` cascade and Voice Contract
   Rule 1.
+
+- **"gap" carries two candidate meanings.** The Encounter's `gap`/`GapKind`
+  (engine, UPI 073) names a disaster a *proposed setup* cannot survive — it is not
+  CLI status vocabulary. Separately, UPI 080's draft display classifier proposes
+  "gap" as one of four row signals; that reuse was previously rejected as CLI
+  vocabulary (superseded by sealed/waning/exposed) and needs a deliberate grill
+  call, not silent adoption. Until the 080 grill rules, "gap" in prose means the
+  Encounter/derivation sense.
 
 - **"Backup" the verb vs "backup" the noun.** Casual project usage treats them
   as interchangeable; in precise contexts, a *backup* is the noun ("an external

--- a/docs/00-foundation/guides/encounter-staging-protocol.md
+++ b/docs/00-foundation/guides/encounter-staging-protocol.md
@@ -1,0 +1,215 @@
+# The Encounter Staging Protocol
+
+> **TL;DR:** A real, physical staging machine — Fedora Workstation, native btrfs with
+> the default `/` + `/home` layout, one external btrfs drive reserved for the lab —
+> is the ground truth for Urd's first-encounter experience. First impressions burn on
+> first use, so this protocol makes blank slates repeatable: a guarded reset script
+> (`scripts/staging-reset.sh`) unwinds every artifact Urd creates, an observation
+> template captures each run, a scenario matrix defines coverage, and a findings loop
+> feeds field reality back into designs and issues. The lab outlives the Encounter
+> arc: any future change to the first-meeting flow is validated here before release.
+
+## Purpose
+
+The Encounter (the journey from Urd's GitHub page to the first sealed promise) can
+only be validated by actually encountering it on a machine Urd has never seen — and
+every field test consumes the blank slate it needs. Without a disciplined reset and
+observation protocol, field testing degenerates into one-shot anecdotes. The staging
+machine also supplies what no mock can: real `lsblk`/`findmnt` output for discovery
+parser fixtures, real sudoers friction, real USB and LUKS behavior.
+
+The reset script is repo tooling for this lab only. It is deliberately **not** a urd
+command — a shipped "reset" verb would violate every fail-closed deletion instinct
+Urd is built on (ADR-107) and hand users a footgun.
+
+## The staging machine contract
+
+The lab machine must be:
+
+- **Real hardware**, not a VM — USB hotplug, desktop auto-mount, and sudo friction
+  are part of what is being tested.
+- **Fedora Workstation** with the default btrfs layout: one filesystem hosting the
+  `/` and `/home` subvolumes. (Validation is deliberately Fedora-only for v1.0.)
+- Equipped with **one external btrfs drive reserved for the lab**, never used for
+  real backups. Keep it **LUKS-formatted** on purpose — that is the realistic
+  GNOME-formatted case, and the locked-drive scenario depends on it.
+- Otherwise disposable: nothing on the machine may be data anyone would miss.
+
+## One-time setup: the marker file
+
+The reset script refuses to run unless `~/.config/urd-staging-marker` exists. Placing
+the marker — by hand, once, on the staging machine only — is the act of consent. It
+was chosen over a hostname check so the public repo embeds no machine identity and the
+script cannot be pattern-matched onto a new host by accident.
+
+The marker is also the **deletion contract**: it declares the scope the script may
+touch. Snapshot deletion only ever happens under roots declared here.
+
+```
+# urd staging contract — hand-authored once on the staging machine.
+# Its presence authorizes scripts/staging-reset.sh on this machine.
+snapshot_root=/home/<user>/.snapshots     # repeatable, absolute literal paths only
+drive_uuid=<filesystem-uuid>              # optional: the ONE lab drive's btrfs UUID
+drive_snapshot_root=.snapshots            # optional: relative on the drive (default)
+```
+
+Rules, enforced at parse (the script refuses on violation): `snapshot_root` values
+must be absolute literal paths (no `~`, no variables); `drive_snapshot_root` must be
+relative with no `..`; unknown keys warn. If the config file declares a snapshot root
+the marker does not, the script warns and does not touch it — the marker, not the
+config, is the authority (the config is itself a reset target and may be absent or
+half-unwound; the marker is the only file the reset never deletes).
+
+**Threat-model boundary (do not "fix" this):** the marker is a consent rail against
+*mistakes* — running the script on the wrong machine, or with the wrong drive. It is
+not a security boundary against a malicious local process; such a process already has
+the user's shell and could place the marker itself. Treating it as a security feature
+would only invite false confidence.
+
+## The reset script
+
+```
+scripts/staging-reset.sh [--apply] [--drive UUID] [--full]
+```
+
+Dry-run is the default and prints the full deletion plan; only `--apply` executes.
+`--drive UUID` includes the external drive (category 5); `--full` includes installed
+binaries (category 9, for install-experience testing).
+
+Exit codes: `0` clean · `2` usage · `3` refusal (missing/invalid marker, running as
+root, drive sanity) · `4` typed-confirmation mismatch · `5` backup lock held ·
+`6` finished with per-item failures (the summary lists them — the machine is *not* a
+clean slate).
+
+### Safety rails
+
+1. **Marker-file allowlist** — no marker, no run (see above).
+2. **Dry-run by default** — `--apply` is the only execution path; there is no `--yes`
+   and no environment override.
+3. **Contract-scoped deletion** — subvolume deletion only under marker-declared
+   roots, only for directory names matching the snapshot-name contract
+   (`YYYYMMDD-HHMM-*`, legacy `YYYYMMDD-*` — ADR-105), only for real directories
+   (symlinks are reported as anomalies, never followed — `btrfs subvolume delete`
+   resolves symlinks), and only after `sudo btrfs subvolume show` confirms the path
+   is a subvolume. There is no recursive `rm` outside the known, bounded `logs/`
+   directory.
+4. **External drive by UUID + typed confirmation** — the drive is addressed by
+   `--drive UUID` (never a mount path), must match the marker's declared
+   `drive_uuid`, must resolve to exactly one removable mountpoint (`/run/media/*` or
+   `/media/*`, never `/` or `/home` — on the Fedora default layout those share one
+   btrfs UUID, an easy copy-paste trap), and must not be the filesystem backing any
+   declared local snapshot root. Under `--apply` the operator then types the drive's
+   filesystem label (or its full UUID when unlabeled) before anything on the drive is
+   touched. The script never mounts and never unlocks — a locked LUKS drive is simply
+   not mounted, and the honest skip is the correct outcome.
+
+Two more guards: the script refuses to run as root (it invokes `sudo` itself only for
+the btrfs and sudoers steps), and after stopping the systemd units it probes Urd's
+backup advisory lock — if a backup is still running, the reset aborts rather than
+delete state under a live run. Per-item failures never abort a category: the script
+isolates them, continues, and lists every failure in the summary.
+
+### What it unwinds
+
+| # | Category | Where |
+|---|----------|-------|
+| 1 | Config | `~/.config/urd/` — `urd.toml` + `urd migrate` backups (`.legacy`, `.v1`) |
+| 2 | State | `~/.local/share/urd/` — `urd.db` (+`-wal`/`-shm`), `urd.lock`, `heartbeat.json`, `backup.prom`, `logs/` |
+| 3 | Local snapshots | contract-named subvolumes under each marker-declared root |
+| 4 | Pin files | `.last-external-parent-{LABEL}` (+ legacy form) in each snapshot dir |
+| 5 | External drive | contract-named snapshots + `.urd-drive-token` under the drive's snapshot root (`--drive` only) |
+| 6 | Sudoers | `/etc/sudoers.d/urd` (removed, never edited — absence is the pre-Urd state) |
+| 7 | systemd | `urd-backup.timer`, `urd-backup.service`, `urd-sentinel.service`: disabled, unit files removed, `daemon-reload` + `reset-failed` |
+| 8 | Completions | the prescribed install paths (below) |
+| 9 | Binary | `--full` only: `~/.cargo/bin/urd` and `~/.local/bin/urd` |
+
+Categories the current run does not cover are reported as honest skips, never
+silently omitted — an external drive left unreset would contaminate the next
+scenario with foreign urd data.
+
+**Completions on the staging machine** must be installed to these paths, so the reset
+can honestly unwind them (`urd completions` writes to stdout; the lab prescribes where
+it lands): `~/.local/share/bash-completion/completions/urd`, `~/.zfunc/_urd`,
+`~/.config/fish/completions/urd.fish`.
+
+### A full reset, worked
+
+```bash
+# 1. Preview — always. Read every line; anomalies mean something needs a look.
+scripts/staging-reset.sh --drive <uuid>
+
+# 2. Execute (type the drive label when prompted).
+scripts/staging-reset.sh --drive <uuid> --apply
+
+# 3. Verify the blank slate.
+urd status                      # must fail: no config
+ls ~/.config/urd ~/.local/share/urd 2>&1        # both gone
+systemctl --user list-units 'urd-*'             # none
+sudo ls /etc/sudoers.d/urd 2>&1                 # gone
+findmnt <drive-mount> && ls -a <drive-mount>/.snapshots 2>&1   # no urd artifacts
+```
+
+## Observation capture
+
+Every field-test run produces one report:
+`docs/99-reports/YYYY-MM-DD-encounter-field-test-NN.md` (local-only). Capture the
+terminal with `script(1)` — start it before the first command the scenario calls for.
+
+Template:
+
+```markdown
+# Encounter field test NN — <scenario name>
+
+- **Date / urd version / commit:**
+- **Scenario:** <id + one line>
+- **Timings:** time-to-config · question count · time-to-first-snapshot · time-to-seal
+- **Transcript:** (script(1) output, attached or inlined)
+- **Friction log:** hesitations, wording that fell flat, questions the tester could
+  not answer, anything reached for that did not exist
+- **Generated urd.toml:** (verbatim)
+- **Seal outcome:** (`urd status` output after)
+- **Verdict:** would a stranger have made it through, and does the config match what
+  they would have wanted?
+```
+
+## Scenario matrix
+
+Minimum coverage; run the full matrix per built seal-path UPI and before release.
+
+| # | Scenario | Expected behavior |
+|---|----------|-------------------|
+| 1 | Golden path — fresh system, empty unlocked external btrfs drive | Full journey: discovery → conversation → runestone → carve → earn → seal |
+| 2 | No external drive | Honest-fate exit: everything recorded, the gap named, one come-back command |
+| 3 | External drive present but LUKS-locked | Named-as-absent honesty: one sentence naming the locked drive, zero-drive derivation, "unlock it with your file manager, then run `urd init` again" — no unlock flow |
+| 4 | Sudo declined at the earning | "Configured but unsealed" state; `urd status` names it and points at `urd init` |
+| 5 | Quit mid-conversation, run again | Clean exit, nothing persisted; returning starts over |
+| 6 | Config already exists | The refusal: names the existing file and the two paths forward; no override flag |
+| 7 | Non-TTY invocation | Pointer sentence + distinct non-zero exit; never a conversation |
+| 8 | Expert skip | `--config <path>` honored; the Encounter only ever offers |
+
+## The findings loop
+
+```
+field test → report → triage → journal
+```
+
+Triage each finding into exactly one of:
+
+- **Pre-build** (the design was wrong): amend the relevant design capsule directly.
+- **Post-build** (the code is wrong): file a GitHub issue.
+- **Wording** (the sentence fell flat): add to the voice-rewrite list — the
+  post-arc voice pass consumes it; do not wordsmith mid-arc.
+
+Notable lessons go to a journal entry. The UPI 078 registry row links every
+field-test report, so the arc's evidence trail stays one click from the UPI table.
+
+**Cadence:** first use is *before* the Encounter is built — capture discovery parser
+fixtures (`lsblk -J`, `findmnt`) and rehearse the manual setup path to baseline
+today's friction; that baseline is the number the Encounter must beat. Then one full
+matrix pass per built seal-path UPI, and a final full pass before release.
+
+## Non-goals
+
+No VM or loopback-image harness (automation may come later; the physical machine is
+the ground truth). No CI integration. No distro other than Fedora. No multi-machine
+scenarios.

--- a/scripts/staging-reset.sh
+++ b/scripts/staging-reset.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# staging-reset.sh — Reset the Encounter staging machine to a blank slate (UPI 078).
+#
+# Unwinds every artifact urd creates: config, state DB, heartbeat, metrics, logs,
+# lock, local snapshots, pin files, external-drive snapshots + token, sudoers file,
+# systemd user units, shell completions, and (--full) installed binaries.
+#
+# This script deletes btrfs subvolumes as root. It is guarded by four rails
+# (docs/00-foundation/guides/encounter-staging-protocol.md):
+#   1. Marker-file allowlist — refuses to run unless ~/.config/urd-staging-marker
+#      exists. The marker is hand-authored once on the staging machine and declares
+#      the deletion scope (snapshot roots, the lab drive's UUID). It is a consent
+#      rail against mistakes, not a security boundary.
+#   2. Dry-run by default — prints the full plan; executes only with --apply.
+#   3. Contract-scoped deletion — subvolume deletion only under marker-declared
+#      roots, only for ADR-105 contract names (YYYYMMDD-HHMM-* / legacy YYYYMMDD-*),
+#      only for real directories (never symlinks), and only after
+#      `sudo btrfs subvolume show` confirms the path is a subvolume.
+#   4. External drive addressed by --drive UUID (never a mount path), which must
+#      match the marker's declared drive_uuid, resolve to a removable mountpoint,
+#      and be confirmed by typing the drive's label (or UUID when unlabeled).
+#
+# This is repo tooling for the staging lab — NOT a urd command, and not for
+# production machines. A shipped "reset" verb would violate ADR-107.
+#
+# Usage: scripts/staging-reset.sh [--apply] [--drive UUID] [--full]
+#
+# Exit codes:
+#   0 clean · 2 usage · 3 refusal (no/invalid marker, root, drive sanity)
+#   4 typed confirmation mismatch · 5 backup lock held · 6 finished with failures
+
+set -euo pipefail
+shopt -s nullglob
+
+MARKER="$HOME/.config/urd-staging-marker"
+CONFIG_DIR="$HOME/.config/urd"
+CONFIG_FILE="$CONFIG_DIR/urd.toml"
+STATE_DIR="$HOME/.local/share/urd"
+LOCK_FILE="$STATE_DIR/urd.lock"          # state_db.with_extension("lock")
+SUDOERS_FILE="/etc/sudoers.d/urd"
+UNIT_DIR="$HOME/.config/systemd/user"
+UNITS=(urd-backup.timer urd-backup.service urd-sentinel.service)
+COMPLETIONS=(
+    "$HOME/.local/share/bash-completion/completions/urd"
+    "$HOME/.zfunc/_urd"
+    "$HOME/.config/fish/completions/urd.fish"
+)
+# ~/.local/bin/urd is the presumed release-binary location; confirm when UPI 076
+# pins the documented install path, and update here if it differs.
+BINARIES=("$HOME/.cargo/bin/urd" "$HOME/.local/bin/urd")
+
+# ADR-105 snapshot-name contract: YYYYMMDD-HHMM-{short_name}, legacy YYYYMMDD-{name}.
+SNAP_RE='^[0-9]{8}(-[0-9]{4})?-..*$'
+
+APPLY=0
+FULL=0
+DRIVE_UUID=""
+
+usage() {
+    echo "Usage: scripts/staging-reset.sh [--apply] [--drive UUID] [--full]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --apply) APPLY=1 ;;
+        --full)  FULL=1 ;;
+        --drive)
+            [[ $# -ge 2 ]] || { usage; exit 2; }
+            DRIVE_UUID="$2"
+            shift
+            ;;
+        *) usage; exit 2 ;;
+    esac
+    shift
+done
+
+refuse() {
+    echo "REFUSED: $1" >&2
+    exit 3
+}
+
+[[ $EUID -ne 0 ]] || refuse "do not run as root — user-scope paths and systemctl --user would be wrong. The script invokes sudo itself where needed."
+
+# ── Rail 1: the marker is the staging contract ───────────────────────────
+
+[[ -f "$MARKER" ]] || refuse "$MARKER not found. This script only runs on the staging machine; placing that marker (hand-authored, once) is the act of consent. See docs/00-foundation/guides/encounter-staging-protocol.md."
+
+LOCAL_ROOTS=()
+MARKER_DRIVE_UUID=""
+DRIVE_SNAP_ROOT=".snapshots"
+
+while IFS= read -r line; do
+    line="${line%%#*}"
+    line="$(echo "$line" | xargs 2>/dev/null || true)"   # trim
+    [[ -n "$line" ]] || continue
+    key="${line%%=*}"
+    val="${line#*=}"
+    case "$key" in
+        snapshot_root)
+            [[ "$val" == /* ]] || refuse "marker: snapshot_root must be an absolute path (got: $val)"
+            LOCAL_ROOTS+=("$val")
+            ;;
+        drive_uuid)
+            MARKER_DRIVE_UUID="$val"
+            ;;
+        drive_snapshot_root)
+            [[ "$val" != /* ]] || refuse "marker: drive_snapshot_root must be relative (got: $val)"
+            [[ "$val" != *..* ]] || refuse "marker: drive_snapshot_root must not contain '..' (got: $val)"
+            DRIVE_SNAP_ROOT="$val"
+            ;;
+        *)
+            echo "WARNING: marker: unknown key '$key' ignored" >&2
+            ;;
+    esac
+done < "$MARKER"
+
+MODE="dry-run"
+[[ $APPLY -eq 1 ]] && MODE="APPLY"
+echo "staging-reset ($MODE) — marker: $MARKER"
+echo
+
+# ── Config cross-check (warns only; the marker is the authority) ─────────
+
+if [[ -f "$CONFIG_FILE" ]]; then
+    # Only absolute snapshot_root values participate: v2 configs put a *relative*
+    # snapshot_root on every [[drives]] block, which would false-positive here.
+    while IFS= read -r raw; do
+        val="${raw#*=}"
+        val="$(echo "$val" | xargs 2>/dev/null || true)"
+        val="${val%\"}"; val="${val#\"}"
+        val="${val/#\~\//$HOME/}"
+        [[ "$val" == /* ]] || continue
+        found=0
+        for r in "${LOCAL_ROOTS[@]:-}"; do
+            [[ "$r" == "$val" ]] && found=1
+        done
+        if [[ $found -eq 0 ]]; then
+            echo "WARNING: config knows a root the marker does not — not touched: $val" >&2
+        fi
+    done < <(grep -E '^\s*snapshot_root\s*=' "$CONFIG_FILE" || true)
+
+    # State artifacts escape the reset if the config moves them off XDG defaults.
+    for key in state_db metrics_file log_dir heartbeat_file; do
+        if grep -Eq "^\s*${key}\s*=" "$CONFIG_FILE"; then
+            echo "WARNING: config sets ${key} — the reset unwinds only the XDG default paths" >&2
+        fi
+    done
+fi
+
+# ── Shared plumbing ──────────────────────────────────────────────────────
+
+FAILURES=()
+
+# do_rm <description> <path>  — rm -f one file (or rm -rf for a trailing-/ dir)
+do_rm() {
+    local desc="$1" path="$2"
+    if [[ $APPLY -eq 1 ]]; then
+        local rc=0
+        if [[ "$path" == */ ]]; then rm -rf "$path" || rc=$?; else rm -f "$path" || rc=$?; fi
+        if [[ $rc -ne 0 ]]; then FAILURES+=("$desc: $path"); echo "  FAILED: $path" >&2; return 1; fi
+        echo "  removed: $path"
+    else
+        echo "  would remove: $path"
+    fi
+}
+
+# delete_snapshots_under <root> <privilege-note>
+# Enumerates {root}/{subvol-dir}/{candidate}; prints/deletes contract-named
+# subvolumes. Returns counts via globals SNAP_COUNT / ANOMALY_COUNT.
+SNAP_COUNT=0
+ANOMALY_COUNT=0
+delete_snapshots_under() {
+    local root="$1"
+    if [[ ! -d "$root" ]]; then
+        echo "  root not present — skipped: $root"
+        return 0
+    fi
+    local subdir entry name
+    for subdir in "$root"/*/; do
+        subdir="${subdir%/}"
+        if [[ -L "$subdir" ]]; then
+            echo "  ANOMALY (symlink, not touched): $subdir"
+            ANOMALY_COUNT=$((ANOMALY_COUNT + 1))
+            continue
+        fi
+        [[ -d "$subdir" ]] || continue
+        for entry in "$subdir"/*; do
+            name="$(basename "$entry")"
+            [[ "$name" =~ $SNAP_RE ]] || continue
+            if [[ -L "$entry" || ! -d "$entry" ]]; then
+                echo "  ANOMALY (contract-named but symlink/non-dir, not touched): $entry"
+                ANOMALY_COUNT=$((ANOMALY_COUNT + 1))
+                continue
+            fi
+            if [[ $APPLY -eq 1 ]]; then
+                if ! sudo btrfs subvolume show "$entry" >/dev/null 2>&1; then
+                    echo "  ANOMALY (contract-named but not a subvolume, not touched): $entry"
+                    ANOMALY_COUNT=$((ANOMALY_COUNT + 1))
+                    continue
+                fi
+                if sudo btrfs subvolume delete "$entry" >/dev/null; then
+                    echo "  deleted subvolume: $entry"
+                    SNAP_COUNT=$((SNAP_COUNT + 1))
+                else
+                    FAILURES+=("subvolume delete: $entry")
+                    echo "  FAILED: $entry" >&2
+                fi
+            else
+                echo "  candidate (subvolume check at apply): $entry"
+                SNAP_COUNT=$((SNAP_COUNT + 1))
+            fi
+        done
+    done
+}
+
+# remove_pins_under <root> — pin files + rmdir emptied subvol dirs
+PIN_COUNT=0
+remove_pins_under() {
+    local root="$1"
+    [[ -d "$root" ]] || return 0
+    local subdir pin
+    for subdir in "$root"/*/; do
+        subdir="${subdir%/}"
+        [[ -d "$subdir" && ! -L "$subdir" ]] || continue
+        for pin in "$subdir"/.last-external-parent-* "$subdir"/.last-external-parent; do
+            [[ -f "$pin" ]] || continue
+            do_rm "pin file" "$pin" && PIN_COUNT=$((PIN_COUNT + 1)) || true
+        done
+        if [[ $APPLY -eq 1 ]]; then
+            rmdir "$subdir" 2>/dev/null || true   # non-empty = safe no-op
+        fi
+    done
+}
+
+# ── Category 7: systemd units (first — nothing may recreate state mid-reset) ──
+
+echo "[systemd units]"
+UNIT_COUNT=0
+for unit in "${UNITS[@]}"; do
+    if [[ $APPLY -eq 1 ]]; then
+        systemctl --user disable --now "$unit" >/dev/null 2>&1 || true
+        systemctl --user stop "$unit" >/dev/null 2>&1 || true
+    else
+        echo "  would disable --now: $unit"
+    fi
+    if [[ -f "$UNIT_DIR/$unit" ]]; then
+        do_rm "unit file" "$UNIT_DIR/$unit" && UNIT_COUNT=$((UNIT_COUNT + 1)) || true
+    fi
+done
+if [[ $APPLY -eq 1 ]]; then
+    systemctl --user daemon-reload >/dev/null 2>&1 || true
+    systemctl --user reset-failed 'urd-*' >/dev/null 2>&1 || true
+    echo "  daemon-reload + reset-failed done"
+else
+    echo "  would daemon-reload + reset-failed 'urd-*'"
+fi
+echo
+
+# ── Hardening C: never reset under a live backup ─────────────────────────
+
+if [[ -e "$LOCK_FILE" ]] && ! flock -n "$LOCK_FILE" true 2>/dev/null; then
+    if [[ $APPLY -eq 1 ]]; then
+        echo "ABORT: backup advisory lock is held ($LOCK_FILE) — a backup is running. Nothing further was touched." >&2
+        exit 5
+    else
+        echo "WARNING: backup advisory lock is held ($LOCK_FILE) — apply would abort here" >&2
+    fi
+fi
+
+# ── Category 3+4: local snapshots + pin files (marker-declared roots only) ──
+
+echo "[local snapshots + pins]"
+if [[ ${#LOCAL_ROOTS[@]} -eq 0 ]]; then
+    echo "  no snapshot_root declared in marker — skipped (0)"
+else
+    for root in "${LOCAL_ROOTS[@]}"; do
+        echo "  root: $root"
+        delete_snapshots_under "$root"
+        remove_pins_under "$root"
+    done
+fi
+echo
+
+# ── Category 5: external drive (only with --drive UUID) ─────────────────
+
+echo "[external drive]"
+EXT_COUNT_BEFORE=$SNAP_COUNT
+if [[ -z "$DRIVE_UUID" ]]; then
+    echo "  skipped — no --drive given (drive snapshots and token untouched)"
+else
+    [[ -n "$MARKER_DRIVE_UUID" ]] || refuse "--drive given but the marker declares no drive_uuid"
+    [[ "$DRIVE_UUID" == "$MARKER_DRIVE_UUID" ]] || refuse "--drive $DRIVE_UUID does not match the marker's drive_uuid"
+
+    mapfile -t TARGETS < <(findmnt -rn -S "UUID=$DRIVE_UUID" -o TARGET 2>/dev/null || true)
+    if [[ ${#TARGETS[@]} -eq 0 ]]; then
+        echo "  skipped — UUID $DRIVE_UUID is not mounted (the script never mounts or unlocks)"
+    else
+        MOUNT=""
+        REMOVABLE_MATCHES=0
+        for t in "${TARGETS[@]}"; do
+            [[ "$t" == "/" || "$t" == "/home" ]] && refuse "UUID $DRIVE_UUID resolves to $t — that is the system filesystem, not the lab drive"
+            if [[ "$t" == /run/media/* || "$t" == /media/* ]]; then
+                REMOVABLE_MATCHES=$((REMOVABLE_MATCHES + 1))
+                MOUNT="$t"
+            fi
+        done
+        [[ $REMOVABLE_MATCHES -eq 1 ]] || refuse "UUID $DRIVE_UUID does not resolve to exactly one removable mountpoint (/run/media/* or /media/*) — refusing as ambiguous"
+        for r in "${LOCAL_ROOTS[@]:-}"; do
+            ROOT_UUID="$(findmnt -no UUID -T "$r" 2>/dev/null || true)"
+            [[ "$ROOT_UUID" != "$DRIVE_UUID" ]] || refuse "UUID $DRIVE_UUID backs local snapshot root $r — that is an internal filesystem, not the lab drive"
+        done
+
+        EXT_ROOT="$MOUNT/$DRIVE_SNAP_ROOT"
+        LABEL="$(lsblk -rno LABEL "/dev/disk/by-uuid/$DRIVE_UUID" 2>/dev/null || true)"
+        CONFIRM_TOKEN="${LABEL:-$DRIVE_UUID}"
+
+        echo "  drive: UUID=$DRIVE_UUID label=${LABEL:-'(none)'} mount=$MOUNT"
+        if [[ ! -d "$EXT_ROOT" ]]; then
+            echo "  no $DRIVE_SNAP_ROOT on the drive — nothing to unwind"
+        else
+            if [[ $APPLY -eq 1 ]]; then
+                echo
+                echo "  About to delete urd's snapshots and token under: $EXT_ROOT"
+                printf '  Type the drive %s to confirm: ' "$([[ -n "$LABEL" ]] && echo "label ($LABEL)" || echo "UUID")"
+                read -r ANSWER
+                if [[ "$ANSWER" != "$CONFIRM_TOKEN" ]]; then
+                    echo "ABORT: confirmation mismatch — nothing on the drive was touched." >&2
+                    exit 4
+                fi
+            fi
+            delete_snapshots_under "$EXT_ROOT"
+            if [[ -f "$EXT_ROOT/.urd-drive-token" ]]; then
+                do_rm "drive token" "$EXT_ROOT/.urd-drive-token" || true
+            fi
+        fi
+    fi
+fi
+EXT_COUNT=$((SNAP_COUNT - EXT_COUNT_BEFORE))
+echo
+
+# ── Category 6: sudoers ──────────────────────────────────────────────────
+
+echo "[sudoers]"
+if [[ $APPLY -eq 1 ]]; then
+    if sudo rm -f "$SUDOERS_FILE"; then
+        echo "  removed: $SUDOERS_FILE"
+    else
+        FAILURES+=("sudoers: $SUDOERS_FILE")
+        echo "  FAILED: $SUDOERS_FILE" >&2
+    fi
+else
+    echo "  would remove (sudo): $SUDOERS_FILE"
+fi
+echo
+
+# ── Category 2: state ────────────────────────────────────────────────────
+
+echo "[state]"
+for f in urd.db urd.db-wal urd.db-shm urd.lock heartbeat.json backup.prom; do
+    [[ -e "$STATE_DIR/$f" ]] && { do_rm "state" "$STATE_DIR/$f" || true; }
+done
+[[ -d "$STATE_DIR/logs" ]] && { do_rm "state logs" "$STATE_DIR/logs/" || true; }
+[[ $APPLY -eq 1 ]] && rmdir "$STATE_DIR" 2>/dev/null || true
+echo
+
+# ── Category 1: config ───────────────────────────────────────────────────
+
+echo "[config]"
+for f in urd.toml urd.toml.legacy urd.toml.v1; do
+    [[ -e "$CONFIG_DIR/$f" ]] && { do_rm "config" "$CONFIG_DIR/$f" || true; }
+done
+[[ $APPLY -eq 1 ]] && rmdir "$CONFIG_DIR" 2>/dev/null || true
+echo
+
+# ── Category 8: completions ──────────────────────────────────────────────
+
+echo "[completions]"
+for f in "${COMPLETIONS[@]}"; do
+    [[ -e "$f" ]] && { do_rm "completions" "$f" || true; }
+done
+echo
+
+# ── Category 9: binaries (--full only) ───────────────────────────────────
+
+echo "[binaries]"
+if [[ $FULL -eq 1 ]]; then
+    for f in "${BINARIES[@]}"; do
+        [[ -e "$f" ]] && { do_rm "binary" "$f" || true; }
+    done
+else
+    echo "  skipped — no --full (installed urd binaries untouched)"
+fi
+echo
+
+# ── Summary ──────────────────────────────────────────────────────────────
+
+LOCAL_COUNT=$((SNAP_COUNT - EXT_COUNT))
+VERB="deleted"
+[[ $APPLY -eq 1 ]] || VERB="candidate(s)"
+echo "summary ($MODE): local snapshots: $LOCAL_COUNT $VERB · pins: $PIN_COUNT · external: $EXT_COUNT $VERB · anomalies: $ANOMALY_COUNT · unit files: $UNIT_COUNT"
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+    echo
+    echo "FAILURES (${#FAILURES[@]}) — the machine is NOT a clean slate:" >&2
+    for f in "${FAILURES[@]}"; do
+        echo "  $f" >&2
+    done
+    exit 6
+fi


### PR DESCRIPTION
## Summary

- First deliverable of the Encounter arc (UPIs 070–078): the staging lab that makes first-encounter field tests repeatable, built 078-first per the arc grill.
- New guide `docs/00-foundation/guides/encounter-staging-protocol.md`: staging-machine contract, marker-file setup (consent + deletion scope, no machine identity in the repo), reset-script usage, observation-capture template, 8-scenario matrix, findings loop.
- New `scripts/staging-reset.sh`: unwinds all nine urd artifact categories. It deletes subvolumes as root, so it is fenced by four rails — marker-file allowlist, dry-run by default, contract-scoped deletion (ADR-105 names, no symlinks, subvolume-show gate, marker-declared roots only), and drive-by-UUID with typed confirmation + mountpoint sanity refusals — plus a refuse-root guard, a backup-lock abort, and per-item failure isolation.
- Glossary: new Encounter cluster (runestone, gap/GapKind, the seal) + a flagged ambiguity fencing "gap" off from UPI 080's unresolved signal vocabulary.

## Testing

- cargo clippy: pass (no Rust touched; tree guarded)
- cargo test: 1893 passed, 0 failed
- Reset script: `bash -n` clean; 12-case dry-run smoke matrix pass (marker refusals, malformed-marker refusals, symlink anomaly, lock-held warning, drive-mismatch refusals, honest skips, nothing touched in dry-run). Apply-path validation is deliberately deferred to the staging machine's field day — this dev machine runs production urd.
- Doc gates: check-docs, check-registry, check-present-not-journey all pass; PII scan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)