### PR TITLE
chore: field-test-01 follow-ups — reset unwind gaps + setup-guide friction

### DIFF
--- a/docs/00-foundation/guides/encounter-staging-protocol.md
+++ b/docs/00-foundation/guides/encounter-staging-protocol.md
@@ -77,9 +77,15 @@ Dry-run is the default and prints the full deletion plan; only `--apply` execute
 binaries (category 9, for install-experience testing).
 
 Exit codes: `0` clean · `2` usage · `3` refusal (missing/invalid marker, running as
-root, drive sanity) · `4` typed-confirmation mismatch · `5` backup lock held ·
-`6` finished with per-item failures (the summary lists them — the machine is *not* a
-clean slate).
+root, drive sanity) · `4` typed-confirmation mismatch or EOF at the prompt · `5`
+backup lock held · `6` finished with per-item failures (the summary lists them — the
+machine is *not* a clean slate).
+
+**`--apply` with `--drive` needs an interactive terminal.** The typed drive
+confirmation reads from stdin; a non-interactive stdin (pipe, harness passthrough,
+CI) EOFs the prompt, which exits 4 and aborts the drive category *and every category
+after it* — categories already processed stay applied, leaving a half-reset machine
+(observed live in field test 01). Dry-runs never prompt and are safe anywhere.
 
 ### Safety rails
 
@@ -114,10 +120,10 @@ isolates them, continues, and lists every failure in the summary.
 | # | Category | Where |
 |---|----------|-------|
 | 1 | Config | `~/.config/urd/` — `urd.toml` + `urd migrate` backups (`.legacy`, `.v1`) |
-| 2 | State | `~/.local/share/urd/` — `urd.db` (+`-wal`/`-shm`), `urd.lock`, `heartbeat.json`, `backup.prom`, `logs/` |
+| 2 | State | `~/.local/share/urd/` — `urd.db` (+`-wal`/`-shm`), `urd.lock`, `heartbeat.json`, `sentinel-state.json`, `backup.prom`, `logs/`; warns if anything it does not know survives |
 | 3 | Local snapshots | contract-named subvolumes under each marker-declared root |
 | 4 | Pin files | `.last-external-parent-{LABEL}` (+ legacy form) in each snapshot dir |
-| 5 | External drive | contract-named snapshots + `.urd-drive-token` under the drive's snapshot root (`--drive` only) |
+| 5 | External drive | contract-named snapshots + `.urd-drive-token` under the drive's snapshot root, then emptied per-subvolume dirs (`--drive` only) |
 | 6 | Sudoers | `/etc/sudoers.d/urd` (removed, never edited — absence is the pre-Urd state) |
 | 7 | systemd | `urd-backup.timer`, `urd-backup.service`, `urd-sentinel.service`: disabled, unit files removed, `daemon-reload` + `reset-failed` |
 | 8 | Completions | the prescribed install paths (below) |

--- a/docs/00-foundation/guides/operating-urd.md
+++ b/docs/00-foundation/guides/operating-urd.md
@@ -11,8 +11,9 @@ Urd compiles to a single binary. The systemd unit expects it at `~/.cargo/bin/ur
 
 ### First-time install
 
+From the root of your clone:
+
 ```bash
-cd ~/projects/urd
 cargo build --release
 cp target/release/urd ~/.cargo/bin/urd
 ```
@@ -27,10 +28,10 @@ cargo install --path .
 
 **This is the step people forget.** Code changes (new features, bug fixes, review fixes)
 only take effect after rebuilding and replacing the binary. If you pull new code or merge
-a PR but don't rebuild, the running binary is still the old version.
+a PR but don't rebuild, the running binary is still the old version. From the root of
+your clone:
 
 ```bash
-cd ~/projects/urd
 git pull                          # or: merge the PR branch
 cargo build --release
 cp target/release/urd ~/.cargo/bin/urd
@@ -53,6 +54,12 @@ automatically — the service unit runs `%h/.cargo/bin/urd backup` each time, so
 always picks up whatever binary is at that path. No `daemon-reload` needed for binary
 updates (only for unit file changes).
 
+> **This manual path is interim.** The Encounter — Urd's guided first-run
+> conversation, in development — replaces everything from here through Initial
+> Setup: generated config, initialized drive, created directories, verified
+> identity. Until it ships, follow these steps exactly and in order; the traps
+> called out below were all hit in live field testing (2026-07-04).
+
 ## Sudoers Configuration
 
 Urd runs as a regular user and calls `sudo btrfs` for privileged filesystem operations.
