### PR TITLE
feat: CI quality gate on pull requests (UPI 077 PR-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+# CI quality gate (UPI 077). Both jobs are required status checks on master.
+#
+# Action pins are full commit SHAs — mutable tags can be repointed by a compromised
+# action repo, the same attack class the no-`curl | bash` install posture refuses.
+# The tag in the trailing comment is informational only; bump by editing the SHA.
+#
+# No `cargo fmt --check`: HEAD is formatted with an older rustfmt and the current
+# version mass-reformats many files (see CLAUDE.md, Project State).
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+# Superseded pushes to the same PR cancel their stale runs; master pushes never cancel.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - run: cargo clippy --all-targets --locked -- -D warnings
+      - run: cargo test --locked
+
+  docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - run: bash scripts/check-docs.sh
+      - run: bash scripts/check-present-not-journey.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Continuous integration on every pull request: clippy (warnings-as-errors), the full
+  test suite, and documentation link/convention lint now run as GitHub Actions required
+  checks before anything merges. Third-party actions are pinned to full commit SHAs.
+
 ### Fixed
 - Two new clippy lints on current stable (Rust 1.97) in `discovery` and `sudoers` —
   mechanical rewrites, no behavior change — and an ETXTBSY race in the Encounter's

--- a/docs/00-foundation/decisions/2026-03-24-ADR-100-planner-executor-separation.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-100-planner-executor-separation.md
@@ -73,7 +73,7 @@ the send/pin dependency is structural, not implicit.
 
 ## Related
 
-- [Roadmap](../../96-project-supervisor/roadmap.md) §Architecture: Key Design Principles
-- [Phase 1 journal](../../98-journals/2026-03-22-urd-phase01.md) — original implementation
-- [Phase 2 journal](../../98-journals/2026-03-22-urd-phase02.md) — Executor Contract
+- Roadmap (`docs/96-project-supervisor/roadmap.md`) §Architecture: Key Design Principles
+- Phase 1 journal (`docs/98-journals/2026-03-22-urd-phase01.md`) — original implementation
+- Phase 2 journal (`docs/98-journals/2026-03-22-urd-phase02.md`) — Executor Contract
 - ADR-101: BtrfsOps trait (the executor's interface to btrfs)

--- a/docs/00-foundation/decisions/2026-03-24-ADR-101-btrfsops-trait.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-101-btrfsops-trait.md
@@ -76,6 +76,6 @@ other modules interact with btrfs exclusively through this trait.
 ## Related
 
 - ADR-100: Planner/executor separation (the trait's primary consumer)
-- [Phase 2 journal](../../98-journals/2026-03-22-urd-phase02.md) — send/receive pipeline design
-- [Phase 3 adversary review](../../99-reports/2026-03-22-phase3-adversary-review.md) —
+- Phase 2 journal (`docs/98-journals/2026-03-22-urd-phase02.md`) — send/receive pipeline design
+- Phase 3 adversary review (`docs/99-reports/2026-03-22-phase3-adversary-review.md`) —
   removed `to_string_lossy()` from `RealBtrfs`

--- a/docs/00-foundation/decisions/2026-03-24-ADR-102-filesystem-truth-sqlite-history.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-102-filesystem-truth-sqlite-history.md
@@ -74,6 +74,6 @@ made historical queries impossible ("when did the last backup run? how long did 
 ## Related
 
 - ADR-100: Planner/executor separation (planner reads filesystem through trait)
-- [Roadmap](../../96-project-supervisor/roadmap.md) §SQLite Schema — documents the decision
+- Roadmap (`docs/96-project-supervisor/roadmap.md`) §SQLite Schema — documents the decision
   to remove the `snapshots` table
-- [Phase 2 journal](../../98-journals/2026-03-22-urd-phase02.md) — state.rs implementation
+- Phase 2 journal (`docs/98-journals/2026-03-22-urd-phase02.md`) — state.rs implementation

--- a/docs/00-foundation/decisions/2026-03-24-ADR-103-interval-scheduling.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-103-interval-scheduling.md
@@ -68,6 +68,6 @@ model — there is no `[defaults]` section; configs are self-describing artifact
 ## Related
 
 - ADR-104: Graduated retention (the retention model that handles frequent snapshots)
-- [Phase 1 journal](../../98-journals/2026-03-22-urd-phase01.md) — documents the redesign
+- Phase 1 journal (`docs/98-journals/2026-03-22-urd-phase01.md`) — documents the redesign
   from calendar schedules to intervals
-- [Roadmap](../../96-project-supervisor/roadmap.md) — original Schedule enum specification
+- Roadmap (`docs/96-project-supervisor/roadmap.md`) — original Schedule enum specification

--- a/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
@@ -141,5 +141,5 @@ already-shipped recommendation outputs.
 - ADR-105: Backward-compatibility contracts (Amendment 2026-05-15 — `monthly = 0` semantic shift)
 - ADR-111: Config system architecture (Amendment 2026-05-15 — `config_version = 2`)
 - ADR-115: Retention shape symmetry and the recommendation layer (4-slot recommender scope)
-- [Phase 1 journal](../../98-journals/2026-03-22-urd-phase01.md) — retention redesign
-- [Roadmap](../../96-project-supervisor/roadmap.md) — original flat retention specification
+- Phase 1 journal (`docs/98-journals/2026-03-22-urd-phase01.md`) — retention redesign
+- Roadmap (`docs/96-project-supervisor/roadmap.md`) — original flat retention specification

--- a/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
@@ -228,6 +228,6 @@ correct under the softened heartbeat contract above.
 - ADR-109: Config-boundary validation (v2 rejects `monthly = 0` at parse time)
 - ADR-111: Config system architecture (Amendment 2026-05-15 — `config_version = 2`,
   migration command, dual-parser dispatcher)
-- [Roadmap](../../96-project-supervisor/roadmap.md) §Backward Compatibility, §Prometheus Metrics
-- [Pre-cutover hardening journal](../../98-journals/2026-03-24-pre-cutover-hardening.md) —
+- Roadmap (`docs/96-project-supervisor/roadmap.md`) §Backward Compatibility, §Prometheus Metrics
+- Pre-cutover hardening journal (`docs/98-journals/2026-03-24-pre-cutover-hardening.md`) —
   legacy pin handling refinement

--- a/docs/00-foundation/decisions/2026-03-24-ADR-106-defense-in-depth-data-integrity.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-106-defense-in-depth-data-integrity.md
@@ -85,7 +85,7 @@ Silent data loss requires all three layers to fail simultaneously on the same sn
 
 - ADR-100: Planner/executor separation (the layers map to the planner/executor boundary)
 - ADR-104: Graduated retention (the retention logic where these layers operate)
-- [Phase 1 hardening review](../../99-reports/2026-03-22-phase1-hardening-review.md) —
+- Phase 1 hardening review (`docs/99-reports/2026-03-22-phase1-hardening-review.md`) —
   unsent snapshot protection introduced
-- [Phase 3.5 adversary review](../../99-reports/2026-03-22-arch-adversary-phase35.md) —
+- Phase 3.5 adversary review (`docs/99-reports/2026-03-22-arch-adversary-phase35.md`) —
   "three layers of protection" articulated

--- a/docs/00-foundation/decisions/2026-03-24-ADR-107-fail-open-cleanup-on-failure.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-107-fail-open-cleanup-on-failure.md
@@ -97,8 +97,8 @@ fail-open was constrained to prevent masking a real problem.
 
 - ADR-106: Defense-in-depth (deletion fails closed while backup fails open)
 - ADR-102: Filesystem truth (crash recovery relies on filesystem, not SQLite)
-- [Space estimation adversary review](../../99-reports/2026-03-23-arch-adversary-space-estimation.md) —
+- Space estimation adversary review (`docs/99-reports/2026-03-23-arch-adversary-space-estimation.md`) —
   "No history → allow the send"
-- [Awareness model design review](../../99-reports/2026-03-23-awareness-model-design-review.md) —
+- Awareness model design review (`docs/99-reports/2026-03-23-awareness-model-design-review.md`) —
   clock skew exception
-- [Phase 2 journal](../../98-journals/2026-03-22-urd-phase02.md) — crash recovery design
+- Phase 2 journal (`docs/98-journals/2026-03-22-urd-phase02.md`) — crash recovery design

--- a/docs/00-foundation/decisions/2026-03-24-ADR-108-pure-function-module-pattern.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-108-pure-function-module-pattern.md
@@ -97,9 +97,9 @@ Tests are deterministic — same inputs always produce same outputs.
 ## Related
 
 - ADR-100: Planner/executor separation (the original instance of this pattern)
-- [Awareness model design review](../../99-reports/2026-03-23-awareness-model-design-review.md) —
+- Awareness model design review (`docs/99-reports/2026-03-23-awareness-model-design-review.md`) —
   "Following the planner pattern"
-- [Presentation layer design review](../../99-reports/2026-03-24-presentation-layer-design-review.md) —
+- Presentation layer design review (`docs/99-reports/2026-03-24-presentation-layer-design-review.md`) —
   "commands produce structured types, not formatted strings"
-- [Vision architecture review](../../99-reports/2026-03-23-vision-architecture-review.md) §2 —
+- Vision architecture review (`docs/99-reports/2026-03-23-vision-architecture-review.md`) §2 —
   awareness model must work without Sentinel

--- a/docs/00-foundation/decisions/2026-03-24-ADR-109-config-boundary-validation.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-109-config-boundary-validation.md
@@ -103,7 +103,7 @@ are separate from config validation because they come from a different trust bou
 
 - ADR-101: BtrfsOps trait (the module where validated paths reach sudo commands)
 - ADR-111: Config system architecture (structural vs runtime error distinction, new fields)
-- [Phase 1 hardening review](../../99-reports/2026-03-22-phase1-hardening-review.md) —
+- Phase 1 hardening review (`docs/99-reports/2026-03-22-phase1-hardening-review.md`) —
   path validation introduced
-- [Phase 3.5 adversary review](../../99-reports/2026-03-22-arch-adversary-phase35.md) —
+- Phase 3.5 adversary review (`docs/99-reports/2026-03-22-arch-adversary-phase35.md`) —
   "Every path that reaches `sudo btrfs` has been validated"

--- a/docs/00-foundation/decisions/2026-05-09-ADR-115-retention-shape-symmetry-and-recommendation-layer.md
+++ b/docs/00-foundation/decisions/2026-05-09-ADR-115-retention-shape-symmetry-and-recommendation-layer.md
@@ -24,7 +24,7 @@ ADR-113 (do-no-harm invariant), ADR-114 (structured event log)
 
 Six weeks of autonomous operation produced the first evidence-based view of
 per-subvolume cost
-([report](../../99-reports/2026-05-09-retention-tuning-from-real-world-data.md)).
+(report: `docs/99-reports/2026-05-09-retention-tuning-from-real-world-data.md`).
 Two patterns emerged:
 
 1. **Named-level retention shapes are decoupled from real cost.** The same


### PR DESCRIPTION
## Summary

- First CI for the repo: `quality` (clippy `-D warnings` + full test suite, `--locked`, stable toolchain) and `docs` (link integrity + present-not-journey lint) run on every PR and on pushes to master. Both jobs will become required checks once this first run is green (UPI 077 Step 2).
- Third-party actions pinned to full commit SHAs (supply-chain posture; tags in comments are informational).
- Repairs 24 links in ADRs 100–109/115 that pointed into the private gitignored docs ranges — dead in CI checkouts and for every public reader. Converted to backticked path pointers; decision text untouched.
- No `cargo fmt` gate (rustfmt version skew — see CLAUDE.md Project State); no release-profile build on PRs (covered by `/release` Phase 5 locally).

## Testing

- cargo clippy --all-targets --locked -- -D warnings: pass (local, exact CI command set)
- cargo test --locked: 2271 passed, 0 failed, 5 ignored (one pre-existing ETXTBSY test flake identified during repeated runs — fix follows in a separate PR before checks become required)
- Docs jobs validated against a tracked-files-only checkout: 66/66 links resolve, both scripts pass
- This PR's own CI run is the live test of the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)