### PR TITLE
docs: OKF frontmatter on the public tier (ADR-118, N7)

### DIFF
--- a/docs/00-foundation/architecture.md
+++ b/docs/00-foundation/architecture.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: Architecture at a Glance
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-07-13T02:14:58+02:00'
+---
 # Architecture at a Glance
 
 > **TL;DR:** Urd is a strict pipeline — *config → plan → execute → btrfs* — with a

--- a/docs/00-foundation/decisions/2026-03-24-ADR-100-planner-executor-separation.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-100-planner-executor-separation.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Planner/Executor Separation
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-100: Planner/Executor Separation
 
 > **TL;DR:** The planner is a pure function that decides what operations to run. The executor

--- a/docs/00-foundation/decisions/2026-03-24-ADR-101-btrfsops-trait.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-101-btrfsops-trait.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: BtrfsOps Trait as Sole Btrfs Interface
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-101: BtrfsOps Trait as Sole Btrfs Interface
 
 > **TL;DR:** All btrfs subprocess calls go through a single trait (`BtrfsOps`) in a single

--- a/docs/00-foundation/decisions/2026-03-24-ADR-102-filesystem-truth-sqlite-history.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-102-filesystem-truth-sqlite-history.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Filesystem as Source of Truth, SQLite as History
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-102: Filesystem as Source of Truth, SQLite as History
 
 > **TL;DR:** Snapshot directories and pin files on disk are the authoritative record of

--- a/docs/00-foundation/decisions/2026-03-24-ADR-103-interval-scheduling.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-103-interval-scheduling.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Interval-Based Scheduling
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-103: Interval-Based Scheduling
 
 > **TL;DR:** Urd uses time intervals (`15m`, `1h`, `1d`) for snapshot and send scheduling

--- a/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-104-graduated-retention.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Graduated Retention Model
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-104: Graduated Retention Model
 
 > **TL;DR:** Urd uses Time Machine-style graduated retention — keep everything recent, thin

--- a/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-105-backward-compatibility-contracts.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Backward Compatibility Contracts
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-105: Backward Compatibility Contracts
 
 > **TL;DR:** Four data formats are load-bearing — snapshot names, snapshot directory

--- a/docs/00-foundation/decisions/2026-03-24-ADR-106-defense-in-depth-data-integrity.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-106-defense-in-depth-data-integrity.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Defense-in-Depth for Data Integrity
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-106: Defense-in-Depth for Data Integrity
 
 > **TL;DR:** Retention and deletion logic uses multiple independent layers of protection so

