### PR TITLE
feat: the first seal — drive adoption, systemd units, first snapshot, send offer, second look, summary (UPI 075)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **The first seal (UPI 075, Encounter arc 6/9).** Everything between "the
+  config exists and root is granted" and "the terminal closes on a protected
+  system" now happens in one guided pass, and `urd init` resumes it at the
+  first incomplete stage. After the earning: **drive adoption** (each mounted,
+  UUID-verified drive gets its snapshot home and identity token — the
+  `urd drives adopt` decision, shared; unreachable drives get one honest
+  sentence and the seal continues); **systemd units** embedded in the binary
+  (repo `systemd/` files are the compile-time source of truth; ExecStart is
+  substituted with this binary's resolved path — a timer pointing at a missing
+  binary would be a silent protection failure) written to
+  `~/.config/systemd/user/` and enabled with consent, the sentinel service
+  included when the granularity answer chose sentinel mode; **the first local
+  snapshot**, immediately, through the normal backup pipeline — the Encounter
+  never ends with zero threads spun; **the first-send offer**, explicit and
+  honest about duration, never time-limited (Enter sends now, `t` defers to
+  tonight's timer, declined is recorded nowhere); **the privileged second
+  look** (`btrfs subvolume list` via a new `BtrfsRead` method and one new
+  read-only sudoers line), classified in subvol-path space and capped at one
+  advisory sentence; and **the summary scroll** — what was woven, when Urd
+  acts next (derived only from what the installed units actually do), and the
+  handoff to `urd status`. `urd status`/bare `urd` now name the first
+  incomplete seal stage (`seal_gap`: privilege / units / first-thread — one
+  gap, one sentence, replacing the unreleased `unsealed` boolean). `urd
+  doctor` gains a **units drift advisory** (installed files diffed against
+  what this binary would render, both ExecStart paths named) and a **linger
+  check** — user timers fire only while a session exists; `Linger=no` earns
+  one honest sentence and `loginctl enable-linger` is named, never run.
+  Hosts sealed under the 071 grant show one Missing coverage line
+  (`subvolume list`) in doctor until `urd init` re-renders the grant.
+  ~35 new tests.
 - **Privilege bootstrap — guided sudoers (UPI 071, Encounter arc 2/9).** Urd
   now earns root instead of asking you to hand-edit sudoers. New pure
   `sudoers` module is the single oracle for the scoped grant: one

--- a/docs/00-foundation/guides/operating-urd.md
+++ b/docs/00-foundation/guides/operating-urd.md
@@ -54,11 +54,13 @@ automatically — the service unit runs `%h/.cargo/bin/urd backup` each time, so
 always picks up whatever binary is at that path. No `daemon-reload` needed for binary
 updates (only for unit file changes).
 
-> **This manual path is interim.** The Encounter — Urd's guided first-run
-> conversation, in development — replaces everything from here through Initial
-> Setup: generated config, initialized drive, created directories, verified
-> identity. Until it ships, follow these steps exactly and in order; the traps
-> called out below were all hit in live field testing (2026-07-04).
+> **The guided path replaces this manual path.** The Encounter — run `urd` (or
+> `urd init`) on an unconfigured system — now covers everything from here
+> through Initial Setup: generated config, the sudoers earning, drive adoption,
+> installed + enabled systemd units, the first local snapshot, and the offer of
+> the first send. `urd init` also resumes an interrupted seal at its first
+> incomplete stage. The manual steps below remain as the fallback reference;
+> the traps called out were all hit in live field testing (2026-07-04).
 
 ## Sudoers Configuration
 
@@ -191,6 +193,9 @@ urd calibrate
 urd backup
 
 # 7. Install the systemd units for nightly backups and the sentinel
+#    (the seal does this for you — `urd init` — including substituting this
+#    binary's real path into ExecStart; the cp below installs the repo units
+#    verbatim with the %h/.cargo/bin path)
 mkdir -p ~/.config/systemd/user
 cp systemd/urd-*.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
@@ -201,6 +206,12 @@ systemctl --user enable --now urd-sentinel.service   # recommended; see below
 The sentinel is the continuous protection layer — without it, Urd runs only at
 04:00 and promise states drift between runs. Skip the sentinel enable line if you
 want the nightly cron without the always-on watchdog.
+
+**Lingering.** User-level timers fire only while you have an active session. With
+lingering off, a logged-out night is skipped (and caught up at your next login via
+`Persistent=true`); a headless box never runs. `loginctl enable-linger $USER` lets
+the timer fire always — the seal and `urd doctor` name this when it applies, but
+Urd never changes it for you.
 
 ## CLI Commands
 
@@ -306,8 +317,9 @@ is recommended.
 | `urd-sentinel.service` | Long-running daemon: drive events, promise refresh, notifications |
 
 All three run at low priority (`Nice=19`, `IOSchedulingClass=idle`). The backup
-service allows up to 6 hours for large sends. The sentinel restarts on failure
-with a 30-second back-off.
+service never time-limits a run (`TimeoutStartSec=infinity` — a first full send
+can legitimately run longer than a day). The sentinel restarts on failure with a
+30-second back-off.
 
 The sentinel is the integration layer — drive plug/unplug detection, sub-hourly
 promise-state updates, and notification dispatch all live there. Without it,
@@ -315,7 +327,18 @@ Urd is a nightly cron job; with it, Urd is a continuous protection layer.
 
 ### Install / update units
 
-From the root of your clone:
+**The guided path: `urd init`.** The seal renders the units embedded in the
+binary (repo `systemd/` files are the compile-time source of truth), substitutes
+this binary's resolved path into `ExecStart`, writes them to
+`~/.config/systemd/user/`, and enables them with consent. Which units it installs
+follows the config's `run_frequency`: the nightly pair always, plus the sentinel
+service in sentinel mode. `urd doctor` diffs the installed files against what
+this binary would render and names any drift (a doctor run from a different
+binary — e.g. a dev build — reports an expected ExecStart difference naming both
+paths).
+
+Manual fallback, from the root of your clone (installs the repo units verbatim,
+with the `%h/.cargo/bin/urd` path):
 
 ```bash
 mkdir -p ~/.config/systemd/user
@@ -325,7 +348,7 @@ systemctl --user enable --now urd-backup.timer
 systemctl --user enable --now urd-sentinel.service   # optional but recommended
 ```
 
-Re-run this after modifying unit files in the repo. Copying (rather than
+Re-run `urd init` (or this recipe) after unit files change. Copying (rather than
 symlinking) keeps the installed units stable across `git checkout` operations.
 
 ### Monitor

--- a/docs/20-reference/cli.md
+++ b/docs/20-reference/cli.md
@@ -75,9 +75,11 @@ Each subcommand declares whether it requires a config load:
 ### `urd` (no subcommand)
 
 **Contract.** With a config: a one-screen promise summary (compact status);
-interactively it probes the sudo grant once (`sudo -n`, never prompts) and
-appends a "configured but unsealed — `urd init` resumes the earning" clause
-when the grant is clearly denied. Without a config: offers the Encounter
+interactively it checks the seal once (a `sudo -n` probe, never prompting,
+then unit-file existence and first-snapshot presence) and appends one clause
+for the first incomplete seal stage — configured-but-unsealed, schedule not
+yet enabled, or first thread not yet spun — each pointing at `urd init`.
+Without a config: offers the Encounter
 when a human is on both ends (stdin and stdout are terminals); otherwise
 prints the pointer and exits 3. Declining or quitting the Encounter writes
 nothing — the config file appears only at the carve, after explicit
@@ -154,11 +156,14 @@ requires reading the heartbeat or metrics, not the exit code.
 drive presence, and overall data safety. Reads filesystem, SQLite, and the
 heartbeat file; writes nothing. Safe under any condition, including a
 running backup (advisory locking via `lock.rs` makes the read non-conflicting).
-Interactively it also probes the sudo grant once (`sudo -n`, never prompts) and,
-when the grant is clearly denied, names the **configured but unsealed** state
-with `urd init` as the resume verb. Daemon runs never probe (a denied probe
-writes an auth-log line), so the `unsealed` field is absent from daemon JSON —
-it serializes only when true, and only interactive runs check.
+Interactively it also checks the seal once (a `sudo -n` probe, never prompting,
+plus unit-file existence and first-snapshot presence) and names the **first
+incomplete seal stage** — `privilege` (configured but unsealed), `units` (the
+schedule is not enabled), or `first_thread` (a promise has no local snapshot) —
+with `urd init` as the resume verb, one gap, one sentence. Daemon runs never
+probe (a denied probe writes an auth-log line), so the `seal_gap` field is
+absent from daemon JSON — it serializes only when a gap exists, and only
+interactive runs check.
 
 **Output.** Interactive — voice-rendered status block answering "is my data
 safe?" Daemon — JSON.
@@ -217,18 +222,43 @@ Encounter (pointer + exit 3 without a terminal on both ends). Invalid
 config + terminal → the fix-it loop ((e)dit in `$VISUAL`/`$EDITOR` /
 (q)uit keeping the file, error named), then continues into the checks;
 I/O failures (permissions) always surface instead. With a loadable
-config and a terminal on both ends, a clearly denied sudo grant
-resumes **the seal at the earning** (UPI 071): render the scoped
-sudoers file from the config, `visudo -c` gate, show + consent,
-staged fail-closed install (`/etc/sudoers.d/urd.staging`, root-side
-re-validation, atomic rename to `/etc/sudoers.d/urd`), then a
-passwordless verification probe and a `sudo -l` coverage cross-check.
-Declining prints the content and the manual command; nothing is
-installed without consent, and EOF never installs. After (or without)
-the earning: ensures the state DB directory and heartbeat directory
-exist, runs the same infrastructure checks `doctor` runs, and exits
-cleanly. Safe to run multiple times. The install step prompts for
-your password via sudo.
+config and a terminal on both ends, ANY incomplete seal stage resumes
+**the seal at its first incomplete stage** (UPI 071/075); a fully
+sealed system enters no ceremony. The stages, each opening with an
+idempotent done-check:
+
+1. **The earning** (denied grant): render the scoped sudoers file from
+   the config, `visudo -c` gate, show + consent, staged fail-closed
+   install (`/etc/sudoers.d/urd.staging`, root-side re-validation,
+   atomic rename to `/etc/sudoers.d/urd`), passwordless verification
+   probe + `sudo -l` coverage cross-check. Declining prints the content
+   and the manual command; EOF never installs. A declined or unverified
+   earning ends the seal (later stages need the grant).
+2. **Drive adoption**: each configured, mounted, UUID-verified drive
+   gets its snapshot home and identity token (the `urd drives adopt`
+   decision, shared). Unreachable drives get one honest sentence each;
+   the seal continues.
+3. **Units**: the embedded systemd units (ExecStart substituted with
+   this binary's resolved path), written to `~/.config/systemd/user/`
+   and enabled with consent — the nightly pair, plus the sentinel
+   service in sentinel mode. Lingering off earns one honest sentence
+   (user timers fire only while logged in); Urd never enables lingering.
+4. **The first local snapshot**: local snapshot homes are created, then
+   a normal `backup --local-only` run through the full pipeline.
+5. **The first-send offer**: explicit, honest about duration, never
+   time-limited; Enter sends now, `t`/EOF defer to tonight's timer.
+   Declining is recorded nowhere — a later `urd init` re-offers.
+6. **The second look** (privileged, annotate-only): `btrfs subvolume
+   list` per promised pool; at most one summary sentence about
+   subvolumes no promise covers. Never re-opens the conversation.
+7. **The summary scroll**: what was woven, when Urd acts next (derived
+   only from the installed units), the honest partial states, and the
+   handoff — `urd status`.
+
+After (or without) the seal: ensures the state DB directory and
+heartbeat directory exist, runs the same infrastructure checks
+`doctor` runs, and exits cleanly. Safe to run multiple times. The
+install steps prompt for your password via sudo.
 
 **Output.** Interactive — the conversation or the checklist of
 infrastructure items; `{"status":"not_configured"}` in daemon mode
@@ -345,7 +375,8 @@ config first). Writes to the state DB.
 
 **Contract.** Runs the full diagnostic battery: config preflight,
 infrastructure checks (DB, dirs, sudo btrfs), the sudoers drift advisory,
-drive UUID fingerprinting, and local-space trend warnings. Read-only.
+the systemd-units drift advisory + linger check, drive UUID fingerprinting,
+and local-space trend warnings. Read-only.
 Designed to be the first thing an operator runs when something feels off.
 The drift advisory diffs the config's expected grants (single oracle:
 `sudoers.rs`) against effective privileges from `sudo -n -l`: a working
@@ -354,6 +385,12 @@ covering grant warns and names `urd init` as the re-render verb; a listing
 that needs a password, contains negations, or resists parsing is an honest
 "cannot verify" warning — never a silent pass. When the grant itself is
 denied, only the sudo-btrfs check speaks (one cause, one finding).
+The units advisory diffs the installed unit files against what THIS binary
+would render (single oracle: `systemd_units.rs`): all-match is one Ok row;
+a missing unit warns with `urd init` as the completing verb; a differing
+unit warns naming both ExecStart paths (a doctor run from a dev build
+self-diagnoses). With the units in place, `Linger=no` earns one Warn naming
+`loginctl enable-linger` — user timers fire only while a session exists.
 
 **Notable flags.**
 

--- a/src/btrfs.rs
+++ b/src/btrfs.rs
@@ -36,6 +36,13 @@ pub trait BtrfsRead {
     /// (UPI 054-b pre-send sweep, adversary F1). Same `subvolume show` call
     /// as `subvolume_generation` — no new sudoers surface.
     fn received_uuid(&self, path: &Path) -> crate::error::Result<Option<String>>;
+
+    /// Every subvolume of the filesystem containing `path`, as printed by
+    /// `btrfs subvolume list` — paths relative to the filesystem's top
+    /// level, NOT to `path` or its mountpoint (UPI 075 second look; callers
+    /// must map config paths into subvol-path space before comparing). New
+    /// sudoers verb — `expected_grant_lines` carries the matching line.
+    fn list_subvolumes(&self, path: &Path) -> crate::error::Result<Vec<PathBuf>>;
 }
 
 /// Trait abstracting btrfs operations. `RealBtrfs` calls the btrfs binary;
@@ -558,6 +565,40 @@ pub fn parse_received_uuid(output: &str) -> Option<String> {
     None
 }
 
+/// Parse `btrfs subvolume list` output into subvolume paths. Each line is
+/// `ID <n> gen <g> top level <t> path <p>`; the path runs to end-of-line and
+/// may contain spaces, so split on the ` path ` marker, not whitespace.
+/// Paths are relative to the filesystem's top level. Any malformed line is
+/// an error — the second look degrades to no annotation rather than a
+/// partial guess (UPI 075).
+pub fn parse_subvolume_list(output: &str) -> crate::error::Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    for line in output.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let path = line
+            .starts_with("ID ")
+            .then(|| line.split_once(" path "))
+            .flatten()
+            .map(|(_, path)| path);
+        match path {
+            Some(p) if !p.is_empty() => paths.push(PathBuf::from(p)),
+            _ => {
+                return Err(UrdError::Btrfs {
+                    context: BtrfsErrorContext {
+                        operation: BtrfsOperation::List,
+                        exit_code: None,
+                        stderr: format!("unrecognized subvolume list line: {line}"),
+                        bytes_transferred: None,
+                    },
+                });
+            }
+        }
+    }
+    Ok(paths)
+}
+
 /// Run `sudo btrfs subvolume show` and return its stdout. Shared by the
 /// `BtrfsRead` field readers (`subvolume_generation`, `received_uuid`) — one
 /// invocation, one sudoers surface.