@@ -64,8 +71,14 @@ Create `/etc/sudoers.d/urd` (requires root):
 sudo visudo -f /etc/sudoers.d/urd
 ```
 
-Paste the following template, replacing `<user>` with your username, `<btrfs>` with the
-path to your btrfs binary (`which btrfs`), and adjusting paths to match your layout:
+Below is a complete, working example for user **`alice`** backing up `/home` to the
+local snapshot root `/home/alice/.snapshots` and an external drive labeled
+**`backup-1`**, with btrfs at `/usr/bin/btrfs`. **Do not paste it unchanged** —
+substitute three things for your system first:
+
+1. the username (`alice` → yours),
+2. the btrfs path (use the output of `which btrfs`, everywhere it appears),
+3. the source and snapshot-root paths (from your config).
 
 ```sudoers
 # Urd — scoped btrfs permissions for automated backups
@@ -74,23 +87,28 @@ path to your btrfs binary (`which btrfs`), and adjusting paths to match your lay
 # show/sync are read-only diagnostics.
 
 # Snapshot creation — scoped to snapshot directories
-# Add one line per source → snapshot-root mapping in your config.
-<user> ALL=(root) NOPASSWD: <btrfs> subvolume snapshot -r /path/to/source /path/to/snapshot-root/*
+# One line per source → snapshot-root mapping in your config.
+alice ALL=(root) NOPASSWD: /usr/bin/btrfs subvolume snapshot -r /home /home/alice/.snapshots/*
 
 # Snapshot deletion — scoped to snapshot directories only
-# Add one line per snapshot root (local and each external drive).
-<user> ALL=(root) NOPASSWD: <btrfs> subvolume delete /path/to/snapshot-root/*
-<user> ALL=(root) NOPASSWD: <btrfs> subvolume delete /run/media/<user>/drive-label/.snapshots/*
+# One line per snapshot root (local and each external drive).
+alice ALL=(root) NOPASSWD: /usr/bin/btrfs subvolume delete /home/alice/.snapshots/*
+alice ALL=(root) NOPASSWD: /usr/bin/btrfs subvolume delete /run/media/alice/backup-1/.snapshots/*
 
 # Send/receive — broad paths (source subvolumes and external drives vary)
-<user> ALL=(root) NOPASSWD: <btrfs> send *
-<user> ALL=(root) NOPASSWD: <btrfs> receive *
+alice ALL=(root) NOPASSWD: /usr/bin/btrfs send *
+alice ALL=(root) NOPASSWD: /usr/bin/btrfs receive *
 
 # Read-only commands — space estimation, diagnostics, sync after delete
-<user> ALL=(root) NOPASSWD: <btrfs> subvolume show *
-<user> ALL=(root) NOPASSWD: <btrfs> filesystem show *
-<user> ALL=(root) NOPASSWD: <btrfs> subvolume sync *
+alice ALL=(root) NOPASSWD: /usr/bin/btrfs subvolume show *
+alice ALL=(root) NOPASSWD: /usr/bin/btrfs filesystem show *
+alice ALL=(root) NOPASSWD: /usr/bin/btrfs subvolume sync *
 ```
+
+If visudo reports `syntax error` lines when you save and drops you at a
+`What now?` prompt, type `e` to re-open the file and fix it — usually a
+placeholder or path left unsubstituted. visudo never installs a broken file,
+so nothing is damaged; just correct and re-save.
 
 Verify it works:
 
@@ -110,36 +128,45 @@ pair in your config. One deletion line per snapshot directory (each local snapsh
 plus each external drive's snapshot directory). The read-only commands and send/receive
 are one line each.
 
-> **Path note:** The btrfs binary path varies by distribution. Common locations:
-> `/usr/sbin/btrfs` (Fedora, RHEL), `/usr/bin/btrfs` (Arch, Ubuntu).
-> Check with `which btrfs`.
+> **Path note:** run `which btrfs` and use that exact path both here and in the
+> config's btrfs path. Current Fedora resolves `/usr/bin/btrfs` (`/usr/sbin` is a
+> symlink to `bin`; a sudoers line written against either spelling matches an
+> invocation via the other — verified on Fedora 44, sudo 1.9.17). Older
+> Fedora/RHEL report `/usr/sbin/btrfs`; Arch and Ubuntu use `/usr/bin/btrfs`.
 
 ## Initial Setup
 
-After the first install, configure and validate:
+After the first install, configure and validate. Run the `cp` steps from the root
+of your clone (wherever you cloned the repo — the paths below are repo-relative):
 
 ```bash
-# 1. Create config from template
-cp ~/projects/urd/config/urd.toml.example ~/.config/urd/urd.toml
+# 1. Create config from template (~/.config/urd/ does not exist on a fresh
+#    system — create it first)
+mkdir -p ~/.config/urd
+cp config/urd.toml.example ~/.config/urd/urd.toml
 # Edit: set drive mount paths, subvolume sources, snapshot roots for your system
 
 # 2. Validate system readiness
 urd init
 
-# 3. Measure snapshot sizes (space estimation for first external sends)
-urd calibrate
-
-# 4. Preview the backup plan
+# 3. Preview the backup plan
 urd plan
 
-# 5. Dry-run to confirm
+# 4. Dry-run to confirm
 urd backup --dry-run
 
-# 6. Run a real backup
+# 5. Create the first local snapshot, then measure it (calibrate reads local
+#    snapshots — on a fresh system it skips with "no local snapshots" until
+#    one exists)
+urd backup --local-only
+urd calibrate
+
+# 6. Run a real backup (external sends now have size estimates)
 urd backup
 
 # 7. Install the systemd units for nightly backups and the sentinel
-cp ~/projects/urd/systemd/urd-*.{service,timer} ~/.config/systemd/user/
+mkdir -p ~/.config/systemd/user
+cp systemd/urd-*.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now urd-backup.timer
 systemctl --user enable --now urd-sentinel.service   # recommended; see below
@@ -262,8 +289,11 @@ Urd is a nightly cron job; with it, Urd is a continuous protection layer.
 
 ### Install / update units
 
+From the root of your clone:
+
 ```bash
-cp ~/projects/urd/systemd/urd-*.{service,timer} ~/.config/systemd/user/
+mkdir -p ~/.config/systemd/user
+cp systemd/urd-*.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
 systemctl --user enable --now urd-backup.timer
 systemctl --user enable --now urd-sentinel.service   # optional but recommended
@@ -325,8 +355,9 @@ systemctl --user daemon-reload
 
 ### After merging new code
 
+From the root of your clone:
+
 ```bash
-cd ~/projects/urd
 git pull
 cargo build --release
 cp target/release/urd ~/.cargo/bin/urd
@@ -371,7 +402,7 @@ Common causes:
   (shown as "estimated ~X exceeds Y available" in the skip reason)
 - **Broken chain** — parent snapshot deleted or missing on external drive. Next send
   will be a full send (large but self-repairing)
-- **Sudo permission** — `urd init` validates this; check `/etc/sudoers.d/btrfs-backup`
+- **Sudo permission** — `urd init` validates this; check `/etc/sudoers.d/urd`
 
 ### Recalibrate after major data changes
 

--- a/scripts/staging-reset.sh
+++ b/scripts/staging-reset.sh
@@ -25,9 +25,16 @@
 #
 # Usage: scripts/staging-reset.sh [--apply] [--drive UUID] [--full]
 #
+# --apply with --drive reads the typed drive confirmation from stdin: run it in a
+# real interactive terminal. A non-interactive stdin (pipe, harness passthrough,
+# CI) EOFs the prompt, which exits 4 and aborts the drive category AND everything
+# after it — categories already processed stay applied, leaving a half-reset
+# machine. Dry-runs (no --apply) never prompt and are safe non-interactively.
+#
 # Exit codes:
 #   0 clean · 2 usage · 3 refusal (no/invalid marker, root, drive sanity)
-#   4 typed confirmation mismatch · 5 backup lock held · 6 finished with failures
+#   4 typed confirmation mismatch or EOF at the prompt · 5 backup lock held
+#   6 finished with failures
 
 set -euo pipefail
 shopt -s nullglob
@@ -329,6 +336,14 @@ else
                 fi
             fi
             delete_snapshots_under "$EXT_ROOT"
+            if [[ $APPLY -eq 1 ]]; then
+                # mirror remove_pins_under: drop per-subvolume dirs the deletions emptied
+                for subdir in "$EXT_ROOT"/*/; do
+                    subdir="${subdir%/}"
+                    [[ -d "$subdir" && ! -L "$subdir" ]] || continue
+                    rmdir "$subdir" 2>/dev/null || true   # non-empty = safe no-op
+                done
+            fi
             if [[ -f "$EXT_ROOT/.urd-drive-token" ]]; then
                 do_rm "drive token" "$EXT_ROOT/.urd-drive-token" || true
             fi
