### PR TITLE
feat: privilege bootstrap — guided sudoers (UPI 071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Privilege bootstrap — guided sudoers (UPI 071, Encounter arc 2/9).** Urd
+  now earns root instead of asking you to hand-edit sudoers. New pure
+  `sudoers` module is the single oracle for the scoped grant: one
+  snapshot-creation line per source→snapshot-root mapping, one deletion line
+  per snapshot directory, broad send/receive, read-only diagnostics — derived
+  from the config, never a template to edit. The renderer refuses (never
+  escapes) anything that could change a sudoers line's meaning: control
+  characters, `#`, non-UTF-8, near-root snapshot scopes (no `delete /*` can
+  ever be minted), and reserved usernames. After the carve — or via `urd
+  init` at any time — **the earning** shows the exact file, explains what
+  each section permits, and with consent installs it fail-closed: staged
+  inertly as `/etc/sudoers.d/urd.staging` (a dot-name sudo ignores),
+  re-validated by root-side `visudo -c`, activated by atomic rename — a crash
+  or a same-uid race can never leave a broken file that locks sudo host-wide.
+  Verification drops the cached sudo ticket, probes passwordlessly, and
+  cross-checks coverage against `sudo -l`. Declining prints the exact content
+  and manual command; `urd status` and bare `urd` name the **configured but
+  unsealed** state (yellow, never red — nothing was lost) and `urd init`
+  resumes the earning. `urd doctor` gains a sudoers **drift advisory**: config
+  mappings with no covering grant warn with the re-render verb; a listing that
+  needs a password or resists interpretation is an honest "cannot verify",
+  never a silent pass. The sudo-btrfs infrastructure check now distinguishes
+  "grant denied" from "grant works, btrfs failed" (ext4-root hosts no longer
+  read as sudoers problems). Daemon paths never probe sudo. ~60 new tests,
+  including injection-refusal and brute-force grant-model invariants.
 - **The Fate Conversation + entry trigger (UPI 072, Encounter arc 3/9).** The
   Encounter is now reachable: bare `urd` or `urd init` with no config and a
   terminal on both ends offers a guided first-time conversation — Urd looks at

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,12 @@ anyhow = "1"
 uuid = { version = "1", features = ["v4"] }
 
 # System
-nix = { version = "0.31", features = ["fs", "poll"] }
+nix = { version = "0.31", features = ["fs", "poll", "user"] }
 dirs = "6"
 ctrlc = "3"
+# The earning (UPI 071) stages the rendered sudoers file unprivileged
+# before the visudo gate — production use, not just tests.
+tempfile = "3"
 
 # Output formatting
 colored = "3"
@@ -40,8 +43,6 @@ colored = "3"
 log = "0.4"
 env_logger = "0.11"
 
-[dev-dependencies]
-tempfile = "3"
 
 # Integration tests live under tests/integration/ (CLAUDE.md convention) and are
 # #[ignore]'d by default (they build + shell out to the binary). Run with

--- a/docs/00-foundation/guides/operating-urd.md
+++ b/docs/00-foundation/guides/operating-urd.md
@@ -65,6 +65,32 @@ updates (only for unit file changes).
 Urd runs as a regular user and calls `sudo btrfs` for privileged filesystem operations.
 A scoped sudoers file grants exactly the permissions needed — nothing more.
 
+**The guided path (recommended): let Urd render and install it.** The sudoers content
+is derived from your config, and `urd` is the single oracle for its shape
+(`src/sudoers.rs` — the module doc carries the full scope rationale). After the Fate
+Conversation carves a config — or any time later — run:
+
+```bash
+urd init
+```
+
+With a config present and no working grant, `urd init` resumes **the earning**: it
+renders the exact file your config requires, checks it with `visudo -c`, shows it to
+you, and — with your consent — installs it fail-closed (staged inertly inside
+`/etc/sudoers.d` under a dot-name sudo ignores, re-validated as root, then activated
+by an atomic rename). It verifies the grant afterwards with a passwordless probe and
+cross-checks coverage via `sudo -l`. If you decline, Urd prints the content and the
+manual command instead; `urd status` names the "configured but unsealed" state until
+the grant exists, and `urd doctor` warns when the installed grant drifts behind a
+grown config.
+
+> **Declined-path note for monitoring operators:** human-invoked `urd` commands
+> (`status`, `init`, `doctor`, bare `urd`) each probe the grant with a single
+> non-interactive `sudo -n` call. On an unsealed system that denied probe writes one
+> auth-log line per invocation — whitelist it or seal. Urd's daemons (sentinel,
+> heartbeat, metrics) never probe.
+
+**The manual path** (also the printed fallback when you refuse the guided install).
 Create `/etc/sudoers.d/urd` (requires root):
 
 ```bash

--- a/docs/20-reference/cli.md
+++ b/docs/20-reference/cli.md
@@ -74,11 +74,14 @@ Each subcommand declares whether it requires a config load:
 
 ### `urd` (no subcommand)
 
-**Contract.** With a config: a one-screen promise summary (compact status).
-Without one: offers the Encounter when a human is on both ends (stdin and
-stdout are terminals); otherwise prints the pointer and exits 3. Declining
-or quitting the Encounter writes nothing — the config file appears only at
-the carve, after explicit approval of the runestone.
+**Contract.** With a config: a one-screen promise summary (compact status);
+interactively it probes the sudo grant once (`sudo -n`, never prompts) and
+appends a "configured but unsealed — `urd init` resumes the earning" clause
+when the grant is clearly denied. Without a config: offers the Encounter
+when a human is on both ends (stdin and stdout are terminals); otherwise
+prints the pointer and exits 3. Declining or quitting the Encounter writes
+nothing — the config file appears only at the carve, after explicit
+approval of the runestone.
 
 **Output.** Stdout — text; `{"status":"not_configured"}` in daemon mode.
 
@@ -151,6 +154,11 @@ requires reading the heartbeat or metrics, not the exit code.
 drive presence, and overall data safety. Reads filesystem, SQLite, and the
 heartbeat file; writes nothing. Safe under any condition, including a
 running backup (advisory locking via `lock.rs` makes the read non-conflicting).
+Interactively it also probes the sudo grant once (`sudo -n`, never prompts) and,
+when the grant is clearly denied, names the **configured but unsealed** state
+with `urd init` as the resume verb. Daemon runs never probe (a denied probe
+writes an auth-log line), so the `unsealed` field is absent from daemon JSON —
+it serializes only when true, and only interactive runs check.
 
 **Output.** Interactive — voice-rendered status block answering "is my data
 safe?" Daemon — JSON.
@@ -209,10 +217,18 @@ Encounter (pointer + exit 3 without a terminal on both ends). Invalid
 config + terminal → the fix-it loop ((e)dit in `$VISUAL`/`$EDITOR` /
 (q)uit keeping the file, error named), then continues into the checks;
 I/O failures (permissions) always surface instead. With a loadable
-config: ensures the state DB directory and heartbeat directory exist,
-runs the same infrastructure checks `doctor` runs, and exits cleanly.
-Safe to run multiple times. May prompt for sudo if the configured
-`btrfs_path` requires testing.
+config and a terminal on both ends, a clearly denied sudo grant
+resumes **the seal at the earning** (UPI 071): render the scoped
+sudoers file from the config, `visudo -c` gate, show + consent,
+staged fail-closed install (`/etc/sudoers.d/urd.staging`, root-side
+re-validation, atomic rename to `/etc/sudoers.d/urd`), then a
+passwordless verification probe and a `sudo -l` coverage cross-check.
+Declining prints the content and the manual command; nothing is
+installed without consent, and EOF never installs. After (or without)
+the earning: ensures the state DB directory and heartbeat directory
+exist, runs the same infrastructure checks `doctor` runs, and exits
+cleanly. Safe to run multiple times. The install step prompts for
+your password via sudo.
 
 **Output.** Interactive — the conversation or the checklist of
 infrastructure items; `{"status":"not_configured"}` in daemon mode
@@ -328,9 +344,16 @@ config first). Writes to the state DB.
 ### `urd doctor`
 
 **Contract.** Runs the full diagnostic battery: config preflight,
-infrastructure checks (DB, dirs, sudo btrfs), drive UUID fingerprinting,
-and local-space trend warnings. Read-only. Designed to be the first thing
-an operator runs when something feels off.
+infrastructure checks (DB, dirs, sudo btrfs), the sudoers drift advisory,
+drive UUID fingerprinting, and local-space trend warnings. Read-only.
+Designed to be the first thing an operator runs when something feels off.
+The drift advisory diffs the config's expected grants (single oracle:
+`sudoers.rs`) against effective privileges from `sudo -n -l`: a working
+grant with full coverage renders one Ok row; a config mapping with no
+covering grant warns and names `urd init` as the re-render verb; a listing
+that needs a password, contains negations, or resists parsing is an honest
+"cannot verify" warning — never a silent pass. When the grant itself is
+denied, only the sudo-btrfs check speaks (one cause, one finding).
 
 **Notable flags.**
 

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -95,6 +95,9 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         .into_iter()
         .max_by(|a, b| a.tier.cmp(&b.tier).then(a.host_root.cmp(&b.host_root)));
 
+    // Configured but unsealed (UPI 071) — see `seal::probe_unsealed`.
+    let unsealed = crate::commands::seal::probe_unsealed(&config, output_mode);
+
     let output = DefaultStatusOutput {
         total,
         waning_names,
@@ -106,6 +109,7 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         best_advice,
         total_needing_attention,
         storage_posture,
+        unsealed,
     };
 
     let rendered = voice::render_default_status(&output, output_mode);

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -81,7 +81,8 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     };
 
     // ── 2. Infrastructure checks (I/O: DB, dirs, sudo btrfs) ─────
-    let init_checks = init::collect_infrastructure_checks(&config);
+    let sudo_probe = crate::commands::seal::probe_grant(&config.general.btrfs_path);
+    let init_checks = init::collect_infrastructure_checks(&config, &sudo_probe);
     let mut infra_checks: Vec<DoctorCheck> = init_checks
         .into_iter()
         .map(|c| {
@@ -104,6 +105,38 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
             }
         })
         .collect();
+
+    // ── Sudoers drift (UPI 071) — three-arm gate (adversary F4) ──
+    // Granted → diff effective privileges against the config's expected
+    // grants; Denied → silent here (the sudo-btrfs check above already
+    // speaks — one cause, one finding); Unclear → an honest cannot-verify
+    // Warn, never a silent skip. Not --thorough-gated: drift causes
+    // failures that look like bugs.
+    let drift_checks = match sudo_probe.0 {
+        crate::sudoers::GrantProbe::Denied => Vec::new(),
+        crate::sudoers::GrantProbe::Unclear => vec![cannot_verify_grant_check(format!(
+            "could not determine the sudo grant state: {}",
+            sudo_probe.1
+        ))],
+        crate::sudoers::GrantProbe::Granted => {
+            let listing = std::process::Command::new("sudo")
+                .env("LC_ALL", "C")
+                .args(["-n", "-l"])
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| String::from_utf8_lossy(&o.stdout).into_owned());
+            build_sudoers_drift_checks(&config, listing.as_deref())
+        }
+    };
+    for check in &drift_checks {
+        match check.status {
+            DoctorCheckStatus::Warn => warn_count += 1,
+            DoctorCheckStatus::Error => error_count += 1,
+            DoctorCheckStatus::Ok => {}
+        }
+    }
+    infra_checks.extend(drift_checks);
 
     // UUID fingerprinting checks for mounted drives
     for (label, _uuid, snippet) in drives::check_missing_uuids(&config.drives) {
@@ -339,6 +372,95 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     print!("{}", voice::render_doctor(&output, output_mode));
 
     Ok(())
+}
+
+/// The honest-skip row for a drift check that cannot run: never a silent
+/// pass (arc grill; adversary F4).
+fn cannot_verify_grant_check(detail: String) -> DoctorCheck {
+    DoctorCheck {
+        name: "sudoers drift".to_string(),
+        status: DoctorCheckStatus::Warn,
+        detail: Some(detail),
+        suggestion: Some(
+            "Run `sudo -l` yourself, or re-run `urd doctor` after `sudo -v`.".to_string(),
+        ),
+    }
+}
+
+/// Diff the config's expected grants (`sudoers::expected_grant_lines`, the
+/// single oracle) against effective privileges from `sudo -n -l`. Pure
+/// over the injected listing text; the subprocess stays in `run()`.
+/// `listing = None` means the listing needed a password or failed to run.
+fn build_sudoers_drift_checks(config: &Config, listing: Option<&str>) -> Vec<DoctorCheck> {
+    let expected = match crate::sudoers::expected_grant_lines(config) {
+        Ok(expected) => expected,
+        // A config the oracle refuses to render (hostile characters,
+        // shallow scopes) is its own advisory — nothing to diff against.
+        Err(refusal) => {
+            return vec![DoctorCheck {
+                name: "sudoers drift".to_string(),
+                status: DoctorCheckStatus::Warn,
+                detail: Some(refusal.to_string()),
+                suggestion: Some("Fix the named config value, then re-run `urd init`.".to_string()),
+            }];
+        }
+    };
+    let Some(listing) = listing else {
+        return vec![cannot_verify_grant_check(
+            "the privilege listing needs a password (sudo -n -l) — cannot verify \
+             the grant against the config without interaction"
+                .to_string(),
+        )];
+    };
+    let listing = match crate::sudoers::parse_privilege_listing(listing) {
+        Ok(listing) => listing,
+        Err(uncertain) => return vec![cannot_verify_grant_check(uncertain.reason)],
+    };
+    match crate::sudoers::coverage(&expected, &listing) {
+        crate::sudoers::Coverage::AllCovered => vec![DoctorCheck {
+            name: "sudoers grant covers the config".to_string(),
+            status: DoctorCheckStatus::Ok,
+            detail: None,
+            suggestion: None,
+        }],
+        crate::sudoers::Coverage::CannotInterpret { reason } => {
+            vec![cannot_verify_grant_check(reason)]
+        }
+        crate::sudoers::Coverage::Gaps { missing, uncertain } => {
+            let mut checks: Vec<DoctorCheck> = missing
+                .into_iter()
+                .map(|spec| DoctorCheck {
+                    name: "sudoers drift".to_string(),
+                    status: DoctorCheckStatus::Warn,
+                    detail: Some(format!(
+                        "no grant covers `{spec}` — a config mapping the installed \
+                         sudoers file predates"
+                    )),
+                    suggestion: Some(
+                        "Run `urd init` to re-render and reinstall the grant.".to_string(),
+                    ),
+                })
+                .collect();
+            if !uncertain.is_empty() {
+                checks.push(DoctorCheck {
+                    name: "sudoers drift".to_string(),
+                    status: DoctorCheckStatus::Warn,
+                    detail: Some(format!(
+                        "{} config mapping(s) have no exact covering grant, but broader \
+                         wildcard grants exist that urd does not interpret: {}",
+                        uncertain.len(),
+                        uncertain.join("; ")
+                    )),
+                    suggestion: Some(
+                        "Compare `sudo -l` against the config yourself, or run `urd init` \
+                         to install the exact scoped grant."
+                            .to_string(),
+                    ),
+                });
+            }
+            checks
+        }
+    }
 }
 
 /// Build the `--thorough` Retention-section advisories (#125): one `DoctorCheck`
@@ -728,6 +850,91 @@ fn unpack_advice(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── Sudoers drift (UPI 071) ────────────────────────────────────────
+
+    fn drift_config() -> Config {
+        Config::from_str(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/data/.snapshots"
+protection = "recorded"
+"#,
+        )
+        .unwrap()
+    }
+
+    fn listing_of(specs: &[String]) -> String {
+        let rules: String = specs
+            .iter()
+            .map(|s| format!("    (root) NOPASSWD: {s}\n"))
+            .collect();
+        format!("User alice may run the following commands on example-host:\n{rules}")
+    }
+
+    #[test]
+    fn drift_all_covered_renders_one_ok_row() {
+        let config = drift_config();
+        let expected = crate::sudoers::expected_grant_lines(&config).unwrap();
+        let checks = build_sudoers_drift_checks(&config, Some(&listing_of(&expected)));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Ok);
+        assert!(checks[0].name.contains("covers the config"));
+    }
+
+    #[test]
+    fn drift_missing_mapping_warns_with_the_reinstall_verb() {
+        let config = drift_config();
+        let expected: Vec<String> = crate::sudoers::expected_grant_lines(&config)
+            .unwrap()
+            .into_iter()
+            .filter(|s| !s.contains(" delete "))
+            .collect();
+        let checks = build_sudoers_drift_checks(&config, Some(&listing_of(&expected)));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
+        let detail = checks[0].detail.as_deref().unwrap();
+        assert!(detail.contains("subvolume delete /data/.snapshots/*"), "{detail}");
+        let suggestion = checks[0].suggestion.as_deref().unwrap();
+        assert!(suggestion.contains("urd init"), "{suggestion}");
+    }
+
+    #[test]
+    fn drift_wildcard_grants_are_honest_uncertainty_not_missing() {
+        let config = drift_config();
+        let mut specs: Vec<String> = crate::sudoers::expected_grant_lines(&config)
+            .unwrap()
+            .into_iter()
+            .filter(|s| !s.contains("snapshot -r"))
+            .collect();
+        specs.push("/usr/sbin/btrfs subvolume snapshot -r /data/* /data/.snapshots/*".to_string());
+        let checks = build_sudoers_drift_checks(&config, Some(&listing_of(&specs)));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
+        let detail = checks[0].detail.as_deref().unwrap();
+        assert!(detail.contains("does not interpret"), "{detail}");
+    }
+
+    #[test]
+    fn drift_unlistable_is_an_honest_skip_never_silent() {
+        let checks = build_sudoers_drift_checks(&drift_config(), None);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
+        assert!(checks[0].detail.as_deref().unwrap().contains("password"));
+    }
+
+    #[test]
+    fn drift_unparseable_listing_is_an_honest_skip() {
+        let checks = build_sudoers_drift_checks(&drift_config(), Some("garbage output"));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
+    }
 
     // ── unpack_advice (UPI 029 Change 4, via 079-c) ───────────────────
 

--- a/src/commands/encounter.rs
+++ b/src/commands/encounter.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use anyhow::{bail, Context};
 use chrono::NaiveDate;
 
+use crate::commands::seal::SealOutcome;
 use crate::commands::CliExit;
 use crate::config::Config;
 use crate::config_render::generate_config;
@@ -22,6 +23,23 @@ use crate::encounter::{
 };
 use crate::strategy::ProposedStrategy;
 use crate::voice;
+
+/// The seal step both terminal carve branches run — injected so tests of
+/// the conversation and editor loops never spawn sudo.
+type SealFn<'a> = &'a dyn Fn(&Config, &Path) -> anyhow::Result<SealOutcome>;
+
+/// Post-carve tail shared by every valid-config exit: name the file, then
+/// run the seal from the **reloaded on-disk config** — a delve edit may
+/// have changed mappings, and sealing from the strategy-derived config
+/// would ship day-one sudoers drift (adversary G6). The reload is the only
+/// config in scope here, so the drift cannot regress silently.
+fn post_carve(path: &Path, seal: SealFn<'_>) -> anyhow::Result<CliExit> {
+    print!("{}", voice::render_post_carve(path));
+    let config = Config::load(Some(path))
+        .with_context(|| format!("reloading the carved config at {}", path.display()))?;
+    seal(&config, path)?;
+    Ok(CliExit::Done)
+}
 
 /// Staging file for the atomic publish, sibling to the final config.
 const TEMP_NAME: &str = ".urd.toml.tmp";
@@ -152,12 +170,12 @@ pub fn run_conversation(config_path: Option<&Path>) -> anyhow::Result<CliExit> {
                 // self-check failure) surfaces as the error it is —
                 // nothing was written, the sentence says so.
                 carve_config(&strategy, today, &target)?;
+                let seal: SealFn<'_> = &|config, path| {
+                    crate::commands::seal::resume_seal(config, path)
+                };
                 return match then {
-                    AfterCarve::Confirm => {
-                        print!("{}", voice::render_post_carve(&target));
-                        Ok(CliExit::Done)
-                    }
-                    AfterCarve::Edit => delve(&strategy, today, &target),
+                    AfterCarve::Confirm => post_carve(&target, seal),
+                    AfterCarve::Edit => delve(&strategy, today, &target, seal),
                 };
             }
         }
@@ -165,8 +183,9 @@ pub fn run_conversation(config_path: Option<&Path>) -> anyhow::Result<CliExit> {
 }
 
 /// One line from stdin; `None` on EOF. Prompts end without a newline
-/// marker, so flush before blocking.
-fn read_input_line() -> anyhow::Result<Option<String>> {
+/// marker, so flush before blocking. Shared with the earning's consent
+/// loop (`commands::seal`).
+pub(crate) fn read_input_line() -> anyhow::Result<Option<String>> {
     print!("> ");
     std::io::stdout().flush().ok();
     let mut line = String::new();
@@ -215,14 +234,20 @@ fn parse_editor_choice(line: &str, revert_available: bool) -> Option<EditorChoic
 /// the config loads or the user keeps it broken. The editor's exit
 /// status is deliberately ignored — re-validation of the file is the
 /// only truth (no editor reports abort reliably).
-fn delve(strategy: &ProposedStrategy, today: NaiveDate, path: &Path) -> anyhow::Result<CliExit> {
+fn delve(
+    strategy: &ProposedStrategy,
+    today: NaiveDate,
+    path: &Path,
+    seal: SealFn<'_>,
+) -> anyhow::Result<CliExit> {
     let Some(command) = editor_from_env() else {
         // The file is already carved and valid — keeping it is the
-        // honest fallback, never deletion.
+        // honest fallback, never deletion. This exit skips the earning;
+        // the sentence names `urd init` as the resume verb.
         print!("{}", voice::render_no_editor(path));
         return Ok(CliExit::Done);
     };
-    delve_with(&command, strategy, today, path)
+    delve_with(&command, strategy, today, path, seal)
 }
 
 /// `resolve_editor` over the live environment — the only env read in
@@ -249,22 +274,19 @@ fn delve_with(
     strategy: &ProposedStrategy,
     today: NaiveDate,
     path: &Path,
+    seal: SealFn<'_>,
 ) -> anyhow::Result<CliExit> {
     loop {
         open_in_editor(command, path)?;
         let error = match Config::load(Some(path)) {
-            Ok(_) => {
-                print!("{}", voice::render_post_carve(path));
-                return Ok(CliExit::Done);
-            }
+            Ok(_) => return post_carve(path, seal),
             Err(e) => e.to_string(),
         };
         match failure_loop_choice(&error, true)? {
             EditorChoice::EditAgain => {}
             EditorChoice::Revert => {
                 overwrite_with_generated(strategy, today, path)?;
-                print!("{}", voice::render_post_carve(path));
-                return Ok(CliExit::Done);
+                return post_carve(path, seal);
             }
             EditorChoice::QuitKeep => return Err(kept_invalid(path)),
         }
@@ -603,9 +625,49 @@ mod tests {
         let path = dir.path().join("urd.toml");
         carve_config(&strategy, today(), &path).unwrap();
 
-        let result = delve_with(&["/bin/true".to_string()], &strategy, today(), &path);
+        let no_seal: SealFn<'_> = &|_, _| Ok(SealOutcome::Sealed);
+        let result = delve_with(&["/bin/true".to_string()], &strategy, today(), &path, no_seal);
         assert_eq!(result.unwrap(), CliExit::Done);
         assert!(Config::load(Some(&path)).is_ok());
+    }
+
+    #[test]
+    fn delve_seals_from_the_reloaded_config_not_the_strategy() {
+        // Adversary G6: an editor that adds a drive must reach the seal —
+        // sealing from the strategy-derived config would render a sudoers
+        // file missing the new mapping on day one.
+        let strategy = sheltered_strategy();
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("urd.toml");
+        carve_config(&strategy, today(), &path).unwrap();
+
+        let script = dir.path().join("add-drive.sh");
+        std::fs::write(
+            &script,
+            "#!/bin/sh\ncat >> \"$1\" <<'EOF'\n\n[[drives]]\nlabel = \"delve-added\"\n\
+             mount_path = \"/run/media/alice/delve-added\"\nsnapshot_root = \".snapshots\"\n\
+             role = \"offsite\"\nEOF\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt as _;
+        let mut perms = std::fs::metadata(&script).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&script, perms).unwrap();
+
+        let sealed_labels = std::cell::RefCell::new(Vec::<String>::new());
+        let capture: SealFn<'_> = &|config, _| {
+            sealed_labels
+                .borrow_mut()
+                .extend(config.drives.iter().map(|d| d.label.clone()));
+            Ok(SealOutcome::Sealed)
+        };
+        let result = delve_with(&[script.display().to_string()], &strategy, today(), &path, capture);
+        assert_eq!(result.unwrap(), CliExit::Done);
+        assert!(
+            sealed_labels.borrow().iter().any(|l| l == "delve-added"),
+            "the seal must see the drive the edit added: {:?}",
+            sealed_labels.borrow()
+        );
     }
 
     #[test]
@@ -625,7 +687,9 @@ mod tests {
         perms.set_mode(0o755);
         std::fs::set_permissions(&script, perms).unwrap();
 
-        let result = delve_with(&[script.display().to_string()], &strategy, today(), &path);
+        let no_seal: SealFn<'_> = &|_, _| Ok(SealOutcome::Sealed);
+        let result =
+            delve_with(&[script.display().to_string()], &strategy, today(), &path, no_seal);
         let err = result.unwrap_err();
         assert!(err.to_string().contains("kept as you left it"), "{err}");
         assert!(

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -3,7 +3,9 @@ use std::path::Path;
 
 use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::chain;
+use crate::commands::seal;
 use crate::commands::CliExit;
+use crate::sudoers::GrantProbe;
 use crate::config::Config;
 use crate::drives;
 use crate::output::{
@@ -51,12 +53,26 @@ pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::R
             crate::commands::Doorstep::Pointer => return Err(e.into()),
         },
     };
-    run(config).map(|()| CliExit::Done)
+
+    // The resume verb (arc grill Q5, UPI 071): loadable config + human on
+    // both ends + the grant clearly not answering → resume the seal at the
+    // earning, then continue into the checks. This sits AFTER the whole
+    // match so the fix-it-repaired path resumes too. Unclear never
+    // triggers a ceremony on a guess; non-TTY reports via the checks.
+    let mut sudo_probe = seal::probe_grant(&config.general.btrfs_path);
+    if doorstep == crate::commands::Doorstep::Offer && sudo_probe.0 == GrantProbe::Denied {
+        let path = crate::commands::resolve_config_path(config_path)?;
+        seal::resume_seal(&config, &path)?;
+        // Re-probe: the checks below must describe the post-seal state.
+        sudo_probe = seal::probe_grant(&config.general.btrfs_path);
+    }
+
+    run(config, &sudo_probe).map(|()| CliExit::Done)
 }
 
-pub fn run(config: Config) -> anyhow::Result<()> {
+pub fn run(config: Config, sudo_probe: &(GrantProbe, String)) -> anyhow::Result<()> {
     let fs_state = RealFileSystemState { state: None };
-    let mut output = collect_init_data(&config, &fs_state);
+    let mut output = collect_init_data(&config, &fs_state, sudo_probe);
 
     // Render the report (before interactive prompts)
     let mode = OutputMode::detect();
@@ -83,8 +99,12 @@ pub fn run(config: Config) -> anyhow::Result<()> {
 }
 
 /// Collect all init check data. Pure-ish (does I/O for checks, but produces structured output).
-fn collect_init_data(config: &Config, fs_state: &dyn FilesystemQuery) -> InitOutput {
-    let infrastructure = collect_infrastructure_checks(config);
+fn collect_init_data(
+    config: &Config,
+    fs_state: &dyn FilesystemQuery,
+    sudo_probe: &(GrantProbe, String),
+) -> InitOutput {
+    let infrastructure = collect_infrastructure_checks(config, sudo_probe);
     let subvolume_sources = collect_subvolume_sources(config);
     let snapshot_roots = collect_snapshot_roots(config);
     let drives = collect_drive_status(config);
@@ -108,7 +128,10 @@ fn collect_init_data(config: &Config, fs_state: &dyn FilesystemQuery) -> InitOut
     }
 }
 
-pub(crate) fn collect_infrastructure_checks(config: &Config) -> Vec<InitCheck> {
+pub(crate) fn collect_infrastructure_checks(
+    config: &Config,
+    sudo_probe: &(GrantProbe, String),
+) -> Vec<InitCheck> {
     let mut checks = Vec::new();
 
     // State database
@@ -185,41 +208,34 @@ pub(crate) fn collect_infrastructure_checks(config: &Config) -> Vec<InitCheck> {
         }
     }
 
-    // sudo btrfs
-    match std::process::Command::new("sudo")
-        .env("LC_ALL", "C")
-        .arg("-n")
-        .arg(&config.general.btrfs_path)
-        .args(["filesystem", "show", "/"])
-        .output()
-    {
-        Ok(output) if output.status.success() => {
-            checks.push(InitCheck {
-                name: "sudo btrfs".to_string(),
-                status: InitStatus::Ok,
-                detail: None,
-            });
-        }
-        Ok(output) => {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            checks.push(InitCheck {
-                name: "sudo btrfs".to_string(),
-                status: InitStatus::Error,
-                detail: Some(format!(
-                    "exit {}: {} — check sudoers config",
-                    output.status.code().unwrap_or(-1),
-                    stderr.trim()
-                )),
-            });
-        }
-        Err(e) => {
-            checks.push(InitCheck {
-                name: "sudo btrfs".to_string(),
-                status: InitStatus::Error,
-                detail: Some(e.to_string()),
-            });
-        }
-    }
+    // sudo btrfs — classified (adversary G3): the probe result is supplied
+    // by the caller (one probe per invocation, shared with the resume
+    // gate). A working grant whose btrfs command failed (ext4-root host)
+    // is Ok-with-detail, never "check sudoers config".
+    let (grant, detail) = sudo_probe;
+    checks.push(match grant {
+        GrantProbe::Granted => InitCheck {
+            name: "sudo btrfs".to_string(),
+            status: InitStatus::Ok,
+            detail: if detail.is_empty() {
+                None
+            } else {
+                Some(format!("grant works; btrfs reported: {detail}"))
+            },
+        },
+        GrantProbe::Denied => InitCheck {
+            name: "sudo btrfs".to_string(),
+            status: InitStatus::Error,
+            detail: Some(format!(
+                "{detail} — configured but unsealed; `urd init` resumes the earning"
+            )),
+        },
+        GrantProbe::Unclear => InitCheck {
+            name: "sudo btrfs".to_string(),
+            status: InitStatus::Warn,
+            detail: Some(format!("could not determine the grant state: {detail}")),
+        },
+    });
 
     checks
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod migrate;
 pub mod init;
 pub mod plan_cmd;
 pub mod retention_preview;
+pub mod seal;
 pub mod status;
 pub mod sentinel;
 pub mod storage_signals;

--- a/src/commands/seal.rs
+++ b/src/commands/seal.rs
@@ -1,0 +1,451 @@
+//! The seal's I/O: resume-at-first-incomplete-stage over the closing
+//! ceremony. Today the seal has one stage — **the earning** (UPI 071):
+//! consented, fail-closed privilege bootstrap. 075 appends its stages
+//! (units, first snapshot, adoption) to `resume_seal` without rework.
+//!
+//! The earning's install sequence (adversary F1, user-approved deviation
+//! from the grill's literal command):
+//!   render (pure) → unprivileged `visudo -c -f` gate → show + consent →
+//!   `sudo install` to `/etc/sudoers.d/urd.staging` (the `.` in the name
+//!   makes includedir ignore it — inert if anything stops here) →
+//!   root-side read-back byte-compared to the shown render (binds what
+//!   activates to what was consented, closing the same-uid temp-swap
+//!   window) → `sudo visudo -c -f` on the root-owned staged bytes →
+//!   atomic `sudo mv` into place (no partial file is ever active) →
+//!   `sudo -k` + passwordless probe + coverage cross-check.
+//!
+//! Never `sudo tee`. Every failure path leaves either nothing or an
+//! inert file, and says so. TTY-gated by both callers (the Encounter's
+//! post-carve tail and `urd init`'s resume).
+
+use std::io::Write as _;
+use std::os::unix::fs::PermissionsExt as _;
+use std::path::Path;
+use std::process::Command;
+
+use anyhow::{anyhow, bail, Context};
+
+use crate::config::Config;
+use crate::output::OutputMode;
+use crate::sudoers::{self, Coverage, GrantProbe, RenderContext};
+use crate::voice;
+
+/// The active grant file. The name carries no `.` — includedir reads it.
+pub const SUDOERS_DEST: &str = "/etc/sudoers.d/urd";
+/// The staging name. The `.` makes includedir skip it: inert by design.
+const SUDOERS_STAGING: &str = "/etc/sudoers.d/urd.staging";
+
+/// How the seal's privilege stage ended. All outcomes are honest
+/// conclusions, not errors — the carve already succeeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SealOutcome {
+    /// Grant installed, probe answered, coverage confirmed.
+    Sealed,
+    /// Grant installed and probing; coverage could not be confirmed.
+    SealedUnverifiedCoverage,
+    /// Nothing installed (declined, deferred, or sudo unavailable).
+    Declined,
+    /// Installed, but the passwordless probe did not answer.
+    InstalledUnverified,
+}
+
+/// Resume the seal at its first incomplete stage. Stage 1: the earning.
+/// (075 extends this with further stages; keep the early-return shape.)
+pub fn resume_seal(config: &Config, config_path: &Path) -> anyhow::Result<SealOutcome> {
+    earn_privilege(config, config_path)
+}
+
+// ── Stage 1: the earning ────────────────────────────────────────────────
+
+fn earn_privilege(config: &Config, config_path: &Path) -> anyhow::Result<SealOutcome> {
+    let dest = Path::new(SUDOERS_DEST);
+
+    // Already answers (e.g. a broader hand-managed grant)? Nothing to ask;
+    // the doctor drift advisory watches coverage.
+    if probe_grant(&config.general.btrfs_path).0 == GrantProbe::Granted {
+        print!("{}", voice::render_earning_already());
+        return Ok(SealOutcome::Sealed);
+    }
+
+    let user = invoking_username()?;
+
+    // The grant names the configured btrfs binary; a grant for a missing
+    // binary would verify never and confuse always.
+    let btrfs = Path::new(&config.general.btrfs_path);
+    if !btrfs.exists() {
+        bail!(
+            "btrfs not found at {} — fix `btrfs_path` in {} (try `which btrfs`), \
+             then run `urd init` to resume the earning",
+            btrfs.display(),
+            config_path.display()
+        );
+    }
+
+    let rendered = sudoers::render_sudoers(
+        config,
+        &RenderContext {
+            user: &user,
+            config_path,
+            today: chrono::Local::now().date_naive(),
+        },
+    )
+    .map_err(|refusal| anyhow!("{refusal}"))?;
+
+    // Stage unprivileged, 0440 before the gate (visudo owner/mode variance).
+    let tmp = stage_rendered(&rendered)?;
+
+    // Unprivileged visudo gate — early, before anyone is asked anything.
+    match Command::new("visudo").arg("-c").arg("-f").arg(tmp.path()).output() {
+        Err(e) => {
+            // No visudo at all: nothing installable by us — print the
+            // manual path and leave the decision with the user.
+            print!("{}", voice::render_earning_declined(&rendered, dest));
+            println!("(visudo could not be run here: {e})");
+            return Ok(SealOutcome::Declined);
+        }
+        Ok(out) if !out.status.success() => {
+            // A render visudo refuses is a bug in urd, never installable.
+            let kept = tmp.keep().context("keeping the refused file for inspection")?.1;
+            print!(
+                "{}",
+                voice::render_visudo_refusal(&kept, &String::from_utf8_lossy(&out.stderr))
+            );
+            bail!("visudo refused the rendered sudoers file — nothing was activated");
+        }
+        Ok(_) => {}
+    }
+
+    // The asking: exact content, plain meaning, lettered consent.
+    print!("{}", voice::render_earning_request(&rendered, dest));
+    let choice = loop {
+        let line = crate::commands::encounter::read_input_line()?;
+        match line {
+            // EOF is walking away — the least destructive reading.
+            None => break EarningChoice::Decline,
+            Some(line) => {
+                if let Some(choice) = parse_earning_choice(&line) {
+                    break choice;
+                }
+                print!("{}", voice::render_earning_request(&rendered, dest));
+            }
+        }
+    };
+    match choice {
+        EarningChoice::Install => {}
+        EarningChoice::Print => {
+            print!("{}", voice::render_earning_declined(&rendered, dest));
+            return Ok(SealOutcome::Declined);
+        }
+        EarningChoice::Decline => {
+            print!("{}", voice::render_earning_deferred());
+            return Ok(SealOutcome::Declined);
+        }
+    }
+
+    // Consented: stage inertly as root, re-validate the root-owned bytes,
+    // then activate atomically. Interactive sudo may prompt — that's the
+    // ceremony, and both callers are TTY-gated.
+    let install = Command::new("sudo")
+        .args(["install", "-m", "0440", "-o", "root", "-g", "root"])
+        .arg(tmp.path())
+        .arg(SUDOERS_STAGING)
+        .status()
+        .context("failed to run sudo install")?;
+    if !install.success() {
+        print!(
+            "{}",
+            voice::render_earning_unavailable(&format!("`sudo install` exited {install}"))
+        );
+        print!("{}", voice::render_earning_declined(&rendered, dest));
+        return Ok(SealOutcome::Declined);
+    }
+
+    // Root-side integrity check: read the now-root-owned staged bytes back
+    // and confirm they are exactly what was rendered and shown. `install`
+    // copied whatever the unprivileged temp held at that instant; a same-uid
+    // writer could have swapped its content between the consent prompt and
+    // that copy. Comparing the staged bytes to `rendered` (not merely
+    // re-checking syntax) binds what activates to what the user approved.
+    let staged = Command::new("sudo")
+        .arg("cat")
+        .arg(SUDOERS_STAGING)
+        .output()
+        .context("failed to read the staged sudoers file back")?;
+    if !staged.status.success() || staged.stdout != rendered.as_bytes() {
+        remove_staging();
+        print!(
+            "{}",
+            voice::render_visudo_refusal(
+                Path::new(SUDOERS_STAGING),
+                "the staged file did not match the rendered grant",
+            )
+        );
+        bail!(
+            "the staged sudoers file did not match what was shown — nothing was \
+             activated (the staged file was removed)"
+        );
+    }
+
+    // Root-side re-validation: the staged bytes are now beyond a same-uid
+    // writer's reach. visudo prints its own diagnosis to the terminal.
+    let revalidate = Command::new("sudo")
+        .args(["visudo", "-c", "-f", SUDOERS_STAGING])
+        .status()
+        .context("failed to run sudo visudo -c on the staged file")?;
+    if !revalidate.success() {
+        remove_staging();
+        print!(
+            "{}",
+            voice::render_visudo_refusal(
+                Path::new(SUDOERS_STAGING),
+                "visudo reported the error above",
+            )
+        );
+        bail!("root-side visudo refused the staged sudoers file — nothing was activated");
+    }
+
+    // Same-directory rename: atomic, never a partial file under includedir.
+    let activate = Command::new("sudo")
+        .args(["mv", SUDOERS_STAGING, SUDOERS_DEST])
+        .status()
+        .context("failed to run sudo mv")?;
+    if !activate.success() {
+        bail!(
+            "could not activate the grant: `sudo mv` exited {activate}. \
+             The staged file at {SUDOERS_STAGING} is inert (includedir skips \
+             dot-names); `urd init` retries the earning"
+        );
+    }
+    drop(tmp);
+
+    // Verify. `sudo -k` first: the install cached a credential ticket, and
+    // without dropping it the probe would pass regardless of file content.
+    let _ = Command::new("sudo").arg("-k").status();
+    let (probe, detail) = probe_grant(&config.general.btrfs_path);
+    match probe {
+        GrantProbe::Granted => {}
+        GrantProbe::Denied | GrantProbe::Unclear => {
+            print!("{}", voice::render_earning_verify_failed(&detail));
+            return Ok(SealOutcome::InstalledUnverified);
+        }
+    }
+
+    // Coverage cross-check (adversary F3): the probe proves *a* grant;
+    // this proves *the* grant, at the one moment the user is watching.
+    match check_coverage(config) {
+        Ok(()) => {
+            print!("{}", voice::render_earning_installed());
+            Ok(SealOutcome::Sealed)
+        }
+        Err(reason) => {
+            print!("{}", voice::render_earning_coverage_unconfirmed(&reason));
+            Ok(SealOutcome::SealedUnverifiedCoverage)
+        }
+    }
+}
+
+/// The invoking user's passwd name — what the sudoers User_List matches.
+/// Never `$USER` (wrong under `su`); no passwd entry is an honest failure,
+/// never a guess.
+fn invoking_username() -> anyhow::Result<String> {
+    let uid = nix::unistd::Uid::current();
+    let user = nix::unistd::User::from_uid(uid)
+        .with_context(|| format!("passwd lookup failed for uid {uid}"))?
+        .ok_or_else(|| anyhow!("no passwd entry for uid {uid} — cannot name the grantee"))?;
+    Ok(user.name)
+}
+
+/// The user's answer at the asking. Enter installs; EOF declines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EarningChoice {
+    Install,
+    Print,
+    Decline,
+}
+
+/// Classify one consent line: `""`/`i` install, `p` print, `q` not now.
+fn parse_earning_choice(line: &str) -> Option<EarningChoice> {
+    match line.trim().to_lowercase().as_str() {
+        "" | "i" => Some(EarningChoice::Install),
+        "p" => Some(EarningChoice::Print),
+        "q" => Some(EarningChoice::Decline),
+        _ => None,
+    }
+}
+
+/// Best-effort removal of the inert staged file after a rejected install.
+/// The dot-name is includedir-ignored, so a leftover is harmless — but
+/// tidying it keeps the next earning's staging path clear.
+fn remove_staging() {
+    let _ = Command::new("sudo").args(["rm", "-f", SUDOERS_STAGING]).status();
+}
+
+/// Write the rendered content to an unprivileged temp file, fsynced,
+/// mode 0440 (visudo `-c -f` owner/mode variance across sudo versions).
+fn stage_rendered(rendered: &str) -> anyhow::Result<tempfile::NamedTempFile> {
+    let mut tmp = tempfile::Builder::new()
+        .prefix(".urd-sudoers-")
+        .tempfile()
+        .context("failed to create a staging file for the rendered grant")?;
+    tmp.write_all(rendered.as_bytes())
+        .context("failed to write the rendered grant")?;
+    tmp.as_file().sync_all().context("failed to sync the rendered grant")?;
+    let mut perms = tmp.as_file().metadata()?.permissions();
+    perms.set_mode(0o440);
+    tmp.as_file().set_permissions(perms)?;
+    Ok(tmp)
+}
+
+/// Whether a status surface should name the "configured but unsealed" state.
+/// Single owner of the rule (adversary F5): interactive only — a denied
+/// probe writes an auth log line, so automated and monitoring callers must
+/// never generate that noise — and only on a clear denial (`Unclear` stays
+/// silent rather than guess).
+pub(crate) fn probe_unsealed(config: &Config, output_mode: OutputMode) -> bool {
+    output_mode == OutputMode::Interactive
+        && probe_grant(&config.general.btrfs_path).0 == GrantProbe::Denied
+}
+
+/// The passwordless probe (`LC_ALL=C sudo -n <btrfs> filesystem show /`),
+/// classified. Returns the classification plus a human detail string for
+/// honest failure sentences. Shared by the seal, `urd init`'s resume, the
+/// status banner, and doctor. Never prompts (`-n`); never run from a
+/// daemon path (plan invariant — a denied probe writes an auth log line).
+pub(crate) fn probe_grant(btrfs_path: &str) -> (GrantProbe, String) {
+    match Command::new("sudo")
+        .env("LC_ALL", "C")
+        .arg("-n")
+        .arg(btrfs_path)
+        .args(["filesystem", "show", "/"])
+        .output()
+    {
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr);
+            let probe = sudoers::classify_probe(out.status.success(), &stderr);
+            let detail = if out.status.success() {
+                String::new()
+            } else {
+                format!(
+                    "exit {}: {}",
+                    out.status.code().unwrap_or(-1),
+                    stderr.trim()
+                )
+            };
+            (probe, detail)
+        }
+        Err(e) => (GrantProbe::Unclear, format!("could not run sudo: {e}")),
+    }
+}
+
+/// Diff effective privileges (`LC_ALL=C sudo -n -l`) against the config's
+/// expected grants. `Ok(())` = fully covered; `Err(reason)` = the honest
+/// cannot-confirm sentence's substance (never a silent pass).
+pub(crate) fn check_coverage(config: &Config) -> Result<(), String> {
+    let expected = sudoers::expected_grant_lines(config).map_err(|r| r.to_string())?;
+    let out = Command::new("sudo")
+        .env("LC_ALL", "C")
+        .args(["-n", "-l"])
+        .output()
+        .map_err(|e| format!("could not run sudo -n -l: {e}"))?;
+    if !out.status.success() {
+        return Err("the privilege listing needs a password (sudo -n -l)".to_string());
+    }
+    let listing = sudoers::parse_privilege_listing(&String::from_utf8_lossy(&out.stdout))
+        .map_err(|u| u.reason)?;
+    match sudoers::coverage(&expected, &listing) {
+        Coverage::AllCovered => Ok(()),
+        Coverage::CannotInterpret { reason } => Err(reason),
+        Coverage::Gaps { missing, uncertain } => {
+            let mut gaps: Vec<String> = missing;
+            gaps.extend(uncertain);
+            Err(format!(
+                "the privilege listing does not echo these grants verbatim: {}",
+                gaps.join("; ")
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_earning_choice_defaults_to_install_and_knows_the_letters() {
+        assert_eq!(parse_earning_choice(""), Some(EarningChoice::Install));
+        assert_eq!(parse_earning_choice("i"), Some(EarningChoice::Install));
+        assert_eq!(parse_earning_choice("I"), Some(EarningChoice::Install));
+        assert_eq!(parse_earning_choice("p"), Some(EarningChoice::Print));
+        assert_eq!(parse_earning_choice("q"), Some(EarningChoice::Decline));
+        assert_eq!(parse_earning_choice("x"), None);
+        assert_eq!(parse_earning_choice("install"), None);
+    }
+
+    #[test]
+    fn stage_rendered_writes_content_at_mode_0440() {
+        let tmp = stage_rendered("# rendered grant\n").unwrap();
+        let on_disk = std::fs::read_to_string(tmp.path()).unwrap();
+        assert_eq!(on_disk, "# rendered grant\n");
+        let mode = tmp.as_file().metadata().unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o440, "visudo -c gate wants a sober mode");
+    }
+
+    #[test]
+    fn kept_staging_file_survives_drop() {
+        // The grilled decision: a visudo refusal names the temp path — so
+        // the path must outlive the handle (adversary F1/G5).
+        let tmp = stage_rendered("refused content\n").unwrap();
+        let kept = tmp.keep().unwrap().1;
+        assert!(kept.exists());
+        assert_eq!(std::fs::read_to_string(&kept).unwrap(), "refused content\n");
+        std::fs::remove_file(&kept).unwrap();
+    }
+
+    /// Real `visudo -c -f` over a real render: the gate accepts what urd
+    /// renders and refuses garbage. `#[ignore]`: shells out to visudo.
+    #[test]
+    #[ignore]
+    fn visudo_accepts_the_render_and_refuses_garbage() {
+        let config = crate::config::Config::from_str(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/data/.snapshots"
+protection = "recorded"
+"#,
+        )
+        .unwrap();
+        let rendered = sudoers::render_sudoers(
+            &config,
+            &RenderContext {
+                user: "alice",
+                config_path: Path::new("/home/alice/.config/urd/urd.toml"),
+                today: chrono::NaiveDate::from_ymd_opt(2026, 7, 5).unwrap(),
+            },
+        )
+        .unwrap();
+
+        let good = stage_rendered(&rendered).unwrap();
+        let ok = Command::new("visudo")
+            .arg("-c")
+            .arg("-f")
+            .arg(good.path())
+            .output()
+            .expect("visudo must exist for this ignored test");
+        assert!(ok.status.success(), "visudo refused urd's render:\n{rendered}");
+
+        let bad = stage_rendered("alice ALL=(root NOPASSWD /broken\n").unwrap();
+        let refused = Command::new("visudo")
+            .arg("-c")
+            .arg("-f")
+            .arg(bad.path())
+            .output()
+            .unwrap();
+        assert!(!refused.status.success(), "visudo must refuse garbage");
+    }
+}

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -32,6 +32,10 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     };
     let drive_labels: Vec<String> = config.drives.iter().map(|d| d.label.clone()).collect();
 