@@ -611,6 +652,37 @@ impl BtrfsRead for RealBtrfs {
     fn received_uuid(&self, path: &Path) -> crate::error::Result<Option<String>> {
         let stdout = subvolume_show(path)?;
         Ok(parse_received_uuid(&stdout))
+    }
+
+    fn list_subvolumes(&self, path: &Path) -> crate::error::Result<Vec<PathBuf>> {
+        let output = Command::new("sudo")
+            .env("LC_ALL", "C")
+            .arg(&self.btrfs_path)
+            .args(["subvolume", "list"])
+            .arg(path)
+            .output()
+            .map_err(|e| UrdError::Btrfs {
+                context: BtrfsErrorContext {
+                    operation: BtrfsOperation::List,
+                    exit_code: None,
+                    stderr: e.to_string(),
+                    bytes_transferred: None,
+                },
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+            return Err(UrdError::Btrfs {
+                context: BtrfsErrorContext {
+                    operation: BtrfsOperation::List,
+                    exit_code: output.status.code(),
+                    stderr,
+                    bytes_transferred: None,
+                },
+            });
+        }
+
+        parse_subvolume_list(&String::from_utf8_lossy(&output.stdout))
     }
 }
 
@@ -870,6 +942,11 @@ pub struct MockBtrfs {
     pub received_uuids: RefCell<HashMap<PathBuf, Option<String>>>,
     /// Paths for which received_uuid() should return an error.
     pub fail_received_uuids: RefCell<HashSet<PathBuf>>,
+    /// Subvolume listings per queried path (filesystem-relative results).
+    /// Unconfigured paths error — the fail-closed default.
+    pub subvolume_lists: RefCell<HashMap<PathBuf, Vec<PathBuf>>>,
+    /// Paths for which list_subvolumes() should return an error.
+    pub fail_subvolume_lists: RefCell<HashSet<PathBuf>>,
 }
 
 #[allow(dead_code)]
@@ -890,6 +967,8 @@ impl MockBtrfs {
             fail_generations: RefCell::new(HashSet::new()),
             received_uuids: RefCell::new(HashMap::new()),
             fail_received_uuids: RefCell::new(HashSet::new()),
+            subvolume_lists: RefCell::new(HashMap::new()),
+            fail_subvolume_lists: RefCell::new(HashSet::new()),
         }
     }
 
@@ -942,6 +1021,26 @@ impl BtrfsRead for MockBtrfs {
                 source: std::io::Error::new(
                     std::io::ErrorKind::NotFound,
                     "mock: no received_uuid configured",
+                ),
+            })
+    }
+
+    fn list_subvolumes(&self, path: &Path) -> crate::error::Result<Vec<PathBuf>> {
+        if self.fail_subvolume_lists.borrow().contains(path) {
+            return Err(UrdError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::other("mock: subvolume list failed"),
+            });
+        }
+        self.subvolume_lists
+            .borrow()
+            .get(path)
+            .cloned()
+            .ok_or_else(|| UrdError::Io {
+                path: path.to_path_buf(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "mock: no subvolume list configured",
                 ),
             })
     }
@@ -1302,6 +1401,67 @@ mod tests {
         assert!(mock.received_uuid(&failing).is_err());
         // Unconfigured path errors — sweep callers fail closed.
         assert!(mock.received_uuid(Path::new("/elsewhere")).is_err());
+    }
+
+    // ── parse_subvolume_list (UPI 075 second look) ──────────────────────
+
+    #[test]
+    fn parse_subvolume_list_multiline_nested_and_spaced_paths() {
+        let output = "ID 256 gen 41234 top level 5 path home\n\
+                      ID 257 gen 41230 top level 5 path root\n\
+                      ID 300 gen 41111 top level 256 path home/alice/My Projects\n\
+                      ID 301 gen 40000 top level 5 path data/.snapshots/20260705-0400-docs\n";
+        let paths = parse_subvolume_list(output).unwrap();
+        assert_eq!(
+            paths,
+            vec![
+                PathBuf::from("home"),
+                PathBuf::from("root"),
+                PathBuf::from("home/alice/My Projects"),
+                PathBuf::from("data/.snapshots/20260705-0400-docs"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_subvolume_list_empty_output_is_no_subvolumes() {
+        assert_eq!(parse_subvolume_list("").unwrap(), Vec::<PathBuf>::new());
+        assert_eq!(parse_subvolume_list("\n\n").unwrap(), Vec::<PathBuf>::new());
+    }
+
+    #[test]
+    fn parse_subvolume_list_malformed_line_is_an_error_not_a_guess() {
+        // A recognizable-but-wrong line must fail the whole parse: the
+        // second look omits its annotation rather than undercounting.
+        for bad in [
+            "ID 256 gen 41234 top level 5",        // no path marker
+            "totally unexpected format",           // no ID prefix
+            "ID 256 gen 41234 top level 5 path ",  // empty path
+        ] {
+            assert!(
+                parse_subvolume_list(bad).is_err(),
+                "line should refuse to parse: {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn mock_subvolume_list_lookup_and_failure() {
+        let mock = MockBtrfs::new();
+        let pool = PathBuf::from("/");
+        let failing = PathBuf::from("/data");
+        mock.subvolume_lists
+            .borrow_mut()
+            .insert(pool.clone(), vec![PathBuf::from("home"), PathBuf::from("root")]);
+        mock.fail_subvolume_lists.borrow_mut().insert(failing.clone());
+
+        assert_eq!(
+            mock.list_subvolumes(&pool).unwrap(),
+            vec![PathBuf::from("home"), PathBuf::from("root")]
+        );
+        assert!(mock.list_subvolumes(&failing).is_err());
+        // Unconfigured path errors — the fail-closed default.
+        assert!(mock.list_subvolumes(Path::new("/elsewhere")).is_err());
     }
 
     // ── pump_with_cancel (UPI 033, cancel-responsive writes UPI 054-b) ─

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -95,8 +95,8 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         .into_iter()
         .max_by(|a, b| a.tier.cmp(&b.tier).then(a.host_root.cmp(&b.host_root)));
 
-    // Configured but unsealed (UPI 071) — see `seal::probe_unsealed`.
-    let unsealed = crate::commands::seal::probe_unsealed(&config, output_mode);
+    // An incomplete seal stage (UPI 071/075) — see `seal::seal_completeness`.
+    let seal_gap = crate::commands::seal::seal_completeness(&config, output_mode);
 
     let output = DefaultStatusOutput {
         total,
@@ -109,7 +109,7 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         best_advice,
         total_needing_attention,
         storage_posture,
-        unsealed,
+        seal_gap,
     };
 
     let rendered = voice::render_default_status(&output, output_mode);

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -138,6 +138,45 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     }
     infra_checks.extend(drift_checks);
 
+    // ── Units drift + linger (UPI 075) ───────────────────────────
+    // The oracle (`systemd_units::expected_units`) diffed against the
+    // installed files — content included, since ExecStart carries the
+    // resolved binary path (adversary F6: the detail names both paths so a
+    // dev-build doctor self-diagnoses). Not --thorough-gated. The linger
+    // row (adversary F1) speaks only when the units are in place: a user
+    // timer fires only while a session exists.
+    let exe = std::env::current_exe()
+        .and_then(std::fs::canonicalize)
+        .ok();
+    let installed = dirs::config_dir().map(|d| {
+        let dir = d.join("systemd/user");
+        expected_unit_name_set(&config.general.run_frequency)
+            .into_iter()
+            .map(|name| {
+                (
+                    name.to_string(),
+                    std::fs::read_to_string(dir.join(name)).ok(),
+                )
+            })
+            .collect::<std::collections::HashMap<_, _>>()
+    });
+    let mut units_checks =
+        build_units_drift_checks(&config, exe.as_deref(), installed.as_ref());
+    if units_checks
+        .iter()
+        .all(|c| c.status == DoctorCheckStatus::Ok)
+    {
+        units_checks.extend(linger_check());
+    }
+    for check in &units_checks {
+        match check.status {
+            DoctorCheckStatus::Warn => warn_count += 1,
+            DoctorCheckStatus::Error => error_count += 1,
+            DoctorCheckStatus::Ok => {}
+        }
+    }
+    infra_checks.extend(units_checks);
+
     // UUID fingerprinting checks for mounted drives
     for (label, _uuid, snippet) in drives::check_missing_uuids(&config.drives) {
         warn_count += 1;
@@ -460,6 +499,155 @@ fn build_sudoers_drift_checks(config: &Config, listing: Option<&str>) -> Vec<Doc
             }
             checks
         }
+    }
+}
+
+/// The unit filenames the cadence answer expects — the doctor-side twin of
+/// `seal::expected_unit_names` (names only; content comes from the oracle).
+fn expected_unit_name_set(run_frequency: &crate::types::RunFrequency) -> Vec<&'static str> {
+    match run_frequency {
+        crate::types::RunFrequency::Sentinel => {
+            vec!["urd-backup.service", "urd-backup.timer", "urd-sentinel.service"]
+        }
+        crate::types::RunFrequency::Timer { .. } => {
+            vec!["urd-backup.service", "urd-backup.timer"]
+        }
+    }
+}
+
+/// Diff the units oracle (`systemd_units::expected_units`) against the
+/// installed unit files. Pure over the injected exe path and contents map;
+/// the filesystem reads stay in `run()`. `exe = None` = the binary path
+/// could not be resolved; `installed = None` = no config dir — both honest
+/// skips, never a silent pass.
+fn build_units_drift_checks(
+    config: &Config,
+    exe: Option<&std::path::Path>,
+    installed: Option<&std::collections::HashMap<String, Option<String>>>,
+) -> Vec<DoctorCheck> {
+    let cannot_verify = |detail: String| {
+        vec![DoctorCheck {
+            name: "systemd units drift".to_string(),
+            status: DoctorCheckStatus::Warn,
+            detail: Some(detail),
+            suggestion: Some("Run `urd init` to re-render and reinstall the units.".to_string()),
+        }]
+    };
+    let Some(exe) = exe else {
+        return cannot_verify(
+            "could not resolve this urd binary's path — cannot verify the installed units"
+                .to_string(),
+        );
+    };
+    let expected = match crate::systemd_units::expected_units(&config.general.run_frequency, exe)
+    {
+        Ok(expected) => expected,
+        Err(refusal) => return cannot_verify(refusal.to_string()),
+    };
+    let Some(installed) = installed else {
+        return cannot_verify("no config directory for this user".to_string());
+    };
+
+    let drift = crate::systemd_units::diff_units(&expected, installed);
+    if drift.is_empty() {
+        return vec![DoctorCheck {
+            name: "systemd units match this binary".to_string(),
+            status: DoctorCheckStatus::Ok,
+            detail: None,
+            suggestion: None,
+        }];
+    }
+    drift
+        .into_iter()
+        .map(|d| match d.kind {
+            crate::systemd_units::UnitDriftKind::Missing => DoctorCheck {
+                name: "systemd units drift".to_string(),
+                status: DoctorCheckStatus::Warn,
+                detail: Some(format!("{} is not installed", d.name)),
+                suggestion: Some("Run `urd init` to complete the seal.".to_string()),
+            },
+            crate::systemd_units::UnitDriftKind::Differs => {
+                // F6: name both paths — the installed ExecStart vs. this
+                // binary — so a dev-build doctor run reads as what it is.
+                let installed_exec = installed
+                    .get(d.name)
+                    .and_then(|c| c.as_ref())
+                    .and_then(|c| c.lines().find(|l| l.starts_with("ExecStart=")))
+                    .unwrap_or("no ExecStart line")
+                    .to_string();
+                DoctorCheck {
+                    name: "systemd units drift".to_string(),
+                    status: DoctorCheckStatus::Warn,
+                    detail: Some(format!(
+                        "{} differs from what this binary ({}) would render \
+                         (installed: {installed_exec})",
+                        d.name,
+                        exe.display()
+                    )),
+                    suggestion: Some(
+                        "Run `urd init` to re-render and reinstall the units.".to_string(),
+                    ),
+                }
+            }
+        })
+        .collect()
+}
+
+/// The linger advisory (UPI 075, adversary F1): user timers fire only
+/// while a session exists. `Linger=no` → one Warn with the exact command;
+/// an unanswerable loginctl → an honest skip; `Linger=yes` → silence (a
+/// real pass needs no row).
+fn linger_check() -> Vec<DoctorCheck> {
+    let row = |status, detail: String, suggestion: Option<String>| {
+        vec![DoctorCheck {
+            name: "session lingering".to_string(),
+            status,
+            detail: Some(detail),
+            suggestion,
+        }]
+    };
+    let Ok(user) = crate::commands::seal::invoking_username() else {
+        return row(
+            DoctorCheckStatus::Warn,
+            "could not name the invoking user — cannot check lingering".to_string(),
+            None,
+        );
+    };
+    match std::process::Command::new("loginctl")
+        .env("LC_ALL", "C")
+        .args(["show-user", &user, "--property=Linger"])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            match String::from_utf8_lossy(&out.stdout).trim() {
+                "Linger=no" => row(
+                    DoctorCheckStatus::Warn,
+                    "lingering is off: backups run only while you are logged in \
+                     (missed nights catch up at next login)"
+                        .to_string(),
+                    Some(format!("Run `loginctl enable-linger {user}` to free them.")),
+                ),
+                "Linger=yes" => Vec::new(),
+                other => row(
+                    DoctorCheckStatus::Warn,
+                    format!("could not read the lingering state: {other:?}"),
+                    None,
+                ),
+            }
+        }
+        Ok(out) => row(
+            DoctorCheckStatus::Warn,
+            format!(
+                "loginctl could not answer: {}",
+                String::from_utf8_lossy(&out.stderr).trim()
+            ),
+            None,
+        ),
+        Err(e) => row(
+            DoctorCheckStatus::Warn,
+            format!("could not run loginctl: {e}"),
+            None,
+        ),
     }
 }
 
@@ -876,6 +1064,73 @@ protection = "recorded"
             .map(|s| format!("    (root) NOPASSWD: {s}\n"))
             .collect();
         format!("User alice may run the following commands on example-host:\n{rules}")
+    }
+
+    // ── Units drift (UPI 075) ──────────────────────────────────────────
+
+    fn installed_map(
+        units: &[crate::systemd_units::UnitFile],
+    ) -> std::collections::HashMap<String, Option<String>> {
+        units
+            .iter()
+            .map(|u| (u.name.to_string(), Some(u.content.clone())))
+            .collect()
+    }
+
+    #[test]
+    fn units_all_matching_render_one_ok_row() {
+        let config = drift_config();
+        let exe = std::path::Path::new("/home/alice/.cargo/bin/urd");
+        let expected =
+            crate::systemd_units::expected_units(&config.general.run_frequency, exe).unwrap();
+        let checks = build_units_drift_checks(&config, Some(exe), Some(&installed_map(&expected)));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Ok);
+    }
+
+    #[test]
+    fn units_missing_one_warns_with_the_seal_verb() {
+        let config = drift_config();
+        let exe = std::path::Path::new("/home/alice/.cargo/bin/urd");
+        let expected =
+            crate::systemd_units::expected_units(&config.general.run_frequency, exe).unwrap();
+        let mut installed = installed_map(&expected);
+        installed.insert("urd-backup.timer".to_string(), None);
+        let checks = build_units_drift_checks(&config, Some(exe), Some(&installed));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
+        assert!(checks[0].detail.as_deref().unwrap().contains("urd-backup.timer"));
+        assert!(checks[0].suggestion.as_deref().unwrap().contains("urd init"));
+    }
+
+    /// Adversary F6: a Differs row names both binaries — the installed
+    /// ExecStart and the doctor's own path — so a dev-build run
+    /// self-diagnoses instead of alarming.
+    #[test]
+    fn units_differing_detail_names_both_exe_paths() {
+        let config = drift_config();
+        let sealed_exe = std::path::Path::new("/home/alice/.cargo/bin/urd");
+        let doctor_exe = std::path::Path::new("/home/alice/dev/urd/target/debug/urd");
+        let sealed =
+            crate::systemd_units::expected_units(&config.general.run_frequency, sealed_exe)
+                .unwrap();
+        let checks =
+            build_units_drift_checks(&config, Some(doctor_exe), Some(&installed_map(&sealed)));
+        // The timer has no ExecStart and matches; the service differs.
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
+        let detail = checks[0].detail.as_deref().unwrap();
+        assert!(detail.contains("target/debug/urd"), "{detail}");
+        assert!(detail.contains(".cargo/bin/urd"), "{detail}");
+    }
+
+    #[test]
+    fn units_unresolvable_exe_is_an_honest_skip_never_silent() {
+        let config = drift_config();
+        let checks = build_units_drift_checks(&config, None, None);
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
+        assert!(checks[0].detail.as_deref().unwrap().contains("binary"));
     }
 
     #[test]

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -150,7 +150,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         .ok();
     let installed = dirs::config_dir().map(|d| {
         let dir = d.join("systemd/user");
-        expected_unit_name_set(&config.general.run_frequency)
+        crate::systemd_units::expected_unit_names(&config.general.run_frequency)
             .into_iter()
             .map(|name| {
                 (
@@ -498,19 +498,6 @@ fn build_sudoers_drift_checks(config: &Config, listing: Option<&str>) -> Vec<Doc
                 });
             }
             checks
-        }
-    }
-}
-
-/// The unit filenames the cadence answer expects — the doctor-side twin of
-/// `seal::expected_unit_names` (names only; content comes from the oracle).
-fn expected_unit_name_set(run_frequency: &crate::types::RunFrequency) -> Vec<&'static str> {
-    match run_frequency {
-        crate::types::RunFrequency::Sentinel => {
-            vec!["urd-backup.service", "urd-backup.timer", "urd-sentinel.service"]
-        }
-        crate::types::RunFrequency::Timer { .. } => {
-            vec!["urd-backup.service", "urd-backup.timer"]
         }
     }
 }