--- a/docs/00-foundation/decisions/2026-03-24-ADR-107-fail-open-cleanup-on-failure.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-107-fail-open-cleanup-on-failure.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Fail-Open for Backups, Clean Up on Failure
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-107: Fail-Open for Backups, Clean Up on Failure
 
 > **TL;DR:** When Urd cannot determine whether an operation is safe (missing size data,

--- a/docs/00-foundation/decisions/2026-03-24-ADR-108-pure-function-module-pattern.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-108-pure-function-module-pattern.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Pure-Function Module Pattern
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-108: Pure-Function Module Pattern
 
 > **TL;DR:** Core logic modules are pure functions: inputs in (config, state, time),

--- a/docs/00-foundation/decisions/2026-03-24-ADR-109-config-boundary-validation.md
+++ b/docs/00-foundation/decisions/2026-03-24-ADR-109-config-boundary-validation.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Config-Boundary Validation
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-24'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-109: Config-Boundary Validation
 
 > **TL;DR:** All user-provided paths and names are validated once at config load time.

--- a/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
+++ b/docs/00-foundation/decisions/2026-03-26-ADR-110-protection-promises.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Protection Promises
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-26'
+timestamp: '2026-05-30T21:25:09+02:00'
+---
 # ADR-110: Protection Promises
 
 > **TL;DR:** Protection promises are named levels that map to concrete operational policies.

--- a/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
+++ b/docs/00-foundation/decisions/2026-03-27-ADR-111-config-system-architecture.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Config System Architecture
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-27'
+timestamp: '2026-07-02T01:04:01+02:00'
+---
 # ADR-111: Config System Architecture
 
 > **TL;DR:** The config file is a complete, self-describing artifact with no hidden inheritance.

--- a/docs/00-foundation/decisions/2026-03-28-ADR-112-semver-and-release-workflow.md
+++ b/docs/00-foundation/decisions/2026-03-28-ADR-112-semver-and-release-workflow.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: SemVer Versioning and Release Workflow
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-28'
+timestamp: '2026-03-28T15:15:38+01:00'
+---
 # ADR-112: SemVer Versioning and Release Workflow
 
 > **TL;DR:** Urd uses standard Semantic Versioning (SemVer) for all releases. Versions

--- a/docs/00-foundation/decisions/2026-04-18-ADR-113-do-no-harm-invariant.md
+++ b/docs/00-foundation/decisions/2026-04-18-ADR-113-do-no-harm-invariant.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: The Do-No-Harm Invariant
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-04-21'
+timestamp: '2026-06-26T12:00:41+02:00'
+---
 # ADR-113: The Do-No-Harm Invariant
 
 > **TL;DR:** Urd shall not be the proximate cause of local storage pressure on monitored

--- a/docs/00-foundation/decisions/2026-04-30-ADR-114-structured-event-log.md
+++ b/docs/00-foundation/decisions/2026-04-30-ADR-114-structured-event-log.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Structured Event Log for Decisions and State Transitions
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-04-30'
+timestamp: '2026-05-29T18:25:12+02:00'
+---
 # ADR-114: Structured Event Log for Decisions and State Transitions
 
 > **TL;DR:** Urd shall persist a typed, immutable log of state changes and decisions —

--- a/docs/00-foundation/decisions/2026-05-09-ADR-115-retention-shape-symmetry-and-recommendation-layer.md
+++ b/docs/00-foundation/decisions/2026-05-09-ADR-115-retention-shape-symmetry-and-recommendation-layer.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Retention Shape Symmetry and the Recommendation Layer
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-14'
+timestamp: '2026-07-11T09:19:17+02:00'
+---
 # ADR-115: Retention Shape Symmetry and the Recommendation Layer
 
 > **TL;DR:** The cost of retaining a snapshot is **symmetric across source and

--- a/docs/00-foundation/decisions/2026-06-02-ADR-116-offsite-rotation-expected-absence.md
+++ b/docs/00-foundation/decisions/2026-06-02-ADR-116-offsite-rotation-expected-absence.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Offsite Rotation Is Expected Absence
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-06-02'
+timestamp: '2026-06-15T01:37:42+02:00'
+---
 # ADR-116: Offsite Rotation Is Expected Absence
 
 > **TL;DR:** An *offsite* drive defends against site loss and is **intermittently present

--- a/docs/00-foundation/decisions/2026-07-11-ADR-117-release-artifact-contract.md
+++ b/docs/00-foundation/decisions/2026-07-11-ADR-117-release-artifact-contract.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Release Artifact Contract
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-07-11'
+timestamp: '2026-07-11T09:39:50+02:00'
+---
 # ADR-117: Release Artifact Contract
 
 > **TL;DR:** Every release publishes one statically linked musl binary named

--- a/docs/00-foundation/decisions/2026-07-15-ADR-118-documentation-boundary-per-document-sensitivity.md
+++ b/docs/00-foundation/decisions/2026-07-15-ADR-118-documentation-boundary-per-document-sensitivity.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Documentation Boundary as Per-Document Sensitivity
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-07-15'
+timestamp: '2026-07-15T12:39:55+02:00'
+---
 # ADR-118: Documentation Boundary as Per-Document Sensitivity
 
 > **TL;DR:** Urd's six internal doc directories (`90-archive`, `95-ideas`,

--- a/docs/00-foundation/decisions/ADR-relating-to-bash-script/2026-03-21-ADR-020-daily-external-backups.md
+++ b/docs/00-foundation/decisions/ADR-relating-to-bash-script/2026-03-21-ADR-020-daily-external-backups.md
@@ -1,3 +1,13 @@
+---
+type: ADR
+title: Daily External Backups with Incremental Sends
+categories: ['[[ADR]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-23'
+timestamp: '2026-05-02T19:40:32+02:00'
+---
 # ADR-020: Daily External Backups with Incremental Sends
 
 **Date:** 2026-03-21

--- a/docs/00-foundation/glossary.md
+++ b/docs/00-foundation/glossary.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: Glossary
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-07-13T02:14:58+02:00'
+---
 # Glossary
 
 > **TL;DR:** Single source for Urd's controlled vocabulary — promise states, voice

--- a/docs/00-foundation/guides/encounter-staging-protocol.md
+++ b/docs/00-foundation/guides/encounter-staging-protocol.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: The Encounter Staging Protocol
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-07-03'
+timestamp: '2026-07-04T15:47:41+02:00'
+---
 # The Encounter Staging Protocol
 
 > **TL;DR:** A real, physical staging machine — Fedora Workstation, native btrfs with

--- a/docs/00-foundation/guides/operating-urd.md
+++ b/docs/00-foundation/guides/operating-urd.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: Operating Urd
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-03-23'
+timestamp: '2026-07-05T15:58:56+02:00'
+---
 # Operating Urd
 
 > **TL;DR:** How to build, install, update, and run Urd day-to-day. Covers the full

--- a/docs/00-foundation/source-documentation/README.md
+++ b/docs/00-foundation/source-documentation/README.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: Source Documentation
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-04-05'
+timestamp: '2026-05-02T19:40:32+02:00'
+---
 # Source Documentation
 
 Reference documents for Urd's key dependencies and toolchain. Written to help

--- a/docs/00-foundation/source-documentation/btrfs-reference.md
+++ b/docs/00-foundation/source-documentation/btrfs-reference.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: BTRFS Reference for Backup Tooling
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-04-05'
+timestamp: '2026-05-02T19:40:32+02:00'
+---
 # BTRFS Reference for Backup Tooling
 
 > Based on btrfs-progs documentation through v6.12+ (training data).

--- a/docs/00-foundation/source-documentation/colored-3.md
+++ b/docs/00-foundation/source-documentation/colored-3.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: colored 3.x Reference
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-04-05'
+timestamp: '2026-05-02T19:40:32+02:00'
+---
 # colored 3.x Reference
 
 > Urd dependency: `colored = "3"` (resolves to 3.1.1)

--- a/docs/00-foundation/source-documentation/nix-0.31.md
+++ b/docs/00-foundation/source-documentation/nix-0.31.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: nix 0.31 Reference
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-04-05'
+timestamp: '2026-05-02T19:40:32+02:00'
+---
 # nix 0.31 Reference
 
 > Urd dependency: `nix = { version = "0.31", features = ["fs"] }`

--- a/docs/00-foundation/source-documentation/rusqlite-0.39.md
+++ b/docs/00-foundation/source-documentation/rusqlite-0.39.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: rusqlite 0.39 Reference
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-04-05'
+timestamp: '2026-05-02T19:40:32+02:00'
+---
 # rusqlite 0.39 Reference
 
 > Urd dependency: `rusqlite = { version = "0.39", features = ["bundled"] }`

--- a/docs/00-foundation/source-documentation/rust-2024-edition.md
+++ b/docs/00-foundation/source-documentation/rust-2024-edition.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: Rust 2024 Edition Reference
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-04-05'
+timestamp: '2026-05-02T19:40:32+02:00'
+---
 # Rust 2024 Edition Reference
 
 > Stabilized in Rust 1.85.0 (2025-02-20). Urd uses `edition = "2024"`.

--- a/docs/00-foundation/source-documentation/toml-1.md
+++ b/docs/00-foundation/source-documentation/toml-1.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: toml 1.x Reference
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-04-05'
+timestamp: '2026-05-02T19:40:32+02:00'
+---
 # toml 1.x Reference
 
 > Urd dependency: `toml = "1"` (resolves to 1.1.2)

--- a/docs/10-operations/postmortems/2026-03-24-local-space-exhaustion.md
+++ b/docs/10-operations/postmortems/2026-03-24-local-space-exhaustion.md
@@ -1,3 +1,13 @@
+---
+type: Report
+title: 'Postmortem: Local Space Exhaustion on System Drive'
+categories: ['[[Report]]']
+project: ['[[urd]]']
+sensitivity: public
+status: final
+created: '2026-05-02'
+timestamp: '2026-05-02T19:55:41+02:00'
+---
 # Postmortem: Local Space Exhaustion on System Drive
 
 > **TL;DR:** Urd filled the host's NVMe system drive with local snapshots and

--- a/docs/10-operations/postmortems/template.md
+++ b/docs/10-operations/postmortems/template.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: 'Postmortem: {Incident Title}'
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-05-02T19:55:41+02:00'
+---
 # Postmortem: {Incident Title}
 
 > **TL;DR:** {What happened, what the blast radius was, what invariant was added

--- a/docs/10-operations/runbooks/doctor-walk.md
+++ b/docs/10-operations/runbooks/doctor-walk.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: 'Runbook: Walking the Doctor Output'
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-05-02T20:45:51+02:00'
+---
 # Runbook: Walking the Doctor Output
 
 > **TL;DR:** `urd doctor` is the first thing to run when something feels

--- a/docs/10-operations/runbooks/drive-rotation.md
+++ b/docs/10-operations/runbooks/drive-rotation.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: 'Runbook: Drive Rotation'
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-05-02T20:45:51+02:00'
+---
 # Runbook: Drive Rotation
 
 > **TL;DR:** Removable backup drives can be disconnected and reconnected

--- a/docs/10-operations/runbooks/mapper-zombie.md
+++ b/docs/10-operations/runbooks/mapper-zombie.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: 'Runbook: "File exists" on Re-unlocking a LUKS Backup Drive'
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-05-02T20:45:51+02:00'
+---
 # Runbook: "File exists" on Re-unlocking a LUKS Backup Drive
 
 > **TL;DR:** When a removable LUKS drive is unplugged and reconnected, the

--- a/docs/10-operations/runbooks/sentinel-restart.md
+++ b/docs/10-operations/runbooks/sentinel-restart.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: 'Runbook: Restarting the Sentinel'
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-05-02T21:54:24+02:00'
+---
 # Runbook: Restarting the Sentinel
 
 > **TL;DR:** The Sentinel is a stateless observer of the SQLite event log

--- a/docs/20-reference/cli.md
+++ b/docs/20-reference/cli.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: CLI Reference
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-07-05T15:58:56+02:00'
+---
 # CLI Reference
 
 > **TL;DR:** Reference for every `urd` subcommand — its contract (what it

--- a/docs/20-reference/heartbeat-schema.md
+++ b/docs/20-reference/heartbeat-schema.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: Heartbeat Schema Reference
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-05-02T20:45:51+02:00'
+---
 # Heartbeat Schema Reference
 
 > **TL;DR:** `heartbeat.json` is a JSON health signal Urd writes after every

--- a/docs/20-reference/metrics.md
+++ b/docs/20-reference/metrics.md
@@ -1,3 +1,13 @@
+---
+type: Guide
+title: Prometheus Metrics Reference
+categories: ['[[Guide]]']
+project: ['[[urd]]']
+sensitivity: public
+status: active
+created: '2026-05-02'
+timestamp: '2026-06-10T08:44:18+02:00'
+---
 # Prometheus Metrics Reference
 
 > **TL;DR:** Urd writes a Prometheus textfile (`backup.prom`) consumed by

--- a/scripts/check-present-not-journey.sh
+++ b/scripts/check-present-not-journey.sh
@@ -59,8 +59,23 @@ for file in "${targets[@]}"; do
     checked=$((checked + 1))
 
     lineno=0
+    in_frontmatter=0
     while IFS= read -r raw || [[ -n "$raw" ]]; do
         lineno=$((lineno + 1))
+
+        # Skip the YAML frontmatter block (ADR-118: public-tier docs now carry OKF
+        # frontmatter, e.g. `created: '2026-05-02'`). Structured metadata dates are not
+        # journey narration -- the lint governs prose, not the schema built to hold dates.
+        if [[ $lineno -eq 1 && "$raw" == "---" ]]; then
+            in_frontmatter=1
+            continue
+        fi
+        if [[ $in_frontmatter -eq 1 ]]; then
+            if [[ "$raw" == "---" ]]; then
+                in_frontmatter=0
+            fi
+            continue
+        fi
 
         # Strip inline-code spans (`…`) and markdown link targets ](…) so dated-filename
         # pointers and path references don't trip the lint. Link *text* is kept.


### PR DESCRIPTION
## Summary
- Adds OKF frontmatter (`type`, `sensitivity: public`, `status`, `created`, `timestamp`) to all 40 files in `00-foundation/` (including all 19 ADRs), `10-operations/`, and `20-reference/`.
- The existing house style (H1 + `> **TL;DR:**` + bold metadata lines) is untouched — frontmatter is added on top, not a replacement.
- `type: ADR` for `docs/00-foundation/decisions/`, `type: Report` for the one postmortem (point-in-time incident record) and `type: Guide` for everything else (architecture.md, glossary.md, guides, source-documentation references, runbooks, the postmortem template, and the 20-reference docs).
- `created`/`timestamp` derived from real git history (`git log --follow`), not filename guesses — these files are tracked, so the dates are exact.
- Fixes `scripts/check-present-not-journey.sh`: it now skips the YAML frontmatter block before scanning for journey-narration patterns. Without this, the new `created:`/`timestamp:` dates in `architecture.md` tripped the bare-date-in-prose rule — structured metadata isn't prose narration, and the lint's own intent (per its header comment) was always about CLAUDE.md/architecture.md's *prose*, not a schema that didn't exist yet when it was written.

This is N7 from the docs-vault-migration plan (`docs/97-plans/2026-07-15-docs-vault-migration-guidance.md`), the second and final PR of the migration — the first (#328) moved the internal `9x` directories into the private Huldr vault and untracked `CLAUDE.md`.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 2385 passed, 0 failed, 5 ignored
- [x] `scripts/check-docs.sh` passes (65 links, 44 tracked files)
- [x] `scripts/check-present-not-journey.sh` passes after the frontmatter-skip fix
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)