+    // ── The seal (UPI 071) ──────────────────────────────────────────
+    // "Configured but unsealed" is a named state, not a degraded render.
+    let unsealed = crate::commands::seal::probe_unsealed(&config, output_mode);
+
     // ── Awareness model ─────────────────────────────────────────────
     let now = chrono::Local::now().naive_local();
     // Gather storage signals (read-only) and thread the per-subvol map into
@@ -90,6 +94,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         total_pins,
         &config,
         now,
+        unsealed,
     );
 
     let rendered = voice::render_status(&status_output, output_mode);
@@ -118,6 +123,7 @@ fn assemble_status_output(
     total_pins: usize,
     config: &Config,
     now: NaiveDateTime,
+    unsealed: bool,
 ) -> StatusOutput {
     // ── Chain health per subvolume (derived from awareness assessment) ──
     let chain_health_entries: Vec<ChainHealthEntry> = assessments
@@ -188,6 +194,7 @@ fn assemble_status_output(
         advice,
         storage_postures,
         storage_adaptations,
+        unsealed,
     }
 }
 
@@ -303,7 +310,28 @@ local_retention = "transient"
             0,
             config,
             dt(2026, 6, 10, 12, 0),
+            false,
         )
+    }
+
+    #[test]
+    fn assemble_threads_the_unsealed_state() {
+        // UPI 071: the banner's substance travels through the pure
+        // assembler untouched — probe at the edge, truth in the middle.
+        let config = test_config();
+        let out = assemble_status_output(
+            &[],
+            vec![],
+            vec![],
+            vec![],
+            None,
+            0,
+            &config,
+            dt(2026, 6, 10, 12, 0),
+            true,
+        );
+        assert!(out.unsealed);
+        assert!(!assemble(&[], &config).unsealed);
     }
 
     // ── Chain-health worst-selection ────────────────────────────────