--- a/src/commands/drives.rs
+++ b/src/commands/drives.rs
@@ -165,18 +165,18 @@ pub fn run_drives_adopt(
         .format("%Y-%m-%dT%H:%M:%S")
         .to_string();
 
-    let action = match (on_disk_token, sqlite_token) {
-        // Both exist and match — nothing to do.
-        (Some(ref disk), Some(ref db)) if disk == db => AdoptAction::AlreadyCurrent,
-
-        // On-disk token exists but differs from SQLite (or SQLite has no record).
-        (Some(disk_token), _) => {
+    let action = match crate::drives::decide_adoption(
+        on_disk_token.as_deref(),
+        sqlite_token.as_deref(),
+    ) {
+        crate::drives::AdoptDecision::AlreadyCurrent => AdoptAction::AlreadyCurrent,
+        crate::drives::AdoptDecision::AdoptExisting => {
+            let disk_token = on_disk_token
+                .ok_or_else(|| anyhow::anyhow!("AdoptExisting implies an on-disk token"))?;
             state.store_drive_token(label, &disk_token, &now)?;
             AdoptAction::AdoptedExisting { token: disk_token }
         }
-
-        // No on-disk token — generate new.
-        (None, _) => {
+        crate::drives::AdoptDecision::GenerateNew => {
             let token = generate_drive_token();
             write_drive_token(drive, &token)?;
             state.store_drive_token(label, &token, &now)?;

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -54,13 +54,17 @@ pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::R
         },
     };
 
-    // The resume verb (arc grill Q5, UPI 071): loadable config + human on
-    // both ends + the grant clearly not answering → resume the seal at the
-    // earning, then continue into the checks. This sits AFTER the whole
+    // The resume verb (arc grill Q5, UPI 071/075): loadable config + human
+    // on both ends + ANY incomplete seal stage (denied grant, missing
+    // units, no first thread) → resume the seal at its first incomplete
+    // stage, then continue into the checks. This sits AFTER the whole
     // match so the fix-it-repaired path resumes too. Unclear never
-    // triggers a ceremony on a guess; non-TTY reports via the checks.
+    // triggers a ceremony on a guess; non-TTY reports via the checks;
+    // a fully sealed system enters no ceremony (Q5: nothing to do).
     let mut sudo_probe = seal::probe_grant(&config.general.btrfs_path);
-    if doorstep == crate::commands::Doorstep::Offer && sudo_probe.0 == GrantProbe::Denied {
+    if doorstep == crate::commands::Doorstep::Offer
+        && seal::seal_gap_given_probe(&config, sudo_probe.0).is_some()
+    {
         let path = crate::commands::resolve_config_path(config_path)?;
         seal::resume_seal(&config, &path)?;
         // Re-probe: the checks below must describe the post-seal state.

--- a/src/commands/seal.rs
+++ b/src/commands/seal.rs
@@ -20,7 +20,7 @@
 
 use std::io::Write as _;
 use std::os::unix::fs::PermissionsExt as _;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{anyhow, bail, Context};
@@ -49,10 +49,693 @@ pub enum SealOutcome {
     InstalledUnverified,
 }
 
-/// Resume the seal at its first incomplete stage. Stage 1: the earning.
-/// (075 extends this with further stages; keep the early-return shape.)
+/// Resume the seal at its first incomplete stage (UPI 075). Stage order:
+/// earning → adoption → units → first snapshot → send offer → second look →
+/// summary. Each stage opens with an idempotent done-check, so `urd init`
+/// re-enters cleanly from any interruption; no stage failure unwinds a
+/// prior stage (ADR-109).
+///
+/// The earning's outcome decides continuation per variant (adversary F4):
+/// only a grant that answers lets threads spin. `Declined` and
+/// `InstalledUnverified` stop here with their honest sentences already
+/// printed — running a backup that is guaranteed to fail at `sudo btrfs`
+/// would bury the earning's conclusion under executor noise.
 pub fn resume_seal(config: &Config, config_path: &Path) -> anyhow::Result<SealOutcome> {
-    earn_privilege(config, config_path)
+    let outcome = earn_privilege(config, config_path)?;
+    match outcome {
+        SealOutcome::Sealed | SealOutcome::SealedUnverifiedCoverage => {}
+        SealOutcome::Declined | SealOutcome::InstalledUnverified => return Ok(outcome),
+    }
+
+    adopt_drives(config);
+    let units_enabled = install_units(config);
+    let first_thread_spun = first_snapshot(config, config_path);
+    let send = if first_thread_spun {
+        offer_first_send(config, config_path)
+    } else {
+        crate::output::SealSendState::NotApplicable
+    };
+
+    // Stage 6: the privileged second look — annotation only, one sentence
+    // in the summary, never a re-opened conversation (arc Q1). Only with a
+    // grant that answers (reuse the stage-1 outcome; no extra probe, no
+    // extra auth-log line).
+    let uncovered = second_look(
+        config,
+        &crate::btrfs::RealBtrfs::for_reads(&config.general.btrfs_path),
+    );
+
+    // Stage 7: the summary scroll and the handoff to `urd status`.
+    let summary = crate::output::SealSummary {
+        threads: config
+            .resolved_subvolumes()
+            .iter()
+            .filter(|sv| sv.enabled)
+            .map(|sv| crate::output::SealThread {
+                name: sv.name.clone(),
+                level: sv.protection_level.map(|l| l.to_string()),
+            })
+            .collect(),
+        units_enabled,
+        next_action: voice::describe_next_action(&config.general.run_frequency),
+        linger_loose: linger_loose().is_some(),
+        first_thread_spun,
+        send,
+        uncovered_subvolumes: uncovered,
+    };
+    print!("{}", voice::render_seal_summary(&summary));
+
+    Ok(outcome)
+}
+
+// ── Stage 6: the privileged second look ─────────────────────────────────
+
+/// Count the subvolumes on the promised pools that no promise covers.
+/// Annotation, not verification: any failure (probe, findmnt, parse) omits
+/// the note rather than scaring — `None` renders as silence.
+fn second_look(config: &Config, btrfs: &dyn crate::btrfs::BtrfsRead) -> Option<usize> {
+    // Map every enabled source into its pool's subvol-path space
+    // (adversary F2): `btrfs subvolume list` prints paths relative to the
+    // FILESYSTEM root, while config paths are mount-space. findmnt's FSROOT
+    // is the mounted subvolume's path within the filesystem.
+    let mut pools: std::collections::BTreeMap<PathBuf, PoolView> =
+        std::collections::BTreeMap::new();
+    for sv in config.resolved_subvolumes().iter().filter(|sv| sv.enabled) {
+        let (mount, fsroot) = mount_and_fsroot(&sv.source)?;
+        let view = pools.entry(mount.clone()).or_insert_with(|| PoolView {
+            fsroot: fsroot.clone(),
+            covered: Vec::new(),
+            snapshot_homes: Vec::new(),
+        });
+        view.covered
+            .push(fs_relative(&sv.source, &mount, &fsroot)?);
+        if let Some(dir) = config.local_snapshot_dir(&sv.name)
+            && dir.starts_with(&mount)
+        {
+            view.snapshot_homes.push(fs_relative(&dir, &mount, &fsroot)?);
+        }
+    }
+
+    let mut listings = Vec::new();
+    for (mount, view) in pools {
+        let listing = btrfs.list_subvolumes(&mount).ok()?;
+        listings.push((listing, view));
+    }
+    Some(count_uncovered(&listings))
+}
+
+/// One promised pool as the classifier sees it: everything in the pool's
+/// own subvol-path coordinates.
+struct PoolView {
+    #[allow(dead_code)] // fsroot is consumed before the view is stored
+    fsroot: PathBuf,
+    covered: Vec<PathBuf>,
+    snapshot_homes: Vec<PathBuf>,
+}
+
+/// The pure classification (adversary F2 fixtures drive this): a listed
+/// subvolume counts as uncovered unless it IS a covered source, lives under
+/// a snapshot home, carries a `.snapshots` component (snapper convention +
+/// urd's own homes), or is docker layer machinery.
+fn count_uncovered(listings: &[(Vec<PathBuf>, PoolView)]) -> usize {
+    listings
+        .iter()
+        .map(|(listing, view)| {
+            listing
+                .iter()
+                .filter(|sub| {
+                    !view.covered.iter().any(|c| *sub == c)
+                        && !view.snapshot_homes.iter().any(|h| sub.starts_with(h))
+                        && !sub
+                            .components()
+                            .any(|c| c.as_os_str() == ".snapshots")
+                        && !sub.starts_with("var/lib/docker")
+                })
+                .count()
+        })
+        .sum()
+}
+
+/// A config path in its pool's subvol-path space: FSROOT (the mounted
+/// subvolume's in-filesystem path) joined with the path below the mount.
+fn fs_relative(path: &Path, mount: &Path, fsroot: &Path) -> Option<PathBuf> {
+    let below = path.strip_prefix(mount).ok()?;
+    let root = fsroot.strip_prefix("/").unwrap_or(fsroot);
+    Some(root.join(below))
+}
+
+/// One findmnt call: the mountpoint holding `path` and that mount's FSROOT.
+fn mount_and_fsroot(path: &Path) -> Option<(PathBuf, PathBuf)> {
+    let out = Command::new("findmnt")
+        .env("LC_ALL", "C")
+        .args(["-n", "-P", "-o", "TARGET,FSROOT", "--target"])
+        .arg(path)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_findmnt_target_fsroot(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Pure parse of `findmnt -P -o TARGET,FSROOT`: `TARGET="/" FSROOT="/root"`.
+fn parse_findmnt_target_fsroot(stdout: &str) -> Option<(PathBuf, PathBuf)> {
+    let extract = |key: &str| -> Option<PathBuf> {
+        let needle = format!("{key}=\"");
+        let start = stdout.find(&needle)? + needle.len();
+        let rest = &stdout[start..];
+        Some(PathBuf::from(&rest[..rest.find('"')?]))
+    };
+    Some((extract("TARGET")?, extract("FSROOT")?))
+}
+
+// ── Stage 4: the first local snapshot ───────────────────────────────────
+
+/// Spin the first thread: pre-create the local snapshot homes (#250 — the
+/// executor assumes its parents exist), then run the normal backup pipeline
+/// scoped local-only. Reusing `backup::run` wholesale means the first run
+/// behaves exactly like every future run: lock, per-subvolume isolation,
+/// watchdog, heartbeat, and the honest summary all come with it. Returns
+/// whether the promises now hold at least one local thread (the send
+/// offer's gate — a failed spin leaves nothing to send).
+fn first_snapshot(config: &Config, config_path: &Path) -> bool {
+    for root in &config.local_snapshots.roots {
+        if let Err(e) = std::fs::create_dir_all(&root.path) {
+            print!("{}", voice::render_data_dir_failed(&root.path, &e.to_string()));
+        }
+    }
+
+    if !first_thread_pending(config) {
+        print!("{}", voice::render_first_thread_already());
+        return true;
+    }
+
+    print!("{}", voice::render_first_thread_intro());
+    // `backup::run` takes the config by value and `Config` is not `Clone`:
+    // reload from disk, the same posture as `post_carve` (a delve edit may
+    // have changed mappings — sealing from a stale value ships drift).
+    let run = crate::config::Config::load(Some(config_path))
+        .map_err(anyhow::Error::from)
+        .and_then(|fresh| {
+            crate::commands::backup::run(
+                fresh,
+                crate::cli::BackupArgs {
+                    dry_run: false,
+                    priority: None,
+                    subvolume: None,
+                    local_only: true,
+                    external_only: false,
+                    confirm_retention_change: false,
+                    force_full: false,
+                    auto: false,
+                    force_snapshot: false,
+                },
+            )
+        });
+    if let Err(e) = run {
+        print!("{}", voice::render_first_thread_failed(&format!("the run failed: {e}")));
+        return false;
+    }
+    // The executor isolates per-subvolume failures without erring the run —
+    // ask the filesystem of truth, not the exit path.
+    if first_thread_pending(config) {
+        print!(
+            "{}",
+            voice::render_first_thread_failed(
+                "some promises still have no local snapshot (the summary above names them)",
+            )
+        );
+        return false;
+    }
+    true
+}
+
+/// True while any enabled subvolume that PLANS local snapshots (adversary
+/// F5 — a mapping-less subvolume must not pend forever) has none on disk.
+/// Filesystem of truth via `plan::read_snapshot_dir` (absent dir = none).
+fn first_thread_pending(config: &Config) -> bool {
+    config
+        .resolved_subvolumes()
+        .iter()
+        .filter(|sv| sv.enabled)
+        .any(|sv| match config.local_snapshot_dir(&sv.name) {
+            None => false,
+            Some(dir) => crate::plan::read_snapshot_dir(&dir)
+                .map(|snaps| snaps.is_empty())
+                .unwrap_or(false),
+        })
+}
+
+// ── Stage 5: the first-send offer ───────────────────────────────────────
+
+/// The user's answer at the send offer. Enter sends now (the recommended
+/// path — protected before the terminal closes); EOF and `t`/`q` defer to
+/// tonight's timer, the least destructive reading.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SendChoice {
+    SendNow,
+    Tonight,
+}
+
+/// Classify one consent line.
+fn parse_send_choice(line: &str) -> Option<SendChoice> {
+    match line.trim().to_lowercase().as_str() {
+        "" | "s" => Some(SendChoice::SendNow),
+        "t" | "q" => Some(SendChoice::Tonight),
+        _ => None,
+    }
+}
+
+/// Offer the first send when it means something: a promise wants sends, a
+/// configured drive is reachable, and nothing has been sent yet. Declining
+/// is recorded nowhere (arc Q5) — a later `urd init` re-offers, honestly.
+fn offer_first_send(config: &Config, config_path: &Path) -> crate::output::SealSendState {
+    use crate::output::SealSendState;
+    if !wants_send(&config.resolved_subvolumes()) {
+        return SealSendState::NotApplicable;
+    }
+    let reachable: Vec<&crate::config::DriveConfig> = config
+        .drives
+        .iter()
+        .filter(|d| {
+            use crate::drives::DriveAvailability as A;
+            matches!(
+                crate::drives::drive_availability(d),
+                A::Available | A::TokenMissing | A::TokenMismatch { .. } | A::TokenExpectedButMissing
+            )
+        })
+        .collect();
+    if reachable.is_empty() {
+        return SealSendState::NotApplicable;
+    }
+    if already_sent(&reachable, &config.resolved_subvolumes()) {
+        return SealSendState::Sent;
+    }
+
+    print!("{}", voice::render_send_offer());
+    let choice = loop {
+        match crate::commands::encounter::read_input_line() {
+            Err(_) | Ok(None) => break SendChoice::Tonight,
+            Ok(Some(line)) => match parse_send_choice(&line) {
+                Some(choice) => break choice,
+                None => print!("{}", voice::render_send_offer()),
+            },
+        }
+    };
+    match choice {
+        SendChoice::Tonight => {
+            print!("{}", voice::render_send_deferred());
+            SealSendState::Tonight
+        }
+        SendChoice::SendNow => {
+            let run = crate::config::Config::load(Some(config_path))
+                .map_err(anyhow::Error::from)
+                .and_then(|fresh| {
+                    crate::commands::backup::run(
+                        fresh,
+                        crate::cli::BackupArgs {
+                            dry_run: false,
+                            priority: None,
+                            subvolume: None,
+                            local_only: false,
+                            external_only: true,
+                            confirm_retention_change: false,
+                            force_full: false,
+                            auto: false,
+                            force_snapshot: false,
+                        },
+                    )
+                });
+            match run {
+                Ok(()) => SealSendState::Sent,
+                Err(e) => {
+                    print!(
+                        "{}",
+                        voice::render_first_thread_failed(&format!("the send failed: {e}"))
+                    );
+                    SealSendState::Tonight
+                }
+            }
+        }
+    }
+}
+
+/// Does any enabled promise want external sends at all? (Pure.)
+fn wants_send(resolved: &[crate::config::ResolvedSubvolume]) -> bool {
+    resolved.iter().any(|sv| sv.enabled && sv.send_enabled)
+}
+
+/// Has any reachable drive already received a snapshot for a send-enabled
+/// promise? Filesystem of truth over the drives' snapshot homes.
+fn already_sent(
+    drives: &[&crate::config::DriveConfig],
+    resolved: &[crate::config::ResolvedSubvolume],
+) -> bool {
+    drives.iter().any(|drive| {
+        resolved
+            .iter()
+            .filter(|sv| sv.enabled && sv.send_enabled && sv.accepts_drive(&drive.label))
+            .any(|sv| {
+                let dir = crate::drives::external_snapshot_dir(drive, &sv.name);
+                crate::plan::read_snapshot_dir(&dir)
+                    .map(|snaps| !snaps.is_empty())
+                    .unwrap_or(false)
+            })
+    })
+}
+
+// ── Stage 2: drive adoption ─────────────────────────────────────────────
+
+/// Adopt every configured drive that is mounted with a verified UUID:
+/// create its snapshot home (a side effect of the token write) and settle
+/// its identity token, reusing the `urd drives adopt` decision verbatim.
+/// Unreachable drives get one honest sentence each and the seal continues —
+/// the grilled adoption-fail/local-ok state (ADR-109). SQLite trouble never
+/// blocks adoption (ADR-102): the on-disk token is the identity that
+/// matters; the DB record self-heals on the next `verify_drive_token`.
+fn adopt_drives(config: &Config) {
+    use crate::drives::{self, DriveAvailability};
+    use crate::state::StateDb;
+
+    if config.drives.is_empty() {
+        return;
+    }
+
+    let state = match StateDb::open(&config.general.state_db) {
+        Ok(db) => Some(db),
+        Err(e) => {
+            log::warn!("state DB unavailable during adoption, continuing without: {e}");
+            None
+        }
+    };
+    let now = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S").to_string();
+
+    for drive in &config.drives {
+        let reason = match drives::drive_availability(drive) {
+            DriveAvailability::Available
+            | DriveAvailability::TokenMissing
+            | DriveAvailability::TokenMismatch { .. }
+            | DriveAvailability::TokenExpectedButMissing => {
+                match adopt_one(drive, state.as_ref(), &now) {
+                    Ok(action) => {
+                        print!("{}", voice::render_seal_adoption(&drive.label, &action));
+                        continue;
+                    }
+                    Err(e) => format!("adoption failed: {e}"),
+                }
+            }
+            DriveAvailability::NotMounted => {
+                format!("not mounted at {}", drive.mount_path.display())
+            }
+            DriveAvailability::UuidMismatch { expected, found } => format!(
+                "a different filesystem sits at {} (expected UUID {expected}, found {found})",
+                drive.mount_path.display()
+            ),
+            DriveAvailability::UuidCheckFailed(reason) => {
+                format!("its identity could not be verified: {reason}")
+            }
+        };
+        print!(
+            "{}",
+            voice::render_seal_adoption_skipped(&drive.label, &reason)
+        );
+    }
+}
+
+// ── Stage 3: systemd units ──────────────────────────────────────────────
+
+/// What `systemctl --user is-enabled <unit>` answered, classified. Exit 1
+/// with a state word on stdout is a clean "disabled"; an empty stdout means
+/// no user manager answered (container, ssh session without a bus) — a
+/// different sentence, never a doomed consent prompt (adversary F8).
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum EnabledProbe {
+    Enabled,
+    NotEnabled,
+    NoManager(String),
+}
+
+/// Classify one `is-enabled` invocation from its raw pieces (pure).
+fn classify_is_enabled(stdout: &str, stderr: &str) -> EnabledProbe {
+    match stdout.trim() {
+        "enabled" => EnabledProbe::Enabled,
+        "" => EnabledProbe::NoManager(stderr.trim().to_string()),
+        _ => EnabledProbe::NotEnabled,
+    }
+}
+
+/// The user's answer at the units asking. Enter installs; EOF skips.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UnitsChoice {
+    Install,
+    Skip,
+}
+
+/// Classify one consent line: `""`/`i` install, `q` not now.
+fn parse_units_choice(line: &str) -> Option<UnitsChoice> {
+    match line.trim().to_lowercase().as_str() {
+        "" | "i" => Some(UnitsChoice::Install),
+        "q" => Some(UnitsChoice::Skip),
+        _ => None,
+    }
+}
+
+/// Install and enable the unit set the cadence answer selected: oracle
+/// render (exe-substituted), consent, plain writes into the user's own
+/// systemd directory, `daemon-reload` + `enable --now`, then the linger
+/// truth (adversary F1). Every failure is one honest sentence and the seal
+/// continues — units-fail is an enumerated, `urd init`-resumable state.
+/// Returns whether the units ended up installed and enabled.
+fn install_units(config: &Config) -> bool {
+    let exe = match std::env::current_exe().and_then(std::fs::canonicalize) {
+        Ok(p) => p,
+        Err(e) => {
+            print!(
+                "{}",
+                voice::render_units_failed("resolving the urd binary path", &e.to_string())
+            );
+            return false;
+        }
+    };
+    let units = match crate::systemd_units::expected_units(&config.general.run_frequency, &exe)
+    {
+        Ok(units) => units,
+        Err(refusal) => {
+            print!("{}", voice::render_units_failed("rendering the units", &refusal.reason));
+            return false;
+        }
+    };
+    let Some(dir) = dirs::config_dir().map(|d| d.join("systemd/user")) else {
+        print!(
+            "{}",
+            voice::render_units_failed("locating ~/.config", "no config directory for this user")
+        );
+        return false;
+    };
+    let next_action = voice::describe_next_action(&config.general.run_frequency);
+
+    // Enabled-state probe doubles as the user-manager reachability check.
+    let enabled = enabled_units(&units);
+    if let Some(EnabledProbe::NoManager(detail)) =
+        enabled.iter().find(|p| matches!(p, EnabledProbe::NoManager(_)))
+    {
+        print!("{}", voice::render_units_no_manager(detail));
+        return false;
+    }
+
+    // Done-detection: byte-true files + everything enabled → nothing to ask.
+    let installed = installed_unit_contents(&units, &dir);
+    if crate::systemd_units::diff_units(&units, &installed).is_empty()
+        && enabled.iter().all(|p| *p == EnabledProbe::Enabled)
+    {
+        print!("{}", voice::render_units_already(&next_action));
+        print_linger_notice();
+        return true;
+    }
+
+    let names: Vec<&str> = units.iter().map(|u| u.name).collect();
+    print!("{}", voice::render_units_request(&names, &dir, &next_action));
+    loop {
+        match crate::commands::encounter::read_input_line() {
+            Err(e) => {
+                print!("{}", voice::render_units_failed("reading your answer", &e.to_string()));
+                return false;
+            }
+            // EOF is walking away — the least destructive reading.
+            Ok(None) => {
+                print!("{}", voice::render_units_skipped());
+                return false;
+            }
+            Ok(Some(line)) => match parse_units_choice(&line) {
+                Some(UnitsChoice::Install) => break,
+                Some(UnitsChoice::Skip) => {
+                    print!("{}", voice::render_units_skipped());
+                    return false;
+                }
+                None => print!("{}", voice::render_units_request(&names, &dir, &next_action)),
+            },
+        }
+    }
+
+    if let Err(e) = write_units(&units, &dir) {
+        print!("{}", voice::render_units_failed("writing the unit files", &e.to_string()));
+        return false;
+    }
+    if let Err(detail) = systemctl_user(&["daemon-reload"]) {
+        print!("{}", voice::render_units_failed("systemctl --user daemon-reload", &detail));
+        return false;
+    }
+    for unit in enableable(&units) {
+        if let Err(detail) = systemctl_user(&["enable", "--now", unit]) {
+            print!(
+                "{}",
+                voice::render_units_failed(&format!("enabling {unit}"), &detail)
+            );
+            return false;
+        }
+    }
+    print!("{}", voice::render_units_installed(&next_action));
+    print_linger_notice();
+    true
+}
+
+/// The units that get `enable --now`: the timer (which starts the service
+/// by schedule, never a backup run now) and, when present, the sentinel
+/// daemon. The backup service itself is timer-started, not enabled.
+fn enableable(units: &[crate::systemd_units::UnitFile]) -> Vec<&'static str> {
+    units
+        .iter()
+        .filter_map(|u| match u.name {
+            "urd-backup.timer" | "urd-sentinel.service" => Some(u.name),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Probe `is-enabled` for every enableable unit.
+fn enabled_units(units: &[crate::systemd_units::UnitFile]) -> Vec<EnabledProbe> {
+    enableable(units)
+        .iter()
+        .map(|name| match Command::new("systemctl")
+            .env("LC_ALL", "C")
+            .args(["--user", "is-enabled", name])
+            .output()
+        {
+            Ok(out) => classify_is_enabled(
+                &String::from_utf8_lossy(&out.stdout),
+                &String::from_utf8_lossy(&out.stderr),
+            ),
+            Err(e) => EnabledProbe::NoManager(format!("could not run systemctl: {e}")),
+        })
+        .collect()
+}
+
+/// Read every expected unit's installed content (`None` = absent).
+fn installed_unit_contents(
+    units: &[crate::systemd_units::UnitFile],
+    dir: &Path,
+) -> std::collections::HashMap<String, Option<String>> {
+    units
+        .iter()
+        .map(|u| (u.name.to_string(), std::fs::read_to_string(dir.join(u.name)).ok()))
+        .collect()
+}
+
+/// Plain writes into the user's own directory: a torn write is named by the
+/// doctor drift advisory and healed by `urd init` (ponytail — no temp+rename
+/// ceremony here).
+fn write_units(
+    units: &[crate::systemd_units::UnitFile],
+    dir: &Path,
+) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    for unit in units {
+        std::fs::write(dir.join(unit.name), &unit.content)?;
+    }
+    Ok(())
+}
+
+/// Run one `systemctl --user` verb; non-success becomes the failure detail.
+fn systemctl_user(args: &[&str]) -> Result<(), String> {
+    match Command::new("systemctl")
+        .env("LC_ALL", "C")
+        .arg("--user")
+        .args(args)
+        .output()
+    {
+        Ok(out) if out.status.success() => Ok(()),
+        Ok(out) => Err(format!(
+            "exit {}: {}",
+            out.status.code().unwrap_or(-1),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )),
+        Err(e) => Err(format!("could not run systemctl: {e}")),
+    }
+}
+
+/// The linger truth (adversary F1): a user timer fires only while a
+/// session exists. `Some(user)` iff loginctl clearly answers `Linger=no`;
+/// `Linger=yes` and every unreadable answer are `None` — the advisory must
+/// not scare, and doctor carries the standing check.
+fn linger_loose() -> Option<String> {
+    let user = invoking_username().ok()?;
+    let out = Command::new("loginctl")
+        .env("LC_ALL", "C")
+        .args(["show-user", &user, "--property=Linger"])
+        .output()
+        .ok()?;
+    (out.status.success() && String::from_utf8_lossy(&out.stdout).trim() == "Linger=no")
+        .then_some(user)
+}
+
+/// Print the linger sentence at the units stage when the thread is loose.
+fn print_linger_notice() {
+    if let Some(user) = linger_loose() {
+        print!("{}", voice::render_linger_notice(&user));
+    }
+}
+
+/// Settle one reachable drive's identity: the `urd drives adopt` decision
+/// (shared via `decide_adoption`) plus its filesystem actions. The token
+/// write's `create_dir_all` is what creates the drive's snapshot home.
+fn adopt_one(
+    drive: &crate::config::DriveConfig,
+    state: Option<&crate::state::StateDb>,
+    now: &str,
+) -> anyhow::Result<crate::output::AdoptAction> {
+    use crate::drives::{self, AdoptDecision};
+    use crate::output::AdoptAction;
+
+    let on_disk = drives::read_drive_token(drive)?;
+    let stored = match state {
+        Some(db) => db.get_drive_token(&drive.label).unwrap_or_else(|e| {
+            log::warn!("token lookup failed for {}: {e}", drive.label);
+            None
+        }),
+        None => None,
+    };
+    let store = |token: &str| {
+        if let Some(db) = state
+            && let Err(e) = db.store_drive_token(&drive.label, token, now)
+        {
+            log::warn!("could not record {}'s token in the state DB: {e}", drive.label);
+        }
+    };
+    match drives::decide_adoption(on_disk.as_deref(), stored.as_deref()) {
+        AdoptDecision::AlreadyCurrent => Ok(AdoptAction::AlreadyCurrent),
+        AdoptDecision::AdoptExisting => {
+            let token =
+                on_disk.ok_or_else(|| anyhow!("AdoptExisting implies an on-disk token"))?;
+            store(&token);
+            Ok(AdoptAction::AdoptedExisting { token })
+        }
+        AdoptDecision::GenerateNew => {
+            let token = drives::generate_drive_token();
+            drives::write_drive_token(drive, &token)?;
+            store(&token);
+            Ok(AdoptAction::GeneratedNew { token })
+        }
+    }
 }
 
 // ── Stage 1: the earning ────────────────────────────────────────────────
@@ -399,6 +1082,274 @@ mod tests {
         assert!(kept.exists());
         assert_eq!(std::fs::read_to_string(&kept).unwrap(), "refused content\n");
         std::fs::remove_file(&kept).unwrap();
+    }
+
+    #[test]
+    fn parse_units_choice_defaults_to_install_and_knows_the_letters() {
+        assert_eq!(parse_units_choice(""), Some(UnitsChoice::Install));
+        assert_eq!(parse_units_choice("i"), Some(UnitsChoice::Install));
+        assert_eq!(parse_units_choice("Q"), Some(UnitsChoice::Skip));
+        assert_eq!(parse_units_choice("p"), None, "the print option was cut");
+        assert_eq!(parse_units_choice("x"), None);
+    }
+
+    #[test]
+    fn classify_is_enabled_separates_disabled_from_no_manager() {
+        assert_eq!(classify_is_enabled("enabled\n", ""), EnabledProbe::Enabled);
+        assert_eq!(classify_is_enabled("disabled\n", ""), EnabledProbe::NotEnabled);
+        assert_eq!(classify_is_enabled("static\n", ""), EnabledProbe::NotEnabled);
+        assert_eq!(
+            classify_is_enabled("", "Failed to connect to bus: No medium found"),
+            EnabledProbe::NoManager("Failed to connect to bus: No medium found".to_string())
+        );
+    }
+
+    /// Unit files land byte-true and the done-detection reads them back
+    /// (TempDir — mocks are blind to filesystem preconditions).
+    #[test]
+    fn write_units_then_installed_contents_round_trips() {
+        let units = crate::systemd_units::expected_units(
+            &crate::types::RunFrequency::Sentinel,
+            Path::new("/home/alice/.cargo/bin/urd"),
+        )
+        .unwrap();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("systemd/user");
+
+        write_units(&units, &dir).unwrap();
+        let installed = installed_unit_contents(&units, &dir);
+        assert!(crate::systemd_units::diff_units(&units, &installed).is_empty());
+
+        // Tamper with one file: the diff names exactly it.
+        std::fs::write(dir.join("urd-backup.timer"), "[Timer]\n").unwrap();
+        let installed = installed_unit_contents(&units, &dir);
+        let drift = crate::systemd_units::diff_units(&units, &installed);
+        assert_eq!(drift.len(), 1);
+        assert_eq!(drift[0].name, "urd-backup.timer");
+    }
+
+    #[test]
+    fn enableable_targets_the_timer_and_sentinel_never_the_service() {
+        let units = crate::systemd_units::expected_units(
+            &crate::types::RunFrequency::Sentinel,
+            Path::new("/home/alice/.cargo/bin/urd"),
+        )
+        .unwrap();
+        assert_eq!(enableable(&units), vec!["urd-backup.timer", "urd-sentinel.service"]);
+    }
+
+    #[test]
+    fn parse_send_choice_enter_sends_now_and_t_defers() {
+        assert_eq!(parse_send_choice(""), Some(SendChoice::SendNow));
+        assert_eq!(parse_send_choice("s"), Some(SendChoice::SendNow));
+        assert_eq!(parse_send_choice("t"), Some(SendChoice::Tonight));
+        assert_eq!(parse_send_choice("q"), Some(SendChoice::Tonight));
+        assert_eq!(parse_send_choice("x"), None);
+    }
+
+    fn seal_config(toml: &str) -> crate::config::Config {
+        crate::config::Config::from_str(toml).unwrap()
+    }
+
+    #[test]
+    fn wants_send_is_false_for_recorded_only_configs() {
+        let recorded = seal_config(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/data/.snapshots"
+protection = "recorded"
+"#,
+        );
+        assert!(!wants_send(&recorded.resolved_subvolumes()));
+    }
+
+    /// First-thread pending is policy-aware (adversary F5): satisfied once
+    /// every enabled subvolume that plans local snapshots has one on disk.
+    #[test]
+    fn first_thread_pending_follows_the_filesystem_of_truth() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().join(".snapshots");
+        let config = seal_config(&format!(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "{}"
+protection = "recorded"
+"#,
+            root.display()
+        ));
+        // No snapshot dir at all → pending.
+        assert!(first_thread_pending(&config));
+        // A real snapshot dir entry satisfies it.
+        std::fs::create_dir_all(root.join("docs/20260705-0400-docs")).unwrap();
+        assert!(!first_thread_pending(&config));
+    }
+
+    /// Send-offer done-detection over a real (temp) drive layout.
+    #[test]
+    fn already_sent_sees_external_snapshots_on_the_drive() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = seal_config(&format!(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/data/.snapshots"
+protection = "sheltered"
+
+[[drives]]
+label = "backup-1"
+mount_path = "{}"
+snapshot_root = ".snapshots"
+uuid = "abcd-1234"
+role = "primary"
+"#,
+            tmp.path().display()
+        ));
+        let drives: Vec<&crate::config::DriveConfig> = config.drives.iter().collect();
+        let resolved = config.resolved_subvolumes();
+        assert!(wants_send(&resolved), "sheltered promises send");
+        assert!(!already_sent(&drives, &resolved));
+        std::fs::create_dir_all(tmp.path().join(".snapshots/docs/20260705-0400-docs"))
+            .unwrap();
+        assert!(already_sent(&drives, &resolved));
+    }
+
+    // ── The second look's pure classification (adversary F2) ───────────
+
+    #[test]
+    fn parse_findmnt_target_fsroot_reads_both_fields() {
+        assert_eq!(
+            parse_findmnt_target_fsroot("TARGET=\"/home\" FSROOT=\"/home\"\n"),
+            Some((PathBuf::from("/home"), PathBuf::from("/home")))
+        );
+        assert_eq!(
+            parse_findmnt_target_fsroot("TARGET=\"/\" FSROOT=\"/root\"\n"),
+            Some((PathBuf::from("/"), PathBuf::from("/root")))
+        );
+        assert_eq!(parse_findmnt_target_fsroot("garbage"), None);
+    }
+
+    #[test]
+    fn fs_relative_maps_mount_space_into_subvol_space() {
+        // Fedora layout: /home is subvol `home`; /data/docs under a
+        // whole-pool mount at /data stays `docs`... relative to FSROOT.
+        assert_eq!(
+            fs_relative(Path::new("/home/alice"), Path::new("/home"), Path::new("/home")),
+            Some(PathBuf::from("home/alice"))
+        );
+        assert_eq!(
+            fs_relative(Path::new("/data/docs"), Path::new("/data"), Path::new("/")),
+            Some(PathBuf::from("docs"))
+        );
+        assert_eq!(
+            fs_relative(Path::new("/elsewhere"), Path::new("/data"), Path::new("/")),
+            None
+        );
+    }
+
+    /// Fixture shaped like the live host's `btrfs subvolume list` output
+    /// (Fedora `root`/`home` layout): the classifier must not count the
+    /// covered source, urd's own snapshot home, snapper dirs, or docker
+    /// layers — and must count the nested and foreign subvolumes.
+    #[test]
+    fn count_uncovered_classifies_in_subvol_path_space() {
+        let listing = vec![
+            PathBuf::from("home"),                                  // covered source
+            PathBuf::from("root"),                                  // foreign top-level → counts
+            PathBuf::from("home/alice/nested-vm-images"),           // nested under source → counts
+            PathBuf::from("home/alice/.snapshots/docs/20260705-0400-docs"), // urd home
+            PathBuf::from(".snapshots/1/snapshot"),                 // snapper convention
+            PathBuf::from("var/lib/docker/btrfs/subvolumes/abc123"), // docker layer
+        ];
+        let view = PoolView {
+            fsroot: PathBuf::from("/"),
+            covered: vec![PathBuf::from("home")],
+            snapshot_homes: vec![PathBuf::from("home/alice/.snapshots")],
+        };
+        assert_eq!(count_uncovered(&[(listing, view)]), 2);
+    }
+
+    #[test]
+    fn count_uncovered_empty_listing_counts_nothing() {
+        let view = PoolView {
+            fsroot: PathBuf::from("/"),
+            covered: vec![],
+            snapshot_homes: vec![],
+        };
+        assert_eq!(count_uncovered(&[(Vec::new(), view)]), 0);
+    }
+
+    /// The adoption action over a real (temp) filesystem: the token write
+    /// creates the snapshot home, and a re-run without a DB record adopts
+    /// the existing identity instead of minting a new one (mocks are blind
+    /// to filesystem preconditions — CLAUDE.md testing rule).
+    #[test]
+    fn adopt_one_creates_snapshot_home_and_keeps_identity_on_rerun() {
+        use crate::output::AdoptAction;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let drive = crate::config::DriveConfig {
+            label: "backup-1".to_string(),
+            uuid: None,
+            mount_path: tmp.path().to_path_buf(),
+            snapshot_root: ".snapshots".to_string(),
+            role: crate::types::DriveRole::Primary,
+            max_usage_percent: None,
+            min_free_bytes: None,
+            rotation_interval: None,
+        };
+
+        let first = adopt_one(&drive, None, "2026-07-05T12:00:00").unwrap();
+        let AdoptAction::GeneratedNew { token } = first else {
+            panic!("fresh drive should mint a token, got {first:?}");
+        };
+        let root = tmp.path().join(".snapshots");
+        assert!(root.is_dir(), "the token write creates the snapshot home");
+        assert!(root.join(".urd-drive-token").is_file());
+
+        // Re-run (interrupted-seal resume): the on-disk identity survives.
+        let second = adopt_one(&drive, None, "2026-07-05T12:01:00").unwrap();
+        assert_eq!(second, AdoptAction::AdoptedExisting { token });
+    }
+
+    /// With the state DB recording the token, the re-run is a no-op.
+    #[test]
+    fn adopt_one_is_already_current_once_the_db_agrees() {
+        use crate::output::AdoptAction;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let drive = crate::config::DriveConfig {
+            label: "backup-1".to_string(),
+            uuid: None,
+            mount_path: tmp.path().to_path_buf(),
+            snapshot_root: ".snapshots".to_string(),
+            role: crate::types::DriveRole::Primary,
+            max_usage_percent: None,
+            min_free_bytes: None,
+            rotation_interval: None,
+        };
+        let db = crate::state::StateDb::open(&tmp.path().join("urd.db")).unwrap();
+
+        let first = adopt_one(&drive, Some(&db), "2026-07-05T12:00:00").unwrap();
+        assert!(matches!(first, AdoptAction::GeneratedNew { .. }));
+        let second = adopt_one(&drive, Some(&db), "2026-07-05T12:01:00").unwrap();
+        assert_eq!(second, AdoptAction::AlreadyCurrent);
     }
 
     /// Real `visudo -c -f` over a real render: the gate accepts what urd

--- a/src/commands/seal.rs
+++ b/src/commands/seal.rs
@@ -231,28 +231,7 @@ fn first_snapshot(config: &Config, config_path: &Path) -> bool {
     }
 
     print!("{}", voice::render_first_thread_intro());
-    // `backup::run` takes the config by value and `Config` is not `Clone`:
-    // reload from disk, the same posture as `post_carve` (a delve edit may
-    // have changed mappings — sealing from a stale value ships drift).
-    let run = crate::config::Config::load(Some(config_path))
-        .map_err(anyhow::Error::from)
-        .and_then(|fresh| {
-            crate::commands::backup::run(
-                fresh,
-                crate::cli::BackupArgs {
-                    dry_run: false,
-                    priority: None,
-                    subvolume: None,
-                    local_only: true,
-                    external_only: false,
-                    confirm_retention_change: false,
-                    force_full: false,
-                    auto: false,
-                    force_snapshot: false,
-                },
-            )
-        });
-    if let Err(e) = run {
+    if let Err(e) = run_seal_backup(config_path, /* local_only */ true) {
         print!("{}", voice::render_first_thread_failed(&format!("the run failed: {e}")));
         return false;
     }
@@ -347,37 +326,41 @@ fn offer_first_send(config: &Config, config_path: &Path) -> crate::output::SealS
             print!("{}", voice::render_send_deferred());
             SealSendState::Tonight
         }
-        SendChoice::SendNow => {
-            let run = crate::config::Config::load(Some(config_path))
-                .map_err(anyhow::Error::from)
-                .and_then(|fresh| {
-                    crate::commands::backup::run(
-                        fresh,
-                        crate::cli::BackupArgs {
-                            dry_run: false,
-                            priority: None,
-                            subvolume: None,
-                            local_only: false,
-                            external_only: true,
-                            confirm_retention_change: false,
-                            force_full: false,
-                            auto: false,
-                            force_snapshot: false,
-                        },
-                    )
-                });
-            match run {
-                Ok(()) => SealSendState::Sent,
-                Err(e) => {
-                    print!(
-                        "{}",
-                        voice::render_first_thread_failed(&format!("the send failed: {e}"))
-                    );
-                    SealSendState::Tonight
-                }
+        SendChoice::SendNow => match run_seal_backup(config_path, /* local_only */ false) {
+            Ok(()) => SealSendState::Sent,
+            Err(e) => {
+                print!(
+                    "{}",
+                    voice::render_first_thread_failed(&format!("the send failed: {e}"))
+                );
+                SealSendState::Tonight
             }
-        }
+        },
     }
+}
+
+/// One manual-mode run through the full backup pipeline, scoped to the
+/// seal's needs: `local_only` spins the first threads, its inverse
+/// (external-only) carries the first send. `backup::run` takes the config
+/// by value and `Config` is not `Clone`: reload from disk, the same
+/// posture as `post_carve` (a delve edit may have changed mappings —
+/// sealing from a stale value ships drift).
+fn run_seal_backup(config_path: &Path, local_only: bool) -> anyhow::Result<()> {
+    let fresh = crate::config::Config::load(Some(config_path))?;
+    crate::commands::backup::run(
+        fresh,
+        crate::cli::BackupArgs {
+            dry_run: false,
+            priority: None,
+            subvolume: None,
+            local_only,
+            external_only: !local_only,
+            confirm_retention_change: false,
+            force_full: false,
+            auto: false,
+            force_snapshot: false,
+        },
+    )
 }
 
 /// Does any enabled promise want external sends at all? (Pure.)
@@ -1025,23 +1008,9 @@ fn units_missing(config: &Config) -> bool {
     let Some(dir) = dirs::config_dir().map(|d| d.join("systemd/user")) else {
         return false;
     };
-    expected_unit_names(&config.general.run_frequency)
+    crate::systemd_units::expected_unit_names(&config.general.run_frequency)
         .iter()
         .any(|name| !dir.join(name).exists())
-}
-
-/// The expected unit filenames for a cadence answer — the name-only
-/// companion to `systemd_units::expected_units` (which needs the exe path
-/// for content; status must not resolve or render anything).
-fn expected_unit_names(run_frequency: &crate::types::RunFrequency) -> Vec<&'static str> {
-    match run_frequency {
-        crate::types::RunFrequency::Sentinel => {
-            vec!["urd-backup.service", "urd-backup.timer", "urd-sentinel.service"]
-        }
-        crate::types::RunFrequency::Timer { .. } => {
-            vec!["urd-backup.service", "urd-backup.timer"]
-        }
-    }
 }
 
 /// The passwordless probe (`LC_ALL=C sudo -n <btrfs> filesystem show /`),

--- a/src/commands/seal.rs
+++ b/src/commands/seal.rs
@@ -930,7 +930,7 @@ fn earn_privilege(config: &Config, config_path: &Path) -> anyhow::Result<SealOut
 /// The invoking user's passwd name — what the sudoers User_List matches.
 /// Never `$USER` (wrong under `su`); no passwd entry is an honest failure,
 /// never a guess.
-fn invoking_username() -> anyhow::Result<String> {
+pub(crate) fn invoking_username() -> anyhow::Result<String> {
     let uid = nix::unistd::Uid::current();
     let user = nix::unistd::User::from_uid(uid)
         .with_context(|| format!("passwd lookup failed for uid {uid}"))?
@@ -979,14 +979,69 @@ fn stage_rendered(rendered: &str) -> anyhow::Result<tempfile::NamedTempFile> {
     Ok(tmp)
 }
 
-/// Whether a status surface should name the "configured but unsealed" state.
-/// Single owner of the rule (adversary F5): interactive only — a denied
-/// probe writes an auth log line, so automated and monitoring callers must
-/// never generate that noise — and only on a clear denial (`Unclear` stays
-/// silent rather than guess).
-pub(crate) fn probe_unsealed(config: &Config, output_mode: OutputMode) -> bool {
-    output_mode == OutputMode::Interactive
-        && probe_grant(&config.general.btrfs_path).0 == GrantProbe::Denied
+/// The first incomplete seal stage a status surface should name (UPI 075
+/// widened `probe_unsealed`; single owner of the rule). Interactive only —
+/// a denied probe writes an auth log line, so automated and monitoring
+/// callers must never generate that noise — and only on clear evidence:
+/// `Unclear` probes and unreadable directories stay silent rather than
+/// guess. Seal order decides: privilege → units → first thread (one
+/// sentence, one cause — adversary F4/F7). The units arm checks file
+/// EXISTENCE only (content drift is doctor's job; no systemctl call here),
+/// and the first-thread arm is policy-aware (F5).
+pub(crate) fn seal_completeness(
+    config: &Config,
+    output_mode: OutputMode,
+) -> Option<crate::output::SealGap> {
+    if output_mode != OutputMode::Interactive {
+        return None;
+    }
+    seal_gap_given_probe(config, probe_grant(&config.general.btrfs_path).0)
+}
+
+/// The gap decision with the probe injected — `urd init` already holds a
+/// probe result and must not pay (or log) a second one.
+pub(crate) fn seal_gap_given_probe(
+    config: &Config,
+    probe: GrantProbe,
+) -> Option<crate::output::SealGap> {
+    use crate::output::SealGap;
+
+    if probe == GrantProbe::Denied {
+        return Some(SealGap::Privilege);
+    }
+    if units_missing(config) {
+        return Some(SealGap::Units);
+    }
+    if first_thread_pending(config) {
+        return Some(SealGap::FirstThread);
+    }
+    None
+}
+
+/// Is any expected unit file absent? Existence only, by expected name —
+/// no exe resolution and no content compare on the status path; an
+/// unresolvable config dir stays silent (never a guess).
+fn units_missing(config: &Config) -> bool {
+    let Some(dir) = dirs::config_dir().map(|d| d.join("systemd/user")) else {
+        return false;
+    };
+    expected_unit_names(&config.general.run_frequency)
+        .iter()
+        .any(|name| !dir.join(name).exists())
+}
+
+/// The expected unit filenames for a cadence answer — the name-only
+/// companion to `systemd_units::expected_units` (which needs the exe path
+/// for content; status must not resolve or render anything).
+fn expected_unit_names(run_frequency: &crate::types::RunFrequency) -> Vec<&'static str> {
+    match run_frequency {
+        crate::types::RunFrequency::Sentinel => {
+            vec!["urd-backup.service", "urd-backup.timer", "urd-sentinel.service"]
+        }
+        crate::types::RunFrequency::Timer { .. } => {
+            vec!["urd-backup.service", "urd-backup.timer"]
+        }
+    }
 }
 
 /// The passwordless probe (`LC_ALL=C sudo -n <btrfs> filesystem show /`),

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -32,9 +32,9 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     };
     let drive_labels: Vec<String> = config.drives.iter().map(|d| d.label.clone()).collect();
 
-    // ── The seal (UPI 071) ──────────────────────────────────────────
-    // "Configured but unsealed" is a named state, not a degraded render.
-    let unsealed = crate::commands::seal::probe_unsealed(&config, output_mode);
+    // ── The seal (UPI 071/075) ──────────────────────────────────────
+    // An incomplete seal stage is a named state, not a degraded render.
+    let seal_gap = crate::commands::seal::seal_completeness(&config, output_mode);
 
     // ── Awareness model ─────────────────────────────────────────────
     let now = chrono::Local::now().naive_local();
@@ -94,7 +94,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         total_pins,
         &config,
         now,
-        unsealed,
+        seal_gap,
     );
 
     let rendered = voice::render_status(&status_output, output_mode);
@@ -123,7 +123,7 @@ fn assemble_status_output(
     total_pins: usize,
     config: &Config,
     now: NaiveDateTime,
-    unsealed: bool,
+    seal_gap: Option<crate::output::SealGap>,
 ) -> StatusOutput {
     // ── Chain health per subvolume (derived from awareness assessment) ──
     let chain_health_entries: Vec<ChainHealthEntry> = assessments
@@ -194,7 +194,7 @@ fn assemble_status_output(
         advice,
         storage_postures,
         storage_adaptations,
-        unsealed,
+        seal_gap,
     }
 }
 
@@ -310,28 +310,34 @@ local_retention = "transient"
             0,
             config,
             dt(2026, 6, 10, 12, 0),
-            false,
+            None,
         )
     }
 
     #[test]
-    fn assemble_threads_the_unsealed_state() {
-        // UPI 071: the banner's substance travels through the pure
+    fn assemble_threads_the_seal_gap() {
+        // UPI 071/075: the banner's substance travels through the pure
         // assembler untouched — probe at the edge, truth in the middle.
         let config = test_config();
-        let out = assemble_status_output(
-            &[],
-            vec![],
-            vec![],
-            vec![],
-            None,
-            0,
-            &config,
-            dt(2026, 6, 10, 12, 0),
-            true,
-        );
-        assert!(out.unsealed);
-        assert!(!assemble(&[], &config).unsealed);
+        for gap in [
+            crate::output::SealGap::Privilege,
+            crate::output::SealGap::Units,
+            crate::output::SealGap::FirstThread,
+        ] {
+            let out = assemble_status_output(
+                &[],
+                vec![],
+                vec![],
+                vec![],
+                None,
+                0,
+                &config,
+                dt(2026, 6, 10, 12, 0),
+                Some(gap),
+            );
+            assert_eq!(out.seal_gap, Some(gap));
+        }
+        assert_eq!(assemble(&[], &config).seal_gap, None);
     }
 
     // ── Chain-health worst-selection ────────────────────────────────
@@ -514,7 +520,7 @@ local_retention = "transient"
             0,
             &test_config(),
             dt(2026, 6, 10, 12, 0),
-            false,
+            None,
         );
         assert_eq!(out.last_run_age_secs, Some(7200));
     }

