### PR TITLE
refactor: the observed-world prelude collapses five hand-rolled command preludes (UPI 082-b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the executor's in-run away-shed also re-confirms a drive's presence right before
   shedding its pin, so a drive that reconnects mid-run keeps its chain instead of losing
   it to a stale pre-lock snapshot.
+- `status`, bare `urd`, `doctor`, `plan`, and `backup` now assemble their read-only world
+  (state DB, filesystem, btrfs handle) through one shared prelude instead of five
+  hand-rolled copies. Minor accepted side effect: `status`/`doctor`/bare `urd` now try to
+  open the state DB unconditionally like `backup` already does, so a config that's never
+  been backed up or sealed may see `urd.db` created on a plain inspection command.
 
 ## [0.33.4] - 2026-07-08
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,3 +1,5 @@
 disallowed-methods = [
   { path = "urd::awareness::assess", reason = "call advice::assess_view — surfaces render the assessment view, never raw assessments" },
+  { path = "urd::advice::assess_view", reason = "call world::assess / World::view — the prelude is the sanctioned door" },
+  { path = "urd::commands::storage_signals::writeback::advance_and_writeback", reason = "backup's single post-execution writeback is the sole sanctioned caller — read paths never advance posture state" },
 ]

--- a/docs/00-foundation/architecture.md
+++ b/docs/00-foundation/architecture.md
@@ -189,6 +189,7 @@ the documentation convention in `contributing-internal.md`).
 | `sentinel.rs` | Pure state machine for the Sentinel daemon (events, actions, circuit breaker) | Perform I/O (`sentinel_runner.rs` does that) |
 | `sentinel_runner.rs` | I/O wrapper around the Sentinel state machine — the daemon's only I/O surface; also drives the idle emergency-eject poll (ADR-113 Layer 3, `maybe_emergency_reclaim`), the daemon's sole filesystem-mutating action, as a side-path outside the state machine | Make state-machine decisions (`sentinel.rs` does that) |
 | `error.rs` | Error types; `translate_btrfs_error()` for actionable messages | Recovery logic |
+| `commands/world.rs` | The observed-world prelude: `World::open` owns the best-effort `StateDb` + read-only `RealBtrfs`; Layer 1 `world.view()` returns an owned `WorldView { signals, assessments }` for `status`/`default`/`doctor`; Layer 2 `world.fs()`/`world.observation()` serve `plan_cmd`/`backup`, which hold the `Observation` for their own timing; the sole sanctioned production door onto `advice::assess_view` (clippy `disallowed-methods` guard) via `world::assess` | Compute or decide anything; cache signals across calls |
 | `commands/` | CLI subcommand handlers (wire pure modules to I/O) | Core logic (delegate to the modules above) |
 
 ## What the events table is for (ADR-114)

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -552,6 +552,9 @@ pub fn compute_redundancy_advisories(
 
 // ── Tests ──────────────────────────────────────────────────────────────
 
+// Module-under-test calls its own assess_view directly (clippy
+// disallowed-methods guard — world.rs is the sanctioned production door).
+#[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -7,11 +7,11 @@ use std::time::{Duration, Instant};
 
 use colored::Colorize;
 
-use crate::advice;
 use crate::awareness::{self, ChainStatus, PromiseStatus, SubvolAssessment};
 use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::cli::BackupArgs;
 use crate::commands::storage_signals;
+use crate::commands::world::{self, World};
 use crate::config::Config;
 use crate::drives;
 use crate::events::{Event, EventPayload};
@@ -68,26 +68,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         "full"
     };
 
-    let state_db = match StateDb::open(&config.general.state_db) {
-        Ok(db) => Some(db),
-        Err(e) => {
-            log::warn!("Failed to open state DB, continuing without history: {e}");
-            None
-        }
-    };
-
-    let fs_state = RealFileSystemState {
-        state: state_db.as_ref(),
-    };
+    let world = World::open(&config);
+    let fs_state = world.fs();
     // Near-unit btrfs handle for plan/assess generation reads (UPI 052):
     // a generation read needs no live byte counter and no compression
     // negotiation. The executor builds its own full RealBtrfs at send time.
-    let plan_btrfs = RealBtrfs::for_reads(&config.general.btrfs_path);
-    let observation = plan::Observation {
-        fs: &fs_state,
-        history: &fs_state,
-        btrfs: &plan_btrfs,
-    };
+    let observation = world.observation(&fs_state);
 
     // ── Single pre-plan storage gather + arming (UPI 031-b AB1/S2 — INVARIANT;
     // UPI 082 Branch B) ──
@@ -101,7 +87,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // awareness judges staleness against, surfacing a correctly-adapting
     // subvolume as false AT RISK. See [`storage_signals::RunArming`] for the
     // full single-resolution-site invariant this artifact carries.
-    let signals = storage_signals::gather(&config, state_db.as_ref());
+    let signals = storage_signals::gather(&config, world.db());
     let arming = storage_signals::RunArming::resolve(&signals, &config, &fs_state);
 
     let mut backup_plan = plan::plan(&config, now, &filters, &observation, &arming)?;
