### PR TITLE
release: v0.33.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.4] - 2026-07-08
+
 ### Fixed
 - `urd status`/bare `urd` no longer prescribe `urd backup` on a machine whose privileges
   aren't confirmed — command-producing advice suppresses until the grant is earned, and a
@@ -1598,7 +1600,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.33.3...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.33.4...HEAD
+[0.33.4]: https://github.com/vonrobak/urd/compare/v0.33.3...v0.33.4
 [0.33.3]: https://github.com/vonrobak/urd/compare/v0.33.2...v0.33.3
 [0.33.2]: https://github.com/vonrobak/urd/compare/v0.33.1...v0.33.2
 [0.33.1]: https://github.com/vonrobak/urd/compare/v0.33.0...v0.33.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.33.3"
+version = "0.33.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.33.3"
+version = "0.33.4"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.33.4**. Sealment-aware doctor and status advice, plus the closing ceremony's
own failure voice (UPI 081, #289/#291) — closes #275, #276, #277, #279, #280.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 2224 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)