### PR TITLE
feat: the Fate Conversation + entry trigger (UPI 072)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **The Fate Conversation + entry trigger (UPI 072, Encounter arc 3/9).** The
+  Encounter is now reachable: bare `urd` or `urd init` with no config and a
+  terminal on both ends offers a guided first-time conversation — Urd looks at
+  what the machine holds (pools, subvolumes, drives, honest notes), asks only
+  questions whose answers change the derived config (per-subvolume importance
+  with a proposed default, one granularity scene, a conditional residence
+  scene, one question per ambiguous drive), and presents the runestone: the
+  proposed promises, adopted drives (every disk of a multi-device pool named),
+  the gaps this setup cannot survive, and what was left out. Accepting carves
+  the config; delve-deeper carves then opens `$VISUAL`/`$EDITOR` on the real
+  file with a visudo-shaped re-validate loop ((e)dit / (r)evert to generated /
+  (q)uit keeping the file). Quitting anywhere writes nothing. `urd init` is
+  the make-whole verb: an invalid config re-enters the fix-it loop on a
+  terminal. Machines with no btrfs (or only locked drives) get one honest
+  report, never a conversation about nothing. New pure state machine
+  (`encounter`) + renderer (`voice/encounter`) + stdin loop; ~100 new tests
+  including grid-wide question-economy and runestone↔strategy properties.
+
 - **Config generation + self-check (UPI 074, Encounter arc 5/9).** New
   `config_render` module converts an approved `ProposedStrategy` into a fully
   explicit, commented v2 config — intention comments anchored to the subvolume
@@ -40,7 +58,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the conversation to resolve. Engine only — no CLI surface until the Encounter
   conversation (UPI 072) consumes it.
 
+### Changed
+- **Exit code 3 = "not configured".** Every command that needs a config now
+  prints a one-sentence pointer (JSON `{"status":"not_configured"}` in daemon
+  mode) and exits 3 when none exists, replacing raw I/O errors (exit 1) on
+  most commands and exit 0 on non-interactive bare `urd` / `urd init`.
+  Documented in `docs/20-reference/cli.md`; 1 stays generic failure, 2 stays
+  clap usage errors.
+
 ### Fixed
