### PR TITLE
fix: sealment-aware doctor + status advice (UPI 081-b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `urd status`/bare `urd` no longer prescribe `urd backup` on a machine whose privileges
+  aren't confirmed — command-producing advice suppresses until the grant is earned, and a
+  new cannot-verify line speaks when the probe itself can't tell (sudo erroring) instead of
+  falling silent (#276).
+- `urd doctor` collapses an all-missing sudoers grant to one "not sealed yet" line instead
+  of burying the real cause under a row per expected command (#280).
+- `urd doctor` omits the Sentinel section entirely on a nightly-timer machine instead of
+  warning about a daemon unit that config never installs (#279).
+
 ## [0.33.3] - 2026-07-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ live in `docs/00-foundation/architecture.md`.
 - `config_render.rs` — approved strategy → `Config` + commented v2 TOML (pure; the Encounter's carving)
 - `encounter.rs` — the Fate Conversation state machine (pure; the Encounter's asking — prompts, views, typed carve/farewell effects)
 - `sudoers.rs` — render the scoped sudoers grant and parse `sudo -n -l` for drift (pure; the single oracle); `systemd_units.rs` — render + diff the embedded systemd user units (pure; the units oracle)
-- `commands/seal.rs` — `resume_seal`'s staged closing ceremony (earning → adoption → units → first snapshot → send offer → second look → summary; thin I/O) + the `seal_completeness` gap seam status surfaces call
+- `commands/seal.rs` — `resume_seal`'s staged closing ceremony (earning → adoption → units → first snapshot → send offer → second look → summary; thin I/O) + the `seal_posture` gap/earned/unclear seam status surfaces call
 - `output.rs` / `voice/` — structured output types / mythic-voice rendering
 - `events.rs` / `voice_events.rs` — typed event payloads / their renderer
 - `notify.rs`, `heartbeat.rs`, `metrics.rs` — notification + health surfaces

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -36,11 +36,16 @@ pub struct ActionableAdvice {
 /// Compute actionable advice for a subvolume based on its assessment.
 ///
 /// Returns `None` when the subvolume is protected and healthy (no action needed).
+/// `earned`: whether the machine's privileges are confirmed (UPI 081) — command-producing
+/// advice suppresses when `false` (the seal-gap banner speaks once instead of a `urd backup`
+/// that would just fail at `sudo btrfs`); config/physical advice (branches 2/3/5/8) is valid
+/// regardless of earned state and stays unguarded.
 /// `send_enabled`: whether external sends are configured for this subvolume.
 /// `external_only`: true when local retention is transient (no local recovery).
 #[must_use]
 pub fn compute_advice(
     assessment: &SubvolAssessment,
+    earned: bool,
     send_enabled: bool,
     external_only: bool,
 ) -> Option<ActionableAdvice> {
@@ -56,6 +61,9 @@ pub fn compute_advice(
     // When sends are disabled, only local staleness matters.
     if !send_enabled {
         if assessment.status == PromiseStatus::AtRisk {
+            if !earned {
+                return None;
+            }
             return Some(ActionableAdvice {
                 subvolume: name.clone(),
                 issue: format!("waning{}", format_age_suffix(assessment, false)),
@@ -98,6 +106,9 @@ pub fn compute_advice(
         || assessment.status == PromiseStatus::Unprotected)
         && let Some(broken) = find_broken_chain_on_mounted_drive(assessment)
     {
+        if !earned {
+            return None;
+        }
         return Some(ActionableAdvice {
             subvolume: name.clone(),
             issue: format_age_issue(assessment, external_only),
@@ -123,6 +134,9 @@ pub fn compute_advice(
 
     // Branch 6: At Risk + drive mounted, no chain break
     if assessment.status == PromiseStatus::AtRisk {
+        if !earned {
+            return None;
+        }
         return Some(ActionableAdvice {
             subvolume: name.clone(),
             issue: format_age_issue(assessment, external_only),
@@ -136,6 +150,13 @@ pub fn compute_advice(
         && assessment.health == OperationalHealth::Degraded
     {
         if let Some(broken) = find_broken_chain_on_mounted_drive(assessment) {
+            // M2 (adversary): the guard sits here, inside branch 7's own
+            // `Some`, never at this block's header — the header also guards
+            // branch 8 below, whose "connect {drive}" physical advice stays
+            // valid regardless of earned state.
+            if !earned {
+                return None;
+            }
             return Some(ActionableAdvice {
                 subvolume: name.clone(),
                 issue: format!("degraded — thread to {} broken", broken.drive_label),
@@ -1518,13 +1539,13 @@ local_retention = "transient"
     #[test]
     fn advice_protected_healthy_returns_none() {
         let a = test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Healthy);
-        assert!(compute_advice(&a, true, false).is_none());
+        assert!(compute_advice(&a, true, true, false).is_none());
     }
 
     #[test]
     fn advice_unprotected_no_drives() {
         let a = test_assessment_for_advice("sv1", PromiseStatus::Unprotected, OperationalHealth::Healthy);
-        let advice = compute_advice(&a, true, false).unwrap();
+        let advice = compute_advice(&a, true, true, false).unwrap();
         assert_eq!(advice.issue, "exposed — no external drives configured");
         assert!(advice.command.is_none());
         assert!(advice.reason.unwrap().contains("[[drives]]"));
@@ -1534,7 +1555,7 @@ local_retention = "transient"
     fn advice_unprotected_all_drives_absent() {
         let mut a = test_assessment_for_advice("sv1", PromiseStatus::Unprotected, OperationalHealth::Blocked);
         a.external = vec![drive_assessment("WD-18TB", false, None)];
-        let advice = compute_advice(&a, true, false).unwrap();
+        let advice = compute_advice(&a, true, true, false).unwrap();
         assert_eq!(advice.issue, "exposed — all drives disconnected");
         assert!(advice.command.is_none());
         assert!(advice.reason.unwrap().contains("Connect WD-18TB"));
@@ -1551,7 +1572,7 @@ local_retention = "transient"
                 pin_parent: None,
             },
         }];
-        let advice = compute_advice(&a, true, false).unwrap();
+        let advice = compute_advice(&a, true, true, false).unwrap();
         assert!(advice.command.as_ref().unwrap().contains("--force-full"));
         assert!(advice.reason.as_ref().unwrap().contains("thread to WD-18TB broken"));
     }
@@ -1560,7 +1581,7 @@ local_retention = "transient"
     fn advice_at_risk_drive_absent() {
         let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
         a.external = vec![drive_assessment("WD-18TB", false, Some(48))];
-        let advice = compute_advice(&a, true, false).unwrap();
+        let advice = compute_advice(&a, true, true, false).unwrap();
         assert!(advice.command.is_none());
         assert!(advice.reason.as_ref().unwrap().contains("Connect WD-18TB"));
     }
@@ -1569,7 +1590,7 @@ local_retention = "transient"
     fn advice_at_risk_drive_mounted_no_break() {
         let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Healthy);
         a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
-        let advice = compute_advice(&a, true, false).unwrap();
+        let advice = compute_advice(&a, true, true, false).unwrap();
         assert!(advice.command.as_ref().unwrap().contains("urd backup --subvolume sv1"));
         assert!(!advice.command.as_ref().unwrap().contains("--force-full"));
         assert!(advice.reason.is_none());
@@ -1586,7 +1607,7 @@ local_retention = "transient"
                 pin_parent: None,
             },
         }];
-        let advice = compute_advice(&a, true, false).unwrap();
+        let advice = compute_advice(&a, true, true, false).unwrap();
         assert!(advice.issue.contains("degraded"));
         assert!(advice.command.as_ref().unwrap().contains("--force-full"));
         assert!(advice.reason.as_ref().unwrap().contains("full send"));
@@ -1600,7 +1621,7 @@ local_retention = "transient"
             test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Degraded);
         a.external = vec![drive_assessment("WD-18TB1", false, Some(48))];
         a.health_reasons = vec!["WD-18TB1 overdue for 45 days".to_string()];
-        let advice = compute_advice(&a, true, false).unwrap();
+        let advice = compute_advice(&a, true, true, false).unwrap();
         assert_eq!(advice.issue, "degraded — WD-18TB1 away");
         assert!(advice.reason.as_ref().unwrap().contains("Consider connecting WD-18TB1"));
     }
@@ -1619,7 +1640,7 @@ local_retention = "transient"
         ];
         a.health_reasons = vec!["space tight on WD-18TB".to_string()];
         assert!(
-            compute_advice(&a, true, false).is_none(),
+            compute_advice(&a, true, true, false).is_none(),
             "must not recommend connecting an offsite whose absence is not the cause"
         );
     }
@@ -1633,7 +1654,7 @@ local_retention = "transient"
         a.external = vec![drive_assessment("WD-18TB", false, Some(48))];
         a.health_reasons = vec!["WD-18TB1 overdue for 45 days".to_string()];
         assert!(
-            compute_advice(&a, true, false).is_none(),
+            compute_advice(&a, true, true, false).is_none(),
             "a reason about WD-18TB1 must not flag WD-18TB as the cause"
         );
     }
@@ -1642,7 +1663,7 @@ local_retention = "transient"
     fn advice_send_disabled_ignores_external() {
         let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
         a.external = vec![drive_assessment("WD-18TB", false, None)];
-        let advice = compute_advice(&a, false, false).unwrap();
+        let advice = compute_advice(&a, true, false, false).unwrap();
         assert!(advice.command.as_ref().unwrap().contains("urd backup --subvolume sv1"));
         assert!(!advice.command.as_ref().unwrap().contains("--force-full"));
     }
@@ -1652,7 +1673,7 @@ local_retention = "transient"
         let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Healthy);
         // Local age is 2h (from test_assessment_for_advice), but external send was 48h ago
         a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
-        let advice = compute_advice(&a, true, true).unwrap();
+        let advice = compute_advice(&a, true, true, true).unwrap();
         assert!(
             advice.issue.contains("last external send"),
             "expected 'last external send' in issue: {}",
@@ -1663,6 +1684,67 @@ local_retention = "transient"
             "should not say 'last backup' when external_only: {}",
             advice.issue
         );
+    }
+
+    // ── UPI 081 B1: !earned suppresses command-producing advice ────────
+
+    #[test]
+    fn advice_unearned_send_disabled_at_risk_returns_none() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", false, None)];
+        assert!(compute_advice(&a, false, false, false).is_none());
+    }
+
+    #[test]
+    fn advice_unearned_chain_broken_mounted_returns_none() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
+        a.chain_health = vec![DriveChainHealth {
+            drive_label: "WD-18TB".to_string(),
+            status: ChainStatus::Broken {
+                reason: ChainBreakReason::PinMissingLocally,
+                pin_parent: None,
+            },
+        }];
+        assert!(compute_advice(&a, false, true, false).is_none());
+    }
+
+    #[test]
+    fn advice_unearned_at_risk_drive_mounted_returns_none() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Healthy);
+        a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
+        assert!(compute_advice(&a, false, true, false).is_none());
+    }
+
+    #[test]
+    fn advice_unearned_protected_degraded_chain_broken_returns_none() {
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", true, Some(6))];
+        a.chain_health = vec![DriveChainHealth {
+            drive_label: "WD-18TB".to_string(),
+            status: ChainStatus::Broken {
+                reason: ChainBreakReason::NoPinFile,
+                pin_parent: None,
+            },
+        }];
+        assert!(compute_advice(&a, false, true, false).is_none());
+    }
+
+    /// M2 regression: the branch-7 guard sits inside branch 7's own `Some`,
+    /// never at the shared `Protected && Degraded` block header — an
+    /// unearned machine must still get branch 8's physical "connect the
+    /// drive" advice when a drive's absence is the documented health cause
+    /// (no broken chain in this scenario, so branch 7 never applies).
+    #[test]
+    fn advice_unearned_branch8_still_fires_when_absence_is_the_cause() {
+        let mut a =
+            test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB1", false, Some(48))];
+        a.health_reasons = vec!["WD-18TB1 overdue for 45 days".to_string()];
+        let advice = compute_advice(&a, false, true, false).unwrap();
+        assert_eq!(advice.issue, "degraded — WD-18TB1 away");
+        assert!(advice.command.is_none());
+        assert!(advice.reason.as_ref().unwrap().contains("Consider connecting WD-18TB1"));
     }
 
     // ── count_distinct_causes (UPI 079-a §3) ───────────────────────────

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -75,13 +75,23 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         }
     }
 
+    // An incomplete seal stage (UPI 071/075/081) — see `seal::seal_posture`.
+    // Computed before advice: the advice loop needs `posture.earned` to
+    // suppress command-producing advice on an unearned machine.
+    let posture = crate::commands::seal::seal_posture(&config, output_mode);
+
     // Compute actionable advice
     let resolved = config.resolved_subvolumes();
     let advice_items: Vec<advice::ActionableAdvice> = assessments
         .iter()
         .filter_map(|a| {
             let sv = resolved.iter().find(|sv| sv.name == a.name)?;
-            advice::compute_advice(a, sv.send_enabled, sv.local_retention.is_transient())
+            advice::compute_advice(
+                a,
+                posture.earned,
+                sv.send_enabled,
+                sv.local_retention.is_transient(),
+            )
         })
         .collect();
 
@@ -95,9 +105,6 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         .into_iter()
         .max_by(|a, b| a.tier.cmp(&b.tier).then(a.host_root.cmp(&b.host_root)));
 
-    // An incomplete seal stage (UPI 071/075) — see `seal::seal_completeness`.
-    let seal_gap = crate::commands::seal::seal_completeness(&config, output_mode);
-
     let output = DefaultStatusOutput {
         total,
         waning_names,
@@ -109,7 +116,8 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         best_advice,
         total_needing_attention,
         storage_posture,
-        seal_gap,
+        seal_gap: posture.gap,
+        privilege_unclear: posture.privilege_unclear,
     };
 
     let rendered = voice::render_default_status(&output, output_mode);

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -246,7 +246,8 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
             let sv_config = resolved.iter().find(|sv| sv.name == a.name);
             let send_enabled = sv_config.is_none_or(|sv| sv.send_enabled);
             let external_only = sv_config.is_some_and(|sv| sv.local_retention.is_transient());
-            let advice = advice::compute_advice(a, send_enabled, external_only);
+            let earned = sudo_probe.0 == crate::sudoers::GrantProbe::Granted;
+            let advice = advice::compute_advice(a, earned, send_enabled, external_only);
 
             // Extract structured advice into doctor display fields.
             let (issue, suggestion, reason) = match a.status {
@@ -287,40 +288,48 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         })
         .collect();
 
-    // ── 4. Sentinel status ────────────────────────────────────────
-    let state_path = sentinel_runner::sentinel_state_path(&config);
-    let sentinel = match sentinel_runner::read_sentinel_state_file(&state_path) {
-        Some(state) if sentinel_runner::is_pid_alive(state.pid) => {
-            // Compute uptime from started timestamp
-            let uptime = chrono::NaiveDateTime::parse_from_str(&state.started, "%Y-%m-%dT%H:%M:%S")
-                .ok()
-                .or_else(|| {
-                    chrono::NaiveDateTime::parse_from_str(&state.started, "%Y-%m-%d %H:%M:%S").ok()
-                })
-                .map(|started| {
-                    let dur = now - started;
-                    let hours = dur.num_hours();
-                    let minutes = dur.num_minutes() % 60;
-                    if hours > 0 {
-                        format!("{hours}h {minutes}m")
-                    } else {
-                        format!("{minutes}m")
-                    }
-                });
-            DoctorSentinelStatus {
-                running: true,
-                pid: Some(state.pid),
-                uptime,
+    // ── 4. Sentinel status (UPI 081 B4: Timer-cadence machines omit this
+    // section entirely — a stopped daemon that config never installs is
+    // not a warning) ────────────────────────────────────────────────
+    let sentinel = if config.general.run_frequency == crate::types::RunFrequency::Sentinel {
+        let state_path = sentinel_runner::sentinel_state_path(&config);
+        Some(match sentinel_runner::read_sentinel_state_file(&state_path) {
+            Some(state) if sentinel_runner::is_pid_alive(state.pid) => {
+                // Compute uptime from started timestamp
+                let uptime =
+                    chrono::NaiveDateTime::parse_from_str(&state.started, "%Y-%m-%dT%H:%M:%S")
+                        .ok()
+                        .or_else(|| {
+                            chrono::NaiveDateTime::parse_from_str(&state.started, "%Y-%m-%d %H:%M:%S")
+                                .ok()
+                        })
+                        .map(|started| {
+                            let dur = now - started;
+                            let hours = dur.num_hours();
+                            let minutes = dur.num_minutes() % 60;
+                            if hours > 0 {
+                                format!("{hours}h {minutes}m")
+                            } else {
+                                format!("{minutes}m")
+                            }
+                        });
+                DoctorSentinelStatus {
+                    running: true,
+                    pid: Some(state.pid),
+                    uptime,
+                }
             }
-        }
-        _ => {
-            warn_count += 1;
-            DoctorSentinelStatus {
-                running: false,
-                pid: None,
-                uptime: None,
+            _ => {
+                warn_count += 1;
+                DoctorSentinelStatus {
+                    running: false,
+                    pid: None,
+                    uptime: None,
+                }
             }
-        }
+        })
+    } else {
+        None
     };
 
     // ── 5. Verify (optional — --thorough only) ────────────────────
@@ -466,6 +475,22 @@ fn build_sudoers_drift_checks(config: &Config, listing: Option<&str>) -> Vec<Doc
             vec![cannot_verify_grant_check(reason)]
         }
         crate::sudoers::Coverage::Gaps { missing, uncertain } => {
+            // UPI 081 B3: every expected line is missing (self-implies
+            // uncertain is empty too) → this machine was never sealed, not
+            // a config that drifted since. One earning-vocabulary line, not
+            // N "predates" rows that bury the real cause.
+            if missing.len() == expected.len() {
+                return vec![DoctorCheck {
+                    name: "sudoers drift".to_string(),
+                    status: DoctorCheckStatus::Warn,
+                    detail: Some(
+                        "This machine isn't sealed yet — run `urd init` to earn root's leave \
+                         for btrfs."
+                            .to_string(),
+                    ),
+                    suggestion: Some("Run `urd init` to earn the grant.".to_string()),
+                }];
+            }
             let mut checks: Vec<DoctorCheck> = missing
                 .into_iter()
                 .map(|spec| DoctorCheck {
@@ -1144,6 +1169,25 @@ protection = "recorded"
         assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
         let detail = checks[0].detail.as_deref().unwrap();
         assert!(detail.contains("subvolume delete /data/.snapshots/*"), "{detail}");
+        let suggestion = checks[0].suggestion.as_deref().unwrap();
+        assert!(suggestion.contains("urd init"), "{suggestion}");
+    }
+
+    /// UPI 081 B3 (#280): every expected line missing → this machine was
+    /// never sealed, not a config that drifted since. One "not sealed"
+    /// line, not N per-spec "predates" rows that bury the real cause.
+    #[test]
+    fn drift_all_missing_collapses_to_one_not_sealed_line() {
+        let config = drift_config();
+        // A grant unrelated to any expected line: every expected spec is
+        // missing, none uncertain (a real grant that covers nothing urd
+        // asked for — distinct from an unparseable/empty listing).
+        let unrelated = vec!["/usr/sbin/some-other-tool run".to_string()];
+        let checks = build_sudoers_drift_checks(&config, Some(&listing_of(&unrelated)));
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].status, DoctorCheckStatus::Warn);
+        let detail = checks[0].detail.as_deref().unwrap();
+        assert!(detail.contains("isn't sealed yet"), "{detail}");
         let suggestion = checks[0].suggestion.as_deref().unwrap();
         assert!(suggestion.contains("urd init"), "{suggestion}");
     }

--- a/src/commands/seal.rs
+++ b/src/commands/seal.rs
@@ -1067,23 +1067,46 @@ fn stage_rendered(rendered: &str) -> anyhow::Result<tempfile::NamedTempFile> {
     Ok(tmp)
 }
 
-/// The first incomplete seal stage a status surface should name (UPI 075
-/// widened `probe_unsealed`; single owner of the rule). Interactive only —
-/// a denied probe writes an auth log line, so automated and monitoring
-/// callers must never generate that noise — and only on clear evidence:
-/// `Unclear` probes and unreadable directories stay silent rather than
-/// guess. Seal order decides: privilege → units → first thread (one
-/// sentence, one cause — adversary F4/F7). The units arm checks file
-/// EXISTENCE only (content drift is doctor's job; no systemctl call here),
-/// and the first-thread arm is policy-aware (F5).
-pub(crate) fn seal_completeness(
-    config: &Config,
-    output_mode: OutputMode,
-) -> Option<crate::output::SealGap> {
-    if output_mode != OutputMode::Interactive {
-        return None;
+/// The full picture a status surface needs (UPI 081): the first incomplete
+/// seal stage alongside whether the machine is earned (grant answers) and
+/// whether the probe itself couldn't confirm (`Unclear`, e.g. sudo erroring).
+/// A single probe backs all three fields — probing twice would double the
+/// auth-log line (memory `feedback_never_time_limit_sends`/071).
+pub(crate) struct SealPosture {
+    pub gap: Option<crate::output::SealGap>,
+    pub earned: bool,
+    pub privilege_unclear: bool,
+}
+
+/// Interactive only — a denied probe writes an auth log line, so automated
+/// and monitoring callers must never generate that noise; non-interactive
+/// callers get no probe (`earned` defaults true — machine consumers keep
+/// today's advice, the suppression is a human-UX concern).
+pub(crate) fn seal_posture(config: &Config, output_mode: OutputMode) -> SealPosture {
+    let probe =
+        (output_mode == OutputMode::Interactive).then(|| probe_grant(&config.general.btrfs_path).0);
+    posture_from_probe(config, probe)
+}
+
+/// The pure mapping from an already-run probe (`None` = non-interactive, no
+/// probe) to a `SealPosture`. Seal order decides the gap: privilege → units
+/// → first thread (one sentence, one cause — adversary F4/F7). The units arm
+/// checks file EXISTENCE only (content drift is doctor's job; no systemctl
+/// call here), and the first-thread arm is policy-aware (F5). `Unclear`
+/// never falls through to `seal_gap_given_probe`: we don't presume
+/// Units/FirstThread stages when privilege itself is unconfirmed.
+pub(crate) fn posture_from_probe(config: &Config, probe: Option<GrantProbe>) -> SealPosture {
+    let Some(probe) = probe else {
+        return SealPosture { gap: None, earned: true, privilege_unclear: false };
+    };
+    SealPosture {
+        gap: match probe {
+            GrantProbe::Unclear => None,
+            p => seal_gap_given_probe(config, p),
+        },
+        earned: probe == GrantProbe::Granted,
+        privilege_unclear: probe == GrantProbe::Unclear,
     }
-    seal_gap_given_probe(config, probe_grant(&config.general.btrfs_path).0)
 }
 
 /// The cheap gap decision with the probe injected — status surfaces only.
@@ -1445,6 +1468,51 @@ protection = "recorded"
         // A real snapshot dir entry satisfies it.
         std::fs::create_dir_all(root.join("docs/20260705-0400-docs")).unwrap();
         assert!(!first_thread_pending(&config));
+    }
+
+    #[test]
+    fn posture_from_probe_maps_each_probe_class() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().join(".snapshots");
+        let config = seal_config(&format!(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "{}"
+protection = "recorded"
+"#,
+            root.display()
+        ));
+        // No snapshot on disk yet: first_thread_pending is true, so this
+        // config is incomplete regardless of the ambient units state.
+
+        let non_interactive = posture_from_probe(&config, None);
+        assert_eq!(non_interactive.gap, None);
+        assert!(non_interactive.earned);
+        assert!(!non_interactive.privilege_unclear);
+
+        let denied = posture_from_probe(&config, Some(GrantProbe::Denied));
+        assert_eq!(denied.gap, Some(crate::output::SealGap::Privilege));
+        assert!(!denied.earned);
+        assert!(!denied.privilege_unclear);
+
+        let granted = posture_from_probe(&config, Some(GrantProbe::Granted));
+        assert!(granted.gap.is_some());
+        assert!(granted.earned);
+        assert!(!granted.privilege_unclear);
+
+        // Unclear, even though the same config is incomplete: gap stays None
+        // — never presume Units/FirstThread when privilege itself is
+        // unconfirmed (the one behavior change vs. the old seal_completeness).
+        let unclear = posture_from_probe(&config, Some(GrantProbe::Unclear));
+        assert_eq!(unclear.gap, None);
+        assert!(!unclear.earned);
+        assert!(unclear.privilege_unclear);
     }
 
     /// Send-offer done-detection over a real (temp) drive layout.

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -32,9 +32,9 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     };
     let drive_labels: Vec<String> = config.drives.iter().map(|d| d.label.clone()).collect();
 
-    // ── The seal (UPI 071/075) ──────────────────────────────────────
+    // ── The seal (UPI 071/075/081) ──────────────────────────────────
     // An incomplete seal stage is a named state, not a degraded render.
-    let seal_gap = crate::commands::seal::seal_completeness(&config, output_mode);
+    let posture = crate::commands::seal::seal_posture(&config, output_mode);
 
     // ── Awareness model ─────────────────────────────────────────────
     let now = chrono::Local::now().naive_local();
@@ -94,7 +94,9 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         total_pins,
         &config,
         now,
-        seal_gap,
+        posture.gap,
+        posture.earned,
+        posture.privilege_unclear,
     );
 
     let rendered = voice::render_status(&status_output, output_mode);
@@ -119,6 +121,8 @@ fn assemble_status_output(
     config: &Config,
     now: NaiveDateTime,
     seal_gap: Option<crate::output::SealGap>,
+    earned: bool,
+    privilege_unclear: bool,
 ) -> StatusOutput {
     // ── Chain health per subvolume (derived from awareness assessment) ──
     let chain_health_entries: Vec<ChainHealthEntry> = assessments
@@ -174,7 +178,7 @@ fn assemble_status_output(
         .iter()
         .filter_map(|a| {
             let sv = resolved.iter().find(|sv| sv.name == a.name)?;
-            advice::compute_advice(a, sv.send_enabled, sv.local_retention.is_transient())
+            advice::compute_advice(a, earned, sv.send_enabled, sv.local_retention.is_transient())
         })
         .collect();
 
@@ -190,6 +194,7 @@ fn assemble_status_output(
         storage_postures,
         storage_adaptations,
         seal_gap,
+        privilege_unclear,
     }
 }
 
@@ -306,6 +311,8 @@ local_retention = "transient"
             config,
             dt(2026, 6, 10, 12, 0),
             None,
+            true,
+            false,
         )
     }
 
@@ -329,10 +336,34 @@ local_retention = "transient"
                 &config,
                 dt(2026, 6, 10, 12, 0),
                 Some(gap),
+                true,
+                false,
             );
             assert_eq!(out.seal_gap, Some(gap));
         }
         assert_eq!(assemble(&[], &config).seal_gap, None);
+    }
+
+    /// UPI 081 B2: `privilege_unclear` travels through the pure assembler
+    /// untouched, same as `seal_gap`.
+    #[test]
+    fn assemble_threads_privilege_unclear() {
+        let config = test_config();
+        let out = assemble_status_output(
+            &[],
+            vec![],
+            vec![],
+            vec![],
+            None,
+            0,
+            &config,
+            dt(2026, 6, 10, 12, 0),
+            None,
+            false,
+            true,
+        );
+        assert!(out.privilege_unclear);
+        assert!(!assemble(&[], &config).privilege_unclear);
     }
 
     // ── Chain-health worst-selection ────────────────────────────────
@@ -516,6 +547,8 @@ local_retention = "transient"
             &test_config(),
             dt(2026, 6, 10, 12, 0),
             None,
+            true,
+            false,
         );
         assert_eq!(out.last_run_age_secs, Some(7200));
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -205,6 +205,13 @@ pub struct StatusOutput {
     /// paths never probe); `None` means "sealed or not checked".
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seal_gap: Option<SealGap>,
+    /// The privilege probe couldn't confirm the grant (UPI 081) — e.g. sudo
+    /// erroring rather than answering Granted/Denied. Mutually exclusive
+    /// with `seal_gap` by construction (`seal::seal_posture`): a status
+    /// surface must not fall silent, nor presume a seal stage, when
+    /// privilege itself is unconfirmed.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub privilege_unclear: bool,
 }
 
 /// The seal stage `urd status` names as incomplete, in seal order —
