### PR TITLE
release: v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-07-15
+
 ### Fixed
 - `urd backup`'s post-run table and `--json` output now carry the same complete
   promise fields (`promise_level`, `retention_summary`, `external_only`) that
@@ -1723,7 +1725,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.35.0...HEAD
+[0.35.0]: https://github.com/vonrobak/urd/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/vonrobak/urd/compare/v0.33.4...v0.34.0
 [0.33.4]: https://github.com/vonrobak/urd/compare/v0.33.3...v0.33.4
 [0.33.3]: https://github.com/vonrobak/urd/compare/v0.33.2...v0.33.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.34.0"
+version = "0.35.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.35.0**. Two behavior-neutral refactor arcs — plan/ region interfaces (UPI 089, #298: #325/#327/#330) and backup-orchestration deepening (UPI 088: #321/#322/#324) — plus the promise-fields fix (#297) and the verified-binary install flow (#323).

## Testing

- cargo clippy --all-targets -- -D warnings: pass
- cargo test: 2396 passed, 0 failed
- cargo build --release: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)