### PR TITLE
fix: the Encounter seals on the Fedora default layout (F1/F7/F8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The Encounter can now seal on the Fedora default layout. Strategy
+  derivation no longer proposes a snapshot root the earning must refuse:
+  when a pool's canonical mount is too shallow for the sudoers scope floor
+  (a pool mounted at `/` derives `/.snapshots`), the root falls back to a
+  home-relative `~/.snapshots` — user-writable, on the same pool, and able
+  to host a promise on `/` itself. Pools mounted deeper keep one common
+  `{pool mount}/.snapshots`. The floor now has a single oracle
+  (`sudoers::scope_deep_enough`) that derivation consults, and discovery
+  attributes the user's home to its pool with a targeted `findmnt` probe —
+  never path guessing.
+- Virgin first backups no longer fail on a missing per-subvolume snapshot
+  directory: the executor now creates `{root}/{subvol}/` before the first
+  local snapshot (mirroring the drive-side destination mkdir), so ordinary
+  runs self-heal too. It still refuses to fabricate a missing snapshot
+  root — an absent root means the configured filesystem is not there.
+- The staging-reset lab script unwinds two artifacts it previously left
+  behind: one-time acknowledgment markers and the persistent timer's
+  last-trigger stamp (which caused a catch-up run on freshly reset
+  machines).
+
 ## [0.33.1] - 2026-07-05
 
 ### Fixed

--- a/scripts/staging-reset.sh
+++ b/scripts/staging-reset.sh
@@ -261,6 +261,14 @@ if [[ $APPLY -eq 1 ]]; then
 else
     echo "  would daemon-reload + reset-failed 'urd-*'"
 fi
+# Persistent=true timers leave a last-trigger stamp that survives unit
+# removal — a "reset" machine would fire a catch-up run the moment the
+# units come back (field visit 2026-07-06, F13).
+for unit in "${UNITS[@]}"; do
+    [[ "$unit" == *.timer ]] || continue
+    stamp="$HOME/.local/share/systemd/timers/stamp-$unit"
+    [[ -e "$stamp" ]] && { do_rm "timer stamp" "$stamp" || true; }
+done
 echo
 
 # ── Hardening C: never reset under a live backup ─────────────────────────
@@ -375,6 +383,9 @@ for f in urd.db urd.db-wal urd.db-shm urd.lock heartbeat.json sentinel-state.jso
     [[ -e "$STATE_DIR/$f" ]] && { do_rm "state" "$STATE_DIR/$f" || true; }
 done
 [[ -d "$STATE_DIR/logs" ]] && { do_rm "state logs" "$STATE_DIR/logs/" || true; }
+# One-time acknowledgment markers (commands/acknowledgment.rs) — field
+# visit 2026-07-06, F5: the reset's own honest-warning caught this dir.
+[[ -d "$STATE_DIR/.acknowledgments" ]] && { do_rm "state acknowledgments" "$STATE_DIR/.acknowledgments/" || true; }
 if [[ $APPLY -eq 1 && -d "$STATE_DIR" ]]; then
     if ! rmdir "$STATE_DIR" 2>/dev/null; then
         echo "  WARNING: $STATE_DIR is not empty after the pass — this script does not know these files (unwind gap?):" >&2

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -49,6 +49,26 @@ pub struct SystemInventory {
     pub subvolumes: Vec<DiscoveredSubvol>,
     pub drives: Vec<CandidateDrive>,
     pub notes: Vec<DiscoveryNote>,
+    /// The invoking user's home directory, `None` when `$HOME` is unset
+    /// or relative. Strategy derivation falls back to a home-relative
+    /// snapshot root when a pool's canonical mount is too shallow for the
+    /// sudoers scope floor (field test 02, 2026-07-06).
+    pub home: Option<DiscoveredHome>,
+}
+
+/// The invoking user's home directory with pool attribution from a
+/// targeted `findmnt` probe — never path-prefix guessing: a non-btrfs
+/// `/home` mounted over a btrfs `/` is invisible to the btrfs-only mount
+/// listing, so containment in that listing proves nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveredHome {
+    /// Absolute path from `$HOME`.
+    pub path: PathBuf,
+    /// UUID of the btrfs pool the home directory lives on; `None` when
+    /// home is not on btrfs or the probe degraded. A snapshot root must
+    /// share its source's filesystem, so no attribution means no
+    /// home-relative fallback.
+    pub pool_uuid: Option<String>,
 }
 
 /// A btrfs filesystem seen by lsblk, keyed by filesystem UUID. One pool may
