### PR TITLE
feat: config generation + self-check (UPI 074)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Config generation + self-check (UPI 074, Encounter arc 5/9).** New
+  `config_render` module converts an approved `ProposedStrategy` into a fully
+  explicit, commented v2 config — intention comments anchored to the subvolume
+  or drive they explain, typed exclusion and gap commentary, and a tool-agnostic
+  header stating that comments do not survive a rewrite. Born through the
+  self-check: the rendered TOML must survive the real load path *and* reload to
+  exactly the approved strategy, or nothing is written. The carve wiring
+  (`commands/encounter.rs`) publishes atomically via hard-link (an existing
+  config is never overwritten, even by a race) and refuses empty strategies.
+  Acceptance property: every strategy the derivation grid can produce
+  round-trips exactly and raises zero preflight advisories. Engine + carve
+  wiring only — no CLI surface until the Encounter conversation (UPI 072).
+
 - **Strategy derivation engine (UPI 073, Encounter arc 4/9).** New `strategy`
   module derives a `ProposedStrategy` from the system inventory plus the fate
   conversation's answers: per-subvolume promises mapped onto the existing named
@@ -26,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   statvfs). Ask-don't-guess: conflicting drive signals classify as Ambiguous for
   the conversation to resolve. Engine only — no CLI surface until the Encounter
   conversation (UPI 072) consumes it.
+
+### Fixed
+- **Multi-device btrfs pools no longer derive duplicate backup drives.** A
+  filesystem spanning two external disks made strategy derivation adopt every
+  bearing drive — duplicate drive UUIDs that config validation rejects (and
+  would have meant double-sends into one filesystem). One pool now adopts one
+  destination, first bearing drive wins.
 
 ## [0.32.0] - 2026-07-03
 

