### PR TITLE
refactor: send seam + NothingNew type (UPI 089-b, arc slice 2 of 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   regions on the arc's typed-inputs path. A live run-pair against the current
   binary confirmed `urd plan`, `urd plan --auto`, and `urd backup --dry-run`
   are byte-identical. No behavior change (#325).
+- The send seam continues the `plan/` arc: `plan_external_send` and
+  `plan_external_retention` take typed inputs (`SendInputs`,
+  `ExternalRetentionInputs`) and return a `PlanFragment`, and drive-availability
+  gating is now a typed `DriveGate` — an unavailable drive can no longer be
+  skipped without recording why. The stranded-snapshot marker is type-enforced:
+  it derives its reason prose from a `NothingNew` conclusion and can only be set
+  through two constructors, so the marker and its prose can no longer drift. A
+  live run-pair confirmed `urd plan`, `urd plan --auto`, and
+  `urd backup --dry-run` are byte-identical. No behavior change (#327).
 
 ## [0.34.0] - 2026-07-11
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -3662,18 +3662,12 @@ source = "/data/beta"
             operations: vec![],
             timestamp: chrono::NaiveDateTime::default(),
             skipped: vec![
-                crate::types::PlannedSkip {
-                    name: "htpc-home".to_string(),
-                    reason: "drive WD-18TB not mounted".to_string(),
-                    next_due_minutes: None,
-                    nothing_new_to_send: false,
-                },
-                crate::types::PlannedSkip {
-                    name: "htpc-docs".to_string(),
-                    reason: "disabled".to_string(),
-                    next_due_minutes: None,
-                    nothing_new_to_send: false,
-                },
+                crate::types::PlannedSkip::deferred(
+                    "htpc-home",
+                    "drive WD-18TB not mounted".to_string(),
+                    None,
+                ),
+                crate::types::PlannedSkip::deferred("htpc-docs", "disabled".to_string(), None),
             ],
             events: Vec::new(),
         };
@@ -4335,12 +4329,7 @@ source = "/data/beta"
                 .unwrap(),
             skipped: skipped
                 .into_iter()
-                .map(|(n, r)| crate::types::PlannedSkip {
-                    name: n.to_string(),
-                    reason: r.to_string(),
-                    next_due_minutes: None,
-                    nothing_new_to_send: false,
-                })
+                .map(|(n, r)| crate::types::PlannedSkip::deferred(n, r.to_string(), None))
                 .collect(),
             events: Vec::new(),
         }

--- a/src/commands/plan_cmd.rs
+++ b/src/commands/plan_cmd.rs
@@ -117,7 +117,7 @@ pub(crate) fn collapse_skipped(skipped: &[PlannedSkip]) -> Vec<SkippedSubvolume>
         let category = SkipCategory::from_reason(&skip.reason);
         if category == SkipCategory::Unchanged {
             unchanged_idx.insert(skip.name.as_str(), out.len());
-        } else if skip.nothing_new_to_send
+        } else if skip.is_nothing_new()
             && let Some((_, drive)) = skip.reason.split_once(" already on ")
             && let Some(&idx) = unchanged_idx.get(skip.name.as_str())
         {
@@ -280,7 +280,7 @@ fn build_operation_entry(
 mod tests {
     use super::*;
     use crate::plan::MockFileSystemState;
-    use crate::types::{BackupPlan, SendKind, SnapshotName};
+    use crate::types::{BackupPlan, NothingNew, SendKind, SnapshotName};
     use std::path::PathBuf;
 
     fn dummy_snap(subvol: &str) -> SnapshotName {
@@ -532,21 +532,21 @@ source = "/data/htpc-docs"
     // ── Skip-collapse tests (#212 / 079-b §6) ─────────────────────────
 
     fn unchanged_skip(name: &str) -> PlannedSkip {
-        PlannedSkip {
-            name: name.to_string(),
-            reason: "unchanged \u{2014} no changes since last snapshot (3d ago)".to_string(),
-            next_due_minutes: None,
-            nothing_new_to_send: false,
-        }
+        PlannedSkip::deferred(
+            name,
+            "unchanged \u{2014} no changes since last snapshot (3d ago)".to_string(),
+            None,
+        )
     }
 
     fn already_on_skip(name: &str, drive: &str) -> PlannedSkip {
-        PlannedSkip {
-            name: name.to_string(),
-            reason: format!("20260329-0404-{name} already on {drive}"),
-            next_due_minutes: None,
-            nothing_new_to_send: true,
-        }
+        PlannedSkip::nothing_new(
+            name,
+            &NothingNew::AlreadyOn {
+                snapshot: SnapshotName::parse(&format!("20260329-0404-{name}")).expect("valid"),
+                drive: drive.to_string(),
+            },
+        )
     }
 
     #[test]
@@ -586,12 +586,11 @@ source = "/data/htpc-docs"
         // Under --auto a subvolume can be caught up on a drive while its
         // snapshot interval hasn't elapsed — two distinct facts, no merge.
         let skips = vec![
-            PlannedSkip {
-                name: "htpc-home".to_string(),
-                reason: "interval not elapsed (next in ~2h)".to_string(),
-                next_due_minutes: Some(120),
-                nothing_new_to_send: false,
-            },
+            PlannedSkip::deferred(
+                "htpc-home",
+                "interval not elapsed (next in ~2h)".to_string(),
+                Some(120),
+            ),
             already_on_skip("htpc-home", "WD-18TB"),
         ];
         let collapsed = collapse_skipped(&skips);
@@ -620,12 +619,11 @@ source = "/data/htpc-docs"
         let skips = vec![
             unchanged_skip("htpc-home"),
             already_on_skip("htpc-home", "WD-18TB"),
-            PlannedSkip {
-                name: "htpc-home".to_string(),
-                reason: "send to WD-18TB1 not due (next in ~4h)".to_string(),
-                next_due_minutes: Some(240),
-                nothing_new_to_send: false,
-            },
+            PlannedSkip::deferred(
+                "htpc-home",
+                "send to WD-18TB1 not due (next in ~4h)".to_string(),
+                Some(240),
+            ),
         ];
         let collapsed = collapse_skipped(&skips);
         assert_eq!(collapsed.len(), 2, "the send-interval deferral is its own fact");

--- a/src/plan/external.rs
+++ b/src/plan/external.rs
@@ -1,24 +1,20 @@
-use std::collections::HashSet;
-
-use chrono::NaiveDateTime;
-
-use crate::config::{DriveConfig, ResolvedSubvolume};
-use crate::events::UnstampedEvent;
 use crate::retention;
-use crate::types::{PlannedOperation, SnapshotName};
+use crate::types::PlannedOperation;
 
-use super::Observation;
-use super::fragment::stamp_context;
+use super::fragment::{ExternalRetentionInputs, PlanFragment, SubvolInputs, stamp_context};
 
-pub(super) fn plan_external_retention(
-    subvol: &ResolvedSubvolume,
-    drive: &DriveConfig,
-    now: NaiveDateTime,
-    obs: &Observation,
-    pinned: &HashSet<SnapshotName>,
-    operations: &mut Vec<PlannedOperation>,
-    events: &mut Vec<UnstampedEvent>,
-) {
+pub(super) fn plan_external_retention(i: &ExternalRetentionInputs) -> PlanFragment {
+    let ExternalRetentionInputs {
+        core,
+        drive,
+        pinned,
+    } = *i;
+    let SubvolInputs {
+        subvol, now, obs, ..
+    } = core;
+
+    let mut f = PlanFragment::default();
+
     let ext_dir = crate::drives::external_snapshot_dir(drive, &subvol.name);
     let ext_snaps = obs
         .fs
@@ -26,7 +22,7 @@ pub(super) fn plan_external_retention(
         .unwrap_or_default();
 
     if ext_snaps.is_empty() {
-        return;
+        return f;
     }
 
     let free_bytes = obs.fs.filesystem_free_bytes(&ext_dir).unwrap_or(u64::MAX);
@@ -42,7 +38,7 @@ pub(super) fn plan_external_retention(
     );
 
     for rd in result.delete {
-        operations.push(PlannedOperation::DeleteSnapshot {
+        f.push_operation(PlannedOperation::DeleteSnapshot {
             path: ext_dir.join(rd.snapshot.as_str()),
             reason: rd.reason,
             subvolume_name: subvol.name.clone(),
@@ -51,5 +47,210 @@ pub(super) fn plan_external_retention(
     }
 
     stamp_context(&mut result.events, Some(&subvol.name), Some(&drive.label));
-    events.extend(result.events);
+    f.extend_events(result.events);
+    f
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+
+    use chrono::{NaiveDate, NaiveDateTime};
+
+    use crate::btrfs::MockBtrfs;
+    use crate::config::{DriveConfig, ResolvedSubvolume};
+    use crate::events::RunContext;
+    use crate::observation::Observation;
+    use crate::plan::testkit::MockFileSystemState;
+    use crate::types::{
+        DriveRole, Interval, LocalRetentionPolicy, MonthlyCount, ResolvedGraduatedRetention,
+        SnapshotName,
+    };
+
+    use super::*;
+
+    fn now() -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(15, 0, 0)
+            .unwrap()
+    }
+
+    fn snap(s: &str) -> SnapshotName {
+        SnapshotName::parse(s).unwrap()
+    }
+
+    fn drive() -> DriveConfig {
+        DriveConfig {
+            label: "D1".to_string(),
+            uuid: None,
+            mount_path: PathBuf::from("/mnt/d1"),
+            snapshot_root: ".snapshots".to_string(),
+            role: DriveRole::Primary,
+            max_usage_percent: None,
+            min_free_bytes: None,
+            rotation_interval: None,
+        }
+    }
+
+    /// A subvolume whose external retention keeps nothing — every non-pinned
+    /// external snapshot becomes a deletion candidate (the simplest forcing
+    /// function for the region's delete-emission path).
+    fn subvol_keep_nothing() -> ResolvedSubvolume {
+        ResolvedSubvolume {
+            name: "sv1".to_string(),
+            short_name: "one".to_string(),
+            source: PathBuf::from("/data/sv1"),
+            priority: 1,
+            enabled: true,
+            snapshot_interval: Interval::hours(1),
+            send_interval: Interval::hours(4),
+            send_enabled: true,
+            local_retention: LocalRetentionPolicy::Transient,
+            external_retention: ResolvedGraduatedRetention {
+                hourly: 0,
+                daily: 0,
+                weekly: 0,
+                monthly: MonthlyCount::Count(0),
+                yearly: 0,
+            },
+            protection_level: None,
+            drives: None,
+            snapshot_root: Some(PathBuf::from("/snap")),
+            min_free_bytes: None,
+        }
+    }
+
+    fn run(i: &ExternalRetentionInputs) -> PlanFragment {
+        plan_external_retention(i)
+    }
+
+    fn core<'a>(
+        sv: &'a ResolvedSubvolume,
+        eff: &'a crate::storage_critical::EffectivePolicy,
+        obs: &'a Observation<'a>,
+    ) -> SubvolInputs<'a> {
+        SubvolInputs {
+            subvol: sv,
+            eff,
+            local_dir: std::path::Path::new("/snap/sv1"),
+            local_snaps: &[],
+            now: now(),
+            obs,
+        }
+    }
+
+    fn eff() -> crate::storage_critical::EffectivePolicy {
+        crate::storage_critical::EffectivePolicy {
+            local_retention: LocalRetentionPolicy::Transient,
+            send_interval: Interval::hours(4),
+            clear_all: false,
+            protect_away_pins: true,
+        }
+    }
+
+    #[test]
+    fn empty_external_returns_empty_fragment() {
+        let sv = subvol_keep_nothing();
+        let e = eff();
+        let fs = MockFileSystemState::new();
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let d = drive();
+        let pinned = HashSet::new();
+        let mut ops = Vec::new();
+        let mut skipped = Vec::new();
+        let mut events = Vec::new();
+        run(&ExternalRetentionInputs {
+            core: core(&sv, &e, &obs),
+            drive: &d,
+            pinned: &pinned,
+        })
+        .drain_into(&mut ops, &mut skipped, &mut events);
+        assert!(ops.is_empty() && events.is_empty());
+    }
+
+    #[test]
+    fn over_retention_emits_deletes_with_stamped_events() {
+        let sv = subvol_keep_nothing();
+        let e = eff();
+        let mut fs = MockFileSystemState::new();
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![snap("20260320-0400-one"), snap("20260321-0400-one")],
+        );
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let d = drive();
+        let pinned = HashSet::new();
+        let mut ops = Vec::new();
+        let mut skipped = Vec::new();
+        let mut events = Vec::new();
+        run(&ExternalRetentionInputs {
+            core: core(&sv, &e, &obs),
+            drive: &d,
+            pinned: &pinned,
+        })
+        .drain_into(&mut ops, &mut skipped, &mut events);
+
+        assert!(
+            ops.iter()
+                .any(|op| matches!(op, PlannedOperation::DeleteSnapshot { .. })),
+            "keep-nothing retention deletes external snapshots: {ops:?}",
+        );
+        // Retention events carry the subvol + drive context (stamp_context).
+        let ctx = RunContext::outside_run();
+        for ev in events {
+            let stamped = ev.stamp(&ctx);
+            assert_eq!(stamped.subvolume.as_deref(), Some("sv1"));
+            assert_eq!(stamped.drive_label.as_deref(), Some("D1"));
+        }
+    }
+
+    #[test]
+    fn pinned_external_snapshots_are_never_deleted() {
+        let sv = subvol_keep_nothing();
+        let e = eff();
+        let s0 = snap("20260320-0400-one");
+        let s1 = snap("20260321-0400-one");
+        let mut fs = MockFileSystemState::new();
+        fs.external_snapshots.insert(
+            ("D1".to_string(), "sv1".to_string()),
+            vec![s0.clone(), s1.clone()],
+        );
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let d = drive();
+        // Pin BOTH — even keep-nothing retention must not delete a pinned snap
+        // (ADR-106 planner layer).
+        let pinned: HashSet<SnapshotName> = [s0, s1].into_iter().collect();
+        let mut ops = Vec::new();
+        let mut skipped = Vec::new();
+        let mut events = Vec::new();
+        run(&ExternalRetentionInputs {
+            core: core(&sv, &e, &obs),
+            drive: &d,
+            pinned: &pinned,
+        })
+        .drain_into(&mut ops, &mut skipped, &mut events);
+        assert!(
+            !ops
+                .iter()
+                .any(|op| matches!(op, PlannedOperation::DeleteSnapshot { .. })),
+            "pinned snapshots survive keep-nothing retention: {ops:?}",
+        );
+    }
 }

--- a/src/plan/fragment.rs
+++ b/src/plan/fragment.rs
@@ -155,12 +155,7 @@ mod tests {
             subvolume_name: "pre".to_string(),
             kind: crate::types::DeleteKind::Policy,
         }];
-        let mut skipped = vec![PlannedSkip {
-            name: "pre".to_string(),
-            reason: "prefix".to_string(),
-            next_due_minutes: None,
-            nothing_new_to_send: false,
-        }];
+        let mut skipped = vec![PlannedSkip::deferred("pre", "prefix".to_string(), None)];
         let mut events = Vec::new();
 
         let mut fragment = PlanFragment::default();
@@ -242,6 +237,6 @@ mod tests {
         let mut events = Vec::new();
         fragment.drain_into(&mut operations, &mut skipped, &mut events);
 
-        assert!(!skipped[0].nothing_new_to_send);
+        assert!(!skipped[0].is_nothing_new());
     }
 }

--- a/src/plan/fragment.rs
+++ b/src/plan/fragment.rs
@@ -3,10 +3,10 @@ use std::path::Path;
 
 use chrono::NaiveDateTime;
 
-use crate::config::ResolvedSubvolume;
+use crate::config::{DriveConfig, ResolvedSubvolume};
 use crate::events::{DeferScope, Event, EventPayload, UnstampedEvent};
 use crate::storage_critical::EffectivePolicy;
-use crate::types::{PlannedOperation, PlannedSkip, SnapshotName};
+use crate::types::{NothingNew, PlannedOperation, PlannedSkip, SnapshotName};
 
 use super::{Observation, PlanFilters};
 
@@ -26,13 +26,17 @@ impl PlanFragment {
         self.operations.push(op);
     }
 
+    pub(crate) fn push_event(&mut self, event: UnstampedEvent) {
+        self.events.push(event);
+    }
+
     pub(crate) fn extend_events(&mut self, events: impl IntoIterator<Item = UnstampedEvent>) {
         self.events.extend(events);
     }
 
     /// `record_defer`'s successor: one skip + its `PlannerDefer` event,
-    /// together. Never sets the `nothing_new_to_send` marker — that
-    /// conclusion is only ever reached by the send-planning region (slice b).
+    /// together. Always marker-false — the marker-true path is
+    /// [`Self::defer_nothing_new`].
     pub(crate) fn defer(
         &mut self,
         subvol: &str,
@@ -42,7 +46,28 @@ impl PlanFragment {
         scope: DeferScope,
         now: NaiveDateTime,
     ) {
-        let (skip, event) = defer_parts(subvol, drive, reason, next_due, false, scope, now);
+        let (skip, event) = defer_parts(subvol, drive, reason, next_due, scope, now);
+        self.skipped.push(skip);
+        self.events.push(event);
+    }
+
+    /// The ONLY path to a marker-true skip: takes a sanctioned [`NothingNew`]
+    /// conclusion, derives its prose (via [`NothingNew::reason`]) and its defer
+    /// coordinates (drive scope) from the variant, and emits the skip +
+    /// `PlannerDefer` event as one unit. The internal exhaustive `match` — no
+    /// wildcard — is the second compile-fail guard on the variant set (the
+    /// first is `reason()`); it also keeps `DeferScope` derivation in
+    /// `plan/` rather than forcing a `types.rs → events.rs` dependency. The
+    /// event is built through the shared [`defer_event`], the same seam
+    /// `defer_parts` uses (UPI 089-b).
+    pub(crate) fn defer_nothing_new(&mut self, subvol: &str, why: NothingNew, now: NaiveDateTime) {
+        let (drive_label, scope) = match &why {
+            NothingNew::AlreadyOn { drive, .. } => (Some(drive.as_str()), DeferScope::Drive),
+            NothingNew::NoLocalSnapshots { .. } => (None, DeferScope::Subvolume),
+        };
+        // `nothing_new` derives the reason once; the event reuses it.
+        let skip = PlannedSkip::nothing_new(subvol, &why);
+        let event = defer_event(subvol, drive_label, &skip.reason, scope, now);
         self.skipped.push(skip);
         self.events.push(event);
     }
@@ -63,28 +88,49 @@ impl PlanFragment {
 
 /// The ONE home for the skip+event construction `record_defer` and
 /// `PlanFragment::defer` both need — the anti-twin seam CLAUDE.md's
-/// symmetric-fix rule warns about. `record_defer` (mod.rs, surviving for
-/// unreshaped callers until slice c) calls this with the caller-supplied
-/// `nothing_new_to_send`; `PlanFragment::defer` always passes `false`.
+/// symmetric-fix rule warns about. Always produces a marker-false skip (via
+/// [`PlannedSkip::deferred`]); the only marker-true path is
+/// [`PlanFragment::defer_nothing_new`]. The event half goes through the shared
+/// [`defer_event`], the same seam `defer_nothing_new` uses — so the two defer
+/// paths cannot build the `PlannerDefer` event differently (UPI 089-b,
+/// adversary F1).
 pub(super) fn defer_parts(
     subvol_name: &str,
     drive_label: Option<&str>,
     reason: String,
     next_due_minutes: Option<i64>,
-    nothing_new_to_send: bool,
     scope: DeferScope,
     now: NaiveDateTime,
 ) -> (PlannedSkip, UnstampedEvent) {
-    let skip = PlannedSkip {
-        name: subvol_name.to_string(),
-        reason: reason.clone(),
-        next_due_minutes,
-        nothing_new_to_send,
-    };
-    let mut event = Event::pure(now, EventPayload::PlannerDefer { reason, scope });
+    // Build the event first (borrowing `reason`), then move `reason` into the
+    // skip — one allocation.
+    let event = defer_event(subvol_name, drive_label, &reason, scope, now);
+    let skip = PlannedSkip::deferred(subvol_name, reason, next_due_minutes);
+    (skip, event)
+}
+
+/// The single home for the `PlannerDefer` event both defer paths emit
+/// (`defer_parts` for ordinary deferrals, `defer_nothing_new` for the
+/// sanctioned nothing-new conclusions). Keeping it one function means a change
+/// to how the event is built — a new field, a changed fill — can't diverge
+/// between the two paths (UPI 089-b, adversary F1).
+pub(super) fn defer_event(
+    subvol_name: &str,
+    drive_label: Option<&str>,
+    reason: &str,
+    scope: DeferScope,
+    now: NaiveDateTime,
+) -> UnstampedEvent {
+    let mut event = Event::pure(
+        now,
+        EventPayload::PlannerDefer {
+            reason: reason.to_string(),
+            scope,
+        },
+    );
     event.fill_subvolume(Some(subvol_name.to_string()));
     event.fill_drive_label(drive_label.map(str::to_string));
-    (skip, event)
+    event
 }
 
 /// Fill `subvolume` and/or `drive_label` onto events that don't already
@@ -125,6 +171,23 @@ pub(crate) struct LocalRetentionInputs<'a> {
     pub core: SubvolInputs<'a>,
     pub pinned: &'a HashSet<SnapshotName>,
     pub mounted_pins: &'a HashSet<SnapshotName>,
+}
+
+pub(crate) struct SendInputs<'a> {
+    pub core: SubvolInputs<'a>,
+    pub drive: &'a DriveConfig,
+    /// The just-planned snapshot (UPI 069 anti-strand augmentation): send
+    /// planning must consider it so a caught-up state does not strand tonight's
+    /// snapshot. `plan_external_send` augments `core.local_snaps` with it.
+    pub planned_snap: Option<&'a SnapshotName>,
+    pub force: bool,
+    pub skip_intervals: bool,
+}
+
+pub(crate) struct ExternalRetentionInputs<'a> {
+    pub core: SubvolInputs<'a>,
+    pub drive: &'a DriveConfig,
+    pub pinned: &'a HashSet<SnapshotName>,
 }
 
 /// The planned-snapshot outcome: the name (threaded into send planning by
@@ -238,5 +301,63 @@ mod tests {
         fragment.drain_into(&mut operations, &mut skipped, &mut events);
 
         assert!(!skipped[0].is_nothing_new());
+    }
+
+    #[test]
+    fn defer_nothing_new_derives_marker_prose_scope_and_drive() {
+        let why = NothingNew::AlreadyOn {
+            snapshot: SnapshotName::parse("20260322-1330-one").expect("valid"),
+            drive: "D1".to_string(),
+        };
+        let mut fragment = PlanFragment::default();
+        fragment.defer_nothing_new("sv1", why, now());
+
+        let mut operations = Vec::new();
+        let mut skipped = Vec::new();
+        let mut events = Vec::new();
+        fragment.drain_into(&mut operations, &mut skipped, &mut events);
+
+        assert!(skipped[0].is_nothing_new());
+        assert_eq!(skipped[0].reason, "20260322-1330-one already on D1");
+
+        let ctx = crate::events::RunContext::outside_run();
+        let stamped = events[0].clone().stamp(&ctx);
+        assert_eq!(stamped.subvolume.as_deref(), Some("sv1"));
+        assert_eq!(stamped.drive_label.as_deref(), Some("D1"));
+        match &stamped.payload {
+            EventPayload::PlannerDefer { reason, scope } => {
+                assert_eq!(reason, "20260322-1330-one already on D1");
+                assert_eq!(*scope, DeferScope::Drive);
+            }
+            other => panic!("expected PlannerDefer, got {other:?}"),
+        }
+    }
+
+    /// F1: `defer_parts` and `defer_nothing_new` must build the `PlannerDefer`
+    /// event identically — same (subvol, drive_label, reason, scope, now) ⇒
+    /// byte-identical event. Guards the shared `defer_event` seam against a
+    /// future divergence between the two defer paths.
+    #[test]
+    fn both_defer_paths_build_identical_events() {
+        let why = NothingNew::AlreadyOn {
+            snapshot: SnapshotName::parse("20260322-1330-one").expect("valid"),
+            drive: "D1".to_string(),
+        };
+
+        let mut fragment = PlanFragment::default();
+        fragment.defer_nothing_new("sv1", why.clone(), now());
+        let mut operations = Vec::new();
+        let mut skipped = Vec::new();
+        let mut events = Vec::new();
+        fragment.drain_into(&mut operations, &mut skipped, &mut events);
+
+        // Same coordinates through the ordinary-defer path.
+        let (_, direct) = defer_parts("sv1", Some("D1"), why.reason(), None, DeferScope::Drive, now());
+
+        let ctx = crate::events::RunContext::outside_run();
+        assert_eq!(
+            format!("{:?}", events[0].clone().stamp(&ctx)),
+            format!("{:?}", direct.stamp(&ctx)),
+        );
     }
 }

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -676,7 +676,7 @@ fn orphan_invariant_violations(
         // contradictory alongside a planned create.
         for skip in skipped
             .iter()
-            .filter(|s| s.name == j.name && s.nothing_new_to_send)
+            .filter(|s| s.name == j.name && s.is_nothing_new())
         {
             violations.push(format!(
                 "{} has CreateSnapshot alongside a nothing-new-to-send defer ({:?}) — \

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -42,19 +42,10 @@ fn record_defer(
     drive_label: Option<&str>,
     reason: String,
     next_due_minutes: Option<i64>,
-    nothing_new_to_send: bool,
     scope: DeferScope,
     now: NaiveDateTime,
 ) {
-    let (skip, event) = fragment::defer_parts(
-        subvol_name,
-        drive_label,
-        reason,
-        next_due_minutes,
-        nothing_new_to_send,
-        scope,
-        now,
-    );
+    let (skip, event) = fragment::defer_parts(subvol_name, drive_label, reason, next_due_minutes, scope, now);
     skipped.push(skip);
     events.push(event);
 }
@@ -191,101 +182,60 @@ pub struct PlanFilters {
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-/// Check if a drive can receive sends. Returns true if available, false (with
-/// skip reason emitted) if not. Handles all DriveAvailability variants.
+/// The outcome of gating a drive for sends: ready to receive, or the defer
+/// fragment explaining why not. Carrying the defer fragment inside `Deferred`
+/// makes the illegal state (unavailable-but-no-defer) unrepresentable — the
+/// caller cannot skip a drive without also recording why (UPI 089-b).
+enum DriveGate {
+    Ready,
+    Deferred(fragment::PlanFragment),
+}
+
+/// Gate a drive for sends. `Ready` if it can receive; `Deferred(fragment)` —
+/// carrying the skip + `PlannerDefer` event — if not. Handles all
+/// `DriveAvailability` variants: `Available` and `TokenMissing` (benign: first
+/// use or pre-token drive) are ready; the other five defer, drive-scoped.
 fn check_drive_availability(
     subvol_name: &str,
     drive: &DriveConfig,
     obs: &Observation,
-    skipped: &mut Vec<PlannedSkip>,
-    events: &mut Vec<UnstampedEvent>,
     now: NaiveDateTime,
-) -> bool {
+) -> DriveGate {
+    // Every defer arm is drive-scoped with no next-due — only the reason prose
+    // differs. One closure keeps the shape single-homed and the reasons the
+    // only per-arm variation.
+    let deferred = |reason: String| {
+        let mut f = fragment::PlanFragment::default();
+        f.defer(
+            subvol_name,
+            Some(&drive.label),
+            reason,
+            None,
+            DeferScope::Drive,
+            now,
+        );
+        DriveGate::Deferred(f)
+    };
     match obs.fs.drive_availability(drive) {
-        DriveAvailability::Available => true,
-        DriveAvailability::NotMounted => {
-            record_defer(
-                skipped,
-                events,
-                subvol_name,
-                Some(&drive.label),
-                format!("drive {} not mounted", drive.label),
-                None,
-                false,
-                DeferScope::Drive,
-                now,
-            );
-            false
-        }
-        DriveAvailability::UuidMismatch { expected, found } => {
-            record_defer(
-                skipped,
-                events,
-                subvol_name,
-                Some(&drive.label),
-                format!(
-                    "drive {} UUID mismatch (expected {}, found {})",
-                    drive.label, expected, found
-                ),
-                None,
-                false,
-                DeferScope::Drive,
-                now,
-            );
-            false
-        }
+        DriveAvailability::Available => DriveGate::Ready,
+        DriveAvailability::NotMounted => deferred(format!("drive {} not mounted", drive.label)),
+        DriveAvailability::UuidMismatch { expected, found } => deferred(format!(
+            "drive {} UUID mismatch (expected {}, found {})",
+            drive.label, expected, found
+        )),
         DriveAvailability::UuidCheckFailed(reason) => {
-            record_defer(
-                skipped,
-                events,
-                subvol_name,
-                Some(&drive.label),
-                format!("drive {} UUID check failed: {}", drive.label, reason),
-                None,
-                false,
-                DeferScope::Drive,
-                now,
-            );
-            false
+            deferred(format!("drive {} UUID check failed: {}", drive.label, reason))
         }
-        DriveAvailability::TokenMismatch { expected, found } => {
-            record_defer(
-                skipped,
-                events,
-                subvol_name,
-                Some(&drive.label),
-                format!(
-                    "drive {} token mismatch (expected {}, found {}) — possible drive swap",
-                    drive.label, expected, found
-                ),
-                None,
-                false,
-                DeferScope::Drive,
-                now,
-            );
-            false
-        }
-        DriveAvailability::TokenExpectedButMissing => {
-            record_defer(
-                skipped,
-                events,
-                subvol_name,
-                Some(&drive.label),
-                format!(
-                    "drive {} token expected but missing \u{2014} run `urd drives adopt {}`",
-                    drive.label, drive.label
-                ),
-                None,
-                false,
-                DeferScope::Drive,
-                now,
-            );
-            false
-        }
-        DriveAvailability::TokenMissing => {
-            // Benign: first use or pre-token drive. Proceed with send.
-            true
-        }
+        DriveAvailability::TokenMismatch { expected, found } => deferred(format!(
+            "drive {} token mismatch (expected {}, found {}) — possible drive swap",
+            drive.label, expected, found
+        )),
+        DriveAvailability::TokenExpectedButMissing => deferred(format!(
+            "drive {} token expected but missing \u{2014} run `urd drives adopt {}`",
+            drive.label, drive.label
+        )),
+        // Benign: first use or pre-token drive. Proceed with send.
+        DriveAvailability::TokenMissing => DriveGate::Ready,
     }
 }
 
@@ -350,7 +300,6 @@ pub fn plan(
                 None,
                 "disabled".to_string(),
                 None,
-                false,
                 DeferScope::Subvolume,
                 now,
             );
@@ -382,7 +331,6 @@ pub fn plan(
                 None,
                 "no snapshot root configured".to_string(),
                 None,
-                false,
                 DeferScope::Subvolume,
                 now,
             );
@@ -522,7 +470,6 @@ pub fn plan(
                     None,
                     reason.clone(),
                     None,
-                    false,
                     DeferScope::Subvolume,
                     now,
                 );
@@ -533,44 +480,31 @@ pub fn plan(
                     continue;
                 }
 
-                if !check_drive_availability(
-                    &subvol.name,
-                    drive,
-                    obs,
-                    &mut skipped,
-                    &mut events,
-                    now,
-                ) {
-                    continue;
+                match check_drive_availability(&subvol.name, drive, obs, now) {
+                    DriveGate::Ready => {}
+                    DriveGate::Deferred(f) => {
+                        f.drain_into(&mut operations, &mut skipped, &mut events);
+                        continue;
+                    }
                 }
 
                 if floor_defer.is_none() {
-                    send::plan_external_send(
-                        subvol,
-                        &eff,
+                    send::plan_external_send(&fragment::SendInputs {
+                        core,
                         drive,
-                        &local_dir,
-                        &local_snaps,
-                        planned_snap.as_ref(),
-                        now,
+                        planned_snap: planned_snap.as_ref(),
                         force,
-                        filters.skip_intervals,
-                        obs,
-                        &mut operations,
-                        &mut skipped,
-                        &mut events,
-                    );
+                        skip_intervals: filters.skip_intervals,
+                    })
+                    .drain_into(&mut operations, &mut skipped, &mut events);
                 }
 
-                external::plan_external_retention(
-                    subvol,
+                external::plan_external_retention(&fragment::ExternalRetentionInputs {
+                    core,
                     drive,
-                    now,
-                    obs,
-                    &pinned,
-                    &mut operations,
-                    &mut events,
-                );
+                    pinned: &pinned,
+                })
+                .drain_into(&mut operations, &mut skipped, &mut events);
             }
         } else if !filters.local_only && !subvol.send_enabled {
             record_defer(
@@ -580,7 +514,6 @@ pub fn plan(
                 None,
                 "local only".to_string(),
                 None,
-                false,
                 DeferScope::Subvolume,
                 now,
             );

--- a/src/plan/send.rs
+++ b/src/plan/send.rs
@@ -1,30 +1,27 @@
-use std::path::Path;
+use crate::events::{DeferScope, Event, EventPayload};
+use crate::types::{FullSendReason, NothingNew, PlannedOperation, SendKind, SnapshotName};
 
-use chrono::NaiveDateTime;
+use super::fragment::{PlanFragment, SendInputs, SubvolInputs};
 
-use crate::config::{DriveConfig, ResolvedSubvolume};
-use crate::events::{DeferScope, Event, EventPayload, UnstampedEvent};
-use crate::storage_critical::EffectivePolicy;
-use crate::types::{FullSendReason, PlannedOperation, PlannedSkip, SendKind, SnapshotName};
+pub(super) fn plan_external_send(i: &SendInputs) -> PlanFragment {
+    let SendInputs {
+        core,
+        drive,
+        planned_snap,
+        force,
+        skip_intervals,
+    } = *i;
+    let SubvolInputs {
+        subvol,
+        eff,
+        local_dir,
+        local_snaps,
+        now,
+        obs,
+    } = core;
 
-use super::Observation;
+    let mut f = PlanFragment::default();
 
-#[allow(clippy::too_many_arguments)]
-pub(super) fn plan_external_send(
-    subvol: &ResolvedSubvolume,
-    eff: &EffectivePolicy,
-    drive: &DriveConfig,
-    local_dir: &Path,
-    local_snaps: &[SnapshotName],
-    planned_snap: Option<&SnapshotName>,
-    now: NaiveDateTime,
-    force: bool,
-    skip_intervals: bool,
-    obs: &Observation,
-    operations: &mut Vec<PlannedOperation>,
-    skipped: &mut Vec<PlannedSkip>,
-    events: &mut Vec<UnstampedEvent>,
-) {
     // Send planning must consider the just-planned snapshot: without this
     // augmentation, a "caught up" state (latest local already on drive)
     // defers the send and strands tonight's snapshot until the next run —
@@ -65,9 +62,7 @@ pub(super) fn plan_external_send(
     if !should_send {
         let next_in = eff.send_interval.as_chrono()
             - now.signed_duration_since(newest_ext.unwrap().datetime());
-        super::record_defer(
-            skipped,
-            events,
+        f.defer(
             &subvol.name,
             Some(&drive.label),
             format!(
@@ -76,32 +71,22 @@ pub(super) fn plan_external_send(
                 super::format_duration_short(next_in.num_minutes())
             ),
             Some(next_in.num_minutes()),
-            false,
             DeferScope::Drive,
             now,
         );
-        return;
+        return f;
     }
 
     // Find the snapshot to send (newest local)
     let Some(snap_to_send) = local_snaps.iter().max() else {
-        let reason = if eff.local_retention.is_transient() {
-            "external-only \u{2014} sends on next backup".to_string()
-        } else {
-            "no local snapshots to send".to_string()
-        };
-        super::record_defer(
-            skipped,
-            events,
+        f.defer_nothing_new(
             &subvol.name,
-            None,
-            reason,
-            None,
-            true,
-            DeferScope::Subvolume,
+            NothingNew::NoLocalSnapshots {
+                transient: eff.local_retention.is_transient(),
+            },
             now,
         );
-        return;
+        return f;
     };
 
     // Check if already on external
@@ -109,18 +94,15 @@ pub(super) fn plan_external_send(
         .iter()
         .any(|s| s.as_str() == snap_to_send.as_str())
     {
-        super::record_defer(
-            skipped,
-            events,
+        f.defer_nothing_new(
             &subvol.name,
-            Some(&drive.label),
-            format!("{} already on {}", snap_to_send, drive.label),
-            None,
-            true,
-            DeferScope::Drive,
+            NothingNew::AlreadyOn {
+                snapshot: snap_to_send.clone(),
+                drive: drive.label.clone(),
+            },
             now,
         );
-        return;
+        return f;
     }
 
     let snap_path = local_dir.join(snap_to_send.as_str());
@@ -186,18 +168,15 @@ pub(super) fn plan_external_send(
                 ByteSize(min_free),
             )
         };
-        super::record_defer(
-            skipped,
-            events,
+        f.defer(
             &subvol.name,
             Some(&drive.label),
             reason,
             None,
-            false,
             DeferScope::Drive,
             now,
         );
-        return;
+        return f;
     }
 
     // Critical (clear_all) writes NO pin: the executor deletes the just-sent
@@ -219,7 +198,7 @@ pub(super) fn plan_external_send(
     if is_incremental {
         let parent_name = pin.unwrap();
         let parent_path = local_dir.join(parent_name.as_str());
-        operations.push(PlannedOperation::SendIncremental {
+        f.push_operation(PlannedOperation::SendIncremental {
             parent: parent_path,
             snapshot: snap_path,
             dest_dir: ext_dir,
@@ -236,7 +215,7 @@ pub(super) fn plan_external_send(
         } else {
             FullSendReason::NoPinFile
         };
-        operations.push(PlannedOperation::SendFull {
+        f.push_operation(PlannedOperation::SendFull {
             snapshot: snap_path,
             dest_dir: ext_dir,
             drive_label: drive.label.clone(),
@@ -257,6 +236,633 @@ pub(super) fn plan_external_send(
         );
         event.fill_subvolume(Some(subvol.name.clone()));
         event.fill_drive_label(Some(drive.label.clone()));
-        events.push(event);
+        f.push_event(event);
+    }
+
+    f
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use chrono::{NaiveDate, NaiveDateTime};
+
+    use crate::btrfs::MockBtrfs;
+    use crate::config::{DriveConfig, ResolvedSubvolume};
+    use crate::events::UnstampedEvent;
+    use crate::observation::Observation;
+    use crate::output::SkipCategory;
+    use crate::plan::testkit::MockFileSystemState;
+    use crate::storage_critical::EffectivePolicy;
+    use crate::types::{
+        DriveRole, Interval, LocalRetentionPolicy, MonthlyCount, PlannedSkip,
+        ResolvedGraduatedRetention,
+    };
+
+    use super::*;
+
+    fn now() -> NaiveDateTime {
+        NaiveDate::from_ymd_opt(2026, 3, 22)
+            .unwrap()
+            .and_hms_opt(15, 0, 0)
+            .unwrap()
+    }
+
+    fn snap(s: &str) -> SnapshotName {
+        SnapshotName::parse(s).unwrap()
+    }
+
+    fn local_dir() -> PathBuf {
+        PathBuf::from("/snap/sv1")
+    }
+
+    fn subvol() -> ResolvedSubvolume {
+        ResolvedSubvolume {
+            name: "sv1".to_string(),
+            short_name: "one".to_string(),
+            source: PathBuf::from("/data/sv1"),
+            priority: 1,
+            enabled: true,
+            snapshot_interval: Interval::hours(1),
+            send_interval: Interval::hours(4),
+            send_enabled: true,
+            local_retention: LocalRetentionPolicy::Transient,
+            external_retention: ResolvedGraduatedRetention {
+                hourly: 0,
+                daily: 30,
+                weekly: 0,
+                monthly: MonthlyCount::Count(0),
+                yearly: 0,
+            },
+            protection_level: None,
+            drives: None,
+            snapshot_root: Some(PathBuf::from("/snap")),
+            min_free_bytes: None,
+        }
+    }
+
+    fn eff(transient: bool, clear_all: bool) -> EffectivePolicy {
+        EffectivePolicy {
+            local_retention: if transient {
+                LocalRetentionPolicy::Transient
+            } else {
+                LocalRetentionPolicy::Graduated(ResolvedGraduatedRetention {
+                    hourly: 0,
+                    daily: 30,
+                    weekly: 0,
+                    monthly: MonthlyCount::Count(0),
+                    yearly: 0,
+                })
+            },
+            send_interval: Interval::hours(4),
+            clear_all,
+            protect_away_pins: true,
+        }
+    }
+
+    fn drive() -> DriveConfig {
+        DriveConfig {
+            label: "D1".to_string(),
+            uuid: None,
+            mount_path: PathBuf::from("/mnt/d1"),
+            snapshot_root: ".snapshots".to_string(),
+            role: DriveRole::Primary,
+            max_usage_percent: None,
+            min_free_bytes: None,
+            rotation_interval: None,
+        }
+    }
+
+    /// Run `plan_external_send` and drain its fragment into flat vecs.
+    fn run(i: &SendInputs) -> (Vec<PlannedOperation>, Vec<PlannedSkip>, Vec<UnstampedEvent>) {
+        let mut ops = Vec::new();
+        let mut skipped = Vec::new();
+        let mut events = Vec::new();
+        plan_external_send(i).drain_into(&mut ops, &mut skipped, &mut events);
+        (ops, skipped, events)
+    }
+
+    // ── NothingNew conclusions ───────────────────────────────────────
+
+    #[test]
+    fn empty_local_no_planned_transient_defers_external_only() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let fs = MockFileSystemState::new();
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: false,
+            skip_intervals: false,
+        });
+        assert!(ops.is_empty());
+        assert!(skipped[0].is_nothing_new());
+        assert_eq!(skipped[0].reason, "external-only \u{2014} sends on next backup");
+        // The transient prose classifies as ExternalOnly, NOT NoSnapshotsAvailable.
+        assert_eq!(
+            SkipCategory::from_reason(&skipped[0].reason),
+            SkipCategory::ExternalOnly
+        );
+    }
+
+    #[test]
+    fn empty_local_no_planned_non_transient_defers_no_snapshots() {
+        let sv = subvol();
+        let e = eff(false, false);
+        let d = drive();
+        let fs = MockFileSystemState::new();
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: false,
+            skip_intervals: false,
+        });
+        assert!(ops.is_empty());
+        assert!(skipped[0].is_nothing_new());
+        assert_eq!(skipped[0].reason, "no local snapshots to send");
+        // The non-transient prose classifies differently — a real gap.
+        assert_eq!(
+            SkipCategory::from_reason(&skipped[0].reason),
+            SkipCategory::NoSnapshotsAvailable
+        );
+    }
+
+    #[test]
+    fn caught_up_no_planned_defers_already_on() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let s = snap("20260322-1330-one");
+        let mut fs = MockFileSystemState::new();
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![s.clone()]);
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: std::slice::from_ref(&s),
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: true, // skip the interval gate so we reach the caught-up check
+            skip_intervals: false,
+        });
+        assert!(ops.is_empty());
+        assert!(skipped[0].is_nothing_new());
+        assert_eq!(skipped[0].reason, "20260322-1330-one already on D1");
+    }
+
+    /// THE 2026-05-02 stranded-snapshot shape, now a region test: a caught-up
+    /// pair (latest local already on drive) plus a freshly planned snapshot
+    /// must SEND it, not defer. Before UPI 069 this stranded tonight's snapshot.
+    #[test]
+    fn caught_up_with_planned_snapshot_sends_instead_of_stranding() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let on_drive = snap("20260321-0400-one");
+        let planned = snap("20260322-1500-one");
+        let mut fs = MockFileSystemState::new();
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![on_drive.clone()]);
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: std::slice::from_ref(&on_drive), // on-disk list is "caught up"
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: Some(&planned), // but tonight's snapshot is planned
+            force: true,
+            skip_intervals: false,
+        });
+        assert_eq!(ops.len(), 1, "the planned snapshot must be sent, not stranded");
+        assert!(skipped.is_empty(), "no nothing-new defer: {skipped:?}");
+    }
+
+    #[test]
+    fn empty_local_with_planned_sends() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let planned = snap("20260322-1500-one");
+        let fs = MockFileSystemState::new();
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: Some(&planned),
+            force: true,
+            skip_intervals: false,
+        });
+        assert_eq!(ops.len(), 1);
+        assert!(skipped.is_empty());
+    }
+
+    // ── Interval gating ──────────────────────────────────────────────
+
+    #[test]
+    fn interval_not_elapsed_defers_with_next_due() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        // ext snapshot 30 min old, send_interval 4h → not due.
+        let recent = snap("20260322-1430-one");
+        let local_newer = snap("20260322-1450-one");
+        let mut fs = MockFileSystemState::new();
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![recent.clone()]);
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[local_newer],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: false,
+            skip_intervals: false,
+        });
+        assert!(ops.is_empty());
+        assert!(!skipped[0].is_nothing_new());
+        assert!(skipped[0].next_due_minutes.is_some());
+        assert_eq!(
+            SkipCategory::from_reason(&skipped[0].reason),
+            SkipCategory::IntervalNotElapsed
+        );
+    }
+
+    #[test]
+    fn skip_intervals_overrides_interval_gate() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let recent = snap("20260322-1430-one");
+        let local_newer = snap("20260322-1450-one");
+        let mut fs = MockFileSystemState::new();
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![recent]);
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[local_newer],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: false,
+            skip_intervals: true,
+        });
+        assert_eq!(ops.len(), 1, "skip_intervals bypasses the send interval");
+        assert!(skipped.is_empty());
+    }
+
+    // ── Parent resolution matrix ─────────────────────────────────────
+
+    #[test]
+    fn pin_with_parent_both_sides_plans_incremental_no_choice_event() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let parent = snap("20260321-0400-one");
+        let newest = snap("20260322-1500-one");
+        let mut fs = MockFileSystemState::new();
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![parent.clone()]);
+        fs.pin_files
+            .insert((local_dir(), "D1".to_string()), parent.clone());
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, _skipped, events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[parent, newest],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: true,
+            skip_intervals: false,
+        });
+        assert!(matches!(ops[0], PlannedOperation::SendIncremental { .. }));
+        assert!(events.is_empty(), "no PlannerSendChoice on incrementals");
+    }
+
+    #[test]
+    fn pin_missing_parent_plans_full_chain_broken() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let missing_parent = snap("20260321-0400-one");
+        let newest = snap("20260322-1500-one");
+        let mut fs = MockFileSystemState::new();
+        // ext has a different snapshot; the pinned parent is on neither side.
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![snap("20260320-0400-one")]);
+        fs.pin_files
+            .insert((local_dir(), "D1".to_string()), missing_parent);
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, _skipped, events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[newest],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: true,
+            skip_intervals: false,
+        });
+        assert!(matches!(
+            ops[0],
+            PlannedOperation::SendFull {
+                reason: FullSendReason::ChainBroken,
+                ..
+            }
+        ));
+        assert_eq!(events.len(), 1, "PlannerSendChoice emitted on full sends");
+    }
+
+    #[test]
+    fn no_pin_empty_ext_plans_full_first_send() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let newest = snap("20260322-1500-one");
+        let fs = MockFileSystemState::new();
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, _skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[newest],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: true,
+            skip_intervals: false,
+        });
+        assert!(matches!(
+            ops[0],
+            PlannedOperation::SendFull {
+                reason: FullSendReason::FirstSend,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn no_pin_nonempty_ext_plans_full_no_pin_file() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let newest = snap("20260322-1500-one");
+        let mut fs = MockFileSystemState::new();
+        fs.external_snapshots
+            .insert(("D1".to_string(), "sv1".to_string()), vec![snap("20260320-0400-one")]);
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, _skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[newest],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: true,
+            skip_intervals: false,
+        });
+        assert!(matches!(
+            ops[0],
+            PlannedOperation::SendFull {
+                reason: FullSendReason::NoPinFile,
+                ..
+            }
+        ));
+    }
+
+    // ── Critical pin-withholding ─────────────────────────────────────
+
+    #[test]
+    fn critical_clear_all_withholds_pin_on_success() {
+        let sv = subvol();
+        let e = eff(true, true); // clear_all = true
+        let d = drive();
+        let newest = snap("20260322-1500-one");
+        let fs = MockFileSystemState::new();
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, _skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[newest],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: true,
+            skip_intervals: false,
+        });
+        match &ops[0] {
+            PlannedOperation::SendFull { pin_on_success, .. } => {
+                assert!(pin_on_success.is_none(), "clear_all withholds the pin");
+            }
+            other => panic!("expected SendFull, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_critical_carries_pin_on_success() {
+        let sv = subvol();
+        let e = eff(true, false); // clear_all = false
+        let d = drive();
+        let newest = snap("20260322-1500-one");
+        let fs = MockFileSystemState::new();
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, _skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[newest],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: true,
+            skip_intervals: false,
+        });
+        match &ops[0] {
+            PlannedOperation::SendFull { pin_on_success, .. } => {
+                assert!(pin_on_success.is_some(), "non-Critical carries the pin");
+            }
+            other => panic!("expected SendFull, got {other:?}"),
+        }
+    }
+
+    // ── Size-estimate guard ──────────────────────────────────────────
+
+    #[test]
+    fn estimated_size_exceeds_available_defers() {
+        let sv = subvol();
+        let e = eff(true, false);
+        let d = drive();
+        let newest = snap("20260322-1500-one");
+        let mut fs = MockFileSystemState::new();
+        // A full-send estimate far exceeding the ~1 byte free on the dest pool.
+        // `exceeds_available_space` reads free bytes at the drive's mount_path.
+        fs.send_sizes.insert(
+            ("sv1".to_string(), "D1".to_string(), SendKind::Full),
+            5_000_000_000,
+        );
+        fs.free_bytes.insert(d.mount_path.clone(), 1);
+        let btrfs = MockBtrfs::new();
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        let (ops, skipped, _events) = run(&SendInputs {
+            core: SubvolInputs {
+                subvol: &sv,
+                eff: &e,
+                local_dir: &local_dir(),
+                local_snaps: &[newest],
+                now: now(),
+                obs: &obs,
+            },
+            drive: &d,
+            planned_snap: None,
+            force: true,
+            skip_intervals: false,
+        });
+        assert!(ops.is_empty(), "over-budget send is deferred");
+        assert!(!skipped[0].is_nothing_new());
+        assert_eq!(
+            SkipCategory::from_reason(&skipped[0].reason),
+            SkipCategory::SpaceExceeded
+        );
     }
 }

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -125,6 +125,86 @@ local_retention = "transient"
 }
 
 #[test]
