### PR TITLE
fix: init's resume gate sees the drift doctor names (deep seal gap)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `urd doctor`'s drift advisories now point at a verb that heals them:
+  `urd init`'s resume gate sees what doctor sees — sudoers coverage gaps
+  (expected grant lines the listing definitively lacks) and systemd-unit
+  content drift — instead of only the cheap probe and file existence. The
+  earning re-offers the render when the config has outgrown an answering
+  grant, naming the missing lines; declining a re-render lets the seal
+  continue (the grant still answers), so the units heal is never stranded.
+  Wildcard-grant uncertainty stays doctor's: hand-managed broad grants are
+  never nagged, and the uncertain advisory no longer names `urd init`.
+
 ## [0.33.0] - 2026-07-05
 
 ### Added

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -490,10 +490,11 @@ fn build_sudoers_drift_checks(config: &Config, listing: Option<&str>) -> Vec<Doc
                         uncertain.len(),
                         uncertain.join("; ")
                     )),
+                    // No `urd init` here: the resume verb acts only on
+                    // definitively missing lines — a hand-managed wildcard
+                    // grant is honest uncertainty, never a nag (071).
                     suggestion: Some(
-                        "Compare `sudo -l` against the config yourself, or run `urd init` \
-                         to install the exact scoped grant."
-                            .to_string(),
+                        "Compare `sudo -l` against the config yourself.".to_string(),
                     ),
                 });
             }
@@ -1161,6 +1162,11 @@ protection = "recorded"
         assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
         let detail = checks[0].detail.as_deref().unwrap();
         assert!(detail.contains("does not interpret"), "{detail}");
