### PR TITLE
fix: the ceremony narrates its own failures (UPI 081-a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of burying the real cause under a row per expected command (#280).
 - `urd doctor` omits the Sentinel section entirely on a nightly-timer machine instead of
   warning about a daemon unit that config never installs (#279).
+- `urd init` now names its own blocked earning honestly — btrfs missing or the sudoers
+  render refusing — instead of a raw error, and never reads as though you declined (#275).
+- `urd init`'s first-snapshot and first-send ceremony no longer leaks raw executor log
+  lines above the mythic-voice summary; `--verbose` still shows them (#277).
 
 ## [0.33.3] - 2026-07-07
 

--- a/src/commands/seal.rs
+++ b/src/commands/seal.rs
@@ -289,7 +289,7 @@ fn first_snapshot(config: &Config, config_path: &Path) -> bool {
     }
 
     print!("{}", voice::render_first_thread_intro());
-    if let Err(e) = run_seal_backup(config_path, /* local_only */ true) {
+    if let Err(e) = with_logs_suppressed(|| run_seal_backup(config_path, /* local_only */ true)) {
         print!("{}", voice::render_first_thread_failed(&format!("the run failed: {e}")));
         return false;
     }
@@ -384,7 +384,9 @@ fn offer_first_send(config: &Config, config_path: &Path) -> crate::output::SealS
             print!("{}", voice::render_send_deferred());
             SealSendState::Tonight
         }
-        SendChoice::SendNow => match run_seal_backup(config_path, /* local_only */ false) {
+        SendChoice::SendNow => match with_logs_suppressed(|| {
+            run_seal_backup(config_path, /* local_only */ false)
+        }) {
             Ok(()) => SealSendState::Sent,
             Err(e) => {
                 print!(
@@ -419,6 +421,32 @@ fn run_seal_backup(config_path: &Path, local_only: bool) -> anyhow::Result<()> {
             force_snapshot: false,
         },
     )
+}
+
+/// Restores the prior `log` max level on drop — the error/panic path must
+/// un-suppress too, or a failure inside `f` would leave every later log call
+/// silent for the rest of the process (UPI 081 A3).
+struct LogLevelGuard(log::LevelFilter);
+impl Drop for LogLevelGuard {
+    fn drop(&mut self) {
+        log::set_max_level(self.0);
+    }
+}
+
+/// Suppresses `log!` echoes for the duration of `f` (#277): the ceremony's
+/// backup calls would otherwise leak raw `ERROR urd::executor` lines above
+/// the mythic-voice summary. Honors `--verbose` (only suppresses below
+/// `Debug`). Safe to suppress broadly — every `error!` that names a real
+/// failure is a companion to a returned `OperationOutcome::Failure`/`Err`
+/// that the (unsuppressed) `print!` summary already renders; the bracket
+/// loses log echoes, never the failure itself (adversary M1, design A3).
+fn with_logs_suppressed<T>(f: impl FnOnce() -> T) -> T {
+    let prev = log::max_level();
+    let _guard = LogLevelGuard(prev);
+    if prev < log::LevelFilter::Debug {
+        log::set_max_level(log::LevelFilter::Off);
+    }
+    f()
 }
 
 /// Does any enabled promise want external sends at all? (Pure.)
@@ -810,23 +838,35 @@ fn earn_privilege(config: &Config, config_path: &Path) -> anyhow::Result<SealOut
     // binary would verify never and confuse always.
     let btrfs = Path::new(&config.general.btrfs_path);
     if !btrfs.exists() {
-        bail!(
-            "btrfs not found at {} — fix `btrfs_path` in {} (try `which btrfs`), \
-             then run `urd init` to resume the earning",
-            btrfs.display(),
-            config_path.display()
+        // Declined here = Urd-blocked, not user-declined; no consumer
+        // distinguishes — see design A1 (UPI 081 M4).
+        print!(
+            "{}",
+            voice::render_earning_blocked(&format!(
+                "btrfs not found at {} — fix `btrfs_path` in {} (try `which btrfs`)",
+                btrfs.display(),
+                config_path.display()
+            ))
         );
+        return Ok(declined);
     }
 
-    let rendered = sudoers::render_sudoers(
+    let rendered = match sudoers::render_sudoers(
         config,
         &RenderContext {
             user: &user,
             config_path,
             today: chrono::Local::now().date_naive(),
         },
-    )
-    .map_err(|refusal| anyhow!("{refusal}"))?;
+    ) {
+        Ok(rendered) => rendered,
+        Err(refusal) => {
+            // Declined here = Urd-blocked, not user-declined; no consumer
+            // distinguishes — see design A1 (UPI 081 M4).
+            print!("{}", voice::render_earning_blocked(&refusal.to_string()));
+            return Ok(declined);
+        }
+    };
 
     // Stage unprivileged, 0440 before the gate (visudo owner/mode variance).
     let tmp = stage_rendered(&rendered)?;
@@ -1271,6 +1311,35 @@ fn coverage_missing(config: &Config) -> Vec<String> {
 mod tests {
     use super::*;
 
+    /// UPI 081 A3 (#277): sets `Off` for the closure's duration and always
+    /// restores the prior level after — on the success path, and on the
+    /// panic path via the `Drop` guard (M1: the broad suppression is safe
+    /// only because it always un-suppresses). One test, not three: global
+    /// `log::max_level()` state would race across parallel test threads.
+    #[test]
+    fn with_logs_suppressed_restores_level_on_success_and_panic() {
+        let before = log::max_level();
+
+        let seen_during = with_logs_suppressed(log::max_level);
+        assert_eq!(seen_during, log::LevelFilter::Off);
+        assert_eq!(log::max_level(), before, "must restore after a normal return");
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            with_logs_suppressed(|| panic!("boom"));
+        }));
+        assert!(result.is_err());
+        assert_eq!(log::max_level(), before, "the Drop guard must restore even after a panic");
+
+        log::set_max_level(log::LevelFilter::Debug);
+        let seen_at_debug = with_logs_suppressed(log::max_level);
+        assert_eq!(
+            seen_at_debug,
+            log::LevelFilter::Debug,
+            "--verbose (Debug+) must not be suppressed"
+        );
+        log::set_max_level(before);
+    }
+
     #[test]
     fn declined_outcome_stops_a_fresh_earning_and_continues_a_regrant() {
         // F4 continuation table: no grant → the seal stops; a grant that
@@ -1423,6 +1492,60 @@ mod tests {
 
     fn seal_config(toml: &str) -> crate::config::Config {
         crate::config::Config::from_str(toml).unwrap()
+    }
+
+    /// UPI 081 A2 (#275): btrfs-not-found routes through `render_earning_blocked`
+    /// and returns `Ok(Declined)`, never `Err` — a blocked first-timer is an
+    /// honest conclusion, not a crash.
+    #[test]
+    fn earn_privilege_declined_not_err_when_btrfs_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().join(".snapshots");
+        let config = seal_config(&format!(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+btrfs_path = "/nonexistent/btrfs-for-test"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "{}"
+protection = "recorded"
+"#,
+            root.display()
+        ));
+        let outcome = earn_privilege(&config, &tmp.path().join("urd.toml")).unwrap();
+        assert_eq!(outcome, SealOutcome::Declined);
+    }
+
+    /// UPI 081 A2 (#275): a sudoers render refusal (here: a scope too
+    /// shallow for the floor) routes through `render_earning_blocked` and
+    /// returns `Ok(Declined)`, never `Err`. `btrfs_path` points at a real,
+    /// existing binary that carries no grant of its own (`/usr/bin/true`),
+    /// so the probe reads Denied rather than Granted regardless of the test
+    /// runner's own cached sudo ticket — the "already earns" shortcut must
+    /// not mask the render refusal this test targets.
+    #[test]
+    fn earn_privilege_declined_not_err_when_render_refuses() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config = seal_config(
+            r#"
+[general]
+config_version = 2
+run_frequency = "daily"
+btrfs_path = "/usr/bin/true"
+
+[[subvolumes]]
+name = "docs"
+source = "/data/docs"
+snapshot_root = "/"
+protection = "recorded"
+"#,
+        );
+        let outcome = earn_privilege(&config, &tmp.path().join("urd.toml")).unwrap();
+        assert_eq!(outcome, SealOutcome::Declined);
     }
 
     #[test]

--- a/src/voice/encounter.rs
+++ b/src/voice/encounter.rs
@@ -812,6 +812,24 @@ pub fn render_earning_deferred() -> String {
         .to_string()
 }
 
+/// UPI 081 A1/A3 (#275): the earning could not proceed for a reason Urd
+/// itself controls (btrfs missing, the sudoers render refused) — never a
+/// reason the user chose. Register is *Urd-couldn't*, modeled on
+/// `render_first_thread_failed`'s posture (name the state, name the way
+/// back) — explicitly NOT the *you-declined* register of
+/// `render_earning_deferred` above: a blocked first-timer must not read as
+/// having walked away (/steve 2026-07-08). Yellow, never red — the config
+/// is still carved, nothing was lost.
+#[must_use]
+pub fn render_earning_blocked(reason: &str) -> String {
+    format!(
+        "{} {reason}\n\
+         The promises are carved but not in force until the earning.\n\
+         `urd init` resumes it at any time.\n",
+        "Couldn't earn:".yellow().bold()
+    )
+}
+
 /// sudo itself is not available to this user (not a sudoer, or sudo
 /// missing) — its own sentence, never a generic error.
 #[must_use]
@@ -1615,6 +1633,26 @@ mod tests {
         let out = render_earning_unavailable("alice is not in the sudoers file");
         assert!(out.contains("cannot use sudo"), "{out}");
         assert!(out.contains("not in the sudoers file"), "{out}");
+    }
+
+    /// UPI 081 A1 (#275): names the reason, the carved-not-sealed state, and
+    /// the `urd init` way back — yellow, never red (Urd-couldn't, not
+    /// you-declined).
+    #[test]
+    fn earning_blocked_names_reason_state_and_way_back() {
+        let _color = color_guard(false);
+        let out = render_earning_blocked("btrfs not found at /usr/sbin/btrfs");
+        assert!(out.contains("btrfs not found at /usr/sbin/btrfs"), "{out}");
+        assert!(out.contains("carved but not in force"), "{out}");
+        assert!(out.contains("urd init"), "{out}");
+    }
+
+    #[test]
+    fn earning_blocked_is_yellow_not_red() {
+        let _color = color_guard(true);
+        let out = render_earning_blocked("the sudoers render refused");
+        assert!(out.contains(";33m") || out.contains("[33m"), "must be yellow: {out:?}");
+        assert!(!out.contains(";31m") && !out.contains("[31m"), "must not be red: {out:?}");
     }
 
     #[test]

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -51,9 +51,9 @@ pub use doctor::render_doctor;
 pub use drives::{render_drives_adopt, render_drives_list};
 pub use emergency::{render_emergency, render_emergency_result};
 pub use encounter::{
-    render_earning_already, render_earning_coverage_unconfirmed, render_earning_declined,
-    render_earning_deferred, render_earning_installed, render_earning_regrant,
-    render_earning_request,
+    render_earning_already, render_earning_blocked, render_earning_coverage_unconfirmed,
+    render_earning_declined, render_earning_deferred, render_earning_installed,
+    render_earning_regrant, render_earning_request,
     describe_next_action, render_confirm_relook, render_data_dir_failed,
     render_earning_unavailable,
     render_earning_verify_failed, render_editor_failure, render_farewell,


### PR DESCRIPTION
## Summary

Slice 081-a of UPI 081 — the closing ceremony's own failure voice (the read-surfaces half
landed as 081-b, #289, merged). Recreated as a fresh PR targeting `master` after #289's
squash-merge closed the original stacked PR (#290) by deleting its base branch; rebased
cleanly onto `master` with no changes to content.

- **A1** — `voice::render_earning_blocked(reason)`: a new renderer for the *Urd-couldn't*
  register (modeled on `render_first_thread_failed`), explicitly distinct from the
  *you-declined* register of `render_earning_deferred` — a blocked first-timer must not
  read as having walked away (#275).
- **A2** — `earn_privilege`'s two Urd-controlled stop points (btrfs missing, the sudoers
  render refusing) now route through `render_earning_blocked` and return
  `Ok(SealOutcome::Declined)` instead of a raw `bail!` — matching their sibling failure
  paths (visudo-missing, install-failed) that already render voice and return gracefully
  (#275).
- **A3** — a new `with_logs_suppressed()` RAII helper brackets the ceremony's two backup
  calls (`first_snapshot`, `offer_first_send`'s `SendNow` arm), suppressing raw
  `ERROR urd::executor` log leakage above the mythic-voice summary. Honors `--verbose`,
  restores the prior log level unconditionally — including on a panic, via the `Drop`
  guard (#277).

Design + review + plan: `docs/95-ideas/2026-07-08-design-081-…`,
`docs/99-reports/2026-07-08-design-review-081-…`,
`docs/97-plans/2026-07-08-plan-081-…`.

## Testing

- `cargo clippy --all-targets -- -D warnings`: pass
- `cargo test`: 2224 passed, 0 failed, 5 ignored
- `cargo build --release`: pass
- `./scripts/check-present-not-journey.sh`: pass
- Live-verified (pty) on a real machine: a bogus `btrfs_path` makes `urd init` print the
  blocked voice sentence ("Couldn't earn: btrfs not found at …" + the carved-not-sealed
  state + the `urd init` way back) instead of a raw `Error:`, exit 0 (#275). #277's log
  suppression is covered by a deterministic unit test proving the RAII guard restores the
  log level on both the success and panic paths and honors `--verbose` — live
  reproduction would require installing a real sudoers grant on this production machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)