@@ -448,6 +455,10 @@ pub struct DefaultStatusOutput {
     /// `StatusOutput::seal_gap`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub seal_gap: Option<SealGap>,
+    /// The privilege probe couldn't confirm the grant (UPI 081) — see
+    /// `StatusOutput::privilege_unclear`.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub privilege_unclear: bool,
 }
 
 fn is_zero(n: &usize) -> bool {
@@ -609,7 +620,12 @@ pub struct DoctorOutput {
     pub config_checks: Vec<DoctorCheck>,
     pub infra_checks: Vec<DoctorCheck>,
     pub data_safety: Vec<DoctorDataSafety>,
-    pub sentinel: DoctorSentinelStatus,
+    /// Sentinel daemon status (UPI 081 B4). `None` under `RunFrequency::Timer`
+    /// — a stopped daemon that a nightly-timer config never installs is not a
+    /// warning; the section omits rather than alarming about a unit that was
+    /// never supposed to run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sentinel: Option<DoctorSentinelStatus>,
     /// Schema deprecation notice (UPI 042 Branch G). `Some(_)` when the
     /// loaded config is legacy or v1; voice renders a single-line notice
     /// suggesting `urd migrate`. `None` for v2.
@@ -2398,11 +2414,11 @@ source = "/data/sv2"
             config_checks: vec![],
             infra_checks: vec![],
             data_safety: vec![],
-            sentinel: DoctorSentinelStatus {
+            sentinel: Some(DoctorSentinelStatus {
                 running: false,
                 pid: None,
                 uptime: None,
-            },
+            }),
             schema_status: None,
             verify: None,
             churn: None,
@@ -2423,11 +2439,11 @@ source = "/data/sv2"
             config_checks: vec![],
             infra_checks: vec![],
             data_safety: vec![],
-            sentinel: DoctorSentinelStatus {
+            sentinel: Some(DoctorSentinelStatus {
                 running: false,
                 pid: None,
                 uptime: None,
-            },
+            }),
             schema_status: None,
             verify: None,
             churn: None,

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -157,39 +157,40 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
         }
     }
 
