### PR TITLE
fix: decouple 16 tests from developer-machine environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mechanical rewrites, no behavior change — and an ETXTBSY race in the Encounter's
   fake-editor tests that made the suite flake roughly once per two dozen runs: the
   test editors now run as `sh script` instead of exec'ing the freshly written file.
+- Sixteen tests were coupled to the developer machine's environment and failed on a
+  stock Ubuntu CI runner: executor fixtures used `/snap` as the snapshot root (absent
+  on Fedora, present on Ubuntu via snapd, turning the mkdir fail-open guard into a
+  real permission error), and one sealing test assumed no passwordless root (a CI
+  runner's NOPASSWD grant short-circuited the earning before the render refusal under
+  test). Fixtures now use an absent-everywhere root; the earning tests inject a
+  stubbed privilege probe.
 
 ### Changed
 - The sentinel's idle emergency-eject decisions (ADR-113 Layer 3) — the ~60 s timer

--- a/src/commands/seal.rs
+++ b/src/commands/seal.rs
@@ -813,13 +813,24 @@ fn adopt_one(
 // ── Stage 1: the earning ────────────────────────────────────────────────
 
 fn earn_privilege(config: &Config, config_path: &Path) -> anyhow::Result<SealOutcome> {
+    earn_privilege_with(config, config_path, probe_grant)
+}
+
+/// `earn_privilege` with the live-sudo probe injected — tests stub it, since
+/// the machine's own grant state (e.g. a CI runner's passwordless root)
+/// otherwise short-circuits the paths under test before they are reached.
+fn earn_privilege_with(
+    config: &Config,
+    config_path: &Path,
+    probe: impl FnOnce(&str) -> (GrantProbe, String),
+) -> anyhow::Result<SealOutcome> {
     let dest = Path::new(SUDOERS_DEST);
 
     // Already answers (e.g. a broader hand-managed grant)? Ask again only
     // on clear evidence: expected lines the listing definitively lacks (a
     // config the installed grant predates). Wildcard uncertainty stays
     // doctor's — a hand-managed broad grant is never nagged (071).
-    let regrant = if probe_grant(&config.general.btrfs_path).0 == GrantProbe::Granted {
+    let regrant = if probe(&config.general.btrfs_path).0 == GrantProbe::Granted {
         let missing = coverage_missing(config);
         if missing.is_empty() {
             print!("{}", voice::render_earning_already());
@@ -1532,17 +1543,18 @@ protection = "recorded"
 "#,
             root.display()
         ));
-        let outcome = earn_privilege(&config, &tmp.path().join("urd.toml")).unwrap();
+        let outcome = earn_privilege_with(&config, &tmp.path().join("urd.toml"), denied_probe)
+            .unwrap();
         assert_eq!(outcome, SealOutcome::Declined);
     }
 
     /// UPI 081 A2 (#275): a sudoers render refusal (here: a scope too
     /// shallow for the floor) routes through `render_earning_blocked` and
-    /// returns `Ok(Declined)`, never `Err`. `btrfs_path` points at a real,
-    /// existing binary that carries no grant of its own (`/usr/bin/true`),
-    /// so the probe reads Denied rather than Granted regardless of the test
-    /// runner's own cached sudo ticket — the "already earns" shortcut must
-    /// not mask the render refusal this test targets.
+    /// returns `Ok(Declined)`, never `Err`. The probe is stubbed Denied:
+    /// on a machine where sudo answers without a password (a CI runner's
+    /// NOPASSWD grant covers any binary, `/usr/bin/true` included), the
+    /// live probe reads Granted and the "already earns" shortcut would
+    /// return Sealed before the render refusal this test targets.
     #[test]
     fn earn_privilege_declined_not_err_when_render_refuses() {
         let tmp = tempfile::TempDir::new().unwrap();
@@ -1560,8 +1572,15 @@ snapshot_root = "/"
 protection = "recorded"
 "#,
         );
-        let outcome = earn_privilege(&config, &tmp.path().join("urd.toml")).unwrap();
+        let outcome = earn_privilege_with(&config, &tmp.path().join("urd.toml"), denied_probe)
+            .unwrap();
         assert_eq!(outcome, SealOutcome::Declined);
+    }
+
+    /// Probe stub for `earn_privilege_with`: the no-grant machine state the
+    /// earning tests exercise, independent of the runner's real sudo.
+    fn denied_probe(_btrfs: &str) -> (GrantProbe, String) {
+        (GrantProbe::Denied, "password required (stub)".to_string())
     }
 
     #[test]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -2062,7 +2062,7 @@ log_dir = "/tmp/urd-test"
 
 [local_snapshots]
 roots = [
-  { path = "/snap", subvolumes = ["sv-a", "sv-b"] }
+  { path = "/nonexistent-urd/snap", subvolumes = ["sv-a", "sv-b"] }
 ]
 
 [defaults]
@@ -2103,19 +2103,19 @@ source = "/data/b"
             operations: vec![
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::SendIncremental {
-                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
-                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    parent: PathBuf::from("/nonexistent-urd/snap/sv-a/20260321-a"),
+                    snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                     drive_label: "TEST-DRIVE".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     pin_on_success: None,
                 },
                 PlannedOperation::DeleteSnapshot {
-                    path: PathBuf::from("/snap/sv-a/20260310-a"),
+                    path: PathBuf::from("/nonexistent-urd/snap/sv-a/20260310-a"),
                     reason: "expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     kind: DeleteKind::Policy,
@@ -2157,7 +2157,7 @@ source = "/data/b"
         // Make sv-a's create fail
         mock.fail_creates
             .borrow_mut()
-            .insert(PathBuf::from("/snap/sv-a/20260322-1430-a"));
+            .insert(PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"));
 
         let config = test_config();
         let shutdown = no_shutdown();
@@ -2172,12 +2172,12 @@ source = "/data/b"
             operations: vec![
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/b"),
-                    dest: PathBuf::from("/snap/sv-b/20260322-1430-b"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-b/20260322-1430-b"),
                     subvolume_name: "sv-b".to_string(),
                 },
             ],
@@ -2265,7 +2265,7 @@ source = "/data/b"
         let mock = MockBtrfs::new();
         mock.fail_creates
             .borrow_mut()
-            .insert(PathBuf::from("/snap/sv-a/20260322-1430-a"));
+            .insert(PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"));
 
         let config = test_config();
         let shutdown = no_shutdown();
@@ -2280,11 +2280,11 @@ source = "/data/b"
             operations: vec![
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::SendFull {
-                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                     drive_label: "TEST-DRIVE".to_string(),
                     subvolume_name: "sv-a".to_string(),
@@ -2336,7 +2336,7 @@ source = "/data/b"
         let plan = BackupPlan {
             lifecycles: HashMap::new(),
             operations: vec![PlannedOperation::SendFull {
-                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                 dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
@@ -2365,7 +2365,7 @@ source = "/data/b"
         BackupPlan {
             lifecycles: HashMap::new(),
             operations: vec![PlannedOperation::SendFull {
-                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                 dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
@@ -2382,14 +2382,15 @@ source = "/data/b"
     #[test]
     fn watchdog_tripped_pool_skips_send() {
         // C2 (executor side): when this subvolume's source pool is in `tripped`,
-        // the send is gated — no `send_receive` runs. sv-a resolves to `/snap`.
+        // the send is gated — no `send_receive` runs. sv-a resolves to the
+        // absent-everywhere test root.
         let mock = MockBtrfs::new();
         let config = test_config();
         let shutdown = no_shutdown();
         let mut executor = Executor::new(&mock, None, &config, &shutdown);
         let coord = Arc::new(Mutex::new(WatchdogCoord {
             in_flight: None,
-            tripped: [PathBuf::from("/snap")].into_iter().collect(),
+            tripped: [PathBuf::from("/nonexistent-urd/snap")].into_iter().collect(),
         }));
         executor.set_watchdog_coord(coord);
 
@@ -2442,10 +2443,10 @@ source = "/data/b"
         let mock = MockBtrfs::new();
         mock.fail_creates
             .borrow_mut()
-            .insert(PathBuf::from("/snap/sv-a/20260322-1430-a"));
+            .insert(PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"));
         mock.fail_creates
             .borrow_mut()
-            .insert(PathBuf::from("/snap/sv-b/20260322-1430-b"));
+            .insert(PathBuf::from("/nonexistent-urd/snap/sv-b/20260322-1430-b"));
 
         let config = test_config();
         let shutdown = no_shutdown();
@@ -2460,12 +2461,12 @@ source = "/data/b"
             operations: vec![
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/b"),
-                    dest: PathBuf::from("/snap/sv-b/20260322-1430-b"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-b/20260322-1430-b"),
                     subvolume_name: "sv-b".to_string(),
                 },
             ],
@@ -2589,7 +2590,7 @@ source = "/data/b"
         let plan = BackupPlan {
             lifecycles: HashMap::new(),
             operations: vec![PlannedOperation::SendFull {
-                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                 dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
@@ -2889,7 +2890,7 @@ log_dir = "/tmp/urd-test"
 
 [local_snapshots]
 roots = [
-  { path = "/snap", subvolumes = ["sv-a", "sv-b"], min_free_bytes = "100GB" }
+  { path = "/nonexistent-urd/snap", subvolumes = ["sv-a", "sv-b"], min_free_bytes = "100GB" }
 ]
 
 [defaults]
@@ -2938,19 +2939,19 @@ source = "/data/b"
             lifecycles: HashMap::new(),
             operations: vec![
                 PlannedOperation::DeleteSnapshot {
-                    path: PathBuf::from("/snap/sv-a/20260301-a"),
+                    path: PathBuf::from("/nonexistent-urd/snap/sv-a/20260301-a"),
                     reason: "space pressure".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     kind: DeleteKind::SpacePressure,
                 },
                 PlannedOperation::DeleteSnapshot {
-                    path: PathBuf::from("/snap/sv-a/20260302-a"),
+                    path: PathBuf::from("/nonexistent-urd/snap/sv-a/20260302-a"),
                     reason: "space pressure".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     kind: DeleteKind::SpacePressure,
                 },
                 PlannedOperation::DeleteSnapshot {
-                    path: PathBuf::from("/snap/sv-a/20260303-a"),
+                    path: PathBuf::from("/nonexistent-urd/snap/sv-a/20260303-a"),
                     reason: "space pressure".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     kind: DeleteKind::SpacePressure,
@@ -2997,7 +2998,7 @@ source = "/data/b"
         let plan = BackupPlan {
             lifecycles: HashMap::new(),
             operations: vec![PlannedOperation::SendFull {
-                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                 dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
@@ -3023,16 +3024,16 @@ source = "/data/b"
         let ops = vec![
             PlannedOperation::CreateSnapshot {
                 source: PathBuf::from("/a"),
-                dest: PathBuf::from("/snap/a"),
+                dest: PathBuf::from("/nonexistent-urd/snap/a"),
                 subvolume_name: "sv-a".to_string(),
             },
             PlannedOperation::CreateSnapshot {
                 source: PathBuf::from("/b"),
-                dest: PathBuf::from("/snap/b"),
+                dest: PathBuf::from("/nonexistent-urd/snap/b"),
                 subvolume_name: "sv-b".to_string(),
             },
             PlannedOperation::DeleteSnapshot {
-                path: PathBuf::from("/snap/a/old"),
+                path: PathBuf::from("/nonexistent-urd/snap/a/old"),
                 reason: "expired".to_string(),
                 subvolume_name: "sv-a".to_string(),
                 kind: DeleteKind::Policy,
@@ -3063,12 +3064,12 @@ source = "/data/b"
             operations: vec![
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/b"),
-                    dest: PathBuf::from("/snap/sv-b/20260322-1430-b"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-b/20260322-1430-b"),
                     subvolume_name: "sv-b".to_string(),
                 },
             ],
@@ -3101,12 +3102,12 @@ source = "/data/b"
             operations: vec![
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/b"),
-                    dest: PathBuf::from("/snap/sv-b/20260322-1430-b"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-b/20260322-1430-b"),
                     subvolume_name: "sv-b".to_string(),
                 },
             ],
@@ -3147,7 +3148,7 @@ source = "/data/b"
         let plan = BackupPlan {
             lifecycles: HashMap::new(),
             operations: vec![PlannedOperation::SendFull {
-                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                 dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
@@ -3371,11 +3372,11 @@ source = "/data/b"
             operations: vec![
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::SendFull {
-                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     dest_dir: dest_dir.clone(),
                     drive_label: "TEST-DRIVE".to_string(),
                     subvolume_name: "sv-a".to_string(),
@@ -3421,11 +3422,11 @@ source = "/data/b"
             operations: vec![
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::SendFull {
-                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     dest_dir,
                     drive_label: "TEST-DRIVE".to_string(),
                     subvolume_name: "sv-a".to_string(),
@@ -3461,7 +3462,7 @@ log_dir = "/tmp/urd-test"
 
 [local_snapshots]
 roots = [
-  {{ path = "/snap", subvolumes = ["sv1"] }}
+  {{ path = "/nonexistent-urd/snap", subvolumes = ["sv1"] }}
 ]
 
 [defaults]
@@ -3557,7 +3558,7 @@ source = "/data/sv1"
         BackupPlan {
             lifecycles: HashMap::new(),
             operations: vec![PlannedOperation::SendFull {
-                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                 dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
@@ -3654,7 +3655,7 @@ source = "/data/sv1"
         BackupPlan {
             lifecycles: HashMap::new(),
             operations: vec![PlannedOperation::SendFull {
-                snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                 dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                 drive_label: "TEST-DRIVE".to_string(),
                 subvolume_name: "sv-a".to_string(),
@@ -3745,7 +3746,7 @@ source = "/data/sv1"
         // Fail snapshot creation for sv-b so it genuinely fails
         mock.fail_creates
             .borrow_mut()
-            .insert(PathBuf::from("/snap/sv-b/20260322-1430-b"));
+            .insert(PathBuf::from("/nonexistent-urd/snap/sv-b/20260322-1430-b"));
 
         let config = test_config();
         let shutdown = no_shutdown();
@@ -3761,7 +3762,7 @@ source = "/data/sv1"
             operations: vec![
                 // sv-a: chain-break full send → will be deferred
                 PlannedOperation::SendFull {
-                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     dest_dir: PathBuf::from("/mnt/test/.snapshots/sv-a"),
                     drive_label: "TEST-DRIVE".to_string(),
                     subvolume_name: "sv-a".to_string(),
@@ -3772,7 +3773,7 @@ source = "/data/sv1"
                 // sv-b: snapshot create that will fail
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/b"),
-                    dest: PathBuf::from("/snap/sv-b/20260322-1430-b"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-b/20260322-1430-b"),
                     subvolume_name: "sv-b".to_string(),
                 },
             ],
@@ -4378,13 +4379,13 @@ local_retention = "transient"
             lifecycles: HashMap::new(),
             operations: vec![
                 PlannedOperation::DeleteSnapshot {
-                    path: PathBuf::from("/snap/sv-a/20260301-a"),
+                    path: PathBuf::from("/nonexistent-urd/snap/sv-a/20260301-a"),
                     reason: "space pressure: expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     kind: DeleteKind::SpacePressure,
                 },
                 PlannedOperation::DeleteSnapshot {
-                    path: PathBuf::from("/snap/sv-a/20260302-a"),
+                    path: PathBuf::from("/nonexistent-urd/snap/sv-a/20260302-a"),
                     reason: "space pressure: expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     kind: DeleteKind::SpacePressure,
@@ -4411,19 +4412,19 @@ local_retention = "transient"
         assert_eq!(relevant.len(), 4);
         assert!(matches!(
             relevant[0],
-            MockBtrfsCall::DeleteSubvolume { path } if path == Path::new("/snap/sv-a/20260301-a")
+            MockBtrfsCall::DeleteSubvolume { path } if path == Path::new("/nonexistent-urd/snap/sv-a/20260301-a")
         ));
         assert!(matches!(
             relevant[1],
-            MockBtrfsCall::SyncSubvolumes { path } if path == Path::new("/snap/sv-a")
+            MockBtrfsCall::SyncSubvolumes { path } if path == Path::new("/nonexistent-urd/snap/sv-a")
         ));
         assert!(matches!(
             relevant[2],
-            MockBtrfsCall::DeleteSubvolume { path } if path == Path::new("/snap/sv-a/20260302-a")
+            MockBtrfsCall::DeleteSubvolume { path } if path == Path::new("/nonexistent-urd/snap/sv-a/20260302-a")
         ));
         assert!(matches!(
             relevant[3],
-            MockBtrfsCall::SyncSubvolumes { path } if path == Path::new("/snap/sv-a")
+            MockBtrfsCall::SyncSubvolumes { path } if path == Path::new("/nonexistent-urd/snap/sv-a")
         ));
     }
 
@@ -4433,7 +4434,7 @@ local_retention = "transient"
         // Fail sync for the snapshot root
         mock.fail_syncs
             .borrow_mut()
-            .insert(PathBuf::from("/snap/sv-a"));
+            .insert(PathBuf::from("/nonexistent-urd/snap/sv-a"));
 
         let config = test_config();
         let shutdown = no_shutdown();
@@ -4448,14 +4449,14 @@ local_retention = "transient"
             operations: vec![
                 // SpacePressure kind so the sync path runs (and is configured to fail).
                 PlannedOperation::DeleteSnapshot {
-                    path: PathBuf::from("/snap/sv-a/20260301-a"),
+                    path: PathBuf::from("/nonexistent-urd/snap/sv-a/20260301-a"),
                     reason: "space pressure: expired".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     kind: DeleteKind::SpacePressure,
                 },
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
             ],
@@ -4646,7 +4647,8 @@ local_retention = "transient"
 
         let mock = MockBtrfs::new();
         *mock.mock_bytes_transferred.borrow_mut() = Some(1_000_000);
-        // test_config() uses /snap which doesn't exist on the test runner —
+        // test_config()'s snapshot root exists on no machine (deliberately —
+        // a literal `/snap` once did exist on Ubuntu CI runners via snapd) —
         // statvfs returns Err, source_free_bytes becomes None.
         let config = test_config();
         let shutdown = no_shutdown();
@@ -4675,7 +4677,7 @@ local_retention = "transient"
         // Fail the only send in simple_plan.
         mock.fail_sends
             .borrow_mut()
-            .insert(PathBuf::from("/snap/sv-a/20260322-1430-a"));
+            .insert(PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"));
 
         let config = test_config();
         let shutdown = no_shutdown();
@@ -4731,20 +4733,20 @@ local_retention = "transient"
             operations: vec![
                 PlannedOperation::CreateSnapshot {
                     source: PathBuf::from("/data/a"),
-                    dest: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    dest: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::SendIncremental {
-                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
-                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    parent: PathBuf::from("/nonexistent-urd/snap/sv-a/20260321-a"),
+                    snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     dest_dir: PathBuf::from("/mnt/drive-a/.snapshots/sv-a"),
                     drive_label: "DRIVE-A".to_string(),
                     subvolume_name: "sv-a".to_string(),
                     pin_on_success: None,
                 },
                 PlannedOperation::SendIncremental {
-                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
-                    snapshot: PathBuf::from("/snap/sv-a/20260322-1430-a"),
+                    parent: PathBuf::from("/nonexistent-urd/snap/sv-a/20260321-a"),
+                    snapshot: PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a"),
                     dest_dir: PathBuf::from("/mnt/drive-b/.snapshots/sv-a"),
                     drive_label: "DRIVE-B".to_string(),
                     subvolume_name: "sv-a".to_string(),
@@ -4784,8 +4786,8 @@ local_retention = "transient"
         // so the fail_sends set will fail BOTH. Use two distinct snapshots
         // instead by having two CreateSnapshot ops.
 
-        let snap_a = PathBuf::from("/snap/sv-a/20260322-1430-a");
-        let snap_b = PathBuf::from("/snap/sv-b/20260322-1430-b");
+        let snap_a = PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-a");
+        let snap_b = PathBuf::from("/nonexistent-urd/snap/sv-b/20260322-1430-b");
         // Fail sv-a's send only.
         mock.fail_sends.borrow_mut().insert(snap_a.clone());
 
@@ -4796,7 +4798,7 @@ local_retention = "transient"
         // honest, both sends must be within the same subvolume.
         // Workaround: rename the snapshots to distinct paths but keep
         // subvolume_name = "sv-a" on both ops.
-        let snap_b_for_sv_a = PathBuf::from("/snap/sv-a/20260322-1430-b-second");
+        let snap_b_for_sv_a = PathBuf::from("/nonexistent-urd/snap/sv-a/20260322-1430-b-second");
         let config = test_config();
         let shutdown = no_shutdown();
         let db = StateDb::open_memory().unwrap();
@@ -4816,7 +4818,7 @@ local_retention = "transient"
                     subvolume_name: "sv-a".to_string(),
                 },
                 PlannedOperation::SendIncremental {
-                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
+                    parent: PathBuf::from("/nonexistent-urd/snap/sv-a/20260321-a"),
                     snapshot: snap_a.clone(),
                     dest_dir: PathBuf::from("/mnt/drive-a/.snapshots/sv-a"),
                     drive_label: "DRIVE-A".to_string(),
@@ -4824,7 +4826,7 @@ local_retention = "transient"
                     pin_on_success: None,
                 },
                 PlannedOperation::SendIncremental {
-                    parent: PathBuf::from("/snap/sv-a/20260321-a"),
+                    parent: PathBuf::from("/nonexistent-urd/snap/sv-a/20260321-a"),
                     snapshot: snap_b_for_sv_a.clone(),
                     dest_dir: PathBuf::from("/mnt/drive-b/.snapshots/sv-a"),
                     drive_label: "DRIVE-B".to_string(),
@@ -5875,7 +5877,7 @@ metrics_file = "/tmp/urd-test/backup.prom"
 log_dir = "/tmp/urd-test"
 
 [local_snapshots]
-roots = [ { path = "/snap", subvolumes = ["named-transient", "named-graduated"] } ]
+roots = [ { path = "/nonexistent-urd/snap", subvolumes = ["named-transient", "named-graduated"] } ]
 
 [defaults]
 snapshot_interval = "1h"


### PR DESCRIPTION
## Summary

- PR #316's first `quality` run exposed 16 environment-coupled tests that pass on the Fedora dev machine but fail on a stock Ubuntu runner — the CI run acted as an involuntary hermeticity sweep of all 2,271 tests.
- **Executor (15 tests):** fixtures used `/snap` as the local snapshot root — absent on Fedora (mkdir fail-open guard skips real I/O), present on Ubuntu via snapd (guard passes → real `create_dir_all("/snap/sv-a")` → EACCES → op Failure). Fixtures now use `/nonexistent-urd/…`, absent by construction.
- **Seal (1 test):** the render-refusal test assumed no passwordless root; the runner's NOPASSWD grant made the live `sudo -n` probe read Granted, short-circuiting to Sealed before the refusal under test. The probe is now injected (`earn_privilege_with`, mirroring encounter's `delve_with` pattern) and stubbed Denied in tests; production wrapper passes the live probe, behavior unchanged.

## Testing

- cargo clippy --all-targets --locked -- -D warnings: pass (Rust 1.97.0, same as CI)
- cargo test --locked: 2271 passed, 0 failed, 5 ignored
- Runner-side proof: PR #316 rebases onto this and its quality job re-runs on Ubuntu — the environment that caught all 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)