### PR TITLE
docs: README Install flip to verified-binary headline (UPI 077 PR-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,18 +65,32 @@ Protection levels you set once; Urd derives the retention and send schedule from
 - `btrfs-progs`
 - systemd — optional, for the nightly timer and the Sentinel monitoring daemon
 
-**From source** (recommended today — needs a Rust toolchain):
+**Prebuilt binary** (x86_64 Linux, statically linked — no toolchain needed):
+
+```bash
+curl -LO https://github.com/vonrobak/urd/releases/latest/download/urd-x86_64-linux
+curl -LO https://github.com/vonrobak/urd/releases/latest/download/SHA256SUMS
+
+# Verify it is the binary the author published, then put it on your PATH
+sha256sum --ignore-missing -c SHA256SUMS
+install -Dm755 urd-x86_64-linux ~/.local/bin/urd
+```
+
+If `urd: command not found` follows, `~/.local/bin` isn't on your `PATH` — add it and
+open a new shell. Want proof of who built the binary, not just that it arrived intact?
+Every release carries a [build provenance
+attestation](https://github.com/vonrobak/urd/attestations): `gh attestation verify
+urd-x86_64-linux --repo vonrobak/urd`.
+
+**From source** (needs a Rust toolchain):
 
 ```bash
 git clone https://github.com/vonrobak/urd.git && cd urd
 cargo install --path .    # installs to ~/.cargo/bin/urd
 ```
 
-A prebuilt one-step binary, with checksum verification, is coming with the release
-pipeline — watch the [releases page](https://github.com/vonrobak/urd/releases).
-
-There is no `curl | bash` installer, and there won't be — not when the binary lands
-either. You check the sum yourself and decide when Urd has earned the password it asks for.
+There is no `curl | bash` installer, and there won't be. You check the sum yourself
+and decide when Urd has earned the password it asks for.
 
 ## Getting started
 


### PR DESCRIPTION
## Summary

- Flips the README Install section to the prebuilt-binary headline; `cargo install --path .` demotes to the from-source fallback (077 design, Stage 3, criteria #1/#3).
- The four install commands are pinned by the clean-machine verification on fedora-jern (2026-07-12): executed verbatim from the real v0.34.0 release through checksum, `install -Dm755` (which created `~/.local/bin` fresh — the F3 evidence), `urd 0.34.0`, and a sealed first Encounter run. **Future edits to those four lines should re-trigger a clean-machine run.**
- Uses stable `releases/latest/download/` URLs (ADR-117) so the section never version-drifts; `--ignore-missing` keeps the command valid if future releases add more assets.
- Light `/steve` pass ran (Install-section scope, per 077 design decision 9): restored the PATH doorstep line (2026-07-09 review Ask #1) and the checksum trust-comment from the twice-reviewed 076 draft; the `curl | bash` refusal paragraph stays, minus its now-obsolete "not when the binary lands either" hedge.

## Testing

- cargo clippy: not applicable (README-only)
- cargo test: not applicable (README-only)
- Field verification: v0.34.0 install test on fedora-jern, 2026-07-12 — all four commands exit 0, checksum OK, Encounter sealed first snapshot, `status`/`doctor` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)