+        // Uncertainty never points at the resume verb: `urd init`'s deep
+        // gate acts only on definitively missing lines, so naming it here
+        // would be a dead suggestion (and a nag for hand-managed grants).
+        let suggestion = checks[0].suggestion.as_deref().unwrap();
+        assert!(!suggestion.contains("urd init"), "{suggestion}");
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -61,9 +61,11 @@ pub fn run_cli(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::R
     // match so the fix-it-repaired path resumes too. Unclear never
     // triggers a ceremony on a guess; non-TTY reports via the checks;
     // a fully sealed system enters no ceremony (Q5: nothing to do).
+    // The gate is the DEEP one (coverage + units content): init is the
+    // verb doctor's drift advisories name, so it must see what they see.
     let mut sudo_probe = seal::probe_grant(&config.general.btrfs_path);
     if doorstep == crate::commands::Doorstep::Offer
-        && seal::seal_gap_given_probe(&config, sudo_probe.0).is_some()
+        && seal::seal_gap_deep(&config, sudo_probe.0).is_some()
     {
         let path = crate::commands::resolve_config_path(config_path)?;
         seal::resume_seal(&config, &path)?;

--- a/src/commands/seal.rs
+++ b/src/commands/seal.rs
@@ -726,12 +726,25 @@ fn adopt_one(
 fn earn_privilege(config: &Config, config_path: &Path) -> anyhow::Result<SealOutcome> {
     let dest = Path::new(SUDOERS_DEST);
 
-    // Already answers (e.g. a broader hand-managed grant)? Nothing to ask;
-    // the doctor drift advisory watches coverage.
-    if probe_grant(&config.general.btrfs_path).0 == GrantProbe::Granted {
-        print!("{}", voice::render_earning_already());
-        return Ok(SealOutcome::Sealed);
-    }
+    // Already answers (e.g. a broader hand-managed grant)? Ask again only
+    // on clear evidence: expected lines the listing definitively lacks (a
+    // config the installed grant predates). Wildcard uncertainty stays
+    // doctor's — a hand-managed broad grant is never nagged (071).
+    let regrant = if probe_grant(&config.general.btrfs_path).0 == GrantProbe::Granted {
+        let missing = coverage_missing(config);
+        if missing.is_empty() {
+            print!("{}", voice::render_earning_already());
+            return Ok(SealOutcome::Sealed);
+        }
+        print!("{}", voice::render_earning_regrant(&missing));
+        true
+    } else {
+        false
+    };
+    // A declined RE-render leaves a grant that still answers: later stages
+    // can proceed, so the seal continues with coverage unconfirmed instead
+    // of stopping as a fresh earning's decline does (F4 table).
+    let declined = declined_outcome(regrant);
 
     let user = invoking_username()?;
 
@@ -767,7 +780,7 @@ fn earn_privilege(config: &Config, config_path: &Path) -> anyhow::Result<SealOut
             // manual path and leave the decision with the user.
             print!("{}", voice::render_earning_declined(&rendered, dest));
             println!("(visudo could not be run here: {e})");
-            return Ok(SealOutcome::Declined);
+            return Ok(declined);
         }
         Ok(out) if !out.status.success() => {
             // A render visudo refuses is a bug in urd, never installable.
@@ -800,11 +813,11 @@ fn earn_privilege(config: &Config, config_path: &Path) -> anyhow::Result<SealOut
         EarningChoice::Install => {}
         EarningChoice::Print => {
             print!("{}", voice::render_earning_declined(&rendered, dest));
-            return Ok(SealOutcome::Declined);
+            return Ok(declined);
         }
         EarningChoice::Decline => {
             print!("{}", voice::render_earning_deferred());
-            return Ok(SealOutcome::Declined);
+            return Ok(declined);
         }
     }
 
@@ -823,7 +836,7 @@ fn earn_privilege(config: &Config, config_path: &Path) -> anyhow::Result<SealOut
             voice::render_earning_unavailable(&format!("`sudo install` exited {install}"))
         );
         print!("{}", voice::render_earning_declined(&rendered, dest));
-        return Ok(SealOutcome::Declined);
+        return Ok(declined);
     }
 
     // Root-side integrity check: read the now-root-owned staged bytes back
@@ -929,6 +942,18 @@ enum EarningChoice {
     Decline,
 }
 
+/// What a not-installed conclusion means for the seal (pure). A fresh
+/// earning's decline leaves no grant — the seal stops (F4). A re-render's
+/// decline leaves a grant that still answers — the seal continues with
+/// coverage unconfirmed.
+fn declined_outcome(regrant: bool) -> SealOutcome {
+    if regrant {
+        SealOutcome::SealedUnverifiedCoverage
+    } else {
+        SealOutcome::Declined
+    }
+}
+
 /// Classify one consent line: `""`/`i` install, `p` print, `q` not now.
 fn parse_earning_choice(line: &str) -> Option<EarningChoice> {
     match line.trim().to_lowercase().as_str() {
@@ -981,8 +1006,9 @@ pub(crate) fn seal_completeness(
     seal_gap_given_probe(config, probe_grant(&config.general.btrfs_path).0)
 }
 
-/// The gap decision with the probe injected — `urd init` already holds a
-/// probe result and must not pay (or log) a second one.
+/// The cheap gap decision with the probe injected — status surfaces only.
+/// `urd init` gates on `seal_gap_deep` instead: the make-whole verb also
+/// sees coverage gaps and units content drift.
 pub(crate) fn seal_gap_given_probe(
     config: &Config,
     probe: GrantProbe,
@@ -999,6 +1025,52 @@ pub(crate) fn seal_gap_given_probe(
         return Some(SealGap::FirstThread);
     }
     None
+}
+
+/// The make-whole verb's deeper gate (`urd init` only): the content-level
+/// checks the cheap status probe deliberately avoids (adversary F7 scoped
+/// the existence-only rule to status surfaces, not to the explicit resume
+/// verb). Privilege also gaps on a grant that answers but definitively
+/// lacks expected lines (a config the installed file predates); units also
+/// gap on content drift (e.g. an ExecStart naming another binary). Both
+/// arms stay silent on uncertainty — clear evidence only, as everywhere —
+/// and both stages' done-checks make re-entry idempotent and consent-gated.
+pub(crate) fn seal_gap_deep(
+    config: &Config,
+    probe: GrantProbe,
+) -> Option<crate::output::SealGap> {
+    use crate::output::SealGap;
+
+    if probe == GrantProbe::Denied {
+        return Some(SealGap::Privilege);
+    }
+    if probe == GrantProbe::Granted && !coverage_missing(config).is_empty() {
+        return Some(SealGap::Privilege);
+    }
+    if units_missing(config) || units_drifted(config) {
+        return Some(SealGap::Units);
+    }
+    if first_thread_pending(config) {
+        return Some(SealGap::FirstThread);
+    }
+    None
+}
+
+/// Has any expected unit's installed content drifted from what THIS binary
+/// would render? Deep-gate only; any resolution failure is silence, never
+/// a guess — doctor owns the honest cannot-verify sentences.
+fn units_drifted(config: &Config) -> bool {
+    let Ok(exe) = std::env::current_exe().and_then(std::fs::canonicalize) else {
+        return false;
+    };
+    let Ok(units) = crate::systemd_units::expected_units(&config.general.run_frequency, &exe)
+    else {
+        return false;
+    };
+    let Some(dir) = dirs::config_dir().map(|d| d.join("systemd/user")) else {
+        return false;
+    };
+    !crate::systemd_units::diff_units(&units, &installed_unit_contents(&units, &dir)).is_empty()
 }
 
 /// Is any expected unit file absent? Existence only, by expected name —
@@ -1048,18 +1120,7 @@ pub(crate) fn probe_grant(btrfs_path: &str) -> (GrantProbe, String) {
 /// expected grants. `Ok(())` = fully covered; `Err(reason)` = the honest
 /// cannot-confirm sentence's substance (never a silent pass).
 pub(crate) fn check_coverage(config: &Config) -> Result<(), String> {
-    let expected = sudoers::expected_grant_lines(config).map_err(|r| r.to_string())?;
-    let out = Command::new("sudo")
-        .env("LC_ALL", "C")
-        .args(["-n", "-l"])
-        .output()
-        .map_err(|e| format!("could not run sudo -n -l: {e}"))?;
-    if !out.status.success() {
-        return Err("the privilege listing needs a password (sudo -n -l)".to_string());
-    }
-    let listing = sudoers::parse_privilege_listing(&String::from_utf8_lossy(&out.stdout))
-        .map_err(|u| u.reason)?;
-    match sudoers::coverage(&expected, &listing) {
+    match effective_coverage(config)? {
         Coverage::AllCovered => Ok(()),
         Coverage::CannotInterpret { reason } => Err(reason),
         Coverage::Gaps { missing, uncertain } => {
@@ -1073,9 +1134,48 @@ pub(crate) fn check_coverage(config: &Config) -> Result<(), String> {
     }
 }
 
+/// Effective privileges (`LC_ALL=C sudo -n -l`) diffed against the
+/// config's expected grants. `Err` = the listing could not be rendered,
+/// obtained, or parsed.
+fn effective_coverage(config: &Config) -> Result<Coverage, String> {
+    let expected = sudoers::expected_grant_lines(config).map_err(|r| r.to_string())?;
+    let out = Command::new("sudo")
+        .env("LC_ALL", "C")
+        .args(["-n", "-l"])
+        .output()
+        .map_err(|e| format!("could not run sudo -n -l: {e}"))?;
+    if !out.status.success() {
+        return Err("the privilege listing needs a password (sudo -n -l)".to_string());
+    }
+    let listing = sudoers::parse_privilege_listing(&String::from_utf8_lossy(&out.stdout))
+        .map_err(|u| u.reason)?;
+    Ok(sudoers::coverage(&expected, &listing))
+}
+
+/// The expected grant lines the effective listing DEFINITIVELY lacks.
+/// Empty on full coverage — and on every uncertainty (unlistable,
+/// unparseable, wildcard candidates urd does not interpret): the deep
+/// gate and the earning's done-check act only on clear evidence; doctor
+/// owns the honest uncertain sentences.
+fn coverage_missing(config: &Config) -> Vec<String> {
+    match effective_coverage(config) {
+        Ok(Coverage::Gaps { missing, .. }) => missing,
+        _ => Vec::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn declined_outcome_stops_a_fresh_earning_and_continues_a_regrant() {
+        // F4 continuation table: no grant → the seal stops; a grant that
+        // still answers (declined re-render) → the seal continues with
+        // coverage unconfirmed, so the units heal is never stranded.
+        assert_eq!(declined_outcome(false), SealOutcome::Declined);
+        assert_eq!(declined_outcome(true), SealOutcome::SealedUnverifiedCoverage);
+    }
 
     #[test]
     fn parse_earning_choice_defaults_to_install_and_knows_the_letters() {

--- a/src/voice/encounter.rs
+++ b/src/voice/encounter.rs
@@ -718,6 +718,24 @@ pub fn render_earning_already() -> String {
     )
 }
 
+/// The grant answers but the config has outgrown it: name the lines no
+/// grant covers, then the same asking follows with the full re-render.
+#[must_use]
+pub fn render_earning_regrant(missing: &[String]) -> String {
+    let mut out = String::new();
+    writeln!(out).ok();
+    writeln!(
+        out,
+        "{} Root leave answers, but the config has outgrown it — no grant covers:",
+        "The grant has drifted.".bold()
+    )
+    .ok();
+    for line in missing {
+        writeln!(out, "    {line}").ok();
+    }
+    out
+}
+
 /// `q) not now`: the user saw the content and deferred — no re-print,
 /// just the honest state and the resume verb.
 #[must_use]
@@ -1488,6 +1506,20 @@ mod tests {
         let deferred = render_earning_deferred();
         assert!(deferred.contains("not in force"), "{deferred}");
         assert!(deferred.contains("urd init"), "{deferred}");
+    }
+
+    #[test]
+    fn earning_regrant_names_every_missing_line() {
+        let _color = color_guard(false);
+        let missing = vec![
+            "/usr/sbin/btrfs subvolume list *".to_string(),
+            "/usr/sbin/btrfs sync /mnt".to_string(),
+        ];
+        let out = render_earning_regrant(&missing);
+        assert!(out.contains("outgrown"), "{out}");
+        for line in &missing {
+            assert!(out.contains(line), "{out}");
+        }
     }
 
     #[test]

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -52,7 +52,8 @@ pub use drives::{render_drives_adopt, render_drives_list};
 pub use emergency::{render_emergency, render_emergency_result};
 pub use encounter::{
     render_earning_already, render_earning_coverage_unconfirmed, render_earning_declined,
-    render_earning_deferred, render_earning_installed, render_earning_request,
+    render_earning_deferred, render_earning_installed, render_earning_regrant,
+    render_earning_request,
     describe_next_action, render_data_dir_failed, render_earning_unavailable,
     render_earning_verify_failed, render_editor_failure, render_farewell,
     render_first_thread_already, render_first_thread_failed, render_first_thread_intro,


### PR DESCRIPTION
## Summary

- **Live-found gap (post-0.33.0 re-seal):** doctor's sudoers-coverage and units-drift advisories say "Run `urd init`", but init's resume gate checked only the grant *probe* and unit-file *existence* — content-level drift never triggered the seal, making the suggestion a dead pointer.
- New `seal_gap_deep` gates `urd init` only: Privilege gap also on an answering grant that definitively lacks expected lines; Units gap also on content drift (`diff_units` vs this binary's render). Status surfaces keep the cheap existence-only probe (adversary F7 scoped that decision to status).
- The earning's done-check becomes coverage-aware: missing lines get the re-render offer (naming them) through the unchanged staged-consent ceremony; declining a **re**-render maps to `SealedUnverifiedCoverage` so the seal continues and the units stage can still heal.
- Wildcard uncertainty stays doctor's (071: hand-managed broad grants are never nagged); its advisory drops the now-dead `urd init` clause.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 2190 passed, 0 failed (+2 new: decline-outcome mapping, regrant voice)
- Live pty run on the drifted host (declining every offer, nothing installed): gate fires, regrant offer names the missing `subvolume list *` line, decline continues to the units offer, first-snapshot/send stages done-check silently.
- Noted for the 078 matrix: on decline-of-re-render, stage 6's second look runs `sudo btrfs subvolume list` non-`-n` and can prompt for a password when that exact line is the uncovered one (pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)