--- a/src/drives.rs
+++ b/src/drives.rs
@@ -294,6 +294,30 @@ pub fn generate_drive_token() -> String {
     uuid::Uuid::new_v4().to_string()
 }
 
+/// What adopting a drive requires, given both token sources. Pure — shared
+/// by `urd drives adopt` and the seal's adoption stage (UPI 075) so the two
+/// verbs can never diverge on the decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdoptDecision {
+    /// On-disk and stored tokens agree — nothing to write.
+    AlreadyCurrent,
+    /// An on-disk token exists that SQLite doesn't know (or knows stale):
+    /// store it, don't regenerate — the drive keeps its identity.
+    AdoptExisting,
+    /// No on-disk token: mint one, write it, store it.
+    GenerateNew,
+}
+
+/// Decide the adoption action from the on-disk token and the SQLite record.
+#[must_use]
+pub fn decide_adoption(on_disk: Option<&str>, stored: Option<&str>) -> AdoptDecision {
+    match (on_disk, stored) {
+        (Some(disk), Some(db)) if disk == db => AdoptDecision::AlreadyCurrent,
+        (Some(_), _) => AdoptDecision::AdoptExisting,
+        (None, _) => AdoptDecision::GenerateNew,
+    }
+}
+
 /// Verify the drive session token against the stored reference in SQLite.
 ///
 /// Call this AFTER `drive_availability()` returns `Available`.