@@ -356,11 +371,16 @@ echo
 # ── Category 2: state ────────────────────────────────────────────────────
 
 echo "[state]"
-for f in urd.db urd.db-wal urd.db-shm urd.lock heartbeat.json backup.prom; do
+for f in urd.db urd.db-wal urd.db-shm urd.lock heartbeat.json sentinel-state.json backup.prom; do
     [[ -e "$STATE_DIR/$f" ]] && { do_rm "state" "$STATE_DIR/$f" || true; }
 done
 [[ -d "$STATE_DIR/logs" ]] && { do_rm "state logs" "$STATE_DIR/logs/" || true; }
-if [[ $APPLY -eq 1 ]]; then rmdir "$STATE_DIR" 2>/dev/null || true; fi
+if [[ $APPLY -eq 1 && -d "$STATE_DIR" ]]; then
+    if ! rmdir "$STATE_DIR" 2>/dev/null; then
+        echo "  WARNING: $STATE_DIR is not empty after the pass — this script does not know these files (unwind gap?):" >&2
+        find "$STATE_DIR" -mindepth 1 -maxdepth 1 -printf '    %f\n' >&2 2>/dev/null || true
+    fi
+fi
 echo
 
 # ── Category 1: config ───────────────────────────────────────────────────
@@ -369,7 +389,12 @@ echo "[config]"
 for f in urd.toml urd.toml.legacy urd.toml.v1; do
     [[ -e "$CONFIG_DIR/$f" ]] && { do_rm "config" "$CONFIG_DIR/$f" || true; }
 done