@@ -673,6 +693,7 @@ fn build_inventory(
         subvolumes,
         drives,
         notes,
+        home: None,
     }
 }
 
@@ -715,6 +736,17 @@ fn run_findmnt() -> crate::error::Result<String> {
     run_probe("findmnt", &["-t", "btrfs", "-J"], true)
 }
 
+/// Which filesystem holds `path`? (`--target` walks up to the nearest
+/// mount, so the path itself need not be a mountpoint.)
+fn run_findmnt_target(path: &Path) -> crate::error::Result<String> {
+    let target = path.to_string_lossy();
+    run_probe(
+        "findmnt",
+        &["-J", "-o", "TARGET,FSTYPE,UUID", "--target", &target],
+        true,
+    )
+}
+
 /// Probe the system and build the inventory. Never fails: a failed probe
 /// degrades the inventory and leaves a [`DiscoveryNote::ProbeDegraded`]
 /// so 072 can say so (fail open, observable).
@@ -747,7 +779,29 @@ pub fn discover() -> SystemInventory {
     // Probe degradation is the most important note — surface it first.
     probe_notes.append(&mut inventory.notes);
     inventory.notes = probe_notes;
+    inventory.home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .map(|path| {
+            let pool_uuid = run_findmnt_target(&path)
+                .ok()
+                .and_then(|out| parse_findmnt_target(&out));
+            DiscoveredHome { path, pool_uuid }
+        });
     inventory
+}
+
+/// The btrfs pool UUID of the filesystem holding the probed path, from
+/// `findmnt --target` output; `None` for non-btrfs filesystems or
+/// unparseable output.
+fn parse_findmnt_target(json: &str) -> Option<String> {
+    let root: serde_json::Value = serde_json::from_str(json).ok()?;
+    let fs = root.get("filesystems")?.as_array()?.first()?;
+    if fs.get("fstype")?.as_str()? != "btrfs" {
+        return None;
+    }
+    let uuid = fs.get("uuid")?.as_str()?;
+    (!uuid.is_empty()).then(|| uuid.to_string())
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -767,6 +821,38 @@ mod tests {
     const EXTERNAL_POOL: &str = "44444444-4444-4444-8444-444444444444";
     const SYSTEM_MAPPER: &str = "luks-11111111-1111-4111-8111-111111111111";
     const EXTERNAL_MAPPER: &str = "luks-33333333-3333-4333-8333-333333333333";
+
+    #[test]
+    fn parse_findmnt_target_btrfs_yields_pool_uuid() {
+        let json = format!(
+            r#"{{"filesystems":[{{"target":"/home","fstype":"btrfs","uuid":"{SYSTEM_POOL}"}}]}}"#
+        );
+        assert_eq!(
+            parse_findmnt_target(&json),
+            Some(SYSTEM_POOL.to_string())
+        );
+    }
+
+    #[test]
+    fn parse_findmnt_target_non_btrfs_yields_none() {
+        // An ext4 /home over a btrfs / must not be attributed to the pool
+        // — a home-relative snapshot root there would cross filesystems.
+        let json = format!(
+            r#"{{"filesystems":[{{"target":"/home","fstype":"ext4","uuid":"{SYSTEM_POOL}"}}]}}"#
+        );
+        assert_eq!(parse_findmnt_target(&json), None);
+    }
+
+    #[test]
+    fn parse_findmnt_target_degraded_output_yields_none() {
+        assert_eq!(parse_findmnt_target(""), None);
+        assert_eq!(parse_findmnt_target("{}"), None);
+        assert_eq!(parse_findmnt_target(r#"{"filesystems":[]}"#), None);
+        assert_eq!(
+            parse_findmnt_target(r#"{"filesystems":[{"target":"/","fstype":"btrfs","uuid":""}]}"#),
+            None
+        );
+    }
 
     fn node(name: &str) -> LsblkNode {
         LsblkNode {

--- a/src/encounter.rs
+++ b/src/encounter.rs
@@ -865,6 +865,7 @@ mod tests {
                 size: None,
                 transport: None,
             }],
+            home: None,
         };
         let r = EncounterState::begin(inv, today());
         match r.effect {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -890,6 +890,28 @@ impl<'a> Executor<'a> {
             dest.display()
         );
 
+        // Local snapshots land in `{root}/{subvol_name}/` and nothing else
+        // creates that dir — the seal creates only the roots (field test 03,
+        // F8, 2026-07-06). Self-heal here, mirroring the dest-dir mkdir in
+        // execute_send, so ordinary runs recover too. Same guard: only when
+        // the snapshot root itself is real — never manufacture a missing
+        // root on whatever filesystem happens to sit at its path.
+        if let Some(dir) = dest.parent()
+            && !dir.exists()
+            && dir.parent().is_some_and(Path::exists)
+        {
+            log::info!("Creating local snapshot directory: {}", dir.display());
+            if let Err(e) = std::fs::create_dir_all(dir) {
+                let err = UrdError::Io {
+                    path: dir.to_path_buf(),
+                    source: e,
+                };
+                log::error!("Snapshot directory creation failed: {err}");
+                failed_creates.insert(dest);
+                return outcome_failure("snapshot", None, &err, start.elapsed());
+            }
+        }
+
         match self.btrfs.create_readonly_snapshot(source, dest) {
             Ok(()) => outcome_success("snapshot", None, None, start.elapsed()),
             Err(e) => {
@@ -2183,6 +2205,71 @@ source = "/data/b"
         assert_eq!(result.overall, RunResult::Partial);
         assert!(!result.subvolume_results[0].success); // sv-a failed
         assert!(result.subvolume_results[1].success); // sv-b succeeded
+    }
+
+    #[test]
+    fn create_self_heals_missing_local_snapshot_dir() {
+        // Field test 03, F8: the seal creates only the snapshot roots;
+        // `{root}/{subvol}/` must self-heal here or every virgin first
+        // thread (and any run after the dir vanishes) fails.
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+
+        let root = tempfile::TempDir::new().unwrap();
+        let dir = root.path().join("sv-a");
+        let dest = dir.join("20260322-1430-a");
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::CreateSnapshot {
+                source: PathBuf::from("/data/a"),
+                dest,
+                subvolume_name: "sv-a".to_string(),
+            }],
+            timestamp: NaiveDate::from_ymd_opt(2026, 3, 22)
+                .unwrap()
+                .and_hms_opt(14, 30, 0)
+                .unwrap(),
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        let result = executor.execute(&plan, "full");
+
+        assert_eq!(result.overall, RunResult::Success);
+        assert!(dir.is_dir(), "the per-subvolume snapshot dir was created");
+    }
+
+    #[test]
+    fn create_never_manufactures_a_missing_snapshot_root() {
+        // The self-heal covers only the per-subvolume dir: a missing root
+        // means the configured filesystem is not there (unmounted, wrong
+        // path) — creating it would fabricate a snapshot home on whatever
+        // sits underneath.
+        let mock = MockBtrfs::new();
+        let config = test_config();
+        let shutdown = no_shutdown();
+        let executor = Executor::new(&mock, None, &config, &shutdown);
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dir = tmp.path().join("missing-root").join("sv-a");
+        let plan = BackupPlan {
+            operations: vec![PlannedOperation::CreateSnapshot {
+                source: PathBuf::from("/data/a"),
+                dest: dir.join("20260322-1430-a"),
+                subvolume_name: "sv-a".to_string(),
+            }],
+            timestamp: NaiveDate::from_ymd_opt(2026, 3, 22)
+                .unwrap()
+                .and_hms_opt(14, 30, 0)
+                .unwrap(),
+            skipped: vec![],
+            events: Vec::new(),
+        };
+
+        executor.execute(&plan, "full");
+
+        assert!(!dir.exists(), "no dir chain fabricated under a missing root");
     }
 
     #[test]

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -567,7 +567,7 @@ pub fn derive_strategy(
         subvolumes.push(ProposedSubvolume {
             name,
             source: candidate.mountpoint.clone(),
-            snapshot_root: snapshot_root_for(candidate, &inventory.pools),
+            snapshot_root: snapshot_root_for(candidate, inventory),
             level,
             policy,
         });
@@ -654,18 +654,44 @@ fn role_for(residence: Option<ResidenceAnswer>) -> DriveRole {
     }
 }
 
-/// `{pool canonical mountpoint}/.snapshots`. The fallback (the subvol's
-/// own mountpoint) is safe, not just convenient: that mountpoint is a
-/// mount of the same pool, so the snapshot dir still lands on the right
-/// filesystem.
-fn snapshot_root_for(candidate: &CandidateSubvol, pools: &[DiscoveredPool]) -> PathBuf {
-    pools
+/// `{pool canonical mountpoint}/.snapshots` — one common root per pool —
+/// unless that root sits below the sudoers scope floor
+/// (`sudoers::scope_deep_enough`, the earning's single oracle): on the
+/// Fedora default layout the pool's canonical mount is `/`, and proposing
+/// `/.snapshots` carves a config the earning must refuse (field test 02,
+/// 2026-07-06). A local snapshot root must be deep enough for the floor,
+/// on the same pool as its source, and user-writable (field test 03, F7)
+/// — the home-relative fallback satisfies all three with no chown
+/// ceremony, and covers a promise on `/` itself (home shares the pool on
+/// the default layout). The last resort (the subvol's own mountpoint) is
+/// same-pool by construction; a promise on `/` with home on a different
+/// pool still derives `/.snapshots` there — the documented residual the
+/// earning refuses honestly.
+fn snapshot_root_for(candidate: &CandidateSubvol, inventory: &SystemInventory) -> PathBuf {
+    let pool_root = inventory
+        .pools
         .iter()
         .find(|p| p.uuid == candidate.pool_uuid)
         .and_then(canonical_mount)
         .cloned()
         .unwrap_or_else(|| candidate.mountpoint.clone())
-        .join(".snapshots")
+        .join(".snapshots");
+    if crate::sudoers::scope_deep_enough(&pool_root) {
+        return pool_root;
+    }
+    // Pool attribution comes from discovery's targeted probe, never
+    // path-prefix guessing: a non-btrfs `/home` mounted over a btrfs `/`
+    // is invisible to the btrfs-only mount listing. A snapshot root must
+    // share its source's filesystem, so no attribution = no fallback.
+    if let Some(home) = &inventory.home
+        && home.pool_uuid.as_deref() == Some(candidate.pool_uuid.as_str())
+    {
+        let home_root = home.path.join(".snapshots");
+        if crate::sudoers::scope_deep_enough(&home_root) {
+            return home_root;
+        }
+    }
+    candidate.mountpoint.join(".snapshots")
 }
 
 fn granularity_intention(granularity: GranularityAnswer, today: NaiveDate) -> Intention {
@@ -815,6 +841,12 @@ pub(crate) mod test_support {
             subvolumes,
             drives,
             notes: Vec::new(),
+            // The fixture user's home lives on the system pool's `/home`
+            // subvolume, like the Fedora default layout it models.
+            home: Some(crate::discovery::DiscoveredHome {
+                path: PathBuf::from("/home/user"),
+                pool_uuid: Some(SYSTEM_POOL.to_string()),
+            }),
         }
     }
 
@@ -1678,17 +1710,73 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_root_is_pool_canonical_mount_dot_snapshots() {
-        // Fedora: the pool's canonical (shortest) mount is `/`, shared by
-        // both subvolumes — snapper-familiar `/.snapshots`.
+    fn snapshot_root_shallow_pool_falls_back_to_home_relative() {
+        // Fedora: the pool's canonical (shortest) mount is `/`, so the
+        // snapper-familiar `/.snapshots` sits below the sudoers scope
+        // floor and the earning would refuse it (field test 02). Home
+        // shares the pool, so every subvolume — `/` included — gets one
+        // common home-relative root, user-writable with no chown ceremony.
         let inv = fedora_with_external();
         let strategy = derive_strategy(&inv, &base_answers(), today());
+        assert!(!strategy.subvolumes.is_empty());
         assert!(
             strategy
                 .subvolumes
                 .iter()
-                .all(|s| s.snapshot_root == Path::new("/.snapshots"))
+                .all(|s| s.snapshot_root == Path::new("/home/user/.snapshots"))
         );
+    }
+
+    #[test]
+    fn snapshot_root_deep_pool_keeps_pool_canonical() {
+        // A pool mounted deep enough for the sudoers floor keeps one
+        // common `{pool mount}/.snapshots` — the live-fleet shape.
+        let inv = inventory(
+            vec![pool(SYSTEM_POOL, &["/mnt/btrfs-pool"])],
+            vec![subvol("/mnt/btrfs-pool/tank", "/tank", SYSTEM_POOL)],
+            vec![drive(
+                "sda",
+                DriveClass::Internal,
+                LuksState::NotEncrypted,
+                Some("btrfs"),
+                Some(SYSTEM_POOL),
+            )],
+        );
+        let strategy = derive_strategy(&inv, &base_answers(), today());
+        assert!(!strategy.subvolumes.is_empty());
+        assert!(
+            strategy
+                .subvolumes
+                .iter()
+                .all(|s| s.snapshot_root == Path::new("/mnt/btrfs-pool/.snapshots"))
+        );
+    }
+
+    #[test]
+    fn snapshot_root_home_off_pool_falls_back_to_own_mountpoint() {
+        // Home not attributed to the candidate's pool (ext4 home, another
+        // pool, or a degraded probe): the home-relative root could cross
+        // filesystems, so each subvolume falls back to its own mountpoint.
+        // A promise on `/` keeps the documented residual `/.snapshots`
+        // the earning refuses honestly.
+        let mut inv = fedora_with_external();
+        inv.home.as_mut().unwrap().pool_uuid = None;
+        let strategy = derive_strategy(&inv, &base_answers(), today());
+        let home = subvol_named(&strategy, "home");
+        assert_eq!(home.snapshot_root, Path::new("/home/.snapshots"));
+        let root = subvol_named(&strategy, "root");
+        assert_eq!(root.snapshot_root, Path::new("/.snapshots"));
+    }
+
+    #[test]
+    fn snapshot_root_unknown_home_falls_back_to_own_mountpoint() {
+        let mut inv = fedora_with_external();
+        inv.home = None;
+        let strategy = derive_strategy(&inv, &base_answers(), today());
+        let home = subvol_named(&strategy, "home");
+        assert_eq!(home.snapshot_root, Path::new("/home/.snapshots"));
+        let root = subvol_named(&strategy, "root");
+        assert_eq!(root.snapshot_root, Path::new("/.snapshots"));
     }
 
     // ── Step 5: drives, roles, gaps ────────────────────────────────────

--- a/src/sudoers.rs
+++ b/src/sudoers.rs
@@ -141,17 +141,25 @@ fn escape_cmnd_token(s: &str) -> String {
 /// root — same blast radius).
 fn checked_scope(what: &'static str, dir: &Path) -> Result<String, SudoersRefusal> {
     let s = checked_path(what, dir)?;
-    let depth = dir
-        .components()
-        .filter(|c| matches!(c, Component::Normal(_)))
-        .count();
-    if depth < 2 {
+    if !scope_deep_enough(dir) {
         return Err(SudoersRefusal::ShallowScope {
             what,
             scope: s.to_string(),
         });
     }
     Ok(escape_cmnd_token(s))
+}
+
+/// The scope floor as a public predicate: would `dir` survive
+/// `checked_scope`'s depth check? Strategy derivation consults this so it
+/// never proposes a snapshot root the earning must later refuse — the rule
+/// lives here, in the single oracle, not copied into the deriver.
+#[must_use]
+pub fn scope_deep_enough(dir: &Path) -> bool {
+    dir.components()
+        .filter(|c| matches!(c, Component::Normal(_)))
+        .count()
+        >= 2
 }
 
 /// Usernames are never escaped — only accepted or refused. Beyond the


### PR DESCRIPTION
## Summary

- **F1 (critical, field test 02):** strategy derivation proposed `/.snapshots` on any pool mounted at `/` — the exact scope the sudoers floor categorically refuses, so every virgin Encounter on stock Fedora carved a config and then crashed at the earning. The depth floor is now a public single oracle (`sudoers::scope_deep_enough`) consulted by derivation.
- **F7 (high, field test 03):** a local snapshot root must be deep enough for the floor, on the same pool as its source, *and user-writable*. Shallow pools now derive a home-relative `~/.snapshots` root, which satisfies all three and can host a promise on `/` itself. Discovery attributes home to its pool with a targeted `findmnt --target` probe (path-prefix guessing is blind to a non-btrfs `/home` over a btrfs `/`). Deep pools keep one common `{pool mount}/.snapshots`.
- **F8 (high, field test 03):** nothing created `{root}/{subvol}/` on the local side, so every virgin first thread failed. The executor now self-heals that dir (mirroring its drive-side dest mkdir) while still refusing to fabricate a missing snapshot root.
- **F5/F13 (low):** the staging-reset lab script unwinds `.acknowledgments/` and the persistent timer stamp.

Replaces the fedora-jern lab candidates (`e5a9f9f`, `a8b7ef8`) after the main-session design decision (recorded in the 073/075 design capsules). Live re-validation of scenario 1 on the staging machine is still pending — the lab build that sealed end-to-end used the mountpoint fallback, not the home-relative one.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 2199 passed, 0 failed
- Integration tests: not applicable (Encounter paths are unit/fixture tested; live scenario-1 retake queued for the next staging visit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)