@@ -486,6 +514,7 @@ local_retention = "transient"
             0,
             &test_config(),
             dt(2026, 6, 10, 12, 0),
+            false,
         );
         assert_eq!(out.last_run_age_secs, Some(7200));
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -185,8 +185,9 @@ pub fn translate_btrfs_error(
             summary: "Insufficient permissions".to_string(),
             cause: format!("btrfs {operation} was denied by the system"),
             remediation: vec![
-                "Verify sudoers configuration: `urd init` checks this".to_string(),
-                "Expected entry: <user> ALL=(root) NOPASSWD: /usr/bin/btrfs".to_string(),
+                "Run `urd init` — it verifies the grant and re-renders it from your config"
+                    .to_string(),
+                "`urd doctor` diffs the installed grant against the config".to_string(),
             ],
         };
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod sentinel_runner;
 mod state;
 mod storage_critical;
 mod strategy;
+mod sudoers;
 mod types;
 mod voice;
 #[cfg(test)]

--- a/src/output.rs
+++ b/src/output.rs
@@ -197,6 +197,12 @@ pub struct StatusOutput {
     /// no subvolume is adapting, so a Roomy system stays silent.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub storage_adaptations: Vec<AdaptationSummary>,
+    /// Configured but unsealed (UPI 071): the sudo grant does not answer a
+    /// passwordless probe, so the promises are not yet in force. Probed only
+    /// on interactive runs (a denied probe writes an auth log line — daemon
+    /// paths never probe); false means "sealed or not checked".
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub unsealed: bool,
 }
 
 /// Serializable wrapper around SubvolAssessment data.
