### PR TITLE
release: v0.33.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.2] - 2026-07-07
+
 ### Fixed
 - `urd status`/`doctor`/`plan` no longer reach an interactive `sudo` prompt on a
   configured-but-unsealed machine. A symmetric review of every `Command::new("sudo")`
@@ -1564,7 +1566,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.33.1...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.33.2...HEAD
+[0.33.2]: https://github.com/vonrobak/urd/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/vonrobak/urd/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/vonrobak/urd/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/vonrobak/urd/compare/v0.31.0...v0.32.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.33.1"
+version = "0.33.2"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.33.2** — two field-visit fix batches on top of v0.33.1:

- **#273** (merged `604a71f`) — the 078 field visit's three golden-path blockers on stock Fedora: F1 (snapshot-root/sudoers-floor contradiction), F7 (non-user-writable root), F8 (missing per-subvol dir). Confirmed live by the 2026-07-06 retake (zero findings, ~2 min entry→sealed-schedule).
- **#284** (merged `6ff5300`) — a six-issue quick-fix batch: #274 (bare-`sudo` interactive-prompt sweep), #252 (`urd init` drive/UUID mismatch check), #253 (XDG-honest example config + init says what it creates), #251 (snapshot-ENOENT remediation naming), #282 (earning creates deep-pool snapshot roots), #278 (trust-repair acknowledgment retired).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 2198 passed, 0 failed, 5 ignored
- cargo build --release: pass
- PII scan: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)