@@ -397,6 +421,16 @@ mod tests {
             min_free_bytes: None,
             rotation_interval: None,
         }
+    }
+
+    #[test]
+    fn decide_adoption_covers_every_token_pairing() {
+        use AdoptDecision::*;
+        assert_eq!(decide_adoption(Some("t1"), Some("t1")), AlreadyCurrent);
+        assert_eq!(decide_adoption(Some("t1"), Some("t2")), AdoptExisting);
+        assert_eq!(decide_adoption(Some("t1"), None), AdoptExisting);
+        assert_eq!(decide_adoption(None, Some("t2")), GenerateNew);
+        assert_eq!(decide_adoption(None, None), GenerateNew);
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,6 +13,7 @@ pub enum BtrfsOperation {
     Delete,
     Show,
     Sync,
+    List,
 }
 
 impl fmt::Display for BtrfsOperation {
@@ -24,6 +25,7 @@ impl fmt::Display for BtrfsOperation {
             Self::Delete => write!(f, "delete"),
             Self::Show => write!(f, "show"),
             Self::Sync => write!(f, "sync"),
+            Self::List => write!(f, "list"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod state;
 mod storage_critical;
 mod strategy;
 mod sudoers;
+mod systemd_units;
 mod types;
 mod voice;
 #[cfg(test)]

--- a/src/output.rs
+++ b/src/output.rs
@@ -1643,7 +1643,7 @@ pub struct DriveAdoptOutput {
 }
 
 /// What the adopt command did.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq, Eq)]
 #[serde(tag = "action", rename_all = "snake_case")]
 pub enum AdoptAction {
     /// Adopted an existing on-disk token into SQLite.
@@ -1652,6 +1652,44 @@ pub enum AdoptAction {
     GeneratedNew { token: String },
     /// On-disk token already matches SQLite — no action taken.
     AlreadyCurrent,
+}
+
+// ── The seal's summary scroll (UPI 075) ─────────────────────────────────
+// Plain structs, no serde: the scroll is interactive-only ceremony
+// (ponytail-pinned — no `--json` parity, no schema contract).
+
+/// Everything the closing scroll states: what was woven, what runs when,
+/// and the honest partial states with their resume verb.
+#[derive(Debug)]
+pub struct SealSummary {
+    pub threads: Vec<SealThread>,
+    pub units_enabled: bool,
+    /// When Urd acts next — derived only from installed units (F3).
+    pub next_action: String,
+    /// Lingering is off: timers fire only while logged in (F1).
+    pub linger_loose: bool,
+    pub first_thread_spun: bool,
+    pub send: SealSendState,
+    /// The second look's one-sentence annotation; `None` = silence.
+    pub uncovered_subvolumes: Option<usize>,
+}
+
+/// One woven promise: subvolume and its protection level (display form).
+#[derive(Debug)]
+pub struct SealThread {
+    pub name: String,
+    pub level: Option<String>,
+}
+
+/// Where the first send stands when the scroll is written.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SealSendState {
+    /// An external snapshot exists (sent now, or found already sent).
+    Sent,
+    /// Deferred to the timer.
+    Tonight,
+    /// No sends promised, or no drive reachable.
+    NotApplicable,
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────

--- a/src/output.rs
+++ b/src/output.rs
@@ -197,12 +197,27 @@ pub struct StatusOutput {
     /// no subvolume is adapting, so a Roomy system stays silent.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub storage_adaptations: Vec<AdaptationSummary>,
-    /// Configured but unsealed (UPI 071): the sudo grant does not answer a
-    /// passwordless probe, so the promises are not yet in force. Probed only
-    /// on interactive runs (a denied probe writes an auth log line — daemon
-    /// paths never probe); false means "sealed or not checked".
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub unsealed: bool,
+    /// The first incomplete seal stage (UPI 071/075), if any: privilege
+    /// (the sudo grant does not answer a passwordless probe), units (the
+    /// schedule is not installed), or first-thread (a promise has no local
+    /// snapshot yet). One gap, one sentence, one cause. Checked only on
+    /// interactive runs (a denied probe writes an auth log line — daemon
+    /// paths never probe); `None` means "sealed or not checked".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seal_gap: Option<SealGap>,
+}
+
+/// The seal stage `urd status` names as incomplete, in seal order —
+/// the first gap wins (adversary F4/F7: one sentence, one cause).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SealGap {
+    /// The earning: the grant does not answer.
+    Privilege,
+    /// The schedule: expected systemd units are not installed.
+    Units,
+    /// The first thread: a promise that plans local snapshots has none.
+    FirstThread,
 }
 
 /// Serializable wrapper around SubvolAssessment data.
@@ -429,9 +444,10 @@ pub struct DefaultStatusOutput {
     /// bare-`urd` clause. Omitted when all pools are Roomy.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_posture: Option<PoolPostureSummary>,
-    /// Configured but unsealed (UPI 071) — see `StatusOutput::unsealed`.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub unsealed: bool,
+    /// The first incomplete seal stage (UPI 071/075) — see
+    /// `StatusOutput::seal_gap`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seal_gap: Option<SealGap>,
 }
 
 fn is_zero(n: &usize) -> bool {

--- a/src/sudoers.rs
+++ b/src/sudoers.rs
@@ -20,7 +20,10 @@
 //! - **Send/receive stay broad** (`send *`, `receive *`): source subvolumes
 //!   and external mount points vary, and both operations are non-destructive
 //!   (send is read-only; receive creates new subvolumes).
-//! - **show / filesystem show / subvolume sync** are read-only diagnostics.
+//! - **show / list / filesystem show / subvolume sync** are read-only
+//!   diagnostics; `subvolume list` is the post-seal second look's inventory
+//!   read (UPI 075). Hosts sealed before it existed show one Missing line in
+//!   doctor's coverage diff until `urd init` re-renders the grant.
 //! - Known caveat: sudoers wildcards use fnmatch without FNM_PATHNAME, so
 //!   the tail `*` in a scoped line matches across `/` and whitespace. The
 //!   scoped directory prefix is the boundary that matters; the tail is
@@ -228,6 +231,7 @@ fn grant_sections(config: &Config) -> Result<GrantSections, SudoersRefusal> {
         send_receive: vec![format!("{btrfs} send *"), format!("{btrfs} receive *")],
         read_only: vec![
             format!("{btrfs} subvolume show *"),
+            format!("{btrfs} subvolume list *"),
             format!("{btrfs} filesystem show *"),
             format!("{btrfs} subvolume sync *"),
         ],
@@ -740,6 +744,7 @@ protection = "sheltered"
                 "/usr/sbin/btrfs send *",
                 "/usr/sbin/btrfs receive *",
                 "/usr/sbin/btrfs subvolume show *",
+                "/usr/sbin/btrfs subvolume list *",
                 "/usr/sbin/btrfs filesystem show *",
                 "/usr/sbin/btrfs subvolume sync *",
             ]
@@ -1331,6 +1336,7 @@ User alice may run the following commands on example-host:
              (root) NOPASSWD: /usr/sbin/btrfs send *\n    \
              (root) NOPASSWD: /usr/sbin/btrfs receive *\n    \
              (root) NOPASSWD: /usr/sbin/btrfs subvolume show *\n    \
+             (root) NOPASSWD: /usr/sbin/btrfs subvolume list *\n    \
              (root) NOPASSWD: /usr/sbin/btrfs filesystem show *\n    \
              (root) NOPASSWD: /usr/sbin/btrfs subvolume sync *\n",
         )
@@ -1413,8 +1419,8 @@ User alice may run the following commands on example-host:
                     .unwrap_or_else(|| panic!("unexpected line shape: {line}"));
                 let allowlisted = matches!(
                     spec,
-                    "send *" | "receive *" | "subvolume show *" | "filesystem show *"
-                        | "subvolume sync *"
+                    "send *" | "receive *" | "subvolume show *" | "subvolume list *"
+                        | "filesystem show *" | "subvolume sync *"
                 );
                 let scoped_creation = spec.starts_with("subvolume snapshot -r /")
                     && spec.ends_with("/*")

--- a/src/systemd_units.rs
+++ b/src/systemd_units.rs
@@ -1,0 +1,281 @@
+//! The systemd-units oracle (UPI 075): the single source of what unit files
+//! the seal installs and what `urd doctor` diffs installed files against.
+//! Pure — rendering is a function of the embedded repo `systemd/` files (the
+//! compile-time source of truth, arc grill Q8) and the resolved urd binary
+//! path; no I/O lives here. The seal's install step and doctor's drift
+//! advisory both render through `expected_units`, so grant and check can
+//! never disagree.
+//!
+//! ExecStart substitution: the embedded `.service` files start
+//! `%h/.cargo/bin/urd` (correct for cargo installs only). A unit pointing at
+//! a missing binary is a silent protection failure — the timer fires,
+//! nothing runs, nobody is told — so the oracle substitutes the resolved
+//! `current_exe()` path at render time. Substitution **refuses** rather than
+//! escapes a path systemd could misread (whitespace, control characters,
+//! non-UTF-8): the sudoers posture, one trust boundary further on.
+
+use std::collections::HashMap;
+use std::fmt;
+use std::path::Path;
+
+use crate::types::RunFrequency;
+
+/// The embedded unit sources — repo `systemd/` is the compile-time truth.
+const BACKUP_SERVICE: &str = include_str!("../systemd/urd-backup.service");
+const BACKUP_TIMER: &str = include_str!("../systemd/urd-backup.timer");
+const SENTINEL_SERVICE: &str = include_str!("../systemd/urd-sentinel.service");
+
+/// The ExecStart binary token the embedded `.service` files carry.
+const EMBEDDED_EXEC_PREFIX: &str = "ExecStart=%h/.cargo/bin/urd";
+
+/// One renderable unit: its installed filename and exact expected content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnitFile {
+    pub name: &'static str,
+    pub content: String,
+}
+
+/// Why the oracle refused to render. Fail-closed: nothing renders, the
+/// message names the offending path and the manual fallback.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnitsRefusal {
+    pub reason: String,
+}
+
+impl fmt::Display for UnitsRefusal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.reason)
+    }
+}
+
+impl std::error::Error for UnitsRefusal {}
+
+/// The unit set this config's cadence answer selected, with ExecStart
+/// substituted to `exe`. The nightly pair is always required; the sentinel
+/// service joins it when the granularity answer chose sentinel mode (arc
+/// grill Q8 — the answer selects the set, the seal installs it).
+pub fn expected_units(
+    run_frequency: &RunFrequency,
+    exe: &Path,
+) -> Result<Vec<UnitFile>, UnitsRefusal> {
+    let exe = checked_exe(exe)?;
+    let mut units = vec![
+        UnitFile {
+            name: "urd-backup.service",
+            content: substitute_exec_start(BACKUP_SERVICE, &exe),
+        },
+        UnitFile {
+            name: "urd-backup.timer",
+            content: BACKUP_TIMER.to_string(),
+        },
+    ];
+    if matches!(run_frequency, RunFrequency::Sentinel) {
+        units.push(UnitFile {
+            name: "urd-sentinel.service",
+            content: substitute_exec_start(SENTINEL_SERVICE, &exe),
+        });
+    }
+    Ok(units)
+}
+
+/// Refuse an exe path a systemd ExecStart line could misread. Escaping is
+/// not attempted — a path with whitespace or control characters gets the
+/// honest sentence and the manual fallback instead of a quoted guess.
+fn checked_exe(exe: &Path) -> Result<String, UnitsRefusal> {
+    let Some(s) = exe.to_str() else {
+        return Err(UnitsRefusal {
+            reason: format!(
+                "the urd binary path {} is not valid UTF-8 — cannot write it into a \
+                 systemd unit",
+                exe.display()
+            ),
+        });
+    };
+    if s.is_empty() || !s.starts_with('/') {
+        return Err(UnitsRefusal {
+            reason: format!("the urd binary path {s:?} is not absolute"),
+        });
+    }
+    if s.chars().any(|c| c.is_whitespace() || c.is_control()) {
+        return Err(UnitsRefusal {
+            reason: format!(
+                "the urd binary path {s:?} contains whitespace or control characters — \
+                 refusing to write it into a systemd ExecStart line"
+            ),
+        });
+    }
+    Ok(s.to_string())
+}
+
+/// Replace the embedded `%h/.cargo/bin/urd` binary token on `ExecStart=`
+/// lines with the resolved path. Only ExecStart lines are touched — every
+/// other line (including `TimeoutStartSec=infinity`) passes through
+/// byte-identical.
+fn substitute_exec_start(unit: &str, exe: &str) -> String {
+    let mut out = String::with_capacity(unit.len());
+    for line in unit.lines() {
+        if let Some(rest) = line.strip_prefix(EMBEDDED_EXEC_PREFIX) {
+            out.push_str("ExecStart=");
+            out.push_str(exe);
+            out.push_str(rest);
+        } else {
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    out
+}
+
+/// How one installed unit differs from the oracle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnitDriftKind {
+    /// Not installed at all.
+    Missing,
+    /// Installed but not byte-equal to the expected render.
+    Differs,
+}
+
+/// One drifted unit, by installed filename.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnitDrift {
+    pub name: &'static str,
+    pub kind: UnitDriftKind,
+}
+
+/// Pure drift compare for doctor: expected renders vs. installed contents
+/// (`None` = file absent). Only expected units are judged — a stray foreign
+/// file in the units directory is not urd's to complain about.
+#[must_use = "the drift list is the doctor advisory's substance"]
+pub fn diff_units(
+    expected: &[UnitFile],
+    installed: &HashMap<String, Option<String>>,
+) -> Vec<UnitDrift> {
+    expected
+        .iter()
+        .filter_map(|unit| {
+            let kind = match installed.get(unit.name).and_then(|c| c.as_ref()) {
+                None => UnitDriftKind::Missing,
+                Some(content) if *content != unit.content => UnitDriftKind::Differs,
+                Some(_) => return None,
+            };
+            Some(UnitDrift {
+                name: unit.name,
+                kind,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::Interval;
+    use std::path::PathBuf;
+
+    fn timer_mode() -> RunFrequency {
+        RunFrequency::Timer {
+            interval: Interval::days(1),
+        }
+    }
+
+    fn exe() -> PathBuf {
+        PathBuf::from("/home/alice/.cargo/bin/urd")
+    }
+
+    #[test]
+    fn timer_mode_selects_the_nightly_pair_only() {
+        let units = expected_units(&timer_mode(), &exe()).unwrap();
+        let names: Vec<&str> = units.iter().map(|u| u.name).collect();
+        assert_eq!(names, vec!["urd-backup.service", "urd-backup.timer"]);
+    }
+
+    #[test]
+    fn sentinel_mode_adds_the_sentinel_service() {
+        let units = expected_units(&RunFrequency::Sentinel, &exe()).unwrap();
+        let names: Vec<&str> = units.iter().map(|u| u.name).collect();
+        assert_eq!(
+            names,
+            vec!["urd-backup.service", "urd-backup.timer", "urd-sentinel.service"]
+        );
+    }
+
+    #[test]
+    fn substitution_touches_only_exec_start_and_keeps_the_timer_verbatim() {
+        let units = expected_units(&RunFrequency::Sentinel, &exe()).unwrap();
+        let service = &units[0].content;
+        assert!(
+            service.contains("ExecStart=/home/alice/.cargo/bin/urd backup --auto"),
+            "backup ExecStart must carry the resolved path:\n{service}"
+        );
+        assert!(!service.contains("%h/.cargo/bin"), "no embedded token survives");
+        let sentinel = &units[2].content;
+        assert!(sentinel.contains("ExecStart=/home/alice/.cargo/bin/urd sentinel run"));
+        // The timer has no ExecStart: byte-identical to the embedded file.
+        assert_eq!(units[1].content, BACKUP_TIMER);
+    }
+
+    /// Sends are never time-limited (project invariant): the rendered
+    /// backup service must always carry the infinite start timeout. This
+    /// test fails loudly if the embedded unit file is ever edited
+    /// carelessly.
+    #[test]
+    fn rendered_backup_service_never_time_limits_sends() {
+        let units = expected_units(&timer_mode(), &exe()).unwrap();
+        assert!(units[0].content.contains("TimeoutStartSec=infinity"));
+    }
+
+    #[test]
+    fn hostile_exe_paths_are_refused_not_escaped() {
+        for bad in [
+            "relative/urd",
+            "",
+            "/home/alice/my tools/urd",
+            "/home/alice/urd\nExecStartPre=/bin/evil",
+            "/home/alice/urd\t",
+        ] {
+            assert!(
+                expected_units(&timer_mode(), Path::new(bad)).is_err(),
+                "exe path should be refused: {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn diff_reports_missing_and_differing_units_only() {
+        let expected = expected_units(&timer_mode(), &exe()).unwrap();
+        let mut installed: HashMap<String, Option<String>> = HashMap::new();
+        // service matches, timer differs, nothing else installed — but the
+        // set has only two units, so exercise Missing via an empty map too.
+        installed.insert(
+            "urd-backup.service".to_string(),
+            Some(expected[0].content.clone()),
+        );
+        installed.insert(
+            "urd-backup.timer".to_string(),
+            Some("[Timer]\nOnCalendar=hourly\n".to_string()),
+        );
+        let drift = diff_units(&expected, &installed);
+        assert_eq!(
+            drift,
+            vec![UnitDrift {
+                name: "urd-backup.timer",
+                kind: UnitDriftKind::Differs,
+            }]
+        );
+
+        let none_installed = HashMap::new();
+        let drift = diff_units(&expected, &none_installed);
+        assert_eq!(drift.len(), 2);
+        assert!(drift.iter().all(|d| d.kind == UnitDriftKind::Missing));
+    }
+
+    #[test]
+    fn all_matching_units_report_no_drift() {
+        let expected = expected_units(&RunFrequency::Sentinel, &exe()).unwrap();
+        let installed: HashMap<String, Option<String>> = expected
+            .iter()
+            .map(|u| (u.name.to_string(), Some(u.content.clone())))
+            .collect();
+        assert!(diff_units(&expected, &installed).is_empty());
+    }
+}

--- a/src/systemd_units.rs
+++ b/src/systemd_units.rs
@@ -50,6 +50,19 @@ impl fmt::Display for UnitsRefusal {
 
 impl std::error::Error for UnitsRefusal {}
 
+/// The unit filenames a cadence answer selects — the name-only view for
+/// existence checks (status, doctor's read map) that must not resolve an
+/// exe path or render anything.
+#[must_use]
+pub fn expected_unit_names(run_frequency: &RunFrequency) -> Vec<&'static str> {
+    match run_frequency {
+        RunFrequency::Sentinel => {
+            vec!["urd-backup.service", "urd-backup.timer", "urd-sentinel.service"]
+        }
+        RunFrequency::Timer { .. } => vec!["urd-backup.service", "urd-backup.timer"],
+    }
+}
+
 /// The unit set this config's cadence answer selected, with ExecStart
 /// substituted to `exe`. The nightly pair is always required; the sentinel
 /// service joins it when the granularity answer chose sentinel mode (arc

--- a/src/voice/encounter.rs
+++ b/src/voice/encounter.rs
@@ -739,6 +739,294 @@ pub fn render_earning_unavailable(detail: &str) -> String {
     )
 }
 
+// ── The seal's later stages (UPI 075) ───────────────────────────────────
+
+/// One adopted drive, by decision. The token is identity, not secret —
+/// `urd drives adopt` already prints it.
+#[must_use]
+pub fn render_seal_adoption(label: &str, action: &crate::output::AdoptAction) -> String {
+    use crate::output::AdoptAction;
+    match action {
+        AdoptAction::GeneratedNew { .. } => format!(
+            "{} {} — snapshot home created, identity written.\n",
+            "Adopted:".bold(),
+            label
+        ),
+        AdoptAction::AdoptedExisting { .. } => format!(
+            "{} {} — it already carried an identity; Urd now remembers it.\n",
+            "Adopted:".bold(),
+            label
+        ),
+        AdoptAction::AlreadyCurrent => {
+            format!("{} {} — already adopted.\n", "Known:".bold(), label)
+        }
+    }
+}
+
+/// A drive the adoption stage could not reach — honest per-drive skip,
+/// never red: the seal continues and `urd init` re-adopts when it's back.
+#[must_use]
+pub fn render_seal_adoption_skipped(label: &str, reason: &str) -> String {
+    format!(
+        "{} {} — {reason}\n\
+         Local protection proceeds without it; `urd init` adopts it once it's reachable.\n",
+        "Not adopted:".yellow().bold(),
+        label
+    )
+}
+
+/// When Urd acts next, derived ONLY from what the units actually do
+/// (adversary F3): the timer fires around 04:00 regardless of configured
+/// intervals (interval gating decides the work at run time), and the
+/// sentinel watches — it never snapshots. Promising sub-daily cadence here
+/// would be a fiction.
+#[must_use]
+pub fn describe_next_action(run_frequency: &crate::types::RunFrequency) -> String {
+    match run_frequency {
+        crate::types::RunFrequency::Sentinel => {
+            "The nightly timer acts around 04:00; the sentinel watches between runs."
+                .to_string()
+        }
+        crate::types::RunFrequency::Timer { .. } => {
+            "The nightly timer acts around 04:00.".to_string()
+        }
+    }
+}
+
+/// The units asking: what will be written where, what enabling means, and
+/// the two-way choice (no print option — the files land in the user's own
+/// config, and declining names the manual path).
+#[must_use]
+pub fn render_units_request(unit_names: &[&str], dir: &Path, next_action: &str) -> String {
+    let mut out = String::new();
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "{} To act unattended, Urd asks systemd to carry her:",
+        "The promises need a schedule.".bold()
+    )
+    .ok();
+    writeln!(out).ok();
+    for name in unit_names {
+        writeln!(out, "    {}", dir.join(name).display()).ok();
+    }
+    writeln!(out).ok();
+    writeln!(out, "{next_action}").ok();
+    writeln!(out).ok();
+    writeln!(out, "  i) write and enable them  (Enter)").ok();
+    writeln!(out, "  q) not now").ok();
+    out
+}
+
+/// Units written and enabled.
+#[must_use]
+pub fn render_units_installed(next_action: &str) -> String {
+    format!("{} {next_action}\n", "Scheduled:".bold())
+}
+
+/// Everything already installed, enabled, and byte-true to the oracle.
+#[must_use]
+pub fn render_units_already(next_action: &str) -> String {
+    format!("{} Already woven into systemd. {next_action}\n", "Scheduled:".bold())
+}
+
+/// `q`: nothing written; the promises have no schedule until `urd init`.
+#[must_use]
+pub fn render_units_skipped() -> String {
+    format!(
+        "{} Nothing was written. Until the units are enabled, Urd acts only when\n\
+         you invoke her. `urd init` resumes this step; the repository's systemd/\n\
+         directory holds the files if you prefer to install them yourself.\n",
+        "Not scheduled:".yellow().bold()
+    )
+}
+
+/// A concrete step failed (write, daemon-reload, enable): name it, keep
+/// the seal moving, point at the resume verb.
+#[must_use]
+pub fn render_units_failed(step: &str, detail: &str) -> String {
+    format!(
+        "{} {step} failed: {detail}\n\
+         The promises hold, but nothing runs unattended yet. `urd init` retries.\n",
+        "Not scheduled:".yellow().bold()
+    )
+}
+
+/// No systemd user manager answers here (container, ssh without a session
+/// bus): its own sentence, never a doomed consent prompt.
+#[must_use]
+pub fn render_units_no_manager(detail: &str) -> String {
+    format!(
+        "{} No systemd user manager answers on this session: {detail}\n\
+         Urd cannot schedule herself here; she acts when you invoke her.\n",
+        "Not scheduled:".yellow().bold()
+    )
+}
+
+/// Lingering is off: the truth about what a user timer does and the one
+/// command that changes it. Urd never enables lingering herself
+/// (adversary F1).
+#[must_use]
+pub fn render_linger_notice(user: &str) -> String {
+    format!(
+        "{} Backups run while you are logged in; missed nights catch up at your\n\
+         next login. To let Urd act even when you are logged out:\n\
+         \x20   loginctl enable-linger {user}\n",
+        "One thread loose:".yellow().bold()
+    )
+}
+
+/// One line before the first local run — the backup's own summary is the
+/// report; this only names the moment.
+#[must_use]
+pub fn render_first_thread_intro() -> String {
+    format!(
+        "\n{} Spinning the first thread now — a local snapshot of every promise.\n\n",
+        "The first thread.".bold()
+    )
+}
+
+/// Every promise that plans local snapshots already has at least one.
+#[must_use]
+pub fn render_first_thread_already() -> String {
+    format!("{} The first threads are already spun.\n", "Recorded:".bold())
+}
+
+/// The grilled truthful state: sealed, first thread not yet spun, with the
+/// exact resume verb.
+#[must_use]
+pub fn render_first_thread_failed(detail: &str) -> String {
+    format!(
+        "{} {detail}\n\
+         Sealed, but the first thread is not yet spun — `urd init` spins it.\n",
+        "Not yet recorded:".yellow().bold()
+    )
+}
+
+/// A local snapshot home could not be created (#250 data-path dirs): one
+/// honest sentence per root, the run proceeds and reports per-subvolume.
+#[must_use]
+pub fn render_data_dir_failed(path: &Path, detail: &str) -> String {
+    format!(
+        "{} could not create {}: {detail}\n",
+        "Snapshot home:".yellow().bold(),
+        path.display()
+    )
+}
+
+/// The first-send offer: explicit, honest about duration, and without a
+/// deadline — sends are never time-limited. Enter sends now (the
+/// recommended path); `t` leaves it to tonight's timer.
+#[must_use]
+pub fn render_send_offer() -> String {
+    let mut out = String::new();
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "{} Your snapshots live beside the data they guard. A copy on the\n\
+         external drive is what survives this machine.",
+        "The first send.".bold()
+    )
+    .ok();
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "A first full send copies everything once. On a large home this can take\n\
+         hours; Urd never cuts a send short, and later sends move only changes."
+    )
+    .ok();
+    writeln!(out).ok();
+    writeln!(out, "  s) send now  (Enter — leave the terminal open, watch it run)").ok();
+    writeln!(out, "  t) tonight — the timer takes the first send at ~04:00").ok();
+    out
+}
+
+/// The deferred path: no scolding, one fact, one place to look.
+#[must_use]
+pub fn render_send_deferred() -> String {
+    "Tonight, then. The timer takes the first send at ~04:00; until it lands,\n\
+     `urd status` names what is not yet sheltered.\n"
+        .to_string()
+}
+
+/// The summary scroll: what was woven, what survives what, when Urd acts
+/// next, and the one command that matters from now on. Honest partial
+/// states carry their `urd init` resume sentence, yellow, never red.
+#[must_use]
+pub fn render_seal_summary(summary: &crate::output::SealSummary) -> String {
+    use crate::output::SealSendState;
+
+    let mut out = String::new();
+    writeln!(out).ok();
+    writeln!(out, "{}", "The seal.".bold()).ok();
+    writeln!(out).ok();
+    for thread in &summary.threads {
+        match &thread.level {
+            Some(level) => writeln!(out, "  {} — {level}", thread.name.bold()).ok(),
+            None => writeln!(out, "  {}", thread.name.bold()).ok(),
+        };
+    }
+    writeln!(out).ok();
+
+    if summary.first_thread_spun {
+        writeln!(out, "The first threads are spun — your history begins today.").ok();
+    } else {
+        writeln!(
+            out,
+            "{}",
+            "Sealed, but the first thread is not yet spun — `urd init` spins it.".yellow()
+        )
+        .ok();
+    }
+    match summary.send {
+        SealSendState::Sent => {
+            writeln!(out, "A copy rests on the external drive — it survives this machine.").ok();
+        }
+        SealSendState::Tonight => {
+            writeln!(out, "The first send waits for tonight's timer.").ok();
+        }
+        SealSendState::NotApplicable => {}
+    }
+    if summary.units_enabled {
+        writeln!(out, "{}", summary.next_action).ok();
+    } else {
+        writeln!(
+            out,
+            "{}",
+            "No schedule is enabled — Urd acts only when invoked. `urd init` completes it."
+                .yellow()
+        )
+        .ok();
+    }
+    if summary.linger_loose {
+        writeln!(
+            out,
+            "{}",
+            "Backups run while you are logged in; `loginctl enable-linger` frees them."
+                .yellow()
+        )
+        .ok();
+    }
+    if let Some(n) = summary.uncovered_subvolumes
+        && n > 0
+    {
+        let plural = if n == 1 { "subvolume" } else { "subvolumes" };
+        writeln!(
+            out,
+            "I also see {n} {plural} your promises don't cover — `urd init` hears new answers."
+        )
+        .ok();
+    }
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "From now on, one command matters: {}. Silence means your data is safe.",
+        "urd status".bold()
+    )
+    .ok();
+    out
+}
+
 // ── The delve-deeper editor loop (rendered here, driven by commands) ────
 
 /// The visudo-shaped failure prompt after an edit broke the config.
@@ -786,6 +1074,76 @@ mod tests {
     };
     use crate::voice::test_fixtures::color_guard;
     use std::path::PathBuf;
+
+    // ── The seal's later stages (UPI 075) ───────────────────────────────
+
+    /// Adversary F3: "when Urd acts next" derives only from installed
+    /// units — never a sub-daily snapshot promise, in either mode.
+    #[test]
+    fn next_action_never_promises_sub_daily_cadence() {
+        let timer = describe_next_action(&crate::types::RunFrequency::Timer {
+            interval: crate::types::Interval::days(1),
+        });
+        assert!(timer.contains("04:00"));
+        assert!(!timer.contains("hour"));
+
+        let sentinel = describe_next_action(&crate::types::RunFrequency::Sentinel);
+        assert!(sentinel.contains("04:00"), "the timer is still what acts");
+        assert!(sentinel.contains("watches"), "the sentinel watches, never snapshots");
+        assert!(!sentinel.contains("hour"));
+    }
+
+    #[test]
+    fn seal_summary_names_threads_states_and_the_one_command() {
+        let _guard = color_guard(false);
+        let summary = crate::output::SealSummary {
+            threads: vec![crate::output::SealThread {
+                name: "docs".to_string(),
+                level: Some("sheltered".to_string()),
+            }],
+            units_enabled: true,
+            next_action: "The nightly timer acts around 04:00.".to_string(),
+            linger_loose: true,
+            first_thread_spun: true,
+            send: crate::output::SealSendState::Tonight,
+            uncovered_subvolumes: Some(2),
+        };
+        let out = render_seal_summary(&summary);
+        assert!(out.contains("docs"));
+        assert!(out.contains("sheltered"));
+        assert!(out.contains("04:00"));
+        assert!(out.contains("tonight's timer"));
+        assert!(out.contains("enable-linger"));
+        assert!(out.contains("2 subvolumes"));
+        assert!(out.contains("urd status"));
+    }
+
+    #[test]
+    fn seal_summary_partial_states_carry_the_resume_verb() {
+        let _guard = color_guard(false);
+        let summary = crate::output::SealSummary {
+            threads: vec![],
+            units_enabled: false,
+            next_action: String::new(),
+            linger_loose: false,
+            first_thread_spun: false,
+            send: crate::output::SealSendState::NotApplicable,
+            uncovered_subvolumes: None,
+        };
+        let out = render_seal_summary(&summary);
+        assert!(out.contains("not yet spun"));
+        assert!(out.contains("urd init"));
+        assert!(out.contains("No schedule is enabled"));
+        assert!(!out.contains("subvolumes your promises"), "None renders as silence");
+    }
+
+    #[test]
+    fn adoption_skip_sentence_names_the_drive_and_the_resume_verb() {
+        let _guard = color_guard(false);
+        let out = render_seal_adoption_skipped("backup-1", "not mounted at /run/media/x");
+        assert!(out.contains("backup-1"));
+        assert!(out.contains("urd init"));
+    }
 
     fn offer_spec() -> PromptSpec {
         PromptSpec {

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -472,7 +472,7 @@ pub(crate) mod test_fixtures {
 
     pub(crate) fn test_status_output() -> StatusOutput {
         StatusOutput {
-            unsealed: false,
+            seal_gap: None,
             assessments: vec![
                 StatusAssessment {
                     name: "htpc-home".to_string(),
@@ -704,7 +704,7 @@ pub(crate) mod test_fixtures {
 
     pub(crate) fn test_default_status_output() -> DefaultStatusOutput {
         DefaultStatusOutput {
-            unsealed: false,
+            seal_gap: None,
             total: 4,
             waning_names: vec![],
             exposed_names: vec![],

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -53,9 +53,15 @@ pub use emergency::{render_emergency, render_emergency_result};
 pub use encounter::{
     render_earning_already, render_earning_coverage_unconfirmed, render_earning_declined,
     render_earning_deferred, render_earning_installed, render_earning_request,
-    render_earning_unavailable, render_earning_verify_failed, render_editor_failure,
-    render_farewell, render_invalid_notice, render_no_editor, render_post_carve,
-    render_prompt, render_visudo_refusal,
+    describe_next_action, render_data_dir_failed, render_earning_unavailable,
+    render_earning_verify_failed, render_editor_failure, render_farewell,
+    render_first_thread_already, render_first_thread_failed, render_first_thread_intro,
+    render_invalid_notice, render_linger_notice, render_no_editor, render_post_carve,
+    render_prompt, render_seal_adoption, render_seal_adoption_skipped,
+    render_seal_summary, render_send_deferred, render_send_offer, render_units_already,
+    render_units_failed,
+    render_units_installed, render_units_no_manager, render_units_request,
+    render_units_skipped, render_visudo_refusal,
 };
 pub use get::render_get;
 pub use history::{render_events, render_history, render_subvolume_history};

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -45,12 +45,10 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
     // ── Summary line ────────────────────────────────────────────────
     render_summary_line(data, &mut out);
 
-    // ── The seal (UPI 071) ──────────────────────────────────────────
-    // Configured but unsealed: said once, high, with the resume verb.
-    // Yellow, never red — nothing was lost (Rule 6, red is earned). The
-    // wording names the state, not the probe: 075 widens what "sealed"
-    // takes (units, first snapshot) without rewording this banner.
-    render_unsealed_banner(data, &mut out);
+    // ── The seal (UPI 071/075) ──────────────────────────────────────
+    // The first incomplete seal stage: said once, high, with the resume
+    // verb. Yellow, never red — nothing was lost (Rule 6, red is earned).
+    render_seal_gap_banner(data, &mut out);
 
     // ── Storage adaptation prose (UPI 031-b AB3.1) ──────────────────
     // Rendered HIGH (right under the summary, ahead of any routine staleness
@@ -117,19 +115,32 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
     out
 }
 
-/// The unsealed banner (UPI 071): the promises are carved but not in
-/// force until root leave exists. One sentence, one resume verb.
-pub(super) fn render_unsealed_banner(data: &StatusOutput, out: &mut String) {
-    if !data.unsealed {
+/// The seal-gap banner (UPI 071/075): the first incomplete seal stage,
+/// one sentence, one resume verb — `urd init` resumes every one of them.
+pub(super) fn render_seal_gap_banner(data: &StatusOutput, out: &mut String) {
+    let Some(gap) = data.seal_gap else {
         return;
-    }
-    writeln!(
-        out,
-        "{}",
-        "Configured but unsealed — the promises are not yet in force.".yellow()
-    )
-    .ok();
-    writeln!(out, "Run `urd init` to resume the earning (root leave for btrfs).").ok();
+    };
+    let sentence = match gap {
+        crate::output::SealGap::Privilege => {
+            "Configured but unsealed — the promises are not yet in force."
+        }
+        crate::output::SealGap::Units => {
+            "Sealed, but the nightly weave is not yet enabled."
+        }
+        crate::output::SealGap::FirstThread => {
+            "Sealed, but the first thread is not yet spun."
+        }
+    };
+    writeln!(out, "{}", sentence.yellow()).ok();
+    let verb = match gap {
+        crate::output::SealGap::Privilege => {
+            "Run `urd init` to resume the earning (root leave for btrfs)."
+        }
+        crate::output::SealGap::Units => "Run `urd init` to complete the schedule.",
+        crate::output::SealGap::FirstThread => "Run `urd init` to spin it.",
+    };
+    writeln!(out, "{verb}").ok();
 }
 
 pub(super) fn render_summary_line(data: &StatusOutput, out: &mut String) {
@@ -753,14 +764,21 @@ fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
         write!(out, "{colored}").ok();
     }
 
-    // Configured but unsealed (UPI 071): one clause, the resume verb.
-    if data.unsealed {
-        write!(
-            out,
-            " {}",
-            "Configured but unsealed — `urd init` resumes the earning.".yellow()
-        )
-        .ok();
+    // The first incomplete seal stage (UPI 071/075): one clause, the
+    // resume verb.
+    if let Some(gap) = data.seal_gap {
+        let clause = match gap {
+            crate::output::SealGap::Privilege => {
+                "Configured but unsealed — `urd init` resumes the earning."
+            }
+            crate::output::SealGap::Units => {
+                "The nightly weave is not yet enabled — `urd init` completes it."
+            }
+            crate::output::SealGap::FirstThread => {
+                "The first thread is not yet spun — `urd init` spins it."
+            }
+        };
+        write!(out, " {}", clause.yellow()).ok();
     }
 
     // Last backup age (pre-computed by command handler to keep voice pure)
@@ -1283,41 +1301,52 @@ mod tests {
     }
 
     #[test]
-    fn interactive_unsealed_banner_names_state_and_resume_verb() {
+    fn interactive_seal_gap_banner_names_each_state_and_the_resume_verb() {
         let _color = color_guard(false);
-        let mut data = crate::voice::test_fixtures::test_status_output();
-        data.unsealed = true;
-        let out = render_status(&data, OutputMode::Interactive);
-        assert!(out.contains("unsealed"), "{out}");
-        assert!(out.contains("not yet in force"), "{out}");
-        assert!(out.contains("urd init"), "{out}");
+        for (gap, marker) in [
+            (crate::output::SealGap::Privilege, "not yet in force"),
+            (crate::output::SealGap::Units, "not yet enabled"),
+            (crate::output::SealGap::FirstThread, "not yet spun"),
+        ] {
+            let mut data = crate::voice::test_fixtures::test_status_output();
+            data.seal_gap = Some(gap);
+            let out = render_status(&data, OutputMode::Interactive);
+            assert!(out.contains(marker), "{gap:?}: {out}");
+            assert!(out.contains("urd init"), "{gap:?}: {out}");
+        }
     }
 
     #[test]
-    fn interactive_sealed_carries_no_unsealed_banner() {
+    fn interactive_sealed_carries_no_seal_banner() {
         let _color = color_guard(false);
         let out = render_status(
             &crate::voice::test_fixtures::test_status_output(),
             OutputMode::Interactive,
         );
         assert!(!out.contains("unsealed"), "{out}");
+        assert!(!out.contains("not yet spun"), "{out}");
     }
 
     #[test]
-    fn default_unsealed_clause_points_at_init() {
+    fn default_seal_gap_clause_points_at_init() {
         let _color = color_guard(false);
-        let mut data = crate::voice::test_fixtures::test_default_status_output();
-        data.unsealed = true;
-        let out = render_default_status(&data, OutputMode::Interactive);
-        assert!(out.contains("unsealed"), "{out}");
-        assert!(out.contains("urd init"), "{out}");
+        for gap in [
+            crate::output::SealGap::Privilege,
+            crate::output::SealGap::Units,
+            crate::output::SealGap::FirstThread,
+        ] {
+            let mut data = crate::voice::test_fixtures::test_default_status_output();
+            data.seal_gap = Some(gap);
+            let out = render_default_status(&data, OutputMode::Interactive);
+            assert!(out.contains("urd init"), "{gap:?}: {out}");
+        }
     }
 
     #[test]
     fn interactive_no_subvolumes() {
         let _color = color_guard(false);
         let data = StatusOutput {
-            unsealed: false,
+            seal_gap: None,
             assessments: vec![],
             chain_health: vec![],
             drives: vec![],
@@ -1394,7 +1423,7 @@ mod tests {
     fn interactive_no_last_run() {
         let _color = color_guard(false);
         let data = StatusOutput {
-            unsealed: false,
+            seal_gap: None,
             assessments: vec![],
             chain_health: vec![],
             drives: vec![],
@@ -1997,7 +2026,7 @@ mod tests {
     fn default_some_exposed() {
         let _color = color_guard(false);
         let data = DefaultStatusOutput {
-            unsealed: false,
+            seal_gap: None,
             total: 9,
             waning_names: vec![],
             exposed_names: vec!["htpc-root".to_string(), "docs".to_string()],
@@ -2032,7 +2061,7 @@ mod tests {
     fn default_some_waning() {
         let _color = color_guard(false);
         let data = DefaultStatusOutput {
-            unsealed: false,
+            seal_gap: None,
             total: 5,
             waning_names: vec!["htpc-config".to_string()],
             exposed_names: vec!["htpc-root".to_string()],
@@ -2089,7 +2118,7 @@ mod tests {
     fn default_no_last_backup() {
         let _color = color_guard(false);
         let data = DefaultStatusOutput {
-            unsealed: false,
+            seal_gap: None,
             total: 2,
             waning_names: vec![],
             exposed_names: vec![],
@@ -2111,7 +2140,7 @@ mod tests {
     #[test]
     fn default_daemon_json() {
         let data = DefaultStatusOutput {
-            unsealed: false,
+            seal_gap: None,
             total: 3,
             waning_names: vec!["sv1".to_string()],
             exposed_names: vec![],

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -1110,23 +1110,29 @@ mod contract {
     }
 
     #[test]
-    fn rule6_unsealed_banner_is_yellow_never_red() {
-        // UPI 071: "configured but unsealed" is a designed state on the
-        // declined path — nothing was lost, so the banner must not borrow
-        // red's gravity. Red is earned by exposure, not by a pending
-        // ceremony.
+    fn rule6_seal_gap_banner_is_yellow_never_red() {
+        // UPI 071/075: every incomplete-seal state is designed, not
+        // damaged — nothing was lost, so no banner may borrow red's
+        // gravity. Red is earned by exposure, not by a pending ceremony.
         let _color = color_guard(true);
-        let mut data = all_sealed_status();
-        data.unsealed = true;
-        let output = render_status(&data, OutputMode::Interactive);
-        let banner: Vec<&str> = output.lines().filter(|l| l.contains("unsealed")).collect();
-        assert!(!banner.is_empty(), "unsealed banner must render:\n{output}");
-        for line in banner {
-            assert_eq!(
-                helpers::count_red(line),
-                0,
-                "the unsealed banner must never be red: {line:?}"
-            );
+        for (gap, marker) in [
+            (crate::output::SealGap::Privilege, "unsealed"),
+            (crate::output::SealGap::Units, "not yet enabled"),
+            (crate::output::SealGap::FirstThread, "not yet spun"),
+        ] {
+            let mut data = all_sealed_status();
+            data.seal_gap = Some(gap);
+            let output = render_status(&data, OutputMode::Interactive);
+            let banner: Vec<&str> =
+                output.lines().filter(|l| l.contains(marker)).collect();
+            assert!(!banner.is_empty(), "{gap:?} banner must render:\n{output}");
+            for line in banner {
+                assert_eq!(
+                    helpers::count_red(line),
+                    0,
+                    "the seal-gap banner must never be red: {line:?}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The Encounter's closing stage (arc 6/9). Everything between "config carved, root earned" and "the terminal closes on a protected system" now happens in one guided pass, resumable at the first incomplete stage via `urd init`.

**`seal::resume_seal` grows six stages after the earning**, each opening with an idempotent done-check, no stage failure unwinding a prior one (ADR-109):

1. **Drive adoption** — reachable, UUID-verified drives get their snapshot home + identity token (`decide_adoption` extracted from `urd drives adopt` and shared); unreachable drives get one honest sentence each.
2. **Systemd units** — embedded via `include_str!` (repo `systemd/` = compile-time source of truth) in the new pure `systemd_units.rs` oracle; ExecStart substituted with this binary's resolved path (fail-closed refusal of hostile paths); written + `enable --now` with consent; the sentinel service joins in sentinel mode; the linger truth spoken when `Linger=no`.
3. **First local snapshot** — data-path dirs pre-created (#250), then a normal `backup --local-only` through the full pipeline (lock, isolation, watchdog, heartbeat all reused).
4. **First-send offer** — explicit, honest duration, never time-limited; Enter sends now, `t`/EOF defer to tonight's timer; declined is recorded nowhere.
5. **Second look** — `BtrfsRead::list_subvolumes` (new trait method + one read-only sudoers line), classified in subvol-path space (FSROOT mapping), capped at one advisory sentence.
6. **Summary scroll** — what was woven, when Urd acts next (derived only from installed units), honest partial states, handoff to `urd status`.

**Surfaces:** `urd status`/bare `urd` name the first incomplete seal stage (`seal_gap: privilege|units|first_thread` replaces the unreleased `unsealed` bool — one field, one owner); `urd init` resumes on any gap and enters no ceremony when fully sealed; `urd doctor` gains a units-drift advisory (Differs names both ExecStart paths) and a linger check.

## Review trail

Design grilled (arc 2026-07-03) → plan → /ponytail (5 findings integrated) → arch-adversary (8 findings: 3 significant — linger, subvol-path space, sentinel-cadence honesty — all integrated, no rebuttals) → build → /tidy → /check.

## Verification

- 2188 tests passing (+34), clippy `--all-targets -D warnings` clean.
- Live on the sealed host (read-only surfaces): doctor shows exactly the predicted one Missing coverage line (`subvolume list`, pre-075 grant) + the expected units Differs row naming both binaries; interactive status renders "All sealed" with no gap banner; `seal_gap` absent from daemon JSON.
- Remaining live matrix (interactive re-seal, encounter end-to-end, linger-off, unmounted drive) is staged for the 078 field visit / a supervised `urd init` run.

Note: after this merges and the host re-seals via `urd init`, the doctor drift rows self-heal. Docs-row PR for `systemd_units.rs` (architecture.md + CLAUDE.md) follows separately per convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)