+fn drive_gate_truth_table_all_seven_availability_variants() {
+    let config = two_drive_config(None);
+    let drive = &config.drives[0]; // label "PRIMARY"
+    let btrfs = MockBtrfs::new();
+
+    // Two Ready arms: Available and the benign TokenMissing (first use).
+    for avail in [DriveAvailability::Available, DriveAvailability::TokenMissing] {
+        let mut fs = MockFileSystemState::new();
+        fs.drive_availability_overrides
+            .insert("PRIMARY".into(), avail.clone());
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        assert!(
+            matches!(
+                check_drive_availability("sv1", drive, &obs, now()),
+                DriveGate::Ready
+            ),
+            "{avail:?} should be Ready",
+        );
+    }
+
+    // Five Deferred arms, each with its exact prose.
+    let deferred = [
+        (DriveAvailability::NotMounted, "drive PRIMARY not mounted"),
+        (
+            DriveAvailability::UuidMismatch {
+                expected: "aaa".into(),
+                found: "bbb".into(),
+            },
+            "drive PRIMARY UUID mismatch (expected aaa, found bbb)",
+        ),
+        (
+            DriveAvailability::UuidCheckFailed("io error".into()),
+            "drive PRIMARY UUID check failed: io error",
+        ),
+        (
+            DriveAvailability::TokenMismatch {
+                expected: "t1".into(),
+                found: "t2".into(),
+            },
+            "drive PRIMARY token mismatch (expected t1, found t2) — possible drive swap",
+        ),
+        (
+            DriveAvailability::TokenExpectedButMissing,
+            "drive PRIMARY token expected but missing \u{2014} run `urd drives adopt PRIMARY`",
+        ),
+    ];
+    for (avail, expected_reason) in deferred {
+        let mut fs = MockFileSystemState::new();
+        fs.drive_availability_overrides
+            .insert("PRIMARY".into(), avail.clone());
+        let obs = Observation {
+            fs: &fs,
+            history: &fs,
+            btrfs: &btrfs,
+        };
+        match check_drive_availability("sv1", drive, &obs, now()) {
+            DriveGate::Deferred(f) => {
+                let mut ops = Vec::new();
+                let mut skipped = Vec::new();
+                let mut events = Vec::new();
+                f.drain_into(&mut ops, &mut skipped, &mut events);
+                assert!(ops.is_empty(), "{avail:?}");
+                assert_eq!(skipped.len(), 1, "{avail:?}");
+                assert_eq!(skipped[0].reason, expected_reason, "{avail:?}");
+                assert!(
+                    !skipped[0].is_nothing_new(),
+                    "a gate defer is never nothing-new: {avail:?}",
+                );
+                assert_eq!(events.len(), 1, "one PlannerDefer event per gate defer");
+            }
+            DriveGate::Ready => panic!("{avail:?} should defer"),
+        }
+    }
+}
+
+#[test]
 fn drive_scopes_classifies_presence_and_reads_all_pins() {
     let config = two_drive_config(None);
     let resolved = config.resolved_subvolumes();

--- a/src/plan/tests.rs
+++ b/src/plan/tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::storage_critical::{ArmedTierMap, TightnessTier};
 use crate::btrfs::MockBtrfs;
 use crate::events::EventPayload;
-use crate::types::FullSendReason;
+use crate::types::{FullSendReason, NothingNew};
 use chrono::NaiveDate;
 
 fn test_config() -> Config {
@@ -4569,7 +4569,7 @@ fn assert_marker(result: &BackupPlan, name: &str, substr: &str, expected: bool) 
             )
         });
     assert_eq!(
-        skip.nothing_new_to_send, expected,
+        skip.is_nothing_new(), expected,
         "nothing_new_to_send mismatch for skip {:?}",
         skip.reason
     );
