### PR TITLE
refactor: concentrate findmnt/statvfs probing in pools.rs (UPI 084)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `drives.rs` and `discovery.rs`'s per-path `findmnt` UUID/mountpoint lookups now delegate
+  to one concentrated probe in `pools.rs`; `drives.rs`'s statvfs free-bytes wrapper now
+  delegates to `pools.rs`'s too. No behavior change — one probe surface instead of three
+  hand-rolled parsers (#302).
+
 ### Fixed
 - The external-send space guard now checks the same failed/aborted-send floor
   `estimated_send_size` already used, so a subvolume whose only size signal is a failed

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -739,17 +739,6 @@ fn run_findmnt() -> crate::error::Result<String> {
     run_probe("findmnt", &["-t", "btrfs", "-J"], true)
 }
 
-/// Which filesystem holds `path`? (`--target` walks up to the nearest
-/// mount, so the path itself need not be a mountpoint.)
-fn run_findmnt_target(path: &Path) -> crate::error::Result<String> {
-    let target = path.to_string_lossy();
-    run_probe(
-        "findmnt",
-        &["-J", "-o", "TARGET,FSTYPE,UUID", "--target", &target],
-        true,
-    )
-}
-
 /// Probe the system and build the inventory. Never fails: a failed probe
 /// degrades the inventory and leaves a [`DiscoveryNote::ProbeDegraded`]
 /// so 072 can say so (fail open, observable).
@@ -786,25 +775,26 @@ pub fn discover() -> SystemInventory {
         .map(PathBuf::from)
         .filter(|p| p.is_absolute())
         .map(|path| {
-            let pool_uuid = run_findmnt_target(&path)
+            let pool_uuid = crate::pools::findmnt_probe_target(&path)
                 .ok()
-                .and_then(|out| parse_findmnt_target(&out));
+                .and_then(|entry| btrfs_pool_uuid(&entry));
             DiscoveredHome { path, pool_uuid }
         });
     inventory
 }
 
-/// The btrfs pool UUID of the filesystem holding the probed path, from
-/// `findmnt --target` output; `None` for non-btrfs filesystems or
-/// unparseable output.
-fn parse_findmnt_target(json: &str) -> Option<String> {
-    let root: serde_json::Value = serde_json::from_str(json).ok()?;
-    let fs = root.get("filesystems")?.as_array()?.first()?;
-    if fs.get("fstype")?.as_str()? != "btrfs" {
-        return None;
+/// Gate a [`pools::FindmntEntry`] to its UUID only when the filesystem is
+/// btrfs — an ext4 `/home` over a btrfs `/` must not be attributed to the
+/// pool (a home-relative snapshot root there would cross filesystems). This
+/// gate is specific to discovery's zero-state home-pool lookup, so it stays
+/// here rather than in the shared probe in `pools.rs` (UPI 084).
+#[must_use]
+fn btrfs_pool_uuid(entry: &crate::pools::FindmntEntry) -> Option<String> {
+    if entry.fstype.as_deref() == Some("btrfs") {
+        entry.uuid.clone()
+    } else {
+        None
     }
-    let uuid = fs.get("uuid")?.as_str()?;
-    (!uuid.is_empty()).then(|| uuid.to_string())
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────
@@ -826,33 +816,36 @@ mod tests {
     const EXTERNAL_MAPPER: &str = "luks-33333333-3333-4333-8333-333333333333";
 
     #[test]
-    fn parse_findmnt_target_btrfs_yields_pool_uuid() {
-        let json = format!(
-            r#"{{"filesystems":[{{"target":"/home","fstype":"btrfs","uuid":"{SYSTEM_POOL}"}}]}}"#
-        );
-        assert_eq!(
-            parse_findmnt_target(&json),
-            Some(SYSTEM_POOL.to_string())
-        );
+    fn btrfs_pool_uuid_btrfs_yields_pool_uuid() {
+        let entry = crate::pools::FindmntEntry {
+            target: Some(PathBuf::from("/home")),
+            fstype: Some("btrfs".to_string()),
+            uuid: Some(SYSTEM_POOL.to_string()),
+        };
+        assert_eq!(btrfs_pool_uuid(&entry), Some(SYSTEM_POOL.to_string()));
     }
 
     #[test]
-    fn parse_findmnt_target_non_btrfs_yields_none() {
+    fn btrfs_pool_uuid_non_btrfs_yields_none() {
         // An ext4 /home over a btrfs / must not be attributed to the pool
         // — a home-relative snapshot root there would cross filesystems.
-        let json = format!(
-            r#"{{"filesystems":[{{"target":"/home","fstype":"ext4","uuid":"{SYSTEM_POOL}"}}]}}"#
-        );
-        assert_eq!(parse_findmnt_target(&json), None);
+        let entry = crate::pools::FindmntEntry {
+            target: Some(PathBuf::from("/home")),
+            fstype: Some("ext4".to_string()),
+            uuid: Some(SYSTEM_POOL.to_string()),
+        };
+        assert_eq!(btrfs_pool_uuid(&entry), None);
     }
 
     #[test]
-    fn parse_findmnt_target_degraded_output_yields_none() {
-        assert_eq!(parse_findmnt_target(""), None);
-        assert_eq!(parse_findmnt_target("{}"), None);
-        assert_eq!(parse_findmnt_target(r#"{"filesystems":[]}"#), None);
+    fn btrfs_pool_uuid_degraded_entry_yields_none() {
+        assert_eq!(btrfs_pool_uuid(&crate::pools::FindmntEntry::default()), None);
         assert_eq!(
-            parse_findmnt_target(r#"{"filesystems":[{"target":"/","fstype":"btrfs","uuid":""}]}"#),
+            btrfs_pool_uuid(&crate::pools::FindmntEntry {
+                target: Some(PathBuf::from("/")),
+                fstype: Some("btrfs".to_string()),
+                uuid: None,
+            }),
             None
         );
     }

--- a/src/drives.rs
+++ b/src/drives.rs
@@ -1,5 +1,4 @@
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use crate::config::DriveConfig;
 use crate::error::UrdError;
@@ -70,40 +69,13 @@ pub fn drive_availability(drive: &DriveConfig) -> DriveAvailability {
 
 /// Get the filesystem UUID of the filesystem mounted at the given path.
 ///
-/// Uses `findmnt -n -o UUID <mount_path>` which works without sudo and
-/// handles LUKS-encrypted drives transparently (returns the inner filesystem UUID).
+/// Delegates to the concentrated `findmnt --target` probe in `pools.rs`
+/// (UPI 084) — works without sudo and handles LUKS-encrypted drives
+/// transparently (returns the inner filesystem UUID). `--target` matches an
+/// exact mountpoint directly, so this is unchanged for `drive.mount_path`
+/// (always a real mountpoint).
 pub fn get_filesystem_uuid(mount_path: &Path) -> crate::error::Result<Option<String>> {
-    let mount_str = mount_path.to_str().ok_or_else(|| UrdError::Io {
-        path: mount_path.to_path_buf(),
-        source: std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "mount path is not valid UTF-8",
-        ),
-    })?;
-
-    let output = Command::new("findmnt")
-        .env("LC_ALL", "C")
-        .args(["-n", "-o", "UUID", mount_str])
-        .output()
-        .map_err(|e| UrdError::Io {
-            path: PathBuf::from("findmnt"),
-            source: e,
-        })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(UrdError::Io {
-            path: mount_path.to_path_buf(),
-            source: std::io::Error::other(format!("findmnt failed: {}", stderr.trim())),
-        });
-    }
-
-    let uuid = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if uuid.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(uuid))
-    }
+    crate::pools::pool_uuid_for_path(mount_path)
 }
 
 /// Check mounted drives for missing UUID configuration.
@@ -215,13 +187,10 @@ pub fn is_path_mounted(mount_path: &Path) -> bool {
     false
 }
 
-/// Get free bytes on the filesystem containing the given path.
+/// Get free bytes on the filesystem containing the given path. Delegates to
+/// the single statvfs wrapper in `pools.rs` (UPI 084).
 pub fn filesystem_free_bytes(path: &Path) -> crate::error::Result<u64> {
-    let stat = nix::sys::statvfs::statvfs(path).map_err(|e| UrdError::Io {
-        path: path.to_path_buf(),
-        source: std::io::Error::other(e.to_string()),
-    })?;
-    Ok(stat.blocks_available() * stat.fragment_size())
+    crate::pools::pool_free_bytes(path)
 }
 
 /// Get the external snapshot directory for a subvolume on a drive.

--- a/src/pools.rs
+++ b/src/pools.rs
@@ -41,29 +41,50 @@ pub struct DriveResolution {
 // duplicate contract.
 use crate::metrics::PoolMetric;
 
+/// One resolved row from the concentrated `findmnt --target` probe: which
+/// filesystem (if any) holds an arbitrary path. All three fields are
+/// independent — a mount can resolve a `target` with an empty `uuid` (no
+/// superblock UUID), and `fstype` lets a caller gate on "must be btrfs"
+/// without a second probe (UPI 084; see `discover()`'s home-pool lookup).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FindmntEntry {
+    pub target: Option<PathBuf>,
+    pub fstype: Option<String>,
+    pub uuid: Option<String>,
+}
+
 /// Resolve the BTRFS filesystem UUID hosting an arbitrary path.
-/// `findmnt -n -o UUID --target <path>` — walks up internally. `Ok(None)`
-/// for non-BTRFS sources, missing paths, or mounts without a UUID.
-///
-/// Findmnt typically returns non-zero exit and writes to stderr for missing
-/// paths; we map non-zero exit with empty stdout to `Ok(None)`, and non-zero
-/// exit with stderr content to `Err`. Empty stdout on success → `Ok(None)`.
+/// `Ok(None)` for missing paths or mounts without a UUID.
 pub fn pool_uuid_for_path(path: &Path) -> crate::error::Result<Option<String>> {
-    findmnt_target(path, "UUID")
+    Ok(findmnt_probe_target(path)?.uuid)
 }
 
 /// Resolve a source path's pool UUID **and** mountpoint in a **single**
-/// `findmnt` call (UPI 031-a, S3). Replaces the prior pair of calls
-/// (`pool_uuid_for_path` + `pool_mountpoint_for_path`) on the hot path,
-/// halving the per-subvolume fork count.
+/// `findmnt` call (UPI 031-a, S3). Halves the per-subvolume fork count vs.
+/// two separate probes.
 ///
-/// Both columns are returned independently: a non-BTRFS or UUID-less mount
-/// still yields its `TARGET` (so storage-signal gathering can read free-ratio
-/// for a pool it cannot key to a UUID — S5). `Err` only on a findmnt I/O
-/// failure with stderr content; a missing/unmounted path → `Ok((None, None))`.
+/// Both columns are returned independently: a UUID-less mount still yields
+/// its `TARGET` (so storage-signal gathering can read free-ratio for a pool
+/// it cannot key to a UUID — S5).
 pub fn resolve_source_pool(
     path: &Path,
 ) -> crate::error::Result<(Option<String>, Option<PathBuf>)> {
+    let entry = findmnt_probe_target(path)?;
+    Ok((entry.uuid, entry.target))
+}
+
+/// The concentrated `findmnt --target` probe (UPI 084): one subprocess spawn
+/// and one parser for "which filesystem holds this path?" queries, shared by
+/// `pool_uuid_for_path`, `resolve_source_pool`, `drives::get_filesystem_uuid`,
+/// and `discovery`'s home-pool lookup (which additionally gates on
+/// `fstype == "btrfs"` at its call site, since that filter is specific to
+/// discovery's zero-state inventory and not shared by the other consumers).
+///
+/// Uses `-J` (JSON) output — the most robust `findmnt` format to parse,
+/// tolerant of field reordering and locale quirks that broke the older `-P`
+/// key="value" parser. `Err` only on a findmnt I/O failure with stderr
+/// content; a missing/unmounted path → `Ok(FindmntEntry::default())`.
+pub fn findmnt_probe_target(path: &Path) -> crate::error::Result<FindmntEntry> {
     let path_str = path.to_str().ok_or_else(|| UrdError::Io {
         path: path.to_path_buf(),
         source: std::io::Error::new(
@@ -74,7 +95,7 @@ pub fn resolve_source_pool(
 
     let output = Command::new("findmnt")
         .env("LC_ALL", "C")
-        .args(["-n", "-P", "-o", "UUID,TARGET", "--target", path_str])
+        .args(["-J", "-o", "TARGET,FSTYPE,UUID", "--target", path_str])
         .output()
         .map_err(|e| UrdError::Io {
             path: PathBuf::from("findmnt"),
@@ -85,7 +106,7 @@ pub fn resolve_source_pool(
     if !output.status.success() {
         if stdout.trim().is_empty() {
             // findmnt complained about a missing path; treat as "unresolved".
-            return Ok((None, None));
+            return Ok(FindmntEntry::default());
         }
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(UrdError::Io {
@@ -94,63 +115,26 @@ pub fn resolve_source_pool(
         });
     }
 
-    Ok(parse_findmnt_uuid_target(&stdout))
+    Ok(parse_findmnt_probe_target(&stdout))
 }
 
-/// Pure parse of `findmnt -P -o UUID,TARGET` output:
-/// `UUID="6c1…" TARGET="/"`. Empty quoted values map to `None`. Tolerates
-/// either ordering and surrounding whitespace. Extracted for unit testing
-/// (the subprocess wrapper above stays a thin I/O shim).
+/// Pure parse of `findmnt -J -o TARGET,FSTYPE,UUID --target <path>` output —
+/// a single-entry `filesystems` array. Empty/absent fields map to `None`.
+/// Extracted for unit testing (the subprocess wrapper above stays a thin I/O
+/// shim).
 #[must_use]
-fn parse_findmnt_uuid_target(stdout: &str) -> (Option<String>, Option<PathBuf>) {
-    let extract = |key: &str| -> Option<String> {
-        let needle = format!("{key}=\"");
-        let start = stdout.find(&needle)? + needle.len();
-        let rest = &stdout[start..];
-        let end = rest.find('"')?;
-        let val = &rest[..end];
-        (!val.is_empty()).then(|| val.to_string())
+fn parse_findmnt_probe_target(json: &str) -> FindmntEntry {
+    let Some(fs) = serde_json::from_str::<serde_json::Value>(json)
+        .ok()
+        .and_then(|root| root.get("filesystems")?.as_array()?.first().cloned())
+    else {
+        return FindmntEntry::default();
     };
-    let uuid = extract("UUID");
-    let target = extract("TARGET").map(PathBuf::from);
-    (uuid, target)
-}
-
-fn findmnt_target(path: &Path, column: &str) -> crate::error::Result<Option<String>> {
-    let path_str = path.to_str().ok_or_else(|| UrdError::Io {
-        path: path.to_path_buf(),
-        source: std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "path is not valid UTF-8",
-        ),
-    })?;
-
-    let output = Command::new("findmnt")
-        .env("LC_ALL", "C")
-        .args(["-n", "-o", column, "--target", path_str])
-        .output()
-        .map_err(|e| UrdError::Io {
-            path: PathBuf::from("findmnt"),
-            source: e,
-        })?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if !output.status.success() {
-        if stdout.is_empty() {
-            // findmnt complained about a missing path; treat as "no UUID".
-            return Ok(None);
-        }
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(UrdError::Io {
-            path: path.to_path_buf(),
-            source: std::io::Error::other(format!("findmnt failed: {}", stderr.trim())),
-        });
-    }
-
-    if stdout.is_empty() {
-        Ok(None)
-    } else {
-        Ok(Some(stdout))
+    let non_empty = |v: Option<&str>| v.filter(|s| !s.is_empty()).map(str::to_string);
+    FindmntEntry {
+        target: non_empty(fs.get("target").and_then(serde_json::Value::as_str)).map(PathBuf::from),
+        fstype: non_empty(fs.get("fstype").and_then(serde_json::Value::as_str)),
+        uuid: non_empty(fs.get("uuid").and_then(serde_json::Value::as_str)),
     }
 }
 
@@ -396,40 +380,47 @@ mod tests {
         std::fs::write(dir.join("total_bytes"), total).unwrap();
     }
 
-    // ── UPI 031-a: combined findmnt parser ──────────────────────────
+    // ── UPI 084: concentrated findmnt --target probe ────────────────
 
     #[test]
-    fn parse_findmnt_uuid_target_both_present() {
-        let (uuid, target) =
-            parse_findmnt_uuid_target("UUID=\"6c1a-1234\" TARGET=\"/\"\n");
-        assert_eq!(uuid.as_deref(), Some("6c1a-1234"));
-        assert_eq!(target, Some(PathBuf::from("/")));
+    fn parse_findmnt_probe_target_both_present() {
+        let entry = parse_findmnt_probe_target(
+            r#"{"filesystems":[{"target":"/","fstype":"btrfs","uuid":"6c1a-1234"}]}"#,
+        );
+        assert_eq!(entry.uuid.as_deref(), Some("6c1a-1234"));
+        assert_eq!(entry.target, Some(PathBuf::from("/")));
+        assert_eq!(entry.fstype.as_deref(), Some("btrfs"));
     }
 
     #[test]
-    fn parse_findmnt_uuid_target_empty_uuid_is_none() {
+    fn parse_findmnt_probe_target_empty_uuid_is_none() {
         // Non-BTRFS mount: TARGET resolves, UUID is empty → mountpoint still
         // surfaces so storage-signal gathering can read free-ratio (S5).
-        let (uuid, target) =
-            parse_findmnt_uuid_target("UUID=\"\" TARGET=\"/boot\"");
-        assert_eq!(uuid, None);
-        assert_eq!(target, Some(PathBuf::from("/boot")));
-    }
-
-    #[test]
-    fn parse_findmnt_uuid_target_empty_output_is_none_none() {
-        let (uuid, target) = parse_findmnt_uuid_target("");
-        assert_eq!(uuid, None);
-        assert_eq!(target, None);
-    }
-
-    #[test]
-    fn parse_findmnt_uuid_target_tolerates_target_with_space() {
-        let (uuid, target) = parse_findmnt_uuid_target(
-            "UUID=\"abcd\" TARGET=\"/mnt/my drive\"",
+        let entry = parse_findmnt_probe_target(
+            r#"{"filesystems":[{"target":"/boot","fstype":"vfat","uuid":""}]}"#,
         );
-        assert_eq!(uuid.as_deref(), Some("abcd"));
-        assert_eq!(target, Some(PathBuf::from("/mnt/my drive")));
+        assert_eq!(entry.uuid, None);
+        assert_eq!(entry.target, Some(PathBuf::from("/boot")));
+        assert_eq!(entry.fstype.as_deref(), Some("vfat"));
+    }
+
+    #[test]
+    fn parse_findmnt_probe_target_empty_output_is_default() {
+        assert_eq!(parse_findmnt_probe_target(""), FindmntEntry::default());
+        assert_eq!(parse_findmnt_probe_target("{}"), FindmntEntry::default());
+        assert_eq!(
+            parse_findmnt_probe_target(r#"{"filesystems":[]}"#),
+            FindmntEntry::default()
+        );
+    }
+
+    #[test]
+    fn parse_findmnt_probe_target_tolerates_target_with_space() {
+        let entry = parse_findmnt_probe_target(
+            r#"{"filesystems":[{"target":"/mnt/my drive","fstype":"btrfs","uuid":"abcd"}]}"#,
+        );
+        assert_eq!(entry.uuid.as_deref(), Some("abcd"));
+        assert_eq!(entry.target, Some(PathBuf::from("/mnt/my drive")));
     }
 
     /// A `space_resolver` that ignores the path and always reports the same


### PR DESCRIPTION
## Summary

- `pools.rs` now owns the single concentrated `findmnt --target -J` probe (`FindmntEntry`) and the single statvfs wrapper (`pool_space`/`pool_free_bytes`).
- `drives::get_filesystem_uuid` and `drives::filesystem_free_bytes` delegate to `pools.rs` instead of rolling their own `Command::new("findmnt")` / `statvfs` calls.
- `discovery.rs`'s per-path home-pool UUID lookup delegates to the same probe; its btrfs-only gate moved to the call site (`btrfs_pool_uuid`), since that filter is specific to discovery's zero-state inventory.
- `discovery.rs`'s full-tree `findmnt -t btrfs -J` inventory scan (`parse_findmnt`) is kept separate, as the issue's proposed direction allows — it parses a recursive mount tree for system inventory, a genuinely different query shape from a single-path lookup.
- No behavior change: `--target` resolves an exact mountpoint identically to the old bare positional-argument form; the older `-P` parser is replaced by the more robust `-J` JSON form used elsewhere in the codebase.

Closes #302.

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 2240 passed, 0 failed, 5 ignored (unchanged count)
- cargo build --release: pass
- Live sanity checks against the real machine: `urd status`, `urd drives`, `urd doctor` all resolve correct UUIDs and free-space figures through the new delegation path

🤖 Generated with [Claude Code](https://claude.com/claude-code)