-if [[ $APPLY -eq 1 ]]; then rmdir "$CONFIG_DIR" 2>/dev/null || true; fi
+if [[ $APPLY -eq 1 && -d "$CONFIG_DIR" ]]; then
+    if ! rmdir "$CONFIG_DIR" 2>/dev/null; then
+        echo "  WARNING: $CONFIG_DIR is not empty after the pass — this script does not know these files (unwind gap?):" >&2
+        find "$CONFIG_DIR" -mindepth 1 -maxdepth 1 -printf '    %f\n' >&2 2>/dev/null || true
+    fi
+fi
 echo
 
 # ── Category 8: completions ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **staging-reset.sh** — the first-ever field `--apply` (2026-07-04) found two unwind gaps: `sentinel-state.json` missing from the category-2 state whitelist, and drive-side per-subvolume dirs surviving category 5. Both fixed; the silent `rmdir || true` on the state/config dirs is now a WARNING with a file listing when anything the script doesn't know survives (same silent-narrowing class as the #249 marker fix).
- **Interactive-stdin requirement documented** (script header + protocol guide): `--apply --drive` reads the typed drive confirmation from stdin; EOF exits 4 and aborts every remaining category — a half-reset machine, observed live. The skip-drive-and-continue redesign question is deferred to the Encounter-arc design review.
- **operating-urd.md** — five friction fixes from the timed rehearsal (guide-following setup took ~29 min, 3× the expert path): concrete sudoers example replacing paste-hostile placeholders + visudo recovery note; verified btrfs-path/symlink guidance (`/usr/sbin → bin` on unified-usr Fedora, sudo matches either spelling — tested live on sudo 1.9.17); `mkdir -p` before the config copy and unit install; repo-relative `cp` sources; `calibrate` moved to after the first `backup --local-only`. Manual setup is framed as the interim path the Encounter replaces.
- Companion issues from the same field day: #250, #251, #252, #253, #254. Evidence: field-test report 01 + triage doc (docs/99-reports, local).

## Testing

- shellcheck: clean (0 findings)
- scripts/check-docs.sh: 89 links / 42 files, all resolve
- Dry-run smoke vs a scratch $HOME with marker + state fixtures: sentinel-state.json now planned; exit 0
- New warn-on-nonempty blocks exercised in isolation: non-empty dir warns and lists, empty dir removed silently
- cargo: not applicable (no Rust changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)