--- a/src/commands/encounter.rs
+++ b/src/commands/encounter.rs
@@ -1,0 +1,288 @@
+//! The Encounter's carve wiring (UPI 074) — the I/O half of config
+//! generation. The conversation that produces the approved strategy is
+//! UPI 072's; this module owns the last step: self-check the generated
+//! config, refuse anything dishonest, and publish the file atomically
+//! without ever clobbering an existing one.
+//!
+//! Refusal order is load-bearing: the checks that touch nothing (empty
+//! strategy, self-check) run before any filesystem side effect.
+
+use std::fs;
+use std::io::Write as _;
+use std::path::Path;
+
+use anyhow::{bail, Context};
+use chrono::NaiveDate;
+
+use crate::config::Config;
+use crate::config_render::generate_config;
+use crate::strategy::ProposedStrategy;
+
+/// Staging file for the atomic publish, sibling to the final config.
+const TEMP_NAME: &str = ".urd.toml.tmp";
+
+/// Carve the approved strategy into `path`: generate, self-check, refuse
+/// or publish. Nothing is ever written unless every check passes; an
+/// existing config is never overwritten (deleting a config is a human
+/// act — the designed refusal sentence is 072's trigger-time rendering,
+/// this one is the race backstop).
+#[allow(dead_code)] // Consumed by UPI 072 (conversation).
+pub fn carve_config(
+    strategy: &ProposedStrategy,
+    today: NaiveDate,
+    path: &Path,
+) -> anyhow::Result<()> {
+    // An empty strategy would carve a config that protects nothing while
+    // silencing the "no config → offer the encounter" trigger. 072 renders
+    // the empty case honestly and never calls carve; this is the backstop.
+    if strategy.subvolumes.is_empty() {
+        bail!("the encounter proposed nothing to protect — nothing to carve, nothing written");
+    }
+
+    let generated = generate_config(strategy, today);
+
+    // Self-check, migrate's pattern plus the equality half: the rendered
+    // TOML must survive the full load path (parse → expand_paths →
+    // validate) AND reload to exactly the config it was rendered from.
+    // Parse+validate alone would pass a divergent-but-valid render (e.g. a
+    // non-UTF-8 path rendered lossily names a phantom source) — a config
+    // that differs from what the runestone showed must never reach disk.
+    let reparsed = match Config::from_str(&generated.toml) {
+        Ok(config) => config,
+        Err(e) => bail!(
+            "the encounter would produce an invalid config — nothing written.\n\
+             load check: {e}"
+        ),
+    };
+    let mut expected = generated.config;
+    expected.expand_paths();
+    if reparsed != expected {
+        bail!(
+            "the carved config would not reload to the approved strategy — nothing written.\n\
+             (render/parse divergence: a bug in urd, not in your answers)"
+        );
+    }
+
+    if path.exists() {
+        return Err(exists_refusal(path));
+    }
+
+    let dir = path
+        .parent()
+        .with_context(|| format!("config path {} has no parent directory", path.display()))?;
+    fs::create_dir_all(dir)
+        .with_context(|| format!("failed to create config directory {}", dir.display()))?;
+
+    // Stage next to the target, then publish via hard_link — which fails
+    // with AlreadyExists instead of clobbering, so a config that appeared
+    // mid-carve survives and the carve loses loudly.
+    let temp = dir.join(TEMP_NAME);
+    stage(&temp, &generated.toml)
+        .with_context(|| format!("failed to stage config at {}", temp.display()))?;
+
+    if let Err(e) = fs::hard_link(&temp, path) {
+        let _ = fs::remove_file(&temp);
+        if e.kind() == std::io::ErrorKind::AlreadyExists {
+            return Err(exists_refusal(path));
+        }
+        return Err(e)
+            .with_context(|| format!("failed to publish config at {}", path.display()));
+    }
+    let _ = fs::remove_file(&temp);
+    Ok(())
+}
+
+/// Write and fsync the staged config, truncating any stale temp a crashed
+/// carve left behind.
+fn stage(temp: &Path, toml: &str) -> std::io::Result<()> {
+    let mut file = fs::File::create(temp)?;
+    file.write_all(toml.as_bytes())?;
+    file.sync_all()
+}
+
+fn exists_refusal(path: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "a config already exists at {} — nothing written.\n\
+         Edit it yourself, or move it aside and run `urd init` again.",
+        path.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::strategy::test_support::{
+        drive, external_btrfs_drive, inventory, pool, subvol, today, EXTERNAL_POOL, SYSTEM_POOL,
+    };
+    use crate::discovery::{DriveClass, LuksState};
+    use crate::strategy::{
+        derive_strategy, FateAnswers, GranularityAnswer, Importance, ImportanceAnswer,
+    };
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    /// A real derivable strategy: Fedora pair + one usable external drive,
+    /// `/home` classified irreplaceable.
+    fn sheltered_strategy() -> crate::strategy::ProposedStrategy {
+        let mut inv = inventory(
+            vec![pool(SYSTEM_POOL, &["/", "/home"])],
+            vec![
+                subvol("/", "/root", SYSTEM_POOL),
+                subvol("/home", "/home", SYSTEM_POOL),
+            ],
+            vec![drive(
+                "nvme0n1",
+                DriveClass::Internal,
+                LuksState::NotEncrypted,
+                Some("btrfs"),
+                Some(SYSTEM_POOL),
+            )],
+        );
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/backup"]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+
+        let answers = FateAnswers {
+            importance: vec![ImportanceAnswer {
+                mountpoint: PathBuf::from("/home"),
+                importance: Importance::Irreplaceable,
+            }],
+            residence: None,
+            granularity: GranularityAnswer::YesterdayIsFine,
+            drive_residency: Vec::new(),
+        };
+        derive_strategy(&inv, &answers, today())
+    }
+
+    /// All-whole-pool inventory: zero candidates, empty strategy.
+    fn empty_strategy() -> crate::strategy::ProposedStrategy {
+        let inv = inventory(
+            vec![pool(SYSTEM_POOL, &["/"])],
+            vec![subvol("/", "/", SYSTEM_POOL)],
+            vec![drive(
+                "nvme0n1",
+                DriveClass::Internal,
+                LuksState::NotEncrypted,
+                Some("btrfs"),
+                Some(SYSTEM_POOL),
+            )],
+        );
+        let answers = FateAnswers {
+            importance: Vec::new(),
+            residence: None,
+            granularity: GranularityAnswer::YesterdayIsFine,
+            drive_residency: Vec::new(),
+        };
+        derive_strategy(&inv, &answers, today())
+    }
+
+    #[test]
+    fn carve_writes_a_config_that_reloads() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        carve_config(&sheltered_strategy(), today(), &path).unwrap();
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(Config::from_str(&on_disk).is_ok());
+        assert!(!dir.path().join(TEMP_NAME).exists(), "temp not cleaned up");
+    }
+
+    #[test]
+    fn carve_creates_missing_parent_directories() {
+        // #250 finding 16: nothing created ~/.config/urd on a fresh system.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("nested/config/urd/urd.toml");
+        carve_config(&sheltered_strategy(), today(), &path).unwrap();
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn carve_refuses_existing_config_with_nothing_written() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        std::fs::write(&path, "# hand-written\n").unwrap();
+
+        let err = carve_config(&sheltered_strategy(), today(), &path).unwrap_err();
+        assert!(err.to_string().contains("already exists"));
+        assert!(err.to_string().contains(&path.display().to_string()));
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "# hand-written\n");
+        assert!(!dir.path().join(TEMP_NAME).exists());
+    }
+
+    #[test]
+    fn carve_refuses_empty_strategy() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        let err = carve_config(&empty_strategy(), today(), &path).unwrap_err();
+        assert!(err.to_string().contains("nothing written"));
+        assert!(!path.exists());
+        assert!(!dir.path().join(TEMP_NAME).exists());
+    }
+
+    #[test]
+    fn carve_self_check_refuses_hostile_path_with_nothing_written() {
+        // A quote in a mountpoint breaks the unescaped render — the
+        // self-check must refuse the parse failure, never write garbage.
+        let mut strategy = sheltered_strategy();
+        strategy.subvolumes[0].source = PathBuf::from("/data/\"quoted\"");
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        let err = carve_config(&strategy, today(), &path).unwrap_err();
+        assert!(err.to_string().contains("invalid config"));
+        assert!(err.to_string().contains("nothing written"));
+        assert!(!path.exists());
+        assert!(!dir.path().join(TEMP_NAME).exists());
+    }
+
+    #[test]
+    fn carve_refuses_divergent_render_nothing_written() {
+        // 074 adversary F2: a non-UTF-8 source renders lossily, PARSES
+        // validly, and names a phantom path — only the equality half of
+        // the self-check catches it.
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        let mut strategy = sheltered_strategy();
+        strategy.subvolumes[0].source =
+            PathBuf::from(OsStr::from_bytes(b"/data/\xff-photos"));
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        let err = carve_config(&strategy, today(), &path).unwrap_err();
+        assert!(err.to_string().contains("would not reload"));
+        assert!(err.to_string().contains("nothing written"));
+        assert!(!path.exists());
+        assert!(!dir.path().join(TEMP_NAME).exists());
+    }
+
+    #[test]
+    fn carve_overwrites_a_stale_temp_file() {
+        // A crash between stage and publish leaves a temp behind; the next
+        // carve truncates it and still publishes cleanly.
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        std::fs::write(dir.path().join(TEMP_NAME), "stale junk").unwrap();
+
+        carve_config(&sheltered_strategy(), today(), &path).unwrap();
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(Config::from_str(&on_disk).is_ok());
+        assert!(!dir.path().join(TEMP_NAME).exists());
+    }
+
+    #[test]
+    fn carve_result_reloads_via_load_path_equivalence() {
+        // What lands on disk must reload to exactly the config the
+        // self-check approved — guards divergence between the checked
+        // string and the written bytes.
+        let strategy = sheltered_strategy();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        carve_config(&strategy, today(), &path).unwrap();
+
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        let reloaded = Config::from_str(&on_disk).unwrap();
+        let mut expected = crate::config_render::generate_config(&strategy, today()).config;
+        expected.expand_paths();
+        assert_eq!(reloaded, expected);
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod default;
 pub mod doctor;
 pub mod drives;
 pub mod emergency;
+pub mod encounter;
 pub mod events;
 pub mod get;
 pub mod history;

--- a/src/config.rs
+++ b/src/config.rs
@@ -130,7 +130,7 @@ pub struct SubvolumeConfig {
     pub drives: Option<Vec<String>>,
 }
 
-fn default_priority() -> u8 {
+pub(crate) fn default_priority() -> u8 {
     2
 }
 
@@ -399,7 +399,7 @@ impl Config {
         resolved
     }
 
-    fn expand_paths(&mut self) {
+    pub(crate) fn expand_paths(&mut self) {
         self.general.state_db = expand_tilde(&self.general.state_db);
         self.general.metrics_file = expand_tilde(&self.general.metrics_file);
         self.general.log_dir = expand_tilde(&self.general.log_dir);
@@ -635,7 +635,7 @@ struct V1SubvolumeConfig {
 /// Fallback `[defaults]` synthesized for v1/v2 Custom or unset protection
 /// levels. Values match full_retention / full_external_retention from
 /// `derive_policy()` in types.rs (`yearly: None` ↔ resolved 0).
-fn parser_fallback_defaults() -> DefaultsConfig {
+pub(crate) fn parser_fallback_defaults() -> DefaultsConfig {
     DefaultsConfig {
         snapshot_interval: Interval::days(1),
         send_interval: Interval::days(1),
@@ -1021,6 +1021,24 @@ struct V2GeneralConfig {
     btrfs_path: String,
     #[serde(default = "default_heartbeat_path")]
     heartbeat_file: PathBuf,
+}
+
+/// The `GeneralConfig` a v2 config with everything but `config_version`
+/// omitted parses to: `config_version` pinned to 2, every other field at its
+/// `V2GeneralConfig` serde default, tilde forms unexpanded. The normal-form
+/// oracle for config generation (UPI 074): `strategy_to_config` pins exactly
+/// these values, so round-trip equality checks against the parser's own
+/// defaults instead of a re-implementation.
+pub(crate) fn v2_general_defaults(run_frequency: RunFrequency) -> GeneralConfig {
+    GeneralConfig {
+        config_version: Some(2),
+        state_db: default_v1_state_db(),
+        metrics_file: default_v1_metrics_file(),
+        log_dir: default_v1_log_dir(),
+        btrfs_path: default_btrfs_path(),
+        heartbeat_file: default_heartbeat_path(),
+        run_frequency,
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -4090,6 +4108,35 @@ min_free_bytes = "10GB"
             defaults.external_retention.resolved(),
             policy.external_retention
         );
+    }
+
+    #[test]
+    fn v2_general_defaults_match_the_v2_parser() {
+        // The oracle must equal what the v2 parser produces for a [general]
+        // section carrying only config_version — proven against the real
+        // load path (parse → expand_paths), not the serde attributes.
+        let config_str = r#"
+[general]
+config_version = 2
+
+[[subvolumes]]
+name = "home"
+source = "/home"
+snapshot_root = "/.snapshots"
+protection = "recorded"
+"#;
+        let parsed = Config::from_str(config_str).unwrap();
+
+        let mut expected = Config {
+            general: v2_general_defaults(default_run_frequency()),
+            local_snapshots: LocalSnapshotsConfig { roots: vec![] },
+            defaults: parser_fallback_defaults(),
+            drives: vec![],
+            subvolumes: vec![],
+            notifications: crate::notify::NotificationConfig::default(),
+        };
+        expected.expand_paths();
+        assert_eq!(parsed.general, expected.general);
     }
 
     #[test]

--- a/src/config_render.rs
+++ b/src/config_render.rs
@@ -24,7 +24,9 @@ use crate::config::{
     default_priority, parser_fallback_defaults, v2_general_defaults, Config, DriveConfig,
     LocalSnapshotsConfig, SnapshotRoot, SubvolumeConfig,
 };
-use crate::strategy::{ExclusionReason, IntentionAnchor, ProposedStrategy};
+use crate::strategy::{
+    ExclusionReason, Gap, GapKind, IntentionAnchor, ProposedStrategy, UnusableReason,
+};
 
 /// The carving's two halves: the `Config` the rendered TOML must reload to,
 /// and the rendered TOML itself. `commands/encounter.rs` self-checks one
@@ -184,8 +186,7 @@ fn header_intentions(strategy: &ProposedStrategy) -> Vec<&str> {
 
 /// Factual gap commentary: the disaster, who was held back, what hardware
 /// is present but unusable.
-fn gap_lines(gap: &crate::strategy::Gap) -> Vec<String> {
-    use crate::strategy::{GapKind, UnusableReason};
+fn gap_lines(gap: &Gap) -> Vec<String> {
     let mut lines = Vec::new();
     match gap.kind {
         GapKind::NoExternalDrive => {
@@ -306,6 +307,9 @@ fn render_subvolumes(out: &mut String, config: &Config, strategy: &ProposedStrat
         let _ = writeln!(out, "[[subvolumes]]");
         let _ = writeln!(out, "name = \"{}\"", sv.name);
         let _ = writeln!(out, "source = \"{}\"", sv.source.display());
+        // A rootless subvolume (a strategy_to_config bug) renders no
+        // snapshot_root line, so the required-field parse failure surfaces
+        // in the self-check — deliberately loud, never silently wrong.
         if let Some(root) = config.snapshot_root_for(&sv.name) {
             let _ = writeln!(out, "snapshot_root = \"{}\"", root.display());
         }
@@ -381,10 +385,9 @@ mod tests {
     use super::*;
     use crate::strategy::test_support::for_each_grid_case;
     use crate::strategy::{
-        Gap, GapKind, Intention, ProposedDrive, ProposedSubvolume, UnusableDrive, UnusableReason,
+        ExcludedSubvol, Intention, ProposedDrive, ProposedSubvolume, UnusableDrive,
     };
     use crate::types::{derive_policy, DriveRole, Interval, ProtectionLevel, RunFrequency};
-    use crate::strategy::ExcludedSubvol;
 
     const POOL_UUID: &str = "44444444-4444-4444-8444-444444444444";
 

--- a/src/config_render.rs
+++ b/src/config_render.rs
@@ -1,0 +1,833 @@
+//! Config generation — the Encounter's carving (UPI 074).
+//!
+//! Converts an approved [`ProposedStrategy`] into the internal [`Config`]
+//! normal form and hand-renders it as a fully explicit, commented v2 TOML
+//! file. Hand-rendering is required, not stylistic: serde cannot place
+//! comments, and `Config`'s `Serialize` emits the legacy shape
+//! (`[local_snapshots]` + `[defaults]` sections), not the v2 wire format.
+//!
+//! Pure (ADR-108): no I/O, no clock, no environment — the carve date is
+//! injected, and the self-check (which reads `$HOME` via tilde expansion)
+//! lives in `commands/encounter.rs`, the migrate precedent.
+//!
+//! The one public entry is [`generate_config`]: the conversion and the
+//! renderer are private so a `Config`/`ProposedStrategy` mismatch is
+//! unrepresentable outside this module.
+
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use chrono::NaiveDate;
+
+use crate::config::{
+    default_priority, parser_fallback_defaults, v2_general_defaults, Config, DriveConfig,
+    LocalSnapshotsConfig, SnapshotRoot, SubvolumeConfig,
+};
+use crate::strategy::{ExclusionReason, IntentionAnchor, ProposedStrategy};
+
+/// The carving's two halves: the `Config` the rendered TOML must reload to,
+/// and the rendered TOML itself. `commands/encounter.rs` self-checks one
+/// against the other before anything touches disk.
+#[derive(Debug)]
+pub struct GeneratedConfig {
+    pub config: Config,
+    pub toml: String,
+}
+
+/// Convert an approved strategy into the internal `Config` normal form and
+/// render it as commented v2 TOML. Pure; `today` is the carve date the
+/// header and nothing else consumes.
+#[allow(dead_code)] // Consumed by UPI 072 (conversation).
+#[must_use]
+pub fn generate_config(strategy: &ProposedStrategy, today: NaiveDate) -> GeneratedConfig {
+    let config = strategy_to_config(strategy);
+    let toml = render_config(&config, strategy, today);
+    GeneratedConfig { config, toml }
+}
+
+// ── Strategy → Config (the parser's normal form) ────────────────────────
+
+/// Build exactly the `Config` that parsing the rendered TOML produces
+/// (before tilde expansion): v2 general defaults with `config_version = 2`,
+/// `[defaults]` from `parser_fallback_defaults`, roots BTreeMap-grouped by
+/// snapshot root, identity fields pinned, and never an operational override
+/// (named levels are opaque — ADR-110; `validate_protection_contract`
+/// rejects overrides outright).
+fn strategy_to_config(strategy: &ProposedStrategy) -> Config {
+    let mut root_map: BTreeMap<PathBuf, Vec<String>> = BTreeMap::new();
+    for sv in &strategy.subvolumes {
+        root_map
+            .entry(sv.snapshot_root.clone())
+            .or_default()
+            .push(sv.name.clone());
+    }
+    let roots: Vec<SnapshotRoot> = root_map
+        .into_iter()
+        .map(|(path, subvolumes)| SnapshotRoot {
+            path,
+            subvolumes,
+            min_free_bytes: None,
+        })
+        .collect();
+
+    let subvolumes: Vec<SubvolumeConfig> = strategy
+        .subvolumes
+        .iter()
+        .map(|sv| SubvolumeConfig {
+            name: sv.name.clone(),
+            short_name: sv.name.clone(),
+            source: sv.source.clone(),
+            priority: default_priority(),
+            enabled: Some(true),
+            snapshot_interval: None,
+            send_interval: None,
+            send_enabled: None,
+            local_retention: None,
+            external_retention: None,
+            protection_level: Some(sv.level),
+            // All configured drives stay in scope: a label list would freeze
+            // the promise to today's drives and lets voiding-override fire.
+            drives: None,
+        })
+        .collect();
+
+    let drives: Vec<DriveConfig> = strategy
+        .drives
+        .iter()
+        .map(|d| DriveConfig {
+            label: d.label.clone(),
+            uuid: Some(d.uuid.clone()),
+            mount_path: d.mount_path.clone(),
+            snapshot_root: d.snapshot_root.clone(),
+            role: d.role,
+            max_usage_percent: None,
+            min_free_bytes: None,
+            rotation_interval: None,
+        })
+        .collect();
+
+    Config {
+        general: v2_general_defaults(strategy.run_frequency),
+        local_snapshots: LocalSnapshotsConfig { roots },
+        defaults: parser_fallback_defaults(),
+        drives,
+        subvolumes,
+        notifications: crate::notify::NotificationConfig::default(),
+    }
+}
+
+// ── Config → commented v2 TOML ──────────────────────────────────────────
+
+const RULE: &str = "─────────────────────────────────────────────────────────────────────";
+
+/// Hand-render the config in the `urd.toml.v2.example` idiom: a generated
+/// header (provenance, gaps, comment-loss sentence), fully explicit
+/// `[general]`, drive and subvolume blocks with their anchored intention
+/// comments, and the exclusion block. `config` must be
+/// `strategy_to_config(strategy)` — the private visibility of both functions
+/// plus [`generate_config`] being the only composition point enforces it.
+fn render_config(config: &Config, strategy: &ProposedStrategy, today: NaiveDate) -> String {
+    let mut out = String::new();
+
+    render_header(&mut out, strategy, today);
+    render_general(&mut out, config);
+    render_drives(&mut out, config, strategy);
+    render_subvolumes(&mut out, config, strategy);
+    render_exclusions(&mut out, strategy);
+    render_notifications_pointer(&mut out);
+
+    out
+}
+
+/// Header: provenance, header-anchored intentions (plus any intention whose
+/// anchor matches nothing — a 073 bug, surfaced rather than dropped), gap
+/// commentary, and the tool-agnostic comment-loss sentence.
+fn render_header(out: &mut String, strategy: &ProposedStrategy, today: NaiveDate) {
+    let version = env!("CARGO_PKG_VERSION");
+    let _ = writeln!(out, "# Urd configuration");
+    let _ = writeln!(
+        out,
+        "# Generated by urd {version} from the first encounter, {today}."
+    );
+    for intention in header_intentions(strategy) {
+        let _ = writeln!(out, "# {}", intention);
+    }
+    for gap in &strategy.gaps {
+        for line in gap_lines(gap) {
+            let _ = writeln!(out, "# {line}");
+        }
+    }
+    let _ = writeln!(
+        out,
+        "#\n# Urd does not preserve these comments when she rewrites this file."
+    );
+    let _ = writeln!(out);
+}
+
+/// Header-anchored intention texts, plus orphaned anchors (nothing in the
+/// config matches) so no sentence is ever silently lost.
+fn header_intentions(strategy: &ProposedStrategy) -> Vec<&str> {
+    strategy
+        .intentions
+        .iter()
+        .filter(|i| match &i.anchor {
+            IntentionAnchor::Header => true,
+            IntentionAnchor::Subvolume(name) => {
+                !strategy.subvolumes.iter().any(|sv| &sv.name == name)
+            }
+            IntentionAnchor::Drive(label) => !strategy.drives.iter().any(|d| &d.label == label),
+        })
+        .map(|i| i.text.as_str())
+        .collect()
+}
+
+/// Factual gap commentary: the disaster, who was held back, what hardware
+/// is present but unusable.
+fn gap_lines(gap: &crate::strategy::Gap) -> Vec<String> {
+    use crate::strategy::{GapKind, UnusableReason};
+    let mut lines = Vec::new();
+    match gap.kind {
+        GapKind::NoExternalDrive => {
+            lines.push(
+                "Gap: no usable external drive — nothing survives drive failure.".to_string(),
+            );
+            if !gap.demoted.is_empty() {
+                lines.push(format!(
+                    "  Held at recorded (classified irreplaceable): {}.",
+                    gap.demoted.join(", ")
+                ));
+            }
+        }
+        GapKind::NoOffsiteDrive => {
+            lines.push(
+                "Gap: no drive kept away from this place — nothing survives site loss."
+                    .to_string(),
+            );
+        }
+    }
+    for drive in &gap.unusable {
+        let what = match &drive.reason {
+            UnusableReason::Locked => "locked (unlock it, then run `urd init` again)".to_string(),
+            UnusableReason::NotBtrfs { fstype: Some(fs) } => format!("not btrfs (found {fs})"),
+            UnusableReason::NotBtrfs { fstype: None } => "not btrfs (no filesystem)".to_string(),
+            UnusableReason::NotMounted => "btrfs but not mounted".to_string(),
+            UnusableReason::Unresolved => "residency unresolved".to_string(),
+        };
+        let label = drive.label.as_deref().unwrap_or(&drive.device);
+        match &drive.size {
+            Some(size) => lines.push(format!("  Present but unusable: {label} ({size}) — {what}.")),
+            None => lines.push(format!("  Present but unusable: {label} — {what}.")),
+        }
+    }
+    lines
+}
+
+/// Fully explicit `[general]`: every field pinned at its value (Q6 — an
+/// omitted field would make renderer drift invisible).
+fn render_general(out: &mut String, config: &Config) {
+    let g = &config.general;
+    let _ = writeln!(out, "[general]");
+    let _ = writeln!(out, "config_version = 2");
+    let _ = writeln!(
+        out,
+        "# How often Urd runs: \"daily\" (systemd timer), \"sentinel\" (daemon), or an interval like \"6h\"."
+    );
+    let _ = writeln!(out, "run_frequency = \"{}\"", g.run_frequency);
+    let _ = writeln!(out, "state_db = \"{}\"", g.state_db.display());
+    let _ = writeln!(out, "metrics_file = \"{}\"", g.metrics_file.display());
+    let _ = writeln!(out, "log_dir = \"{}\"", g.log_dir.display());
+    let _ = writeln!(out, "btrfs_path = \"{}\"", g.btrfs_path);
+    let _ = writeln!(out, "heartbeat_file = \"{}\"", g.heartbeat_file.display());
+    let _ = writeln!(out);
+}
+
+fn render_drives(out: &mut String, config: &Config, strategy: &ProposedStrategy) {
+    if config.drives.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "# ── Drives {RULE}");
+    let _ = writeln!(
+        out,
+        "# uuid pins the drive's identity: snapshots are never sent to a\n\
+         # different disk that happens to mount at the same path."
+    );
+    let _ = writeln!(out);
+    for drive in &config.drives {
+        for intention in anchored(strategy, |a| {
+            matches!(a, IntentionAnchor::Drive(label) if label == &drive.label)
+        }) {
+            let _ = writeln!(out, "# {intention}");
+        }
+        let _ = writeln!(out, "[[drives]]");
+        let _ = writeln!(out, "label = \"{}\"", drive.label);
+        if let Some(uuid) = &drive.uuid {
+            let _ = writeln!(out, "uuid = \"{uuid}\"");
+        }
+        let _ = writeln!(out, "mount_path = \"{}\"", drive.mount_path.display());
+        let _ = writeln!(out, "snapshot_root = \"{}\"", drive.snapshot_root);
+        let _ = writeln!(out, "role = \"{}\"", drive.role);
+        let _ = writeln!(
+            out,
+            "# max_usage_percent = 90                # space threshold for aggressive retention"
+        );
+        let _ = writeln!(
+            out,
+            "# min_free_bytes = \"500GB\"              # refuse sends below this headroom"
+        );
+        let _ = writeln!(
+            out,
+            "# rotation_interval = \"3mo\"             # offsite only: how often it comes home"
+        );
+        let _ = writeln!(out);
+    }
+}
+
+fn render_subvolumes(out: &mut String, config: &Config, strategy: &ProposedStrategy) {
+    if config.subvolumes.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "# ── Protection Promises {RULE}");
+    let _ = writeln!(
+        out,
+        "# Each subvolume declares a protection level; Urd derives intervals\n\
+         # and retention from the promise plus run_frequency:\n\
+         #   recorded  — local snapshots only\n\
+         #   sheltered — local + at least one external drive\n\
+         # Levels are opaque: operational fields belong to custom promises only."
+    );
+    let _ = writeln!(out);
+    for sv in &config.subvolumes {
+        for intention in anchored(strategy, |a| {
+            matches!(a, IntentionAnchor::Subvolume(name) if name == &sv.name)
+        }) {
+            let _ = writeln!(out, "# {intention}");
+        }
+        let _ = writeln!(out, "[[subvolumes]]");
+        let _ = writeln!(out, "name = \"{}\"", sv.name);
+        let _ = writeln!(out, "source = \"{}\"", sv.source.display());
+        if let Some(root) = config.snapshot_root_for(&sv.name) {
+            let _ = writeln!(out, "snapshot_root = \"{}\"", root.display());
+        }
+        let _ = writeln!(out, "short_name = \"{}\"", sv.short_name);
+        let _ = writeln!(out, "priority = {}", sv.priority);
+        if let Some(enabled) = sv.enabled {
+            let _ = writeln!(out, "enabled = {enabled}");
+        }
+        if let Some(level) = sv.protection_level {
+            let _ = writeln!(out, "protection = \"{level}\"");
+        }
+        let _ = writeln!(
+            out,
+            "# min_free_bytes = \"10GB\"               # skip local snapshots below this headroom"
+        );
+        let _ = writeln!(
+            out,
+            "# drives = [\"label\"]                    # restrict sends; omitted = every configured drive"
+        );
+        let _ = writeln!(out);
+    }
+}
+
+/// The left-out block: every discovered-but-excluded subvolume with its
+/// typed reason — visible choice, not silence.
+fn render_exclusions(out: &mut String, strategy: &ProposedStrategy) {
+    if strategy.excluded.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "# ── Left out of this fate {RULE}");
+    for ex in &strategy.excluded {
+        let reason = match ex.reason {
+            ExclusionReason::DeclaredNotWorthHistory => "declared not worth history",
+            ExclusionReason::WholePoolMount => "whole-pool mount — an odd promise, not offered",
+            ExclusionReason::UnknownPool => "source device unknown",
+            ExclusionReason::AmbiguousDevice => "drive residency question unanswered",
+            ExclusionReason::MixedResidency => "pool spans internal and external drives",
+            ExclusionReason::UnknownResidency => "no drive claims this pool",
+        };
+        let _ = writeln!(
+            out,
+            "# {} (subvolume {}): {reason}.",
+            ex.mountpoint.display(),
+            ex.subvol_path
+        );
+    }
+    let _ = writeln!(out);
+}
+
+fn render_notifications_pointer(out: &mut String) {
+    let _ = writeln!(
+        out,
+        "# Notifications can be configured here — see config/urd.toml.v2.example\n\
+         # in the source tree for channel examples."
+    );
+}
+
+/// Intention texts matching an anchor predicate, in emission order.
+fn anchored(
+    strategy: &ProposedStrategy,
+    pred: impl Fn(&IntentionAnchor) -> bool,
+) -> Vec<&str> {
+    strategy
+        .intentions
+        .iter()
+        .filter(|i| pred(&i.anchor))
+        .map(|i| i.text.as_str())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::strategy::test_support::for_each_grid_case;
+    use crate::strategy::{
+        Gap, GapKind, Intention, ProposedDrive, ProposedSubvolume, UnusableDrive, UnusableReason,
+    };
+    use crate::types::{derive_policy, DriveRole, Interval, ProtectionLevel, RunFrequency};
+    use crate::strategy::ExcludedSubvol;
+
+    const POOL_UUID: &str = "44444444-4444-4444-8444-444444444444";
+
+    fn date() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 7, 4).unwrap()
+    }
+
+    fn daily() -> RunFrequency {
+        RunFrequency::Timer {
+            interval: Interval::days(1),
+        }
+    }
+
+    fn psubvol(name: &str, source: &str, root: &str, level: ProtectionLevel) -> ProposedSubvolume {
+        ProposedSubvolume {
+            name: name.to_string(),
+            source: PathBuf::from(source),
+            snapshot_root: PathBuf::from(root),
+            level,
+            policy: derive_policy(level, daily()).unwrap(),
+        }
+    }
+
+    fn pdrive(label: &str) -> ProposedDrive {
+        ProposedDrive {
+            label: label.to_string(),
+            uuid: POOL_UUID.to_string(),
+            mount_path: PathBuf::from(format!("/run/media/user/{label}")),
+            snapshot_root: ".snapshots".to_string(),
+            role: DriveRole::Primary,
+        }
+    }
+
+    /// Fedora-shaped strategy: sheltered root + recorded home sharing one
+    /// snapshot root, one adopted drive, the three 073 intention kinds.
+    fn fedora_strategy() -> ProposedStrategy {
+        ProposedStrategy {
+            run_frequency: daily(),
+            subvolumes: vec![
+                psubvol("root", "/", "/.snapshots", ProtectionLevel::Sheltered),
+                psubvol("home", "/home", "/.snapshots", ProtectionLevel::Recorded),
+            ],
+            drives: vec![pdrive("backup")],
+            excluded: vec![],
+            gaps: vec![],
+            intentions: vec![
+                Intention {
+                    anchor: IntentionAnchor::Header,
+                    text: "granularity chosen during the first encounter, 2026-07-04: daily"
+                        .to_string(),
+                },
+                Intention {
+                    anchor: IntentionAnchor::Subvolume("root".to_string()),
+                    text: "classified irreplaceable during the first encounter, 2026-07-04"
+                        .to_string(),
+                },
+                Intention {
+                    anchor: IntentionAnchor::Drive("backup".to_string()),
+                    text: "adopted as primary drive during the first encounter, 2026-07-04"
+                        .to_string(),
+                },
+            ],
+        }
+    }
+
+    // ── Step 3: strategy_to_config (the parser's normal form) ───────────
+
+    #[test]
+    fn maps_run_frequency_and_pins_config_version_2() {
+        let mut strategy = fedora_strategy();
+        strategy.run_frequency = RunFrequency::Sentinel;
+        for sv in &mut strategy.subvolumes {
+            sv.policy = derive_policy(sv.level, RunFrequency::Sentinel).unwrap();
+        }
+        let config = strategy_to_config(&strategy);
+        assert_eq!(config.general.run_frequency, RunFrequency::Sentinel);
+        assert_eq!(config.general.config_version, Some(2));
+    }
+
+    #[test]
+    fn general_section_equals_the_v2_default_oracle() {
+        let config = strategy_to_config(&fedora_strategy());
+        assert_eq!(config.general, v2_general_defaults(daily()));
+    }
+
+    #[test]
+    fn subvolume_row_maps_name_source_and_level() {
+        let config = strategy_to_config(&fedora_strategy());
+        assert_eq!(config.subvolumes.len(), 2);
+        let root = &config.subvolumes[0];
+        assert_eq!(root.name, "root");
+        assert_eq!(root.source, PathBuf::from("/"));
+        assert_eq!(root.protection_level, Some(ProtectionLevel::Sheltered));
+        let home = &config.subvolumes[1];
+        assert_eq!(home.name, "home");
+        assert_eq!(home.protection_level, Some(ProtectionLevel::Recorded));
+    }
+
+    #[test]
+    fn identity_defaults_pinned_short_name_priority_enabled() {
+        let config = strategy_to_config(&fedora_strategy());
+        for sv in &config.subvolumes {
+            assert_eq!(sv.short_name, sv.name);
+            assert_eq!(sv.priority, default_priority());
+            assert_eq!(sv.enabled, Some(true));
+        }
+    }
+
+    #[test]
+    fn no_operational_overrides_ever() {
+        // Named levels are opaque (ADR-110): an override would make the
+        // generated config fail validate_protection_contract outright.
+        let config = strategy_to_config(&fedora_strategy());
+        for sv in &config.subvolumes {
+            assert_eq!(sv.snapshot_interval, None);
+            assert_eq!(sv.send_interval, None);
+            assert_eq!(sv.send_enabled, None);
+            assert_eq!(sv.local_retention, None);
+            assert_eq!(sv.external_retention, None);
+        }
+    }
+
+    #[test]
+    fn drives_scope_is_global_none() {
+        let config = strategy_to_config(&fedora_strategy());
+        for sv in &config.subvolumes {
+            assert_eq!(sv.drives, None);
+        }
+    }
+
+    #[test]
+    fn roots_grouped_by_snapshot_root_in_btreemap_order() {
+        let mut strategy = fedora_strategy();
+        // The later-sorting root ("/data/.snapshots") is listed FIRST in the
+        // strategy, so a sorted result proves ordering is BTreeMap's, not
+        // insertion order's.
+        strategy.subvolumes.insert(
+            0,
+            psubvol(
+                "store",
+                "/data",
+                "/data/.snapshots",
+                ProtectionLevel::Recorded,
+            ),
+        );
+        let config = strategy_to_config(&strategy);
+        assert_eq!(config.local_snapshots.roots.len(), 2);
+        assert_eq!(
+            config.local_snapshots.roots[0].path,
+            PathBuf::from("/.snapshots")
+        );
+        assert_eq!(
+            config.local_snapshots.roots[1].path,
+            PathBuf::from("/data/.snapshots")
+        );
+    }
+
+    #[test]
+    fn shared_root_lists_all_its_subvolumes() {
+        let config = strategy_to_config(&fedora_strategy());
+        assert_eq!(config.local_snapshots.roots.len(), 1);
+        let root = &config.local_snapshots.roots[0];
+        assert_eq!(root.subvolumes, vec!["root", "home"]);
+    }
+
+    #[test]
+    fn root_min_free_bytes_is_none() {
+        let config = strategy_to_config(&fedora_strategy());
+        assert_eq!(config.local_snapshots.roots[0].min_free_bytes, None);
+    }
+
+    #[test]
+    fn drive_maps_uuid_some_role_and_relative_snapshot_root() {
+        let config = strategy_to_config(&fedora_strategy());
+        assert_eq!(config.drives.len(), 1);
+        let drive = &config.drives[0];
+        assert_eq!(drive.label, "backup");
+        assert_eq!(drive.uuid, Some(POOL_UUID.to_string()));
+        assert_eq!(drive.role, DriveRole::Primary);
+        assert_eq!(drive.snapshot_root, ".snapshots");
+        assert_eq!(drive.max_usage_percent, None);
+        assert_eq!(drive.min_free_bytes, None);
+        assert_eq!(drive.rotation_interval, None);
+    }
+
+    #[test]
+    fn defaults_section_is_parser_fallback_and_subvolume_order_preserved() {
+        let config = strategy_to_config(&fedora_strategy());
+        assert_eq!(config.defaults, parser_fallback_defaults());
+        let names: Vec<&str> = config.subvolumes.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["root", "home"]);
+    }
+
+    // ── Step 4: render_config ───────────────────────────────────────────
+
+    fn rendered_fedora() -> String {
+        let strategy = fedora_strategy();
+        render_config(&strategy_to_config(&strategy), &strategy, date())
+    }
+
+    #[test]
+    fn rendered_general_pins_every_field() {
+        let toml = rendered_fedora();
+        assert!(toml.contains("config_version = 2"));
+        assert!(toml.contains("run_frequency = \"daily\""));
+        assert!(toml.contains("state_db = \"~/.local/share/urd/urd.db\""));
+        assert!(toml.contains("metrics_file = \"~/.local/share/urd/backup.prom\""));
+        assert!(toml.contains("log_dir = \"~/.local/share/urd/logs\""));
+        assert!(toml.contains("btrfs_path = \"/usr/sbin/btrfs\""));
+        assert!(toml.contains("heartbeat_file = \"~/.local/share/urd/heartbeat.json\""));
+    }
+
+    #[test]
+    fn header_carries_date_version_and_comment_loss_sentence() {
+        let toml = rendered_fedora();
+        assert!(toml.contains("2026-07-04"));
+        assert!(toml.contains(env!("CARGO_PKG_VERSION")));
+        assert!(toml.contains("does not preserve these comments"));
+    }
+
+    #[test]
+    fn header_never_names_a_rewriting_tool() {
+        // Branch R retires `urd migrate`; the comment-loss sentence must be
+        // tool-agnostic (arc grill Q6 supersession).
+        assert!(!rendered_fedora().contains("migrate"));
+    }
+
+    #[test]
+    fn header_renders_gap_commentary_with_demoted_and_unusable_facts() {
+        let mut strategy = fedora_strategy();
+        strategy.drives.clear();
+        strategy.subvolumes[0].level = ProtectionLevel::Recorded;
+        strategy.subvolumes[0].policy =
+            derive_policy(ProtectionLevel::Recorded, daily()).unwrap();
+        strategy.gaps = vec![Gap {
+            kind: GapKind::NoExternalDrive,
+            demoted: vec!["root".to_string()],
+            unusable: vec![UnusableDrive {
+                device: "sdd".to_string(),
+                label: Some("old-disk".to_string()),
+                size: Some("500G".to_string()),
+                reason: UnusableReason::Locked,
+            }],
+        }];
+        let toml = render_config(&strategy_to_config(&strategy), &strategy, date());
+        assert!(toml.contains("nothing survives drive failure"));
+        assert!(toml.contains("root"));
+        assert!(toml.contains("old-disk"));
+        assert!(toml.contains("500G"));
+        assert!(toml.contains("locked"));
+    }
+
+    #[test]
+    fn header_anchored_intention_renders_in_header() {
+        let toml = rendered_fedora();
+        let intention = toml.find("granularity chosen").unwrap();
+        let general = toml.find("[general]").unwrap();
+        assert!(intention < general);
+    }
+
+    #[test]
+    fn drive_block_pins_identity_and_comments_optionals() {
+        let toml = rendered_fedora();
+        assert!(toml.contains("label = \"backup\""));
+        assert!(toml.contains(&format!("uuid = \"{POOL_UUID}\"")));
+        assert!(toml.contains("mount_path = \"/run/media/user/backup\""));
+        assert!(toml.contains("snapshot_root = \".snapshots\""));
+        assert!(toml.contains("role = \"primary\""));
+        assert!(toml.contains("# max_usage_percent"));
+        assert!(toml.contains("# min_free_bytes"));
+        assert!(toml.contains("# rotation_interval"));
+    }
+
+    #[test]
+    fn drive_anchored_intention_sits_above_its_block() {
+        let toml = rendered_fedora();
+        let intention = toml.find("adopted as primary drive").unwrap();
+        let block = toml.find("[[drives]]").unwrap();
+        let general = toml.find("[general]").unwrap();
+        assert!(general < intention);
+        assert!(intention < block);
+    }
+
+    #[test]
+    fn subvolume_block_pins_contract_fields() {
+        // Reparse-based: the pinned values must survive the real parser.
+        let toml = rendered_fedora();
+        let config = Config::from_str(&toml).unwrap();
+        let root = &config.subvolumes[0];
+        assert_eq!(root.short_name, "root");
+        assert_eq!(root.priority, default_priority());
+        assert_eq!(root.enabled, Some(true));
+        assert_eq!(root.protection_level, Some(ProtectionLevel::Sheltered));
+    }
+
+    #[test]
+    fn subvolume_anchored_intention_sits_above_its_block() {
+        let toml = rendered_fedora();
+        let intention = toml.find("classified irreplaceable").unwrap();
+        let block = toml.find("name = \"root\"").unwrap();
+        assert!(intention < block);
+    }
+
+    #[test]
+    fn unknown_anchor_intention_falls_back_to_header() {
+        // An anchor matching nothing is a 073 bug — surfaced, never dropped.
+        let mut strategy = fedora_strategy();
+        strategy.intentions.push(Intention {
+            anchor: IntentionAnchor::Subvolume("ghost".to_string()),
+            text: "orphaned sentence about a ghost".to_string(),
+        });
+        let toml = render_config(&strategy_to_config(&strategy), &strategy, date());
+        let orphan = toml.find("orphaned sentence about a ghost").unwrap();
+        let general = toml.find("[general]").unwrap();
+        assert!(orphan < general);
+    }
+
+    #[test]
+    fn exclusion_block_renders_all_six_reasons() {
+        let mut strategy = fedora_strategy();
+        let reasons = [
+            ExclusionReason::DeclaredNotWorthHistory,
+            ExclusionReason::WholePoolMount,
+            ExclusionReason::UnknownPool,
+            ExclusionReason::AmbiguousDevice,
+            ExclusionReason::MixedResidency,
+            ExclusionReason::UnknownResidency,
+        ];
+        strategy.excluded = reasons
+            .iter()
+            .enumerate()
+            .map(|(i, reason)| ExcludedSubvol {
+                mountpoint: PathBuf::from(format!("/mnt/ex{i}")),
+                subvol_path: format!("/ex{i}"),
+                reason: *reason,
+            })
+            .collect();
+        let toml = render_config(&strategy_to_config(&strategy), &strategy, date());
+        for i in 0..reasons.len() {
+            assert!(toml.contains(&format!("/mnt/ex{i}")), "missing exclusion {i}");
+        }
+        assert!(toml.contains("not worth history"));
+        assert!(toml.contains("whole-pool mount"));
+        assert!(toml.contains("device unknown"));
+        assert!(toml.contains("residency question unanswered"));
+        assert!(toml.contains("spans internal and external"));
+        assert!(toml.contains("no drive claims this pool"));
+    }
+
+    #[test]
+    fn reparse_shows_no_operational_fields() {
+        // Non-brittle opacity assertion: whatever the comments say, the
+        // parsed config must carry zero operational overrides.
+        let config = Config::from_str(&rendered_fedora()).unwrap();
+        for sv in &config.subvolumes {
+            assert_eq!(sv.snapshot_interval, None);
+            assert_eq!(sv.send_interval, None);
+            assert_eq!(sv.send_enabled, None);
+            assert_eq!(sv.local_retention, None);
+            assert_eq!(sv.external_retention, None);
+            assert_eq!(sv.drives, None);
+        }
+    }
+
+    #[test]
+    fn sentinel_frequency_renders_and_reparses() {
+        let mut strategy = fedora_strategy();
+        strategy.run_frequency = RunFrequency::Sentinel;
+        for sv in &mut strategy.subvolumes {
+            sv.policy = derive_policy(sv.level, RunFrequency::Sentinel).unwrap();
+        }
+        let toml = render_config(&strategy_to_config(&strategy), &strategy, date());
+        assert!(toml.contains("run_frequency = \"sentinel\""));
+        let config = Config::from_str(&toml).unwrap();
+        assert_eq!(config.general.run_frequency, RunFrequency::Sentinel);
+    }
+
+    #[test]
+    fn generate_config_agrees_with_its_internals() {
+        let strategy = fedora_strategy();
+        let generated = generate_config(&strategy, date());
+        assert_eq!(generated.config, strategy_to_config(&strategy));
+        assert_eq!(
+            generated.toml,
+            render_config(&strategy_to_config(&strategy), &strategy, date())
+        );
+    }
+
+    // ── Step 5: the acceptance property (closes 073 plan decision 2) ────
+
+    #[test]
+    fn prop_rendered_config_reparses_and_equals_construction() {
+        // Zero-subvolume strategies (the all-NotWorthHistory grid rows, and
+        // all-whole-pool inventories) are the carve-refused class: a config
+        // with no [[subvolumes]] must never load — an empty config would
+        // protect nothing while silencing the Encounter's own trigger. The
+        // property asserts that fail-closed shape; every other case must
+        // round-trip exactly.
+        for_each_grid_case(|label, _inv, _answers, strategy| {
+            let generated = generate_config(strategy, date());
+            if strategy.subvolumes.is_empty() {
+                assert!(
+                    Config::from_str(&generated.toml).is_err(),
+                    "{label}: an empty strategy must not render a loadable config"
+                );
+                return;
+            }
+            let reparsed = Config::from_str(&generated.toml)
+                .unwrap_or_else(|e| panic!("{label}: generated config failed to reload: {e}"));
+            let mut expected = generated.config;
+            expected.expand_paths();
+            assert_eq!(reparsed, expected, "{label}: reparse != construction");
+        });
+    }
+
+    #[test]
+    fn prop_preflight_is_empty_for_every_derivable_config() {
+        // The literal half of 073's preflight property, in its resolved
+        // form: no advisory maps to a Gap (gaps name absent hardware,
+        // advisories name config incoherence), so a derived config must
+        // produce zero advisories — anything else is a derivation bug.
+        for_each_grid_case(|label, _inv, _answers, strategy| {
+            if strategy.subvolumes.is_empty() {
+                return; // carve-refused class, covered above
+            }
+            let generated = generate_config(strategy, date());
+            let reparsed = Config::from_str(&generated.toml)
+                .unwrap_or_else(|e| panic!("{label}: generated config failed to reload: {e}"));
+            let checks = crate::preflight::preflight_checks(&reparsed);
+            assert!(
+                checks.is_empty(),
+                "{label}: preflight advisories on a derived config: {:?}",
+                checks.iter().map(|c| c.name).collect::<Vec<_>>()
+            );
+        });
+    }
+
+    #[test]
+    fn prop_render_is_deterministic() {
+        for_each_grid_case(|label, _inv, _answers, strategy| {
+            let first = generate_config(strategy, date()).toml;
+            let second = generate_config(strategy, date()).toml;
+            assert_eq!(first, second, "{label}: nondeterministic render");
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod cli;
 mod cli_validation;
 mod commands;
 mod config;
+mod config_render;
 mod discovery;
 mod drift;
 mod drives;

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -409,7 +409,9 @@ fn exclusion(sv: &DiscoveredSubvol, reason: ExclusionReason) -> ExcludedSubvol {
 /// facts. Usable: resolved `External`, not LUKS-locked (a pre-unlocked
 /// LUKS drive is a plain btrfs drive — arc grill Q10), btrfs, and joined
 /// to a pool with a mountpoint to receive into. Internal drives appear in
-/// neither list.
+/// neither list. One destination per pool: additional drives bearing an
+/// already-adopted pool are skipped (multi-device pools would otherwise
+/// derive duplicate drive uuids).
 ///
 /// `CandidateDrive.mounted` is never consulted: it is subtree-wide, so a
 /// mounted non-btrfs partition beside an unmounted btrfs pool would lie.
@@ -420,7 +422,7 @@ pub fn usable_destinations(
     inventory: &SystemInventory,
     resolutions: &[DriveResidencyAnswer],
 ) -> (Vec<Destination>, Vec<UnusableDrive>) {
-    let mut usable = Vec::new();
+    let mut usable: Vec<Destination> = Vec::new();
     let mut unusable = Vec::new();
     for drive in &inventory.drives {
         match resolved_class(drive, resolutions) {
@@ -448,14 +450,25 @@ pub fn usable_destinations(
             .and_then(|uuid| inventory.pools.iter().find(|p| &p.uuid == uuid))
             .and_then(|pool| canonical_mount(pool).map(|mount| (pool, mount)));
         match joined {
-            Some((pool, mount)) => usable.push(Destination {
-                device: drive.device.clone(),
-                label: drive.label.clone().or_else(|| pool.label.clone()),
-                size: drive.size.clone(),
-                transport: drive.transport.clone(),
-                pool_uuid: pool.uuid.clone(),
-                mount_path: mount.clone(),
-            }),
+            Some((pool, mount)) => {
+                // One pool = one receive target. A multi-device pool is borne
+                // by several drives, all carrying the same filesystem UUID;
+                // adopting each bearer would propose duplicate drive uuids
+                // (config validation rejects them) and double-sends into one
+                // filesystem. First bearer wins — the flatten_disk first-node
+                // precedent (UPI 074 build amendment, adversary F1).
+                if usable.iter().any(|d| d.pool_uuid == pool.uuid) {
+                    continue;
+                }
+                usable.push(Destination {
+                    device: drive.device.clone(),
+                    label: drive.label.clone().or_else(|| pool.label.clone()),
+                    size: drive.size.clone(),
+                    transport: drive.transport.clone(),
+                    pool_uuid: pool.uuid.clone(),
+                    mount_path: mount.clone(),
+                });
+            }
             None => unusable.push(unusable_fact(drive, UnusableReason::NotMounted)),
         }
     }
@@ -724,15 +737,19 @@ fn unique(base: String, taken: &mut BTreeSet<String>) -> String {
 
 // ── Tests ───────────────────────────────────────────────────────────────
 
+/// Shared test scaffolding: inventory builders and the answer × inventory
+/// property grid. Lifted from `mod tests` so config_render's acceptance
+/// property (UPI 074) sweeps the same grid strategy.rs's own properties
+/// sweep — the awareness.rs `test_support` precedent, single grid, no drift.
 #[cfg(test)]
-mod tests {
+pub(crate) mod test_support {
     use super::*;
 
-    const SYSTEM_POOL: &str = "22222222-2222-4222-8222-222222222222";
-    const EXTERNAL_POOL: &str = "44444444-4444-4444-8444-444444444444";
-    const ORPHAN_POOL: &str = "99999999-9999-4999-8999-999999999999";
+    pub(crate) const SYSTEM_POOL: &str = "22222222-2222-4222-8222-222222222222";
+    pub(crate) const EXTERNAL_POOL: &str = "44444444-4444-4444-8444-444444444444";
+    pub(crate) const ORPHAN_POOL: &str = "99999999-9999-4999-8999-999999999999";
 
-    fn pool(uuid: &str, mounts: &[&str]) -> DiscoveredPool {
+    pub(crate) fn pool(uuid: &str, mounts: &[&str]) -> DiscoveredPool {
         DiscoveredPool {
             uuid: uuid.to_string(),
             label: None,
@@ -742,7 +759,7 @@ mod tests {
         }
     }
 
-    fn subvol(mount: &str, path: &str, pool: &str) -> DiscoveredSubvol {
+    pub(crate) fn subvol(mount: &str, path: &str, pool: &str) -> DiscoveredSubvol {
         DiscoveredSubvol {
             mountpoint: PathBuf::from(mount),
             subvol_path: path.to_string(),
@@ -751,7 +768,7 @@ mod tests {
         }
     }
 
-    fn drive(
+    pub(crate) fn drive(
         device: &str,
         class: DriveClass,
         luks: LuksState,
@@ -771,7 +788,7 @@ mod tests {
         }
     }
 
-    fn inventory(
+    pub(crate) fn inventory(
         pools: Vec<DiscoveredPool>,
         subvolumes: Vec<DiscoveredSubvol>,
         drives: Vec<CandidateDrive>,
@@ -786,7 +803,7 @@ mod tests {
 
     /// Fedora default layout: one internal pool, `/root` + `/home` nested
     /// subvolumes, one internal NVMe drive bearing the pool.
-    fn fedora_inventory() -> SystemInventory {
+    pub(crate) fn fedora_inventory() -> SystemInventory {
         inventory(
             vec![pool(SYSTEM_POOL, &["/", "/home"])],
             vec![
@@ -802,6 +819,241 @@ mod tests {
             )],
         )
     }
+
+    pub(crate) fn external_btrfs_drive(device: &str, pool_uuid: &str) -> CandidateDrive {
+        drive(
+            device,
+            DriveClass::External,
+            LuksState::NotEncrypted,
+            Some("btrfs"),
+            Some(pool_uuid),
+        )
+    }
+
+    pub(crate) fn today() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 7, 4).unwrap()
+    }
+
+    /// Fedora base with a third candidate so the mixed-importance row
+    /// exercises all three classifications at once.
+    pub(crate) fn fedora3() -> SystemInventory {
+        let mut inv = fedora_inventory();
+        inv.subvolumes.push(subvol("/var", "/var", SYSTEM_POOL));
+        inv
+    }
+
+    pub(crate) fn grid_scenarios() -> Vec<(&'static str, SystemInventory, Vec<DriveResidencyAnswer>)>
+    {
+        let ext_locked = || {
+            drive(
+                "sdd",
+                DriveClass::External,
+                LuksState::Locked,
+                Some("crypto_LUKS"),
+                None,
+            )
+        };
+        let mut scenarios = Vec::new();
+
+        scenarios.push(("D0", fedora3(), Vec::new()));
+
+        let mut inv = fedora3();
+        inv.drives.push(ext_locked());
+        scenarios.push(("D-locked", inv, Vec::new()));
+
+        let mut inv = fedora3();
+        inv.drives.push(drive(
+            "sdd",
+            DriveClass::External,
+            LuksState::NotEncrypted,
+            Some("ntfs"),
+            None,
+        ));
+        scenarios.push(("D-ntfs", inv, Vec::new()));
+
+        let mut inv = fedora3();
+        inv.pools.push(pool(EXTERNAL_POOL, &[]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        scenarios.push(("D-unmounted", inv, Vec::new()));
+
+        let mut inv = fedora3();
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/dock"]));
+        inv.drives.push(drive(
+            "sdb",
+            DriveClass::Ambiguous,
+            LuksState::NotEncrypted,
+            Some("btrfs"),
+            Some(EXTERNAL_POOL),
+        ));
+        scenarios.push(("D-unresolved", inv, Vec::new()));
+
+        let mut inv = fedora3();
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/backup"]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        scenarios.push(("D1", inv.clone(), Vec::new()));
+
+        inv.pools
+            .push(pool(ORPHAN_POOL, &["/run/media/user/backup2"]));
+        inv.drives.push(external_btrfs_drive("sde", ORPHAN_POOL));
+        scenarios.push(("D2", inv, Vec::new()));
+
+        // F1 (074 adversary): a multi-device pool — two external drives
+        // bearing ONE filesystem — must adopt a single destination, or the
+        // generated config carries duplicate drive uuids.
+        let mut inv = fedora3();
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/raid"]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        inv.drives.push(external_btrfs_drive("sde", EXTERNAL_POOL));
+        scenarios.push(("D2-shared-pool", inv, Vec::new()));
+
+        let mut inv = fedora3();
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/backup"]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        inv.drives.push(drive(
+            "sde",
+            DriveClass::External,
+            LuksState::Locked,
+            Some("crypto_LUKS"),
+            None,
+        ));
+        scenarios.push(("D1+L", inv, Vec::new()));
+
+        let mut inv = fedora3();
+        inv.pools.push(pool(EXTERNAL_POOL, &["/data"]));
+        inv.subvolumes
+            .push(subvol("/data", "/store", EXTERNAL_POOL));
+        inv.drives.push(drive(
+            "sdb",
+            DriveClass::Ambiguous,
+            LuksState::NotEncrypted,
+            Some("btrfs"),
+            Some(EXTERNAL_POOL),
+        ));
+        scenarios.push((
+            "DA-int",
+            inv,
+            vec![DriveResidencyAnswer {
+                device: "sdb".to_string(),
+                class: ResolvedDriveClass::Internal,
+            }],
+        ));
+
+        let mut inv = fedora3();
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/carry"]));
+        inv.drives.push(drive(
+            "sdb",
+            DriveClass::Ambiguous,
+            LuksState::NotEncrypted,
+            Some("btrfs"),
+            Some(EXTERNAL_POOL),
+        ));
+        scenarios.push((
+            "DA-ext",
+            inv,
+            vec![DriveResidencyAnswer {
+                device: "sdb".to_string(),
+                class: ResolvedDriveClass::External,
+            }],
+        ));
+
+        // F1: one disk, two pools — the second pool joins no drive and
+        // must never produce candidates.
+        let mut inv = fedora3();
+        inv.pools.push(pool(ORPHAN_POOL, &["/mnt/second"]));
+        inv.subvolumes
+            .push(subvol("/mnt/second", "/vault", ORPHAN_POOL));
+        scenarios.push(("D-multipool", inv, Vec::new()));
+
+        scenarios
+    }
+
+    pub(crate) const IMPORTANCE_MIXES: [(&str, &[(&str, Importance)]); 5] = [
+        (
+            "all-I",
+            &[
+                ("/", Importance::Irreplaceable),
+                ("/home", Importance::Irreplaceable),
+                ("/var", Importance::Irreplaceable),
+            ],
+        ),
+        (
+            "all-R",
+            &[
+                ("/", Importance::Replaceable),
+                ("/home", Importance::Replaceable),
+                ("/var", Importance::Replaceable),
+            ],
+        ),
+        (
+            "all-N",
+            &[
+                ("/", Importance::NotWorthHistory),
+                ("/home", Importance::NotWorthHistory),
+                ("/var", Importance::NotWorthHistory),
+            ],
+        ),
+        (
+            "mixed",
+            &[
+                ("/", Importance::Irreplaceable),
+                ("/home", Importance::Replaceable),
+                ("/var", Importance::NotWorthHistory),
+            ],
+        ),
+        ("empty", &[]),
+    ];
+
+    pub(crate) const RESIDENCES: [Option<ResidenceAnswer>; 4] = [
+        Some(ResidenceAnswer::FearsSiteLossDriveStays),
+        Some(ResidenceAnswer::DriveKeptElsewhere),
+        Some(ResidenceAnswer::FearsDeletionOnly),
+        None,
+    ];
+
+    pub(crate) const GRANULARITIES: [GranularityAnswer; 2] = [
+        GranularityAnswer::YesterdayIsFine,
+        GranularityAnswer::LastHour,
+    ];
+
+    /// Run `check` over the whole grid with a per-case context label.
+    pub(crate) fn for_each_grid_case(
+        mut check: impl FnMut(&str, &SystemInventory, &FateAnswers, &ProposedStrategy),
+    ) {
+        for (scenario, inv, resolutions) in grid_scenarios() {
+            for (mix_name, mix) in IMPORTANCE_MIXES {
+                for residence in RESIDENCES {
+                    for granularity in GRANULARITIES {
+                        let answers = FateAnswers {
+                            importance: mix
+                                .iter()
+                                .map(|(mount, importance)| ImportanceAnswer {
+                                    mountpoint: PathBuf::from(mount),
+                                    importance: *importance,
+                                })
+                                .collect(),
+                            residence,
+                            granularity,
+                            drive_residency: resolutions.clone(),
+                        };
+                        let strategy = derive_strategy(&inv, &answers, today());
+                        let label = format!("{scenario}/{mix_name}/{residence:?}/{granularity:?}");
+                        check(&label, &inv, &answers, &strategy);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::*;
+    use super::*;
 
     // ── Step 2: protection_candidates ──────────────────────────────────
 
@@ -982,14 +1234,35 @@ mod tests {
 
     // ── Step 3: usable_destinations ────────────────────────────────────
 
-    fn external_btrfs_drive(device: &str, pool_uuid: &str) -> CandidateDrive {
-        drive(
-            device,
-            DriveClass::External,
-            LuksState::NotEncrypted,
-            Some("btrfs"),
-            Some(pool_uuid),
-        )
+    #[test]
+    fn two_drives_bearing_one_pool_adopt_one_destination() {
+        // Multi-device pool (074 adversary F1): both bearers carry the same
+        // filesystem uuid; adopting both would derive duplicate drive uuids.
+        let mut inv = fedora_inventory();
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/raid"]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        inv.drives.push(external_btrfs_drive("sde", EXTERNAL_POOL));
+
+        let (usable, unusable) = usable_destinations(&inv, &[]);
+        assert!(unusable.is_empty());
+        assert_eq!(usable.len(), 1);
+        assert_eq!(usable[0].device, "sdd"); // first bearer wins
+        assert_eq!(usable[0].pool_uuid, EXTERNAL_POOL);
+    }
+
+    #[test]
+    fn shared_pool_drives_derive_a_single_config_drive() {
+        let mut inv = fedora_inventory();
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/raid"]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        inv.drives.push(external_btrfs_drive("sde", EXTERNAL_POOL));
+
+        let answers = with_importance(base_answers(), "/home", Importance::Irreplaceable);
+        let strategy = derive_strategy(&inv, &answers, today());
+        assert_eq!(strategy.drives.len(), 1);
+        assert_eq!(strategy.drives[0].uuid, EXTERNAL_POOL);
     }
 
     #[test]
@@ -1157,10 +1430,6 @@ mod tests {
     }
 
     // ── Steps 4–6: derive_strategy ─────────────────────────────────────
-
-    fn today() -> NaiveDate {
-        NaiveDate::from_ymd_opt(2026, 7, 4).unwrap()
-    }
 
     fn base_answers() -> FateAnswers {
         FateAnswers {
@@ -1579,210 +1848,6 @@ mod tests {
     // The "passes preflight or carries the matching Gap" property in 073
     // form: hand-rolled loops over the whole answer × inventory space.
     // The literal preflight_checks half lands in 074's round-trip test.
-
-    /// Fedora base with a third candidate so the mixed-importance row
-    /// exercises all three classifications at once.
-    fn fedora3() -> SystemInventory {
-        let mut inv = fedora_inventory();
-        inv.subvolumes.push(subvol("/var", "/var", SYSTEM_POOL));
-        inv
-    }
-
-    fn grid_scenarios() -> Vec<(&'static str, SystemInventory, Vec<DriveResidencyAnswer>)> {
-        let ext_locked = || {
-            drive(
-                "sdd",
-                DriveClass::External,
-                LuksState::Locked,
-                Some("crypto_LUKS"),
-                None,
-            )
-        };
-        let mut scenarios = Vec::new();
-
-        scenarios.push(("D0", fedora3(), Vec::new()));
-
-        let mut inv = fedora3();
-        inv.drives.push(ext_locked());
-        scenarios.push(("D-locked", inv, Vec::new()));
-
-        let mut inv = fedora3();
-        inv.drives.push(drive(
-            "sdd",
-            DriveClass::External,
-            LuksState::NotEncrypted,
-            Some("ntfs"),
-            None,
-        ));
-        scenarios.push(("D-ntfs", inv, Vec::new()));
-
-        let mut inv = fedora3();
-        inv.pools.push(pool(EXTERNAL_POOL, &[]));
-        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
-        scenarios.push(("D-unmounted", inv, Vec::new()));
-
-        let mut inv = fedora3();
-        inv.pools
-            .push(pool(EXTERNAL_POOL, &["/run/media/user/dock"]));
-        inv.drives.push(drive(
-            "sdb",
-            DriveClass::Ambiguous,
-            LuksState::NotEncrypted,
-            Some("btrfs"),
-            Some(EXTERNAL_POOL),
-        ));
-        scenarios.push(("D-unresolved", inv, Vec::new()));
-
-        let mut inv = fedora3();
-        inv.pools
-            .push(pool(EXTERNAL_POOL, &["/run/media/user/backup"]));
-        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
-        scenarios.push(("D1", inv.clone(), Vec::new()));
-
-        inv.pools
-            .push(pool(ORPHAN_POOL, &["/run/media/user/backup2"]));
-        inv.drives.push(external_btrfs_drive("sde", ORPHAN_POOL));
-        scenarios.push(("D2", inv, Vec::new()));
-
-        let mut inv = fedora3();
-        inv.pools
-            .push(pool(EXTERNAL_POOL, &["/run/media/user/backup"]));
-        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
-        inv.drives.push(drive(
-            "sde",
-            DriveClass::External,
-            LuksState::Locked,
-            Some("crypto_LUKS"),
-            None,
-        ));
-        scenarios.push(("D1+L", inv, Vec::new()));
-
-        let mut inv = fedora3();
-        inv.pools.push(pool(EXTERNAL_POOL, &["/data"]));
-        inv.subvolumes
-            .push(subvol("/data", "/store", EXTERNAL_POOL));
-        inv.drives.push(drive(
-            "sdb",
-            DriveClass::Ambiguous,
-            LuksState::NotEncrypted,
-            Some("btrfs"),
-            Some(EXTERNAL_POOL),
-        ));
-        scenarios.push((
-            "DA-int",
-            inv,
-            vec![DriveResidencyAnswer {
-                device: "sdb".to_string(),
-                class: ResolvedDriveClass::Internal,
-            }],
-        ));
-
-        let mut inv = fedora3();
-        inv.pools
-            .push(pool(EXTERNAL_POOL, &["/run/media/user/carry"]));
-        inv.drives.push(drive(
-            "sdb",
-            DriveClass::Ambiguous,
-            LuksState::NotEncrypted,
-            Some("btrfs"),
-            Some(EXTERNAL_POOL),
-        ));
-        scenarios.push((
-            "DA-ext",
-            inv,
-            vec![DriveResidencyAnswer {
-                device: "sdb".to_string(),
-                class: ResolvedDriveClass::External,
-            }],
-        ));
-
-        // F1: one disk, two pools — the second pool joins no drive and
-        // must never produce candidates.
-        let mut inv = fedora3();
-        inv.pools.push(pool(ORPHAN_POOL, &["/mnt/second"]));
-        inv.subvolumes
-            .push(subvol("/mnt/second", "/vault", ORPHAN_POOL));
-        scenarios.push(("D-multipool", inv, Vec::new()));
-
-        scenarios
-    }
-
-    const IMPORTANCE_MIXES: [(&str, &[(&str, Importance)]); 5] = [
-        (
-            "all-I",
-            &[
-                ("/", Importance::Irreplaceable),
-                ("/home", Importance::Irreplaceable),
-                ("/var", Importance::Irreplaceable),
-            ],
-        ),
-        (
-            "all-R",
-            &[
-                ("/", Importance::Replaceable),
-                ("/home", Importance::Replaceable),
-                ("/var", Importance::Replaceable),
-            ],
-        ),
-        (
-            "all-N",
-            &[
-                ("/", Importance::NotWorthHistory),
-                ("/home", Importance::NotWorthHistory),
-                ("/var", Importance::NotWorthHistory),
-            ],
-        ),
-        (
-            "mixed",
-            &[
-                ("/", Importance::Irreplaceable),
-                ("/home", Importance::Replaceable),
-                ("/var", Importance::NotWorthHistory),
-            ],
-        ),
-        ("empty", &[]),
-    ];
-
-    const RESIDENCES: [Option<ResidenceAnswer>; 4] = [
-        Some(ResidenceAnswer::FearsSiteLossDriveStays),
-        Some(ResidenceAnswer::DriveKeptElsewhere),
-        Some(ResidenceAnswer::FearsDeletionOnly),
-        None,
-    ];
-
-    const GRANULARITIES: [GranularityAnswer; 2] = [
-        GranularityAnswer::YesterdayIsFine,
-        GranularityAnswer::LastHour,
-    ];
-
-    /// Run `check` over the whole grid with a per-case context label.
-    fn for_each_grid_case(
-        mut check: impl FnMut(&str, &SystemInventory, &FateAnswers, &ProposedStrategy),
-    ) {
-        for (scenario, inv, resolutions) in grid_scenarios() {
-            for (mix_name, mix) in IMPORTANCE_MIXES {
-                for residence in RESIDENCES {
-                    for granularity in GRANULARITIES {
-                        let answers = FateAnswers {
-                            importance: mix
-                                .iter()
-                                .map(|(mount, importance)| ImportanceAnswer {
-                                    mountpoint: PathBuf::from(mount),
-                                    importance: *importance,
-                                })
-                                .collect(),
-                            residence,
-                            granularity,
-                            drive_residency: resolutions.clone(),
-                        };
-                        let strategy = derive_strategy(&inv, &answers, today());
-                        let label = format!("{scenario}/{mix_name}/{residence:?}/{granularity:?}");
-                        check(&label, &inv, &answers, &strategy);
-                    }
-                }
-            }
-        }
-    }
 
     #[test]
     fn prop_sheltered_implies_adopted_drive() {


### PR DESCRIPTION
## Summary

- **New `config_render` module (pure, ADR-108):** converts an approved `ProposedStrategy` into a fully explicit, commented v2 config — intention comments anchored to the subvolume/drive they explain, typed exclusion + gap commentary, tool-agnostic generated header. Single public entry `generate_config` so a config/strategy mismatch is unrepresentable outside the module.
- **New `commands/encounter.rs` carve wiring:** the self-check requires the rendered TOML to survive the real load path *and* reload to exactly the approved strategy (catches divergent-but-valid renders, e.g. lossy non-UTF-8 paths) — otherwise nothing is written. Atomic no-clobber publish via hard-link; refuses existing configs and empty strategies. No CLI surface until the Encounter conversation (UPI 072).
- **Acceptance property (closes UPI 073's deferral):** every strategy the derivation grid can produce round-trips exactly and raises zero preflight advisories — 480 cases via the grid lifted into `strategy::test_support`.
- **Upstream fix:** `usable_destinations` now dedupes by pool uuid — a multi-device btrfs pool (one filesystem across two external disks) adopted every bearing drive, deriving duplicate drive uuids that config validation rejects.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 2029 passed, 0 failed (39 new test fns: config oracle 1, strategy dedupe 2, config_render 28, carve 8)
- Integration tests: not applicable (no btrfs surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)