### PR TITLE
release: v0.33.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.3] - 2026-07-07
+
 ### Added
 - The first-run Encounter now guides you toward an offsite copy. The looking names the
   role it infers for each drive ("a disk inside this machine — where your data lives" /
@@ -1582,7 +1584,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.33.2...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.33.3...HEAD
+[0.33.3]: https://github.com/vonrobak/urd/compare/v0.33.2...v0.33.3
 [0.33.2]: https://github.com/vonrobak/urd/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/vonrobak/urd/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/vonrobak/urd/compare/v0.32.0...v0.33.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.33.2"
+version = "0.33.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.33.2"
+version = "0.33.3"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.33.3** — the UPI 072 choreography amendment (#286). Discovery in the first-run Encounter now happens when you *begin* the conversation and again before the config is written, so a drive plugged in mid-conversation is seen and protected (closes #281), and the runestone guides you toward an offsite copy (advances #283).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 2207 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)