### PR TITLE
fix: clippy on Rust 1.97 + deflake Encounter fake-editor tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Two new clippy lints on current stable (Rust 1.97) in `discovery` and `sudoers` —
+  mechanical rewrites, no behavior change — and an ETXTBSY race in the Encounter's
+  fake-editor tests that made the suite flake roughly once per two dozen runs: the
+  test editors now run as `sh script` instead of exec'ing the freshly written file.
+
 ### Changed
 - The sentinel's idle emergency-eject decisions (ADR-113 Layer 3) — the ~60 s timer
   gate, the eject verdict, the defer-to-a-running-backup, and the re-confirm-under-lock

--- a/src/commands/encounter.rs
+++ b/src/commands/encounter.rs
@@ -661,10 +661,6 @@ mod tests {
              role = \"offsite\"\nEOF\n",
         )
         .unwrap();
-        use std::os::unix::fs::PermissionsExt as _;
-        let mut perms = std::fs::metadata(&script).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&script, perms).unwrap();
 
         let sealed_labels = std::cell::RefCell::new(Vec::<String>::new());
         let capture: SealFn<'_> = &|config, _| {
@@ -673,7 +669,11 @@ mod tests {
                 .extend(config.drives.iter().map(|d| d.label.clone()));
             Ok(SealOutcome::Sealed)
         };
-        let result = delve_with(&[script.display().to_string()], &strategy, today(), &path, capture);
+        // The "editor" runs as `sh script`, never by exec'ing the script itself:
+        // exec of a freshly written file races ETXTBSY against write fds inherited
+        // by other tests' concurrently forked children.
+        let editor = ["sh".to_string(), script.display().to_string()];
+        let result = delve_with(&editor, &strategy, today(), &path, capture);
         assert_eq!(result.unwrap(), CliExit::Done);
         assert!(
             sealed_labels.borrow().iter().any(|l| l == "delve-added"),
@@ -694,14 +694,11 @@ mod tests {
 
         let script = dir.path().join("ruin.sh");
         std::fs::write(&script, "#!/bin/sh\necho 'ruined [[[' > \"$1\"\n").unwrap();
-        use std::os::unix::fs::PermissionsExt as _;
-        let mut perms = std::fs::metadata(&script).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&script, perms).unwrap();
 
         let no_seal: SealFn<'_> = &|_, _| Ok(SealOutcome::Sealed);
-        let result =
-            delve_with(&[script.display().to_string()], &strategy, today(), &path, no_seal);
+        // `sh script`, not the script itself — same ETXTBSY guard as above.
+        let editor = ["sh".to_string(), script.display().to_string()];
+        let result = delve_with(&editor, &strategy, today(), &path, no_seal);
         let err = result.unwrap_err();
         assert!(err.to_string().contains("kept as you left it"), "{err}");
         assert!(

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -413,12 +413,10 @@ fn flatten_disk(disk: &LsblkNode) -> DiskSummary {
                 label: node.label.clone(),
                 mountpoints: real_mountpoints(node),
             }),
-            Some(other) => {
-                if acc.first_other.is_none() {
-                    acc.first_other = Some((other.to_string(), node.label.clone()));
-                }
+            Some(other) if acc.first_other.is_none() => {
+                acc.first_other = Some((other.to_string(), node.label.clone()));
             }
-            None => {}
+            _ => {}
         }
         for child in &node.children {
             walk(child, acc);

--- a/src/sudoers.rs
+++ b/src/sudoers.rs
@@ -430,10 +430,7 @@ fn parse_rule(
         let mut spec = raw.trim();
         // Leading TAG: tokens (NOPASSWD:, PASSWD:, SETENV:, …) update the
         // tag state; only the password tags change what we track.
-        loop {
-            let Some((token, tail)) = spec.split_once(' ') else {
-                break;
-            };
+        while let Some((token, tail)) = spec.split_once(' ') {
             let Some(tag) = token.strip_suffix(':') else {
                 break;
             };


### PR DESCRIPTION
## Summary

- PR #316's first CI run surfaced both issues; this PR makes the suite green on current stable so #316's `quality` job can pass and the checks can become required (UPI 077 Step 2).
- Rust 1.97 clippy: collapsible match arm in `discovery.rs`, while-let-loop in `sudoers.rs` — mechanical rewrites, no behavior change.
- ETXTBSY deflake: the two delve fake-editor tests exec'd a freshly written script; a concurrently forked test child can hold the write fd, failing exec with "Text file busy" (~1-in-23 locally). They now run as `sh script`, which makes the race structurally impossible; chmod boilerplate removed.

## Testing

- cargo clippy --all-targets --locked -- -D warnings: pass (Rust 1.97.0, same as CI)
- cargo test --locked: 2271 passed, 0 failed, 5 ignored
- Deflake evidence: 60 consecutive full-suite runs, zero failures (pre-fix: failed at iteration 23 of a 120-run loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)