@@ -423,6 +429,9 @@ pub struct DefaultStatusOutput {
     /// bare-`urd` clause. Omitted when all pools are Roomy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_posture: Option<PoolPostureSummary>,
+    /// Configured but unsealed (UPI 071) — see `StatusOutput::unsealed`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub unsealed: bool,
 }
 
 fn is_zero(n: &usize) -> bool {

--- a/src/sudoers.rs
+++ b/src/sudoers.rs
@@ -1,0 +1,1436 @@
+//! Sudoers rendering — the earning's single oracle (UPI 071).
+//!
+//! `/etc/sudoers.d/urd` is *derived from the config*: one snapshot-creation
+//! line per source → snapshot-root mapping, one deletion line per snapshot
+//! directory (each local root and each drive's snapshot dir), broad
+//! send/receive, and three read-only diagnostics. This module is the single
+//! oracle for that shape — the operating guide's template documents it, the
+//! earning installs it, and the doctor drift advisory diffs against it.
+//! No second template exists anywhere.
+//!
+//! Pure (ADR-108): no I/O, no clock, no environment — callers supply the
+//! username, config path, and date.
+//!
+//! ## Scope rationale (the rendering spec, shared with operating-urd.md)
+//!
+//! - **Snapshot creation and deletion are path-scoped.** A wildcard like
+//!   `subvolume delete *` would let any process running as the user delete
+//!   any subvolume on the system. Scoping to snapshot directories bounds a
+//!   bug or misuse to snapshots — never live data.
+//! - **Send/receive stay broad** (`send *`, `receive *`): source subvolumes
+//!   and external mount points vary, and both operations are non-destructive
+//!   (send is read-only; receive creates new subvolumes).
+//! - **show / filesystem show / subvolume sync** are read-only diagnostics.
+//! - Known caveat: sudoers wildcards use fnmatch without FNM_PATHNAME, so
+//!   the tail `*` in a scoped line matches across `/` and whitespace. The
+//!   scoped directory prefix is the boundary that matters; the tail is
+//!   deliberately loose (snapshot names vary).
+//!
+//! Rendering **refuses** rather than escapes anything that could change the
+//! meaning of a sudoers line (control characters, `#`, reserved words,
+//! near-filesystem-root scopes): an escaped newline is a sudoers line
+//! *continuation*, so no escaping discipline can make such values safe.
+//! Refusal is total and names the offending value — nothing is rendered.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::path::{Component, Path};
+
+use chrono::NaiveDate;
+
+use crate::config::Config;
+
+/// Caller-supplied facts a render needs beyond the config: who the grant is
+/// for, where the config lives (provenance header), and today's date.
+#[derive(Debug, Clone, Copy)]
+pub struct RenderContext<'a> {
+    pub user: &'a str,
+    pub config_path: &'a Path,
+    pub today: NaiveDate,
+}
+
+/// A value the renderer refuses to place in a sudoers line. Fail-closed:
+/// any refusal means nothing was rendered at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SudoersRefusal {
+    /// The value contains characters that could change the meaning of a
+    /// sudoers line (control characters, `#`, non-UTF-8) or, for the
+    /// username, characters sudoers treats structurally.
+    UnsafeValue { what: &'static str, value: String },
+    /// A snapshot scope too close to the filesystem root — a grant there
+    /// would cover far more than snapshots (e.g. `delete /*`).
+    ShallowScope { what: &'static str, scope: String },
+    /// The username is a sudoers reserved word (`ALL` would grant to every
+    /// user on the host).
+    ReservedUser { user: String },
+}
+
+impl fmt::Display for SudoersRefusal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SudoersRefusal::UnsafeValue { what, value } => write!(
+                f,
+                "cannot render a sudoers grant: {what} {value:?} contains characters \
+                 that could change the meaning of a sudoers line — nothing rendered"
+            ),
+            SudoersRefusal::ShallowScope { what, scope } => write!(
+                f,
+                "cannot render a sudoers grant: {what} {scope:?} is too close to the \
+                 filesystem root — a grant scoped there would cover far more than \
+                 snapshots; nothing rendered"
+            ),
+            SudoersRefusal::ReservedUser { user } => write!(
+                f,
+                "cannot render a sudoers grant for user {user:?} — a sudoers reserved \
+                 word; nothing rendered"
+            ),
+        }
+    }
+}
+
+// ── Refusals and escaping ───────────────────────────────────────────────
+
+/// Refuse control characters and `#` anywhere. Escaping cannot save these:
+/// an escaped newline is a line continuation, and `#` starts a comment.
+fn checked(what: &'static str, value: &str) -> Result<(), SudoersRefusal> {
+    if value.chars().any(char::is_control) || value.contains('#') {
+        return Err(SudoersRefusal::UnsafeValue {
+            what,
+            value: value.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// A path as a checked &str: refuses non-UTF-8 (a lossy render would name a
+/// phantom path) plus everything `checked` refuses.
+fn checked_path<'a>(what: &'static str, path: &'a Path) -> Result<&'a str, SudoersRefusal> {
+    let s = path.to_str().ok_or_else(|| SudoersRefusal::UnsafeValue {
+        what,
+        value: path.display().to_string(),
+    })?;
+    checked(what, s)?;
+    Ok(s)
+}
+
+/// Backslash-escape the characters sudoers treats specially inside a Cmnd
+/// word — structural (`\ , : = ! ( )` and space) and fnmatch metas
+/// (`* ? [ ]`), so config paths always match literally. Wildcards are
+/// appended *after* escaping, never passed through it.
+fn escape_cmnd_token(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if matches!(
+            c,
+            '\\' | ',' | ':' | '=' | '!' | '(' | ')' | ' ' | '*' | '?' | '[' | ']'
+        ) {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// A snapshot scope (creation destination or deletion directory), checked,
+/// floored, and escaped. The floor: at least two real path components —
+/// `/` or `/snapshots` must never mint a `delete /*`-shaped grant. Uniform
+/// for creation and deletion scopes (creation writes into the scope as
+/// root — same blast radius).
+fn checked_scope(what: &'static str, dir: &Path) -> Result<String, SudoersRefusal> {
+    let s = checked_path(what, dir)?;
+    let depth = dir
+        .components()
+        .filter(|c| matches!(c, Component::Normal(_)))
+        .count();
+    if depth < 2 {
+        return Err(SudoersRefusal::ShallowScope {
+            what,
+            scope: s.to_string(),
+        });
+    }
+    Ok(escape_cmnd_token(s))
+}
+
+/// Usernames are never escaped — only accepted or refused. Beyond the
+/// blanket `checked` refusals, refuse whitespace and the characters sudoers
+/// parses structurally in a User_List, and the reserved word `ALL`.
+fn checked_user(user: &str) -> Result<(), SudoersRefusal> {
+    checked("username", user)?;
+    if user.is_empty()
+        || user.chars().any(|c| {
+            c.is_whitespace() || matches!(c, ',' | ':' | '=' | '!' | '(' | ')' | '\\' | '"' | '%')
+        })
+    {
+        return Err(SudoersRefusal::UnsafeValue {
+            what: "username",
+            value: user.to_string(),
+        });
+    }
+    if user == "ALL" {
+        return Err(SudoersRefusal::ReservedUser {
+            user: user.to_string(),
+        });
+    }
+    Ok(())
+}
+
+// ── The grant model ─────────────────────────────────────────────────────
+
+/// The command specs (the part after `NOPASSWD: `), grouped by template
+/// section. Deduplicated and deterministically ordered within each section.
+struct GrantSections {
+    creation: Vec<String>,
+    deletion: Vec<String>,
+    send_receive: Vec<String>,
+    read_only: Vec<String>,
+}
+
+fn grant_sections(config: &Config) -> Result<GrantSections, SudoersRefusal> {
+    checked("btrfs path", &config.general.btrfs_path)?;
+    let btrfs = escape_cmnd_token(&config.general.btrfs_path);
+
+    // One creation line per (source, snapshot root) mapping. Disabled
+    // subvolumes are included: the grant covers the config as declared, so
+    // re-enabling never requires re-earning.
+    let mut creation = BTreeSet::new();
+    for sv in config.resolved_subvolumes() {
+        // validate() guarantees every subvolume has exactly one root; stay
+        // total anyway — a rootless subvolume simply renders no line.
+        let Some(root) = &sv.snapshot_root else {
+            continue;
+        };
+        let source = escape_cmnd_token(checked_path("subvolume source", &sv.source)?);
+        let root = checked_scope("snapshot root", root)?;
+        creation.insert(format!(
+            "{btrfs} subvolume snapshot -r {source} {root}/*"
+        ));
+    }
+
+    // One deletion line per snapshot directory: every local root and every
+    // drive's snapshot dir (mount_path/snapshot_root).
+    let mut deletion_dirs = BTreeSet::new();
+    for root in &config.local_snapshots.roots {
+        deletion_dirs.insert(checked_scope("snapshot root", &root.path)?);
+    }
+    for drive in &config.drives {
+        checked("drive snapshot_root", &drive.snapshot_root)?;
+        let dir = drive.mount_path.join(&drive.snapshot_root);
+        deletion_dirs.insert(checked_scope("drive snapshot directory", &dir)?);
+    }
+    let deletion = deletion_dirs
+        .into_iter()
+        .map(|dir| format!("{btrfs} subvolume delete {dir}/*"))
+        .collect();
+
+    Ok(GrantSections {
+        creation: creation.into_iter().collect(),
+        deletion,
+        send_receive: vec![format!("{btrfs} send *"), format!("{btrfs} receive *")],
+        read_only: vec![
+            format!("{btrfs} subvolume show *"),
+            format!("{btrfs} filesystem show *"),
+            format!("{btrfs} subvolume sync *"),
+        ],
+    })
+}
+
+/// Every command spec the config requires, in render order — the drift
+/// oracle's expected side. Specs are the post-`NOPASSWD: ` portion of each
+/// grant line.
+#[must_use = "the expected grants are the drift oracle"]
+pub fn expected_grant_lines(config: &Config) -> Result<Vec<String>, SudoersRefusal> {
+    let sections = grant_sections(config)?;
+    let mut lines = sections.creation;
+    lines.extend(sections.deletion);
+    lines.extend(sections.send_receive);
+    lines.extend(sections.read_only);
+    Ok(lines)
+}
+
+/// Render the complete `/etc/sudoers.d/urd` content for this config:
+/// provenance header, section rationale comments, and one grant line per
+/// expected command spec. Deterministic; refusal means nothing rendered.
+#[must_use = "the rendered file is the earning's artifact"]
+pub fn render_sudoers(config: &Config, ctx: &RenderContext<'_>) -> Result<String, SudoersRefusal> {
+    checked_user(ctx.user)?;
+    let config_path = checked_path("config path", ctx.config_path)?;
+    let sections = grant_sections(config)?;
+
+    let user = ctx.user;
+    let grant = |spec: &str| format!("{user} ALL=(root) NOPASSWD: {spec}\n");
+
+    let mut out = String::new();
+    out.push_str("# Urd — scoped btrfs permissions for automated backups\n");
+    out.push_str(&format!(
+        "# Generated by urd {} from {} on {}.\n",
+        env!("CARGO_PKG_VERSION"),
+        config_path,
+        ctx.today.format("%Y-%m-%d"),
+    ));
+    out.push_str("# Re-run `urd init` after config changes — it re-renders this file.\n");
+    out.push_str("#\n");
+    out.push_str("# Security principle: scope snapshot creation and deletion to snapshot\n");
+    out.push_str("# directories. send/receive need broad paths (source subvolumes and\n");
+    out.push_str("# external drives vary). show/sync are read-only diagnostics.\n");
+    out.push('\n');
+
+    out.push_str("# Snapshot creation — scoped to snapshot directories\n");
+    out.push_str("# One line per source → snapshot-root mapping in the config.\n");
+    for spec in &sections.creation {
+        out.push_str(&grant(spec));
+    }
+    out.push('\n');
+
+    out.push_str("# Snapshot deletion — scoped to snapshot directories only\n");
+    out.push_str("# One line per snapshot root (local and each external drive).\n");
+    for spec in &sections.deletion {
+        out.push_str(&grant(spec));
+    }
+    out.push('\n');
+
+    out.push_str("# Send/receive — broad paths (source subvolumes and external drives vary)\n");
+    for spec in &sections.send_receive {
+        out.push_str(&grant(spec));
+    }
+    out.push('\n');
+
+    out.push_str("# Read-only commands — space estimation, diagnostics, sync after delete\n");
+    for spec in &sections.read_only {
+        out.push_str(&grant(spec));
+    }
+
+    Ok(out)
+}
+
+// ── The drift oracle's granted side: `sudo -n -l` parsing ──────────────
+//
+// The installed file is 0440 root:root and unreadable unprivileged, so the
+// drift check reads *effective privileges* from `LC_ALL=C sudo -n -l`
+// instead (arc grill). Parsing is conservative: any line the parser cannot
+// place is a `ParseUncertain`, never a guess — the consumer renders an
+// honest "cannot verify", never a silent pass.
+
+/// One command spec from the privilege listing, with its password tag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GrantedCmnd {
+    /// The command spec as sudo prints it (e.g. `/usr/sbin/btrfs send *`),
+    /// or the literal `ALL`.
+    pub spec: String,
+    /// True when the spec carries `NOPASSWD:` — the only tag that counts:
+    /// Urd's automation runs `sudo -n`, so a password-tagged grant is no
+    /// grant at all.
+    pub nopasswd: bool,
+}
+
+/// The parsed `sudo -n -l` listing: root-capable command grants plus a
+/// flag for negated (`!`) specs, whose order-dependent semantics urd
+/// refuses to interpret.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivilegeListing {
+    pub grants: Vec<GrantedCmnd>,
+    pub has_negation: bool,
+}
+
+/// The listing could not be parsed with confidence. The reason is for the
+/// honest-skip sentence, not for recovery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseUncertain {
+    pub reason: String,
+}
+
+fn uncertain(reason: impl Into<String>) -> ParseUncertain {
+    ParseUncertain {
+        reason: reason.into(),
+    }
+}
+
+/// Parse `LC_ALL=C sudo -n -l` output. Layout (verified against live
+/// captures, piped and TTY-wrapped): a "may run the following commands"
+/// header, then one indented rule per line — `(runas) [TAG: …] cmd, cmd`.
+/// TTY mode wraps long rules onto deeper-indented continuation lines that
+/// never start with `(`; joining with a single space reconstructs the
+/// piped form.
+pub fn parse_privilege_listing(output: &str) -> Result<PrivilegeListing, ParseUncertain> {
+    let mut in_commands = false;
+    let mut rules: Vec<String> = Vec::new();
+    for line in output.lines() {
+        if !in_commands {
+            if line.contains("may run the following commands") {
+                in_commands = true;
+            }
+            continue;
+        }
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !line.starts_with(' ') && !line.starts_with('\t') {
+            break; // a new unindented section ends the command list
+        }
+        if trimmed.starts_with('(') {
+            rules.push(trimmed.to_string());
+        } else if let Some(last) = rules.last_mut() {
+            last.push(' ');
+            last.push_str(trimmed);
+        } else {
+            return Err(uncertain("continuation line before any rule"));
+        }
+    }
+    if !in_commands {
+        return Err(uncertain("no \"may run the following commands\" section"));
+    }
+    if rules.is_empty() {
+        return Err(uncertain("a commands header with no rules under it"));
+    }
+
+    let mut grants = Vec::new();
+    let mut has_negation = false;
+    for rule in &rules {
+        parse_rule(rule, &mut grants, &mut has_negation)?;
+    }
+    Ok(PrivilegeListing {
+        grants,
+        has_negation,
+    })
+}
+
+/// One rule line: `(runas) [TAG: …] cmd, cmd, …`. Tags persist across the
+/// comma-separated specs of a rule until changed; each rule starts at the
+/// sudoers default (password required). Non-root-capable runas rules are
+/// skipped — they can never cover a `(root)` grant.
+fn parse_rule(
+    rule: &str,
+    grants: &mut Vec<GrantedCmnd>,
+    has_negation: &mut bool,
+) -> Result<(), ParseUncertain> {
+    let rest = rule
+        .strip_prefix('(')
+        .ok_or_else(|| uncertain(format!("rule without a (runas) prefix: {rule}")))?;
+    let (runas, rest) = rest
+        .split_once(')')
+        .ok_or_else(|| uncertain(format!("unterminated (runas) prefix: {rule}")))?;
+    let root_capable = runas
+        .split([':', ','])
+        .any(|part| matches!(part.trim(), "root" | "ALL"));
+
+    let mut nopasswd = false;
+    for raw in split_unescaped_commas(rest.trim()) {
+        let mut spec = raw.trim();
+        // Leading TAG: tokens (NOPASSWD:, PASSWD:, SETENV:, …) update the
+        // tag state; only the password tags change what we track.
+        loop {
+            let Some((token, tail)) = spec.split_once(' ') else {
+                break;
+            };
+            let Some(tag) = token.strip_suffix(':') else {
+                break;
+            };
+            if tag.is_empty() || !tag.chars().all(|c| c.is_ascii_uppercase() || c == '_') {
+                break;
+            }
+            match tag {
+                "NOPASSWD" => nopasswd = true,
+                "PASSWD" => nopasswd = false,
+                _ => {}
+            }
+            spec = tail.trim_start();
+        }
+        if spec.is_empty() {
+            return Err(uncertain(format!("empty command spec in rule: {rule}")));
+        }
+        if let Some(negated) = spec.strip_prefix('!') {
+            if negated.is_empty() {
+                return Err(uncertain(format!("bare negation in rule: {rule}")));
+            }
+            *has_negation = true;
+            continue;
+        }
+        if root_capable {
+            grants.push(GrantedCmnd {
+                spec: spec.to_string(),
+                nopasswd,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Split a Cmnd list on commas, honoring backslash escapes — rendered
+/// paths escape `,` so a comma inside a path never splits a spec.
+fn split_unescaped_commas(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut escaped = false;
+    for c in s.chars() {
+        if escaped {
+            current.push(c);
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' => {
+                current.push(c);
+                escaped = true;
+            }
+            ',' => {
+                parts.push(std::mem::take(&mut current));
+            }
+            _ => current.push(c),
+        }
+    }
+    parts.push(current);
+    parts
+}
+
+fn has_unescaped_star(spec: &str) -> bool {
+    let mut escaped = false;
+    for c in spec.chars() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' => escaped = true,
+            '*' => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Split a command spec on unescaped whitespace — `My\ Passport` stays one
+/// token, matching how sudoers reads the spec.
+fn split_cmnd_tokens(spec: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut escaped = false;
+    for c in spec.chars() {
+        if escaped {
+            current.push(c);
+            escaped = false;
+            continue;
+        }
+        match c {
+            '\\' => {
+                current.push(c);
+                escaped = true;
+            }
+            c if c.is_whitespace() => {
+                if !current.is_empty() {
+                    tokens.push(std::mem::take(&mut current));
+                }
+            }
+            _ => current.push(c),
+        }
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    tokens
+}
+
+/// Could this wildcard-bearing grant plausibly cover the expected spec?
+/// True iff every granted token before its first wildcard token literally
+/// equals the corresponding expected token — `send *` is a candidate only
+/// for `send …` specs, never for `subvolume delete …`. Deliberately not
+/// full fnmatch: prefix-literal candidates go to *uncertain*, everything
+/// else is honestly *missing*.
+fn wildcard_prefix_candidate(granted: &str, expected: &str) -> bool {
+    if !has_unescaped_star(granted) {
+        return false;
+    }
+    let granted = split_cmnd_tokens(granted);
+    let expected = split_cmnd_tokens(expected);
+    for (i, g) in granted.iter().enumerate() {
+        if has_unescaped_star(g) {
+            return true;
+        }
+        if expected.get(i) != Some(g) {
+            return false;
+        }
+    }
+    false
+}
+
+// ── Coverage: expected grants vs effective privileges ──────────────────
+
+/// The drift verdict, three-state per the arc grill: exact matches with
+/// `NOPASSWD` (or a blanket `NOPASSWD: ALL`) are covered; an unmatched
+/// expected spec is **missing** when nothing could plausibly cover it and
+/// **uncertain** when wildcard grants on the same binary exist that urd
+/// does not interpret (fnmatch subsumption is a rabbit hole; honesty is
+/// not). Password-tagged matches never cover — automation runs `sudo -n`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Coverage {
+    AllCovered,
+    Gaps {
+        missing: Vec<String>,
+        uncertain: Vec<String>,
+    },
+    /// The listing cannot be interpreted (negated specs). The consumer
+    /// says "cannot verify", never a silent pass.
+    CannotInterpret { reason: String },
+}
+
+#[must_use = "the coverage verdict is the drift advisory's substance"]
+pub fn coverage(expected: &[String], listing: &PrivilegeListing) -> Coverage {
+    if listing.has_negation {
+        return Coverage::CannotInterpret {
+            reason: "the privilege listing contains negated (!) command specs, \
+                     which urd does not interpret"
+                .to_string(),
+        };
+    }
+    let nopasswd: Vec<&GrantedCmnd> =
+        listing.grants.iter().filter(|g| g.nopasswd).collect();
+    if nopasswd.iter().any(|g| g.spec == "ALL") {
+        return Coverage::AllCovered;
+    }
+    let mut missing = Vec::new();
+    let mut uncertain_specs = Vec::new();
+    for exp in expected {
+        if nopasswd.iter().any(|g| &g.spec == exp) {
+            continue;
+        }
+        let wildcard_candidate = nopasswd
+            .iter()
+            .any(|g| wildcard_prefix_candidate(&g.spec, exp));
+        if wildcard_candidate {
+            uncertain_specs.push(exp.clone());
+        } else {
+            missing.push(exp.clone());
+        }
+    }
+    if missing.is_empty() && uncertain_specs.is_empty() {
+        Coverage::AllCovered
+    } else {
+        Coverage::Gaps {
+            missing,
+            uncertain: uncertain_specs,
+        }
+    }
+}
+
+// ── Probe classification ────────────────────────────────────────────────
+
+/// What a `LC_ALL=C sudo -n <btrfs> filesystem show /` probe proved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GrantProbe {
+    /// The grant works — including the case where sudo ran the command and
+    /// *btrfs* failed (e.g. `/` is not btrfs on an ext4-root host): the
+    /// privilege boundary was crossed, which is all the probe asks.
+    Granted,
+    /// sudo itself refused: password required, not a sudoer.
+    Denied,
+    /// Unrecognized failure shape. Never treated as Denied — consumers
+    /// stay honest rather than announcing an unsealed state on a guess.
+    Unclear,
+}
+
+/// Classify a probe result from its exit status and stderr. `LC_ALL=C` is
+/// pinned by every caller, so the sudo denial phrases are stable; anything
+/// unrecognized is `Unclear`, never `Denied`.
+#[must_use]
+pub fn classify_probe(exit_ok: bool, stderr: &str) -> GrantProbe {
+    if exit_ok {
+        return GrantProbe::Granted;
+    }
+    const DENIALS: [&str; 4] = [
+        "a password is required",
+        "may not run sudo",
+        "is not in the sudoers file",
+        "a terminal is required",
+    ];
+    if DENIALS.iter().any(|d| stderr.contains(d)) {
+        return GrantProbe::Denied;
+    }
+    // btrfs-level failure with the grant working: sudo stays silent, the
+    // tool speaks (`ERROR: not a valid btrfs filesystem` and kin).
+    if stderr.contains("ERROR:") && !stderr.contains("sudo:") {
+        return GrantProbe::Granted;
+    }
+    GrantProbe::Unclear
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn config_from(toml: &str) -> Config {
+        Config::from_str(toml).expect("fixture config must load")
+    }
+
+    /// Local-only fixture: one subvolume, one root, no drives.
+    fn local_only() -> Config {
+        config_from(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/data/.snapshots"
+protection = "recorded"
+"#,
+        )
+    }
+
+    /// Two subvolumes on two roots, two drives — the full template shape.
+    fn sheltered_pair() -> Config {
+        config_from(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[drives]]
+label = "backup-1"
+mount_path = "/run/media/alice/backup-1"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[drives]]
+label = "backup-2"
+mount_path = "/run/media/alice/backup-2"
+snapshot_root = ".snapshots"
+role = "offsite"
+
+[[subvolumes]]
+name = "home"
+source = "/home"
+snapshot_root = "/home/alice/.snapshots"
+protection = "sheltered"
+
+[[subvolumes]]
+name = "docs"
+source = "/mnt/pool/docs"
+snapshot_root = "/mnt/pool/.snapshots"
+protection = "sheltered"
+"#,
+        )
+    }
+
+    fn ctx(config_path: &Path) -> RenderContext<'_> {
+        RenderContext {
+            user: "alice",
+            config_path,
+            today: NaiveDate::from_ymd_opt(2026, 7, 5).unwrap(),
+        }
+    }
+
+    fn rendered(config: &Config) -> String {
+        render_sudoers(config, &ctx(Path::new("/home/alice/.config/urd/urd.toml"))).unwrap()
+    }
+
+    // ── Shape ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn local_only_renders_creation_deletion_and_fixed_lines() {
+        let lines = expected_grant_lines(&local_only()).unwrap();
+        assert_eq!(
+            lines,
+            vec![
+                "/usr/sbin/btrfs subvolume snapshot -r /data/docs /data/.snapshots/*",
+                "/usr/sbin/btrfs subvolume delete /data/.snapshots/*",
+                "/usr/sbin/btrfs send *",
+                "/usr/sbin/btrfs receive *",
+                "/usr/sbin/btrfs subvolume show *",
+                "/usr/sbin/btrfs filesystem show *",
+                "/usr/sbin/btrfs subvolume sync *",
+            ]
+        );
+    }
+
+    #[test]
+    fn drives_add_one_deletion_line_each() {
+        let lines = expected_grant_lines(&sheltered_pair()).unwrap();
+        let deletes: Vec<&String> = lines.iter().filter(|l| l.contains(" delete ")).collect();
+        assert_eq!(deletes.len(), 4, "two local roots + two drives");
+        assert!(lines.iter().any(|l| l.ends_with(
+            "subvolume delete /run/media/alice/backup-1/.snapshots/*"
+        )));
+        assert!(lines.iter().any(|l| l.ends_with(
+            "subvolume delete /run/media/alice/backup-2/.snapshots/*"
+        )));
+    }
+
+    #[test]
+    fn creation_lines_are_per_source_root_pair() {
+        let lines = expected_grant_lines(&sheltered_pair()).unwrap();
+        let creations: Vec<&String> = lines.iter().filter(|l| l.contains("snapshot -r")).collect();
+        assert_eq!(creations.len(), 2);
+        assert!(creations.iter().any(|l| l.contains("/home /home/alice/.snapshots/*")));
+        assert!(creations
+            .iter()
+            .any(|l| l.contains("/mnt/pool/docs /mnt/pool/.snapshots/*")));
+    }
+
+    #[test]
+    fn shared_root_and_duplicate_mappings_dedupe() {
+        // Two subvolumes on one root: one deletion line; identical
+        // source→root pairs would collapse to one creation line.
+        let config = config_from(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "a"
+source = "/mnt/pool/a"
+snapshot_root = "/mnt/pool/.snapshots"
+protection = "recorded"
+
+[[subvolumes]]
+name = "b"
+source = "/mnt/pool/b"
+snapshot_root = "/mnt/pool/.snapshots"
+protection = "recorded"
+"#,
+        );
+        let lines = expected_grant_lines(&config).unwrap();
+        let deletes = lines.iter().filter(|l| l.contains(" delete ")).count();
+        assert_eq!(deletes, 1, "shared root renders one deletion line");
+    }
+
+    #[test]
+    fn render_is_deterministic() {
+        assert_eq!(rendered(&sheltered_pair()), rendered(&sheltered_pair()));
+    }
+
+    #[test]
+    fn every_expected_grant_line_appears_in_the_render() {
+        let config = sheltered_pair();
+        let out = rendered(&config);
+        for spec in expected_grant_lines(&config).unwrap() {
+            let line = format!("alice ALL=(root) NOPASSWD: {spec}");
+            assert!(out.contains(&line), "missing grant line: {line}");
+        }
+    }
+
+    #[test]
+    fn btrfs_path_comes_from_config_verbatim() {
+        let config = config_from(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+btrfs_path = "/usr/bin/btrfs"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/data/.snapshots"
+protection = "recorded"
+"#,
+        );
+        let lines = expected_grant_lines(&config).unwrap();
+        assert!(lines.iter().all(|l| l.starts_with("/usr/bin/btrfs ")));
+    }
+
+    // ── Header ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn header_carries_provenance_and_the_rerun_verb() {
+        let out = rendered(&local_only());
+        assert!(out.contains("/home/alice/.config/urd/urd.toml"));
+        assert!(out.contains("2026-07-05"));
+        assert!(out.contains(env!("CARGO_PKG_VERSION")));
+        assert!(out.contains("urd init"));
+    }
+
+    #[test]
+    fn header_never_names_a_rewriting_tool() {
+        assert!(!rendered(&local_only()).contains("migrate"));
+    }
+
+    #[test]
+    fn render_carries_the_section_rationale_comments() {
+        let out = rendered(&local_only());
+        assert!(out.contains("scoped to snapshot directories"));
+        assert!(out.contains("read-only diagnostics"));
+    }
+
+    // ── Escaping ────────────────────────────────────────────────────────
+
+    #[test]
+    fn spaced_paths_are_backslash_escaped() {
+        let config = config_from(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[drives]]
+label = "passport"
+mount_path = "/run/media/alice/My Passport"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/data/.snapshots"
+protection = "sheltered"
+"#,
+        );
+        let lines = expected_grant_lines(&config).unwrap();
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains(r"/run/media/alice/My\ Passport/.snapshots/*")),
+            "space must be escaped: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn glob_metacharacters_in_paths_match_literally() {
+        let config = config_from(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/photos [raw]"
+snapshot_root = "/data/.snapshots"
+protection = "recorded"
+"#,
+        );
+        let lines = expected_grant_lines(&config).unwrap();
+        assert!(
+            lines.iter().any(|l| l.contains(r"/data/photos\ \[raw\]")),
+            "fnmatch metas must be escaped: {lines:?}"
+        );
+    }
+
+    #[test]
+    fn escape_cmnd_token_covers_structural_and_glob_characters() {
+        assert_eq!(
+            escape_cmnd_token(r"a b,c:d=e!f(g)h\i*j?k[l]m"),
+            r"a\ b\,c\:d\=e\!f\(g\)h\\i\*j\?k\[l\]m"
+        );
+        assert_eq!(escape_cmnd_token("/plain/path"), "/plain/path");
+    }
+
+    // ── Refusals (injection — these tests protect the host) ────────────
+
+    #[test]
+    fn newline_in_source_refuses_with_nothing_rendered() {
+        // A hand-edited config can smuggle a full sudoers rule through a
+        // TOML escape; an escaped newline is a line continuation, so the
+        // only safe transform is refusal.
+        let config = config_from(
+            "[general]\nconfig_version = 2\nrun_frequency = \"daily\"\n\n\
+             [[subvolumes]]\nname = \"docs\"\n\
+             source = \"/data\\nmallory ALL=(ALL) NOPASSWD: ALL\"\n\
+             snapshot_root = \"/data/.snapshots\"\nprotection = \"recorded\"\n",
+        );
+        let err = render_sudoers(&config, &ctx(Path::new("/etc/urd.toml"))).unwrap_err();
+        assert!(matches!(err, SudoersRefusal::UnsafeValue { what: "subvolume source", .. }));
+        assert!(err.to_string().contains("nothing rendered"));
+    }
+
+    #[test]
+    fn carriage_return_in_mount_path_refuses() {
+        let config = config_from(
+            "[general]\nconfig_version = 2\nrun_frequency = \"daily\"\n\n\
+             [[drives]]\nlabel = \"evil\"\nmount_path = \"/run/media/alice/x\\ry\"\n\
+             snapshot_root = \".snapshots\"\nrole = \"primary\"\n\n\
+             [[subvolumes]]\nname = \"docs\"\nsource = \"/data/docs\"\n\
+             snapshot_root = \"/data/.snapshots\"\nprotection = \"sheltered\"\n",
+        );
+        let err = expected_grant_lines(&config).unwrap_err();
+        assert!(matches!(err, SudoersRefusal::UnsafeValue { .. }));
+    }
+
+    #[test]
+    fn hash_in_drive_snapshot_root_refuses() {
+        // `#` passes config validate_name_safe but starts a sudoers comment
+        // — everything after it would silently vanish from the grant.
+        let config = config_from(
+            r##"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[drives]]
+label = "evil"
+mount_path = "/run/media/alice/backup"
+snapshot_root = "#snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/data/.snapshots"
+protection = "sheltered"
+"##,
+        );
+        let err = expected_grant_lines(&config).unwrap_err();
+        assert!(matches!(
+            err,
+            SudoersRefusal::UnsafeValue { what: "drive snapshot_root", .. }
+        ));
+    }
+
+    #[test]
+    fn non_utf8_path_refuses_instead_of_lossy_rendering() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        let path = PathBuf::from(OsStr::from_bytes(b"/data/\xff-photos"));
+        let err = checked_path("subvolume source", &path).unwrap_err();
+        assert!(matches!(err, SudoersRefusal::UnsafeValue { .. }));
+    }
+
+    #[test]
+    fn control_characters_in_username_refuse() {
+        let config = local_only();
+        for user in ["al\nice", "al\tice", "alice#1", "al ice", "a\\l", "a,b", ""] {
+            let err = render_sudoers(
+                &config,
+                &RenderContext {
+                    user,
+                    config_path: Path::new("/etc/urd.toml"),
+                    today: NaiveDate::from_ymd_opt(2026, 7, 5).unwrap(),
+                },
+            )
+            .unwrap_err();
+            assert!(
+                matches!(err, SudoersRefusal::UnsafeValue { what: "username", .. }),
+                "user {user:?} must refuse"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_username_all_refuses() {
+        // A user literally named ALL would grant to every user on the host.
+        let err = render_sudoers(
+            &local_only(),
+            &RenderContext {
+                user: "ALL",
+                config_path: Path::new("/etc/urd.toml"),
+                today: NaiveDate::from_ymd_opt(2026, 7, 5).unwrap(),
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(err, SudoersRefusal::ReservedUser { .. }));
+    }
+
+    // ── Refusals (scope floor) ─────────────────────────────────────────
+
+    #[test]
+    fn root_level_snapshot_root_refuses() {
+        // `snapshot_root = "/"` would mint `delete /*` — a standing grant
+        // to delete any top-level subvolume. The floor refuses depth < 2.
+        let config = config_from(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/"
+protection = "recorded"
+"#,
+        );
+        let err = expected_grant_lines(&config).unwrap_err();
+        assert!(matches!(err, SudoersRefusal::ShallowScope { .. }));
+    }
+
+    #[test]
+    fn depth_one_scopes_refuse_uniformly() {
+        // Local root at depth 1 and a drive mounted at `/` both land under
+        // the floor — creation and deletion scopes are floored uniformly.
+        let shallow_local = config_from(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/snapshots"
+protection = "recorded"
+"#,
+        );
+        assert!(matches!(
+            expected_grant_lines(&shallow_local).unwrap_err(),
+            SudoersRefusal::ShallowScope { .. }
+        ));
+
+        let shallow_drive = config_from(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[drives]]
+label = "rootmount"
+mount_path = "/"
+snapshot_root = ".snapshots"
+role = "primary"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/data/.snapshots"
+protection = "sheltered"
+"#,
+        );
+        assert!(matches!(
+            expected_grant_lines(&shallow_drive).unwrap_err(),
+            SudoersRefusal::ShallowScope { .. }
+        ));
+    }
+
+    #[test]
+    fn depth_two_scope_is_accepted() {
+        // `/data/.snapshots` (depth 2) is the shallowest legitimate shape.
+        assert!(expected_grant_lines(&local_only()).is_ok());
+    }
+
+    // ── Privilege-listing parser (fixtures: live capture 2026-07-05, ──
+    // ── Fedora 44 / sudo 1.9.17, anonymized to alice/example-host) ─────
+
+    /// Piped (non-TTY) form: one rule per line, comma-joined multi-Cmnd.
+    /// Includes a password-tagged wheel rule, a wildcard grant, and a
+    /// multi-command non-btrfs rule — all shapes seen live.
+    const LISTING_PIPED: &str = "\
+Matching Defaults entries for alice on example-host:
+    !visiblepw, always_set_home, env_reset,
+    secure_path=/usr/local/sbin\\:/usr/local/bin\\:/usr/sbin\\:/usr/bin
+
+User alice may run the following commands on example-host:
+    (ALL) ALL
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume snapshot -r /home /home/alice/.snapshots/*
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume delete /home/alice/.snapshots/*
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume delete /run/media/alice/*/.snapshots/*
+    (root) NOPASSWD: /usr/sbin/btrfs send *
+    (root) NOPASSWD: /usr/sbin/btrfs receive *
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume show *
+    (root) NOPASSWD: /usr/sbin/btrfs filesystem show *
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume sync *
+    (root) NOPASSWD: /usr/sbin/smartctl -j -H -A -i /dev/sda, /usr/sbin/smartctl -j -H -A -i /dev/sdb
+";
+
+    /// The same privileges in TTY-wrapped form (80 columns): long rules
+    /// wrap onto deeper-indented continuation lines without a `(`.
+    const LISTING_WRAPPED: &str = "\
+Matching Defaults entries for alice on example-host:
+    !visiblepw, always_set_home, env_reset,
+    secure_path=/usr/local/sbin\\:/usr/local/bin\\:/usr/sbin\\:/usr/bin
+
+User alice may run the following commands on example-host:
+    (ALL) ALL
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume snapshot -r /home
+        /home/alice/.snapshots/*
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume delete
+        /home/alice/.snapshots/*
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume delete
+        /run/media/alice/*/.snapshots/*
+    (root) NOPASSWD: /usr/sbin/btrfs send *
+    (root) NOPASSWD: /usr/sbin/btrfs receive *
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume show *
+    (root) NOPASSWD: /usr/sbin/btrfs filesystem show *
+    (root) NOPASSWD: /usr/sbin/btrfs subvolume sync *
+    (root) NOPASSWD: /usr/sbin/smartctl -j -H -A -i /dev/sda,
+        /usr/sbin/smartctl -j -H -A -i /dev/sdb
+";
+
+    #[test]
+    fn piped_listing_parses_grants_with_tags() {
+        let listing = parse_privilege_listing(LISTING_PIPED).unwrap();
+        assert!(!listing.has_negation);
+        // Wheel rule: root-capable but password-tagged.
+        assert!(listing
+            .grants
+            .iter()
+            .any(|g| g.spec == "ALL" && !g.nopasswd));
+        // Scoped grant: NOPASSWD.
+        assert!(listing.grants.iter().any(|g| g.spec
+            == "/usr/sbin/btrfs subvolume snapshot -r /home /home/alice/.snapshots/*"
+            && g.nopasswd));
+        // Comma-joined rule splits into individual specs sharing the tag.
+        assert!(listing
+            .grants
+            .iter()
+            .any(|g| g.spec == "/usr/sbin/smartctl -j -H -A -i /dev/sdb" && g.nopasswd));
+    }
+
+    #[test]
+    fn wrapped_listing_parses_to_the_same_grants_as_piped() {
+        // The TTY-wrapped and piped forms describe identical privileges;
+        // continuation-line joining must reconstruct them exactly.
+        assert_eq!(
+            parse_privilege_listing(LISTING_WRAPPED).unwrap(),
+            parse_privilege_listing(LISTING_PIPED).unwrap()
+        );
+    }
+
+    #[test]
+    fn tag_switches_mid_rule_apply_per_spec() {
+        let listing = parse_privilege_listing(
+            "User alice may run the following commands on example-host:\n    \
+             (root) NOPASSWD: /usr/bin/a, PASSWD: /usr/bin/b, NOPASSWD: /usr/bin/c\n",
+        )
+        .unwrap();
+        let by_spec = |s: &str| listing.grants.iter().find(|g| g.spec == s).unwrap();
+        assert!(by_spec("/usr/bin/a").nopasswd);
+        assert!(!by_spec("/usr/bin/b").nopasswd);
+        assert!(by_spec("/usr/bin/c").nopasswd);
+    }
+
+    #[test]
+    fn escaped_commas_do_not_split_a_spec() {
+        let listing = parse_privilege_listing(
+            "User alice may run the following commands on example-host:\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs subvolume delete /data/a\\,b/.snapshots/*\n",
+        )
+        .unwrap();
+        assert_eq!(listing.grants.len(), 1);
+        assert_eq!(
+            listing.grants[0].spec,
+            "/usr/sbin/btrfs subvolume delete /data/a\\,b/.snapshots/*"
+        );
+    }
+
+    #[test]
+    fn non_root_runas_rules_are_not_grant_candidates() {
+        let listing = parse_privilege_listing(
+            "User alice may run the following commands on example-host:\n    \
+             (operator) NOPASSWD: /usr/bin/tape-eject\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs send *\n",
+        )
+        .unwrap();
+        assert_eq!(listing.grants.len(), 1);
+        assert_eq!(listing.grants[0].spec, "/usr/sbin/btrfs send *");
+    }
+
+    #[test]
+    fn negated_specs_set_the_flag_and_are_never_grants() {
+        let listing = parse_privilege_listing(
+            "User alice may run the following commands on example-host:\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs *, !/usr/sbin/btrfs subvolume delete *\n",
+        )
+        .unwrap();
+        assert!(listing.has_negation);
+        assert!(listing.grants.iter().all(|g| !g.spec.starts_with('!')));
+    }
+
+    #[test]
+    fn listings_without_a_commands_section_are_uncertain() {
+        for garbage in [
+            "",
+            "sudo: a password is required\n",
+            "User alice is not allowed to run sudo on example-host.\n",
+        ] {
+            assert!(
+                parse_privilege_listing(garbage).is_err(),
+                "must be uncertain: {garbage:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn malformed_rule_lines_are_uncertain_never_guessed() {
+        let out = parse_privilege_listing(
+            "User alice may run the following commands on example-host:\n    \
+             rule without runas parens\n",
+        );
+        assert!(out.is_err());
+    }
+
+    // ── Coverage ────────────────────────────────────────────────────────
+
+    fn expected_local() -> Vec<String> {
+        expected_grant_lines(&local_only()).unwrap()
+    }
+
+    #[test]
+    fn exact_nopasswd_matches_cover_everything() {
+        let rules: String = expected_local()
+            .iter()
+            .map(|spec| format!("    (root) NOPASSWD: {spec}\n"))
+            .collect();
+        let listing = parse_privilege_listing(&format!(
+            "User alice may run the following commands on example-host:\n{rules}"
+        ))
+        .unwrap();
+        assert_eq!(coverage(&expected_local(), &listing), Coverage::AllCovered);
+    }
+
+    #[test]
+    fn nopasswd_all_covers_everything() {
+        let listing = parse_privilege_listing(
+            "User alice may run the following commands on example-host:\n    \
+             (ALL) NOPASSWD: ALL\n",
+        )
+        .unwrap();
+        assert_eq!(coverage(&expected_local(), &listing), Coverage::AllCovered);
+    }
+
+    #[test]
+    fn password_tagged_grants_never_cover() {
+        // A wheel `(ALL) ALL` allows everything *with a password* — but
+        // automation runs `sudo -n`, so it covers nothing.
+        let listing = parse_privilege_listing(
+            "User alice may run the following commands on example-host:\n    (ALL) ALL\n",
+        )
+        .unwrap();
+        match coverage(&expected_local(), &listing) {
+            Coverage::Gaps { missing, uncertain } => {
+                assert_eq!(missing.len(), expected_local().len());
+                assert!(uncertain.is_empty());
+            }
+            other => panic!("expected all-missing gaps, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_missing_delete_line_is_named() {
+        let expected = expected_local();
+        let rules: String = expected
+            .iter()
+            .filter(|spec| !spec.contains(" delete "))
+            .map(|spec| format!("    (root) NOPASSWD: {spec}\n"))
+            .collect();
+        let listing = parse_privilege_listing(&format!(
+            "User alice may run the following commands on example-host:\n{rules}"
+        ))
+        .unwrap();
+        match coverage(&expected, &listing) {
+            Coverage::Gaps { missing, uncertain } => {
+                assert_eq!(missing.len(), 1);
+                assert!(missing[0].contains("subvolume delete /data/.snapshots/*"));
+                assert!(uncertain.is_empty(), "no wildcard candidates here: {uncertain:?}");
+            }
+            other => panic!("expected a gap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn wildcard_grants_make_unmatched_specs_uncertain_not_missing() {
+        // The live host grants `snapshot -r /mnt/pool/* /mnt/pool/.snapshots/*`
+        // — hand-managed wildcards can cover expected lines in ways urd
+        // does not interpret. Honest uncertainty, not a false MISSING.
+        let listing = parse_privilege_listing(
+            "User alice may run the following commands on example-host:\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs subvolume snapshot -r /data/* /data/.snapshots/*\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs subvolume delete /data/.snapshots/*\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs send *\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs receive *\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs subvolume show *\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs filesystem show *\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs subvolume sync *\n",
+        )
+        .unwrap();
+        match coverage(&expected_local(), &listing) {
+            Coverage::Gaps { missing, uncertain } => {
+                assert!(missing.is_empty(), "wildcards must not read as missing: {missing:?}");
+                assert_eq!(uncertain.len(), 1);
+                assert!(uncertain[0].contains("subvolume snapshot -r /data/docs"));
+            }
+            other => panic!("expected uncertain gap, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn negations_make_coverage_uninterpretable() {
+        let listing = parse_privilege_listing(
+            "User alice may run the following commands on example-host:\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs *, !/usr/sbin/btrfs subvolume delete *\n",
+        )
+        .unwrap();
+        assert!(matches!(
+            coverage(&expected_local(), &listing),
+            Coverage::CannotInterpret { .. }
+        ));
+    }
+
+    // ── Probe classification ───────────────────────────────────────────
+
+    #[test]
+    fn classify_probe_table() {
+        use GrantProbe::*;
+        let cases: [(bool, &str, GrantProbe); 7] = [
+            (true, "", Granted),
+            (false, "sudo: a password is required\n", Denied),
+            (false, "sudo: sorry, user alice may not run sudo on example-host\n", Denied),
+            (false, "alice is not in the sudoers file.\n", Denied),
+            (false, "sudo: a terminal is required to read the password\n", Denied),
+            // Grant worked; btrfs itself failed (ext4-root host).
+            (false, "ERROR: not a valid btrfs filesystem: /\n", Granted),
+            (false, "something entirely unexpected\n", Unclear),
+        ];
+        for (exit_ok, stderr, want) in cases {
+            assert_eq!(
+                classify_probe(exit_ok, stderr),
+                want,
+                "exit_ok={exit_ok} stderr={stderr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_failures_are_never_denied() {
+        // Risk flag 3: stderr phrasing is sudo-version-sensitive. An
+        // unrecognized shape must stay Unclear so no surface announces an
+        // unsealed state on a guess.
+        assert_eq!(
+            classify_probe(false, "sudo: unbekannter Fehler\n"),
+            GrantProbe::Unclear
+        );
+    }
+
+    // ── Brute-force invariants (recurrence pattern 7) ──────────────────
+
+    /// One test drives every fixture through the renderer and asserts the
+    /// safety properties over *every* output line — the class of
+    /// regression, not the instances listed above.
+    #[test]
+    fn every_rendered_line_is_scoped_or_allowlisted() {
+        for config in [local_only(), sheltered_pair()] {
+            let out = rendered(&config);
+            let btrfs = &config.general.btrfs_path;
+            for line in out.lines() {
+                if line.is_empty() || line.starts_with('#') {
+                    continue;
+                }
+                let prefix = format!("alice ALL=(root) NOPASSWD: {btrfs} ");
+                let spec = line
+                    .strip_prefix(&prefix)
+                    .unwrap_or_else(|| panic!("unexpected line shape: {line}"));
+                let allowlisted = matches!(
+                    spec,
+                    "send *" | "receive *" | "subvolume show *" | "filesystem show *"
+                        | "subvolume sync *"
+                );
+                let scoped_creation = spec.starts_with("subvolume snapshot -r /")
+                    && spec.ends_with("/*")
+                    && !spec.ends_with(" /*");
+                let scoped_deletion = spec.starts_with("subvolume delete /")
+                    && spec.ends_with("/*")
+                    && !spec.ends_with(" /*");
+                assert!(
+                    allowlisted || scoped_creation || scoped_deletion,
+                    "line escapes the grant model: {line}"
+                );
+                assert!(
+                    spec != "*" && !spec.starts_with("* "),
+                    "bare wildcard grant must never render: {line}"
+                );
+            }
+        }
+    }
+}

--- a/src/voice/encounter.rs
+++ b/src/voice/encounter.rs
@@ -589,16 +589,153 @@ pub fn render_empty_report(view: &EmptyView) -> String {
     out
 }
 
-/// After a successful carve: name the file, point at the next verb.
-/// (The seal — sudo grant, first snapshot — is UPI 075; until it lands,
-/// `urd init` verifies the environment.)
+/// After a successful carve: name the file. The earning (UPI 071) follows
+/// immediately in the same flow, so this line no longer points anywhere.
 #[must_use]
 pub fn render_post_carve(path: &Path) -> String {
     format!(
-        "{} {}\n\
-         Your promises are carved. Run `urd init` to verify your setup.\n",
+        "{} {}\nYour promises are carved.\n",
         "Carved:".bold(),
         path.display()
+    )
+}
+
+// ── The earning (UPI 071): asking for root, scoped and shown ───────────
+
+/// The asking: show the exact file, state what each section permits, offer
+/// the lettered choice. The content shown IS the content installed — the
+/// staged copy is re-validated as root before it goes live.
+#[must_use]
+pub fn render_earning_request(rendered: &str, dest: &Path) -> String {
+    let mut out = String::new();
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "{} To keep them, Urd needs leave to run btrfs as root — exactly this, no more:",
+        "The promises need root.".bold()
+    )
+    .ok();
+    writeln!(out).ok();
+    for line in rendered.lines() {
+        writeln!(out, "    {line}").ok();
+    }
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "Creation and deletion stay inside your snapshot directories. Send and receive\n\
+         move snapshots without destroying anything. Show and sync only read.\n\
+         The file goes to {} after a root-side syntax check.",
+        dest.display()
+    )
+    .ok();
+    writeln!(out).ok();
+    writeln!(out, "  i) install it  (Enter — sudo will ask for your password)").ok();
+    writeln!(out, "  p) print the commands; I'll do it myself").ok();
+    writeln!(out, "  q) not now").ok();
+    out
+}
+
+/// The earning held: grant installed, probe passed, coverage confirmed.
+#[must_use]
+pub fn render_earning_installed() -> String {
+    format!(
+        "{} Root leave granted, scoped as shown, verified without a password.\n",
+        "Earned:".bold()
+    )
+}
+
+/// Installed and probing, but the coverage cross-check could not be
+/// confirmed (listing unavailable or uninterpretable). Honest, not red.
+#[must_use]
+pub fn render_earning_coverage_unconfirmed(reason: &str) -> String {
+    format!(
+        "{} The grant is installed and answers a passwordless probe.\n\
+         Full coverage could not be confirmed: {reason}\n\
+         `urd doctor` repeats this check when you wish.\n",
+        "Earned, mostly verified:".bold()
+    )
+}
+
+/// Installed but the verification probe failed — the file is in place and
+/// the grant does not answer. Name it; `urd init` retries the earning.
+#[must_use]
+pub fn render_earning_verify_failed(detail: &str) -> String {
+    format!(
+        "{} The file is installed, but the passwordless probe failed:\n\
+         \x20 {detail}\n\
+         Nothing more was changed. `urd init` retries the earning.\n",
+        "Not yet earned:".bold()
+    )
+}
+
+/// The declined path (or `p`): the exact content plus the manual command.
+/// The promise is carved but not yet in force; `urd init` resumes.
+#[must_use]
+pub fn render_earning_declined(rendered: &str, dest: &Path) -> String {
+    let mut out = String::new();
+    writeln!(out, "Nothing installed. To grant it yourself, put this in {}:", dest.display())
+        .ok();
+    writeln!(out).ok();
+    for line in rendered.lines() {
+        writeln!(out, "    {line}").ok();
+    }
+    writeln!(out).ok();
+    writeln!(out, "  sudo visudo -f {}", dest.display()).ok();
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "Until the grant exists, the promises are carved but not in force.\n\
+         `urd init` resumes the earning at any time."
+    )
+    .ok();
+    out
+}
+
+/// visudo refused the rendered file — fail-closed, nothing reaches
+/// sudoers.d actively. Names the file that holds the refused content
+/// (the unprivileged temp, or the inert root-owned staging file).
+#[must_use]
+pub fn render_visudo_refusal(kept: &Path, stderr: &str) -> String {
+    format!(
+        "{} visudo refused the rendered file — nothing was activated.\n\
+         \x20 {}\n\
+         The refused content is kept at {} for inspection.\n\
+         This is a bug in urd's rendering, not in your answers.\n",
+        "Refused:".bold(),
+        stderr.trim(),
+        kept.display()
+    )
+}
+
+/// A passwordless grant already answers (e.g. a broader hand-managed
+/// rule) — nothing to ask; the drift advisory watches coverage.
+#[must_use]
+pub fn render_earning_already() -> String {
+    format!(
+        "{} Root leave already answers without a password — nothing to ask.\n\
+         `urd doctor` checks its coverage against the config.\n",
+        "Earned:".bold()
+    )
+}
+
+/// `q) not now`: the user saw the content and deferred — no re-print,
+/// just the honest state and the resume verb.
+#[must_use]
+pub fn render_earning_deferred() -> String {
+    "Nothing installed. The promises are carved but not in force until the earning.\n\
+     `urd init` resumes it at any time.\n"
+        .to_string()
+}
+
+/// sudo itself is not available to this user (not a sudoer, or sudo
+/// missing) — its own sentence, never a generic error.
+#[must_use]
+pub fn render_earning_unavailable(detail: &str) -> String {
+    format!(
+        "{} This account cannot use sudo here: {detail}\n\
+         Ask an administrator to install the grant (`p` prints it), or run\n\
+         `urd init` once sudo works.\n",
+        "Cannot ask:".bold()
     )
 }
 
@@ -623,12 +760,14 @@ pub fn render_editor_failure(error: &str, revert_available: bool) -> String {
 
 /// Delve-deeper was chosen but no editor is set. The file is already
 /// carved and valid — keeping it is the honest fallback, never deletion.
+/// The earning has not happened on this exit: name it (arc grill — `urd
+/// init` is the resume verb).
 #[must_use]
 pub fn render_no_editor(path: &Path) -> String {
     format!(
         "No editor is set ($VISUAL and $EDITOR are both empty).\n\
-         The config is carved at {} — edit it yourself when you wish;\n\
-         `urd init` re-checks it afterwards.\n",
+         The config is carved at {} — edit it yourself when you wish.\n\
+         The earning — root leave for btrfs — still awaits; `urd init` resumes it.\n",
         path.display()
     )
 }
@@ -888,11 +1027,12 @@ mod tests {
     }
 
     #[test]
-    fn post_carve_names_the_file_and_next_verb() {
+    fn post_carve_names_the_file() {
+        // No next-verb pointer any more: the earning follows in-flow (071).
         let _color = color_guard(false);
         let out = render_post_carve(Path::new("/home/user/.config/urd/urd.toml"));
         assert!(out.contains("urd.toml"), "{out}");
-        assert!(out.contains("urd init"), "{out}");
+        assert!(out.contains("carved"), "{out}");
     }
 
     #[test]
@@ -918,6 +1058,78 @@ mod tests {
         let out = render_no_editor(Path::new("/tmp/urd.toml"));
         assert!(out.contains("/tmp/urd.toml"), "{out}");
         assert!(out.contains("EDITOR"), "{out}");
+        // This exit skips the earning — the resume verb must be named (071).
+        assert!(out.contains("urd init"), "{out}");
+    }
+
+    // ── The earning (UPI 071) ───────────────────────────────────────────
+
+    const RENDERED: &str = "# header\nalice ALL=(root) NOPASSWD: /usr/sbin/btrfs send *\n";
+    const DEST: &str = "/etc/sudoers.d/urd";
+
+    #[test]
+    fn earning_request_shows_content_dest_and_lettered_choices() {
+        let _color = color_guard(false);
+        let out = render_earning_request(RENDERED, Path::new(DEST));
+        assert!(out.contains("NOPASSWD: /usr/sbin/btrfs send *"), "{out}");
+        assert!(out.contains(DEST), "{out}");
+        for letter in ["i)", "p)", "q)"] {
+            assert!(
+                out.lines().any(|l| l.trim_start().starts_with(letter)),
+                "missing choice {letter}: {out}"
+            );
+        }
+        assert!(out.contains("root"), "{out}");
+    }
+
+    #[test]
+    fn earning_outcomes_speak_honestly() {
+        let _color = color_guard(false);
+        assert!(render_earning_installed().contains("verified"));
+        let unconfirmed = render_earning_coverage_unconfirmed("listing needs a password");
+        assert!(unconfirmed.contains("could not be confirmed"), "{unconfirmed}");
+        assert!(unconfirmed.contains("listing needs a password"), "{unconfirmed}");
+        let failed = render_earning_verify_failed("exit 1: a password is required");
+        assert!(failed.contains("probe failed"), "{failed}");
+        assert!(failed.contains("urd init"), "{failed}");
+    }
+
+    #[test]
+    fn earning_declined_prints_content_and_the_manual_command() {
+        let _color = color_guard(false);
+        let out = render_earning_declined(RENDERED, Path::new(DEST));
+        assert!(out.contains("Nothing installed"), "{out}");
+        assert!(out.contains("NOPASSWD: /usr/sbin/btrfs send *"), "{out}");
+        assert!(out.contains("sudo visudo -f /etc/sudoers.d/urd"), "{out}");
+        assert!(out.contains("urd init"), "{out}");
+    }
+
+    #[test]
+    fn visudo_refusal_is_fail_closed_and_names_the_kept_file() {
+        let _color = color_guard(false);
+        let out = render_visudo_refusal(Path::new("/tmp/.urd-sudoers"), "syntax error near line 3");
+        assert!(out.contains("nothing was activated"), "{out}");
+        assert!(out.contains("/tmp/.urd-sudoers"), "{out}");
+        assert!(out.contains("syntax error"), "{out}");
+    }
+
+    #[test]
+    fn earning_unavailable_has_its_own_sentence() {
+        let _color = color_guard(false);
+        let out = render_earning_unavailable("alice is not in the sudoers file");
+        assert!(out.contains("cannot use sudo"), "{out}");
+        assert!(out.contains("not in the sudoers file"), "{out}");
+    }
+
+    #[test]
+    fn earning_already_and_deferred_speak_the_state() {
+        let _color = color_guard(false);
+        let already = render_earning_already();
+        assert!(already.contains("already answers"), "{already}");
+        assert!(already.contains("urd doctor"), "{already}");
+        let deferred = render_earning_deferred();
+        assert!(deferred.contains("not in force"), "{deferred}");
+        assert!(deferred.contains("urd init"), "{deferred}");
     }
 
     #[test]

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -51,8 +51,11 @@ pub use doctor::render_doctor;
 pub use drives::{render_drives_adopt, render_drives_list};
 pub use emergency::{render_emergency, render_emergency_result};
 pub use encounter::{
-    render_editor_failure, render_farewell, render_invalid_notice, render_no_editor,
-    render_post_carve, render_prompt,
+    render_earning_already, render_earning_coverage_unconfirmed, render_earning_declined,
+    render_earning_deferred, render_earning_installed, render_earning_request,
+    render_earning_unavailable, render_earning_verify_failed, render_editor_failure,
+    render_farewell, render_invalid_notice, render_no_editor, render_post_carve,
+    render_prompt, render_visudo_refusal,
 };
 pub use get::render_get;
 pub use history::{render_events, render_history, render_subvolume_history};
@@ -463,6 +466,7 @@ pub(crate) mod test_fixtures {
 
     pub(crate) fn test_status_output() -> StatusOutput {
         StatusOutput {
+            unsealed: false,
             assessments: vec![
                 StatusAssessment {
                     name: "htpc-home".to_string(),
@@ -694,6 +698,7 @@ pub(crate) mod test_fixtures {
 
     pub(crate) fn test_default_status_output() -> DefaultStatusOutput {
         DefaultStatusOutput {
+            unsealed: false,
             total: 4,
             waning_names: vec![],
             exposed_names: vec![],

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -45,6 +45,13 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
     // ── Summary line ────────────────────────────────────────────────
     render_summary_line(data, &mut out);
 
+    // ── The seal (UPI 071) ──────────────────────────────────────────
+    // Configured but unsealed: said once, high, with the resume verb.
+    // Yellow, never red — nothing was lost (Rule 6, red is earned). The
+    // wording names the state, not the probe: 075 widens what "sealed"
+    // takes (units, first snapshot) without rewording this banner.
+    render_unsealed_banner(data, &mut out);
+
     // ── Storage adaptation prose (UPI 031-b AB3.1) ──────────────────
     // Rendered HIGH (right under the summary, ahead of any routine staleness
     // line) so a deliberately-slowed Critical subvolume does not read as broken
@@ -108,6 +115,21 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
     }
 
     out
+}
+
+/// The unsealed banner (UPI 071): the promises are carved but not in
+/// force until root leave exists. One sentence, one resume verb.
+pub(super) fn render_unsealed_banner(data: &StatusOutput, out: &mut String) {
+    if !data.unsealed {
+        return;
+    }
+    writeln!(
+        out,
+        "{}",
+        "Configured but unsealed — the promises are not yet in force.".yellow()
+    )
+    .ok();
+    writeln!(out, "Run `urd init` to resume the earning (root leave for btrfs).").ok();
 }
 
 pub(super) fn render_summary_line(data: &StatusOutput, out: &mut String) {
@@ -731,6 +753,16 @@ fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
         write!(out, "{colored}").ok();
     }
 
+    // Configured but unsealed (UPI 071): one clause, the resume verb.
+    if data.unsealed {
+        write!(
+            out,
+            " {}",
+            "Configured but unsealed — `urd init` resumes the earning.".yellow()
+        )
+        .ok();
+    }
+
     // Last backup age (pre-computed by command handler to keep voice pure)
     if let Some(age_secs) = data.last_run_age_secs {
         write!(out, " Last backup {} ago.", humanize_duration(age_secs)).ok();
@@ -1251,9 +1283,41 @@ mod tests {
     }
 
     #[test]
+    fn interactive_unsealed_banner_names_state_and_resume_verb() {
+        let _color = color_guard(false);
+        let mut data = crate::voice::test_fixtures::test_status_output();
+        data.unsealed = true;
+        let out = render_status(&data, OutputMode::Interactive);
+        assert!(out.contains("unsealed"), "{out}");
+        assert!(out.contains("not yet in force"), "{out}");
+        assert!(out.contains("urd init"), "{out}");
+    }
+
+    #[test]
+    fn interactive_sealed_carries_no_unsealed_banner() {
+        let _color = color_guard(false);
+        let out = render_status(
+            &crate::voice::test_fixtures::test_status_output(),
+            OutputMode::Interactive,
+        );
+        assert!(!out.contains("unsealed"), "{out}");
+    }
+
+    #[test]
+    fn default_unsealed_clause_points_at_init() {
+        let _color = color_guard(false);
+        let mut data = crate::voice::test_fixtures::test_default_status_output();
+        data.unsealed = true;
+        let out = render_default_status(&data, OutputMode::Interactive);
+        assert!(out.contains("unsealed"), "{out}");
+        assert!(out.contains("urd init"), "{out}");
+    }
+
+    #[test]
     fn interactive_no_subvolumes() {
         let _color = color_guard(false);
         let data = StatusOutput {
+            unsealed: false,
             assessments: vec![],
             chain_health: vec![],
             drives: vec![],
@@ -1330,6 +1394,7 @@ mod tests {
     fn interactive_no_last_run() {
         let _color = color_guard(false);
         let data = StatusOutput {
+            unsealed: false,
             assessments: vec![],
             chain_health: vec![],
             drives: vec![],
@@ -1932,6 +1997,7 @@ mod tests {
     fn default_some_exposed() {
         let _color = color_guard(false);
         let data = DefaultStatusOutput {
+            unsealed: false,
             total: 9,
             waning_names: vec![],
             exposed_names: vec!["htpc-root".to_string(), "docs".to_string()],
@@ -1966,6 +2032,7 @@ mod tests {
     fn default_some_waning() {
         let _color = color_guard(false);
         let data = DefaultStatusOutput {
+            unsealed: false,
             total: 5,
             waning_names: vec!["htpc-config".to_string()],
             exposed_names: vec!["htpc-root".to_string()],
@@ -2022,6 +2089,7 @@ mod tests {
     fn default_no_last_backup() {
         let _color = color_guard(false);
         let data = DefaultStatusOutput {
+            unsealed: false,
             total: 2,
             waning_names: vec![],
             exposed_names: vec![],
@@ -2043,6 +2111,7 @@ mod tests {
     #[test]
     fn default_daemon_json() {
         let data = DefaultStatusOutput {
+            unsealed: false,
             total: 3,
             waning_names: vec!["sv1".to_string()],
             exposed_names: vec![],

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -1110,6 +1110,27 @@ mod contract {
     }
 
     #[test]
+    fn rule6_unsealed_banner_is_yellow_never_red() {
+        // UPI 071: "configured but unsealed" is a designed state on the
+        // declined path — nothing was lost, so the banner must not borrow
+        // red's gravity. Red is earned by exposure, not by a pending
+        // ceremony.
+        let _color = color_guard(true);
+        let mut data = all_sealed_status();
+        data.unsealed = true;
+        let output = render_status(&data, OutputMode::Interactive);
+        let banner: Vec<&str> = output.lines().filter(|l| l.contains("unsealed")).collect();
+        assert!(!banner.is_empty(), "unsealed banner must render:\n{output}");
+        for line in banner {
+            assert_eq!(
+                helpers::count_red(line),
+                0,
+                "the unsealed banner must never be red: {line:?}"
+            );
+        }
+    }
+
+    #[test]
     fn rule6_unprotected_row_emits_red_on_exposure_cell() {
         let _color = color_guard(true);
         let mut data = test_status_output();


### PR DESCRIPTION
## Summary

- **The earning** (UPI 071, Encounter arc 2/9): Urd now renders and installs the scoped `/etc/sudoers.d/urd` grant instead of asking the user to hand-edit it. New pure `sudoers` module is the single oracle for the grant shape — derived from the config, refusing (never escaping) anything that could change a sudoers line's meaning: control characters, `#`, non-UTF-8, near-root scopes that could mint `delete /*`, reserved usernames.
- **Fail-closed install**: staged inertly as `/etc/sudoers.d/urd.staging` (a dot-name sudo's includedir ignores), root-owned bytes read back and byte-compared to what the user was shown, re-validated by `sudo visudo -c`, then activated by atomic rename — a crash or a same-uid content swap can never leave a broken or unapproved file that locks sudo host-wide. Verification drops the cached sudo ticket, probes passwordlessly, and cross-checks coverage against `sudo -l`.
- **Declined path named**: `urd status` and bare `urd` show the "configured but unsealed" state (yellow, never red) with `urd init` as the single resume verb; declining prints the exact content and the manual command.
- **Drift advisory**: `urd doctor` diffs the config's expected grants against effective privileges — honest "cannot verify" when the listing needs a password or resists interpretation, never a silent pass. The sudo-btrfs check now distinguishes "grant denied" from "grant works, btrfs failed" (ext4-root hosts). Daemon paths never probe sudo.

Design grilled 2026-07-03; arch-adversary review (7 findings, all integrated via /post-review — F1 install-mechanics deviation user-approved); /security-review found no reportable vulnerabilities and one defense-in-depth item (root-side byte-compare) was added.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 2154 passed, 0 failed (5+1 ignored); ~60 new tests incl. injection-refusal and brute-force grant-model invariants
- Real `visudo -c` gate exercised via an #[ignore] integration test; live `urd doctor`/`urd status` drift + banner verified on the host
- Integration tests (drive-mounted): not run

🤖 Generated with [Claude Code](https://claude.com/claude-code)