### PR TITLE
refactor: doctor consumes the shared seal-gap-deep derivation (UPI 085)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- `doctor`'s sudoers-drift and units-drift rows now derive from the same shared
+  comparisons `urd init`'s deep seal gate uses, instead of re-parsing the privilege
+  listing and re-reading installed unit files independently. No behavior change (#306).
+
+### Changed
 - `drives.rs` and `discovery.rs`'s per-path `findmnt` UUID/mountpoint lookups now delegate
   to one concentrated probe in `pools.rs`; `drives.rs`'s statvfs free-bytes wrapper now
   delegates to `pools.rs`'s too. No behavior change — one probe surface instead of three

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -150,16 +150,8 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         .and_then(std::fs::canonicalize)
         .ok();
     let installed = dirs::config_dir().map(|d| {
-        let dir = d.join("systemd/user");
-        crate::systemd_units::expected_unit_names(&config.general.run_frequency)
-            .into_iter()
-            .map(|name| {
-                (
-                    name.to_string(),
-                    std::fs::read_to_string(dir.join(name)).ok(),
-                )
-            })
-            .collect::<std::collections::HashMap<_, _>>()
+        let names = crate::systemd_units::expected_unit_names(&config.general.run_frequency);
+        crate::commands::seal::installed_unit_contents(&names, &d.join("systemd/user"))
     });
     let mut units_checks =
         build_units_drift_checks(&config, exe.as_deref(), installed.as_ref());
@@ -446,11 +438,11 @@ fn build_sudoers_drift_checks(config: &Config, listing: Option<&str>) -> Vec<Doc
                 .to_string(),
         )];
     };