+- **A mixed-residency pool is never adopted as a destination (UPI 073).**
+  Found on the first live conversation: a multi-device pool with one
+  external-classified bearer beside internal siblings could be adopted as a
+  send target through that single drive — backups "sheltered" there would
+  never leave the machine. `usable_destinations` now requires the whole
+  pool to resolve external (symmetric with the candidate side's
+  `MixedResidency` exclusion); the refused drive is named in the gaps as a
+  typed fact.
 - **Multi-device btrfs pools no longer derive duplicate backup drives.** A
   filesystem spanning two external disks made strategy derivation adopt every
   bearing drive — duplicate drive UUIDs that config validation rejects (and

--- a/docs/20-reference/cli.md
+++ b/docs/20-reference/cli.md
@@ -27,16 +27,20 @@ to suppress colors even on a TTY.
 
 ### Exit codes
 
-All commands return the standard Unix convention:
-
 - **0** — success or advisory output only (warnings do not raise).
 - **1** — failure. Either an `anyhow::Error` propagated from the command,
   or an explicit `std::process::exit(1)` for partial-success cases (see
   `backup` and `verify` below).
+- **2** — reserved by clap for usage errors (bad flags, unknown
+  subcommands).
+- **3** — not configured. No config file exists at the resolved path; the
+  command printed a one-sentence pointer at `urd init` (JSON
+  `{"status":"not_configured"}` in daemon mode) and did nothing. Scriptable:
+  `urd status; test $? -eq 3` distinguishes "unconfigured" from "broken".
 
-There is no richer code mapping. Distinguish failure causes by parsing the
-diagnostic message or, for monitoring, by reading the heartbeat / metrics
-files instead of the exit code.
+Beyond these, distinguish failure causes by parsing the diagnostic message
+or, for monitoring, by reading the heartbeat / metrics files instead of the
+exit code.
 
 ### stdout vs stderr
 
@@ -57,8 +61,12 @@ files instead of the exit code.
 Each subcommand declares whether it requires a config load:
 
 - **No config required:** `completions`, `migrate`. Run on a fresh system.
-- **Config required:** all other subcommands. A missing or invalid config
-  fails fast with a diagnostic; no partial behavior.
+- **Config offered:** bare `urd` and `urd init` — with no config and a
+  terminal on both stdin and stdout, they offer the Encounter (the guided
+  first-time conversation); otherwise they print the pointer and exit 3.
+- **Config required:** all other subcommands. A missing config prints one
+  pointer sentence and exits 3; an invalid config fails fast with a
+  diagnostic; no partial behavior.
 
 ---
 
@@ -66,14 +74,17 @@ Each subcommand declares whether it requires a config load:
 
 ### `urd` (no subcommand)
 
-**Contract.** Bare `urd` invocation prints orientation: project name, version,
-config status, and a one-screen summary of what to try next. Falls back to
-help-style output when config is absent or invalid. Never modifies state.
+**Contract.** With a config: a one-screen promise summary (compact status).
+Without one: offers the Encounter when a human is on both ends (stdin and
+stdout are terminals); otherwise prints the pointer and exits 3. Declining
+or quitting the Encounter writes nothing — the config file appears only at
+the carve, after explicit approval of the runestone.
 
-**Output.** Stdout — text orientation block.
+**Output.** Stdout — text; `{"status":"not_configured"}` in daemon mode.
 
-**Exit codes.** `0` always (no operation can fail; missing config is a
-displayable state, not an error).
+**Exit codes.** `0` with a config, or after a declined/quit/carved
+Encounter; `3` when unconfigured and no conversation is possible; `1` on
+real failures (including a carve refusal).
 
 ---
 
@@ -193,15 +204,24 @@ part of `urd doctor --thorough`.
 
 ### `urd init`
 
-**Contract.** Sets up Urd's environment: ensures the state DB directory and
-heartbeat directory exist, runs the same infrastructure checks `doctor`
-runs, and exits cleanly. Idempotent — safe to run multiple times. May
-prompt for sudo if the configured `btrfs_path` requires testing.
+**Contract.** The idempotent make-whole verb. No config → offers the
+Encounter (pointer + exit 3 without a terminal on both ends). Invalid
+config + terminal → the fix-it loop ((e)dit in `$VISUAL`/`$EDITOR` /
+(q)uit keeping the file, error named), then continues into the checks;
+I/O failures (permissions) always surface instead. With a loadable
+config: ensures the state DB directory and heartbeat directory exist,
+runs the same infrastructure checks `doctor` runs, and exits cleanly.
+Safe to run multiple times. May prompt for sudo if the configured
+`btrfs_path` requires testing.
 
-**Output.** Interactive — checklist of infrastructure items.
+**Output.** Interactive — the conversation or the checklist of
+infrastructure items; `{"status":"not_configured"}` in daemon mode
+when unconfigured.
 
-**Exit codes.** `0` on success; `1` if any required infrastructure
-cannot be created or verified.
+**Exit codes.** `0` on success (including a declined/quit Encounter);
+`3` unconfigured without a conversation; `1` if the config stays
+invalid (fix-it quit) or required infrastructure cannot be created or
+verified.
 
 ---
 

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -2,24 +2,27 @@ use std::path::Path;
 
 use crate::advice;
 use crate::awareness;
-use crate::commands::storage_signals;
+use crate::commands::{storage_signals, CliExit};
 use crate::config;
-use crate::error::UrdError;
 use crate::output::{DefaultStatusOutput, OutputMode};
 use crate::plan::{Observation, RealFileSystemState};
 use crate::state::StateDb;
 use crate::voice;
 
-pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<()> {
-    // Fallible config load with error discrimination (S1):
-    // file-not-found → first-time user; all other errors → surface.
-    let config = match config::Config::load(config_path) {
-        Ok(c) => c,
-        Err(UrdError::Io { ref source, .. }) if source.kind() == std::io::ErrorKind::NotFound => {
+pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<CliExit> {
+    // Fallible config load through the shared absence seam (S1/UPI 072):
+    // file-not-found → first-time user (exit 3 when non-interactive — the
+    // grill-pinned distinct code; interactive keeps the greeting until the
+    // Encounter offer lands); all other errors → surface.
+    let config = match config::Config::load_or_absent(config_path)? {
+        Some(c) => c,
+        None => {
             print!("{}", voice::render_first_time(output_mode));
-            return Ok(());
+            return Ok(match output_mode {
+                OutputMode::Interactive => CliExit::Done,
+                OutputMode::Daemon => CliExit::NoConfig,
+            });
         }
-        Err(e) => return Err(e.into()),
     };
 
     let state_db = if config.general.state_db.exists() {
@@ -106,7 +109,7 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         output_mode,
     );
     print!("{preamble}{rendered}");
-    Ok(())
+    Ok(CliExit::Done)
 }
 
 #[cfg(test)]
@@ -115,11 +118,25 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
-    fn config_not_found_returns_ok() {
-        // A nonexistent config path should return Ok (first-time path), not an error.
+    fn config_not_found_daemon_reports_no_config_exit() {
+        // A nonexistent config path is the first-time path, not an error —
+        // and non-interactive callers get the distinct exit (grill Q5).
         let bogus = PathBuf::from("/tmp/urd-test-nonexistent-config-12345.toml");
         let result = run(Some(&bogus), OutputMode::Daemon);
-        assert!(result.is_ok(), "config-not-found should return Ok: {result:?}");
+        assert_eq!(
+            result.expect("config-not-found is Ok"),
+            CliExit::NoConfig,
+            "non-TTY no-config must exit 3"
+        );
+    }
+
+    #[test]
+    fn config_not_found_interactive_greets_and_exits_zero() {
+        // Interactive keeps the greeting + exit 0 until the Encounter offer
+        // lands (step 7); the conversation is what changes this, not step 1.
+        let bogus = PathBuf::from("/tmp/urd-test-nonexistent-config-12345.toml");
+        let result = run(Some(&bogus), OutputMode::Interactive);
+        assert_eq!(result.expect("config-not-found is Ok"), CliExit::Done);
     }
 
     #[test]

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -11,17 +11,22 @@ use crate::voice;
 
 pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<CliExit> {
     // Fallible config load through the shared absence seam (S1/UPI 072):
-    // file-not-found → first-time user (exit 3 when non-interactive — the
-    // grill-pinned distinct code; interactive keeps the greeting until the
-    // Encounter offer lands); all other errors → surface.
+    // file-not-found → first-time user. With a human on both ends, bare
+    // `urd` offers the Encounter; otherwise one pointer + exit 3 (grill
+    // Q5). All other errors → surface.
     let config = match config::Config::load_or_absent(config_path)? {
         Some(c) => c,
         None => {
-            print!("{}", voice::render_first_time(output_mode));
-            return Ok(match output_mode {
-                OutputMode::Interactive => CliExit::Done,
-                OutputMode::Daemon => CliExit::NoConfig,
-            });
+            let stdin_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
+            return match crate::commands::doorstep_disposition(output_mode, stdin_tty) {
+                crate::commands::Doorstep::Offer => {
+                    crate::commands::encounter::run_conversation(config_path)
+                }
+                crate::commands::Doorstep::Pointer => {
+                    print!("{}", voice::render_first_time(output_mode));
+                    Ok(CliExit::NoConfig)
+                }
+            };
         }
     };
 
@@ -131,12 +136,14 @@ mod tests {
     }
 
     #[test]
-    fn config_not_found_interactive_greets_and_exits_zero() {
-        // Interactive keeps the greeting + exit 0 until the Encounter offer
-        // lands (step 7); the conversation is what changes this, not step 1.
+    fn config_not_found_interactive_without_stdin_tty_points() {
+        // The test harness has no stdin terminal, so even Interactive
+        // output falls to the pointer (`urd < file` must never converse).
+        // The Offer path needs a human on both ends — the gate decision
+        // itself is covered in commands::cli_exit_tests.
         let bogus = PathBuf::from("/tmp/urd-test-nonexistent-config-12345.toml");
         let result = run(Some(&bogus), OutputMode::Interactive);
-        assert_eq!(result.expect("config-not-found is Ok"), CliExit::Done);
+        assert_eq!(result.expect("config-not-found is Ok"), CliExit::NoConfig);
     }
 
     #[test]

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -1,3 +1,4 @@
+use std::io::IsTerminal as _;
 use std::path::Path;
 
 use crate::advice;
@@ -17,7 +18,7 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
     let config = match config::Config::load_or_absent(config_path)? {
         Some(c) => c,
         None => {
-            let stdin_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
+            let stdin_tty = std::io::stdin().is_terminal();
             return match crate::commands::doorstep_disposition(output_mode, stdin_tty) {
                 crate::commands::Doorstep::Offer => {
                     crate::commands::encounter::run_conversation(config_path)

--- a/src/commands/encounter.rs
+++ b/src/commands/encounter.rs
@@ -31,7 +31,6 @@ const TEMP_NAME: &str = ".urd.toml.tmp";
 /// existing config is never overwritten (deleting a config is a human
 /// act — the designed refusal sentence is 072's trigger-time rendering,
 /// this one is the race backstop).
-#[allow(dead_code)] // Consumed by UPI 072 (conversation).
 pub fn carve_config(
     strategy: &ProposedStrategy,
     today: NaiveDate,
@@ -116,7 +115,6 @@ fn stage(temp: &Path, toml: &str) -> std::io::Result<()> {
 /// stdin, and execute its terminal effect (carve + confirm, carve +
 /// editor, or farewell). The loop itself stays thin — every decision
 /// lives in `encounter.rs` (test the functions, not readline).
-#[allow(dead_code)] // Wired in step 7 (doorstep offer).
 pub fn run_conversation(config_path: Option<&Path>) -> anyhow::Result<CliExit> {
     let target = resolve_target(config_path)?;
     let inventory = crate::discovery::discover();
@@ -224,7 +222,6 @@ fn parse_editor_choice(line: &str, revert_available: bool) -> Option<EditorChoic
 /// the config loads or the user keeps it broken. The editor's exit
 /// status is deliberately ignored — re-validation of the file is the
 /// only truth (no editor reports abort reliably).
-#[allow(dead_code)] // Wired in step 7 (doorstep offer).
 fn delve(strategy: &ProposedStrategy, today: NaiveDate, path: &Path) -> anyhow::Result<CliExit> {
     let visual = std::env::var("VISUAL").ok();
     let editor = std::env::var("EDITOR").ok();
@@ -315,7 +312,6 @@ fn kept_invalid(path: &Path) -> anyhow::Error {
 /// the same failure loop without (r)evert — no generated baseline exists
 /// for a hand-edited file. Returns the loaded config on success so init
 /// can continue being the make-whole verb.
-#[allow(dead_code)] // Wired in step 7 (doorstep offer).
 pub fn fix_invalid_config(path: &Path, initial_error: &str) -> anyhow::Result<Config> {
     let visual = std::env::var("VISUAL").ok();
     let editor = std::env::var("EDITOR").ok();

--- a/src/commands/encounter.rs
+++ b/src/commands/encounter.rs
@@ -9,7 +9,7 @@
 
 use std::fs;
 use std::io::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::{bail, Context};
 use chrono::NaiveDate;
@@ -116,7 +116,7 @@ fn stage(temp: &Path, toml: &str) -> std::io::Result<()> {
 /// editor, or farewell). The loop itself stays thin — every decision
 /// lives in `encounter.rs` (test the functions, not readline).
 pub fn run_conversation(config_path: Option<&Path>) -> anyhow::Result<CliExit> {
-    let target = resolve_target(config_path)?;
+    let target = crate::commands::resolve_config_path(config_path)?;
     let inventory = crate::discovery::discover();
     let today = chrono::Local::now().date_naive();
     let mut result = EncounterState::begin(inventory, today);
@@ -161,13 +161,6 @@ pub fn run_conversation(config_path: Option<&Path>) -> anyhow::Result<CliExit> {
                 };
             }
         }
-    }
-}
-
-fn resolve_target(config_path: Option<&Path>) -> anyhow::Result<PathBuf> {
-    match config_path {
-        Some(p) => Ok(p.to_path_buf()),
-        None => Ok(crate::config::default_config_path()?),
     }
 }
 
@@ -223,15 +216,32 @@ fn parse_editor_choice(line: &str, revert_available: bool) -> Option<EditorChoic
 /// status is deliberately ignored — re-validation of the file is the
 /// only truth (no editor reports abort reliably).
 fn delve(strategy: &ProposedStrategy, today: NaiveDate, path: &Path) -> anyhow::Result<CliExit> {
-    let visual = std::env::var("VISUAL").ok();
-    let editor = std::env::var("EDITOR").ok();
-    let Some(command) = resolve_editor(visual.as_deref(), editor.as_deref()) else {
+    let Some(command) = editor_from_env() else {
         // The file is already carved and valid — keeping it is the
         // honest fallback, never deletion.
         print!("{}", voice::render_no_editor(path));
         return Ok(CliExit::Done);
     };
     delve_with(&command, strategy, today, path)
+}
+
+/// `resolve_editor` over the live environment — the only env read in
+/// this module, shared by delve and the fix-it loop.
+fn editor_from_env() -> Option<Vec<String>> {
+    let visual = std::env::var("VISUAL").ok();
+    let editor = std::env::var("EDITOR").ok();
+    resolve_editor(visual.as_deref(), editor.as_deref())
+}
+
+/// Launch the editor on the file and wait. The exit status is
+/// deliberately dropped: re-validation of the file is the only truth.
+fn open_in_editor(command: &[String], path: &Path) -> anyhow::Result<()> {
+    std::process::Command::new(&command[0])
+        .args(&command[1..])
+        .arg(path)
+        .status()
+        .with_context(|| format!("failed to launch editor `{}`", command[0]))?;
+    Ok(())
 }
 
 fn delve_with(
@@ -241,12 +251,7 @@ fn delve_with(
     path: &Path,
 ) -> anyhow::Result<CliExit> {
     loop {
-        let _status = std::process::Command::new(&command[0])
-            .args(&command[1..])
-            .arg(path)
-            .status()
-            .with_context(|| format!("failed to launch editor `{}`", command[0]))?;
-        // Exit status ignored: revalidate the file, the only truth.
+        open_in_editor(command, path)?;
         let error = match Config::load(Some(path)) {
             Ok(_) => {
                 print!("{}", voice::render_post_carve(path));
@@ -313,25 +318,22 @@ fn kept_invalid(path: &Path) -> anyhow::Error {
 /// for a hand-edited file. Returns the loaded config on success so init
 /// can continue being the make-whole verb.
 pub fn fix_invalid_config(path: &Path, initial_error: &str) -> anyhow::Result<Config> {
-    let visual = std::env::var("VISUAL").ok();
-    let editor = std::env::var("EDITOR").ok();
-    let Some(command) = resolve_editor(visual.as_deref(), editor.as_deref()) else {
+    let Some(command) = editor_from_env() else {
         print!("{}", voice::render_no_editor(path));
-        bail!("the config at {} does not load: {initial_error}", path.display());
+        bail!(
+            "the config at {} does not load: {initial_error}",
+            path.display()
+        );
     };
     let mut error = initial_error.to_string();
     loop {
         match failure_loop_choice(&error, false)? {
-            EditorChoice::EditAgain => {}
-            // Unreachable: r is never offered without a baseline.
-            EditorChoice::Revert => {}
+            // Revert is never offered without a baseline; if it somehow
+            // arrived it would mean edit-again, the safe reading.
+            EditorChoice::EditAgain | EditorChoice::Revert => {}
             EditorChoice::QuitKeep => return Err(kept_invalid(path)),
         }
-        std::process::Command::new(&command[0])
-            .args(&command[1..])
-            .arg(path)
-            .status()
-            .with_context(|| format!("failed to launch editor `{}`", command[0]))?;
+        open_in_editor(&command, path)?;
         match Config::load(Some(path)) {
             Ok(config) => return Ok(config),
             Err(e) => error = e.to_string(),

--- a/src/commands/encounter.rs
+++ b/src/commands/encounter.rs
@@ -1,22 +1,27 @@
-//! The Encounter's carve wiring (UPI 074) — the I/O half of config
-//! generation. The conversation that produces the approved strategy is
-//! UPI 072's; this module owns the last step: self-check the generated
-//! config, refuse anything dishonest, and publish the file atomically
-//! without ever clobbering an existing one.
+//! The Encounter's I/O: the thin stdin loop that drives the pure state
+//! machine (`encounter.rs`, UPI 072), the delve-deeper editor loop, and
+//! the carve (UPI 074) — self-check the generated config, refuse
+//! anything dishonest, and publish the file atomically without ever
+//! clobbering an existing one.
 //!
 //! Refusal order is load-bearing: the checks that touch nothing (empty
 //! strategy, self-check) run before any filesystem side effect.
 
 use std::fs;
 use std::io::Write as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context};
 use chrono::NaiveDate;
 
+use crate::commands::CliExit;
 use crate::config::Config;
 use crate::config_render::generate_config;
+use crate::encounter::{
+    advance, parse_line, AdvanceResult, AfterCarve, Effect, EncounterState, Input,
+};
 use crate::strategy::ProposedStrategy;
+use crate::voice;
 
 /// Staging file for the atomic publish, sibling to the final config.
 const TEMP_NAME: &str = ".urd.toml.tmp";
@@ -39,29 +44,7 @@ pub fn carve_config(
         bail!("the encounter proposed nothing to protect — nothing to carve, nothing written");
     }
 
-    let generated = generate_config(strategy, today);
-
-    // Self-check, migrate's pattern plus the equality half: the rendered
-    // TOML must survive the full load path (parse → expand_paths →
-    // validate) AND reload to exactly the config it was rendered from.
-    // Parse+validate alone would pass a divergent-but-valid render (e.g. a
-    // non-UTF-8 path rendered lossily names a phantom source) — a config
-    // that differs from what the runestone showed must never reach disk.
-    let reparsed = match Config::from_str(&generated.toml) {
-        Ok(config) => config,
-        Err(e) => bail!(
-            "the encounter would produce an invalid config — nothing written.\n\
-             load check: {e}"
-        ),
-    };
-    let mut expected = generated.config;
-    expected.expand_paths();
-    if reparsed != expected {
-        bail!(
-            "the carved config would not reload to the approved strategy — nothing written.\n\
-             (render/parse divergence: a bug in urd, not in your answers)"
-        );
-    }
+    let (toml, _expected) = checked_toml(strategy, today)?;
 
     if path.exists() {
         return Err(exists_refusal(path));
@@ -77,7 +60,7 @@ pub fn carve_config(
     // with AlreadyExists instead of clobbering, so a config that appeared
     // mid-carve survives and the carve loses loudly.
     let temp = dir.join(TEMP_NAME);
-    stage(&temp, &generated.toml)
+    stage(&temp, &toml)
         .with_context(|| format!("failed to stage config at {}", temp.display()))?;
 
     if let Err(e) = fs::hard_link(&temp, path) {
@@ -92,12 +75,272 @@ pub fn carve_config(
     Ok(())
 }
 
+/// Generate and self-check the TOML for an approved strategy: migrate's
+/// pattern plus the equality half. The rendered TOML must survive the
+/// full load path (parse → expand_paths → validate) AND reload to
+/// exactly the config it was rendered from — parse+validate alone would
+/// pass a divergent-but-valid render (e.g. a non-UTF-8 path rendered
+/// lossily names a phantom source). A config that differs from what the
+/// runestone showed must never reach disk.
+fn checked_toml(strategy: &ProposedStrategy, today: NaiveDate) -> anyhow::Result<(String, Config)> {
+    let generated = generate_config(strategy, today);
+    let reparsed = match Config::from_str(&generated.toml) {
+        Ok(config) => config,
+        Err(e) => bail!(
+            "the encounter would produce an invalid config — nothing written.\n\
+             load check: {e}"
+        ),
+    };
+    let mut expected = generated.config;
+    expected.expand_paths();
+    if reparsed != expected {
+        bail!(
+            "the carved config would not reload to the approved strategy — nothing written.\n\
+             (render/parse divergence: a bug in urd, not in your answers)"
+        );
+    }
+    Ok((generated.toml, expected))
+}
+
 /// Write and fsync the staged config, truncating any stale temp a crashed
 /// carve left behind.
 fn stage(temp: &Path, toml: &str) -> std::io::Result<()> {
     let mut file = fs::File::create(temp)?;
     file.write_all(toml.as_bytes())?;
     file.sync_all()
+}
+
+// ── The conversation loop (UPI 072) ─────────────────────────────────────
+
+/// Run the Fate Conversation: discover, walk the pure machine over
+/// stdin, and execute its terminal effect (carve + confirm, carve +
+/// editor, or farewell). The loop itself stays thin — every decision
+/// lives in `encounter.rs` (test the functions, not readline).
+#[allow(dead_code)] // Wired in step 7 (doorstep offer).
+pub fn run_conversation(config_path: Option<&Path>) -> anyhow::Result<CliExit> {
+    let target = resolve_target(config_path)?;
+    let inventory = crate::discovery::discover();
+    let today = chrono::Local::now().date_naive();
+    let mut result = EncounterState::begin(inventory, today);
+    loop {
+        let AdvanceResult {
+            state,
+            effect,
+            notice,
+        } = result;
+        if let Some(notice) = &notice {
+            print!("{}", voice::render_invalid_notice(notice));
+        }
+        match effect {
+            Effect::Prompt(spec) => {
+                print!("{}", voice::render_prompt(&spec));
+                let input = match read_input_line()? {
+                    // Closing stdin is walking away.
+                    None => Input::Quit,
+                    Some(line) => parse_line(&spec, &line),
+                };
+                result = advance(state, input);
+            }
+            Effect::Farewell(kind) => {
+                print!("{}", voice::render_farewell(&kind));
+                return Ok(CliExit::Done);
+            }
+            Effect::Carve {
+                strategy,
+                today,
+                then,
+            } => {
+                // A carve refusal (config appeared mid-conversation, or a
+                // self-check failure) surfaces as the error it is —
+                // nothing was written, the sentence says so.
+                carve_config(&strategy, today, &target)?;
+                return match then {
+                    AfterCarve::Confirm => {
+                        print!("{}", voice::render_post_carve(&target));
+                        Ok(CliExit::Done)
+                    }
+                    AfterCarve::Edit => delve(&strategy, today, &target),
+                };
+            }
+        }
+    }
+}
+
+fn resolve_target(config_path: Option<&Path>) -> anyhow::Result<PathBuf> {
+    match config_path {
+        Some(p) => Ok(p.to_path_buf()),
+        None => Ok(crate::config::default_config_path()?),
+    }
+}
+
+/// One line from stdin; `None` on EOF. Prompts end without a newline
+/// marker, so flush before blocking.
+fn read_input_line() -> anyhow::Result<Option<String>> {
+    print!("> ");
+    std::io::stdout().flush().ok();
+    let mut line = String::new();
+    let n = std::io::stdin()
+        .read_line(&mut line)
+        .context("failed to read from stdin")?;
+    Ok(if n == 0 { None } else { Some(line) })
+}
+
+// ── Delve deeper: the editor loop (UPI 072, arc grill Q7) ──────────────
+
+/// The user's choice in the visudo-shaped failure loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EditorChoice {
+    EditAgain,
+    Revert,
+    QuitKeep,
+}
+
+/// Resolve which editor to launch: `$VISUAL`, then `$EDITOR`, split on
+/// whitespace (first token = program, rest = args; no shell
+/// interpretation — a quoted-argument editor value is a documented
+/// limitation). `None` when neither is set or both are blank.
+fn resolve_editor(visual: Option<&str>, editor: Option<&str>) -> Option<Vec<String>> {
+    [visual, editor]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|v| !v.is_empty())
+        .map(|v| v.split_whitespace().map(str::to_string).collect())
+}
+
+/// Classify one line of the failure-loop prompt. Enter defaults to
+/// edit-again; `r` exists only while a generated baseline does.
+fn parse_editor_choice(line: &str, revert_available: bool) -> Option<EditorChoice> {
+    match line.trim().to_lowercase().as_str() {
+        "" | "e" => Some(EditorChoice::EditAgain),
+        "r" if revert_available => Some(EditorChoice::Revert),
+        "q" => Some(EditorChoice::QuitKeep),
+        _ => None,
+    }
+}
+
+/// Delve deeper: open the carved file in the user's editor, re-validate
+/// on exit, and walk the (e)dit / (r)evert / (q)uit failure loop until
+/// the config loads or the user keeps it broken. The editor's exit
+/// status is deliberately ignored — re-validation of the file is the
+/// only truth (no editor reports abort reliably).
+#[allow(dead_code)] // Wired in step 7 (doorstep offer).
+fn delve(strategy: &ProposedStrategy, today: NaiveDate, path: &Path) -> anyhow::Result<CliExit> {
+    let visual = std::env::var("VISUAL").ok();
+    let editor = std::env::var("EDITOR").ok();
+    let Some(command) = resolve_editor(visual.as_deref(), editor.as_deref()) else {
+        // The file is already carved and valid — keeping it is the
+        // honest fallback, never deletion.
+        print!("{}", voice::render_no_editor(path));
+        return Ok(CliExit::Done);
+    };
+    delve_with(&command, strategy, today, path)
+}
+
+fn delve_with(
+    command: &[String],
+    strategy: &ProposedStrategy,
+    today: NaiveDate,
+    path: &Path,
+) -> anyhow::Result<CliExit> {
+    loop {
+        let _status = std::process::Command::new(&command[0])
+            .args(&command[1..])
+            .arg(path)
+            .status()
+            .with_context(|| format!("failed to launch editor `{}`", command[0]))?;
+        // Exit status ignored: revalidate the file, the only truth.
+        let error = match Config::load(Some(path)) {
+            Ok(_) => {
+                print!("{}", voice::render_post_carve(path));
+                return Ok(CliExit::Done);
+            }
+            Err(e) => e.to_string(),
+        };
+        match failure_loop_choice(&error, true)? {
+            EditorChoice::EditAgain => {}
+            EditorChoice::Revert => {
+                overwrite_with_generated(strategy, today, path)?;
+                print!("{}", voice::render_post_carve(path));
+                return Ok(CliExit::Done);
+            }
+            EditorChoice::QuitKeep => return Err(kept_invalid(path)),
+        }
+    }
+}
+
+/// Prompt the failure loop until a usable letter arrives. EOF keeps the
+/// file (the least destructive reading of a closed stdin).
+fn failure_loop_choice(error: &str, revert_available: bool) -> anyhow::Result<EditorChoice> {
+    loop {
+        print!("{}", voice::render_editor_failure(error, revert_available));
+        let Some(line) = read_input_line()? else {
+            return Ok(EditorChoice::QuitKeep);
+        };
+        if let Some(choice) = parse_editor_choice(&line, revert_available) {
+            return Ok(choice);
+        }
+    }
+}
+
+/// Replace the file with the freshly generated, self-checked TOML — the
+/// one place 072 intentionally overwrites, and only on the user's
+/// explicit (r)evert. Never routed through `carve_config`, whose
+/// no-clobber contract stays absolute.
+fn overwrite_with_generated(
+    strategy: &ProposedStrategy,
+    today: NaiveDate,
+    path: &Path,
+) -> anyhow::Result<()> {
+    let (toml, _expected) = checked_toml(strategy, today)?;
+    let dir = path
+        .parent()
+        .with_context(|| format!("config path {} has no parent directory", path.display()))?;
+    let temp = dir.join(TEMP_NAME);
+    stage(&temp, &toml)
+        .with_context(|| format!("failed to stage config at {}", temp.display()))?;
+    fs::rename(&temp, path)
+        .with_context(|| format!("failed to restore config at {}", path.display()))
+}
+
+fn kept_invalid(path: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "the config at {} does not load — kept as you left it.\n\
+         `urd init` returns to this fix-it loop.",
+        path.display()
+    )
+}
+
+/// `urd init`'s fix-it re-entry for an invalid config (arc grill Q5/Q7):
+/// the same failure loop without (r)evert — no generated baseline exists
+/// for a hand-edited file. Returns the loaded config on success so init
+/// can continue being the make-whole verb.
+#[allow(dead_code)] // Wired in step 7 (doorstep offer).
+pub fn fix_invalid_config(path: &Path, initial_error: &str) -> anyhow::Result<Config> {
+    let visual = std::env::var("VISUAL").ok();
+    let editor = std::env::var("EDITOR").ok();
+    let Some(command) = resolve_editor(visual.as_deref(), editor.as_deref()) else {
+        print!("{}", voice::render_no_editor(path));
+        bail!("the config at {} does not load: {initial_error}", path.display());
+    };
+    let mut error = initial_error.to_string();
+    loop {
+        match failure_loop_choice(&error, false)? {
+            EditorChoice::EditAgain => {}
+            // Unreachable: r is never offered without a baseline.
+            EditorChoice::Revert => {}
+            EditorChoice::QuitKeep => return Err(kept_invalid(path)),
+        }
+        std::process::Command::new(&command[0])
+            .args(&command[1..])
+            .arg(path)
+            .status()
+            .with_context(|| format!("failed to launch editor `{}`", command[0]))?;
+        match Config::load(Some(path)) {
+            Ok(config) => return Ok(config),
+            Err(e) => error = e.to_string(),
+        }
+    }
 }
 
 fn exists_refusal(path: &Path) -> anyhow::Error {
@@ -284,5 +527,112 @@ mod tests {
         let mut expected = crate::config_render::generate_config(&strategy, today()).config;
         expected.expand_paths();
         assert_eq!(reloaded, expected);
+    }
+
+    // ── checked_toml / conversation-loop pieces (UPI 072) ───────────────
+
+    #[test]
+    fn checked_toml_matches_what_carve_writes() {
+        let strategy = sheltered_strategy();
+        let (toml, expected) = checked_toml(&strategy, today()).unwrap();
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        carve_config(&strategy, today(), &path).unwrap();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), toml);
+
+        let reloaded = Config::from_str(&toml).unwrap();
+        assert_eq!(reloaded, expected);
+    }
+
+    #[test]
+    fn resolve_editor_prefers_visual_then_editor_then_none() {
+        assert_eq!(
+            resolve_editor(Some("code --wait"), Some("vi")),
+            Some(vec!["code".to_string(), "--wait".to_string()])
+        );
+        assert_eq!(
+            resolve_editor(None, Some("nano")),
+            Some(vec!["nano".to_string()])
+        );
+        assert_eq!(
+            resolve_editor(Some("  "), Some("vi")),
+            Some(vec!["vi".to_string()]),
+            "blank VISUAL falls through to EDITOR"
+        );
+        assert_eq!(resolve_editor(None, None), None);
+        assert_eq!(resolve_editor(Some(""), Some("   ")), None);
+    }
+
+    #[test]
+    fn parse_editor_choice_defaults_to_edit_and_gates_revert() {
+        assert_eq!(parse_editor_choice("", true), Some(EditorChoice::EditAgain));
+        assert_eq!(parse_editor_choice("e", true), Some(EditorChoice::EditAgain));
+        assert_eq!(parse_editor_choice("E", true), Some(EditorChoice::EditAgain));
+        assert_eq!(parse_editor_choice("r", true), Some(EditorChoice::Revert));
+        assert_eq!(
+            parse_editor_choice("r", false),
+            None,
+            "revert must not exist without a generated baseline"
+        );
+        assert_eq!(parse_editor_choice("q", true), Some(EditorChoice::QuitKeep));
+        assert_eq!(parse_editor_choice("x", true), None);
+    }
+
+    #[test]
+    fn overwrite_with_generated_restores_the_carved_content() {
+        let strategy = sheltered_strategy();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        carve_config(&strategy, today(), &path).unwrap();
+        let carved = std::fs::read_to_string(&path).unwrap();
+
+        std::fs::write(&path, "ruined by an edit [[[").unwrap();
+        overwrite_with_generated(&strategy, today(), &path).unwrap();
+
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), carved);
+        assert!(!dir.path().join(TEMP_NAME).exists(), "temp not cleaned up");
+        assert!(Config::load(Some(&path)).is_ok());
+    }
+
+    #[test]
+    fn delve_with_a_clean_editor_exit_confirms_the_valid_file() {
+        // /bin/true touches nothing: the carved file stays valid and the
+        // delve ends confirmed — the editor's exit status is not what
+        // decides, the file's validity is.
+        let strategy = sheltered_strategy();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        carve_config(&strategy, today(), &path).unwrap();
+
+        let result = delve_with(&["/bin/true".to_string()], &strategy, today(), &path);
+        assert_eq!(result.unwrap(), CliExit::Done);
+        assert!(Config::load(Some(&path)).is_ok());
+    }
+
+    #[test]
+    fn delve_with_a_ruining_editor_keeps_the_file_on_eof() {
+        // An "editor" that writes garbage puts the loop into the failure
+        // prompt; test stdin is at EOF, which reads as quit-keeping-the-
+        // file: the error is named, the user's bytes survive.
+        let strategy = sheltered_strategy();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        carve_config(&strategy, today(), &path).unwrap();
+
+        let script = dir.path().join("ruin.sh");
+        std::fs::write(&script, "#!/bin/sh\necho 'ruined [[[' > \"$1\"\n").unwrap();
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+
+        let result = delve_with(&[script.display().to_string()], &strategy, today(), &path);
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("kept as you left it"), "{err}");
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("ruined"),
+            "the user's keystrokes must survive"
+        );
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -13,28 +13,49 @@ use crate::output::{
 use crate::plan::{FilesystemQuery, RealFileSystemState};
 use crate::state::StateDb;
 
-/// CLI entry with fallible config load and first-time discrimination,
-/// mirroring `commands::default::run`: file-not-found → first-time guidance
-/// (exit 3 when non-interactive — grill Q5's distinct code); all other
-/// errors → surface. The bare-`urd` greeting advertises `urd init` as the
-/// first command — a missing config must greet, not error.
+/// CLI entry for the make-whole verb (arc grill Q5): no config → offer
+/// the Encounter (pointer + exit 3 without a terminal); invalid config →
+/// the TTY fix-it loop, then continue into the checks; loadable config →
+/// the checks. All through the shared absence seam, mirroring
+/// `commands::default::run`.
 pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<CliExit> {
-    let config = match Config::load_or_absent(config_path)? {
-        Some(c) => c,
-        None => {
-            let path = match config_path {
-                Some(p) => p.to_path_buf(),
-                None => crate::config::default_config_path()?,
+    let stdin_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
+    let doorstep = crate::commands::doorstep_disposition(output_mode, stdin_tty);
+    let config = match Config::load_or_absent(config_path) {
+        Ok(Some(c)) => c,
+        Ok(None) => {
+            return match doorstep {
+                crate::commands::Doorstep::Offer => {
+                    crate::commands::encounter::run_conversation(config_path)
+                }
+                crate::commands::Doorstep::Pointer => {
+                    let path = match config_path {
+                        Some(p) => p.to_path_buf(),
+                        None => crate::config::default_config_path()?,
+                    };
+                    print!(
+                        "{}",
+                        crate::voice::render_init_first_time(&path, output_mode)
+                    );
+                    Ok(CliExit::NoConfig)
+                }
             };
-            print!(
-                "{}",
-                crate::voice::render_init_first_time(&path, output_mode)
-            );
-            return Ok(match output_mode {
-                OutputMode::Interactive => CliExit::Done,
-                OutputMode::Daemon => CliExit::NoConfig,
-            });
         }
+        // A config that exists but won't load: with a human present,
+        // re-enter the fix-it loop (grill Q7) and continue made-whole;
+        // otherwise surface the error as ever. I/O failures (permissions,
+        // not-a-file) are never editable states — always surface.
+        Err(e @ crate::error::UrdError::Io { .. }) => return Err(e.into()),
+        Err(e) => match doorstep {
+            crate::commands::Doorstep::Offer => {
+                let path = match config_path {
+                    Some(p) => p.to_path_buf(),
+                    None => crate::config::default_config_path()?,
+                };
+                crate::commands::encounter::fix_invalid_config(&path, &e.to_string())?
+            }
+            crate::commands::Doorstep::Pointer => return Err(e.into()),
+        },
     };
     run(config).map(|()| CliExit::Done)
 }
@@ -477,10 +498,13 @@ mod tests {
     }
 
     #[test]
-    fn run_cli_config_not_found_interactive_greets_and_exits_zero() {
+    fn run_cli_config_not_found_interactive_without_stdin_tty_points() {
+        // No stdin terminal in the harness → the pointer, exit 3. The
+        // offer path needs a human on both ends (gate covered in
+        // commands::cli_exit_tests).
         let bogus = PathBuf::from("/tmp/urd-test-nonexistent-init-config-12345.toml");
         let result = run_cli(Some(&bogus), OutputMode::Interactive);
-        assert_eq!(result.expect("config-not-found is Ok"), CliExit::Done);
+        assert_eq!(result.expect("config-not-found is Ok"), CliExit::NoConfig);
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,4 +1,4 @@
-use std::io::Write as _;
+use std::io::{IsTerminal as _, Write as _};
 use std::path::Path;
 
 use crate::btrfs::{BtrfsOps, RealBtrfs};
@@ -19,7 +19,7 @@ use crate::state::StateDb;
 /// the checks. All through the shared absence seam, mirroring
 /// `commands::default::run`.
 pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<CliExit> {
-    let stdin_tty = std::io::IsTerminal::is_terminal(&std::io::stdin());
+    let stdin_tty = std::io::stdin().is_terminal();
     let doorstep = crate::commands::doorstep_disposition(output_mode, stdin_tty);
     let config = match Config::load_or_absent(config_path) {
         Ok(Some(c)) => c,
@@ -29,10 +29,7 @@ pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::R
                     crate::commands::encounter::run_conversation(config_path)
                 }
                 crate::commands::Doorstep::Pointer => {
-                    let path = match config_path {
-                        Some(p) => p.to_path_buf(),
-                        None => crate::config::default_config_path()?,
-                    };
+                    let path = crate::commands::resolve_config_path(config_path)?;
                     print!(
                         "{}",
                         crate::voice::render_init_first_time(&path, output_mode)
@@ -48,10 +45,7 @@ pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::R
         Err(e @ crate::error::UrdError::Io { .. }) => return Err(e.into()),
         Err(e) => match doorstep {
             crate::commands::Doorstep::Offer => {
-                let path = match config_path {
-                    Some(p) => p.to_path_buf(),
-                    None => crate::config::default_config_path()?,
-                };
+                let path = crate::commands::resolve_config_path(config_path)?;
                 crate::commands::encounter::fix_invalid_config(&path, &e.to_string())?
             }
             crate::commands::Doorstep::Pointer => return Err(e.into()),

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -3,9 +3,9 @@ use std::path::Path;
 
 use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::chain;
+use crate::commands::CliExit;
 use crate::config::Config;
 use crate::drives;
-use crate::error::UrdError;
 use crate::output::{
     InitCheck, InitDriveStatus, InitIncomplete, InitOutput, InitPinFile, InitSnapshotCount,
     InitStatus, OutputMode,
@@ -14,25 +14,29 @@ use crate::plan::{FilesystemQuery, RealFileSystemState};
 use crate::state::StateDb;
 
 /// CLI entry with fallible config load and first-time discrimination,
-/// mirroring `commands::default::run`: file-not-found → first-time guidance;
-/// all other errors → surface. The bare-`urd` greeting advertises `urd init`
-/// as the first command — a missing config must greet, not error.
-pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<()> {
-    let config = match Config::load(config_path) {
-        Ok(c) => c,
-        Err(UrdError::Io {
-            ref path,
-            ref source,
-        }) if source.kind() == std::io::ErrorKind::NotFound => {
+/// mirroring `commands::default::run`: file-not-found → first-time guidance
+/// (exit 3 when non-interactive — grill Q5's distinct code); all other
+/// errors → surface. The bare-`urd` greeting advertises `urd init` as the
+/// first command — a missing config must greet, not error.
+pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<CliExit> {
+    let config = match Config::load_or_absent(config_path)? {
+        Some(c) => c,
+        None => {
+            let path = match config_path {
+                Some(p) => p.to_path_buf(),
+                None => crate::config::default_config_path()?,
+            };
             print!(
                 "{}",
-                crate::voice::render_init_first_time(path, output_mode)
+                crate::voice::render_init_first_time(&path, output_mode)
             );
-            return Ok(());
+            return Ok(match output_mode {
+                OutputMode::Interactive => CliExit::Done,
+                OutputMode::Daemon => CliExit::NoConfig,
+            });
         }
-        Err(e) => return Err(e.into()),
     };
-    run(config)
+    run(config).map(|()| CliExit::Done)
 }
 
 pub fn run(config: Config) -> anyhow::Result<()> {
@@ -456,4 +460,37 @@ fn handle_incomplete_deletions(
     }
 
     Ok(deleted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn run_cli_config_not_found_daemon_reports_no_config_exit() {
+        // Mirrors commands::default — the make-whole verb greets a missing
+        // config, and non-interactive callers get the distinct exit.
+        let bogus = PathBuf::from("/tmp/urd-test-nonexistent-init-config-12345.toml");
+        let result = run_cli(Some(&bogus), OutputMode::Daemon);
+        assert_eq!(result.expect("config-not-found is Ok"), CliExit::NoConfig);
+    }
+
+    #[test]
+    fn run_cli_config_not_found_interactive_greets_and_exits_zero() {
+        let bogus = PathBuf::from("/tmp/urd-test-nonexistent-init-config-12345.toml");
+        let result = run_cli(Some(&bogus), OutputMode::Interactive);
+        assert_eq!(result.expect("config-not-found is Ok"), CliExit::Done);
+    }
+
+    #[test]
+    fn run_cli_invalid_config_surfaces_error() {
+        // An invalid config is never the first-time path — the error must
+        // reach the user (the TTY fix-it loop arrives with the Encounter).
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "this is not valid toml [[[").expect("write garbage");
+        let result = run_cli(Some(&path), OutputMode::Daemon);
+        assert!(result.is_err(), "invalid config must surface as Err");
+    }
 }

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::cli::MigrateArgs;
+use crate::commands::resolve_config_path;
 use crate::types::{DerivedPolicy, Interval, ProtectionLevel, RunFrequency};
 
 /// Run the `urd migrate` command: transform legacy/v1 config → v2 schema.
@@ -103,13 +104,6 @@ pub fn run(config_path: Option<&Path>, args: &MigrateArgs) -> anyhow::Result<()>
     println!();
 
     Ok(())
-}
-
-fn resolve_config_path(path: Option<&Path>) -> anyhow::Result<PathBuf> {
-    match path {
-        Some(p) => Ok(p.to_path_buf()),
-        None => Ok(crate::config::default_config_path()?),
-    }
 }
 
 // ── Version extraction ─────────────────────────────────────────────────

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -44,6 +44,25 @@ impl CliExit {
     }
 }
 
+/// Doorstep disposition for a missing config: the Encounter is offered
+/// only when a human is on both ends — stdout interactive AND stdin a
+/// terminal (`urd < file` gets the pointer, never a conversation that
+/// eats the file). Everything else points and exits 3.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Doorstep {
+    Offer,
+    Pointer,
+}
+
+#[must_use]
+pub fn doorstep_disposition(output_mode: OutputMode, stdin_is_tty: bool) -> Doorstep {
+    if output_mode == OutputMode::Interactive && stdin_is_tty {
+        Doorstep::Offer
+    } else {
+        Doorstep::Pointer
+    }
+}
+
 /// Config load for commands that cannot run unconfigured: a missing
 /// config prints the one-sentence pointer and returns `Ok(None)` (the
 /// caller exits with [`CliExit::NoConfig`]); any other load failure is a
@@ -73,6 +92,19 @@ mod cli_exit_tests {
         // is an external interface change, not a refactor.
         assert_eq!(CliExit::Done.code(), 0);
         assert_eq!(CliExit::NoConfig.code(), 3);
+    }
+
+    #[test]
+    fn doorstep_offers_only_with_a_human_on_both_ends() {
+        use OutputMode::{Daemon, Interactive};
+        assert_eq!(doorstep_disposition(Interactive, true), Doorstep::Offer);
+        assert_eq!(
+            doorstep_disposition(Interactive, false),
+            Doorstep::Pointer,
+            "urd < file must point, never converse"
+        );
+        assert_eq!(doorstep_disposition(Daemon, true), Doorstep::Pointer);
+        assert_eq!(doorstep_disposition(Daemon, false), Doorstep::Pointer);
     }
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,8 @@
+use std::path::Path;
+
+use crate::config::Config;
+use crate::output::OutputMode;
+
 pub mod acknowledgment;
 pub mod backup;
 pub mod calibrate;
@@ -18,3 +23,71 @@ pub mod status;
 pub mod sentinel;
 pub mod storage_signals;
 pub mod verify;
+
+/// How a doorstep-aware command finished. `code()` feeds `main`'s
+/// `ExitCode`: 0 = done, 3 = not configured (the documented distinct
+/// code — 1 stays generic failure via `anyhow`, 2 is reserved by clap
+/// for usage errors).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliExit {
+    Done,
+    NoConfig,
+}
+
+impl CliExit {
+    #[must_use]
+    pub fn code(self) -> u8 {
+        match self {
+            CliExit::Done => 0,
+            CliExit::NoConfig => 3,
+        }
+    }
+}
+
+/// Config load for commands that cannot run unconfigured: a missing
+/// config prints the one-sentence pointer and returns `Ok(None)` (the
+/// caller exits with [`CliExit::NoConfig`]); any other load failure is a
+/// real error. Lives here, not in `main.rs`, so the behavior is testable
+/// in-process.
+pub fn load_or_point(
+    config_path: Option<&Path>,
+    output_mode: OutputMode,
+) -> anyhow::Result<Option<Config>> {
+    match Config::load_or_absent(config_path)? {
+        Some(config) => Ok(Some(config)),
+        None => {
+            print!("{}", crate::voice::render_first_time(output_mode));
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod cli_exit_tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn cli_exit_codes_are_stable() {
+        // Exit 3 is documented in docs/20-reference/cli.md — a change here
+        // is an external interface change, not a refactor.
+        assert_eq!(CliExit::Done.code(), 0);
+        assert_eq!(CliExit::NoConfig.code(), 3);
+    }
+
+    #[test]
+    fn load_or_point_missing_config_points_instead_of_erroring() {
+        let bogus = PathBuf::from("/tmp/urd-test-nonexistent-config-load-or-point.toml");
+        let result = load_or_point(Some(&bogus), OutputMode::Daemon).expect("absent is Ok");
+        assert!(result.is_none(), "missing config must point, not load");
+    }
+
+    #[test]
+    fn load_or_point_invalid_config_surfaces_error() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "this is not valid toml [[[").expect("write garbage");
+        let result = load_or_point(Some(&path), OutputMode::Daemon);
+        assert!(result.is_err(), "invalid config is an error, never a pointer");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -63,6 +63,16 @@ pub fn doorstep_disposition(output_mode: OutputMode, stdin_is_tty: bool) -> Door
     }
 }
 
+/// The config path a command acts on: the `--config` override or the
+/// default location. One owner for the resolution the doorstep, the
+/// carve target, and the first-time pointer all share.
+pub fn resolve_config_path(config_path: Option<&Path>) -> anyhow::Result<std::path::PathBuf> {
+    match config_path {
+        Some(p) => Ok(p.to_path_buf()),
+        None => Ok(crate::config::default_config_path()?),
+    }
+}
+
 /// Config load for commands that cannot run unconfigured: a missing
 /// config prints the one-sentence pointer and returns `Ok(None)` (the
 /// caller exits with [`CliExit::NoConfig`]); any other load failure is a

--- a/src/config.rs
+++ b/src/config.rs
@@ -321,6 +321,23 @@ impl Config {
         Ok(config)
     }
 
+    /// Load like [`Config::load`], but report a missing config file as
+    /// `Ok(None)` — config-absent is a state the doorstep greets, not an
+    /// error. Every site that discriminates a missing config goes through
+    /// this one seam so the `ErrorKind` semantics cannot drift between
+    /// the doorstep and the pointer.
+    pub fn load_or_absent(path: Option<&Path>) -> crate::error::Result<Option<Self>> {
+        match Self::load(path) {
+            Ok(config) => Ok(Some(config)),
+            Err(UrdError::Io { ref source, .. })
+                if source.kind() == std::io::ErrorKind::NotFound =>
+            {
+                Ok(None)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
     /// Parse config from a TOML string with version dispatch — the load
     /// path minus file I/O (parse → expand_paths → validate).
     ///
@@ -2384,6 +2401,34 @@ protection = "sheltered"
         let config = parse_v2(v2_minimal_config_str()).expect("v2 minimal parses");
         assert_eq!(config.general.config_version, Some(2));
         assert_eq!(config.subvolumes.len(), 1);
+    }
+
+    // ── load_or_absent (UPI 072 doorstep seam) ─────────────────────────
+
+    #[test]
+    fn load_or_absent_missing_file_is_none() {
+        let bogus = PathBuf::from("/tmp/urd-test-nonexistent-config-load-or-absent.toml");
+        let result = Config::load_or_absent(Some(&bogus)).expect("absent is Ok");
+        assert!(result.is_none(), "missing config must be Ok(None)");
+    }
+
+    #[test]
+    fn load_or_absent_existing_file_loads() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("urd.toml");
+        std::fs::write(&path, v2_minimal_config_str()).expect("write config");
+        let result = Config::load_or_absent(Some(&path)).expect("valid config loads");
+        let config = result.expect("present config must be Some");
+        assert_eq!(config.subvolumes.len(), 1);
+    }
+
+    #[test]
+    fn load_or_absent_invalid_file_errors() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let path = dir.path().join("urd.toml");
+        std::fs::write(&path, "this is not valid toml [[[").expect("write garbage");
+        let result = Config::load_or_absent(Some(&path));
+        assert!(result.is_err(), "parse errors must surface, not read as absent");
     }
 
     #[test]

--- a/src/config_render.rs
+++ b/src/config_render.rs
@@ -40,7 +40,6 @@ pub struct GeneratedConfig {
 /// Convert an approved strategy into the internal `Config` normal form and
 /// render it as commented v2 TOML. Pure; `today` is the carve date the
 /// header and nothing else consumes.
-#[allow(dead_code)] // Consumed by UPI 072 (conversation).
 #[must_use]
 pub fn generate_config(strategy: &ProposedStrategy, today: NaiveDate) -> GeneratedConfig {
     let config = strategy_to_config(strategy);
@@ -214,6 +213,9 @@ fn gap_lines(gap: &Gap) -> Vec<String> {
             UnusableReason::NotBtrfs { fstype: None } => "not btrfs (no filesystem)".to_string(),
             UnusableReason::NotMounted => "btrfs but not mounted".to_string(),
             UnusableReason::Unresolved => "residency unresolved".to_string(),
+            UnusableReason::MixedPool => {
+                "its filesystem also spans drives inside this machine".to_string()
+            }
         };
         let label = drive.label.as_deref().unwrap_or(&drive.device);
         match &drive.size {

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -48,7 +48,6 @@ pub struct SystemInventory {
     pub pools: Vec<DiscoveredPool>,
     pub subvolumes: Vec<DiscoveredSubvol>,
     pub drives: Vec<CandidateDrive>,
-    #[allow(dead_code)] // Consumed by UPI 072 (rendering).
     pub notes: Vec<DiscoveryNote>,
 }
 
@@ -59,13 +58,15 @@ pub struct SystemInventory {
 pub struct DiscoveredPool {
     pub uuid: String,
     pub label: Option<String>,
-    #[allow(dead_code)] // Consumed by UPI 072 (rendering) / 075 (second look).
+    // The runestone names bearers via `CandidateDrive.device` (top-level
+    // disks, the vocabulary a user recognizes) — these raw btrfs-bearing
+    // nodes serve the privileged second look instead.
+    #[allow(dead_code)] // Consumed by UPI 075 (second look).
     pub device_names: Vec<String>,
     pub mountpoints: Vec<PathBuf>,
     /// One space fact per pool (arc grill decision 4), measured at the
     /// canonical (shortest) mountpoint. `None` when unmounted or the
     /// resolver failed.
-    #[allow(dead_code)] // Consumed by UPI 072 (rendering).
     pub space: Option<PoolSpace>,
 }
 
@@ -102,7 +103,6 @@ pub struct CandidateDrive {
     pub transport: Option<String>,
     /// Subtree-wide (any mounted partition). Deliberately unread by the
     /// strategy layer — pool mountpoints are the mount authority there.
-    #[allow(dead_code)] // Consumed by UPI 072 (rendering).
     pub mounted: bool,
     /// Filesystem UUID of the first btrfs node in this disk's subtree —
     /// the join key to [`DiscoveredPool`]. `None` when no btrfs is visible
@@ -133,7 +133,6 @@ pub enum LuksState {
 
 /// Structured observations — typed data, never pre-rendered English (the
 /// voice belongs to UPI 072's presentation layer).
-#[allow(dead_code)] // Consumed by UPI 072 (rendering).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DiscoveryNote {
     /// A locked LUKS drive was seen; label is unreadable while locked.
@@ -155,7 +154,6 @@ pub enum DiscoveryNote {
     ProbeDegraded { probe: Probe, detail: String },
 }
 
-#[allow(dead_code)] // Consumed by UPI 072 (rendering).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NoiseCategory {
     /// Snapper-convention `.snapshots` subvolume mounts.
@@ -165,7 +163,6 @@ pub enum NoiseCategory {
     DuplicateMounts,
 }
 
-#[allow(dead_code)] // Consumed by UPI 072 (rendering).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Probe {
     Lsblk,
@@ -721,7 +718,6 @@ fn run_findmnt() -> crate::error::Result<String> {
 /// Probe the system and build the inventory. Never fails: a failed probe
 /// degrades the inventory and leaves a [`DiscoveryNote::ProbeDegraded`]
 /// so 072 can say so (fail open, observable).
-#[allow(dead_code)] // Consumed by UPI 072 — the Encounter's entry point.
 #[must_use]
 pub fn discover() -> SystemInventory {
     let mut probe_notes = Vec::new();

--- a/src/encounter.rs
+++ b/src/encounter.rs
@@ -1,0 +1,1511 @@
+//! The Fate Conversation's pure state machine (UPI 072).
+//!
+//! `begin` → `advance` walk the conversation: the looking (inventory +
+//! confirm), per-ambiguous-drive residency, the three escalating disaster
+//! scenes (deleted-folder → granularity, dead-drive → per-subvolume
+//! importance, house-fire → residence), and the runestone. The machine
+//! never performs I/O (sentinel.rs precedent, ADR-108): the thin stdin
+//! loop in `commands/encounter.rs` renders prompts through
+//! `voice/encounter.rs`, feeds parsed input back in, and executes the
+//! terminal [`Effect`]s (carve, farewell). Nothing is persisted before
+//! the carve — quitting at any state costs nothing.
+//!
+//! Question economy is enforced by construction: the question list is
+//! derived from [`protection_candidates`] and [`usable_destinations`],
+//! never invented here.
+
+use std::path::{Path, PathBuf};
+
+use chrono::NaiveDate;
+
+use crate::discovery::{
+    CandidateDrive, DiscoveredPool, DiscoveredSubvol, DiscoveryNote, DriveClass, SystemInventory,
+};
+use crate::strategy::{
+    derive_strategy, protection_candidates, usable_destinations, CandidateSubvol, Destination,
+    DriveResidencyAnswer, ExcludedSubvol, FateAnswers, Gap, GranularityAnswer, Importance,
+    ImportanceAnswer, ProposedStrategy, ProposedSubvolume, ResidenceAnswer, ResolvedDriveClass,
+};
+use crate::types::{DriveRole, RunFrequency};
+
+// ── Input ───────────────────────────────────────────────────────────────
+
+/// One line of user input, parsed against the pending prompt. EOF is
+/// mapped to `Quit` by the loop (closing stdin is walking away).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Input {
+    /// 0-based index into the prompt's `choices`.
+    Choice(usize),
+    Quit,
+    Invalid,
+}
+
+/// Feedback attached to a re-prompt after unusable input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputNotice {
+    /// The line did not name a choice; `choices` is how many exist.
+    InvalidChoice { choices: usize },
+}
+
+/// Parse one input line against the prompt it answers: a 1-based choice
+/// number, the quit token (`q`/`quit`), or — when the prompt carries a
+/// default — an empty line accepting it. Everything else is `Invalid`
+/// (same state, one notice, same prompt again).
+#[must_use]
+pub fn parse_line(spec: &PromptSpec, line: &str) -> Input {
+    let trimmed = line.trim();
+    if trimmed.eq_ignore_ascii_case("q") || trimmed.eq_ignore_ascii_case("quit") {
+        return Input::Quit;
+    }
+    if trimmed.is_empty() {
+        return match spec.default {
+            Some(idx) => Input::Choice(idx),
+            None => Input::Invalid,
+        };
+    }
+    match trimmed.parse::<usize>() {
+        Ok(n) if n >= 1 && n <= spec.choices.len() => Input::Choice(n - 1),
+        _ => Input::Invalid,
+    }
+}
+
+// ── Prompts ─────────────────────────────────────────────────────────────
+
+/// What a numbered choice means. The renderer writes each id's label and
+/// numbers them from [`PromptSpec::choices`] — the same vector
+/// [`parse_line`] validates against, so numbering and parsing cannot
+/// drift.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChoiceId {
+    // Offer
+    Begin,
+    NotNow,
+    // The looking
+    LooksRight,
+    DoesNotMatch,
+    // Ambiguous-drive residency
+    PartOfMachine,
+    CarriedAway,
+    // Granularity (deleted-folder scene)
+    YesterdayIsFine,
+    LastHour,
+    // Importance (dead-drive scene)
+    Irreplaceable,
+    Replaceable,
+    NotWorthHistory,
+    // Residence (house-fire scene)
+    SiteLossDriveStays,
+    KeptElsewhere,
+    DeletionOnly,
+    // Runestone
+    Accept,
+    DelveDeeper,
+}
+
+/// One prompt: typed content for the renderer, the choice vector, and an
+/// optional default (empty line accepts it). Defaults exist only on
+/// importance questions — approving fate at the runestone requires a
+/// deliberate keystroke.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptSpec {
+    pub kind: PromptKind,
+    pub choices: Vec<ChoiceId>,
+    /// 0-based index into `choices`.
+    pub default: Option<usize>,
+}
+
+/// Typed prompt content — data only, never English (voice owns wording).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptKind {
+    Offer,
+    LookingConfirm {
+        view: LookingView,
+    },
+    DriveResidency {
+        drive: CandidateDrive,
+    },
+    Granularity,
+    Importance {
+        mountpoint: PathBuf,
+        subvol_path: String,
+        proposed: Importance,
+        /// 1-based position within the classification round.
+        position: usize,
+        total: usize,
+    },
+    Residence {
+        destinations: Vec<Destination>,
+    },
+    Runestone {
+        view: RunestoneView,
+    },
+}
+
+// ── Views ───────────────────────────────────────────────────────────────
+
+/// The looking, composed: subvolumes grouped under their pools, drive
+/// facts as discovered, typed notes. What a question or the runestone
+/// needs is shown; the rest of the inventory stays held (arc grill).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookingView {
+    pub pools: Vec<LookingPool>,
+    /// Mounted btrfs subvolumes whose pool could not be joined
+    /// (`pool_uuid: None` or an unknown uuid) — shown, not hidden.
+    pub unjoined: Vec<DiscoveredSubvol>,
+    pub drives: Vec<CandidateDrive>,
+    pub notes: Vec<DiscoveryNote>,
+}
+
+/// One pool and the mounted subvolumes it carries.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LookingPool {
+    pub pool: DiscoveredPool,
+    pub subvolumes: Vec<DiscoveredSubvol>,
+}
+
+/// The runestone: the derived proposal enriched with the drive facts the
+/// user must recognize before approving (label, size, transport, every
+/// bearing device, and any data the pool already carries — 073's
+/// runestone obligation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunestoneView {
+    pub run_frequency: RunFrequency,
+    pub subvolumes: Vec<ProposedSubvolume>,
+    pub drives: Vec<RunestoneDrive>,
+    pub gaps: Vec<Gap>,
+    pub excluded: Vec<ExcludedSubvol>,
+}
+
+/// One adopted drive's runestone line. A multi-device pool is one
+/// destination but names **all** its bearing devices — a user with a
+/// two-disk pool must see both disks recognized (074 journal question,
+/// pinned 2026-07-04).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunestoneDrive {
+    /// Config label (what `urd status` will call it).
+    pub label: String,
+    pub role: DriveRole,
+    pub mount_path: PathBuf,
+    pub pool_label: Option<String>,
+    /// Every top-level disk bearing the pool (`CandidateDrive.device`
+    /// vocabulary — disks a user recognizes, not mapper nodes).
+    pub device_names: Vec<String>,
+    /// First bearer's lsblk display size — rendering only.
+    pub size: Option<String>,
+    pub transport: Option<String>,
+    /// Data the pool already carries (its current mountpoints) — a
+    /// misclassified data disk must be recognizable before approval.
+    pub pool_mounts: Vec<PathBuf>,
+}
+
+/// Why the encounter ended with nothing to carve. The two variants are
+/// distinct rendering contracts: nothing-discovered points at hardware
+/// (unlock the drive, this machine has no btrfs), everything-excluded
+/// explains each exclusion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EmptyView {
+    /// No btrfs pools or mounted subvolumes visible at all. Drives and
+    /// notes carry what *was* seen (locked containers, foreign
+    /// filesystems) so the farewell can name the path to more.
+    NothingDiscovered {
+        drives: Vec<CandidateDrive>,
+        notes: Vec<DiscoveryNote>,
+    },
+    /// Subvolumes were found but none is proposable — every one carries
+    /// a typed exclusion reason (possibly `DeclaredNotWorthHistory`).
+    EverythingExcluded { excluded: Vec<ExcludedSubvol> },
+}
+
+// ── Effects ─────────────────────────────────────────────────────────────
+
+/// What the loop must do after an `advance`. The machine is *done* at
+/// `Carve` — the editor failure loop is imperative command-layer code.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Effect {
+    /// Render this prompt and feed the next line back in.
+    Prompt(PromptSpec),
+    /// The user approved the runestone: carve, then confirm or edit.
+    Carve {
+        strategy: ProposedStrategy,
+        /// The date the runestone was composed with — carve must use the
+        /// same one, or a midnight crossing diverges file from promise.
+        today: NaiveDate,
+        then: AfterCarve,
+    },
+    /// The conversation is over; render the farewell and exit cleanly.
+    Farewell(FarewellKind),
+}
+
+/// The two exits that branch *after* the proposal (arc grill Q7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AfterCarve {
+    /// Set-and-forget: confirm the carved file and hand off.
+    Confirm,
+    /// Delve deeper: open `$EDITOR` on the carved file, re-validate.
+    Edit,
+}
+
+/// How a conversation ends without a carve. Nothing was written in any
+/// of these — returning means starting over (grill Q5).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FarewellKind {
+    /// Declined the offer — come back later is free.
+    Declined,
+    /// The looking didn't match reality: mount or unlock what's missing
+    /// and run `urd init` again (re-running is the re-probe).
+    LookingMismatch,
+    /// Quit mid-conversation.
+    Quit,
+    /// Nothing to carve; the view says why, honestly.
+    EmptyReport(EmptyView),
+}
+
+/// One transition's outcome (sentinel's named-result precedent).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdvanceResult {
+    pub state: EncounterState,
+    pub effect: Effect,
+    /// Set when the input was unusable — voice renders one line, then
+    /// the same prompt again.
+    pub notice: Option<InputNotice>,
+}
+
+// ── State ───────────────────────────────────────────────────────────────
+
+/// The conversation's full state: the inventory being discussed, the
+/// answers accumulated so far, and the current phase. Owned by the
+/// machine, not the loop — the question queues are phase-dependent
+/// (candidates exist only after residency answers).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncounterState {
+    inventory: SystemInventory,
+    today: NaiveDate,
+    importance: Vec<ImportanceAnswer>,
+    residence: Option<ResidenceAnswer>,
+    granularity: Option<GranularityAnswer>,
+    drive_residency: Vec<DriveResidencyAnswer>,
+    phase: Phase,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Phase {
+    Offer,
+    Looking,
+    /// One question per `DriveClass::Ambiguous` drive, carrying the
+    /// drive facts so the prompt needs no inventory lookup.
+    DriveResidency {
+        pending: Vec<CandidateDrive>,
+        index: usize,
+    },
+    SceneGranularity,
+    Importance {
+        candidates: Vec<CandidateSubvol>,
+        index: usize,
+    },
+    Residence {
+        destinations: Vec<Destination>,
+    },
+    Runestone {
+        strategy: ProposedStrategy,
+    },
+    Done,
+}
+
+impl EncounterState {
+    /// Start the conversation. An inventory with no btrfs pools and no
+    /// mounted subvolumes short-circuits to an honest nothing-discovered
+    /// farewell — never an offer to look at nothing (locked or foreign
+    /// drives ride along so the farewell can name them).
+    #[must_use]
+    pub fn begin(inventory: SystemInventory, today: NaiveDate) -> AdvanceResult {
+        if inventory.pools.is_empty() && inventory.subvolumes.is_empty() {
+            let view = EmptyView::NothingDiscovered {
+                drives: inventory.drives.clone(),
+                notes: inventory.notes.clone(),
+            };
+            let state = Self::with_phase(inventory, today, Phase::Done);
+            return AdvanceResult {
+                state,
+                effect: Effect::Farewell(FarewellKind::EmptyReport(view)),
+                notice: None,
+            };
+        }
+        let state = Self::with_phase(inventory, today, Phase::Offer);
+        prompt(state)
+    }
+
+    fn with_phase(inventory: SystemInventory, today: NaiveDate, phase: Phase) -> Self {
+        EncounterState {
+            inventory,
+            today,
+            importance: Vec::new(),
+            residence: None,
+            granularity: None,
+            drive_residency: Vec::new(),
+            phase,
+        }
+    }
+}
+
+// ── Prompt composition ──────────────────────────────────────────────────
+
+/// The prompt for the current state — a pure function of state, so
+/// "invalid input re-prompts the same spec" is checkable by equality.
+/// `None` only for the terminal phase (the loop has already exited).
+#[must_use]
+pub fn prompt_for(state: &EncounterState) -> Option<PromptSpec> {
+    match &state.phase {
+        Phase::Offer => Some(PromptSpec {
+            kind: PromptKind::Offer,
+            choices: vec![ChoiceId::Begin, ChoiceId::NotNow],
+            default: None,
+        }),
+        Phase::Looking => Some(PromptSpec {
+            kind: PromptKind::LookingConfirm {
+                view: compose_looking(&state.inventory),
+            },
+            choices: vec![ChoiceId::LooksRight, ChoiceId::DoesNotMatch],
+            default: None,
+        }),
+        Phase::DriveResidency { pending, index } => Some(PromptSpec {
+            kind: PromptKind::DriveResidency {
+                drive: pending[*index].clone(),
+            },
+            choices: vec![ChoiceId::PartOfMachine, ChoiceId::CarriedAway],
+            default: None,
+        }),
+        Phase::SceneGranularity => Some(PromptSpec {
+            kind: PromptKind::Granularity,
+            choices: vec![ChoiceId::YesterdayIsFine, ChoiceId::LastHour],
+            default: None,
+        }),
+        Phase::Importance { candidates, index } => {
+            let candidate = &candidates[*index];
+            let proposed = proposed_importance(candidate);
+            let default = match proposed {
+                Importance::Irreplaceable => 0,
+                Importance::Replaceable => 1,
+                // Never proposed — exclusion is an explicit human act.
+                Importance::NotWorthHistory => {
+                    unreachable!("NotWorthHistory is never proposed")
+                }
+            };
+            Some(PromptSpec {
+                kind: PromptKind::Importance {
+                    mountpoint: candidate.mountpoint.clone(),
+                    subvol_path: candidate.subvol_path.clone(),
+                    proposed,
+                    position: index + 1,
+                    total: candidates.len(),
+                },
+                choices: vec![
+                    ChoiceId::Irreplaceable,
+                    ChoiceId::Replaceable,
+                    ChoiceId::NotWorthHistory,
+                ],
+                default: Some(default),
+            })
+        }
+        Phase::Residence { destinations } => Some(PromptSpec {
+            kind: PromptKind::Residence {
+                destinations: destinations.clone(),
+            },
+            choices: vec![
+                ChoiceId::SiteLossDriveStays,
+                ChoiceId::KeptElsewhere,
+                ChoiceId::DeletionOnly,
+            ],
+            default: None,
+        }),
+        Phase::Runestone { strategy } => Some(PromptSpec {
+            kind: PromptKind::Runestone {
+                view: compose_runestone(strategy, &state.inventory),
+            },
+            choices: vec![ChoiceId::Accept, ChoiceId::DelveDeeper],
+            default: None,
+        }),
+        Phase::Done => None,
+    }
+}
+
+/// The importance default the question carries inline: `/home` (or
+/// anything under it) is proposed irreplaceable, everything else
+/// replaceable. A wrong `/home` default over-protects; a wrong other
+/// default costs one keystroke. `NotWorthHistory` is never proposed.
+#[must_use]
+pub fn proposed_importance(candidate: &CandidateSubvol) -> Importance {
+    if candidate.mountpoint.starts_with(Path::new("/home")) {
+        Importance::Irreplaceable
+    } else {
+        Importance::Replaceable
+    }
+}
+
+/// Group the inventory for the looking: subvolumes under their pools,
+/// unjoinable mounts shown separately, drives and notes as discovered.
+#[must_use]
+pub fn compose_looking(inventory: &SystemInventory) -> LookingView {
+    let pools = inventory
+        .pools
+        .iter()
+        .map(|pool| LookingPool {
+            pool: pool.clone(),
+            subvolumes: inventory
+                .subvolumes
+                .iter()
+                .filter(|sv| sv.pool_uuid.as_deref() == Some(pool.uuid.as_str()))
+                .cloned()
+                .collect(),
+        })
+        .collect();
+    let unjoined = inventory
+        .subvolumes
+        .iter()
+        .filter(|sv| match &sv.pool_uuid {
+            None => true,
+            Some(uuid) => !inventory.pools.iter().any(|p| &p.uuid == uuid),
+        })
+        .cloned()
+        .collect();
+    LookingView {
+        pools,
+        unjoined,
+        drives: inventory.drives.clone(),
+        notes: inventory.notes.clone(),
+    }
+}
+
+/// Enrich the derived proposal with the drive facts the user must
+/// recognize before approving. Pure and machine-independent so the
+/// view↔strategy correspondence is testable over the whole derivation
+/// grid.
+#[must_use]
+pub fn compose_runestone(
+    strategy: &ProposedStrategy,
+    inventory: &SystemInventory,
+) -> RunestoneView {
+    let drives = strategy
+        .drives
+        .iter()
+        .map(|proposed| {
+            let pool = inventory.pools.iter().find(|p| p.uuid == proposed.uuid);
+            // Top-level disk nodes bearing the pool — the vocabulary a
+            // user recognizes ("sdd + sde"), not mapper/partition nodes.
+            let bearers: Vec<&CandidateDrive> = inventory
+                .drives
+                .iter()
+                .filter(|d| d.pool_uuid.as_deref() == Some(proposed.uuid.as_str()))
+                .collect();
+            RunestoneDrive {
+                label: proposed.label.clone(),
+                role: proposed.role,
+                mount_path: proposed.mount_path.clone(),
+                pool_label: pool.and_then(|p| p.label.clone()),
+                device_names: bearers.iter().map(|d| d.device.clone()).collect(),
+                size: bearers.first().and_then(|d| d.size.clone()),
+                transport: bearers.first().and_then(|d| d.transport.clone()),
+                pool_mounts: pool.map(|p| p.mountpoints.clone()).unwrap_or_default(),
+            }
+        })
+        .collect();
+    RunestoneView {
+        run_frequency: strategy.run_frequency,
+        subvolumes: strategy.subvolumes.clone(),
+        drives,
+        gaps: strategy.gaps.clone(),
+        excluded: strategy.excluded.clone(),
+    }
+}
+
+// ── Transitions ─────────────────────────────────────────────────────────
+
+/// Advance the conversation by one parsed input. Pure and total: quit
+/// works everywhere, invalid input returns the same state with a notice
+/// and the same prompt, and the terminal transitions surface as typed
+/// [`Effect`]s. Never performs I/O.
+#[must_use]
+pub fn advance(state: EncounterState, input: Input) -> AdvanceResult {
+    let choice = match input {
+        Input::Quit => return farewell(state, FarewellKind::Quit),
+        Input::Invalid => return invalid(state),
+        Input::Choice(idx) => {
+            let Some(spec) = prompt_for(&state) else {
+                // Done accepts nothing more; treat any input as leaving.
+                return farewell(state, FarewellKind::Quit);
+            };
+            match spec.choices.get(idx) {
+                Some(&choice) => choice,
+                None => return invalid(state),
+            }
+        }
+    };
+
+    let mut state = state;
+    let phase = std::mem::replace(&mut state.phase, Phase::Done);
+    match (phase, choice) {
+        (Phase::Offer, ChoiceId::Begin) => {
+            state.phase = Phase::Looking;
+            prompt(state)
+        }
+        (Phase::Offer, ChoiceId::NotNow) => farewell(state, FarewellKind::Declined),
+
+        (Phase::Looking, ChoiceId::LooksRight) => {
+            let pending: Vec<CandidateDrive> = state
+                .inventory
+                .drives
+                .iter()
+                .filter(|d| d.class == DriveClass::Ambiguous)
+                .cloned()
+                .collect();
+            if pending.is_empty() {
+                candidates_checkpoint(state)
+            } else {
+                state.phase = Phase::DriveResidency { pending, index: 0 };
+                prompt(state)
+            }
+        }
+        (Phase::Looking, ChoiceId::DoesNotMatch) => {
+            farewell(state, FarewellKind::LookingMismatch)
+        }
+
+        (
+            Phase::DriveResidency { pending, index },
+            ChoiceId::PartOfMachine | ChoiceId::CarriedAway,
+        ) => {
+            let class = if choice == ChoiceId::PartOfMachine {
+                ResolvedDriveClass::Internal
+            } else {
+                ResolvedDriveClass::External
+            };
+            state.drive_residency.push(DriveResidencyAnswer {
+                device: pending[index].device.clone(),
+                class,
+            });
+            let next = index + 1;
+            if next >= pending.len() {
+                candidates_checkpoint(state)
+            } else {
+                state.phase = Phase::DriveResidency {
+                    pending,
+                    index: next,
+                };
+                prompt(state)
+            }
+        }
+
+        (Phase::SceneGranularity, ChoiceId::YesterdayIsFine | ChoiceId::LastHour) => {
+            state.granularity = Some(if choice == ChoiceId::YesterdayIsFine {
+                GranularityAnswer::YesterdayIsFine
+            } else {
+                GranularityAnswer::LastHour
+            });
+            importance_phase(state)
+        }
+
+        (
+            Phase::Importance { candidates, index },
+            ChoiceId::Irreplaceable | ChoiceId::Replaceable | ChoiceId::NotWorthHistory,
+        ) => {
+            let importance = match choice {
+                ChoiceId::Irreplaceable => Importance::Irreplaceable,
+                ChoiceId::Replaceable => Importance::Replaceable,
+                _ => Importance::NotWorthHistory,
+            };
+            state.importance.push(ImportanceAnswer {
+                mountpoint: candidates[index].mountpoint.clone(),
+                importance,
+            });
+            let next = index + 1;
+            if next >= candidates.len() {
+                residence_or_runestone(state)
+            } else {
+                state.phase = Phase::Importance {
+                    candidates,
+                    index: next,
+                };
+                prompt(state)
+            }
+        }
+
+        (
+            Phase::Residence { .. },
+            ChoiceId::SiteLossDriveStays | ChoiceId::KeptElsewhere | ChoiceId::DeletionOnly,
+        ) => {
+            state.residence = Some(match choice {
+                ChoiceId::SiteLossDriveStays => ResidenceAnswer::FearsSiteLossDriveStays,
+                ChoiceId::KeptElsewhere => ResidenceAnswer::DriveKeptElsewhere,
+                _ => ResidenceAnswer::FearsDeletionOnly,
+            });
+            runestone_phase(state)
+        }
+
+        (Phase::Runestone { strategy }, ChoiceId::Accept | ChoiceId::DelveDeeper) => {
+            let then = if choice == ChoiceId::Accept {
+                AfterCarve::Confirm
+            } else {
+                AfterCarve::Edit
+            };
+            let today = state.today;
+            AdvanceResult {
+                state,
+                effect: Effect::Carve {
+                    strategy,
+                    today,
+                    then,
+                },
+                notice: None,
+            }
+        }
+
+        // A choice id that doesn't belong to the phase cannot come from
+        // parse_line (it maps into the phase's own vector) — defensive.
+        (phase, _) => {
+            state.phase = phase;
+            invalid(state)
+        }
+    }
+}
+
+/// After the residency answers: derive the question list. Zero
+/// candidates means no scene or classification question may exist — with
+/// nothing carvable, no answer changes anything (question economy).
+fn candidates_checkpoint(mut state: EncounterState) -> AdvanceResult {
+    let split = protection_candidates(&state.inventory, &state.drive_residency);
+    if split.candidates.is_empty() {
+        return farewell(
+            state,
+            FarewellKind::EmptyReport(EmptyView::EverythingExcluded {
+                excluded: split.excluded,
+            }),
+        );
+    }
+    state.phase = Phase::SceneGranularity;
+    prompt(state)
+}
+
+fn importance_phase(mut state: EncounterState) -> AdvanceResult {
+    let split = protection_candidates(&state.inventory, &state.drive_residency);
+    state.phase = Phase::Importance {
+        candidates: split.candidates,
+        index: 0,
+    };
+    prompt(state)
+}
+
+/// House-fire scene only when it can change the derivation: at least one
+/// usable destination AND at least one irreplaceable answer. Otherwise
+/// `residence` stays `None` and the runestone follows directly.
+fn residence_or_runestone(mut state: EncounterState) -> AdvanceResult {
+    let (destinations, _) = usable_destinations(&state.inventory, &state.drive_residency);
+    let any_irreplaceable = state
+        .importance
+        .iter()
+        .any(|a| a.importance == Importance::Irreplaceable);
+    if !destinations.is_empty() && any_irreplaceable {
+        state.phase = Phase::Residence { destinations };
+        prompt(state)
+    } else {
+        runestone_phase(state)
+    }
+}
+
+/// Derive and present the proposal — or, when every candidate was
+/// declared not worth history, the honest empty report (route b; the
+/// carve refusal in `commands/encounter.rs` stays the backstop).
+fn runestone_phase(mut state: EncounterState) -> AdvanceResult {
+    let answers = assembled_answers(&state);
+    let strategy = derive_strategy(&state.inventory, &answers, state.today);
+    if strategy.subvolumes.is_empty() {
+        return farewell(
+            state,
+            FarewellKind::EmptyReport(EmptyView::EverythingExcluded {
+                excluded: strategy.excluded,
+            }),
+        );
+    }
+    state.phase = Phase::Runestone { strategy };
+    prompt(state)
+}
+
+fn assembled_answers(state: &EncounterState) -> FateAnswers {
+    FateAnswers {
+        importance: state.importance.clone(),
+        residence: state.residence,
+        granularity: match state.granularity {
+            Some(g) => g,
+            // SceneGranularity precedes every path that derives.
+            None => unreachable!("granularity is always asked before the runestone"),
+        },
+        drive_residency: state.drive_residency.clone(),
+    }
+}
+
+fn prompt(state: EncounterState) -> AdvanceResult {
+    let effect = match prompt_for(&state) {
+        Some(spec) => Effect::Prompt(spec),
+        // Only Done lacks a prompt, and no prompting transition targets
+        // Done — a miss here is a machine bug, not a user state.
+        None => unreachable!("every prompting phase has a PromptSpec"),
+    };
+    AdvanceResult {
+        state,
+        effect,
+        notice: None,
+    }
+}
+
+fn farewell(mut state: EncounterState, kind: FarewellKind) -> AdvanceResult {
+    state.phase = Phase::Done;
+    AdvanceResult {
+        state,
+        effect: Effect::Farewell(kind),
+        notice: None,
+    }
+}
+
+fn invalid(state: EncounterState) -> AdvanceResult {
+    let (effect, notice) = match prompt_for(&state) {
+        Some(spec) => {
+            let choices = spec.choices.len();
+            (
+                Effect::Prompt(spec),
+                Some(InputNotice::InvalidChoice { choices }),
+            )
+        }
+        // Done accepts nothing more; leaving is the only answer.
+        None => (Effect::Farewell(FarewellKind::Quit), None),
+    };
+    AdvanceResult {
+        state,
+        effect,
+        notice,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::LuksState;
+    use crate::strategy::test_support::{
+        drive, external_btrfs_drive, fedora_inventory, for_each_grid_case, grid_scenarios,
+        inventory, pool, subvol, today, EXTERNAL_POOL, SYSTEM_POOL,
+    };
+    use crate::strategy::{ExclusionReason, GapKind};
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    fn spec_of(result: &AdvanceResult) -> &PromptSpec {
+        match &result.effect {
+            Effect::Prompt(spec) => spec,
+            other => panic!("expected a prompt, got {other:?}"),
+        }
+    }
+
+    /// Advance by choice id, resolving its number from the live prompt —
+    /// the same mapping a user's keystroke takes.
+    fn choose(result: AdvanceResult, id: ChoiceId) -> AdvanceResult {
+        let spec = spec_of(&result);
+        let idx = spec
+            .choices
+            .iter()
+            .position(|c| *c == id)
+            .unwrap_or_else(|| panic!("choice {id:?} not offered: {:?}", spec.choices));
+        advance(result.state, Input::Choice(idx))
+    }
+
+    fn fedora_with_external() -> SystemInventory {
+        let mut inv = fedora_inventory();
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/backup"]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        inv
+    }
+
+    /// Walk the fixed head of the conversation: offer → looking →
+    /// (no ambiguous drives) → granularity.
+    fn to_granularity(inv: SystemInventory) -> AdvanceResult {
+        let r = EncounterState::begin(inv, today());
+        let r = choose(r, ChoiceId::Begin);
+        choose(r, ChoiceId::LooksRight)
+    }
+
+    // ── begin / empty inventory (adversary F2) ──────────────────────────
+
+    #[test]
+    fn begin_empty_inventory_farewells_nothing_discovered() {
+        let r = EncounterState::begin(inventory(vec![], vec![], vec![]), today());
+        match r.effect {
+            Effect::Farewell(FarewellKind::EmptyReport(EmptyView::NothingDiscovered {
+                drives,
+                notes,
+            })) => {
+                assert!(drives.is_empty());
+                assert!(notes.is_empty());
+            }
+            other => panic!("expected nothing-discovered farewell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn begin_locked_only_inventory_carries_the_locked_drive() {
+        // All-LUKS-locked machine: no pools, no subvolumes, but the drive
+        // and its note must reach the farewell so it can name the unlock.
+        let locked = drive(
+            "sdd",
+            DriveClass::External,
+            LuksState::Locked,
+            Some("crypto_LUKS"),
+            None,
+        );
+        let inv = SystemInventory {
+            pools: vec![],
+            subvolumes: vec![],
+            drives: vec![locked.clone()],
+            notes: vec![DiscoveryNote::LockedDrive {
+                device: "sdd".to_string(),
+                size: None,
+                transport: None,
+            }],
+        };
+        let r = EncounterState::begin(inv, today());
+        match r.effect {
+            Effect::Farewell(FarewellKind::EmptyReport(EmptyView::NothingDiscovered {
+                drives,
+                notes,
+            })) => {
+                assert_eq!(drives, vec![locked]);
+                assert_eq!(notes.len(), 1);
+            }
+            other => panic!("expected nothing-discovered farewell, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn begin_fedora_inventory_offers() {
+        let r = EncounterState::begin(fedora_inventory(), today());
+        assert_eq!(spec_of(&r).kind, PromptKind::Offer);
+        assert_eq!(spec_of(&r).default, None, "the offer carries no default");
+    }
+
+    // ── Offer / looking ─────────────────────────────────────────────────
+
+    #[test]
+    fn offer_decline_farewells_declined() {
+        let r = EncounterState::begin(fedora_inventory(), today());
+        let r = choose(r, ChoiceId::NotNow);
+        assert_eq!(r.effect, Effect::Farewell(FarewellKind::Declined));
+    }
+
+    #[test]
+    fn offer_accept_shows_the_looking_grouped_by_pool() {
+        let r = EncounterState::begin(fedora_with_external(), today());
+        let r = choose(r, ChoiceId::Begin);
+        match &spec_of(&r).kind {
+            PromptKind::LookingConfirm { view } => {
+                assert_eq!(view.pools.len(), 2);
+                assert_eq!(view.pools[0].subvolumes.len(), 2, "system pool carries / + /home");
+                assert!(view.unjoined.is_empty());
+                assert_eq!(view.drives.len(), 2);
+            }
+            other => panic!("expected the looking, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn looking_mismatch_farewells() {
+        let r = EncounterState::begin(fedora_inventory(), today());
+        let r = choose(r, ChoiceId::Begin);
+        let r = choose(r, ChoiceId::DoesNotMatch);
+        assert_eq!(r.effect, Effect::Farewell(FarewellKind::LookingMismatch));
+    }
+
+    #[test]
+    fn looking_view_shows_unjoinable_mounts() {
+        let mut inv = fedora_inventory();
+        inv.subvolumes.push(DiscoveredSubvol {
+            mountpoint: PathBuf::from("/mnt/image"),
+            subvol_path: "/img".to_string(),
+            is_whole_pool: false,
+            pool_uuid: None,
+        });
+        let view = compose_looking(&inv);
+        assert_eq!(view.unjoined.len(), 1);
+    }
+
+    // ── Ambiguous-drive residency ───────────────────────────────────────
+
+    #[test]
+    fn ambiguous_drives_get_one_residency_question_each_in_order() {
+        let mut inv = fedora_inventory();
+        inv.drives.push(drive(
+            "sdb",
+            DriveClass::Ambiguous,
+            LuksState::NotEncrypted,
+            Some("btrfs"),
+            None,
+        ));
+        inv.drives.push(drive(
+            "sdc",
+            DriveClass::Ambiguous,
+            LuksState::NotEncrypted,
+            None,
+            None,
+        ));
+        let r = EncounterState::begin(inv, today());
+        let r = choose(r, ChoiceId::Begin);
+        let r = choose(r, ChoiceId::LooksRight);
+        match &spec_of(&r).kind {
+            PromptKind::DriveResidency { drive } => assert_eq!(drive.device, "sdb"),
+            other => panic!("expected residency question, got {other:?}"),
+        }
+        let r = choose(r, ChoiceId::PartOfMachine);
+        match &spec_of(&r).kind {
+            PromptKind::DriveResidency { drive } => assert_eq!(drive.device, "sdc"),
+            other => panic!("expected second residency question, got {other:?}"),
+        }
+        let r = choose(r, ChoiceId::CarriedAway);
+        assert_eq!(spec_of(&r).kind, PromptKind::Granularity);
+    }
+
+    #[test]
+    fn no_ambiguous_drives_skips_straight_to_granularity() {
+        let r = to_granularity(fedora_inventory());
+        assert_eq!(spec_of(&r).kind, PromptKind::Granularity);
+    }
+
+    #[test]
+    fn residency_answer_internal_admits_the_pool_as_candidates() {
+        // DA-int shape: an ambiguous drive's pool carries a mounted
+        // subvolume; resolving it internal makes that subvolume a
+        // classification question.
+        let mut inv = fedora_inventory();
+        inv.pools.push(pool(EXTERNAL_POOL, &["/data"]));
+        inv.subvolumes.push(subvol("/data", "/store", EXTERNAL_POOL));
+        inv.drives.push(drive(
+            "sdb",
+            DriveClass::Ambiguous,
+            LuksState::NotEncrypted,
+            Some("btrfs"),
+            Some(EXTERNAL_POOL),
+        ));
+        let r = EncounterState::begin(inv, today());
+        let r = choose(r, ChoiceId::Begin);
+        let r = choose(r, ChoiceId::LooksRight);
+        let r = choose(r, ChoiceId::PartOfMachine);
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        match &spec_of(&r).kind {
+            PromptKind::Importance { total, .. } => {
+                assert_eq!(*total, 3, "/ + /home + /data are all candidates");
+            }
+            other => panic!("expected importance question, got {other:?}"),
+        }
+    }
+
+    // ── Empty routes ────────────────────────────────────────────────────
+
+    #[test]
+    fn whole_pool_only_inventory_reports_everything_excluded() {
+        let inv = inventory(
+            vec![pool(SYSTEM_POOL, &["/"])],
+            vec![subvol("/", "/", SYSTEM_POOL)],
+            vec![drive(
+                "nvme0n1",
+                DriveClass::Internal,
+                LuksState::NotEncrypted,
+                Some("btrfs"),
+                Some(SYSTEM_POOL),
+            )],
+        );
+        let r = EncounterState::begin(inv, today());
+        let r = choose(r, ChoiceId::Begin);
+        let r = choose(r, ChoiceId::LooksRight);
+        match r.effect {
+            Effect::Farewell(FarewellKind::EmptyReport(EmptyView::EverythingExcluded {
+                excluded,
+            })) => {
+                assert_eq!(excluded.len(), 1);
+                assert_eq!(excluded[0].reason, ExclusionReason::WholePoolMount);
+            }
+            other => panic!("expected everything-excluded report, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn all_not_worth_history_reports_everything_excluded() {
+        // Route b: the emptiness is only knowable after classification —
+        // scenes were asked, nothing is carvable, the report says why.
+        let r = to_granularity(fedora_inventory());
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        let r = choose(r, ChoiceId::NotWorthHistory);
+        let r = choose(r, ChoiceId::NotWorthHistory);
+        match r.effect {
+            Effect::Farewell(FarewellKind::EmptyReport(EmptyView::EverythingExcluded {
+                excluded,
+            })) => {
+                assert_eq!(excluded.len(), 2);
+                assert!(excluded
+                    .iter()
+                    .all(|e| e.reason == ExclusionReason::DeclaredNotWorthHistory));
+            }
+            other => panic!("expected everything-excluded report, got {other:?}"),
+        }
+    }
+
+    // ── Quit / invalid input ────────────────────────────────────────────
+
+    #[test]
+    fn quit_farewells_cleanly_at_every_prompting_state() {
+        // Walk the longest path and fire a quit at each prompt.
+        let mut inv = fedora_with_external();
+        inv.drives.push(drive(
+            "sdb",
+            DriveClass::Ambiguous,
+            LuksState::NotEncrypted,
+            None,
+            None,
+        ));
+        let mut r = EncounterState::begin(inv, today());
+        let script = [
+            ChoiceId::Begin,
+            ChoiceId::LooksRight,
+            ChoiceId::PartOfMachine,
+            ChoiceId::YesterdayIsFine,
+            ChoiceId::Replaceable,
+            ChoiceId::Irreplaceable,
+            ChoiceId::DeletionOnly,
+        ];
+        for step in script {
+            let quit = advance(r.state.clone(), Input::Quit);
+            assert_eq!(
+                quit.effect,
+                Effect::Farewell(FarewellKind::Quit),
+                "quit must work at {:?}",
+                spec_of(&r).kind
+            );
+            r = choose(r, step);
+        }
+        // Final prompt is the runestone; quit works there too.
+        let quit = advance(r.state.clone(), Input::Quit);
+        assert_eq!(quit.effect, Effect::Farewell(FarewellKind::Quit));
+    }
+
+    #[test]
+    fn invalid_input_reprompts_the_identical_spec_with_notice() {
+        let r = EncounterState::begin(fedora_inventory(), today());
+        let before = spec_of(&r).clone();
+        let r2 = advance(r.state, Input::Invalid);
+        assert_eq!(
+            r2.notice,
+            Some(InputNotice::InvalidChoice { choices: 2 })
+        );
+        assert_eq!(spec_of(&r2), &before, "re-prompt must be the same spec");
+    }
+
+    #[test]
+    fn out_of_range_choice_index_is_invalid() {
+        let r = EncounterState::begin(fedora_inventory(), today());
+        let r2 = advance(r.state, Input::Choice(7));
+        assert!(r2.notice.is_some());
+    }
+
+    // ── parse_line ──────────────────────────────────────────────────────
+
+    fn offer_spec() -> PromptSpec {
+        PromptSpec {
+            kind: PromptKind::Offer,
+            choices: vec![ChoiceId::Begin, ChoiceId::NotNow],
+            default: None,
+        }
+    }
+
+    #[test]
+    fn parse_numbers_map_one_based_into_range() {
+        let spec = offer_spec();
+        assert_eq!(parse_line(&spec, "1"), Input::Choice(0));
+        assert_eq!(parse_line(&spec, " 2 "), Input::Choice(1));
+        assert_eq!(parse_line(&spec, "0"), Input::Invalid);
+        assert_eq!(parse_line(&spec, "3"), Input::Invalid);
+        assert_eq!(parse_line(&spec, "yes"), Input::Invalid);
+    }
+
+    #[test]
+    fn parse_empty_line_accepts_default_only_when_one_exists() {
+        let mut spec = offer_spec();
+        assert_eq!(parse_line(&spec, ""), Input::Invalid);
+        spec.default = Some(1);
+        assert_eq!(parse_line(&spec, ""), Input::Choice(1));
+        assert_eq!(parse_line(&spec, "  \n"), Input::Choice(1));
+    }
+
+    #[test]
+    fn parse_quit_tokens() {
+        let spec = offer_spec();
+        assert_eq!(parse_line(&spec, "q"), Input::Quit);
+        assert_eq!(parse_line(&spec, "Q"), Input::Quit);
+        assert_eq!(parse_line(&spec, "quit"), Input::Quit);
+        assert_eq!(parse_line(&spec, "QUIT"), Input::Quit);
+    }
+
+    // ── Scenes → runestone → carve ──────────────────────────────────────
+
+    #[test]
+    fn full_accept_path_carves_the_derived_strategy() {
+        let inv = fedora_with_external();
+        let r = to_granularity(inv.clone());
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        // Candidates in inventory order: "/" (proposed Replaceable),
+        // then "/home" (proposed Irreplaceable).
+        let r = choose(r, ChoiceId::Replaceable);
+        let r = choose(r, ChoiceId::Irreplaceable);
+        // Destination + irreplaceable → the house-fire scene is asked.
+        let r = choose(r, ChoiceId::DeletionOnly);
+        match &spec_of(&r).kind {
+            PromptKind::Runestone { view } => {
+                assert_eq!(view.subvolumes.len(), 2);
+                assert_eq!(view.drives.len(), 1);
+            }
+            other => panic!("expected the runestone, got {other:?}"),
+        }
+        assert_eq!(spec_of(&r).default, None, "approving fate has no default");
+        let r = choose(r, ChoiceId::Accept);
+        let Effect::Carve {
+            strategy,
+            today: carve_today,
+            then,
+        } = r.effect
+        else {
+            panic!("expected carve, got {:?}", r.effect);
+        };
+        assert_eq!(then, AfterCarve::Confirm);
+        assert_eq!(carve_today, today());
+        let expected = derive_strategy(
+            &inv,
+            &FateAnswers {
+                importance: vec![
+                    ImportanceAnswer {
+                        mountpoint: PathBuf::from("/"),
+                        importance: Importance::Replaceable,
+                    },
+                    ImportanceAnswer {
+                        mountpoint: PathBuf::from("/home"),
+                        importance: Importance::Irreplaceable,
+                    },
+                ],
+                residence: Some(ResidenceAnswer::FearsDeletionOnly),
+                granularity: GranularityAnswer::YesterdayIsFine,
+                drive_residency: Vec::new(),
+            },
+            today(),
+        );
+        assert_eq!(strategy, expected, "carved strategy must equal the derivation of the fed answers");
+    }
+
+    #[test]
+    fn delve_deeper_emits_the_edit_exit() {
+        let r = to_granularity(fedora_with_external());
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        let r = choose(r, ChoiceId::Replaceable);
+        let r = choose(r, ChoiceId::Irreplaceable);
+        let r = choose(r, ChoiceId::DeletionOnly);
+        let r = choose(r, ChoiceId::DelveDeeper);
+        match r.effect {
+            Effect::Carve { then, .. } => assert_eq!(then, AfterCarve::Edit),
+            other => panic!("expected carve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn residence_skipped_without_destination() {
+        // Irreplaceable data but no usable drive: the house-fire answer
+        // could change nothing — question economy cuts it.
+        let r = to_granularity(fedora_inventory());
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        let r = choose(r, ChoiceId::Replaceable);
+        let r = choose(r, ChoiceId::Irreplaceable);
+        match &spec_of(&r).kind {
+            PromptKind::Runestone { view } => {
+                assert_eq!(view.gaps.len(), 1);
+                assert_eq!(view.gaps[0].kind, GapKind::NoExternalDrive);
+                assert!(!view.gaps[0].demoted.is_empty(), "irreplaceable held at recorded is named");
+            }
+            other => panic!("expected runestone (residence skipped), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn residence_skipped_without_irreplaceable() {
+        let r = to_granularity(fedora_with_external());
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        let r = choose(r, ChoiceId::Replaceable);
+        let r = choose(r, ChoiceId::Replaceable);
+        match &spec_of(&r).kind {
+            PromptKind::Runestone { view } => {
+                assert!(view.drives.is_empty(), "nothing sends → no drive adopted");
+            }
+            other => panic!("expected runestone (residence skipped), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn granularity_last_hour_selects_sentinel_frequency() {
+        let r = to_granularity(fedora_with_external());
+        let r = choose(r, ChoiceId::LastHour);
+        let r = choose(r, ChoiceId::Replaceable);
+        let r = choose(r, ChoiceId::Irreplaceable);
+        let r = choose(r, ChoiceId::DeletionOnly);
+        let r = choose(r, ChoiceId::Accept);
+        match r.effect {
+            Effect::Carve { strategy, .. } => {
+                assert_eq!(strategy.run_frequency, RunFrequency::Sentinel);
+            }
+            other => panic!("expected carve, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn importance_defaults_home_irreplaceable_everything_else_replaceable() {
+        let case = |mount: &str| {
+            proposed_importance(&CandidateSubvol {
+                mountpoint: PathBuf::from(mount),
+                subvol_path: "/x".to_string(),
+                pool_uuid: SYSTEM_POOL.to_string(),
+            })
+        };
+        assert_eq!(case("/home"), Importance::Irreplaceable);
+        assert_eq!(case("/home/user/photos"), Importance::Irreplaceable);
+        assert_eq!(case("/"), Importance::Replaceable);
+        assert_eq!(case("/srv"), Importance::Replaceable);
+        // Component-wise: /homework is NOT under /home.
+        assert_eq!(case("/homework"), Importance::Replaceable);
+    }
+
+    #[test]
+    fn importance_prompt_carries_the_default_inline() {
+        let r = to_granularity(fedora_with_external());
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        // First candidate "/" → default Replaceable (index 1).
+        let spec = spec_of(&r);
+        assert_eq!(spec.default, Some(1));
+        assert_eq!(parse_line(spec, ""), Input::Choice(1), "empty line accepts the default");
+        match &spec.kind {
+            PromptKind::Importance {
+                proposed, position, total, ..
+            } => {
+                assert_eq!(*proposed, Importance::Replaceable);
+                assert_eq!((*position, *total), (1, 2));
+            }
+            other => panic!("expected importance, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn runestone_names_every_bearer_of_a_shared_pool() {
+        // D2-shared-pool: one filesystem across two disks is one adopted
+        // destination, but the runestone must name both disks (074
+        // journal question, pinned 2026-07-04).
+        let mut inv = fedora_inventory();
+        inv.pools.push(pool(EXTERNAL_POOL, &["/run/media/user/raid"]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        inv.drives.push(external_btrfs_drive("sde", EXTERNAL_POOL));
+        let r = to_granularity(inv);
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        let r = choose(r, ChoiceId::Replaceable);
+        let r = choose(r, ChoiceId::Irreplaceable);
+        let r = choose(r, ChoiceId::DeletionOnly);
+        match &spec_of(&r).kind {
+            PromptKind::Runestone { view } => {
+                assert_eq!(view.drives.len(), 1, "one pool is one destination");
+                assert_eq!(view.drives[0].device_names, vec!["sdd", "sde"]);
+                assert_eq!(
+                    view.drives[0].pool_mounts,
+                    vec![PathBuf::from("/run/media/user/raid")]
+                );
+            }
+            other => panic!("expected runestone, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn runestone_carries_unusable_drives_on_the_gap() {
+        let mut inv = fedora_inventory();
+        inv.drives.push(drive(
+            "sdd",
+            DriveClass::External,
+            LuksState::Locked,
+            Some("crypto_LUKS"),
+            None,
+        ));
+        let r = to_granularity(inv);
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        let r = choose(r, ChoiceId::Replaceable);
+        let r = choose(r, ChoiceId::Irreplaceable);
+        match &spec_of(&r).kind {
+            PromptKind::Runestone { view } => {
+                assert_eq!(view.gaps.len(), 1);
+                assert_eq!(view.gaps[0].unusable.len(), 1);
+            }
+            other => panic!("expected runestone, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn today_at_begin_is_today_on_carve() {
+        let other_day = NaiveDate::from_ymd_opt(2027, 1, 1).unwrap();
+        let r = EncounterState::begin(fedora_with_external(), other_day);
+        let r = choose(r, ChoiceId::Begin);
+        let r = choose(r, ChoiceId::LooksRight);
+        let r = choose(r, ChoiceId::YesterdayIsFine);
+        let r = choose(r, ChoiceId::Replaceable);
+        let r = choose(r, ChoiceId::Irreplaceable);
+        let r = choose(r, ChoiceId::DeletionOnly);
+        let r = choose(r, ChoiceId::Accept);
+        match r.effect {
+            Effect::Carve { today: t, .. } => assert_eq!(t, other_day),
+            other => panic!("expected carve, got {other:?}"),
+        }
+    }
+
+    // ── Grid properties ─────────────────────────────────────────────────
+
+    /// Adversary F1: the runestone view is the last seam between what the
+    /// user approves and what gets carved — assert view↔strategy
+    /// correspondence over the whole derivation grid.
+    #[test]
+    fn prop_runestone_view_corresponds_to_strategy_across_the_grid() {
+        for_each_grid_case(|label, inv, _answers, strategy| {
+            let view = compose_runestone(strategy, inv);
+            assert_eq!(view.subvolumes, strategy.subvolumes, "{label}: promises");
+            assert_eq!(view.gaps, strategy.gaps, "{label}: gaps");
+            assert_eq!(view.excluded, strategy.excluded, "{label}: excluded");
+            assert_eq!(view.run_frequency, strategy.run_frequency, "{label}");
+            assert_eq!(view.drives.len(), strategy.drives.len(), "{label}: drive count");
+            for (rune, proposed) in view.drives.iter().zip(&strategy.drives) {
+                assert_eq!(rune.label, proposed.label, "{label}");
+                assert_eq!(rune.mount_path, proposed.mount_path, "{label}");
+                // Every disk bearing the adopted pool is named.
+                let bearers: Vec<&str> = inv
+                    .drives
+                    .iter()
+                    .filter(|d| d.pool_uuid.as_deref() == Some(proposed.uuid.as_str()))
+                    .map(|d| d.device.as_str())
+                    .collect();
+                assert_eq!(rune.device_names, bearers, "{label}: all bearers named");
+            }
+        });
+    }
+
+    /// Question economy across the grid: residency questions equal the
+    /// ambiguous-drive count, classification questions equal the
+    /// candidate count, granularity is asked exactly once when anything
+    /// is carvable, residence exactly when it can change the derivation.
+    #[test]
+    fn prop_question_count_matches_the_derived_question_list() {
+        for (scenario, inv, resolutions) in grid_scenarios() {
+            let mut residency_asked = 0usize;
+            let mut importance_asked = 0usize;
+            let mut granularity_asked = 0usize;
+            let mut residence_asked = 0usize;
+
+            let mut r = EncounterState::begin(inv.clone(), today());
+            let terminal = loop {
+                let spec = match &r.effect {
+                    Effect::Prompt(spec) => spec.clone(),
+                    terminal => break terminal.clone(),
+                };
+                let next = match &spec.kind {
+                    PromptKind::Offer => ChoiceId::Begin,
+                    PromptKind::LookingConfirm { .. } => ChoiceId::LooksRight,
+                    PromptKind::DriveResidency { drive } => {
+                        residency_asked += 1;
+                        match resolutions.iter().find(|a| a.device == drive.device) {
+                            Some(a) if a.class == ResolvedDriveClass::External => {
+                                ChoiceId::CarriedAway
+                            }
+                            Some(_) => ChoiceId::PartOfMachine,
+                            // The grid left it unresolved; the machine
+                            // still requires an answer — pick internal.
+                            None => ChoiceId::PartOfMachine,
+                        }
+                    }
+                    PromptKind::Granularity => {
+                        granularity_asked += 1;
+                        ChoiceId::YesterdayIsFine
+                    }
+                    PromptKind::Importance { mountpoint, .. } => {
+                        importance_asked += 1;
+                        if mountpoint == Path::new("/home") {
+                            ChoiceId::Irreplaceable
+                        } else {
+                            ChoiceId::Replaceable
+                        }
+                    }
+                    PromptKind::Residence { .. } => {
+                        residence_asked += 1;
+                        ChoiceId::DeletionOnly
+                    }
+                    PromptKind::Runestone { .. } => ChoiceId::Accept,
+                };
+                r = choose(r, next);
+            };
+
+            let ambiguous = inv
+                .drives
+                .iter()
+                .filter(|d| d.class == DriveClass::Ambiguous)
+                .count();
+            assert_eq!(
+                residency_asked, ambiguous,
+                "{scenario}: one residency question per ambiguous drive"
+            );
+
+            // Reconstruct the residency answers the walk gave.
+            let walked: Vec<DriveResidencyAnswer> = inv
+                .drives
+                .iter()
+                .filter(|d| d.class == DriveClass::Ambiguous)
+                .map(|d| DriveResidencyAnswer {
+                    device: d.device.clone(),
+                    class: resolutions
+                        .iter()
+                        .find(|a| a.device == d.device)
+                        .map_or(ResolvedDriveClass::Internal, |a| a.class),
+                })
+                .collect();
+            let candidates = protection_candidates(&inv, &walked).candidates;
+            assert_eq!(
+                importance_asked,
+                candidates.len(),
+                "{scenario}: one classification question per candidate"
+            );
+            if candidates.is_empty() {
+                assert_eq!(granularity_asked, 0, "{scenario}: no scene with nothing carvable");
+                assert!(
+                    matches!(
+                        terminal,
+                        Effect::Farewell(FarewellKind::EmptyReport(_))
+                    ),
+                    "{scenario}: empty report expected"
+                );
+            } else {
+                assert_eq!(granularity_asked, 1, "{scenario}");
+                let (destinations, _) = usable_destinations(&inv, &walked);
+                let any_irreplaceable = candidates
+                    .iter()
+                    .any(|c| c.mountpoint == Path::new("/home"));
+                let expect_residence =
+                    usize::from(!destinations.is_empty() && any_irreplaceable);
+                assert_eq!(
+                    residence_asked, expect_residence,
+                    "{scenario}: residence asked iff it changes the derivation"
+                );
+                assert!(
+                    matches!(
+                        terminal,
+                        Effect::Carve { .. } | Effect::Farewell(FarewellKind::EmptyReport(_))
+                    ),
+                    "{scenario}: conversation must end in carve or empty report"
+                );
+            }
+        }
+    }
+}

--- a/src/encounter.rs
+++ b/src/encounter.rs
@@ -22,9 +22,10 @@ use crate::discovery::{
     CandidateDrive, DiscoveredPool, DiscoveredSubvol, DiscoveryNote, DriveClass, SystemInventory,
 };
 use crate::strategy::{
-    derive_strategy, protection_candidates, usable_destinations, CandidateSubvol, Destination,
-    DriveResidencyAnswer, ExcludedSubvol, FateAnswers, Gap, GranularityAnswer, Importance,
-    ImportanceAnswer, ProposedStrategy, ProposedSubvolume, ResidenceAnswer, ResolvedDriveClass,
+    CandidateSubvol, Destination, DriveResidencyAnswer, ExcludedSubvol, FateAnswers, Gap,
+    GranularityAnswer, Importance, ImportanceAnswer, ProposedStrategy, ProposedSubvolume,
+    ResidenceAnswer, ResolvedDriveClass, derive_strategy, protection_candidates,
+    usable_destinations,
 };
 use crate::types::{DriveRole, RunFrequency};
 
@@ -564,9 +565,7 @@ pub fn advance(state: EncounterState, input: Input) -> AdvanceResult {
                 prompt(state)
             }
         }
-        (Phase::Looking, ChoiceId::DoesNotMatch) => {
-            farewell(state, FarewellKind::LookingMismatch)
-        }
+        (Phase::Looking, ChoiceId::DoesNotMatch) => farewell(state, FarewellKind::LookingMismatch),
 
         (
             Phase::DriveResidency { pending, index },
@@ -787,8 +786,8 @@ mod tests {
     use super::*;
     use crate::discovery::LuksState;
     use crate::strategy::test_support::{
-        drive, external_btrfs_drive, fedora_inventory, for_each_grid_case, grid_scenarios,
-        inventory, pool, subvol, today, EXTERNAL_POOL, SYSTEM_POOL,
+        EXTERNAL_POOL, SYSTEM_POOL, drive, external_btrfs_drive, fedora_inventory,
+        for_each_grid_case, grid_scenarios, inventory, pool, subvol, today,
     };
     use crate::strategy::{ExclusionReason, GapKind};
 
@@ -903,7 +902,11 @@ mod tests {
         match &spec_of(&r).kind {
             PromptKind::LookingConfirm { view } => {
                 assert_eq!(view.pools.len(), 2);
-                assert_eq!(view.pools[0].subvolumes.len(), 2, "system pool carries / + /home");
+                assert_eq!(
+                    view.pools[0].subvolumes.len(),
+                    2,
+                    "system pool carries / + /home"
+                );
                 assert!(view.unjoined.is_empty());
                 assert_eq!(view.drives.len(), 2);
             }
@@ -980,7 +983,8 @@ mod tests {
         // classification question.
         let mut inv = fedora_inventory();
         inv.pools.push(pool(EXTERNAL_POOL, &["/data"]));
-        inv.subvolumes.push(subvol("/data", "/store", EXTERNAL_POOL));
+        inv.subvolumes
+            .push(subvol("/data", "/store", EXTERNAL_POOL));
         inv.drives.push(drive(
             "sdb",
             DriveClass::Ambiguous,
@@ -1043,9 +1047,11 @@ mod tests {
                 excluded,
             })) => {
                 assert_eq!(excluded.len(), 2);
-                assert!(excluded
-                    .iter()
-                    .all(|e| e.reason == ExclusionReason::DeclaredNotWorthHistory));
+                assert!(
+                    excluded
+                        .iter()
+                        .all(|e| e.reason == ExclusionReason::DeclaredNotWorthHistory)
+                );
             }
             other => panic!("expected everything-excluded report, got {other:?}"),
         }
@@ -1094,10 +1100,7 @@ mod tests {
         let r = EncounterState::begin(fedora_inventory(), today());
         let before = spec_of(&r).clone();
         let r2 = advance(r.state, Input::Invalid);
-        assert_eq!(
-            r2.notice,
-            Some(InputNotice::InvalidChoice { choices: 2 })
-        );
+        assert_eq!(r2.notice, Some(InputNotice::InvalidChoice { choices: 2 }));
         assert_eq!(spec_of(&r2), &before, "re-prompt must be the same spec");
     }
 
@@ -1197,7 +1200,10 @@ mod tests {
             },
             today(),
         );
-        assert_eq!(strategy, expected, "carved strategy must equal the derivation of the fed answers");
+        assert_eq!(
+            strategy, expected,
+            "carved strategy must equal the derivation of the fed answers"
+        );
     }
 
     #[test]
@@ -1226,7 +1232,10 @@ mod tests {
             PromptKind::Runestone { view } => {
                 assert_eq!(view.gaps.len(), 1);
                 assert_eq!(view.gaps[0].kind, GapKind::NoExternalDrive);
-                assert!(!view.gaps[0].demoted.is_empty(), "irreplaceable held at recorded is named");
+                assert!(
+                    !view.gaps[0].demoted.is_empty(),
+                    "irreplaceable held at recorded is named"
+                );
             }
             other => panic!("expected runestone (residence skipped), got {other:?}"),
         }
@@ -1286,10 +1295,17 @@ mod tests {
         // First candidate "/" → default Replaceable (index 1).
         let spec = spec_of(&r);
         assert_eq!(spec.default, Some(1));
-        assert_eq!(parse_line(spec, ""), Input::Choice(1), "empty line accepts the default");
+        assert_eq!(
+            parse_line(spec, ""),
+            Input::Choice(1),
+            "empty line accepts the default"
+        );
         match &spec.kind {
             PromptKind::Importance {
-                proposed, position, total, ..
+                proposed,
+                position,
+                total,
+                ..
             } => {
                 assert_eq!(*proposed, Importance::Replaceable);
                 assert_eq!((*position, *total), (1, 2));
@@ -1304,7 +1320,8 @@ mod tests {
         // destination, but the runestone must name both disks (074
         // journal question, pinned 2026-07-04).
         let mut inv = fedora_inventory();
-        inv.pools.push(pool(EXTERNAL_POOL, &["/run/media/user/raid"]));
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/raid"]));
         inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
         inv.drives.push(external_btrfs_drive("sde", EXTERNAL_POOL));
         let r = to_granularity(inv);
@@ -1378,7 +1395,11 @@ mod tests {
             assert_eq!(view.gaps, strategy.gaps, "{label}: gaps");
             assert_eq!(view.excluded, strategy.excluded, "{label}: excluded");
             assert_eq!(view.run_frequency, strategy.run_frequency, "{label}");
-            assert_eq!(view.drives.len(), strategy.drives.len(), "{label}: drive count");
+            assert_eq!(
+                view.drives.len(),
+                strategy.drives.len(),
+                "{label}: drive count"
+            );
             for (rune, proposed) in view.drives.iter().zip(&strategy.drives) {
                 assert_eq!(rune.label, proposed.label, "{label}");
                 assert_eq!(rune.mount_path, proposed.mount_path, "{label}");
@@ -1478,12 +1499,12 @@ mod tests {
                 "{scenario}: one classification question per candidate"
             );
             if candidates.is_empty() {
-                assert_eq!(granularity_asked, 0, "{scenario}: no scene with nothing carvable");
+                assert_eq!(
+                    granularity_asked, 0,
+                    "{scenario}: no scene with nothing carvable"
+                );
                 assert!(
-                    matches!(
-                        terminal,
-                        Effect::Farewell(FarewellKind::EmptyReport(_))
-                    ),
+                    matches!(terminal, Effect::Farewell(FarewellKind::EmptyReport(_))),
                     "{scenario}: empty report expected"
                 );
             } else {
@@ -1492,8 +1513,7 @@ mod tests {
                 let any_irreplaceable = candidates
                     .iter()
                     .any(|c| c.mountpoint == Path::new("/home"));
-                let expect_residence =
-                    usize::from(!destinations.is_empty() && any_irreplaceable);
+                let expect_residence = usize::from(!destinations.is_empty() && any_irreplaceable);
                 assert_eq!(
                     residence_asked, expect_residence,
                     "{scenario}: residence asked iff it changes the derivation"

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ mod config_render;
 mod discovery;
 mod drift;
 mod drives;
+#[allow(dead_code)] // Wired in UPI 072 step 7 (doorstep offer).
+mod encounter;
 mod error;
 mod events;
 mod executor;

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,11 +38,13 @@ mod voice_contract;
 mod voice_events;
 
 use std::io::IsTerminal;
+use std::process::ExitCode;
 
 use clap::Parser;
 use cli::{Cli, Commands};
+use commands::CliExit;
 
-fn main() -> anyhow::Result<()> {
+fn main() -> anyhow::Result<ExitCode> {
     let cli = Cli::parse();
 
     // Force colors off when not a TTY (piped output, daemon mode).
@@ -70,26 +72,29 @@ fn main() -> anyhow::Result<()> {
 
     // Strategy A: config-free commands — dispatch before config load
     if let Some(Commands::Completions(ref args)) = cli.command {
-        return commands::completions::run(args);
+        return commands::completions::run(args).map(|()| ExitCode::SUCCESS);
     }
     if let Some(Commands::Migrate(ref args)) = cli.command {
-        return commands::migrate::run(cli.config.as_deref(), args);
+        return commands::migrate::run(cli.config.as_deref(), args).map(|()| ExitCode::SUCCESS);
     }
 
     let output_mode = output::OutputMode::detect();
 
     // Strategy B: bare urd — fallible config load (handled inside default::run)
     if cli.command.is_none() {
-        return commands::default::run(cli.config.as_deref(), output_mode);
+        return commands::default::run(cli.config.as_deref(), output_mode).map(cli_exit_code);
     }
     // `urd init` also loads fallibly: the bare-`urd` greeting points first-time
     // users at it, so a missing config gets guidance, not an I/O error.
     if let Some(Commands::Init) = cli.command {
-        return commands::init::run_cli(cli.config.as_deref(), output_mode);
+        return commands::init::run_cli(cli.config.as_deref(), output_mode).map(cli_exit_code);
     }
 
-    // Strategy C: mandatory config load (all existing commands)
-    let config = config::Config::load(cli.config.as_deref())?;
+    // Strategy C: config required — a missing config prints the one-sentence
+    // pointer and exits with the distinct not-configured code (UPI 072).
+    let Some(config) = commands::load_or_point(cli.config.as_deref(), output_mode)? else {
+        return Ok(cli_exit_code(CliExit::NoConfig));
+    };
 
     // Safe to unwrap: None case returned above
     match cli.command.unwrap() {
@@ -120,4 +125,9 @@ fn main() -> anyhow::Result<()> {
             unreachable!("handled above")
         }
     }
+    .map(|()| ExitCode::SUCCESS)
+}
+
+fn cli_exit_code(exit: CliExit) -> ExitCode {
+    ExitCode::from(exit.code())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,6 @@ mod config_render;
 mod discovery;
 mod drift;
 mod drives;
-#[allow(dead_code)] // Wired in UPI 072 step 7 (doorstep offer).
 mod encounter;
 mod error;
 mod events;

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -41,7 +41,6 @@ use crate::types::{
 /// ignored; `residence: None` while sheltered subvolumes exist derives
 /// `Primary` roles plus a [`GapKind::NoOffsiteDrive`] gap (conservative:
 /// over-inform, never over-promise).
-#[allow(dead_code)] // Constructed by UPI 072 (conversation).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FateAnswers {
     /// One entry per [`protection_candidates`] candidate, keyed by mountpoint.
@@ -55,7 +54,6 @@ pub struct FateAnswers {
 }
 
 /// Per-subvolume importance classification.
-#[allow(dead_code)] // Constructed by UPI 072 (conversation).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportanceAnswer {
     pub mountpoint: PathBuf,
@@ -63,7 +61,6 @@ pub struct ImportanceAnswer {
 }
 
 /// What losing this data would mean.
-#[allow(dead_code)] // Constructed by UPI 072 (conversation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Importance {
     Irreplaceable,
@@ -72,7 +69,6 @@ pub enum Importance {
 }
 
 /// The site-loss fear and where the external drive lives.
-#[allow(dead_code)] // Constructed by UPI 072 (conversation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResidenceAnswer {
     /// Fears fire/theft and the drive stays home → `Primary` + offsite gap.
@@ -84,7 +80,6 @@ pub enum ResidenceAnswer {
 }
 
 /// How far back "recent enough" reaches.
-#[allow(dead_code)] // Constructed by UPI 072 (conversation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GranularityAnswer {
     /// Yesterday is fine → systemd timer, daily.
@@ -97,7 +92,6 @@ pub enum GranularityAnswer {
 /// drive discovery classified `Ambiguous`. Answers for devices that are
 /// not ambiguous (or unknown) are ignored — the inventory stays
 /// observational; answers never overrule what discovery saw directly.
-#[allow(dead_code)] // Constructed by UPI 072 (conversation).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriveResidencyAnswer {
     pub device: String,
@@ -106,7 +100,6 @@ pub struct DriveResidencyAnswer {
 
 /// Resolution of an ambiguous drive — there is no "still ambiguous" answer;
 /// an unanswered drive simply stays out of `drive_residency`.
-#[allow(dead_code)] // Constructed by UPI 072 (conversation).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResolvedDriveClass {
     Internal,
@@ -227,6 +220,11 @@ pub enum UnusableReason {
     NotMounted,
     /// Classified ambiguous and the residency question went unanswered.
     Unresolved,
+    /// External-classified, but its filesystem also spans drives that
+    /// resolve internal — sending there never leaves the machine. A
+    /// false shelter is worse than none (first seen live 2026-07-05: a
+    /// four-disk pool with one hotplug-signalled bearer).
+    MixedPool,
 }
 
 /// A short factual provenance sentence born at derivation time; UPI 074
@@ -350,7 +348,6 @@ fn pool_residency(
 ///
 /// Subvolumes on external-resolved pools are the destination's own mounts:
 /// neither candidates nor excluded rows (the drive side owns them).
-#[allow(dead_code)] // Consumed by UPI 072 (conversation).
 #[must_use]
 pub fn protection_candidates(
     inventory: &SystemInventory,
@@ -416,7 +413,6 @@ fn exclusion(sv: &DiscoveredSubvol, reason: ExclusionReason) -> ExcludedSubvol {
 /// `CandidateDrive.mounted` is never consulted: it is subtree-wide, so a
 /// mounted non-btrfs partition beside an unmounted btrfs pool would lie.
 /// Pool mountpoints are the sole mount authority.
-#[allow(dead_code)] // Consumed by UPI 072 (conversation).
 #[must_use]
 pub fn usable_destinations(
     inventory: &SystemInventory,
@@ -443,6 +439,28 @@ pub fn usable_destinations(
             let fstype = drive.fstype.clone();
             unusable.push(unusable_fact(drive, UnusableReason::NotBtrfs { fstype }));
             continue;
+        }
+        // The drive being external is not enough: the whole POOL must
+        // resolve external, or a send lands on a filesystem that also
+        // lives inside this machine — a false shelter. (Candidate-side
+        // symmetry: such pools' subvolumes are excluded MixedResidency.)
+        if let Some(uuid) = &drive.pool_uuid {
+            match pool_residency(uuid, &inventory.drives, resolutions) {
+                PoolResidency::External => {}
+                PoolResidency::Mixed => {
+                    unusable.push(unusable_fact(drive, UnusableReason::MixedPool));
+                    continue;
+                }
+                // An unresolved sibling keeps the pool unadoptable; the
+                // sibling's own question is the path to resolution.
+                PoolResidency::Ambiguous => {
+                    unusable.push(unusable_fact(drive, UnusableReason::Unresolved));
+                    continue;
+                }
+                // Internal/Unknown cannot occur for a pool this external
+                // drive itself bears — fall through to the mount check.
+                PoolResidency::Internal | PoolResidency::Unknown => {}
+            }
         }
         let joined = drive
             .pool_uuid
@@ -497,7 +515,6 @@ fn canonical_mount(pool: &DiscoveredPool) -> Option<&PathBuf> {
 /// user answered. Pure and total: any `FateAnswers` produces a proposal
 /// (see the robustness contract on [`FateAnswers`]); `today` is injected
 /// so the intention sentences carry the encounter date without I/O.
-#[allow(dead_code)] // Consumed by UPI 072 (conversation) / 074 (config generation).
 #[must_use]
 pub fn derive_strategy(
     inventory: &SystemInventory,
@@ -969,6 +986,24 @@ pub(crate) mod test_support {
             .push(subvol("/mnt/second", "/vault", ORPHAN_POOL));
         scenarios.push(("D-multipool", inv, Vec::new()));
 
+        // Field find 2026-07-05: a pool spanning an external-classified
+        // drive AND an internal one (four-disk pool, one hotplug-
+        // signalled bearer). The external bearer must never become a
+        // destination — a send there never leaves the machine.
+        let mut inv = fedora3();
+        inv.pools.push(pool(EXTERNAL_POOL, &["/mnt/tank"]));
+        inv.subvolumes
+            .push(subvol("/mnt/tank", "/tank", EXTERNAL_POOL));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        inv.drives.push(drive(
+            "sde",
+            DriveClass::Internal,
+            LuksState::NotEncrypted,
+            Some("btrfs"),
+            Some(EXTERNAL_POOL),
+        ));
+        scenarios.push(("D-mixed-pool", inv, Vec::new()));
+
         scenarios
     }
 
@@ -1263,6 +1298,50 @@ mod tests {
         let strategy = derive_strategy(&inv, &answers, today());
         assert_eq!(strategy.drives.len(), 1);
         assert_eq!(strategy.drives[0].uuid, EXTERNAL_POOL);
+    }
+
+    #[test]
+    fn mixed_residency_pool_is_never_a_destination() {
+        // Field find 2026-07-05: one external-classified bearer beside
+        // internal siblings on the same filesystem. Adopting it sends
+        // "sheltered" data to a pool that never leaves the machine —
+        // the drive side must refuse for the same reason the candidate
+        // side excludes the pool's subvolumes (MixedResidency).
+        let mut inv = fedora_inventory();
+        inv.pools.push(pool(EXTERNAL_POOL, &["/mnt/tank"]));
+        inv.subvolumes
+            .push(subvol("/mnt/tank", "/tank", EXTERNAL_POOL));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        inv.drives.push(drive(
+            "sde",
+            DriveClass::Internal,
+            LuksState::NotEncrypted,
+            Some("btrfs"),
+            Some(EXTERNAL_POOL),
+        ));
+
+        let (usable, unusable) = usable_destinations(&inv, &[]);
+        assert!(usable.is_empty(), "a mixed pool must never be adopted");
+        assert_eq!(unusable.len(), 1);
+        assert_eq!(unusable[0].device, "sdd");
+        assert_eq!(unusable[0].reason, UnusableReason::MixedPool);
+
+        // Candidate-side symmetry: the pool's subvolume is excluded too.
+        let split = protection_candidates(&inv, &[]);
+        assert!(split
+            .excluded
+            .iter()
+            .any(|e| e.mountpoint == Path::new("/mnt/tank")
+                && e.reason == ExclusionReason::MixedResidency));
+
+        // And the derivation demotes rather than falsely shelters.
+        let answers = with_importance(base_answers(), "/home", Importance::Irreplaceable);
+        let strategy = derive_strategy(&inv, &answers, today());
+        assert!(strategy.drives.is_empty());
+        assert!(strategy
+            .gaps
+            .iter()
+            .any(|g| g.kind == GapKind::NoExternalDrive && !g.demoted.is_empty()));
     }
 
     #[test]

--- a/src/voice/encounter.rs
+++ b/src/voice/encounter.rs
@@ -229,7 +229,10 @@ fn drive_facts_line(drive: &CandidateDrive) -> String {
         DriveClass::External => "external",
         DriveClass::Ambiguous => "internal or external — unclear",
     };
-    format!("{} ({class})", parts.join(", "))
+    // Subtree-wide mount fact: a drive already in use should read as in
+    // use before anyone considers it a backup target.
+    let in_use = if drive.mounted { ", in use" } else { "" };
+    format!("{} ({class}{in_use})", parts.join(", "))
 }
 
 /// The per-drive honesty clause: locked and non-btrfs drives are named
@@ -466,6 +469,10 @@ fn unusable_sentence(drive: &UnusableDrive) -> String {
         UnusableReason::Unresolved => {
             format!("{name} stayed unresolved — run `urd init` again to answer for it.")
         }
+        UnusableReason::MixedPool => format!(
+            "{name} shares its filesystem with drives inside this machine — \
+             sending there would never leave the building."
+        ),
     }
 }
 
@@ -970,10 +977,15 @@ mod tests {
             },
             R::NotMounted,
             R::Unresolved,
+            R::MixedPool,
         ];
         for r in &all {
             match r {
-                R::Locked | R::NotBtrfs { .. } | R::NotMounted | R::Unresolved => {}
+                R::Locked
+                | R::NotBtrfs { .. }
+                | R::NotMounted
+                | R::Unresolved
+                | R::MixedPool => {}
             }
         }
         let rendered: Vec<String> = all

--- a/src/voice/encounter.rs
+++ b/src/voice/encounter.rs
@@ -18,7 +18,7 @@ use crate::encounter::{
     ChoiceId, EmptyView, FarewellKind, InputNotice, LookingView, PromptKind, PromptSpec,
     RunestoneView,
 };
-use crate::strategy::{ExclusionReason, Gap, GapKind, UnusableDrive, UnusableReason};
+use crate::strategy::{Destination, ExclusionReason, Gap, GapKind, UnusableDrive, UnusableReason};
 use crate::types::{ProtectionLevel, RunFrequency};
 
 // ── Prompts ─────────────────────────────────────────────────────────────
@@ -503,7 +503,7 @@ fn exclusion_sentence(reason: ExclusionReason) -> &'static str {
     }
 }
 
-fn destination_name(dest: &crate::strategy::Destination) -> String {
+fn destination_name(dest: &Destination) -> String {
     match &dest.label {
         Some(label) => label.clone(),
         None => format!("the drive {}", dest.device),

--- a/src/voice/encounter.rs
+++ b/src/voice/encounter.rs
@@ -157,7 +157,12 @@ pub fn render_invalid_notice(notice: &InputNotice) -> String {
 
 fn render_looking(view: &LookingView) -> String {
     let mut out = String::new();
-    writeln!(out, "{}", "I have looked. Here is what this machine holds:".bold()).ok();
+    writeln!(
+        out,
+        "{}",
+        "I have looked. Here is what this machine holds:".bold()
+    )
+    .ok();
     for entry in &view.pools {
         let label = entry
             .pool
@@ -311,11 +316,18 @@ fn short_uuid(uuid: &str) -> &str {
 
 fn render_runestone(view: &RunestoneView) -> String {
     let mut out = String::new();
-    writeln!(out, "{}", "The runestone. Read it before you answer:".bold()).ok();
+    writeln!(
+        out,
+        "{}",
+        "The runestone. Read it before you answer:".bold()
+    )
+    .ok();
 
     let cadence = match view.run_frequency {
         RunFrequency::Timer { .. } => "Backups run nightly, around 04:00.",
-        RunFrequency::Sentinel => "The sentinel watches continuously — snapshots follow your changes through the day.",
+        RunFrequency::Sentinel => {
+            "The sentinel watches continuously — snapshots follow your changes through the day."
+        }
     };
     writeln!(out, "\n  {cadence}").ok();
 
@@ -479,16 +491,12 @@ fn unusable_sentence(drive: &UnusableDrive) -> String {
 fn exclusion_sentence(reason: ExclusionReason) -> &'static str {
     match reason {
         ExclusionReason::DeclaredNotWorthHistory => "you said it is not worth history",
-        ExclusionReason::WholePoolMount => {
-            "a whole-pool mount — an odd promise; I do not offer it"
-        }
+        ExclusionReason::WholePoolMount => "a whole-pool mount — an odd promise; I do not offer it",
         ExclusionReason::UnknownPool => "no disk I can see explains this mount",
         ExclusionReason::AmbiguousDevice => {
             "its drive stayed unresolved — internal or carried, I cannot say"
         }
-        ExclusionReason::MixedResidency => {
-            "its pool spans drives that live in different places"
-        }
+        ExclusionReason::MixedResidency => "its pool spans drives that live in different places",
         ExclusionReason::UnknownResidency => {
             "no drive claims its pool — I will not guess where it lives"
         }
@@ -509,17 +517,13 @@ fn destination_name(dest: &crate::strategy::Destination) -> String {
 #[must_use]
 pub fn render_farewell(kind: &FarewellKind) -> String {
     match kind {
-        FarewellKind::Declined => {
-            "So be it. Nothing was written.\n\
+        FarewellKind::Declined => "So be it. Nothing was written.\n\
              When you are ready, run `urd init`.\n"
-                .to_string()
-        }
-        FarewellKind::LookingMismatch => {
-            "Then my view is incomplete. Nothing was written.\n\
+            .to_string(),
+        FarewellKind::LookingMismatch => "Then my view is incomplete. Nothing was written.\n\
              Mount or unlock what is missing, then run `urd init` again — \
              looking again is free.\n"
-                .to_string()
-        }
+            .to_string(),
         FarewellKind::Quit => "Nothing was written. Run `urd init` to start over.\n".to_string(),
         FarewellKind::EmptyReport(view) => render_empty_report(view),
     }
@@ -633,13 +637,14 @@ pub fn render_no_editor(path: &Path) -> String {
 mod tests {
     use super::*;
     use crate::discovery::Probe;
-    use crate::encounter::{compose_looking, compose_runestone, EncounterState, Effect, Input};
+    use crate::encounter::{Effect, EncounterState, Input, compose_looking, compose_runestone};
     use crate::strategy::test_support::{
-        drive as mk_drive, external_btrfs_drive, fedora_inventory, inventory, pool, subvol,
-        today, EXTERNAL_POOL, SYSTEM_POOL,
+        EXTERNAL_POOL, SYSTEM_POOL, drive as mk_drive, external_btrfs_drive, fedora_inventory,
+        inventory, pool, subvol, today,
     };
-    use crate::strategy::{derive_strategy, FateAnswers, GranularityAnswer, Importance,
-        ImportanceAnswer};
+    use crate::strategy::{
+        FateAnswers, GranularityAnswer, Importance, ImportanceAnswer, derive_strategy,
+    };
     use crate::voice::test_fixtures::color_guard;
     use std::path::PathBuf;
 
@@ -962,8 +967,10 @@ mod tests {
                 | R::UnknownResidency => {}
             }
         }
-        let rendered: Vec<String> =
-            all.iter().map(|r| exclusion_sentence(*r).to_string()).collect();
+        let rendered: Vec<String> = all
+            .iter()
+            .map(|r| exclusion_sentence(*r).to_string())
+            .collect();
         assert_all_distinct("ExclusionReason", &rendered);
     }
 
@@ -981,11 +988,7 @@ mod tests {
         ];
         for r in &all {
             match r {
-                R::Locked
-                | R::NotBtrfs { .. }
-                | R::NotMounted
-                | R::Unresolved
-                | R::MixedPool => {}
+                R::Locked | R::NotBtrfs { .. } | R::NotMounted | R::Unresolved | R::MixedPool => {}
             }
         }
         let rendered: Vec<String> = all

--- a/src/voice/encounter.rs
+++ b/src/voice/encounter.rs
@@ -1,0 +1,1078 @@
+//! The Fate Conversation's renderer (UPI 072). Interactive-only by
+//! construction — the doorstep gate guarantees a terminal before the
+//! conversation starts, so these renderers take no `OutputMode`
+//! (a `mode` parameter with one reachable arm invites dead daemon arms).
+//!
+//! Register: direct, unflinching, factual. No assumed user behaviors, no
+//! over-explaining, no cheese, no fortune-cookie preambles. Wording gets
+//! one full rewrite post-Voice-arc; tests assert content presence, never
+//! exact phrasing.
+
+use std::fmt::Write;
+use std::path::Path;
+
+use colored::Colorize;
+
+use crate::discovery::{CandidateDrive, DiscoveryNote, DriveClass, LuksState, NoiseCategory};
+use crate::encounter::{
+    ChoiceId, EmptyView, FarewellKind, InputNotice, LookingView, PromptKind, PromptSpec,
+    RunestoneView,
+};
+use crate::strategy::{ExclusionReason, Gap, GapKind, UnusableDrive, UnusableReason};
+use crate::types::{ProtectionLevel, RunFrequency};
+
+// ── Prompts ─────────────────────────────────────────────────────────────
+
+/// Render one prompt: its content, then the numbered choices — numbered
+/// from the same vector `parse_line` validates, so display and parsing
+/// cannot drift. The default (when one exists) is marked as the
+/// Enter-accepts option.
+#[must_use]
+pub fn render_prompt(spec: &PromptSpec) -> String {
+    let mut out = String::new();
+    match &spec.kind {
+        PromptKind::Offer => {
+            writeln!(out, "{}", "Urd is not configured yet.".bold()).ok();
+            writeln!(
+                out,
+                "I can look at what this machine has and propose how to protect it.\n\
+                 Nothing is written without your approval; leaving costs nothing."
+            )
+            .ok();
+        }
+        PromptKind::LookingConfirm { view } => {
+            out.push_str(&render_looking(view));
+            writeln!(out, "\nDoes this match what you have?").ok();
+        }
+        PromptKind::DriveResidency { drive } => {
+            writeln!(out, "{}", drive_facts_line(drive)).ok();
+            writeln!(
+                out,
+                "I cannot tell what this drive is to you.\n\
+                 Is it part of this machine, or one you carry?"
+            )
+            .ok();
+        }
+        PromptKind::Granularity => {
+            writeln!(
+                out,
+                "A folder is deleted and nobody notices until evening.\n\
+                 How far back must your history reach?"
+            )
+            .ok();
+        }
+        PromptKind::Importance {
+            mountpoint,
+            subvol_path,
+            proposed: _,
+            position,
+            total,
+        } => {
+            if *position == 1 {
+                writeln!(
+                    out,
+                    "Now: the drive inside this machine dies tonight.\n\
+                     For each place you keep data, tell me what its loss would mean."
+                )
+                .ok();
+                writeln!(out).ok();
+            }
+            writeln!(
+                out,
+                "{} of {}: {} (subvolume {})",
+                position,
+                total,
+                mountpoint.display().to_string().bold(),
+                subvol_path
+            )
+            .ok();
+        }
+        PromptKind::Residence { destinations } => {
+            let name = destinations
+                .first()
+                .map(destination_name)
+                .unwrap_or_else(|| "the drive".to_string());
+            writeln!(
+                out,
+                "Last: fire, or a break-in. This machine and everything beside it is gone.\n\
+                 Where does {name} live?"
+            )
+            .ok();
+        }
+        PromptKind::Runestone { view } => {
+            out.push_str(&render_runestone(view));
+        }
+    }
+    out.push_str(&render_choices(spec));
+    out
+}
+
+fn render_choices(spec: &PromptSpec) -> String {
+    let mut out = String::new();
+    writeln!(out).ok();
+    for (i, choice) in spec.choices.iter().enumerate() {
+        let marker = if spec.default == Some(i) {
+            "  (Enter)"
+        } else {
+            ""
+        };
+        writeln!(out, "  {}) {}{}", i + 1, choice_label(*choice), marker).ok();
+    }
+    writeln!(out, "  q) leave — nothing is written").ok();
+    out
+}
+
+fn choice_label(id: ChoiceId) -> &'static str {
+    match id {
+        ChoiceId::Begin => "begin",
+        ChoiceId::NotNow => "not now",
+        ChoiceId::LooksRight => "that matches",
+        ChoiceId::DoesNotMatch => "something is missing or wrong",
+        ChoiceId::PartOfMachine => "part of this machine",
+        ChoiceId::CarriedAway => "one I carry",
+        ChoiceId::YesterdayIsFine => "yesterday is fine",
+        ChoiceId::LastHour => "the last hour matters",
+        ChoiceId::Irreplaceable => "irreplaceable — it exists nowhere else",
+        ChoiceId::Replaceable => "replaceable — losing it costs time, not memories",
+        ChoiceId::NotWorthHistory => "not worth history — leave it out",
+        ChoiceId::SiteLossDriveStays => "it stays here, beside the machine",
+        ChoiceId::KeptElsewhere => "it lives somewhere else",
+        ChoiceId::DeletionOnly => "I fear mistakes, not fires",
+        ChoiceId::Accept => "so be it — carve this",
+        ChoiceId::DelveDeeper => "delve deeper — open the file in my editor",
+    }
+}
+
+/// One line after unusable input, then the same prompt again.
+#[must_use]
+pub fn render_invalid_notice(notice: &InputNotice) -> String {
+    match notice {
+        InputNotice::InvalidChoice { choices } => {
+            format!("Choose 1\u{2013}{choices}, or q to leave.\n")
+        }
+    }
+}
+
+// ── The looking ─────────────────────────────────────────────────────────
+
+fn render_looking(view: &LookingView) -> String {
+    let mut out = String::new();
+    writeln!(out, "{}", "I have looked. Here is what this machine holds:".bold()).ok();
+    for entry in &view.pools {
+        let label = entry
+            .pool
+            .label
+            .clone()
+            .unwrap_or_else(|| format!("pool {}", short_uuid(&entry.pool.uuid)));
+        let space = entry
+            .pool
+            .space
+            .as_ref()
+            .map(|s| {
+                format!(
+                    " — {} free of {}",
+                    crate::types::ByteSize(s.free_bytes),
+                    crate::types::ByteSize(s.capacity_bytes)
+                )
+            })
+            .unwrap_or_default();
+        writeln!(out, "\n  {}{}", label.bold(), space).ok();
+        for sv in &entry.subvolumes {
+            writeln!(
+                out,
+                "    {}  (subvolume {})",
+                sv.mountpoint.display(),
+                sv.subvol_path
+            )
+            .ok();
+        }
+        if entry.subvolumes.is_empty() {
+            writeln!(out, "    no mounted subvolumes").ok();
+        }
+    }
+    for sv in &view.unjoined {
+        writeln!(
+            out,
+            "  {} — mounted, but I cannot tell which disk carries it",
+            sv.mountpoint.display()
+        )
+        .ok();
+    }
+    if !view.drives.is_empty() {
+        writeln!(out, "\n  Drives:").ok();
+        for drive in &view.drives {
+            writeln!(out, "    {}", drive_facts_line(drive)).ok();
+            if let Some(sentence) = drive_status_sentence(drive) {
+                writeln!(out, "      {sentence}").ok();
+            }
+        }
+    }
+    for note in &view.notes {
+        writeln!(out, "  {}", note_sentence(note)).ok();
+    }
+    out
+}
+
+fn drive_facts_line(drive: &CandidateDrive) -> String {
+    let mut parts = vec![drive.device.clone()];
+    if let Some(label) = &drive.label {
+        parts.push(label.clone());
+    }
+    if let Some(size) = &drive.size {
+        parts.push(size.clone());
+    }
+    if let Some(transport) = &drive.transport {
+        parts.push(transport.clone());
+    }
+    let class = match drive.class {
+        DriveClass::Internal => "internal",
+        DriveClass::External => "external",
+        DriveClass::Ambiguous => "internal or external — unclear",
+    };
+    format!("{} ({class})", parts.join(", "))
+}
+
+/// The per-drive honesty clause: locked and non-btrfs drives are named
+/// with their exact path to usefulness — and the command Urd will never
+/// run herself (arc grill Q10).
+fn drive_status_sentence(drive: &CandidateDrive) -> Option<String> {
+    if drive.luks == LuksState::Locked {
+        return Some(
+            "locked — unlock it with your file manager, then run `urd init` again; \
+             looking again is free"
+                .to_string(),
+        );
+    }
+    match drive.fstype.as_deref() {
+        Some("btrfs") | None => None,
+        Some(fstype) => Some(format!(
+            "carries {fstype}, not btrfs. To make it a backup drive: \
+             `sudo mkfs.btrfs /dev/{}` — that erases everything on it. \
+             Urd will never run this for you.",
+            drive.device
+        )),
+    }
+}
+
+fn note_sentence(note: &DiscoveryNote) -> String {
+    match note {
+        DiscoveryNote::LockedDrive {
+            device,
+            size,
+            transport,
+        } => {
+            let mut facts = vec![device.clone()];
+            if let Some(s) = size {
+                facts.push(s.clone());
+            }
+            if let Some(t) = transport {
+                facts.push(t.clone());
+            }
+            format!(
+                "A locked drive ({}) — its contents are sealed to me. \
+                 Unlock it with your file manager, then run `urd init` again.",
+                facts.join(", ")
+            )
+        }
+        DiscoveryNote::FilteredNoise { category, count } => match category {
+            NoiseCategory::SnapperSnapshots => {
+                format!("{count} snapper snapshot mounts left out of this view.")
+            }
+            NoiseCategory::DuplicateMounts => {
+                format!("{count} duplicate mounts of the same subvolume left out.")
+            }
+        },
+        DiscoveryNote::HiddenStructureLikely { pool_uuid } => format!(
+            "Pool {} likely holds more subvolumes than I can see unprivileged.",
+            short_uuid(pool_uuid)
+        ),
+        DiscoveryNote::UnjoinableMount { mountpoint, source } => format!(
+            "{} comes from {source}, which no disk I can see explains.",
+            mountpoint.display()
+        ),
+        DiscoveryNote::ProbeDegraded { probe, detail } => {
+            let name = match probe {
+                crate::discovery::Probe::Lsblk => "lsblk",
+                crate::discovery::Probe::Findmnt => "findmnt",
+            };
+            format!("My {name} probe failed ({detail}) — this view is incomplete.")
+        }
+    }
+}
+
+fn short_uuid(uuid: &str) -> &str {
+    uuid.get(..8).unwrap_or(uuid)
+}
+
+// ── The runestone ───────────────────────────────────────────────────────
+
+fn render_runestone(view: &RunestoneView) -> String {
+    let mut out = String::new();
+    writeln!(out, "{}", "The runestone. Read it before you answer:".bold()).ok();
+
+    let cadence = match view.run_frequency {
+        RunFrequency::Timer { .. } => "Backups run nightly, around 04:00.",
+        RunFrequency::Sentinel => "The sentinel watches continuously — snapshots follow your changes through the day.",
+    };
+    writeln!(out, "\n  {cadence}").ok();
+
+    writeln!(out, "\n  {}", "Promises:".bold()).ok();
+    for sv in &view.subvolumes {
+        let meaning = match sv.level {
+            ProtectionLevel::Sheltered => "snapshots kept here and sent to the drive",
+            ProtectionLevel::Recorded => "snapshots kept on this machine only",
+            // Never derived (ADR-110 maturity) — rendered honestly if it
+            // ever appears rather than hidden.
+            ProtectionLevel::Fortified | ProtectionLevel::Custom => "custom protection",
+        };
+        writeln!(
+            out,
+            "    {}  ({})  \u{2014} {}: {}",
+            sv.name.bold(),
+            sv.source.display(),
+            sv.level,
+            meaning
+        )
+        .ok();
+    }
+
+    if !view.drives.is_empty() {
+        writeln!(out, "\n  {}", "Drives:".bold()).ok();
+        for drive in &view.drives {
+            let mut facts = Vec::new();
+            if let Some(label) = &drive.pool_label {
+                facts.push(label.clone());
+            }
+            if let Some(size) = &drive.size {
+                facts.push(size.clone());
+            }
+            if let Some(transport) = &drive.transport {
+                facts.push(transport.clone());
+            }
+            let disks = drive.device_names.join(" + ");
+            let facts = if facts.is_empty() {
+                String::new()
+            } else {
+                format!(" ({})", facts.join(", "))
+            };
+            writeln!(
+                out,
+                "    {}{facts} \u{2014} {}, mounted at {}, adopted as {} drive",
+                drive.label.bold(),
+                if disks.is_empty() {
+                    "disk unknown".to_string()
+                } else {
+                    format!("one filesystem across {disks}")
+                },
+                drive.mount_path.display(),
+                drive.role
+            )
+            .ok();
+            if !drive.pool_mounts.is_empty() {
+                let mounts: Vec<String> = drive
+                    .pool_mounts
+                    .iter()
+                    .map(|m| m.display().to_string())
+                    .collect();
+                writeln!(
+                    out,
+                    "      it already carries data, mounted at {}",
+                    mounts.join(", ")
+                )
+                .ok();
+            }
+        }
+    }
+
+    if !view.gaps.is_empty() {
+        writeln!(out, "\n  {}", "What this cannot survive:".bold()).ok();
+        for gap in &view.gaps {
+            out.push_str(&render_gap(gap));
+        }
+    }
+
+    if !view.excluded.is_empty() {
+        writeln!(out, "\n  {}", "Left out:".bold()).ok();
+        for excluded in &view.excluded {
+            writeln!(
+                out,
+                "    {} \u{2014} {}",
+                excluded.mountpoint.display(),
+                exclusion_sentence(excluded.reason)
+            )
+            .ok();
+        }
+    }
+    out
+}
+
+fn render_gap(gap: &Gap) -> String {
+    let mut out = String::new();
+    match gap.kind {
+        GapKind::NoExternalDrive => {
+            writeln!(
+                out,
+                "    The death of this machine's drive. No usable backup drive exists — \
+                 every snapshot lives beside the data it protects."
+            )
+            .ok();
+            if !gap.demoted.is_empty() {
+                writeln!(
+                    out,
+                    "      You called {} irreplaceable; until a drive arrives, \
+                     I can only record locally. Plug in a btrfs drive and run `urd init`.",
+                    gap.demoted.join(", ")
+                )
+                .ok();
+            }
+        }
+        GapKind::NoOffsiteDrive => {
+            writeln!(
+                out,
+                "    Fire or theft. No drive lives away from this place — \
+                 what burns here, burns everywhere."
+            )
+            .ok();
+        }
+    }
+    for unusable in &gap.unusable {
+        writeln!(out, "      {}", unusable_sentence(unusable)).ok();
+    }
+    out
+}
+
+fn unusable_sentence(drive: &UnusableDrive) -> String {
+    let name = match &drive.label {
+        Some(label) => format!("{} ({})", drive.device, label),
+        None => drive.device.clone(),
+    };
+    match &drive.reason {
+        UnusableReason::Locked => format!(
+            "{name} is locked — unlock it with your file manager, then run `urd init` again."
+        ),
+        UnusableReason::NotBtrfs { fstype } => {
+            let carries = fstype
+                .clone()
+                .unwrap_or_else(|| "no filesystem".to_string());
+            format!(
+                "{name} carries {carries}, not btrfs. To use it: `sudo mkfs.btrfs /dev/{}` \
+                 — that erases everything on it. Urd will never run this for you.",
+                drive.device
+            )
+        }
+        UnusableReason::NotMounted => {
+            format!("{name} is btrfs but not mounted — mount it, then run `urd init` again.")
+        }
+        UnusableReason::Unresolved => {
+            format!("{name} stayed unresolved — run `urd init` again to answer for it.")
+        }
+    }
+}
+
+fn exclusion_sentence(reason: ExclusionReason) -> &'static str {
+    match reason {
+        ExclusionReason::DeclaredNotWorthHistory => "you said it is not worth history",
+        ExclusionReason::WholePoolMount => {
+            "a whole-pool mount — an odd promise; I do not offer it"
+        }
+        ExclusionReason::UnknownPool => "no disk I can see explains this mount",
+        ExclusionReason::AmbiguousDevice => {
+            "its drive stayed unresolved — internal or carried, I cannot say"
+        }
+        ExclusionReason::MixedResidency => {
+            "its pool spans drives that live in different places"
+        }
+        ExclusionReason::UnknownResidency => {
+            "no drive claims its pool — I will not guess where it lives"
+        }
+    }
+}
+
+fn destination_name(dest: &crate::strategy::Destination) -> String {
+    match &dest.label {
+        Some(label) => label.clone(),
+        None => format!("the drive {}", dest.device),
+    }
+}
+
+// ── Endings ─────────────────────────────────────────────────────────────
+
+/// The conversation's ending line(s). Every variant states the one fact
+/// that matters: nothing was written.
+#[must_use]
+pub fn render_farewell(kind: &FarewellKind) -> String {
+    match kind {
+        FarewellKind::Declined => {
+            "So be it. Nothing was written.\n\
+             When you are ready, run `urd init`.\n"
+                .to_string()
+        }
+        FarewellKind::LookingMismatch => {
+            "Then my view is incomplete. Nothing was written.\n\
+             Mount or unlock what is missing, then run `urd init` again — \
+             looking again is free.\n"
+                .to_string()
+        }
+        FarewellKind::Quit => "Nothing was written. Run `urd init` to start over.\n".to_string(),
+        FarewellKind::EmptyReport(view) => render_empty_report(view),
+    }
+}
+
+/// The honest ending when there is nothing to carve. Two distinct
+/// contracts: nothing-discovered points at hardware; everything-excluded
+/// explains each exclusion. Never reaches the carve.
+#[must_use]
+pub fn render_empty_report(view: &EmptyView) -> String {
+    let mut out = String::new();
+    match view {
+        EmptyView::NothingDiscovered { drives, notes } => {
+            writeln!(
+                out,
+                "{}",
+                "I see no btrfs filesystems on this machine.".bold()
+            )
+            .ok();
+            writeln!(
+                out,
+                "Urd preserves btrfs history; without a btrfs filesystem there is \
+                 nothing I can promise."
+            )
+            .ok();
+            for drive in drives {
+                writeln!(out, "  {}", drive_facts_line(drive)).ok();
+                if let Some(sentence) = drive_status_sentence(drive) {
+                    writeln!(out, "    {sentence}").ok();
+                }
+            }
+            for note in notes {
+                writeln!(out, "  {}", note_sentence(note)).ok();
+            }
+            writeln!(out, "Nothing was written.").ok();
+        }
+        EmptyView::EverythingExcluded { excluded } => {
+            writeln!(out, "{}", "Nothing I can promise to protect.".bold()).ok();
+            if excluded.is_empty() {
+                writeln!(
+                    out,
+                    "Everything I found belongs to a destination drive, not to this machine."
+                )
+                .ok();
+            }
+            for entry in excluded {
+                writeln!(
+                    out,
+                    "  {} \u{2014} {}",
+                    entry.mountpoint.display(),
+                    exclusion_sentence(entry.reason)
+                )
+                .ok();
+            }
+            writeln!(
+                out,
+                "Nothing was written. Change what is mounted or classified, \
+                 then run `urd init` again."
+            )
+            .ok();
+        }
+    }
+    out
+}
+
+/// After a successful carve: name the file, point at the next verb.
+/// (The seal — sudo grant, first snapshot — is UPI 075; until it lands,
+/// `urd init` verifies the environment.)
+#[must_use]
+pub fn render_post_carve(path: &Path) -> String {
+    format!(
+        "{} {}\n\
+         Your promises are carved. Run `urd init` to verify your setup.\n",
+        "Carved:".bold(),
+        path.display()
+    )
+}
+
+// ── The delve-deeper editor loop (rendered here, driven by commands) ────
+
+/// The visudo-shaped failure prompt after an edit broke the config.
+/// `(r)evert` appears only when a generated baseline exists (never on
+/// `urd init` re-entry into a hand-edited file).
+#[must_use]
+pub fn render_editor_failure(error: &str, revert_available: bool) -> String {
+    let mut out = String::new();
+    writeln!(out, "The edited config does not load:").ok();
+    writeln!(out, "  {error}").ok();
+    writeln!(out).ok();
+    writeln!(out, "  e) edit again  (Enter)").ok();
+    if revert_available {
+        writeln!(out, "  r) revert to the config Urd carved").ok();
+    }
+    writeln!(out, "  q) keep the file as it is and leave").ok();
+    out
+}
+
+/// Delve-deeper was chosen but no editor is set. The file is already
+/// carved and valid — keeping it is the honest fallback, never deletion.
+#[must_use]
+pub fn render_no_editor(path: &Path) -> String {
+    format!(
+        "No editor is set ($VISUAL and $EDITOR are both empty).\n\
+         The config is carved at {} — edit it yourself when you wish;\n\
+         `urd init` re-checks it afterwards.\n",
+        path.display()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::discovery::Probe;
+    use crate::encounter::{compose_looking, compose_runestone, EncounterState, Effect, Input};
+    use crate::strategy::test_support::{
+        drive as mk_drive, external_btrfs_drive, fedora_inventory, inventory, pool, subvol,
+        today, EXTERNAL_POOL, SYSTEM_POOL,
+    };
+    use crate::strategy::{derive_strategy, FateAnswers, GranularityAnswer, Importance,
+        ImportanceAnswer};
+    use crate::voice::test_fixtures::color_guard;
+    use std::path::PathBuf;
+
+    fn offer_spec() -> PromptSpec {
+        PromptSpec {
+            kind: PromptKind::Offer,
+            choices: vec![ChoiceId::Begin, ChoiceId::NotNow],
+            default: None,
+        }
+    }
+
+    fn sheltered_view() -> RunestoneView {
+        let mut inv = fedora_inventory();
+        inv.pools
+            .push(pool(EXTERNAL_POOL, &["/run/media/user/raid"]));
+        inv.drives.push(external_btrfs_drive("sdd", EXTERNAL_POOL));
+        inv.drives.push(external_btrfs_drive("sde", EXTERNAL_POOL));
+        let answers = FateAnswers {
+            importance: vec![ImportanceAnswer {
+                mountpoint: PathBuf::from("/home"),
+                importance: Importance::Irreplaceable,
+            }],
+            residence: None,
+            granularity: GranularityAnswer::YesterdayIsFine,
+            drive_residency: Vec::new(),
+        };
+        let strategy = derive_strategy(&inv, &answers, today());
+        compose_runestone(&strategy, &inv)
+    }
+
+    // ── Prompt rendering ────────────────────────────────────────────────
+
+    #[test]
+    fn offer_prompt_names_choices_and_quit() {
+        let _color = color_guard(false);
+        let out = render_prompt(&offer_spec());
+        assert!(out.contains("not configured"), "{out}");
+        assert!(out.contains("1)"), "{out}");
+        assert!(out.contains("2)"), "{out}");
+        assert!(out.contains("q)"), "{out}");
+        assert!(out.contains("Nothing is written"), "{out}");
+    }
+
+    #[test]
+    fn looking_prompt_renders_pools_subvols_drives_and_notes() {
+        let _color = color_guard(false);
+        let mut inv = fedora_inventory();
+        inv.drives.push(mk_drive(
+            "sdd",
+            DriveClass::External,
+            LuksState::Locked,
+            Some("crypto_LUKS"),
+            None,
+        ));
+        inv.drives.push(mk_drive(
+            "sde",
+            DriveClass::External,
+            LuksState::NotEncrypted,
+            Some("ntfs"),
+            None,
+        ));
+        inv.notes.push(DiscoveryNote::FilteredNoise {
+            category: NoiseCategory::SnapperSnapshots,
+            count: 3,
+        });
+        let spec = PromptSpec {
+            kind: PromptKind::LookingConfirm {
+                view: compose_looking(&inv),
+            },
+            choices: vec![ChoiceId::LooksRight, ChoiceId::DoesNotMatch],
+            default: None,
+        };
+        let out = render_prompt(&spec);
+        assert!(out.contains("/home"), "{out}");
+        assert!(out.contains("nvme0n1"), "{out}");
+        assert!(out.contains("locked"), "{out}");
+        assert!(out.contains("mkfs.btrfs"), "{out}");
+        assert!(out.contains("erases everything"), "{out}");
+        assert!(out.contains("snapper"), "{out}");
+        assert!(out.contains("match"), "{out}");
+    }
+
+    #[test]
+    fn importance_prompt_marks_the_default_and_position() {
+        let _color = color_guard(false);
+        let spec = PromptSpec {
+            kind: PromptKind::Importance {
+                mountpoint: PathBuf::from("/home"),
+                subvol_path: "/home".to_string(),
+                proposed: Importance::Irreplaceable,
+                position: 1,
+                total: 2,
+            },
+            choices: vec![
+                ChoiceId::Irreplaceable,
+                ChoiceId::Replaceable,
+                ChoiceId::NotWorthHistory,
+            ],
+            default: Some(0),
+        };
+        let out = render_prompt(&spec);
+        assert!(out.contains("1 of 2"), "{out}");
+        assert!(out.contains("/home"), "{out}");
+        assert!(out.contains("(Enter)"), "{out}");
+        assert!(out.contains("irreplaceable"), "{out}");
+        // The default marker sits on the irreplaceable line.
+        let default_line = out
+            .lines()
+            .find(|l| l.contains("(Enter)"))
+            .expect("a default-marked line");
+        assert!(default_line.contains("irreplaceable"), "{default_line}");
+    }
+
+    #[test]
+    fn runestone_prompt_renders_promises_drives_and_cadence() {
+        let _color = color_guard(false);
+        let spec = PromptSpec {
+            kind: PromptKind::Runestone {
+                view: sheltered_view(),
+            },
+            choices: vec![ChoiceId::Accept, ChoiceId::DelveDeeper],
+            default: None,
+        };
+        let out = render_prompt(&spec);
+        assert!(out.contains("04:00"), "{out}");
+        assert!(out.contains("home"), "{out}");
+        assert!(out.contains("sheltered"), "{out}");
+        assert!(out.contains("sdd + sde"), "should name every bearer: {out}");
+        assert!(out.contains("carve"), "{out}");
+        assert!(out.contains("editor"), "{out}");
+    }
+
+    #[test]
+    fn runestone_sentinel_cadence_names_the_watch() {
+        let _color = color_guard(false);
+        let mut view = sheltered_view();
+        view.run_frequency = RunFrequency::Sentinel;
+        let spec = PromptSpec {
+            kind: PromptKind::Runestone { view },
+            choices: vec![ChoiceId::Accept, ChoiceId::DelveDeeper],
+            default: None,
+        };
+        let out = render_prompt(&spec);
+        assert!(out.contains("sentinel"), "{out}");
+        assert!(!out.contains("04:00"), "{out}");
+    }
+
+    #[test]
+    fn runestone_gap_section_names_the_disaster_and_demoted() {
+        let _color = color_guard(false);
+        // Irreplaceable data, no usable drive: demotion gap.
+        let inv = fedora_inventory();
+        let answers = FateAnswers {
+            importance: vec![ImportanceAnswer {
+                mountpoint: PathBuf::from("/home"),
+                importance: Importance::Irreplaceable,
+            }],
+            residence: None,
+            granularity: GranularityAnswer::YesterdayIsFine,
+            drive_residency: Vec::new(),
+        };
+        let strategy = derive_strategy(&inv, &answers, today());
+        let spec = PromptSpec {
+            kind: PromptKind::Runestone {
+                view: compose_runestone(&strategy, &inv),
+            },
+            choices: vec![ChoiceId::Accept, ChoiceId::DelveDeeper],
+            default: None,
+        };
+        let out = render_prompt(&spec);
+        assert!(out.contains("cannot survive"), "{out}");
+        assert!(out.contains("home"), "demoted name shown: {out}");
+        assert!(out.contains("urd init"), "path to more named: {out}");
+    }
+
+    // ── Endings ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn every_farewell_says_nothing_was_written() {
+        let _color = color_guard(false);
+        let kinds = [
+            FarewellKind::Declined,
+            FarewellKind::LookingMismatch,
+            FarewellKind::Quit,
+            FarewellKind::EmptyReport(EmptyView::NothingDiscovered {
+                drives: vec![],
+                notes: vec![],
+            }),
+            FarewellKind::EmptyReport(EmptyView::EverythingExcluded { excluded: vec![] }),
+        ];
+        for kind in &kinds {
+            let out = render_farewell(kind);
+            assert!(
+                out.contains("Nothing was written") || out.contains("nothing was written"),
+                "farewell {kind:?} must state nothing was written: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn nothing_discovered_report_names_hardware_and_unlock_path() {
+        let _color = color_guard(false);
+        let out = render_empty_report(&EmptyView::NothingDiscovered {
+            drives: vec![mk_drive(
+                "sdd",
+                DriveClass::External,
+                LuksState::Locked,
+                Some("crypto_LUKS"),
+                None,
+            )],
+            notes: vec![],
+        });
+        assert!(out.contains("no btrfs"), "{out}");
+        assert!(out.contains("locked"), "{out}");
+        assert!(out.contains("urd init"), "{out}");
+    }
+
+    #[test]
+    fn everything_excluded_report_explains_each_reason() {
+        let _color = color_guard(false);
+        let inv = inventory(
+            vec![pool(SYSTEM_POOL, &["/"])],
+            vec![subvol("/", "/", SYSTEM_POOL)],
+            vec![mk_drive(
+                "nvme0n1",
+                DriveClass::Internal,
+                LuksState::NotEncrypted,
+                Some("btrfs"),
+                Some(SYSTEM_POOL),
+            )],
+        );
+        let r = EncounterState::begin(inv, today());
+        let r = crate::encounter::advance(r.state, Input::Choice(0));
+        let r = crate::encounter::advance(r.state, Input::Choice(0));
+        let Effect::Farewell(kind) = &r.effect else {
+            panic!("expected farewell");
+        };
+        let out = render_farewell(kind);
+        assert!(out.contains("whole-pool"), "{out}");
+        assert!(out.contains("Nothing was written"), "{out}");
+    }
+
+    #[test]
+    fn post_carve_names_the_file_and_next_verb() {
+        let _color = color_guard(false);
+        let out = render_post_carve(Path::new("/home/user/.config/urd/urd.toml"));
+        assert!(out.contains("urd.toml"), "{out}");
+        assert!(out.contains("urd init"), "{out}");
+    }
+
+    #[test]
+    fn editor_failure_offers_revert_only_when_available() {
+        let _color = color_guard(false);
+        let offers = |out: &str, letter: &str| {
+            out.lines()
+                .any(|l| l.trim_start().starts_with(&format!("{letter})")))
+        };
+        let with = render_editor_failure("missing field `source`", true);
+        assert!(offers(&with, "e"), "{with}");
+        assert!(offers(&with, "r"), "{with}");
+        assert!(offers(&with, "q"), "{with}");
+        assert!(with.contains("missing field"), "{with}");
+        let without = render_editor_failure("bad toml", false);
+        assert!(!offers(&without, "r"), "{without}");
+        assert!(offers(&without, "e"), "{without}");
+    }
+
+    #[test]
+    fn no_editor_keeps_the_file_and_names_it() {
+        let _color = color_guard(false);
+        let out = render_no_editor(Path::new("/tmp/urd.toml"));
+        assert!(out.contains("/tmp/urd.toml"), "{out}");
+        assert!(out.contains("EDITOR"), "{out}");
+    }
+
+    #[test]
+    fn invalid_notice_names_the_range() {
+        let _color = color_guard(false);
+        let out = render_invalid_notice(&InputNotice::InvalidChoice { choices: 3 });
+        assert!(out.contains('3'), "{out}");
+        assert!(out.contains('q'), "{out}");
+    }
+
+    // ── Exhaustive-variant render tests (adversary F4) ──────────────────
+    //
+    // One test per reason enum: every variant constructed (the match
+    // makes adding a variant a compile error here), rendered, asserted
+    // non-empty and pairwise distinct — per-surface sampling misses the
+    // variant nobody enumerated (recurrence pattern 7).
+
+    fn assert_all_distinct(label: &str, rendered: &[String]) {
+        for (i, a) in rendered.iter().enumerate() {
+            assert!(!a.trim().is_empty(), "{label}[{i}] rendered empty");
+            for (j, b) in rendered.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "{label}: variants {i} and {j} render identically");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn every_exclusion_reason_renders_a_distinct_sentence() {
+        use ExclusionReason as R;
+        let all = [
+            R::DeclaredNotWorthHistory,
+            R::WholePoolMount,
+            R::UnknownPool,
+            R::AmbiguousDevice,
+            R::MixedResidency,
+            R::UnknownResidency,
+        ];
+        for r in all {
+            match r {
+                R::DeclaredNotWorthHistory
+                | R::WholePoolMount
+                | R::UnknownPool
+                | R::AmbiguousDevice
+                | R::MixedResidency
+                | R::UnknownResidency => {}
+            }
+        }
+        let rendered: Vec<String> =
+            all.iter().map(|r| exclusion_sentence(*r).to_string()).collect();
+        assert_all_distinct("ExclusionReason", &rendered);
+    }
+
+    #[test]
+    fn every_unusable_reason_renders_a_distinct_sentence() {
+        use UnusableReason as R;
+        let all = [
+            R::Locked,
+            R::NotBtrfs {
+                fstype: Some("ntfs".to_string()),
+            },
+            R::NotMounted,
+            R::Unresolved,
+        ];
+        for r in &all {
+            match r {
+                R::Locked | R::NotBtrfs { .. } | R::NotMounted | R::Unresolved => {}
+            }
+        }
+        let rendered: Vec<String> = all
+            .iter()
+            .map(|reason| {
+                unusable_sentence(&UnusableDrive {
+                    device: "sdd".to_string(),
+                    label: None,
+                    size: None,
+                    reason: reason.clone(),
+                })
+            })
+            .collect();
+        assert_all_distinct("UnusableReason", &rendered);
+    }
+
+    #[test]
+    fn every_gap_kind_renders_a_distinct_disaster() {
+        use GapKind as K;
+        let all = [K::NoExternalDrive, K::NoOffsiteDrive];
+        for k in all {
+            match k {
+                K::NoExternalDrive | K::NoOffsiteDrive => {}
+            }
+        }
+        let rendered: Vec<String> = all
+            .iter()
+            .map(|kind| {
+                render_gap(&Gap {
+                    kind: *kind,
+                    demoted: vec![],
+                    unusable: vec![],
+                })
+            })
+            .collect();
+        assert_all_distinct("GapKind", &rendered);
+    }
+
+    #[test]
+    fn every_discovery_note_renders_a_distinct_sentence() {
+        use DiscoveryNote as N;
+        let all = [
+            N::LockedDrive {
+                device: "sdd".to_string(),
+                size: None,
+                transport: None,
+            },
+            N::FilteredNoise {
+                category: NoiseCategory::SnapperSnapshots,
+                count: 2,
+            },
+            N::FilteredNoise {
+                category: NoiseCategory::DuplicateMounts,
+                count: 2,
+            },
+            N::HiddenStructureLikely {
+                pool_uuid: "22222222-2222-4222-8222-222222222222".to_string(),
+            },
+            N::UnjoinableMount {
+                mountpoint: PathBuf::from("/mnt/x"),
+                source: "loop0".to_string(),
+            },
+            N::ProbeDegraded {
+                probe: Probe::Lsblk,
+                detail: "exit 1".to_string(),
+            },
+        ];
+        for n in &all {
+            match n {
+                N::LockedDrive { .. }
+                | N::FilteredNoise { .. }
+                | N::HiddenStructureLikely { .. }
+                | N::UnjoinableMount { .. }
+                | N::ProbeDegraded { .. } => {}
+            }
+        }
+        let rendered: Vec<String> = all.iter().map(note_sentence).collect();
+        assert_all_distinct("DiscoveryNote", &rendered);
+    }
+
+    #[test]
+    fn every_farewell_kind_renders_distinctly() {
+        use FarewellKind as F;
+        let all = [
+            F::Declined,
+            F::LookingMismatch,
+            F::Quit,
+            F::EmptyReport(EmptyView::NothingDiscovered {
+                drives: vec![],
+                notes: vec![],
+            }),
+            F::EmptyReport(EmptyView::EverythingExcluded { excluded: vec![] }),
+        ];
+        for f in &all {
+            match f {
+                F::Declined | F::LookingMismatch | F::Quit | F::EmptyReport(_) => {}
+            }
+        }
+        let rendered: Vec<String> = all.iter().map(render_farewell).collect();
+        assert_all_distinct("FarewellKind", &rendered);
+    }
+}

--- a/src/voice/init.rs
+++ b/src/voice/init.rs
@@ -11,19 +11,18 @@ use colored::Colorize;
 use crate::output::{InitOutput, InitStatus, OutputMode};
 use crate::types::{ByteSize, DriveRole};
 
-/// First-run guidance when `urd init` finds no config. The bare-`urd`
-/// greeting points new users here, so a missing config is the expected
-/// starting state — greet and guide, never error.
+/// First-run pointer when `urd init` finds no config and cannot offer
+/// the Encounter (no terminal on stdin or stdout). A missing config is
+/// the expected starting state — greet and point, never error.
 #[must_use]
 pub fn render_init_first_time(config_path: &Path, mode: OutputMode) -> String {
     match mode {
         OutputMode::Interactive => format!(
             "Urd is not configured yet — nothing to verify.\n\
              \n\
-             To begin, create a config at {}.\n\
-             Start from the annotated example (config/urd.toml.example in the\n\
-             Urd repository, walked through in the README's Configuration\n\
-             section), then run `urd init` again to check your setup.\n",
+             Run `urd init` in a terminal: Urd looks at what this machine\n\
+             holds and proposes how to protect it. Nothing is written\n\
+             without your approval. The config, once carved, lives at {}.\n",
             config_path.display()
         ),
         OutputMode::Daemon => r#"{"status":"not_configured"}"#.to_string(),

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -34,6 +34,8 @@ mod doctor;
 mod drive_row;
 mod drives;
 mod emergency;
+#[allow(dead_code)] // Wired in UPI 072 steps 5-7 (conversation loop + doorstep).
+mod encounter;
 mod get;
 mod history;
 mod init;
@@ -49,6 +51,11 @@ pub use chooser::format_subvolume_chooser;
 pub use doctor::render_doctor;
 pub use drives::{render_drives_adopt, render_drives_list};
 pub use emergency::{render_emergency, render_emergency_result};
+#[allow(unused_imports)] // Wired in UPI 072 steps 5-7 (conversation loop + doorstep).
+pub use encounter::{
+    render_editor_failure, render_empty_report, render_farewell, render_invalid_notice,
+    render_no_editor, render_post_carve, render_prompt,
+};
 pub use get::render_get;
 pub use history::{render_events, render_history, render_subvolume_history};
 pub use init::{render_init, render_init_first_time};

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -34,7 +34,6 @@ mod doctor;
 mod drive_row;
 mod drives;
 mod emergency;
-#[allow(dead_code)] // Wired in UPI 072 steps 5-7 (conversation loop + doorstep).
 mod encounter;
 mod get;
 mod history;
@@ -51,10 +50,9 @@ pub use chooser::format_subvolume_chooser;
 pub use doctor::render_doctor;
 pub use drives::{render_drives_adopt, render_drives_list};
 pub use emergency::{render_emergency, render_emergency_result};
-#[allow(unused_imports)] // Wired in UPI 072 steps 5-7 (conversation loop + doorstep).
 pub use encounter::{
-    render_editor_failure, render_empty_report, render_farewell, render_invalid_notice,
-    render_no_editor, render_post_carve, render_prompt,
+    render_editor_failure, render_farewell, render_invalid_notice, render_no_editor,
+    render_post_carve, render_prompt,
 };
 pub use get::render_get;
 pub use history::{render_events, render_history, render_subvolume_history};
@@ -2637,8 +2635,8 @@ mod tests {
             "must name the path where the config belongs"
         );
         assert!(
-            output.contains("urd.toml.example"),
-            "must point at the annotated example"
+            output.contains("propose"),
+            "must say the Encounter proposes protection"
         );
         assert!(
             output.contains("`urd init`"),


### PR DESCRIPTION
## Summary

The Encounter is now reachable: this PR wires the entire 070→073→074 pipeline (discover → derive → generate → carve) into an interactive first-time conversation, plus the doorstep that offers it.

- **`src/encounter.rs`** (new, pure): the conversation state machine — offer → the looking → per-ambiguous-drive residency → three escalating disaster scenes (deleted-folder/granularity, dead-drive/per-subvolume importance with a `/home → irreplaceable` default inline, house-fire/residence asked only when it can change the derivation) → the runestone → carve. Question list derived from `protection_candidates`/`usable_destinations`, never invented. Quit/EOF anywhere writes nothing. Empty machines (no btrfs, all-locked) get one honest report, never a conversation about nothing.
- **`src/voice/encounter.rs`** (new): all rendering; numbered choices come from the same vector `parse_line` validates, so display and parsing cannot drift. Locked and non-btrfs drives are named with their exact path to usefulness — including the `mkfs.btrfs` command Urd will never run herself.
- **`src/commands/encounter.rs`**: the thin stdin loop, plus the delve-deeper editor flow — carve first, `$VISUAL`/`$EDITOR` on the real file, re-validate on exit, visudo-shaped (e)dit/(r)evert/(q)uit failure loop. Editor exit status is deliberately ignored: re-validation of the file is the only truth. Revert is a distinct consented-overwrite helper; `carve_config`'s no-clobber contract is untouched.
- **Doorstep**: bare `urd` / `urd init` with no config offer the conversation when a human is on both ends (stdin AND stdout terminals); everything else prints one pointer sentence and exits **3** ("not configured" — new documented code; replaces raw I/O errors on most commands). `urd init` is the make-whole verb: an invalid config re-enters the fix-it loop on a terminal.
- **Upstream 073 fix (field find)**: the first live conversation on real hardware surfaced a mixed-residency pool (four disks, one hotplug-signalled bearer) being adopted as a send target through its single external-classified drive — a send there never leaves the machine. `usable_destinations` now gates on pool-level residency, symmetric with the candidate side's `MixedResidency` exclusion; grid gains `D-mixed-pool` (520 cases).

## Verification

- 2095 tests passing (+66 from master), clippy `--all-targets -D warnings` clean.
- Grid properties: runestone↔strategy correspondence and question-economy across all 13 scenarios × 520 cases; per-enum exhaustive-variant render tests (a new reason variant fails compilation until every surface names it — which is exactly how the `MixedPool` fix propagated).
- Live end-to-end on real hardware via pty: offer/decline, the looking against a 4-pool machine, full accept path, carved config loads through the real tri-parser and drives `urd plan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)