### PR TITLE
feat: PromiseRollup — one projection for promise state (UPI 088-a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `urd backup`'s post-run table and `--json` output now carry the same complete
+  promise fields (`promise_level`, `retention_summary`, `external_only`) that
+  `urd status` shows for the same world — the two surfaces no longer disagree.
+  A healthy run's table is unchanged; the PROTECTION column appears only when
+  some promise is degraded, matching status's quiet gate (#297).
+
+### Changed
+- Promise-state reductions (transition detection, degradation direction, the
+  three-way partition, the all-unprotected check) and the notification prose
+  they feed each have exactly one implementation now (`PromiseRollup`,
+  `promise_changes`, `worsened_from`, one shared prose builder) — the backup
+  and sentinel notification paths render byte-identical sentences from one
+  core, pinned by golden tests. No behavior change (#297).
+
 ## [0.34.0] - 2026-07-11
 
 ### Added

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -86,6 +86,24 @@ Mostly separate from `PromiseStatus`: a subvolume can be `PROTECTED` yet `degrad
 lowercase engine word renders directly (`healthy` dimmed, `degraded` yellow, `blocked`
 red), and `urd status` shows the HEALTH column only when some subvolume is non-`healthy`.
 
+**PromiseRollup** (`awareness.rs`, UPI 088-a). The three-way partition of subvolume
+names by promise state — the single home of the protected/at-risk/unprotected
+reduction. Every "how many are sealed?" / "is everything broken?" question reads this
+one projection (`from_assessments` / `from_pairs`); no surface re-derives the
+partition. It rides gravity and carries no `Ord` of its own. Empty-input semantics are
+deliberately asymmetric and load-bearing: `all_protected()` is **vacuously true**
+(zero subvolumes, zero broken promises — `urd doctor` renders "✓ 0 of 0 sealed"),
+`all_unprotected()` is **guarded false** (the alarm needs actual subvolumes).
+
+**promise change** (`PromiseChange`, `awareness.rs`, UPI 088-a). The *detection
+result* of diffing two promise-snapshot sets by name: `name` went `from` → `to`,
+computed only by `awareness::promise_changes` (the single transition detection).
+Distinct from `EventPayload::PromiseTransition`, the *persisted event* a change may
+become downstream — a change is ephemeral analysis; a transition is history. First-run
+suppression belongs to callers, and the two callers differ deliberately: `notify`
+skips transitions on `previous: None` but still evaluates all-unprotected; the
+sentinel runner gates the whole call on `has_initial_assessment`.
+
 ## Cluster: Voice labels (presentation)
 
 The CLI surface renders the promise states with the mythic voice labels below. The
@@ -464,6 +482,20 @@ reads, rather than on the full fused surface.
 | `FileSystemState` | **Retired (UPI 052, 2026-05-29).** Was a bridge supertrait (`FilesystemQuery + HistoryQuery`) with a blanket impl, kept to preserve pre-split callers while the seam was narrowed. Every command-layer caller now depends on exactly the half it uses, so the bridge was deleted. Use `FilesystemQuery` / `HistoryQuery` / `Observation` instead. The concrete `RealFileSystemState` / `MockFileSystemState` types (which impl both halves) are unaffected. |
 
 Source: `observation.rs`, `btrfs.rs`, ADR-100, ADR-101, ADR-102.
+
+## Cluster: Projections (code idiom)
+
+**projection** (a.k.a. *sibling projection*). A small purpose-built type computed
+*from* a wide domain type, instead of widening the domain type with new fields — the
+codebase's standing answer to "this surface needs a different view of X." Instances:
+`ChurnHeartbeatFields` (heartbeat's narrow view of churn), `SubvolumeExtras`
+(status's per-subvolume enrichments), `PromiseRollup` (the promise partition,
+UPI 088-a). The idiom exists because widening is expensive and viral —
+`SubvolAssessment` has ~29 struct-literal construction sites and no `Default`, so
+every added field touches every site — while a sibling projection has one
+constructor and only the consumers that want it. Rule of thumb: if a new field on a
+wide type would be `None`/default at most construction sites, it wants to be a
+projection instead.
 
 ## Cluster: Planner soundness (UPI 069)
 

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -578,6 +578,70 @@ pub fn promise_changes(
         .collect()
 }
 
+/// The three-way partition of subvolume names by promise state — the
+/// single home of the protected/at-risk/unprotected reduction
+/// (UPI 088-a; deepening-05's `PromiseRollup`). Vectors preserve input
+/// order. A projection that rides gravity (`PromiseStatus`'s one `Ord`);
+/// it carries no ordering of its own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromiseRollup {
+    pub protected: Vec<String>,
+    pub at_risk: Vec<String>,
+    pub unprotected: Vec<String>,
+}
+
+impl PromiseRollup {
+    /// Partition assessments by promise state.
+    #[must_use]
+    pub fn from_assessments(assessments: &[SubvolAssessment]) -> Self {
+        Self::from_pairs(assessments.iter().map(|a| (a.name.clone(), a.status)))
+    }
+
+    /// Partition `(name, status)` pairs — the entry point for the other
+    /// promise-state carriers (heartbeat entries, status rows, doctor
+    /// rows).
+    #[must_use]
+    pub fn from_pairs(pairs: impl IntoIterator<Item = (String, PromiseStatus)>) -> Self {
+        let mut rollup = Self {
+            protected: Vec::new(),
+            at_risk: Vec::new(),
+            unprotected: Vec::new(),
+        };
+        for (name, status) in pairs {
+            match status {
+                PromiseStatus::Protected => rollup.protected.push(name),
+                PromiseStatus::AtRisk => rollup.at_risk.push(name),
+                PromiseStatus::Unprotected => rollup.unprotected.push(name),
+            }
+        }
+        rollup
+    }
+
+    /// Total number of subvolumes rolled up.
+    #[must_use]
+    pub fn total(&self) -> usize {
+        self.protected.len() + self.at_risk.len() + self.unprotected.len()
+    }
+
+    /// Is every promise kept? Vacuously TRUE on empty input — zero
+    /// subvolumes means zero broken promises (`urd doctor` says
+    /// "✓ 0 of 0 sealed" for an all-disabled config). Deliberately
+    /// asymmetric with `all_unprotected`.
+    #[must_use]
+    pub fn all_protected(&self) -> bool {
+        self.at_risk.is_empty() && self.unprotected.is_empty()
+    }
+
+    /// Is every promise broken? FALSE on empty input — the alarm only
+    /// rings over actual subvolumes (both notification paths' historic
+    /// `!is_empty()` guard). Deliberately asymmetric with
+    /// `all_protected`.
+    #[must_use]
+    pub fn all_unprotected(&self) -> bool {
+        !self.unprotected.is_empty() && self.protected.is_empty() && self.at_risk.is_empty()
+    }
+}
+
 // ── Core function ──────────────────────────────────────────────────────
 
 /// Diff a previous set of promise snapshots against the current
@@ -5360,6 +5424,81 @@ source = "/data/sv1"
             make_promise_snapshot("newborn", PromiseStatus::Unprotected),
         ];
         assert!(promise_changes(&prev, &curr).is_empty());
+    }
+
+    // ── PromiseRollup (UPI 088-a) ───────────────────────────────────
+
+    #[test]
+    fn rollup_empty_is_vacuously_protected_but_not_unprotected() {
+        // The asymmetry pair: all_protected() is vacuous truth (zero
+        // subvolumes, zero broken promises); all_unprotected() is
+        // guarded false (the alarm needs actual subvolumes).
+        let rollup = PromiseRollup::from_assessments(&[]);
+        assert_eq!(rollup.total(), 0);
+        assert!(rollup.all_protected());
+        assert!(!rollup.all_unprotected());
+    }
+
+    #[test]
+    fn rollup_partitions_mixed_assessments() {
+        let assessments = vec![
+            make_assess("a", PromiseStatus::Protected),
+            make_assess("b", PromiseStatus::AtRisk),
+            make_assess("c", PromiseStatus::Unprotected),
+            make_assess("d", PromiseStatus::Protected),
+        ];
+        let rollup = PromiseRollup::from_assessments(&assessments);
+        assert_eq!(rollup.protected, vec!["a", "d"]);
+        assert_eq!(rollup.at_risk, vec!["b"]);
+        assert_eq!(rollup.unprotected, vec!["c"]);
+        assert_eq!(rollup.total(), 4);
+        assert!(!rollup.all_protected());
+        assert!(!rollup.all_unprotected());
+    }
+
+    #[test]
+    fn rollup_all_protected_when_every_promise_kept() {
+        let assessments = vec![
+            make_assess("a", PromiseStatus::Protected),
+            make_assess("b", PromiseStatus::Protected),
+        ];
+        let rollup = PromiseRollup::from_assessments(&assessments);
+        assert!(rollup.all_protected());
+        assert!(!rollup.all_unprotected());
+    }
+
+    #[test]
+    fn rollup_all_unprotected_when_every_promise_broken() {
+        let assessments = vec![
+            make_assess("a", PromiseStatus::Unprotected),
+            make_assess("b", PromiseStatus::Unprotected),
+        ];
+        let rollup = PromiseRollup::from_assessments(&assessments);
+        assert!(rollup.all_unprotected());
+        assert!(!rollup.all_protected());
+    }
+
+    #[test]
+    fn rollup_preserves_input_order_within_each_partition() {
+        let assessments = vec![
+            make_assess("z", PromiseStatus::AtRisk),
+            make_assess("a", PromiseStatus::AtRisk),
+            make_assess("m", PromiseStatus::AtRisk),
+        ];
+        let rollup = PromiseRollup::from_assessments(&assessments);
+        assert_eq!(rollup.at_risk, vec!["z", "a", "m"]);
+    }
+
+    #[test]
+    fn rollup_from_pairs_matches_from_assessments() {
+        let assessments = vec![
+            make_assess("a", PromiseStatus::Protected),
+            make_assess("b", PromiseStatus::Unprotected),
+        ];
+        let via_pairs = PromiseRollup::from_pairs(
+            assessments.iter().map(|a| (a.name.clone(), a.status)),
+        );
+        assert_eq!(via_pairs, PromiseRollup::from_assessments(&assessments));
     }
 
     #[test]

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -511,6 +511,73 @@ pub struct DriveAssessment {
     pub rotation: Option<DriveRotation>,
 }
 
+// ── Promise snapshots and transition detection (UPI 088-a) ─────────────
+
+/// A snapshot of promise state from a single assessment, used for
+/// comparing state transitions across time.
+///
+/// Formerly defined in `sentinel.rs` — a core→daemon inversion, since
+/// this module's own transition detection consumed it. It lives beside
+/// `PromiseStatus` now; the daemon imports it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromiseSnapshot {
+    pub name: String,
+    pub status: PromiseStatus,
+}
+
+/// Extract promise snapshots from assessments for state storage.
+#[must_use]
+pub fn snapshot_promises(assessments: &[SubvolAssessment]) -> Vec<PromiseSnapshot> {
+    assessments
+        .iter()
+        .map(|a| PromiseSnapshot {
+            name: a.name.clone(),
+            status: a.status,
+        })
+        .collect()
+}
+
+/// One detected promise-state change: `name` went `from` → `to`.
+///
+/// The detection *result* — distinct from the persisted
+/// `EventPayload::PromiseTransition` it may become downstream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromiseChange {
+    pub name: String,
+    pub from: PromiseStatus,
+    pub to: PromiseStatus,
+}
+
+/// The single transition detection: diff two snapshot sets by name and
+/// report every status change, in `current` order.
+///
+/// Names present only in `previous` are silent (a vanished subvolume is
+/// not a transition); names new in `current` are silent too (no `from`
+/// to compare against). Callers own first-run suppression:
+/// `notify::compute_notifications` skips on `previous: None`, the
+/// sentinel runner gates on `has_initial_assessment` — the two
+/// semantics differ deliberately and stay caller-side.
+#[must_use]
+pub fn promise_changes(
+    previous: &[PromiseSnapshot],
+    current: &[PromiseSnapshot],
+) -> Vec<PromiseChange> {
+    current
+        .iter()
+        .filter_map(|curr| {
+            previous
+                .iter()
+                .find(|p| p.name == curr.name)
+                .filter(|prev| prev.status != curr.status)
+                .map(|prev| PromiseChange {
+                    name: curr.name.clone(),
+                    from: prev.status,
+                    to: curr.status,
+                })
+        })
+        .collect()
+}
+
 // ── Core function ──────────────────────────────────────────────────────
 
 /// Diff a previous set of promise snapshots against the current
@@ -519,14 +586,11 @@ pub struct DriveAssessment {
 ///
 /// Pure function. Empty `previous` returns an empty Vec (suppresses
 /// noise on first run, matching the precedent in
-/// `sentinel::has_promise_changes`). Subvolumes present in `previous` but
-/// missing from `current` are silent (deletion is not a transition we
-/// log). Subvolumes new in `current` (not in `previous`) are also
-/// silent — appearance is not a transition either.
+/// `sentinel::has_promise_changes`). Name-set asymmetries are silent —
+/// see `promise_changes`, which owns the detection.
 #[must_use]
-#[allow(dead_code)]
 pub fn diff_promise_states(
-    previous: &[crate::sentinel::PromiseSnapshot],
+    previous: &[PromiseSnapshot],
     current: &[SubvolAssessment],
     now: NaiveDateTime,
     trigger: crate::events::TransitionTrigger,
@@ -534,24 +598,21 @@ pub fn diff_promise_states(
     if previous.is_empty() {
         return Vec::new();
     }
-    let mut events = Vec::new();
-    for assess in current {
-        if let Some(prev) = previous.iter().find(|p| p.name == assess.name)
-            && prev.status != assess.status
-        {
+    promise_changes(previous, &snapshot_promises(current))
+        .into_iter()
+        .map(|change| {
             let mut event = crate::events::Event::pure(
                 now,
                 crate::events::EventPayload::PromiseTransition {
-                    from: prev.status,
-                    to: assess.status,
+                    from: change.from,
+                    to: change.to,
                     trigger,
                 },
             );
-            event.subvolume = Some(assess.name.clone());
-            events.push(event);
-        }
-    }
-    events
+            event.subvolume = Some(change.name);
+            event
+        })
+        .collect()
 }
 
 /// Compute promise states for all enabled subvolumes.
@@ -1925,7 +1986,7 @@ source = "/data/sv1"
         let pre = assess(&config, now, &obs, &signals);
         let post = assess(&config, now, &obs, &signals);
 
-        let prev_snapshots = crate::sentinel::snapshot_promises(&pre);
+        let prev_snapshots = snapshot_promises(&pre);
         let events = diff_promise_states(
             &prev_snapshots,
             &post,
@@ -1949,7 +2010,7 @@ source = "/data/sv1"
         let blind_pre = assess(&config, now, &obs, &StorageSignalMap::new());
         let judged_post = assess(&config, now, &obs, &signals);
 
-        let prev_snapshots = crate::sentinel::snapshot_promises(&blind_pre);
+        let prev_snapshots = snapshot_promises(&blind_pre);
         let events = diff_promise_states(
             &prev_snapshots,
             &judged_post,
@@ -5213,11 +5274,8 @@ source = "/data/sv1"
         }
     }
 
-    fn make_promise_snapshot(
-        name: &str,
-        status: PromiseStatus,
-    ) -> crate::sentinel::PromiseSnapshot {
-        crate::sentinel::PromiseSnapshot {
+    fn make_promise_snapshot(name: &str, status: PromiseStatus) -> PromiseSnapshot {
+        PromiseSnapshot {
             name: name.to_string(),
             status,
         }
@@ -5228,6 +5286,98 @@ source = "/data/sv1"
             .unwrap()
             .and_hms_opt(3, 14, 22)
             .unwrap()
+    }
+
+    // ── snapshot_promises + promise_changes (UPI 088-a) ────────────
+
+    #[test]
+    fn snapshot_promises_roundtrip() {
+        // Moved from sentinel.rs with the function.
+        let assessments = vec![
+            make_assess("sv1", PromiseStatus::Protected),
+            make_assess("sv2", PromiseStatus::AtRisk),
+        ];
+
+        let snaps = snapshot_promises(&assessments);
+        assert_eq!(snaps.len(), 2);
+        assert_eq!(snaps[0].name, "sv1");
+        assert_eq!(snaps[0].status, PromiseStatus::Protected);
+        assert_eq!(snaps[1].name, "sv2");
+        assert_eq!(snaps[1].status, PromiseStatus::AtRisk);
+    }
+
+    #[test]
+    fn promise_changes_empty_inputs_yield_nothing() {
+        assert!(promise_changes(&[], &[]).is_empty());
+    }
+
+    #[test]
+    fn promise_changes_detects_degradation() {
+        let prev = vec![make_promise_snapshot("sv1", PromiseStatus::Protected)];
+        let curr = vec![make_promise_snapshot("sv1", PromiseStatus::AtRisk)];
+        let changes = promise_changes(&prev, &curr);
+        assert_eq!(
+            changes,
+            vec![PromiseChange {
+                name: "sv1".to_string(),
+                from: PromiseStatus::Protected,
+                to: PromiseStatus::AtRisk,
+            }]
+        );
+    }
+
+    #[test]
+    fn promise_changes_detects_recovery() {
+        let prev = vec![make_promise_snapshot("sv1", PromiseStatus::Unprotected)];
+        let curr = vec![make_promise_snapshot("sv1", PromiseStatus::Protected)];
+        let changes = promise_changes(&prev, &curr);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].from, PromiseStatus::Unprotected);
+        assert_eq!(changes[0].to, PromiseStatus::Protected);
+    }
+
+    #[test]
+    fn promise_changes_no_change_is_silent() {
+        let prev = vec![make_promise_snapshot("sv1", PromiseStatus::AtRisk)];
+        let curr = vec![make_promise_snapshot("sv1", PromiseStatus::AtRisk)];
+        assert!(promise_changes(&prev, &curr).is_empty());
+    }
+
+    #[test]
+    fn promise_changes_name_only_in_previous_is_silent() {
+        // A vanished subvolume is not a transition.
+        let prev = vec![make_promise_snapshot("gone", PromiseStatus::Protected)];
+        let curr = vec![make_promise_snapshot("sv1", PromiseStatus::Protected)];
+        assert!(promise_changes(&prev, &curr).is_empty());
+    }
+
+    #[test]
+    fn promise_changes_name_only_in_current_is_silent() {
+        // A new subvolume has no `from` — appearance is not a transition.
+        let prev = vec![make_promise_snapshot("sv1", PromiseStatus::Protected)];
+        let curr = vec![
+            make_promise_snapshot("sv1", PromiseStatus::Protected),
+            make_promise_snapshot("newborn", PromiseStatus::Unprotected),
+        ];
+        assert!(promise_changes(&prev, &curr).is_empty());
+    }
+
+    #[test]
+    fn promise_changes_preserve_current_order() {
+        let prev = vec![
+            make_promise_snapshot("a", PromiseStatus::Protected),
+            make_promise_snapshot("b", PromiseStatus::Protected),
+            make_promise_snapshot("c", PromiseStatus::AtRisk),
+        ];
+        // `current` deliberately reordered vs `previous`: output follows current.
+        let curr = vec![
+            make_promise_snapshot("c", PromiseStatus::Protected),
+            make_promise_snapshot("a", PromiseStatus::Unprotected),
+            make_promise_snapshot("b", PromiseStatus::Protected),
+        ];
+        let changes = promise_changes(&prev, &curr);
+        let names: Vec<&str> = changes.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["c", "a"]);
     }
 
     #[test]

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -204,6 +204,19 @@ pub enum PromiseStatus {
     Protected,
 }
 
+impl PromiseStatus {
+    /// Did the promise worsen relative to `prev`?
+    ///
+    /// The single home of the `to < from` direction test (UPI 088-a) —
+    /// every degradation/recovery decision delegates here. Rides the
+    /// enum's worst-to-best `Ord`; the "do not reorder" contract above
+    /// is what makes this comparison meaningful.
+    #[must_use]
+    pub fn worsened_from(self, prev: Self) -> bool {
+        self < prev
+    }
+}
+
 impl std::fmt::Display for PromiseStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -1418,6 +1431,19 @@ mod tests {
     use crate::plan::MockFileSystemState;
     use crate::types::SnapshotName;
     use chrono::NaiveDate;
+
+    // ── PromiseStatus::worsened_from (UPI 088-a) ────────────────────
+    // Moved from notify.rs (`is_degradation_follows_ord`) when the
+    // direction test got its single home next to the Ord it rides.
+
+    #[test]
+    fn worsened_from_follows_ord() {
+        // Worsening (to < from) is a degradation; improving is not.
+        assert!(PromiseStatus::AtRisk.worsened_from(PromiseStatus::Protected));
+        assert!(PromiseStatus::Unprotected.worsened_from(PromiseStatus::AtRisk));
+        assert!(!PromiseStatus::Protected.worsened_from(PromiseStatus::AtRisk));
+        assert!(!PromiseStatus::Protected.worsened_from(PromiseStatus::Protected));
+    }
 
     /// Test config with one drive and min_free_bytes set.
     fn test_config_with_min_free() -> Config {

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -607,7 +607,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // Backup is canonical for in-run promise transitions (trigger=Run);
     // sentinel skips on BackupCompleted to avoid duplicates.
     if let Some(db) = world.db() {
-        let prev_snapshots = crate::sentinel::snapshot_promises(&pre_assessments);
+        let prev_snapshots = awareness::snapshot_promises(&pre_assessments);
         let promise_events = awareness::diff_promise_states(
             &prev_snapshots,
             &assessments,

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -627,7 +627,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let summary = build_backup_summary(
         &backup_plan,
         &result,
-        &assessments,
+        StatusAssessment::rows(&assessments, &config.resolved_subvolumes(), heartbeat_now),
         transitions,
         exec_duration,
         &preflight_warnings,
@@ -1130,12 +1130,15 @@ fn send_kind_display(op_name: &str) -> Option<&'static str> {
     }
 }
 
-/// Build a structured backup summary from plan, execution results, and awareness assessments.
-/// Pure function — no I/O.
+/// Build a structured backup summary from plan, execution results, and
+/// the completed assessment rows. Pure function — no I/O. The caller
+/// builds rows via `StatusAssessment::rows()` (UPI 088-a), so backup's
+/// rows carry the same promise fields status's do — the split-brain is
+/// closed at the constructor, not by a backfill here.
 fn build_backup_summary(
     plan: &BackupPlan,
     result: &ExecutionResult,
-    assessments: &[SubvolAssessment],
+    assessment_rows: Vec<StatusAssessment>,
     transitions: Vec<TransitionEvent>,
     duration: Duration,
     preflight_warnings: &[preflight::PreflightCheck],
@@ -1312,10 +1315,7 @@ fn build_backup_summary(
         duration_secs: duration.as_secs_f64(),
         subvolumes,
         skipped,
-        assessments: assessments
-            .iter()
-            .map(StatusAssessment::from_assessment)
-            .collect(),
+        assessments: assessment_rows,
         transitions,
         warnings,
         notes,
@@ -3370,6 +3370,75 @@ source = "/data/beta"
         }
     }
 
+    /// Resolved subvolumes matching the given assessments by name —
+    /// `rows()` joins on the name and a miss debug-asserts, so the
+    /// fixture derives from whatever assessments a test passes.
+    fn summary_resolved(
+        assessments: &[SubvolAssessment],
+    ) -> Vec<crate::config::ResolvedSubvolume> {
+        assessments
+            .iter()
+            .map(|a| crate::config::ResolvedSubvolume {
+                name: a.name.clone(),
+                short_name: a.short_name.clone(),
+                source: PathBuf::from(format!("/data/{}", a.name)),
+                priority: 5,
+                enabled: true,
+                snapshot_interval: Interval::hours(1),
+                send_interval: Interval::days(1),
+                send_enabled: true,
+                local_retention: crate::types::LocalRetentionPolicy::Graduated(
+                    crate::types::ResolvedGraduatedRetention {
+                        hourly: 24,
+                        daily: 30,
+                        weekly: 0,
+                        monthly: crate::types::MonthlyCount::Count(0),
+                        yearly: 0,
+                    },
+                ),
+                external_retention: crate::types::ResolvedGraduatedRetention {
+                    hourly: 0,
+                    daily: 30,
+                    weekly: 0,
+                    monthly: crate::types::MonthlyCount::Count(0),
+                    yearly: 0,
+                },
+                protection_level: Some(ProtectionLevel::Sheltered),
+                drives: None,
+                snapshot_root: None,
+                min_free_bytes: None,
+            })
+            .collect()
+    }
+
+    fn summary_now() -> chrono::NaiveDateTime {
+        chrono::NaiveDate::from_ymd_opt(2026, 7, 11)
+            .unwrap()
+            .and_hms_opt(4, 0, 0)
+            .unwrap()
+    }
+
+    /// UPI 088-a: `build_backup_summary` now takes completed rows.
+    /// This wrapper builds them from name-matched fixtures so the
+    /// summary tests stay single calls.
+    fn summary_for_test(
+        plan: &BackupPlan,
+        result: &ExecutionResult,
+        assessments: &[SubvolAssessment],
+        transitions: Vec<TransitionEvent>,
+        duration: Duration,
+        preflight_warnings: &[preflight::PreflightCheck],
+    ) -> BackupSummary {
+        build_backup_summary(
+            plan,
+            result,
+            StatusAssessment::rows(assessments, &summary_resolved(assessments), summary_now()),
+            transitions,
+            duration,
+            preflight_warnings,
+        )
+    }
+
     #[test]
     fn build_summary_extracts_successful_sends_only() {
         let result = ExecutionResult {
@@ -3400,7 +3469,7 @@ source = "/data/beta"
             run_id: Some(10),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &empty_plan(),
             &result,
             &empty_assessments(),
@@ -3426,18 +3495,18 @@ source = "/data/beta"
     }
 
     #[test]
-    fn backup_json_assessment_rows_lack_promise_fields() {
-        // Golden fixture (UPI 088-a, arc R8): pins today's split-brain —
-        // backup's serialized assessment rows carry NO promise_level /
-        // retention_summary / external_only keys (status backfills them,
-        // backup doesn't). Step 6 of 088-a deliberately flips this test
-        // when the mirror becomes total: the keys appear, additively.
+    fn backup_json_assessment_rows_carry_promise_fields() {
+        // Golden fixture, deliberately FLIPPED in step 6 (UPI 088-a):
+        // step 1 pinned these keys ABSENT (the split-brain — status
+        // backfilled them, backup didn't). The mirror is total now;
+        // backup's serialized rows carry the same keys status's do.
+        // This is the slice's one intended visible change.
         let result = ExecutionResult {
             overall: RunResult::Success,
             subvolume_results: vec![],
             run_id: Some(10),
         };
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &empty_plan(),
             &result,
             &sample_assessments(),
@@ -3449,17 +3518,41 @@ source = "/data/beta"
         let json = serde_json::to_value(&summary).expect("summary serializes");
         let row = &json["assessments"][0];
         assert_eq!(row["name"], "htpc-home");
+        assert_eq!(row["promise_level"], "sheltered");
         assert!(
-            row.get("promise_level").is_none(),
-            "backup rows carry no promise_level pre-088-a"
-        );
-        assert!(
-            row.get("retention_summary").is_none(),
-            "backup rows carry no retention_summary pre-088-a"
+            row["retention_summary"].is_string(),
+            "graduated fixture policy renders a retention summary"
         );
         assert!(
             row.get("external_only").is_none(),
-            "external_only is skip-when-false and from_assessment defaults it"
+            "still skip-when-false: the fixture policy is not transient"
+        );
+    }
+
+    #[test]
+    fn backup_rows_match_status_rows_for_same_world() {
+        // The split-brain heal, asserted: for one world, backup's
+        // serialized assessment rows equal the rows status builds.
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![],
+            run_id: Some(10),
+        };
+        let assessments = sample_assessments();
+        let resolved = summary_resolved(&assessments);
+        let summary = summary_for_test(
+            &empty_plan(),
+            &result,
+            &assessments,
+            vec![],
+            Duration::from_secs(5),
+            &[],
+        );
+        let status_rows = StatusAssessment::rows(&assessments, &resolved, summary_now());
+
+        assert_eq!(
+            serde_json::to_value(&summary.assessments).unwrap(),
+            serde_json::to_value(&status_rows).unwrap(),
         );
     }
 
@@ -3492,7 +3585,7 @@ source = "/data/beta"
             run_id: Some(11),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &empty_plan(),
             &result,
             &empty_assessments(),
@@ -3520,7 +3613,7 @@ source = "/data/beta"
             run_id: Some(12),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &empty_plan(),
             &result,
             &empty_assessments(),
@@ -3542,7 +3635,7 @@ source = "/data/beta"
             run_id: Some(13),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &empty_plan(),
             &result,
             &empty_assessments(),
@@ -3598,7 +3691,7 @@ source = "/data/beta"
             run_id: Some(14),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &plan,
             &result,
             &empty_assessments(),
@@ -3663,7 +3756,7 @@ source = "/data/beta"
             )],
             run_id: Some(15),
         };
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &plan,
             &result,
             &empty_assessments(),
@@ -3691,7 +3784,7 @@ source = "/data/beta"
             subvolume_results: vec![],
             run_id: Some(16),
         };
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &plan,
             &result,
             &empty_assessments(),
@@ -3731,7 +3824,7 @@ source = "/data/beta"
             run_id: None,
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &plan,
             &result,
             &empty_assessments(),
@@ -3755,7 +3848,7 @@ source = "/data/beta"
             run_id: Some(15),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &empty_plan(),
             &result,
             &sample_assessments(),
@@ -3777,7 +3870,7 @@ source = "/data/beta"
             run_id: Some(99),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &empty_plan(),
             &result,
             &empty_assessments(),
@@ -3813,7 +3906,7 @@ source = "/data/beta"
             run_id: Some(16),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &empty_plan(),
             &result,
             &empty_assessments(),
@@ -4753,7 +4846,7 @@ source = "/data/beta"
             run_id: Some(1),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &plan, &result, &empty_assessments(),
             vec![], Duration::from_secs(1), &[],
         );
@@ -4776,7 +4869,7 @@ source = "/data/beta"
             run_id: Some(1),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &plan, &result, &empty_assessments(),
             vec![], Duration::from_secs(1), &[],
         );
@@ -4796,7 +4889,7 @@ source = "/data/beta"
             run_id: Some(1),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &plan, &result, &empty_assessments(),
             vec![], Duration::from_secs(1), &[],
         );
@@ -4818,7 +4911,7 @@ source = "/data/beta"
             run_id: Some(1),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &plan, &result, &empty_assessments(),
             vec![], Duration::from_secs(1), &[],
         );
@@ -4837,7 +4930,7 @@ source = "/data/beta"
             run_id: Some(1),
         };
 
-        let summary = build_backup_summary(
+        let summary = summary_for_test(
             &plan, &result, &empty_assessments(),
             vec![], Duration::from_secs(1), &[],
         );

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -3426,6 +3426,44 @@ source = "/data/beta"
     }
 
     #[test]
+    fn backup_json_assessment_rows_lack_promise_fields() {
+        // Golden fixture (UPI 088-a, arc R8): pins today's split-brain —
+        // backup's serialized assessment rows carry NO promise_level /
+        // retention_summary / external_only keys (status backfills them,
+        // backup doesn't). Step 6 of 088-a deliberately flips this test
+        // when the mirror becomes total: the keys appear, additively.
+        let result = ExecutionResult {
+            overall: RunResult::Success,
+            subvolume_results: vec![],
+            run_id: Some(10),
+        };
+        let summary = build_backup_summary(
+            &empty_plan(),
+            &result,
+            &sample_assessments(),
+            vec![],
+            Duration::from_secs(5),
+            &[],
+        );
+
+        let json = serde_json::to_value(&summary).expect("summary serializes");
+        let row = &json["assessments"][0];
+        assert_eq!(row["name"], "htpc-home");
+        assert!(
+            row.get("promise_level").is_none(),
+            "backup rows carry no promise_level pre-088-a"
+        );
+        assert!(
+            row.get("retention_summary").is_none(),
+            "backup rows carry no retention_summary pre-088-a"
+        );
+        assert!(
+            row.get("external_only").is_none(),
+            "external_only is skip-when-false and from_assessment defaults it"
+        );
+    }
+
+    #[test]
     fn build_summary_multi_drive_sends() {
         let result = ExecutionResult {
             overall: RunResult::Success,

--- a/src/commands/default.rs
+++ b/src/commands/default.rs
@@ -40,18 +40,15 @@ pub fn run(config_path: Option<&Path>, output_mode: OutputMode) -> anyhow::Resul
 
     let last_run_age_secs = last_run.as_ref().and_then(|run| run.age_secs(now));
 
-    // Build output — single pass over assessments
-    let total = assessments.len();
-    let mut waning_names = Vec::new();
-    let mut exposed_names = Vec::new();
+    // Build output — promise partition via the one rollup (UPI 088-a);
+    // health is an orthogonal axis, counted locally.
+    let rollup = awareness::PromiseRollup::from_assessments(&assessments);
+    let total = rollup.total();
+    let waning_names = rollup.at_risk;
+    let exposed_names = rollup.unprotected;
     let mut degraded_count = 0usize;
     let mut blocked_count = 0usize;
     for a in &assessments {
-        match a.status {
-            awareness::PromiseStatus::AtRisk => waning_names.push(a.name.clone()),
-            awareness::PromiseStatus::Unprotected => exposed_names.push(a.name.clone()),
-            awareness::PromiseStatus::Protected => {}
-        }
         match a.health {
             awareness::OperationalHealth::Degraded => degraded_count += 1,
             awareness::OperationalHealth::Blocked => blocked_count += 1,

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -11,7 +11,6 @@ use crate::output::{
     AdaptationSummary, ChainHealth, ChainHealthEntry, DriveInfo, LastRunInfo, OutputMode,
     PoolPostureSummary, StatusAssessment, StatusOutput,
 };
-use crate::retention;
 use crate::voice;
 
 pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
@@ -139,24 +138,10 @@ fn assemble_status_output(
     let redundancy_advisories =
         advice::compute_redundancy_advisories(config, assessments);
 
-    // Thread protection_level from resolved config into status assessments
+    // Complete rows at construction (UPI 088-a): the rows() join fills
+    // promise_level / retention_summary / external_only — no backfill.
     let resolved = config.resolved_subvolumes();
-    let assessments_with_promises: Vec<StatusAssessment> = assessments
-        .iter()
-        .map(|a| {
-            let mut sa = StatusAssessment::from_assessment(a);
-            if let Some(sv) = resolved.iter().find(|sv| sv.name == a.name) {
-                sa.promise_level = sv.protection_level.map(|pl| pl.to_string());
-                sa.retention_summary = Some(retention::retention_summary(
-                    &sv.local_retention,
-                    &sv.snapshot_interval,
-                    now,
-                ));
-                sa.external_only = sv.local_retention.is_transient() && sv.send_enabled;
-            }
-            sa
-        })
-        .collect();
+    let assessments_with_promises = StatusAssessment::rows(assessments, &resolved, now);
 
     let advice: Vec<advice::ActionableAdvice> = assessments
         .iter()
@@ -462,8 +447,23 @@ local_retention = "transient"
         assert!(sv2.external_only, "transient + send_enabled is external-only");
     }
 
+    // A name miss is impossible for real assess() output; rows() (UPI
+    // 088-a) debug-asserts on one and fails open in release. Two tests,
+    // one per build profile — the release twin is dormant under normal
+    // `cargo test` (debug) and documents the fail-open contract.
+
+    #[cfg(debug_assertions)]
     #[test]
-    fn stitching_unknown_assessment_name_leaves_fields_default() {
+    #[should_panic(expected = "no resolved subvolume")]
+    fn stitching_unknown_assessment_name_asserts_in_debug() {
+        let _ = assemble(&[assessment("ghost")], &test_config());
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn stitching_unknown_assessment_name_fails_open_in_release() {
+        // Fail-open: the row still renders (a subvolume must never
+        // vanish from a report), with the three joined fields defaulted.
         let out = assemble(&[assessment("ghost")], &test_config());
         let sa = &out.assessments[0];
         assert!(sa.promise_level.is_none());

--- a/src/events.rs
+++ b/src/events.rs
@@ -314,7 +314,7 @@ impl EventPayload {
             Self::PlannerDefer { .. } => Severity::Info,
             Self::PromiseTransition { from, to, .. } => {
                 // PromiseStatus is ordered worst-to-best.
-                if to < from {
+                if to.worsened_from(*from) {
                     Severity::Notice // degradation
                 } else {
                     Severity::Info // recovery (or no-op, but no-ops are filtered upstream)

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -14,7 +14,7 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
-use crate::awareness::{PromiseChange, PromiseSnapshot, PromiseStatus, promise_changes};
+use crate::awareness::{PromiseChange, PromiseRollup, PromiseSnapshot, promise_changes};
 use crate::heartbeat::{Heartbeat, SubvolumeHeartbeat};
 use crate::storage_critical::{TightnessTier, Transition};
 
@@ -244,15 +244,14 @@ pub fn compute_notifications(
     // First-run semantics: `previous: None` yields no transitions, but
     // all-unprotected is still evaluated on `current` — a system born
     // broken must say so.
+    let current_snaps = snapshots(&current.subvolumes);
     let changes = match previous {
-        Some(prev) => promise_changes(&snapshots(&prev.subvolumes), &snapshots(&current.subvolumes)),
+        Some(prev) => promise_changes(&snapshots(&prev.subvolumes), &current_snaps),
         None => Vec::new(),
     };
-    let all_unprotected = !current.subvolumes.is_empty()
-        && current
-            .subvolumes
-            .iter()
-            .all(|sv| sv.promise_status == PromiseStatus::Unprotected);
+    let all_unprotected =
+        PromiseRollup::from_pairs(current_snaps.iter().map(|s| (s.name.clone(), s.status)))
+            .all_unprotected();
 
     let mut notifications = build_promise_change_notifications(&changes, all_unprotected);
 
@@ -798,6 +797,7 @@ fn dispatch_log(notification: &Notification) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::awareness::PromiseStatus;
     use crate::heartbeat::{Heartbeat, SubvolumeHeartbeat};
 
     fn make_heartbeat(statuses: &[(&str, PromiseStatus, Option<bool>)]) -> Heartbeat {

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -14,8 +14,8 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
-use crate::awareness::PromiseStatus;
-use crate::heartbeat::Heartbeat;
+use crate::awareness::{PromiseChange, PromiseSnapshot, PromiseStatus, promise_changes};
+use crate::heartbeat::{Heartbeat, SubvolumeHeartbeat};
 use crate::storage_critical::{TightnessTier, Transition};
 
 // ── Event types ────────────────────────────────────────────────────────
@@ -230,74 +230,31 @@ pub fn compute_notifications(
     previous: Option<&Heartbeat>,
     current: &Heartbeat,
 ) -> Vec<Notification> {
-    let mut notifications = Vec::new();
-
-    // ── Promise state transitions ──────────────────────────────────
-    if let Some(prev) = previous {
-        for current_sv in &current.subvolumes {
-            if let Some(prev_sv) = prev
-                .subvolumes
-                .iter()
-                .find(|s| s.name == current_sv.name)
-                .filter(|prev_sv| prev_sv.promise_status != current_sv.promise_status)
-            {
-                if is_degradation(prev_sv.promise_status, current_sv.promise_status) {
-                    notifications.push(Notification {
-                        event: NotificationEvent::PromiseDegraded {
-                            subvolume: current_sv.name.clone(),
-                            from: prev_sv.promise_status.to_string(),
-                            to: current_sv.promise_status.to_string(),
-                        },
-                        urgency: Urgency::Warning,
-                        title: format!(
-                            "Urd: {} is now {}",
-                            current_sv.name, current_sv.promise_status
-                        ),
-                        body: format!(
-                            "The thread of {} has frayed — it was {}, now {}. \
-                             The well remembers, but the thread grows thin.",
-                            current_sv.name, prev_sv.promise_status, current_sv.promise_status
-                        ),
-                    });
-                } else {
-                    notifications.push(Notification {
-                        event: NotificationEvent::PromiseRecovered {
-                            subvolume: current_sv.name.clone(),
-                            from: prev_sv.promise_status.to_string(),
-                            to: current_sv.promise_status.to_string(),
-                        },
-                        urgency: Urgency::Info,
-                        title: format!(
-                            "Urd: {} restored to {}",
-                            current_sv.name, current_sv.promise_status
-                        ),
-                        body: format!(
-                            "The thread of {} is mended — restored from {} to {}.",
-                            current_sv.name, prev_sv.promise_status, current_sv.promise_status
-                        ),
-                    });
-                }
-            }
-        }
+    fn snapshots(subvolumes: &[SubvolumeHeartbeat]) -> Vec<PromiseSnapshot> {
+        subvolumes
+            .iter()
+            .map(|sv| PromiseSnapshot {
+                name: sv.name.clone(),
+                status: sv.promise_status,
+            })
+            .collect()
     }
 
-    // ── All unprotected ────────────────────────────────────────────
+    // ── Promise state transitions + all-unprotected ────────────────
+    // First-run semantics: `previous: None` yields no transitions, but
+    // all-unprotected is still evaluated on `current` — a system born
+    // broken must say so.
+    let changes = match previous {
+        Some(prev) => promise_changes(&snapshots(&prev.subvolumes), &snapshots(&current.subvolumes)),
+        None => Vec::new(),
+    };
     let all_unprotected = !current.subvolumes.is_empty()
         && current
             .subvolumes
             .iter()
             .all(|sv| sv.promise_status == PromiseStatus::Unprotected);
 
-    if all_unprotected {
-        notifications.push(Notification {
-            event: NotificationEvent::AllUnprotected,
-            urgency: Urgency::Critical,
-            title: "Urd: all promises broken".to_string(),
-            body: "Every thread in the well has snapped. No subvolume is protected. \
-                   Attend to this — your data stands exposed."
-                .to_string(),
-        });
-    }
+    let mut notifications = build_promise_change_notifications(&changes, all_unprotected);
 
     // ── Backup failures ────────────────────────────────────────────
     let failed_count = current
@@ -359,8 +316,67 @@ pub fn compute_notifications(
 /// True when the promise status worsened. `PromiseStatus`'s `Ord` is
 /// worst-to-best (`Unprotected < AtRisk < Protected`), so a degradation is
 /// `to < from`. Named helper documents direction; mirrors `events.rs`.
-fn is_degradation(from: PromiseStatus, to: PromiseStatus) -> bool {
-    to.worsened_from(from)
+/// Render promise-change notifications — THE single home of the
+/// degraded/recovered/all-unprotected prose (UPI 088-a, arc R1).
+///
+/// Both notification paths feed it: `compute_notifications` (heartbeat
+/// diff, backup path) and `sentinel_runner::build_notifications`
+/// (assessment diff, daemon path). First-run suppression is deliberately
+/// the caller's: pass the changes you want spoken and the
+/// all-unprotected verdict you computed — the two callers suppress
+/// differently and must keep doing so.
+#[must_use]
+pub fn build_promise_change_notifications(
+    changes: &[PromiseChange],
+    all_unprotected: bool,
+) -> Vec<Notification> {
+    let mut notifications = Vec::new();
+
+    for change in changes {
+        if change.to.worsened_from(change.from) {
+            notifications.push(Notification {
+                event: NotificationEvent::PromiseDegraded {
+                    subvolume: change.name.clone(),
+                    from: change.from.to_string(),
+                    to: change.to.to_string(),
+                },
+                urgency: Urgency::Warning,
+                title: format!("Urd: {} is now {}", change.name, change.to),
+                body: format!(
+                    "The thread of {} has frayed — it was {}, now {}. \
+                     The well remembers, but the thread grows thin.",
+                    change.name, change.from, change.to
+                ),
+            });
+        } else {
+            notifications.push(Notification {
+                event: NotificationEvent::PromiseRecovered {
+                    subvolume: change.name.clone(),
+                    from: change.from.to_string(),
+                    to: change.to.to_string(),
+                },
+                urgency: Urgency::Info,
+                title: format!("Urd: {} restored to {}", change.name, change.to),
+                body: format!(
+                    "The thread of {} is mended — restored from {} to {}.",
+                    change.name, change.from, change.to
+                ),
+            });
+        }
+    }
+
+    if all_unprotected {
+        notifications.push(Notification {
+            event: NotificationEvent::AllUnprotected,
+            urgency: Urgency::Critical,
+            title: "Urd: all promises broken".to_string(),
+            body: "Every thread in the well has snapped. No subvolume is protected. \
+                   Attend to this — your data stands exposed."
+                .to_string(),
+        });
+    }
+
+    notifications
 }
 
 // ── Drive reconnection notifications ──────────────────────────────────

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -1017,6 +1017,135 @@ mod tests {
         assert!(all_unprotected.is_empty());
     }
 
+    // ── Golden prose (UPI 088-a, arc R8) ───────────────────────────
+    // Byte-exact fixtures for every promise-transition sentence. Before
+    // 088-a nothing pinned these bodies, and sentinel_runner's twin
+    // builder emits the identical prose independently — these goldens
+    // are the acceptance criterion for collapsing both onto one shared
+    // core. Change a string here only as a deliberate voice decision.
+
+    #[test]
+    fn golden_degraded_prose_exact() {
+        let prev = make_heartbeat(&[("home", PromiseStatus::Protected, Some(true))]);
+        let curr = make_heartbeat(&[("home", PromiseStatus::AtRisk, Some(true))]);
+
+        let notifications = compute_notifications(Some(&prev), &curr);
+
+        let degraded: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::PromiseDegraded { .. }))
+            .collect();
+        assert_eq!(degraded.len(), 1);
+        assert_eq!(degraded[0].urgency, Urgency::Warning);
+        assert_eq!(degraded[0].title, "Urd: home is now AT RISK");
+        assert_eq!(
+            degraded[0].body,
+            "The thread of home has frayed — it was PROTECTED, now AT RISK. \
+             The well remembers, but the thread grows thin."
+        );
+    }
+
+    #[test]
+    fn golden_recovered_prose_exact() {
+        let prev = make_heartbeat(&[("home", PromiseStatus::AtRisk, Some(true))]);
+        let curr = make_heartbeat(&[("home", PromiseStatus::Protected, Some(true))]);
+
+        let notifications = compute_notifications(Some(&prev), &curr);
+
+        let recovered: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::PromiseRecovered { .. }))
+            .collect();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].urgency, Urgency::Info);
+        assert_eq!(recovered[0].title, "Urd: home restored to PROTECTED");
+        assert_eq!(
+            recovered[0].body,
+            "The thread of home is mended — restored from AT RISK to PROTECTED."
+        );
+    }
+
+    #[test]
+    fn golden_all_unprotected_prose_exact() {
+        let curr = make_heartbeat(&[
+            ("home", PromiseStatus::Unprotected, Some(true)),
+            ("docs", PromiseStatus::Unprotected, Some(true)),
+        ]);
+
+        let notifications = compute_notifications(None, &curr);
+
+        let all_unprotected: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::AllUnprotected))
+            .collect();
+        assert_eq!(all_unprotected.len(), 1);
+        assert_eq!(all_unprotected[0].urgency, Urgency::Critical);
+        assert_eq!(all_unprotected[0].title, "Urd: all promises broken");
+        assert_eq!(
+            all_unprotected[0].body,
+            "Every thread in the well has snapped. No subvolume is protected. \
+             Attend to this — your data stands exposed."
+        );
+    }
+
+    #[test]
+    fn golden_first_run_all_unprotected_still_fires() {
+        // First run (`previous: None`): transitions are suppressed, but
+        // all-unprotected is still evaluated on `current` — a system that
+        // is born broken must say so.
+        let curr = make_heartbeat(&[("home", PromiseStatus::Unprotected, Some(true))]);
+
+        let notifications = compute_notifications(None, &curr);
+
+        assert!(notifications.iter().all(|n| !matches!(
+            n.event,
+            NotificationEvent::PromiseDegraded { .. }
+                | NotificationEvent::PromiseRecovered { .. }
+        )));
+        let all_unprotected: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::AllUnprotected))
+            .collect();
+        assert_eq!(all_unprotected.len(), 1);
+        assert_eq!(all_unprotected[0].title, "Urd: all promises broken");
+    }
+
+    #[test]
+    fn golden_mixed_transitions_prose_exact() {
+        // One degradation and one recovery in the same diff: both bodies
+        // exact, each carrying its own from/to pair.
+        let prev = make_heartbeat(&[
+            ("home", PromiseStatus::Protected, Some(true)),
+            ("docs", PromiseStatus::AtRisk, Some(true)),
+        ]);
+        let curr = make_heartbeat(&[
+            ("home", PromiseStatus::AtRisk, Some(true)),
+            ("docs", PromiseStatus::Protected, Some(true)),
+        ]);
+
+        let notifications = compute_notifications(Some(&prev), &curr);
+
+        let degraded: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::PromiseDegraded { .. }))
+            .collect();
+        let recovered: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::PromiseRecovered { .. }))
+            .collect();
+        assert_eq!(degraded.len(), 1);
+        assert_eq!(
+            degraded[0].body,
+            "The thread of home has frayed — it was PROTECTED, now AT RISK. \
+             The well remembers, but the thread grows thin."
+        );
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(
+            recovered[0].body,
+            "The thread of docs is mended — restored from AT RISK to PROTECTED."
+        );
+    }
+
     // ── Backup failures ────────────────────────────────────────────
 
     #[test]

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -312,9 +312,6 @@ pub fn compute_notifications(
     notifications
 }
 
-/// True when the promise status worsened. `PromiseStatus`'s `Ord` is
-/// worst-to-best (`Unprotected < AtRisk < Protected`), so a degradation is
-/// `to < from`. Named helper documents direction; mirrors `events.rs`.
 /// Render promise-change notifications — THE single home of the
 /// degraded/recovered/all-unprotected prose (UPI 088-a, arc R1).
 ///

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -360,7 +360,7 @@ pub fn compute_notifications(
 /// worst-to-best (`Unprotected < AtRisk < Protected`), so a degradation is
 /// `to < from`. Named helper documents direction; mirrors `events.rs`.
 fn is_degradation(from: PromiseStatus, to: PromiseStatus) -> bool {
-    to < from
+    to.worsened_from(from)
 }
 
 // ── Drive reconnection notifications ──────────────────────────────────
@@ -1256,27 +1256,6 @@ mod tests {
     }
 
     // ── Degradation direction ──────────────────────────────────────
-
-    #[test]
-    fn is_degradation_follows_ord() {
-        // Worsening (to < from) is a degradation; improving is not.
-        assert!(is_degradation(
-            PromiseStatus::Protected,
-            PromiseStatus::AtRisk
-        ));
-        assert!(is_degradation(
-            PromiseStatus::AtRisk,
-            PromiseStatus::Unprotected
-        ));
-        assert!(!is_degradation(
-            PromiseStatus::AtRisk,
-            PromiseStatus::Protected
-        ));
-        assert!(!is_degradation(
-            PromiseStatus::Protected,
-            PromiseStatus::Protected
-        ));
-    }
 
     // ── Multiple events in one transition ──────────────────────────
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::advice::{ActionableAdvice, RedundancyAdvisory, RedundancyAdvisoryKind};
 use crate::awareness::{DriveAssessment, PromiseStatus, SubvolAssessment};
+use crate::config::ResolvedSubvolume;
 use crate::rotation::WindowSource;
 use crate::storage_critical::{StoragePosture, TightnessTier};
 use crate::types::{ByteSize, DriveRole};
@@ -277,8 +278,58 @@ pub struct StatusAssessment {
 }
 
 impl StatusAssessment {
+    /// Build the complete rows for a set of assessments — the only
+    /// public construction path (UPI 088-a). Joins each assessment to
+    /// its resolved subvolume by name and fills `promise_level`,
+    /// `retention_summary`, and `external_only` at construction: the
+    /// mirror is total, no caller backfills.
+    ///
+    /// A name miss is impossible for real `assess()` output (it emits
+    /// names verbatim from `resolved_subvolumes()`). If a join bug ever
+    /// produces one, the row still renders with those three fields
+    /// defaulted — fail-open: a subvolume must never vanish from a
+    /// report — and debug builds assert loudly.
     #[must_use]
-    pub fn from_assessment(a: &SubvolAssessment) -> Self {
+    pub fn rows(
+        assessments: &[SubvolAssessment],
+        resolved: &[ResolvedSubvolume],
+        now: chrono::NaiveDateTime,
+    ) -> Vec<Self> {
+        assessments
+            .iter()
+            .map(|a| match resolved.iter().find(|sv| sv.name == a.name) {
+                Some(sv) => Self::from_assessment(a, sv, now),
+                None => {
+                    debug_assert!(
+                        false,
+                        "assessment {:?} has no resolved subvolume — join bug",
+                        a.name
+                    );
+                    Self::incomplete_from_assessment(a)
+                }
+            })
+            .collect()
+    }
+
+    /// The total constructor: every field filled, including the three
+    /// config-derived ones the old public constructor left for callers
+    /// to remember.
+    fn from_assessment(a: &SubvolAssessment, sv: &ResolvedSubvolume, now: chrono::NaiveDateTime) -> Self {
+        Self {
+            promise_level: sv.protection_level.map(|pl| pl.to_string()),
+            retention_summary: Some(crate::retention::retention_summary(
+                &sv.local_retention,
+                &sv.snapshot_interval,
+                now,
+            )),
+            external_only: sv.local_retention.is_transient() && sv.send_enabled,
+            ..Self::incomplete_from_assessment(a)
+        }
+    }
+
+    /// Assessment-only fields; the three config-derived fields default.
+    /// Reached in production only through `rows()`'s impossible-miss arm.
+    fn incomplete_from_assessment(a: &SubvolAssessment) -> Self {
         Self {
             name: a.name.clone(),
             short_name: a.short_name.clone(),
@@ -1831,7 +1882,7 @@ mod tests {
             effective_send_interval: None,
         };
 
-        let sa = StatusAssessment::from_assessment(&assessment);
+        let sa = StatusAssessment::incomplete_from_assessment(&assessment);
         assert_eq!(sa.redundancy_advisories.len(), 1);
         assert_eq!(sa.redundancy_advisories[0], advisory);
     }

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -14,7 +14,9 @@ use std::time::{Duration, Instant};
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
-use crate::awareness::{ChainStatus, OperationalHealth, PromiseStatus, SubvolAssessment};
+use crate::awareness::{
+    ChainStatus, OperationalHealth, PromiseSnapshot, PromiseStatus, SubvolAssessment,
+};
 use crate::guard::{self, PoolPressureSample};
 
 // ── Events ──────────────────────────────────────────────────────────────
@@ -89,14 +91,6 @@ pub struct SentinelState {
     pub last_health_states: Vec<HealthSnapshot>,
     /// Circuit breaker state (active mode only, but tracked always).
     pub circuit_breaker: CircuitBreaker,
-}
-
-/// A snapshot of promise states from a single assessment, used for
-/// comparing state transitions to decide notifications.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PromiseSnapshot {
-    pub name: String,
-    pub status: PromiseStatus,
 }
 
 impl SentinelState {
@@ -636,18 +630,9 @@ pub fn should_record_transitions(
 }
 
 // ── Snapshot extractors ───────────────────────────────────────────────
-
-/// Extract promise snapshots from assessments for state storage.
-#[must_use]
-pub fn snapshot_promises(assessments: &[SubvolAssessment]) -> Vec<PromiseSnapshot> {
-    assessments
-        .iter()
-        .map(|a| PromiseSnapshot {
-            name: a.name.clone(),
-            status: a.status,
-        })
-        .collect()
-}
+// (`snapshot_promises` moved to awareness.rs with `PromiseSnapshot`,
+// UPI 088-a — the health twin below stays: `HealthSnapshot` is
+// sentinel-only state.)
 
 /// A snapshot of operational health from a single assessment, for
 /// comparing health transitions to decide notifications.
@@ -1763,21 +1748,6 @@ mod tests {
         let current = vec![make_assessment("sv1", PromiseStatus::Protected)];
 
         assert!(has_promise_changes(&previous, &current));
-    }
-
-    #[test]
-    fn snapshot_promises_roundtrip() {
-        let assessments = vec![
-            make_assessment("sv1", PromiseStatus::Protected),
-            make_assessment("sv2", PromiseStatus::AtRisk),
-        ];
-
-        let snaps = snapshot_promises(&assessments);
-        assert_eq!(snaps.len(), 2);
-        assert_eq!(snaps[0].name, "sv1");
-        assert_eq!(snaps[0].status, PromiseStatus::Protected);
-        assert_eq!(snaps[1].name, "sv2");
-        assert_eq!(snaps[1].status, PromiseStatus::AtRisk);
     }
 
     // ── Chain snapshot + anomaly detection tests ───────────────────────

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -1013,69 +1013,19 @@ pub fn build_notifications(
     previous: &[PromiseSnapshot],
     current: &[SubvolAssessment],
 ) -> Vec<Notification> {
-    let mut notifications = Vec::new();
+    // Thin adapter over the shared prose core (UPI 088-a, arc R1):
+    // detect via awareness, speak via notify. First-run suppression is
+    // NOT here — the `has_initial_assessment && has_promise_changes`
+    // gate in execute_assess owns it (load-bearing: with an empty
+    // `previous`, all-unprotected below would still fire).
+    let changes = awareness::promise_changes(previous, &awareness::snapshot_promises(current));
 
-    // ── Promise state transitions ──────────────────────────────────
-    for assess in current {
-        if let Some(prev) = previous.iter().find(|p| p.name == assess.name)
-            && assess.status != prev.status
-        {
-            let from = prev.status.to_string();
-            let to = assess.status.to_string();
-
-            if assess.status.worsened_from(prev.status) {
-                // Degradation
-                notifications.push(Notification {
-                    event: NotificationEvent::PromiseDegraded {
-                        subvolume: assess.name.clone(),
-                        from: from.clone(),
-                        to: to.clone(),
-                    },
-                    urgency: Urgency::Warning,
-                    title: format!("Urd: {} is now {}", assess.name, to),
-                    body: format!(
-                        "The thread of {} has frayed — it was {}, now {}. \
-                         The well remembers, but the thread grows thin.",
-                        assess.name, from, to
-                    ),
-                });
-            } else {
-                // Recovery
-                notifications.push(Notification {
-                    event: NotificationEvent::PromiseRecovered {
-                        subvolume: assess.name.clone(),
-                        from: from.clone(),
-                        to: to.clone(),
-                    },
-                    urgency: Urgency::Info,
-                    title: format!("Urd: {} restored to {}", assess.name, to),
-                    body: format!(
-                        "The thread of {} is mended — restored from {} to {}.",
-                        assess.name, from, to
-                    ),
-                });
-            }
-        }
-    }
-
-    // ── All unprotected ────────────────────────────────────────────
     let all_unprotected = !current.is_empty()
         && current
             .iter()
             .all(|a| a.status == PromiseStatus::Unprotected);
 
-    if all_unprotected {
-        notifications.push(Notification {
-            event: NotificationEvent::AllUnprotected,
-            urgency: Urgency::Critical,
-            title: "Urd: all promises broken".to_string(),
-            body: "Every thread in the well has snapped. No subvolume is protected. \
-                   Attend to this — your data stands exposed."
-                .to_string(),
-        });
-    }
-
-    notifications
+    notify::build_promise_change_notifications(&changes, all_unprotected)
 }
 
 /// Check whether the heartbeat is stale and a BackupOverdue notification is needed.

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant, SystemTime};
 use chrono::NaiveDateTime;
 
 use crate::advice;
-use crate::awareness::{self, PromiseStatus, SubvolAssessment};
+use crate::awareness::{self, PromiseSnapshot, PromiseStatus, SubvolAssessment};
 use crate::commands::{storage_signals, world};
 use crate::config::Config;
 use crate::drives::{self, DriveAvailability};
@@ -27,8 +27,7 @@ use crate::output::{SentinelCircuitState, SentinelPromiseState, SentinelStateFil
 use crate::plan::{Observation, RealFileSystemState};
 use crate::sentinel::{
     self, CircuitBreakerConfig, EjectAction, EjectEvent, EjectPhase, EjectState,
-    EjectTransition, PromiseSnapshot, SentinelAction, SentinelEvent, SentinelState,
-    TransitionResult,
+    EjectTransition, SentinelAction, SentinelEvent, SentinelState, TransitionResult,
 };
 use crate::state::StateDb;
 
@@ -532,7 +531,7 @@ impl SentinelRunner {
         }
 
         // Update state.
-        self.state.last_promise_states = sentinel::snapshot_promises(&assessments);
+        self.state.last_promise_states = awareness::snapshot_promises(&assessments);
         self.state.last_health_states = sentinel::snapshot_health(&assessments);
         if !self.state.has_initial_assessment {
             self.state.has_initial_assessment = true;

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -17,7 +17,7 @@ use std::time::{Duration, Instant, SystemTime};
 use chrono::NaiveDateTime;
 
 use crate::advice;
-use crate::awareness::{self, PromiseSnapshot, PromiseStatus, SubvolAssessment};
+use crate::awareness::{self, PromiseSnapshot, SubvolAssessment};
 use crate::commands::{storage_signals, world};
 use crate::config::Config;
 use crate::drives::{self, DriveAvailability};
@@ -1019,11 +1019,7 @@ pub fn build_notifications(
     // gate in execute_assess owns it (load-bearing: with an empty
     // `previous`, all-unprotected below would still fire).
     let changes = awareness::promise_changes(previous, &awareness::snapshot_promises(current));
-
-    let all_unprotected = !current.is_empty()
-        && current
-            .iter()
-            .all(|a| a.status == PromiseStatus::Unprotected);
+    let all_unprotected = awareness::PromiseRollup::from_assessments(current).all_unprotected();
 
     notify::build_promise_change_notifications(&changes, all_unprotected)
 }

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -1743,6 +1743,118 @@ mod tests {
         assert!(notifications.is_empty());
     }
 
+    // ── Golden prose (UPI 088-a, arc R8) ────────────────────────────
+    // Twin fixtures: byte-identical to notify.rs's golden section by
+    // design — the two builders emit the same sentences independently,
+    // and these goldens are the acceptance criterion for collapsing
+    // both onto one shared core. See notify.rs for the rationale.
+
+    #[test]
+    fn golden_twin_degraded_prose_exact() {
+        let previous = vec![PromiseSnapshot {
+            name: "home".to_string(),
+            status: PromiseStatus::Protected,
+        }];
+        let current = vec![make_assessment("home", PromiseStatus::AtRisk)];
+
+        let notifications = build_notifications(&previous, &current);
+
+        let degraded: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::PromiseDegraded { .. }))
+            .collect();
+        assert_eq!(degraded.len(), 1);
+        assert_eq!(degraded[0].urgency, Urgency::Warning);
+        assert_eq!(degraded[0].title, "Urd: home is now AT RISK");
+        assert_eq!(
+            degraded[0].body,
+            "The thread of home has frayed — it was PROTECTED, now AT RISK. \
+             The well remembers, but the thread grows thin."
+        );
+    }
+
+    #[test]
+    fn golden_twin_recovered_prose_exact() {
+        let previous = vec![PromiseSnapshot {
+            name: "home".to_string(),
+            status: PromiseStatus::AtRisk,
+        }];
+        let current = vec![make_assessment("home", PromiseStatus::Protected)];
+
+        let notifications = build_notifications(&previous, &current);
+
+        let recovered: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::PromiseRecovered { .. }))
+            .collect();
+        assert_eq!(recovered.len(), 1);
+        assert_eq!(recovered[0].urgency, Urgency::Info);
+        assert_eq!(recovered[0].title, "Urd: home restored to PROTECTED");
+        assert_eq!(
+            recovered[0].body,
+            "The thread of home is mended — restored from AT RISK to PROTECTED."
+        );
+    }
+
+    #[test]
+    fn golden_twin_all_unprotected_prose_exact() {
+        let previous = vec![
+            PromiseSnapshot {
+                name: "home".to_string(),
+                status: PromiseStatus::Protected,
+            },
+            PromiseSnapshot {
+                name: "docs".to_string(),
+                status: PromiseStatus::Protected,
+            },
+        ];
+        let current = vec![
+            make_assessment("home", PromiseStatus::Unprotected),
+            make_assessment("docs", PromiseStatus::Unprotected),
+        ];
+
+        let notifications = build_notifications(&previous, &current);
+
+        let all_unprot: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::AllUnprotected))
+            .collect();
+        assert_eq!(all_unprot.len(), 1);
+        assert_eq!(all_unprot[0].urgency, Urgency::Critical);
+        assert_eq!(all_unprot[0].title, "Urd: all promises broken");
+        assert_eq!(
+            all_unprot[0].body,
+            "Every thread in the well has snapped. No subvolume is protected. \
+             Attend to this — your data stands exposed."
+        );
+    }
+
+    #[test]
+    fn golden_twin_empty_previous_all_unprotected_still_fires() {
+        // This function has NO internal first-run guard: with an empty
+        // `previous`, transitions cannot match but all-unprotected still
+        // fires. The runner's `has_initial_assessment &&
+        // has_promise_changes` gate in execute_assess is what suppresses
+        // first-run noise — that gate is load-bearing, and this test
+        // documents why.
+        let previous: Vec<PromiseSnapshot> = vec![];
+        let current = vec![make_assessment("home", PromiseStatus::Unprotected)];
+
+        let notifications = build_notifications(&previous, &current);
+
+        assert!(notifications.iter().all(|n| !matches!(
+            n.event,
+            NotificationEvent::PromiseDegraded { .. }
+                | NotificationEvent::PromiseRecovered { .. }
+        )));
+        let all_unprot: Vec<_> = notifications
+            .iter()
+            .filter(|n| matches!(n.event, NotificationEvent::AllUnprotected))
+            .collect();
+        assert_eq!(all_unprot.len(), 1);
+        assert_eq!(all_unprot[0].title, "Urd: all promises broken");
+    }
+
     // ── check_backup_overdue (S2: pure function with tests) ─────────
 
     fn dt(s: &str) -> NaiveDateTime {

--- a/src/sentinel_runner.rs
+++ b/src/sentinel_runner.rs
@@ -1024,7 +1024,7 @@ pub fn build_notifications(
             let from = prev.status.to_string();
             let to = assess.status.to_string();
 
-            if assess.status < prev.status {
+            if assess.status.worsened_from(prev.status) {
                 // Degradation
                 notifications.push(Notification {
                     event: NotificationEvent::PromiseDegraded {

--- a/src/voice/backup.rs
+++ b/src/voice/backup.rs
@@ -371,11 +371,20 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
         }
     }
 
-    let has_promises = data.assessments.iter().any(|a| a.promise_level.is_some());
+    // Show PROTECTION only when exposure conflicts with promise — the
+    // same quiet gate as `urd status`, but on backup's OWN license
+    // (RD1, UPI 088-a): there is no summary line here; a completed
+    // healthy run's report is itself the all-well message, and brevity
+    // is part of the promise. (status's gate is licensed by its "All
+    // sealed." line — that reasoning does not transfer.)
+    let show_protection = data
+        .assessments
+        .iter()
+        .any(|a| a.promise_level.is_some() && a.status != PromiseStatus::Protected);
 
     // Build headers: EXPOSURE  [PROTECTION]  SUBVOLUME  LOCAL  [DRIVE1]  [DRIVE2]
     let mut headers: Vec<String> = vec!["EXPOSURE".to_string()];
-    if has_promises {
+    if show_protection {
         // NOTE: Level names (guarded/protected/resilient) stay until Phase 6
         headers.push("PROTECTION".to_string());
     }
@@ -389,7 +398,7 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
     let mut rows: Vec<Vec<String>> = Vec::new();
     for assessment in &data.assessments {
         let mut row = vec![exposure_label(assessment.status)];
-        if has_promises {
+        if show_protection {
             row.push(
                 assessment
                     .promise_level
@@ -775,5 +784,50 @@ mod tests {
             !out.contains("unchanged"),
             "backup summary should suppress unchanged skips, got: {out}"
         );
+    }
+
+    // ── PROTECTION column gate (RD1, UPI 088-a) ─────────────────────
+
+    fn table_summary(assessments: Vec<StatusAssessment>) -> BackupSummary {
+        BackupSummary {
+            result: "success".to_string(),
+            run_id: Some(1),
+            duration_secs: 1.0,
+            subvolumes: vec![],
+            skipped: vec![],
+            assessments,
+            transitions: vec![],
+            warnings: vec![],
+            notes: vec![],
+        }
+    }
+
+    #[test]
+    fn protection_column_hidden_when_all_sealed() {
+        // promise_level is real in backup rows now, but a healthy run's
+        // table stays exactly as before the fields were completed — the
+        // column appears only when some promise is degraded.
+        let mut sealed = assessment_with("WD-18TB", true);
+        sealed.promise_level = Some("sheltered".to_string());
+        let summary = table_summary(vec![sealed]);
+        let mut out = String::new();
+        render_assessment_table(&summary, &mut out);
+        assert!(!out.contains("PROTECTION"), "quiet gate: got {out}");
+    }
+
+    #[test]
+    fn protection_column_shown_when_promise_degraded() {
+        let mut sealed = assessment_with("WD-18TB", true);
+        sealed.promise_level = Some("sheltered".to_string());
+        let mut waning = assessment_with("WD-18TB", true);
+        waning.name = "sv2".to_string();
+        waning.short_name = "sv2".to_string();
+        waning.status = PromiseStatus::AtRisk;
+        waning.promise_level = Some("fortified".to_string());
+        let summary = table_summary(vec![sealed, waning]);
+        let mut out = String::new();
+        render_assessment_table(&summary, &mut out);
+        assert!(out.contains("PROTECTION"), "got: {out}");
+        assert!(out.contains("fortified"), "got: {out}");
     }
 }

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -11,6 +11,7 @@ use std::fmt::Write;
 
 use colored::Colorize;
 
+use crate::awareness::PromiseRollup;
 use crate::output::{DoctorCheck, DoctorCheckStatus, DoctorOutput, DoctorVerdictStatus, OutputMode};
 use crate::plan::format_duration_short;
 use crate::storage_critical::TightnessTier;
@@ -104,7 +105,7 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
     // Promise partition via the one rollup (UPI 088-a). all_protected()
     // is vacuously true on empty input — zero subvolumes renders
     // "✓ 0 of 0 sealed", pinned by the tests below.
-    let rollup = crate::awareness::PromiseRollup::from_pairs(
+    let rollup = PromiseRollup::from_pairs(
         data.data_safety.iter().map(|d| (d.name.clone(), d.status)),
     );
     let sealed_count = rollup.protected.len();

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -11,7 +11,6 @@ use std::fmt::Write;
 
 use colored::Colorize;
 
-use crate::awareness::PromiseStatus;
 use crate::output::{DoctorCheck, DoctorCheckStatus, DoctorOutput, DoctorVerdictStatus, OutputMode};
 use crate::plan::format_duration_short;
 use crate::storage_critical::TightnessTier;
@@ -102,13 +101,15 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
     // Data safety section
     writeln!(out).ok();
     writeln!(out, "  {}", "Data safety".bold()).ok();
-    let sealed_count = data
-        .data_safety
-        .iter()
-        .filter(|d| d.status == PromiseStatus::Protected)
-        .count();
-    let total = data.data_safety.len();
-    if sealed_count == total {
+    // Promise partition via the one rollup (UPI 088-a). all_protected()
+    // is vacuously true on empty input — zero subvolumes renders
+    // "✓ 0 of 0 sealed", pinned by the tests below.
+    let rollup = crate::awareness::PromiseRollup::from_pairs(
+        data.data_safety.iter().map(|d| (d.name.clone(), d.status)),
+    );
+    let sealed_count = rollup.protected.len();
+    let total = rollup.total();
+    if rollup.all_protected() {
         writeln!(
             out,
             "    {} {} of {} sealed",
@@ -121,10 +122,10 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
         writeln!(
             out,
             "    {} {} of {} sealed",
-            if data.data_safety.iter().any(|d| d.status == PromiseStatus::Unprotected) {
-                "\u{2717}".red().to_string()
-            } else {
+            if rollup.unprotected.is_empty() {
                 "\u{26a0}".yellow().to_string()
+            } else {
+                "\u{2717}".red().to_string()
             },
             sealed_count,
             total
@@ -588,5 +589,93 @@ pub(super) fn check_icon_style(status: DoctorCheckStatus) -> (&'static str, fn(&
         DoctorCheckStatus::Ok => ("\u{2713}", |s: &str| s.green().to_string()),
         DoctorCheckStatus::Warn => ("\u{26a0}", |s: &str| s.yellow().to_string()),
         DoctorCheckStatus::Error => ("\u{2717}", |s: &str| s.red().to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::awareness::PromiseStatus;
+    use crate::output::{
+        DOCTOR_OUTPUT_SCHEMA_VERSION, DoctorDataSafety, DoctorOutput, DoctorVerdict,
+    };
+
+    // Characterization tests (UPI 088-a): this renderer had no test
+    // module before the sealed-count reduction moved onto PromiseRollup;
+    // these pin the Data safety lines the swap must not change.
+
+    fn safety(name: &str, status: PromiseStatus) -> DoctorDataSafety {
+        DoctorDataSafety {
+            name: name.to_string(),
+            status,
+            health: "healthy".to_string(),
+            issue: None,
+            suggestion: None,
+            reason: None,
+            storage_posture: None,
+        }
+    }
+
+    fn doctor_output(data_safety: Vec<DoctorDataSafety>) -> DoctorOutput {
+        DoctorOutput {
+            schema_version: DOCTOR_OUTPUT_SCHEMA_VERSION,
+            config_checks: vec![],
+            infra_checks: vec![],
+            data_safety,
+            sentinel: None,
+            schema_status: None,
+            verify: None,
+            churn: None,
+            recommendations: None,
+            retention_checks: vec![],
+            verdict: DoctorVerdict {
+                status: DoctorVerdictStatus::Healthy,
+                count: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn doctor_all_sealed_renders_check_and_counts() {
+        let data = doctor_output(vec![
+            safety("home", PromiseStatus::Protected),
+            safety("docs", PromiseStatus::Protected),
+        ]);
+        let out = render_doctor(&data, OutputMode::Interactive);
+        assert!(out.contains("2 of 2 sealed"), "got: {out}");
+        assert!(out.contains('\u{2713}'));
+    }
+
+    #[test]
+    fn doctor_waning_only_renders_warning_mark() {
+        let data = doctor_output(vec![
+            safety("home", PromiseStatus::Protected),
+            safety("docs", PromiseStatus::AtRisk),
+        ]);
+        let out = render_doctor(&data, OutputMode::Interactive);
+        assert!(out.contains("1 of 2 sealed"), "got: {out}");
+        assert!(out.contains('\u{26a0}'), "waning-only wears ⚠, not ✗");
+    }
+
+    #[test]
+    fn doctor_unprotected_renders_cross_mark() {
+        let data = doctor_output(vec![
+            safety("home", PromiseStatus::Protected),
+            safety("docs", PromiseStatus::Unprotected),
+        ]);
+        let out = render_doctor(&data, OutputMode::Interactive);
+        assert!(out.contains("1 of 2 sealed"), "got: {out}");
+        assert!(out.contains('\u{2717}'), "any exposed subvolume wears ✗");
+    }
+
+    #[test]
+    fn doctor_empty_data_safety_is_vacuously_sealed() {
+        // Zero subvolumes means zero broken promises: "✓ 0 of 0 sealed".
+        // Pins the vacuous-truth branch end-to-end — the rollup's
+        // `all_protected()` must stay TRUE on empty or this flips to ✗/⚠.
+        let data = doctor_output(vec![]);
+        let out = render_doctor(&data, OutputMode::Interactive);
+        assert!(out.contains("0 of 0 sealed"), "got: {out}");
+        assert!(out.contains('\u{2713}'));
     }
 }

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -10,7 +10,7 @@ use std::fmt::Write;
 use colored::Colorize;
 
 use crate::advice::RedundancyAdvisoryKind;
-use crate::awareness::PromiseStatus;
+use crate::awareness::{PromiseRollup, PromiseStatus};
 use crate::output::{
     ChainHealth, DefaultStatusOutput, OutputMode, PoolPostureSummary, StatusAssessment,
     StatusOutput,
@@ -168,35 +168,27 @@ pub(super) fn render_summary_line(data: &StatusOutput, out: &mut String) {
         return;
     }
 
-    let total = data.assessments.len();
-    let safe_count = data
-        .assessments
-        .iter()
-        .filter(|a| a.status == PromiseStatus::Protected)
-        .count();
+    // Promise partition via the one rollup (UPI 088-a). all_protected()
+    // is vacuously true on empty input, but the is_empty() early return
+    // above means this renderer never sees that case.
+    let rollup = PromiseRollup::from_pairs(
+        data.assessments.iter().map(|a| (a.name.clone(), a.status)),
+    );
     let has_health_issues = data.assessments.iter().any(|a| a.health != "healthy");
 
-    let safety_part = if safe_count == total {
+    let safety_part = if rollup.all_protected() {
         "All sealed.".green().to_string()
     } else {
-        let exposed_names: Vec<&str> = data
-            .assessments
-            .iter()
-            .filter(|a| a.status == PromiseStatus::Unprotected)
-            .map(|a| a.name.as_str())
-            .collect();
-        let waning_names: Vec<&str> = data
-            .assessments
-            .iter()
-            .filter(|a| a.status == PromiseStatus::AtRisk)
-            .map(|a| a.name.as_str())
-            .collect();
-        let mut parts = vec![format!("{} of {} sealed.", safe_count, total)];
-        if !exposed_names.is_empty() {
-            parts.push(format!("{} exposed.", exposed_names.join(", ")));
+        let mut parts = vec![format!(
+            "{} of {} sealed.",
+            rollup.protected.len(),
+            rollup.total()
+        )];
+        if !rollup.unprotected.is_empty() {
+            parts.push(format!("{} exposed.", rollup.unprotected.join(", ")));
         }
-        if !waning_names.is_empty() {
-            parts.push(format!("{} waning.", waning_names.join(", ")));
+        if !rollup.at_risk.is_empty() {
+            parts.push(format!("{} waning.", rollup.at_risk.join(", ")));
         }
         parts.join(" ").yellow().to_string()
     };

--- a/src/voice_events.rs
+++ b/src/voice_events.rs
@@ -109,14 +109,11 @@ fn summary_for(payload: &EventPayload) -> String {
             format!("deferred — {reason}")
         }
         EventPayload::PromiseTransition { from, to, trigger } => {
-            let arrow = if to < from { "←" } else { "→" };
+            let worsened = to.worsened_from(*from);
+            let arrow = if worsened { "←" } else { "→" };
             format!(
                 "the thread of this subvolume {} ({} {arrow} {})  [{}]",
-                if to < from {
-                    "frayed"
-                } else {
-                    "is mended"
-                },
+                if worsened { "frayed" } else { "is mended" },
                 from,
                 to,
                 trigger_phrase(*trigger)


### PR DESCRIPTION
## Summary

- **One home per promise reduction** (#297 + deepening-05 A/B): transition detection (`awareness::promise_changes`), degradation direction (`PromiseStatus::worsened_from`), the three-way partition (`PromiseRollup`), and the all-unprotected check now each have exactly one implementation. The byte-identical twin notification builders (`notify::compute_notifications` / `sentinel_runner::build_notifications`) collapse onto one shared prose core, pinned by golden tests that assert full titles AND bodies (nothing pinned prose before this PR).
- **The mirror is total**: `StatusAssessment::rows()` is the only public construction path — the name join fills `promise_level`/`retention_summary`/`external_only` at construction, with fail-open defaulted rows + `debug_assert` on the impossible miss. `commands/status.rs`'s mutable backfill is deleted.
- **One deliberate visible fix**: `urd backup`'s rows are complete — `--json` gains the same three keys `urd status --json` emits, and the interactive table adopts status's quiet PROTECTION gate on backup's own license (healthy runs byte-identical to today; the column appears only when a promise is degraded).
- **Inversion fixed**: `PromiseSnapshot` + `snapshot_promises` move from `sentinel.rs` (daemon) to `awareness.rs` (core), no compatibility re-export. Glossary gains `PromiseRollup`, `promise change`, and a new Projections (code idiom) cluster.

Design: `docs/95-ideas/2026-07-11-design-088-a-promise-rollup.md` (grilled, RD0–RD4) · Arc: 088 backup-orchestration deepening (R1–R10) · Adversary review: 4/5/5/4, no Critical, all findings integrated pre-build.

## Testing

- cargo clippy --all-targets -D warnings: pass
- cargo test: 2301 passed, 0 failed (2271 baseline + 30 new: golden prose fixtures on both twins, promise_changes tables, rollup unit + empty-asymmetry pair, doctor characterization (module had no tests), quiet-gate render tests, backup-rows==status-rows equality)
- Live check: `urd status` interactive + JSON byte-identical to pre-branch captures (ages normalized); heartbeat/metrics untouched by construction
- Integration tests: not applicable (no btrfs surface touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)