-    let listing = match crate::sudoers::parse_privilege_listing(listing) {
-        Ok(listing) => listing,
-        Err(uncertain) => return vec![cannot_verify_grant_check(uncertain.reason)],
+    let coverage = match crate::commands::seal::coverage_from_listing(&expected, listing) {
+        Ok(coverage) => coverage,
+        Err(reason) => return vec![cannot_verify_grant_check(reason)],
     };
-    match crate::sudoers::coverage(&expected, &listing) {
+    match coverage {
         crate::sudoers::Coverage::AllCovered => vec![DoctorCheck {
             name: "sudoers grant covers the config".to_string(),
             status: DoctorCheckStatus::Ok,

--- a/src/commands/seal.rs
+++ b/src/commands/seal.rs
@@ -613,7 +613,8 @@ fn install_units(config: &Config) -> bool {
     }
 
     // Done-detection: byte-true files + everything enabled → nothing to ask.
-    let installed = installed_unit_contents(&units, &dir);
+    let names: Vec<&str> = units.iter().map(|u| u.name).collect();
+    let installed = installed_unit_contents(&names, &dir);
     if crate::systemd_units::diff_units(&units, &installed).is_empty()
         && enabled.iter().all(|p| *p == EnabledProbe::Enabled)
     {
@@ -622,7 +623,6 @@ fn install_units(config: &Config) -> bool {
         return true;
     }
 
-    let names: Vec<&str> = units.iter().map(|u| u.name).collect();
     print!("{}", voice::render_units_request(&names, &dir, &next_action));
     loop {
         match crate::commands::encounter::read_input_line() {
@@ -699,14 +699,17 @@ fn enabled_units(units: &[crate::systemd_units::UnitFile]) -> Vec<EnabledProbe> 
         .collect()
 }
 
-/// Read every expected unit's installed content (`None` = absent).
-fn installed_unit_contents(
-    units: &[crate::systemd_units::UnitFile],
+/// Read every named unit's installed content (`None` = absent). Shared by
+/// `units_drifted` (the deep gate) and doctor's units-drift rows (UPI 085)
+/// so both read the installed map through one loop instead of each
+/// hand-rolling the same `read_to_string` scan.
+pub(crate) fn installed_unit_contents(
+    names: &[&str],
     dir: &Path,
 ) -> std::collections::HashMap<String, Option<String>> {
-    units
+    names
         .iter()
-        .map(|u| (u.name.to_string(), std::fs::read_to_string(dir.join(u.name)).ok()))
+        .map(|name| (name.to_string(), std::fs::read_to_string(dir.join(name)).ok()))
         .collect()
 }
 
@@ -1213,7 +1216,8 @@ fn units_drifted(config: &Config) -> bool {
     let Some(dir) = dirs::config_dir().map(|d| d.join("systemd/user")) else {
         return false;
     };
-    !crate::systemd_units::diff_units(&units, &installed_unit_contents(&units, &dir)).is_empty()
+    let names: Vec<&str> = units.iter().map(|u| u.name).collect();
+    !crate::systemd_units::diff_units(&units, &installed_unit_contents(&names, &dir)).is_empty()
 }
 
 /// Is any expected unit file absent? Existence only, by expected name —
@@ -1290,9 +1294,20 @@ fn effective_coverage(config: &Config) -> Result<Coverage, String> {
     if !out.status.success() {
         return Err("the privilege listing needs a password (sudo -n -l)".to_string());
     }
-    let listing = sudoers::parse_privilege_listing(&String::from_utf8_lossy(&out.stdout))
-        .map_err(|u| u.reason)?;
-    Ok(sudoers::coverage(&expected, &listing))
+    coverage_from_listing(&expected, &String::from_utf8_lossy(&out.stdout))
+}
+
+/// Parse a raw `sudo -n -l` listing and diff it against `expected`. Pure —
+/// the I/O boundary stays with each caller (`effective_coverage`'s own
+/// probe; doctor's injected listing for its test seam) — so the deep gate
+/// and doctor's drift rows share ONE parse-and-compare instead of each
+/// independently calling `parse_privilege_listing`/`coverage` (UPI 085).
+pub(crate) fn coverage_from_listing(
+    expected: &[String],
+    raw_listing: &str,
+) -> Result<Coverage, String> {
+    let listing = sudoers::parse_privilege_listing(raw_listing).map_err(|u| u.reason)?;
+    Ok(sudoers::coverage(expected, &listing))
 }
 
 /// The expected grant lines the effective listing DEFINITIVELY lacks.
@@ -1459,13 +1474,14 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let dir = tmp.path().join("systemd/user");
 
+        let names: Vec<&str> = units.iter().map(|u| u.name).collect();
         write_units(&units, &dir).unwrap();
-        let installed = installed_unit_contents(&units, &dir);
+        let installed = installed_unit_contents(&names, &dir);
         assert!(crate::systemd_units::diff_units(&units, &installed).is_empty());
 
         // Tamper with one file: the diff names exactly it.
         std::fs::write(dir.join("urd-backup.timer"), "[Timer]\n").unwrap();
-        let installed = installed_unit_contents(&units, &dir);
+        let installed = installed_unit_contents(&names, &dir);
         let drift = crate::systemd_units::diff_units(&units, &installed);
         assert_eq!(drift.len(), 1);
         assert_eq!(drift[0].name, "urd-backup.timer");


### PR DESCRIPTION
## Summary

- `doctor` open-coded the deep content-drift derivation (sudoers coverage diff, units content
  diff) that `seal_gap_deep` — `urd init`'s make-whole gate — already computes independently.
  Two implementations of the same comparison risk drifting apart (the same status/doctor-disagree
  shape UPI 081 fixed elsewhere).
- Extracted `coverage_from_listing` (pure parse-and-diff) in `seal.rs`, now called by both
  `effective_coverage` (the deep gate's I/O boundary) and doctor's pure-over-injected-listing
  sudoers-drift builder.
- Exposed `installed_unit_contents` and pointed both `units_drifted` (deep gate) and doctor's
  units-drift row builder at the same read loop.
- Doctor keeps its own presentation (row wording, suggestions) — only the derivation is
  single-sourced now. No behavior change.

Closes #306.

## Testing

- cargo clippy: pass, zero warnings
- cargo test: 2240 passed, 0 failed (same count as before this change)
- cargo build --release: pass
- doc-hygiene lint (present-not-journey): pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)