### PR TITLE
docs: add discovery.rs module row (post-070 drift fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ live in `docs/00-foundation/architecture.md`.
 - `drift.rs` — churn aggregation; `rotation.rs` — offsite rotation cadence + freshness window; `preflight.rs` — achievability advisories
 - `chain.rs` — pin files; `state.rs` — SQLite history (granular wrappers)
 - `drives.rs` / `pools.rs` — drive + BTRFS-pool detection
+- `discovery.rs` — zero-state system inventory from unprivileged probes (the Encounter's looking)
 - `output.rs` / `voice/` — structured output types / mythic-voice rendering
 - `events.rs` / `voice_events.rs` — typed event payloads / their renderer
 - `notify.rs`, `heartbeat.rs`, `metrics.rs` — notification + health surfaces

--- a/docs/00-foundation/architecture.md
+++ b/docs/00-foundation/architecture.md
@@ -173,6 +173,7 @@ the documentation convention in `contributing-internal.md`).
 | `rotation.rs` | Pure: infer offsite rotation cadence (median homecoming gap) and resolve the offsite freshness window from drive-mount history | Perform I/O or persist |
 | `drives.rs` | Detect mounted drives, UUID fingerprinting, check space | Mount/unmount drives |
 | `pools.rs` | Detect BTRFS pools, group subvolumes by pool UUID, read sysfs/statvfs utilization | Know about retention, plans, drive lifecycle, or notification policy |
+| `discovery.rs` | Build the zero-state `SystemInventory` (pools, mounted subvolumes, candidate drives with internal/external class + LUKS state, typed notes) from unprivileged probes — `lsblk -J`/`findmnt -J` parsing, per-disk signal aggregation; observational only | Use sudo or `BtrfsOps`; read config or state DB; vouch for device identity to privileged consumers (they re-verify at action time) |
 | `output.rs` | Define structured output types | Render text (`voice/` does that) |
 | `voice/` | Render structured output as mythic-voice text; per-command sub-modules, with cross-renderer helpers in `voice/mod.rs` exposed `pub(super)` | Perform I/O or compute state |
 | `voice_events.rs` | Per-variant `EventPayload` renderer (columnar + NDJSON) | Perform I/O or query state |


### PR DESCRIPTION
## Summary

- Adds the `discovery.rs` row to the module-responsibility table in `docs/00-foundation/architecture.md` and the one-clause entry in CLAUDE.md's module list — the new module landed in #256 without them.
- Role-and-boundaries wording only (present, not journey).

## Testing

- Docs-only; no Rust surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)