@@ -4885,13 +4885,23 @@ fn op_send(name: &str) -> PlannedOperation {
     }
 }
 
-fn skip_entry(name: &str, reason: &str, nothing_new_to_send: bool) -> PlannedSkip {
-    PlannedSkip {
-        name: name.to_string(),
-        reason: reason.to_string(),
-        next_due_minutes: None,
-        nothing_new_to_send,
-    }
+/// A marker-false deferral (interval, drive-away, floor, space guard — the
+/// benign create-without-send inputs to arm 2).
+fn skip_deferred(name: &str, reason: &str) -> PlannedSkip {
+    PlannedSkip::deferred(name, reason.to_string(), None)
+}
+
+/// A marker-true "already on <drive>" conclusion — the sanctioned nothing-new
+/// input arm 2 keys on. Prose is derived from the variant (`{snapshot} already
+/// on {drive}`), byte-identical to what the planner emits.
+fn skip_already_on(name: &str, snapshot: &str, drive: &str) -> PlannedSkip {
+    PlannedSkip::nothing_new(
+        name,
+        &NothingNew::AlreadyOn {
+            snapshot: snap(snapshot),
+            drive: drive.to_string(),
+        },
+    )
 }
 
 #[test]
@@ -4922,7 +4932,7 @@ fn orphan_invariant_arm2_create_with_nothing_new_defer() {
     let violations = orphan_invariant_violations(
         &[judgment("sv1", false, true)],
         &[op_create("sv1")],
-        &[skip_entry("sv1", "20260430-0402-one already on D1", true)],
+        &[skip_already_on("sv1", "20260430-0402-one", "D1")],
     );
     assert_eq!(violations.len(), 1);
     assert!(violations[0].contains("stranded"), "{violations:?}");
@@ -4938,9 +4948,9 @@ fn orphan_invariant_arm2_marker_false_defers_clean() {
         &[judgment("sv1", false, true)],
         &[op_create("sv1")],
         &[
-            skip_entry("sv1", "send to D1 not due (next in ~2h)", false),
-            skip_entry("sv1", "drive D2 not mounted", false),
-            skip_entry("sv1", "send to D3 skipped: estimated ~1 GB exceeds 0 B available", false),
+            skip_deferred("sv1", "send to D1 not due (next in ~2h)"),
+            skip_deferred("sv1", "drive D2 not mounted"),
+            skip_deferred("sv1", "send to D3 skipped: estimated ~1 GB exceeds 0 B available"),
         ],
     );
     assert!(violations.is_empty(), "{violations:?}");
@@ -4953,7 +4963,7 @@ fn orphan_invariant_no_create_nothing_new_clean() {
     let violations = orphan_invariant_violations(
         &[judgment("sv1", false, true)],
         &[],
-        &[skip_entry("sv1", "20260322-1330-one already on D1", true)],
+        &[skip_already_on("sv1", "20260322-1330-one", "D1")],
     );
     assert!(violations.is_empty(), "{violations:?}");
 }
@@ -4966,7 +4976,7 @@ fn orphan_invariant_arm2_fires_even_with_send_to_other_drive() {
     let violations = orphan_invariant_violations(
         &[judgment("sv1", true, true)],
         &[op_create("sv1"), op_send("sv1")],
-        &[skip_entry("sv1", "20260321-0400-one already on D2", true)],
+        &[skip_already_on("sv1", "20260321-0400-one", "D2")],
     );
     assert_eq!(violations.len(), 1);
     assert!(violations[0].contains("stranded"), "{violations:?}");

--- a/src/plan/transient.rs
+++ b/src/plan/transient.rs
@@ -8,7 +8,9 @@ use crate::events::{DeferScope, UnstampedEvent};
 use crate::storage_critical::EffectivePolicy;
 use crate::types::{PlannedOperation, PlannedSkip, SnapshotName};
 
-use super::fragment::{LocalRetentionInputs, LocalSnapshotInputs, SubvolInputs};
+use super::fragment::{
+    ExternalRetentionInputs, LocalRetentionInputs, LocalSnapshotInputs, SendInputs, SubvolInputs,
+};
 use super::{Observation, PlanFilters};
 
 /// Atomic lifecycle planning for transient subvolumes.
@@ -63,7 +65,6 @@ pub(super) fn plan_transient_lifecycle(
             None,
             reason,
             None,
-            false,
             DeferScope::Subvolume,
             now,
         );
@@ -85,8 +86,12 @@ pub(super) fn plan_transient_lifecycle(
         if !subvol.accepts_drive(&drive.label) {
             continue;
         }
-        if !super::check_drive_availability(&subvol.name, drive, obs, skipped, events, now) {
-            continue; // skip reason already emitted
+        match super::check_drive_availability(&subvol.name, drive, obs, now) {
+            super::DriveGate::Ready => {}
+            super::DriveGate::Deferred(f) => {
+                f.drain_into(operations, skipped, events);
+                continue; // skip reason already emitted
+            }
         }
 
         // Send-interval check: would this drive actually receive a send?
@@ -120,7 +125,6 @@ pub(super) fn plan_transient_lifecycle(
                 None,
                 "transient \u{2014} no drives available for send".to_string(),
                 None,
-                false,
                 DeferScope::Subvolume,
                 now,
             );
@@ -166,7 +170,6 @@ pub(super) fn plan_transient_lifecycle(
                 None,
                 skip_msg,
                 next_dues.iter().map(|(_, m)| *m).min(),
-                false,
                 DeferScope::Subvolume,
                 now,
             );
@@ -217,11 +220,20 @@ pub(super) fn plan_transient_lifecycle(
     // plan_external_send augments local_snaps with the planned snapshot
     // internally (UPI 069) — pass the raw on-disk list plus the plan.
     for (drive, _) in &sendable_drives {
-        super::send::plan_external_send(
-            subvol, eff, drive, local_dir, local_snaps, planned_snap.as_ref(), now,
-            force, filters.skip_intervals, obs, operations, skipped, events,
-        );
-        super::external::plan_external_retention(subvol, drive, now, obs, pinned, operations, events);
+        super::send::plan_external_send(&SendInputs {
+            core,
+            drive,
+            planned_snap: planned_snap.as_ref(),
+            force,
+            skip_intervals: filters.skip_intervals,
+        })
+        .drain_into(operations, skipped, events);
+        super::external::plan_external_retention(&ExternalRetentionInputs {
+            core,
+            drive,
+            pinned,
+        })
+        .drain_into(operations, skipped, events);
     }
 
     // ── Phase 4: Plan transient retention ─────────────────────────

--- a/src/types.rs
+++ b/src/types.rs
@@ -1164,6 +1164,94 @@ pub struct PlannedSkip {
     pub nothing_new_to_send: bool,
 }
 
+/// The two sanctioned send-planning conclusions that mean "this (subvolume,
+/// drive) pair offers nothing new to send" — the ONLY constructors of a
+/// marker-true [`PlannedSkip`] (via [`PlannedSkip::nothing_new`]). The
+/// post-plan orphan invariant's arm 2 (stranded-snapshot tripwire) keys on
+/// the marker; deriving the reason prose from the variant makes marker/prose
+/// drift unrepresentable. A third conclusion is a new variant: greppable,
+/// reviewable, and the exhaustive match in [`NothingNew::reason`] forces the
+/// decision to be explicit (UPI 089-b).
+//
+// 089-b commit 1 is additive: the first PRODUCTION callers of `NothingNew`,
+// `reason()`, `deferred()`, and `nothing_new()` land in commit 2 (the
+// send-region reshape). Until then their only users are tests, so the bin
+// target (compiled without `cfg(test)`) sees them as dead. These `allow`s
+// come off in commit 2. `is_nothing_new()` needs none — arm 2 and
+// `collapse_skipped` already read it.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NothingNew {
+    /// The chosen snapshot is already on the drive ("caught up").
+    AlreadyOn {
+        snapshot: SnapshotName,
+        drive: String,
+    },
+    /// No local snapshots exist to choose from. `transient` selects the
+    /// lifecycle-appropriate prose: transient reads as routine (sends resume
+    /// next backup); non-transient reads as a gap.
+    NoLocalSnapshots { transient: bool },
+}
+
+impl NothingNew {
+    /// The exact reason prose — byte-identical to the strings the planner
+    /// emitted before UPI 089-b. Consumed by `SkipCategory::from_reason` (the
+    /// two `NoLocalSnapshots` forms classify differently) and by
+    /// `collapse_skipped`'s `" already on "` split. Exhaustive match, no
+    /// wildcard: a third variant must decide its own prose here.
+    #[must_use]
+    #[allow(dead_code)] // commit 2 (send-region reshape) is the first production caller
+    pub fn reason(&self) -> String {
+        match self {
+            NothingNew::AlreadyOn { snapshot, drive } => format!("{snapshot} already on {drive}"),
+            NothingNew::NoLocalSnapshots { transient: true } => {
+                "external-only \u{2014} sends on next backup".to_string()
+            }
+            NothingNew::NoLocalSnapshots { transient: false } => {
+                "no local snapshots to send".to_string()
+            }
+        }
+    }
+}
+
+impl PlannedSkip {
+    /// A deferral that is NOT a nothing-new-to-send conclusion. The
+    /// `nothing_new_to_send` marker is always `false`. This is the only
+    /// constructor for every skip except the two sanctioned send conclusions.
+    #[must_use]
+    #[allow(dead_code)] // commit 2 (defer_parts/record_defer bool-drop) is the first production caller
+    pub fn deferred(name: impl Into<String>, reason: String, next_due_minutes: Option<i64>) -> Self {
+        Self {
+            name: name.into(),
+            reason,
+            next_due_minutes,
+            nothing_new_to_send: false,
+        }
+    }
+
+    /// A sanctioned nothing-new-to-send conclusion. The marker is always
+    /// `true` and the reason prose is DERIVED from `why` — the two cannot
+    /// drift. The only true-constructor of the arm-2 marker.
+    #[must_use]
+    #[allow(dead_code)] // commit 2 (send-region reshape) is the first production caller
+    pub fn nothing_new(name: impl Into<String>, why: &NothingNew) -> Self {
+        Self {
+            name: name.into(),
+            reason: why.reason(),
+            next_due_minutes: None,
+            nothing_new_to_send: true,
+        }
+    }
+
+    /// Whether this skip is a sanctioned nothing-new-to-send conclusion —
+    /// the accessor the post-plan orphan invariant's arm 2 and
+    /// `collapse_skipped` consume.
+    #[must_use]
+    pub fn is_nothing_new(&self) -> bool {
+        self.nothing_new_to_send
+    }
+}
+
 /// The lifecycle judgment the planner made for one subvolume (UPI 082,
 /// Branches A/C): the pieces of `EffectivePolicy` the executor needs, carried
 /// on the plan instead of re-derived. Deliberately excludes `send_interval` —
@@ -1377,6 +1465,90 @@ pub fn format_run_duration(started: &str, finished: &str) -> Option<String> {
 mod tests {
     use super::*;
     use chrono::NaiveDate;
+
+    // ── NothingNew / PlannedSkip constructor tests (UPI 089-b) ──────
+    //
+    // The reason prose is a byte-stable contract: `SkipCategory::from_reason`
+    // pattern-classifies these strings (the two NoLocalSnapshots forms land in
+    // DIFFERENT categories) and `collapse_skipped` splits AlreadyOn on
+    // " already on ". These three tests pin the strings byte-for-byte.
+
+    #[test]
+    fn nothing_new_reason_already_on_is_byte_stable() {
+        let why = NothingNew::AlreadyOn {
+            snapshot: SnapshotName::parse("20260430-0402-one").expect("valid"),
+            drive: "WD-18TB".to_string(),
+        };
+        assert_eq!(why.reason(), "20260430-0402-one already on WD-18TB");
+    }
+
+    #[test]
+    fn nothing_new_reason_no_local_transient_is_external_only_prose() {
+        let why = NothingNew::NoLocalSnapshots { transient: true };
+        // em-dash literal, not a hyphen — SkipCategory::ExternalOnly matches
+        // starts_with("external-only").
+        assert_eq!(why.reason(), "external-only \u{2014} sends on next backup");
+    }
+
+    #[test]
+    fn nothing_new_reason_no_local_non_transient_is_gap_prose() {
+        let why = NothingNew::NoLocalSnapshots { transient: false };
+        assert_eq!(why.reason(), "no local snapshots to send");
+    }
+
+    #[test]
+    fn planned_skip_deferred_never_sets_marker() {
+        let skip = PlannedSkip::deferred("sv1", "drive not mounted".to_string(), None);
+        assert!(!skip.is_nothing_new());
+        assert_eq!(skip.reason, "drive not mounted");
+        assert_eq!(skip.next_due_minutes, None);
+    }
+
+    #[test]
+    fn planned_skip_deferred_carries_next_due() {
+        let skip = PlannedSkip::deferred("sv1", "not due".to_string(), Some(42));
+        assert_eq!(skip.next_due_minutes, Some(42));
+        assert!(!skip.is_nothing_new());
+    }
+
+    #[test]
+    fn planned_skip_nothing_new_always_sets_marker_and_derives_reason() {
+        let why = NothingNew::AlreadyOn {
+            snapshot: SnapshotName::parse("20260322-1330-one").expect("valid"),
+            drive: "D1".to_string(),
+        };
+        let skip = PlannedSkip::nothing_new("sv1", &why);
+        assert!(skip.is_nothing_new());
+        assert_eq!(skip.reason, "20260322-1330-one already on D1");
+        assert_eq!(skip.next_due_minutes, None);
+    }
+
+    /// Exhaustive-variant sweep (RD-b1 §6b, adversary F4): every sanctioned
+    /// `NothingNew` variant is strand-tripping (marker-true). The `match` has
+    /// NO wildcard, so a third variant breaks it — forcing an explicit
+    /// decision here about whether it trips arm 2, not merely that prose
+    /// exists for it in `reason()`.
+    #[test]
+    fn nothing_new_every_variant_is_strand_tripping() {
+        for why in [
+            NothingNew::AlreadyOn {
+                snapshot: SnapshotName::parse("20260322-1330-one").expect("valid"),
+                drive: "D1".to_string(),
+            },
+            NothingNew::NoLocalSnapshots { transient: true },
+            NothingNew::NoLocalSnapshots { transient: false },
+        ] {
+            let trips_arm2 = match why {
+                NothingNew::AlreadyOn { .. } => true,
+                NothingNew::NoLocalSnapshots { .. } => true,
+            };
+            assert_eq!(
+                trips_arm2,
+                PlannedSkip::nothing_new("sv", &why).is_nothing_new(),
+                "sanctioned conclusion must trip arm 2: {why:?}",
+            );
+        }
+    }
 
     // ── Interval tests ──────────────────────────────────────────────
 
@@ -1618,12 +1790,11 @@ mod tests {
                 .unwrap()
                 .and_hms_opt(14, 30, 0)
                 .unwrap(),
-            skipped: vec![PlannedSkip {
-                name: "subvol6-tmp".to_string(),
-                reason: "interval not elapsed".to_string(),
-                next_due_minutes: None,
-                nothing_new_to_send: false,
-            }],
+            skipped: vec![PlannedSkip::deferred(
+                "subvol6-tmp",
+                "interval not elapsed".to_string(),
+                None,
+            )],
             events: Vec::new(),
         };
         let s = plan.summary();

--- a/src/types.rs
+++ b/src/types.rs
@@ -1157,11 +1157,14 @@ pub struct PlannedSkip {
     pub reason: String,
     pub next_due_minutes: Option<i64>,
     /// True when send planning concluded the source offers nothing new for a
-    /// drive — set only by the "already on <drive>" and "no local snapshots
-    /// to send" conclusions. That conclusion is contradictory in a run that
-    /// also plans a `CreateSnapshot` for the subvolume; the post-plan orphan
-    /// invariant in `plan.rs` consumes it to detect stranded snapshots.
-    pub nothing_new_to_send: bool,
+    /// drive. Set ONLY by [`PlannedSkip::nothing_new`] (from a sanctioned
+    /// [`NothingNew`] conclusion); [`PlannedSkip::deferred`] always leaves it
+    /// false. Private so the marker cannot be set outside these constructors —
+    /// the field and the reason prose cannot drift. That conclusion is
+    /// contradictory in a run that also plans a `CreateSnapshot` for the
+    /// subvolume; the post-plan orphan invariant's arm 2 consumes it (via
+    /// [`PlannedSkip::is_nothing_new`]) to detect stranded snapshots.
+    nothing_new_to_send: bool,
 }
 
 /// The two sanctioned send-planning conclusions that mean "this (subvolume,
@@ -1172,14 +1175,6 @@ pub struct PlannedSkip {
 /// drift unrepresentable. A third conclusion is a new variant: greppable,
 /// reviewable, and the exhaustive match in [`NothingNew::reason`] forces the
 /// decision to be explicit (UPI 089-b).
-//
-// 089-b commit 1 is additive: the first PRODUCTION callers of `NothingNew`,
-// `reason()`, `deferred()`, and `nothing_new()` land in commit 2 (the
-// send-region reshape). Until then their only users are tests, so the bin
-// target (compiled without `cfg(test)`) sees them as dead. These `allow`s
-// come off in commit 2. `is_nothing_new()` needs none — arm 2 and
-// `collapse_skipped` already read it.
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NothingNew {
     /// The chosen snapshot is already on the drive ("caught up").
@@ -1200,7 +1195,6 @@ impl NothingNew {
     /// `collapse_skipped`'s `" already on "` split. Exhaustive match, no
     /// wildcard: a third variant must decide its own prose here.
     #[must_use]
-    #[allow(dead_code)] // commit 2 (send-region reshape) is the first production caller
     pub fn reason(&self) -> String {
         match self {
             NothingNew::AlreadyOn { snapshot, drive } => format!("{snapshot} already on {drive}"),
@@ -1219,7 +1213,6 @@ impl PlannedSkip {
     /// `nothing_new_to_send` marker is always `false`. This is the only
     /// constructor for every skip except the two sanctioned send conclusions.
     #[must_use]
-    #[allow(dead_code)] // commit 2 (defer_parts/record_defer bool-drop) is the first production caller
     pub fn deferred(name: impl Into<String>, reason: String, next_due_minutes: Option<i64>) -> Self {
         Self {
             name: name.into(),
@@ -1233,7 +1226,6 @@ impl PlannedSkip {
     /// `true` and the reason prose is DERIVED from `why` — the two cannot
     /// drift. The only true-constructor of the arm-2 marker.
     #[must_use]
-    #[allow(dead_code)] // commit 2 (send-region reshape) is the first production caller
     pub fn nothing_new(name: impl Into<String>, why: &NothingNew) -> Self {
         Self {
             name: name.into(),


### PR DESCRIPTION
## Summary

Slice 2 of the 089 `plan/` region-interfaces arc — the send seam gets real interfaces and the stranded-snapshot tripwire becomes type-enforced.

- **Send region reshaped.** `plan_external_send` (13 positional args + 3 `&mut` accumulators) and `plan_external_retention` now take typed inputs (`SendInputs` / `ExternalRetentionInputs` over 089-a's `SubvolInputs` core) and return a `PlanFragment` — directly testable in isolation for the first time.
- **`DriveGate`.** `check_drive_availability` returns `DriveGate::{Ready, Deferred(PlanFragment)}`; an unavailable drive can no longer be skipped without recording why (illegal state unrepresentable).
- **The marker is sealed.** `PlannedSkip.nothing_new_to_send` is privatized behind two constructors; `defer_nothing_new` derives the reason prose from a typed `NothingNew::{AlreadyOn, NoLocalSnapshots}` conclusion, so marker and prose can no longer drift. Both defer paths share one `defer_event` seam.
- Commit 1 is additive (type + constructors + fixture migration); commit 2 is the reshape + seal. The transient composite's signature is untouched (slice c's charter).

## Testing

- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 2385 passed, 0 failed (+20 region tests — incl. the 2026-05-02 anti-strand shape as an isolated regression test, the two no-local prose forms asserting their divergent `SkipCategory`, and a 7-row `DriveGate` truth table). Existing suite passes unmodified.
- Live two-binary run-pair against the real production config: `urd plan`, `urd plan --auto`, `urd backup --dry-run` all **byte-identical** (raw diff empty).
- Arc RD6 verification bar met; no on-disk / metric / config contract touched (no ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)