-    // Sentinel section
-    writeln!(out).ok();
-    writeln!(out, "  {}", "Sentinel".bold()).ok();
-    if data.sentinel.running {
-        let pid_info = data
-            .sentinel
-            .pid
-            .map(|p| format!(" (PID {p})"))
-            .unwrap_or_default();
-        let uptime_info = data
-            .sentinel
-            .uptime
-            .as_ref()
-            .map(|u| format!(", uptime {u}"))
-            .unwrap_or_default();
-        writeln!(
-            out,
-            "    {} Sentinel running{pid_info}{uptime_info}",
-            "\u{2713}".green()
-        )
-        .ok();
-    } else {
-        writeln!(
-            out,
-            "    {} Sentinel not running",
-            "\u{26a0}".yellow()
-        )
-        .ok();
-        writeln!(
-            out,
-            "      \u{2192} Start with `systemctl --user start urd-sentinel`"
-        )
-        .ok();
+    // Sentinel section — omitted entirely under Timer cadence (UPI 081 B4):
+    // a stopped daemon that config never installs is not a warning.
+    if let Some(sentinel) = &data.sentinel {
+        writeln!(out).ok();
+        writeln!(out, "  {}", "Sentinel".bold()).ok();
+        if sentinel.running {
+            let pid_info = sentinel
+                .pid
+                .map(|p| format!(" (PID {p})"))
+                .unwrap_or_default();
+            let uptime_info = sentinel
+                .uptime
+                .as_ref()
+                .map(|u| format!(", uptime {u}"))
+                .unwrap_or_default();
+            writeln!(
+                out,
+                "    {} Sentinel running{pid_info}{uptime_info}",
+                "\u{2713}".green()
+            )
+            .ok();
+        } else {
+            writeln!(
+                out,
+                "    {} Sentinel not running",
+                "\u{26a0}".yellow()
+            )
+            .ok();
+            writeln!(
+                out,
+                "      \u{2192} Start with `systemctl --user start urd-sentinel`"
+            )
+            .ok();
+        }
     }
 
     // Verify section (--thorough)

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -475,6 +475,7 @@ pub(crate) mod test_fixtures {
     pub(crate) fn test_status_output() -> StatusOutput {
         StatusOutput {
             seal_gap: None,
+            privilege_unclear: false,
             assessments: vec![
                 StatusAssessment {
                     name: "htpc-home".to_string(),
@@ -690,11 +691,11 @@ pub(crate) mod test_fixtures {
                     storage_posture: None,
                 },
             ],
-            sentinel: DoctorSentinelStatus {
+            sentinel: Some(DoctorSentinelStatus {
                 running: true,
                 pid: Some(12345),
                 uptime: Some("3h 12m".to_string()),
-            },
+            }),
             schema_status: None,
             verify: None,
             churn: None,
@@ -707,6 +708,7 @@ pub(crate) mod test_fixtures {
     pub(crate) fn test_default_status_output() -> DefaultStatusOutput {
         DefaultStatusOutput {
             seal_gap: None,
+            privilege_unclear: false,
             total: 4,
             waning_names: vec![],
             exposed_names: vec![],
@@ -3328,6 +3330,22 @@ mod tests {
         assert!(parsed["infra_checks"].is_array());
         assert!(parsed["data_safety"].is_array());
         assert_eq!(parsed["sentinel"]["running"], true);
+    }
+
+    /// UPI 081 B4 (#279): a Timer-cadence machine never installs the
+    /// sentinel unit, so a stopped daemon there is not a warning — the
+    /// whole section omits, both interactive and JSON.
+    #[test]
+    fn doctor_sentinel_section_omitted_under_timer_cadence() {
+        let _color = color_guard(false);
+        let mut data = test_doctor_output();
+        data.sentinel = None;
+        let output = render_doctor(&data, OutputMode::Interactive);
+        assert!(!output.contains("Sentinel"), "{output}");
+
+        let json_output = render_doctor(&data, OutputMode::Daemon);
+        let parsed: serde_json::Value = serde_json::from_str(&json_output).unwrap();
+        assert!(parsed.get("sentinel").is_none(), "{json_output}");
     }
 
     #[test]

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -45,9 +45,12 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
     // ── Summary line ────────────────────────────────────────────────
     render_summary_line(data, &mut out);
 
-    // ── The seal (UPI 071/075) ──────────────────────────────────────
+    // ── The seal (UPI 071/075/081) ────────────────────────────────────
     // The first incomplete seal stage: said once, high, with the resume
     // verb. Yellow, never red — nothing was lost (Rule 6, red is earned).
+    // `privilege_unclear` and `seal_gap` are mutually exclusive by
+    // `seal::seal_posture`'s construction, so only one of these speaks.
+    render_privilege_unclear_banner(data.privilege_unclear, &mut out);
     render_seal_gap_banner(data, &mut out);
 
     // ── Storage adaptation prose (UPI 031-b AB3.1) ──────────────────
@@ -113,6 +116,23 @@ pub(super) fn render_status_interactive(data: &StatusOutput) -> String {
     }
 
     out
+}
+
+/// UPI 081 B2: the probe itself couldn't confirm the grant (e.g. sudo
+/// erroring rather than answering Granted/Denied). Shared by both status
+/// renderers so the cannot-verify sentence stays word-for-word identical.
+pub(super) const PRIVILEGE_UNCLEAR_SENTENCE: &str =
+    "Urd couldn't confirm its privileges just now — run `urd doctor` to see why.";
+
+/// The cannot-verify line: never silent when the probe itself failed, never
+/// a guess at which seal stage is incomplete. Mutually exclusive with the
+/// seal-gap banner by `seal::seal_posture`'s construction (`gap` is always
+/// `None` when this is `true`).
+pub(super) fn render_privilege_unclear_banner(privilege_unclear: bool, out: &mut String) {
+    if !privilege_unclear {
+        return;
+    }
+    writeln!(out, "{}", PRIVILEGE_UNCLEAR_SENTENCE.yellow()).ok();
 }
 
 /// The seal-gap banner (UPI 071/075): the first incomplete seal stage,
@@ -765,7 +785,8 @@ fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
     }
 
     // The first incomplete seal stage (UPI 071/075): one clause, the
-    // resume verb.
+    // resume verb. `privilege_unclear` (UPI 081 B2) is mutually exclusive
+    // with `seal_gap` by `seal::seal_posture`'s construction.
     if let Some(gap) = data.seal_gap {
         let clause = match gap {
             crate::output::SealGap::Privilege => {
@@ -779,6 +800,8 @@ fn render_default_status_interactive(data: &DefaultStatusOutput) -> String {
             }
         };
         write!(out, " {}", clause.yellow()).ok();
+    } else if data.privilege_unclear {
+        write!(out, " {}", PRIVILEGE_UNCLEAR_SENTENCE.yellow()).ok();
     }
 
     // Last backup age (pre-computed by command handler to keep voice pure)
@@ -1327,6 +1350,34 @@ mod tests {
         assert!(!out.contains("not yet spun"), "{out}");
     }
 
+    /// UPI 081 B2: an Unclear probe renders the cannot-verify line, never
+    /// the seal-gap banner (mutually exclusive by construction) and never
+    /// silent.
+    #[test]
+    fn interactive_privilege_unclear_renders_cannot_verify_not_seal_gap() {
+        let _color = color_guard(false);
+        let mut data = crate::voice::test_fixtures::test_status_output();
+        data.privilege_unclear = true;
+        let out = render_status(&data, OutputMode::Interactive);
+        assert!(out.contains("couldn't confirm its privileges"), "{out}");
+        assert!(out.contains("urd doctor"), "{out}");
+        assert!(!out.contains("unsealed"), "{out}");
+        assert!(!out.contains("not yet spun"), "{out}");
+        assert!(!out.contains("not yet enabled"), "{out}");
+    }
+
+    /// A Granted/sealed posture renders neither the cannot-verify line nor
+    /// the seal-gap banner.
+    #[test]
+    fn interactive_sealed_carries_no_privilege_unclear_line() {
+        let _color = color_guard(false);
+        let out = render_status(
+            &crate::voice::test_fixtures::test_status_output(),
+            OutputMode::Interactive,
+        );
+        assert!(!out.contains("couldn't confirm its privileges"), "{out}");
+    }
+
     #[test]
     fn default_seal_gap_clause_points_at_init() {
         let _color = color_guard(false);
@@ -1342,11 +1393,24 @@ mod tests {
         }
     }
 
+    /// UPI 081 B2: bare `urd`'s compact clause also carries the
+    /// cannot-verify line, never a silent status.
+    #[test]
+    fn default_privilege_unclear_clause_names_doctor() {
+        let _color = color_guard(false);
+        let mut data = crate::voice::test_fixtures::test_default_status_output();
+        data.privilege_unclear = true;
+        let out = render_default_status(&data, OutputMode::Interactive);
+        assert!(out.contains("couldn't confirm its privileges"), "{out}");
+        assert!(out.contains("urd doctor"), "{out}");
+    }
+
     #[test]
     fn interactive_no_subvolumes() {
         let _color = color_guard(false);
         let data = StatusOutput {
             seal_gap: None,
+            privilege_unclear: false,
             assessments: vec![],
             chain_health: vec![],
             drives: vec![],
@@ -1424,6 +1488,7 @@ mod tests {
         let _color = color_guard(false);
         let data = StatusOutput {
             seal_gap: None,
+            privilege_unclear: false,
             assessments: vec![],
             chain_health: vec![],
             drives: vec![],
@@ -2027,6 +2092,7 @@ mod tests {
         let _color = color_guard(false);
         let data = DefaultStatusOutput {
             seal_gap: None,
+            privilege_unclear: false,
             total: 9,
             waning_names: vec![],
             exposed_names: vec!["htpc-root".to_string(), "docs".to_string()],
@@ -2062,6 +2128,7 @@ mod tests {
         let _color = color_guard(false);
         let data = DefaultStatusOutput {
             seal_gap: None,
+            privilege_unclear: false,
             total: 5,
             waning_names: vec!["htpc-config".to_string()],
             exposed_names: vec!["htpc-root".to_string()],
@@ -2119,6 +2186,7 @@ mod tests {
         let _color = color_guard(false);
         let data = DefaultStatusOutput {
             seal_gap: None,
+            privilege_unclear: false,
             total: 2,
             waning_names: vec![],
             exposed_names: vec![],
@@ -2141,6 +2209,7 @@ mod tests {
     fn default_daemon_json() {
         let data = DefaultStatusOutput {
             seal_gap: None,
+            privilege_unclear: false,
             total: 3,
             waning_names: vec!["sv1".to_string()],
             exposed_names: vec![],


### PR DESCRIPTION
## Summary

Five field-observed issues (#275/#276/#277/#279/#280) share one root: Urd's read surfaces
render text without first consulting whether the machine is *earned* (grant answers) and
*sealed*. This is slice 081-b of UPI 081 — the read-surfaces half; 081-a (the ceremony's own
failure narration) follows as a separate PR.

- **B0** — collapse `seal::seal_completeness` into `seal::seal_posture`, one probe backing
  `gap` + `earned` + `privilege_unclear` (no doubled auth-log line).
- **B1** — `compute_advice()` gains an `earned` param; suppresses command-producing advice
  (`urd backup`, `--force-full`) when the machine isn't earned, so it never prescribes a
  command that would just fail at `sudo btrfs`. Physical advice (connect a drive, add
  `[[drives]]`) stays valid and unguarded (#276).
- **B2** — a cannot-verify line renders when the privilege probe itself can't confirm the
  grant (sudo erroring), instead of falling silent or presuming a seal stage (#276/B6).
- **B3** — `urd doctor` collapses an all-missing sudoers grant to one "not sealed yet" line
  instead of nine per-command "predates" rows (#280).
- **B4** — `urd doctor` omits the Sentinel section entirely on a nightly-timer machine
  instead of warning about a daemon unit config never installs (#279).

Design + review + plan: `docs/95-ideas/2026-07-08-design-081-…`,
`docs/99-reports/2026-07-08-design-review-081-…`,
`docs/97-plans/2026-07-08-plan-081-…` (all 7 arch-adversary findings addressed inline).

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: 2219 passed, 0 failed, 5 ignored
- `cargo build --release`: pass
- `./scripts/check-present-not-journey.sh`: pass
- Live-verified on a real machine: Timer-cadence `urd doctor --json` omits `sentinel` key
  entirely (#279); a Denied privilege probe (bogus `btrfs_path`) renders the seal-gap banner
  and suppresses `urd backup` command advice while keeping physical "connect drive" advice
  (#276/B1). B2 (Unclear) and B3 (all-missing drift) are covered by deterministic unit tests
  — their live scenarios aren't safely reproducible without breaking sudo itself on a
  production machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)