@@ -122,7 +108,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
             crate::commands::plan_cmd::build_plan_output(&backup_plan, &fs_state, &config);
         crate::commands::plan_cmd::populate_token_warnings(
             &mut plan_output,
-            state_db.as_ref(),
+            world.db(),
             &config,
         );
         let mode = crate::output::OutputMode::detect();
@@ -140,7 +126,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // Emergency pre-flight: if any snapshot root is critically below threshold
     // (< 50% of min_free_bytes), run emergency retention before planning.
     // Runs under the lock because it performs destructive btrfs deletions.
-    let emergency_ran = run_emergency_preflight(&config, state_db.as_ref())?;
+    let emergency_ran = run_emergency_preflight(&config, world.db())?;
 
     // Re-plan if emergency freed space — plan may have different space_pressure
     // decisions. Reuses the SAME pre-plan `arming` (AB1: never re-resolve
@@ -164,7 +150,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
             println!("{}", "Nothing to do.".dimmed());
         }
         let heartbeat_now = chrono::Local::now().naive_local();
-        let churn_views = build_churn_views(&config, state_db.as_ref(), heartbeat_now);
+        let churn_views = build_churn_views(&config, world.db(), heartbeat_now);
         let observability = gather_pool_observability(&config, &churn_views, &fs_state);
         write_metrics_for_skipped(
             &config,
@@ -182,7 +168,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         // re-gathering here would be judged after the emergency preflight may
         // have freed space, desyncing this heartbeat from the plan's tier).
         let assessments =
-            advice::assess_view(&config, heartbeat_now, &observation, &signals.by_subvol);
+            world::assess(&config, heartbeat_now, &observation, &signals.by_subvol);
         let hb = heartbeat::build(
             &config,
             heartbeat_now,
@@ -253,7 +239,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let btrfs = RealBtrfs::new(&config.general.btrfs_path, bytes_counter.clone(), sys.supports_compressed_data)
         .with_cancel(watchdog_abort.clone());
 
-    let mut executor = Executor::new(&btrfs, state_db.as_ref(), &config, &shutdown);
+    let mut executor = Executor::new(&btrfs, world.db(), &config, &shutdown);
 
     // Wire the watchdog coordination (UPI 065-b) only when a pool is armed (a
     // Roomy-only run stays byte-identical — no coord lock, no cancel reset). The
@@ -275,7 +261,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // This excludes fail-open paths (unreadable token file) from being treated as verified.
     // Probes (the I/O) are gathered here at the boundary; the classification and the
     // plan mutation are pure (`resolve_token_gating` / `apply_token_gating`).
-    if let Some(ref db) = state_db {
+    if let Some(db) = world.db() {
         let probes: Vec<(String, drives::DriveAvailability, bool)> = config
             .drives
             .iter()
@@ -323,7 +309,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         // actually caused. An empty map here judged the pre against declared
         // intervals while the post was judged against effective tight-tier
         // intervals — fabricating transitions out of the judgment mismatch.
-        advice::assess_view(&config, pre_now, &observation, &signals.by_subvol)
+        world::assess(&config, pre_now, &observation, &signals.by_subvol)
     };
 
     // Build progress context after token filtering so counters reflect actual work.
@@ -459,7 +445,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
                     None => (0, Vec::new(), chrono::Local::now().naive_local()),
                 }
             };
-        if let Some(ref db) = state_db {
+        if let Some(db) = world.db() {
             let mut ev = Event::pure(
                 event_ts,
                 EventPayload::WatchdogAbort {
@@ -509,7 +495,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         .collect();
     if !offsite_releases.is_empty() {
         let now_ts = chrono::Local::now().naive_local();
-        if let Some(ref db) = state_db {
+        if let Some(db) = world.db() {
             let events: Vec<Event> = offsite_releases
                 .iter()
                 .map(|r| r.to_event(now_ts, result.run_id))
@@ -535,7 +521,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // Compute churn views from the just-recorded drift samples, then thread
     // the same projection into both metrics and heartbeat (UPI 030).
     let heartbeat_now = chrono::Local::now().naive_local();
-    let churn_views = build_churn_views(&config, state_db.as_ref(), heartbeat_now);
+    let churn_views = build_churn_views(&config, world.db(), heartbeat_now);
     let observability = gather_pool_observability(&config, &churn_views, &fs_state);
 
     // Write metrics
@@ -556,7 +542,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // used), then `advance_and_writeback` persists the pre-resolved tier and
     // surfaces escalation transitions for the notification path (D6).
     let assessments =
-        advice::assess_view(&config, heartbeat_now, &observation, &signals.by_subvol);
+        world::assess(&config, heartbeat_now, &observation, &signals.by_subvol);
     let hb = heartbeat::build(
         &config,
         heartbeat_now,
@@ -577,9 +563,16 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // blind to posture (D6), so backup is the sole dispatcher — this is separate
     // from the heartbeat-driven promise notifications below and runs regardless
     // of whether the sentinel is up. Best-effort throughout: never blocks a run.
-    if let Some(ref db) = state_db {
-        let escalations =
-            storage_signals::advance_and_writeback(db, heartbeat_now, &arming, result.run_id);
+    if let Some(db) = world.db() {
+        // The one sanctioned caller of the raw writeback (clippy
+        // disallowed-methods guard — backup is the sole posture writer, D6).
+        #[allow(clippy::disallowed_methods)]
+        let escalations = storage_signals::writeback::advance_and_writeback(
+            db,
+            heartbeat_now,
+            &arming,
+            result.run_id,
+        );
         let notes: Vec<notify::Notification> = escalations
             .iter()
             .map(|e| {
@@ -613,7 +606,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
 
     // Backup is canonical for in-run promise transitions (trigger=Run);
     // sentinel skips on BackupCompleted to avoid duplicates.
-    if let Some(ref db) = state_db {
+    if let Some(db) = world.db() {
         let prev_snapshots = crate::sentinel::snapshot_promises(&pre_assessments);
         let promise_events = awareness::diff_promise_states(
             &prev_snapshots,

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -3,11 +3,10 @@ use std::path::Path;
 
 use crate::advice;
 use crate::awareness;
+use crate::commands::world::{World, WorldView};
 use crate::commands::{storage_signals, CliExit};
 use crate::config;
 use crate::output::{DefaultStatusOutput, OutputMode};
-use crate::plan::{Observation, RealFileSystemState};
-use crate::state::StateDb;
 use crate::voice;
 
 pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Result<CliExit> {
@@ -31,28 +30,13 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
         }
     };
 
-    let state_db = if config.general.state_db.exists() {
-        StateDb::open(&config.general.state_db).ok()
-    } else {
-        None
-    };
-    let fs_state = RealFileSystemState {
-        state: state_db.as_ref(),
-    };
-    let assess_btrfs = crate::btrfs::RealBtrfs::for_reads(&config.general.btrfs_path);
-    let observation = Observation {
-        fs: &fs_state,
-        history: &fs_state,
-        btrfs: &assess_btrfs,
-    };
+    let world = World::open(&config);
 
     // Awareness assessment — lighter than status (no chain health, no drive info, no pins)
     let now = chrono::Local::now().naive_local();
-    let signals = storage_signals::gather(&config, state_db.as_ref());
-    let assessments =
-        advice::assess_view(&config, now, &observation, &signals.by_subvol);
+    let WorldView { signals, assessments } = world.view(&config, now);
 
-    let last_run = state_db.as_ref().and_then(|db| db.last_run_info());
+    let last_run = world.db().and_then(|db| db.last_run_info());
 
     let last_run_age_secs = last_run.as_ref().and_then(|run| run.age_secs(now));
 

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use crate::advice;
 use crate::awareness::{self, PromiseStatus};
 use crate::cli::{DoctorArgs, VerifyArgs};
+use crate::commands::world::World;
 use crate::config::Config;
 use crate::drives;
 use crate::output::{
@@ -11,7 +12,7 @@ use crate::output::{
     DoctorRecommendationView, DoctorSentinelStatus, DoctorVerdict, InitStatus, OutputMode,
     SchemaStatus,
 };
-use crate::plan::{Observation, RealFileSystemState};
+use crate::plan::RealFileSystemState;
 use crate::recommendation::{
     self, AdjustmentReason, HeadroomContext, HeadroomSeverity, ShapeRole,
 };
@@ -219,25 +220,10 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     }
 
     // ── 3. Data safety (awareness model) ──────────────────────────
-    let state_db = if config.general.state_db.exists() {
-        StateDb::open(&config.general.state_db).ok()
-    } else {
-        None
-    };
-    let fs_state = RealFileSystemState {
-        state: state_db.as_ref(),
-    };
-    let assess_btrfs = crate::btrfs::RealBtrfs::for_reads(&config.general.btrfs_path);
-    let observation = Observation {
-        fs: &fs_state,
-        history: &fs_state,
-        btrfs: &assess_btrfs,
-    };
+    let world = World::open(&config);
     let now = chrono::Local::now().naive_local();
-    // Read-only gather: thread storage posture into the data-safety section.
-    let signals = crate::commands::storage_signals::gather(&config, state_db.as_ref());
-    let assessments =
-        advice::assess_view(&config, now, &observation, &signals.by_subvol);
+    // Read-only view: thread storage posture into the data-safety section.
+    let assessments = world.view(&config, now).assessments;
 
     let resolved = config.resolved_subvolumes();
     let data_safety: Vec<DoctorDataSafety> = assessments
@@ -351,14 +337,14 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
 
     // ── 5.5 Churn (UPI 030 — only with --thorough) ────────────────
     let churn_view = if args.thorough {
-        Some(build_doctor_churn_view(&config, state_db.as_ref()))
+        Some(build_doctor_churn_view(&config, world.db()))
     } else {
         None
     };
 
     // ── 5.6 Recommendations (UPI 041 — only with --thorough) ──────
     let recommendation_view = if args.thorough {
-        Some(build_doctor_recommendation_view(&config, state_db.as_ref()))
+        Some(build_doctor_recommendation_view(&config, world.db()))
     } else {
         None
     };

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -23,6 +23,7 @@ pub mod status;
 pub mod sentinel;
 pub mod storage_signals;
 pub mod verify;
+pub mod world;
 
 /// How a doorstep-aware command finished. `code()` feeds `main`'s
 /// `ExitCode`: 0 = done, 3 = not configured (the documented distinct

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -2,13 +2,14 @@ use std::collections::HashMap;
 
 use crate::cli::PlanArgs;
 use crate::commands::storage_signals;
+use crate::commands::world::World;
 use crate::config::{Config, DriveConfig};
 use crate::drives;
 use crate::output::{
     OutputMode, PlanOperationEntry, PlanOutput, PlanSummaryOutput, SkipCategory,
     SkippedSubvolume,
 };
-use crate::plan::{self, HistoryQuery, Observation, PlanFilters, RealFileSystemState};
+use crate::plan::{self, HistoryQuery, PlanFilters};
 use crate::state::StateDb;
 use crate::types::{PlannedOperation, PlannedSkip};
 use crate::voice;
@@ -26,27 +27,20 @@ pub fn run(config: Config, args: PlanArgs, mode: OutputMode) -> anyhow::Result<(
         force_snapshot: args.force_snapshot,
     };
 
-    let state_db = StateDb::open(&config.general.state_db).ok();
-    let fs_state = RealFileSystemState {
-        state: state_db.as_ref(),
-    };
-    let plan_btrfs = crate::btrfs::RealBtrfs::for_reads(&config.general.btrfs_path);
-    let observation = Observation {
-        fs: &fs_state,
-        history: &fs_state,
-        btrfs: &plan_btrfs,
-    };
+    let world = World::open(&config);
+    let fs_state = world.fs();
+    let observation = world.observation(&fs_state);
     // Storage-adapted preview (031-b M5): gather the same read-only signals the
     // backup path uses and resolve the armed tier, so `urd plan` shows the
     // truth of what `urd backup` will do (transient route / no pin at Critical)
     // rather than declared policy. Degrades gracefully — an unmounted/unmeasurable
     // pool yields free_ratio None → Roomy → declared behavior.
-    let signals = storage_signals::gather(&config, state_db.as_ref());
+    let signals = storage_signals::gather(&config, world.db());
     let arming = storage_signals::RunArming::resolve(&signals, &config, &fs_state);
     let backup_plan = plan::plan(&config, now, &filters, &observation, &arming)?;
 
     let mut output = build_plan_output(&backup_plan, &fs_state, &config);
-    populate_token_warnings(&mut output, state_db.as_ref(), &config);
+    populate_token_warnings(&mut output, world.db(), &config);
     print!("{}", voice::render_plan(&output, mode, args.verbose));
 
     Ok(())

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -3,33 +3,19 @@ use chrono::NaiveDateTime;
 use crate::advice;
 use crate::awareness::{ChainBreakReason, ChainStatus, SubvolAssessment};
 use crate::chain;
+use crate::commands::storage_signals;
+use crate::commands::world::{World, WorldView};
 use crate::config::Config;
 use crate::drives;
 use crate::output::{
     AdaptationSummary, ChainHealth, ChainHealthEntry, DriveInfo, LastRunInfo, OutputMode,
     PoolPostureSummary, StatusAssessment, StatusOutput,
 };
-use crate::plan::{Observation, RealFileSystemState};
-use crate::commands::storage_signals;
 use crate::retention;
-use crate::state::StateDb;
 use crate::voice;
 
 pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
-    let state_db = if config.general.state_db.exists() {
-        StateDb::open(&config.general.state_db).ok()
-    } else {
-        None
-    };
-    let fs_state = RealFileSystemState {
-        state: state_db.as_ref(),
-    };
-    let assess_btrfs = crate::btrfs::RealBtrfs::for_reads(&config.general.btrfs_path);
-    let observation = Observation {
-        fs: &fs_state,
-        history: &fs_state,
-        btrfs: &assess_btrfs,
-    };
+    let world = World::open(&config);
     let drive_labels: Vec<String> = config.drives.iter().map(|d| d.label.clone()).collect();
 
     // ── The seal (UPI 071/075/081) ──────────────────────────────────
@@ -38,11 +24,8 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
 
     // ── Awareness model ─────────────────────────────────────────────
     let now = chrono::Local::now().naive_local();
-    // Gather storage signals (read-only) and thread the per-subvol map into
-    // assess(); status reflects the stabilized tier but never advances it (S1).
-    let signals = storage_signals::gather(&config, state_db.as_ref());
-    let assessments =
-        advice::assess_view(&config, now, &observation, &signals.by_subvol);
+    // status reflects the stabilized tier but never advances it (S1).
+    let WorldView { signals, assessments } = world.view(&config, now);
     let storage_postures = storage_signals::aggregate(&assessments, &signals, now);
     // §2: collapse per-subvolume adaptations to one line per group (needs
     // `signals.pools`, which the renderer can't see — so aggregate here where
@@ -70,7 +53,7 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         .collect();
 
     // ── Last run ────────────────────────────────────────────────────
-    let last_run = state_db.as_ref().and_then(|db| db.last_run_info());
+    let last_run = world.db().and_then(|db| db.last_run_info());
 
     // ── Pin count ───────────────────────────────────────────────────
     let total_pins: usize = config

--- a/src/commands/storage_signals.rs
+++ b/src/commands/storage_signals.rs
@@ -9,11 +9,14 @@
 //!   pure display aggregators (`aggregate()`, and `aggregate_adaptations()` for
 //!   `status`) only — they *reflect* the hysteresis-stabilized tier and never
 //!   advance state (S1: a read can never fire a transition).
-//! - **`backup`** additionally calls `advance_and_writeback()` after its
-//!   post-execution `assess()`: it re-runs the pure hysteresis per
+//! - **`backup`** additionally calls `writeback::advance_and_writeback()` after
+//!   its post-execution `assess()`: it re-runs the pure hysteresis per
 //!   UUID-resolvable pool, persists `(armed_tier, since)` best-effort, and
 //!   returns escalation transitions for the notification path (D6). UUID-less
-//!   pools are skipped entirely — status-only, never persisted (S5).
+//!   pools are skipped entirely — status-only, never persisted (S5). The
+//!   write half lives in the `writeback` submodule (UPI 082-b, Branch E) —
+//!   a structural read/write split backed by a clippy `disallowed-methods`
+//!   guard, so a read path cannot reach for it by accident.
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -22,11 +25,10 @@ use chrono::NaiveDateTime;
 
 use crate::awareness::{PromiseStatus, ResolvedStorageSignal, StorageSignalMap, SubvolAssessment};
 use crate::config::Config;
-use crate::events::{Event, EventPayload};
 use crate::output::{AdaptationSummary, PoolPostureSummary};
 use crate::pools::{self, PoolSpace};
 use crate::state::StateDb;
-use crate::storage_critical::{self, ArmedTierMap, TightnessTier, Transition};
+use crate::storage_critical::{self, ArmedTierMap, TightnessTier};
 
 /// Per-pool resolved signal (UPI 031-a). The command-layer view that backs
 /// both `aggregate()` (display) and `advance_and_writeback()` (persistence).
@@ -73,17 +75,6 @@ pub struct PoolSignal {
 pub struct StorageSignals {
     pub by_subvol: StorageSignalMap,
     pub pools: Vec<PoolSignal>,
-}
-
-/// An escalating pool transition surfaced by `advance_and_writeback` for the
-/// notification path (D6). Carries everything the notification needs without a
-/// back-correlation: the display label, the host-root escalation flag, and the
-/// tier change.
-#[derive(Debug, Clone, PartialEq)]
-pub struct PostureEscalation {
-    pub pool_label: String,
-    pub host_root: bool,
-    pub transition: Transition,
 }
 
 /// How distinct pools are grouped within `gather_with`: by UUID when known,
@@ -389,63 +380,90 @@ pub fn resolve_armed_tiers(signals: &StorageSignals) -> RunArming {
     }
 }
 
-/// Persist the pre-resolved armed tier per UUID-resolvable pool best-effort and
-/// return the **escalation** transitions (backup path only — read paths must
-/// never call this). Consumes the [`RunArming`] resolved pre-lock: it does
-/// **not** re-resolve (AB1 — clear-all frees space mid-run; a re-resolve would
-/// falsely de-escalate). `since` advances to `now` only when the tier changes;
-/// otherwise the prior `since` is preserved so the "flagged since" timestamp
-/// stays stable. UUID-less pools are skipped (S5) — no persist, no
-/// notification, status-only degrade.
-#[must_use]
-pub fn advance_and_writeback(
-    state_db: &StateDb,
-    now: NaiveDateTime,
-    resolved: &RunArming,
-    run_id: Option<i64>,
-) -> Vec<PostureEscalation> {
-    let mut escalations = Vec::new();
-    for pool in &resolved.pools {
-        let Some(uuid) = pool.uuid.as_deref() else {
-            continue; // UUID-less: status-only (S5)
-        };
-        let new = pool.new_tier; // pre-resolved (AB1: never re-resolve)
-        let since = if new == pool.prior_armed_tier {
-            pool.prior_since.unwrap_or(now)
-        } else {
-            now
-        };
-        state_db.upsert_armed_tier_best_effort(uuid, new, since);
+/// The write half of storage-signal handling (UPI 082-b, Branch E): the sole
+/// production caller is `backup`'s single post-execution writeback
+/// (`commands/backup.rs`), sanctioned via a clippy `disallowed-methods` allow
+/// — the same structural guard `world.rs` uses for `assess_view`. Read paths
+/// (`status`, bare `urd`, `doctor`, `urd plan`) never advance state (S1); this
+/// module is where that boundary is enforced, not just documented.
+pub mod writeback {
+    use chrono::NaiveDateTime;
 
-        if let Some(transition) = storage_critical::transition(pool.prior_armed_tier, new) {
-            // (F6, UPI 064-b) Record EVERY transition — escalation AND
-            // de-escalation — for a complete `urd events` audit (closing the #202
-            // gap where transitions notified but wrote no row). This is a strict
-            // superset of the escalation-only NOTIFICATIONS below and does NOT
-            // violate "de-escalation is silent": that rule governs notifications,
-            // not the audit log.
-            let mut ev = Event::pure(
-                now,
-                EventPayload::StorageTierTransition {
-                    pool_label: pool.label.clone(),
-                    from: transition.from.as_db_str().to_string(),
-                    to: transition.to.as_db_str().to_string(),
-                    host_root: pool.host_root,
-                },
-            );
-            ev.run_id = run_id;
-            state_db.record_events_best_effort(&[ev]);
+    use crate::events::{Event, EventPayload};
+    use crate::state::StateDb;
+    use crate::storage_critical::{self, Transition};
 
-            if transition.is_escalation() {
-                escalations.push(PostureEscalation {
-                    pool_label: pool.label.clone(),
-                    host_root: pool.host_root,
-                    transition,
-                });
+    use super::RunArming;
+
+    /// An escalating pool transition surfaced by `advance_and_writeback` for the
+    /// notification path (D6). Carries everything the notification needs without a
+    /// back-correlation: the display label, the host-root escalation flag, and the
+    /// tier change.
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct PostureEscalation {
+        pub pool_label: String,
+        pub host_root: bool,
+        pub transition: Transition,
+    }
+
+    /// Persist the pre-resolved armed tier per UUID-resolvable pool best-effort and
+    /// return the **escalation** transitions (backup path only — read paths must
+    /// never call this). Consumes the [`RunArming`] resolved pre-lock: it does
+    /// **not** re-resolve (AB1 — clear-all frees space mid-run; a re-resolve would
+    /// falsely de-escalate). `since` advances to `now` only when the tier changes;
+    /// otherwise the prior `since` is preserved so the "flagged since" timestamp
+    /// stays stable. UUID-less pools are skipped (S5) — no persist, no
+    /// notification, status-only degrade.
+    #[must_use]
+    pub fn advance_and_writeback(
+        state_db: &StateDb,
+        now: NaiveDateTime,
+        resolved: &RunArming,
+        run_id: Option<i64>,
+    ) -> Vec<PostureEscalation> {
+        let mut escalations = Vec::new();
+        for pool in &resolved.pools {
+            let Some(uuid) = pool.uuid.as_deref() else {
+                continue; // UUID-less: status-only (S5)
+            };
+            let new = pool.new_tier; // pre-resolved (AB1: never re-resolve)
+            let since = if new == pool.prior_armed_tier {
+                pool.prior_since.unwrap_or(now)
+            } else {
+                now
+            };
+            state_db.upsert_armed_tier_best_effort(uuid, new, since);
+
+            if let Some(transition) = storage_critical::transition(pool.prior_armed_tier, new) {
+                // (F6, UPI 064-b) Record EVERY transition — escalation AND
+                // de-escalation — for a complete `urd events` audit (closing the #202
+                // gap where transitions notified but wrote no row). This is a strict
+                // superset of the escalation-only NOTIFICATIONS below and does NOT
+                // violate "de-escalation is silent": that rule governs notifications,
+                // not the audit log.
+                let mut ev = Event::pure(
+                    now,
+                    EventPayload::StorageTierTransition {
+                        pool_label: pool.label.clone(),
+                        from: transition.from.as_db_str().to_string(),
+                        to: transition.to.as_db_str().to_string(),
+                        host_root: pool.host_root,
+                    },
+                );
+                ev.run_id = run_id;
+                state_db.record_events_best_effort(&[ev]);
+
+                if transition.is_escalation() {
+                    escalations.push(PostureEscalation {
+                        pool_label: pool.label.clone(),
+                        host_root: pool.host_root,
+                        transition,
+                    });
+                }
             }
         }
+        escalations
     }
-    escalations
 }
 
 /// Aggregate the per-subvolume postures into one display line per tight pool
@@ -589,9 +607,13 @@ pub fn aggregate_adaptations(
         .collect()
 }
 
+// Module-under-test calls its own writeback::advance_and_writeback directly
+// (clippy disallowed-methods guard — backup.rs is the sanctioned production door).
+#[allow(clippy::disallowed_methods)]
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::events::EventPayload;
     use crate::storage_critical::{StoragePosture, TightnessTier};
 
     fn dt(s: &str) -> NaiveDateTime {
@@ -747,7 +769,8 @@ source = "/"
         let signals =
             gather_with(&cfg(), &HashMap::new(), Some("root-uuid"), resolver, space_tight);
 
-        let transitions = advance_and_writeback(&db, now, &resolve_armed_tiers(&signals), None);
+        let transitions =
+            writeback::advance_and_writeback(&db, now, &resolve_armed_tiers(&signals), None);
         // Both pools start Roomy; data escalates to Tight, root stays Roomy.
         assert_eq!(transitions.len(), 1);
         assert_eq!(transitions[0].pool_label, "/data");
@@ -797,7 +820,8 @@ source = "/"
             gather_with(&cfg(), &prior, Some("root-uuid"), resolver, space_tight);
         let now = dt("2026-05-30T04:00:00");
 
-        let transitions = advance_and_writeback(&db, now, &resolve_armed_tiers(&signals), None);
+        let transitions =
+            writeback::advance_and_writeback(&db, now, &resolve_armed_tiers(&signals), None);
         assert!(transitions.is_empty()); // no escalation on steady state
         let stored = db.all_armed_tiers().unwrap().get("data-uuid").copied();
         assert_eq!(stored, Some((TightnessTier::Tight, prior_since)));
@@ -818,7 +842,8 @@ source = "/"
             gather_with(&cfg(), &prior, Some("root-uuid"), resolver, space_full);
         let now = dt("2026-05-30T04:00:00");
 
-        let escalations = advance_and_writeback(&db, now, &resolve_armed_tiers(&signals), None);
+        let escalations =
+            writeback::advance_and_writeback(&db, now, &resolve_armed_tiers(&signals), None);
         // De-escalation is silent — no notification.
         assert!(escalations.is_empty());
         // But the recovery IS persisted, with `since` advanced to now.
@@ -848,8 +873,12 @@ source = "/"
             resolver_no_uuid,
             space_tight,
         );
-        let transitions =
-            advance_and_writeback(&db, dt("2026-05-30T04:00:00"), &resolve_armed_tiers(&signals), None);
+        let transitions = writeback::advance_and_writeback(
+            &db,
+            dt("2026-05-30T04:00:00"),
+            &resolve_armed_tiers(&signals),
+            None,
+        );
         assert!(transitions.is_empty());
         // Nothing written.
         assert!(db.all_armed_tiers().unwrap().is_empty());
@@ -1069,7 +1098,7 @@ local_retention = "transient"
             .unwrap();
         assert_eq!(data.new_tier, TightnessTier::Critical);
 
-        let _ = advance_and_writeback(&db, now, &resolved, None);
+        let _ = writeback::advance_and_writeback(&db, now, &resolved, None);
         let stored = db.all_armed_tiers().unwrap().get("data-uuid").copied();
         assert_eq!(stored.map(|(t, _)| t), Some(TightnessTier::Critical));
     }

--- a/src/commands/world.rs
+++ b/src/commands/world.rs
@@ -1,0 +1,180 @@
+//! The observed-world prelude (UPI 082-b): the `StateDb` → `RealFileSystemState` →
+//! `RealBtrfs::for_reads` → `Observation` → `storage_signals::gather` →
+//! `advice::assess_view` sequence, hand-rolled five times before this module,
+//! collapsed to one owner. `World::open` holds the long-lived adapters;
+//! `WorldView` is the one-call path for the three handlers that need only a
+//! judged view; `fs()`/`observation()` serve the two handlers (`plan_cmd`,
+//! `backup`) that need the `Observation` itself. Does NOT compute or decide —
+//! it assembles the read-only world others judge.
+
+use chrono::NaiveDateTime;
+
+use crate::advice;
+use crate::awareness::{StorageSignalMap, SubvolAssessment};
+use crate::btrfs::RealBtrfs;
+use crate::commands::storage_signals::{self, StorageSignals};
+use crate::config::Config;
+use crate::plan::{Observation, RealFileSystemState};
+use crate::state::StateDb;
+
+/// The long-lived adapters every command prelude assembles: a best-effort
+/// state DB handle and a read-only btrfs generation-counter seam.
+pub struct World {
+    state_db: Option<StateDb>,
+    btrfs: RealBtrfs,
+}
+
+/// Layer 1's owned return: the gathered storage signals plus the judged
+/// assessment view, for handlers that need no live borrow past this call.
+pub struct WorldView {
+    pub signals: StorageSignals,
+    pub assessments: Vec<SubvolAssessment>,
+}
+
+impl World {
+    /// Open the world: best-effort state DB (warn-and-continue on failure,
+    /// exactly `backup.rs`'s existing semantics) and a read-only btrfs handle.
+    #[must_use]
+    pub fn open(config: &Config) -> Self {
+        let state_db = match StateDb::open(&config.general.state_db) {
+            Ok(db) => Some(db),
+            Err(e) => {
+                log::warn!("Failed to open state DB, continuing without history: {e}");
+                None
+            }
+        };
+        let btrfs = RealBtrfs::for_reads(&config.general.btrfs_path);
+        Self { state_db, btrfs }
+    }
+
+    /// The state DB handle, for callers that need history reads `view()`
+    /// doesn't surface (last-run info, drift samples).
+    #[must_use]
+    pub fn db(&self) -> Option<&StateDb> {
+        self.state_db.as_ref()
+    }
+
+    /// Layer 2: the cheap filesystem-of-truth borrow-struct, held by the
+    /// caller for the scope it needs an `Observation` in.
+    #[must_use]
+    pub fn fs(&self) -> RealFileSystemState<'_> {
+        RealFileSystemState {
+            state: self.state_db.as_ref(),
+        }
+    }
+
+    /// Layer 2: assemble the `Observation` from a caller-held `fs()` borrow —
+    /// no self-referential storage.
+    #[must_use]
+    pub fn observation<'a>(&'a self, fs: &'a RealFileSystemState<'a>) -> Observation<'a> {
+        Observation {
+            fs,
+            history: fs,
+            btrfs: &self.btrfs,
+        }
+    }
+
+    /// Layer 1: gather signals and judge the assessment view in one call —
+    /// the path for `status`, `default`, `doctor` (no borrows escape).
+    #[must_use]
+    pub fn view(&self, config: &Config, now: NaiveDateTime) -> WorldView {
+        let fs = self.fs();
+        let observation = self.observation(&fs);
+        let signals = storage_signals::gather(config, self.state_db.as_ref());
+        let assessments = assess(config, now, &observation, &signals.by_subvol);
+        WorldView {
+            signals,
+            assessments,
+        }
+    }
+}
+
+/// The sanctioned `assess_view` gateway for callers with their own timing
+/// (`plan_cmd`/`backup`'s pre/post/empty-plan judgments, `sentinel_runner`) —
+/// `World::view` calls this internally too, so `world.rs` is the sole
+/// production door onto `advice::assess_view` (clippy `disallowed-methods`
+/// guard in `clippy.toml`).
+#[must_use]
+pub fn assess(
+    config: &Config,
+    now: NaiveDateTime,
+    obs: &Observation,
+    storage_signals: &StorageSignalMap,
+) -> Vec<SubvolAssessment> {
+    #[allow(clippy::disallowed_methods)]
+    advice::assess_view(config, now, obs, storage_signals)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(state_db_path: &std::path::Path) -> Config {
+        let toml_str = format!(
+            r#"
+drives = []
+subvolumes = []
+
+[general]
+state_db = "{}"
+metrics_file = "/tmp/urd-world-test.prom"
+log_dir = "/tmp"
+
+[local_snapshots]
+roots = []
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "1d"
+send_enabled = true
+enabled = true
+[defaults.local_retention]
+hourly = 24
+daily = 30
+weekly = 26
+monthly = 12
+[defaults.external_retention]
+daily = 30
+weekly = 26
+monthly = 0
+"#,
+            state_db_path.display()
+        );
+        toml::from_str(&toml_str).expect("test config should parse")
+    }
+
+    #[test]
+    fn open_with_missing_state_db_degrades_to_none_without_panic() {
+        // State DB open failure (e.g. an unwritable path) must warn and
+        // continue, never panic — `World::open` mirrors backup.rs's
+        // existing best-effort semantics exactly.
+        let unwritable = std::path::PathBuf::from("/nonexistent-dir-for-urd-test/urd.db");
+        let config = test_config(&unwritable);
+        let world = World::open(&config);
+        assert!(world.db().is_none());
+    }
+
+    #[test]
+    fn open_with_creatable_state_db_yields_a_handle() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let db_path = dir.path().join("urd.db");
+        let config = test_config(&db_path);
+        let world = World::open(&config);
+        assert!(world.db().is_some());
+    }
+
+    #[test]
+    fn view_returns_empty_signals_and_assessments_for_an_empty_config() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let db_path = dir.path().join("urd.db");
+        let config = test_config(&db_path);
+        let world = World::open(&config);
+        let now = chrono::NaiveDate::from_ymd_opt(2026, 7, 10)
+            .expect("valid date")
+            .and_hms_opt(12, 0, 0)
+            .expect("valid time");
+        let view = world.view(&config, now);
+        assert!(view.signals.by_subvol.is_empty());
+        assert!(view.assessments.is_empty());
+    }
+}

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -18,7 +18,7 @@ use chrono::NaiveDateTime;
 
 use crate::advice;
 use crate::awareness::{self, PromiseStatus, SubvolAssessment};
-use crate::commands::storage_signals;
+use crate::commands::{storage_signals, world};
 use crate::config::Config;
 use crate::drives::{self, DriveAvailability};
 use crate::heartbeat;
@@ -414,7 +414,7 @@ impl SentinelRunner {
         // reflect-only (S1: reads never advance hysteresis); the backup's
         // post-exec writeback remains the only place the armed tier advances.
         let signals = storage_signals::gather(&self.config, state_db.as_ref());
-        let assessments = advice::assess_view(
+        let assessments = world::assess(
             &self.config,
             now,
             &observation,


### PR DESCRIPTION
## Summary

- Introduces `commands/world.rs`: `World::open` owns the `StateDb`/`RealBtrfs` adapters. Layer 1 (`world.view()`) serves `status`/`default`/`doctor` with an owned `WorldView`. Layer 2 (`world.fs()`/`world.observation()`) serves `plan_cmd`/`backup`, which hold the `Observation` for their own assess timing.
- `world::assess` is now the sole sanctioned production door onto `advice::assess_view`, enforced by a clippy `disallowed-methods` guard mirroring the existing `awareness::assess` guard. `sentinel_runner`'s sixth production caller (found by the plan's grep sweep) routes through the same gateway.
- Splits `storage_signals::advance_and_writeback` + `PostureEscalation` into a `writeback` submodule with its own `disallowed-methods` guard, so the read/write posture split (backup writes, all read paths never advance state) is structural, not just documented.
- Closes issue #296. PR 2 of UPI 082, following #309 (082-a).

**Accepted minor behavior delta (flagged before implementation, decided to proceed):** `World::open` drops the `.exists()` guard that `status`/`doctor`/`default` used before opening the state DB, matching `backup.rs`'s existing best-effort-open semantics exactly (per the plan's Step 8, "exactly `backup.rs:71-77` semantics"). A config that's never been backed up or sealed may now see `urd.db` created by a plain inspection command — a narrow edge case, since the seal ceremony already creates the DB during onboarding.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 2238 passed, 0 failed, 5 ignored
- cargo build --release: pass
- Doc lint (present-not-journey): pass
- Live smoke on this host: `urd plan` and `urd status` against the real config, output as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)