### PR TITLE
release: v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-07-05
+
 ### Added
 - **The first seal (UPI 075, Encounter arc 6/9).** Everything between "the
   config exists and root is granted" and "the terminal closes on a protected
@@ -1481,7 +1483,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.32.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.33.0...HEAD
+[0.33.0]: https://github.com/vonrobak/urd/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/vonrobak/urd/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/vonrobak/urd/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/vonrobak/urd/compare/v0.29.0...v0.30.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.33.0** — the complete Encounter. Ships the whole guided first-run arc (UPIs 070–075, PRs #256 #258 #260 #262 #264 #266): zero-state discovery, the Fate Conversation, strategy derivation, config generation, the sudoers earning, and the first seal — plus the non-TTY exit-3 interface change and the 073 fixes.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 2188 passed, 0 failed (5+1 ignored)
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)