### PR TITLE
release: v0.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.1] - 2026-07-05
+
 ### Fixed
 - The seal's second look now counts honestly on multi-mount filesystems:
   pools are keyed by filesystem UUID instead of mount point, so Fedora's
@@ -1503,7 +1505,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.33.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.33.1...HEAD
+[0.33.1]: https://github.com/vonrobak/urd/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/vonrobak/urd/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/vonrobak/urd/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/vonrobak/urd/compare/v0.30.0...v0.31.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.33.0"
+version = "0.33.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.33.0"
+version = "0.33.1"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.33.1**. Patch release with two seal fixes: the deep resume gate so doctor's "Run `urd init`" advisories actually heal (#269), and the second look's honest count on multi-mount filesystems + `sudo -n` probing (#271).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 2191 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)