### PR TITLE
chore: deterministic toolchain scripts (tooling pass, wave 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ scripts/*
 !scripts/check-registry.sh
 !scripts/check-present-not-journey.sh
 !scripts/staging-reset.sh
+!scripts/check.sh
+!scripts/release-preflight.sh
+!scripts/release-bump.sh
+!scripts/collect-diagnostics.sh

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# check.sh — the /check quality gate as one command with a compact roll-up.
+#
+# Gates, in order: clippy (--all-targets, warnings are errors), unit tests,
+# release build, then the present-not-journey doc lint (independent of
+# compilation, always runs). Prints one verdict line per gate plus a test
+# count computed from cargo's own summary lines — never hand-typed.
+#
+# On the green path only the roll-up is printed. When a gate fails, its full
+# output is replayed after the roll-up (the fix needs it); cargo gates after
+# a failed cargo gate are skipped, the doc lint still runs, exit code is 1.
+#
+# Usage: scripts/check.sh [test-filter]
+#   With a filter, runs only `cargo test <filter>` and reports that one gate.
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Sum cargo's "test result: ok. X passed; Y failed; Z ignored; ..." lines
+# across all test binaries in a captured log.
+test_counts() {
+    awk '/^test result:/ {
+        for (i = 1; i <= NF; i++) {
+            if ($(i+1) == "passed;")  p  += $i
+            if ($(i+1) == "failed;")  f  += $i
+            if ($(i+1) == "ignored;") ig += $i
+        }
+    } END { printf "%d passed, %d failed, %d ignored", p, f, ig }' "$1"
+}
+
+declare -a LINES=() REPLAY=()
+FAILED=0
+
+run_gate() { # <label> <logfile> <command...> -> 0/1, records verdict line
+    local label="$1" log="$2"; shift 2
+    if "$@" >"$log" 2>&1; then
+        LINES+=("$(printf '%-9s PASS' "$label")")
+        return 0
+    fi
+    LINES+=("$(printf '%-9s FAIL' "$label")")
+    REPLAY+=("$label:$log")
+    FAILED=1
+    return 1
+}
+
+finish() {
+    printf '%s\n' "${LINES[@]}"
+    if [[ $FAILED -eq 0 ]]; then
+        echo "All checks passed."
+        exit 0
+    fi
+    for entry in "${REPLAY[@]}"; do
+        echo
+        echo "--- ${entry%%:*} output ---"
+        cat "${entry#*:}"
+    done
+    exit 1
+}
+
+# Filter mode: just the matching tests.
+if [[ $# -ge 1 ]]; then
+    if run_gate "tests" "$WORK/tests.log" cargo test "$1"; then
+        LINES[0]="$(printf '%-9s PASS  %s (filter: %s)' "tests" "$(test_counts "$WORK/tests.log")" "$1")"
+    fi
+    finish
+fi
+
+if run_gate "clippy" "$WORK/clippy.log" cargo clippy --all-targets -- -D warnings; then
+    if run_gate "tests" "$WORK/tests.log" cargo test; then
+        LINES[1]="$(printf '%-9s PASS  %s' "tests" "$(test_counts "$WORK/tests.log")")"
+        run_gate "build" "$WORK/build.log" cargo build --release || true
+    else
+        LINES+=("$(printf '%-9s SKIP  (tests failed)' "build")")
+    fi
+else
+    LINES+=("$(printf '%-9s SKIP  (clippy failed)' "tests")")
+    LINES+=("$(printf '%-9s SKIP  (clippy failed)' "build")")
+fi
+
+run_gate "doc-lint" "$WORK/doclint.log" ./scripts/check-present-not-journey.sh || true
+
+finish

--- a/scripts/collect-diagnostics.sh
+++ b/scripts/collect-diagnostics.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# collect-diagnostics.sh — one-pass, read-only Urd state capture for debugging.
+#
+# Evidence first: run this BEFORE investigating or fixing — once a fix is
+# applied the original state is gone. Unprivileged; btrfs-level detail
+# (subvolume lists, qgroups) needs sudo and is deliberately out of scope —
+# run `sudo btrfs subvolume list <mount>` separately if needed.
+#
+# Sections: install/config, snapshot roots on disk (with snapshot-name
+# format check), pin-file integrity, drive/UUID state, heartbeat and
+# state-db freshness, lock file, systemd user units, repo git state, and
+# `urd status` / `urd plan` output.
+#
+# Usage: scripts/collect-diagnostics.sh [--no-urd]
+#   --no-urd  skip invoking the urd binary (pure filesystem capture;
+#             note that `urd status` may create urd.db if absent)
+
+set -uo pipefail
+
+RUN_URD=1
+[[ "${1:-}" == "--no-urd" ]] && RUN_URD=0
+
+CONFIG="$HOME/.config/urd/urd.toml"
+DATA_DIR="$HOME/.local/share/urd"
+
+section() { printf '\n== %s ==\n' "$1"; }
+
+age_of() { # <file> -> "Xh Ym ago (mtime ...)"
+    local mtime now diff
+    mtime="$(stat -c %Y "$1" 2>/dev/null)" || { echo "unreadable"; return; }
+    now="$(date +%s)"
+    diff=$(( now - mtime ))
+    printf '%dh %dm ago (%s)' $(( diff / 3600 )) $(( (diff % 3600) / 60 )) "$(date -d "@$mtime" '+%F %H:%M')"
+}
+
+echo "Urd diagnostics — $(date '+%F %H:%M:%S') (unprivileged, read-only)"
+
+section "install / config"
+if command -v urd >/dev/null 2>&1; then
+    echo "binary: $(command -v urd) — $(urd --version 2>&1 | head -1)"
+else
+    echo "binary: urd not on PATH"
+fi
+if [[ -f "$CONFIG" ]]; then
+    echo "config: $CONFIG — modified $(age_of "$CONFIG")"
+else
+    echo "config: $CONFIG MISSING"
+fi
+
+# Absolute snapshot roots from config ("~" expanded). Drive-relative roots
+# (e.g. ".snapshots") resolve against each drive's mount and are reported
+# under the drives section instead.
+declare -a ROOTS=()
+if [[ -f "$CONFIG" ]]; then
+    while IFS= read -r r; do
+        r="${r/#\~/$HOME}"
+        [[ "$r" == /* ]] && ROOTS+=("$r")
+    done < <(grep -E '^[[:space:]]*snapshot_root[[:space:]]*=' "$CONFIG" \
+             | sed -E 's/.*"([^"]+)".*/\1/' | sort -u)
+fi
+
+section "snapshot roots on disk"
+if [[ ${#ROOTS[@]} -eq 0 ]]; then
+    echo "no absolute snapshot_root entries found in config"
+fi
+# Layout: {snapshot_root}/{subvolume-short-name}/{YYYYMMDD-HHMM-name}
+for root in "${ROOTS[@]}"; do
+    if [[ ! -d "$root" ]]; then
+        echo "$root: MISSING"
+        continue
+    fi
+    echo "$root:"
+    while IFS= read -r subvol_dir; do
+        mapfile -t snaps < <(find "$root/$subvol_dir" -mindepth 1 -maxdepth 1 -not -name '.*' -printf '%f\n' 2>/dev/null | sort)
+        line="  $subvol_dir: ${#snaps[@]} snapshot(s)"
+        if [[ ${#snaps[@]} -gt 0 ]]; then
+            line+=", oldest ${snaps[0]}, newest ${snaps[-1]}"
+        fi
+        echo "$line"
+        # Names outside the on-disk contract (YYYYMMDD-HHMM-name; legacy YYYYMMDD-name)
+        malformed="$(printf '%s\n' "${snaps[@]}" | grep -vE '^[0-9]{8}(-[0-9]{4})?-.+' || true)"
+        if [[ -n "$malformed" ]]; then
+            echo "    MALFORMED names (won't parse as snapshots):"
+            echo "$malformed" | sed 's/^/      /'
+        fi
+    done < <(find "$root" -mindepth 1 -maxdepth 1 -type d -not -name '.*' -printf '%f\n' 2>/dev/null | sort)
+done
+
+section "pin files (.last-external-parent-*)"
+found_pin=0
+for root in "${ROOTS[@]}"; do
+    [[ -d "$root" ]] || continue
+    while IFS= read -r pin; do
+        found_pin=1
+        content="$(tr -d '[:space:]' < "$pin" 2>/dev/null || echo '<unreadable>')"
+        # The pinned snapshot lives beside its pin file, in the same subvolume dir.
+        target="$(dirname "$pin")/$(basename "$content")"
+        if [[ -e "$target" ]]; then
+            echo "$pin -> $content [target exists]"
+        else
+            echo "$pin -> $content [TARGET MISSING beside pin]"
+        fi
+    done < <(find "$root" -maxdepth 2 -name '.last-external-parent-*' 2>/dev/null)
+done
+[[ $found_pin -eq 0 ]] && echo "none found under the absolute snapshot roots"
+
+section "drives (lsblk) vs config"
+lsblk -o NAME,LABEL,UUID,FSTYPE,SIZE,MOUNTPOINT 2>/dev/null | awk 'NR==1 || /btrfs|crypt/' || echo "lsblk unavailable"
+if [[ -f "$CONFIG" ]]; then
+    echo "config drives:"
+    grep -E '^[[:space:]]*(label|uuid)[[:space:]]*=' "$CONFIG" | sed 's/^[[:space:]]*/  /' || true
+fi
+
+section "heartbeat / state / lock ($DATA_DIR)"
+for f in heartbeat.json sentinel-state.json; do
+    if [[ -f "$DATA_DIR/$f" ]]; then
+        echo "$f: updated $(age_of "$DATA_DIR/$f")"
+        if command -v jq >/dev/null 2>&1; then
+            jq -c . "$DATA_DIR/$f" 2>/dev/null | cut -c1-400 | sed 's/^/  /'
+        fi
+    else
+        echo "$f: missing"
+    fi
+done
+if [[ -f "$DATA_DIR/urd.db" ]]; then
+    echo "urd.db: $(stat -c %s "$DATA_DIR/urd.db") bytes, modified $(age_of "$DATA_DIR/urd.db")"
+else
+    echo "urd.db: missing (urd status/doctor may create it — accepted cost)"
+fi
+if [[ -f "$DATA_DIR/urd.lock" ]]; then
+    echo "urd.lock: present, modified $(age_of "$DATA_DIR/urd.lock")"
+    pid="$(tr -cd '0-9' < "$DATA_DIR/urd.lock" 2>/dev/null | head -c 10)"
+    if [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        echo "  holder PID $pid is ALIVE"
+    elif [[ -n "$pid" ]]; then
+        echo "  recorded PID $pid not running (advisory lock; liveness is fcntl-based)"
+    fi
+else
+    echo "urd.lock: absent"
+fi
+
+section "systemd user units"
+systemctl --user list-units 'urd*' --all --no-pager --no-legend 2>/dev/null || echo "systemctl unavailable"
+systemctl --user list-timers --all --no-pager 2>/dev/null | awk 'NR==1 || /urd/' || true
+
+section "repo git state"
+repo_dir="$(cd "$(dirname "$0")/.." && pwd)"
+if git -C "$repo_dir" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "repo: $repo_dir @ $(git -C "$repo_dir" branch --show-current), $(git -C "$repo_dir" status --porcelain | wc -l) dirty entries"
+    git -C "$repo_dir" log --oneline -5 | sed 's/^/  /'
+else
+    echo "not running from a git checkout"
+fi
+
+if [[ $RUN_URD -eq 1 ]] && command -v urd >/dev/null 2>&1; then
+    section "urd status"
+    timeout 60 urd status 2>&1 || echo "(urd status exited $?)"
+    section "urd plan"
+    timeout 60 urd plan 2>&1 || echo "(urd plan exited $?)"
+fi
+
+echo
+echo "Capture complete. For btrfs-level detail: sudo btrfs subvolume list <mount>."

--- a/scripts/pre-commit-pii.sh
+++ b/scripts/pre-commit-pii.sh
@@ -12,10 +12,20 @@
 #     stderr and exits 1, so the operator must either fix the diff or pass
 #     --no-verify deliberately.
 #
+# Report mode (--report): scans the working tree instead of the staged diff —
+# `git diff HEAD` plus untracked files — prints the same classified report to
+# stdout, and always exits 0. For pre-staging review (/commit-push-pr Phase 2);
+# the hook still re-scans the staged diff at commit time.
+#
 # Bypass for a single commit (use sparingly): git commit --no-verify
 # Install: scripts/install-hooks.sh
 
 set -euo pipefail
+
+MODE="hook"
+if [[ "${1:-}" == "--report" ]]; then
+    MODE="report"
+fi
 
 # Resolve identifiers we will scan for.
 USERNAME="$(whoami)"
@@ -32,10 +42,28 @@ fi
 HOME_PATH="/home/${USERNAME}/"
 MEDIA_PATH="/run/media/${USERNAME}/"
 
-# Pull only the staged additions. -U0 strips context so we only see new lines.
-DIFF="$(git diff --cached --no-color -U0 --diff-filter=ACMR || true)"
+# Pull only the added lines. -U0 strips context so we only see new lines.
+# Hook mode scans the staged diff; report mode scans the working tree vs HEAD
+# and appends untracked text files as synthetic additions (same classifier).
+if [[ "$MODE" == "report" ]]; then
+    SRC="$(mktemp)"
+    trap 'rm -f "$SRC"' EXIT
+    git diff HEAD --no-color -U0 --diff-filter=ACMR > "$SRC" 2>/dev/null || true
+    while IFS= read -r f; do
+        [[ -f "$f" ]] || continue
+        grep -qI . "$f" 2>/dev/null || continue   # skip binary/empty
+        printf '+++ b/%s\n' "$f" >> "$SRC"
+        sed 's/^/+/' "$f" >> "$SRC"
+    done < <(git ls-files --others --exclude-standard)
+    DIFF="$(cat "$SRC")"
+else
+    DIFF="$(git diff --cached --no-color -U0 --diff-filter=ACMR || true)"
+fi
 
 if [[ -z "$DIFF" ]]; then
+    if [[ "$MODE" == "report" ]]; then
+        echo "PII report: no changes to scan (working tree matches HEAD)."
+    fi
     exit 0
 fi
 
@@ -95,13 +123,18 @@ while IFS= read -r line; do
 done <<< "$DIFF"
 
 if [[ $TOTAL -eq 0 ]]; then
+    if [[ "$MODE" == "report" ]]; then
+        echo "PII report: clean — no matches in working tree vs HEAD (incl. untracked)."
+    fi
     exit 0
 fi
 
-{
+emit_report() {
+    local scope="staged diff"
+    [[ "$MODE" == "report" ]] && scope="working tree (vs HEAD, incl. untracked)"
     echo
     echo "================================================================="
-    echo "  PII pre-commit scan: ${TOTAL} potential match(es) in staged diff"
+    echo "  PII scan: ${TOTAL} potential match(es) in ${scope}"
     echo "================================================================="
 
     if [[ ${#CODE_HITS[@]} -gt 0 ]]; then
@@ -127,9 +160,20 @@ fi
     echo "    ${USERNAME} (standalone)"
     [[ -n "$HOSTNAME_VAL" ]] && echo "    ${HOSTNAME_VAL} (standalone)"
     echo
-    echo "  Review with: git diff --cached"
+    if [[ "$MODE" == "report" ]]; then
+        echo "  Fix source/config hits before staging; docs hits are operator judgment."
+    else
+        echo "  Review with: git diff --cached"
+    fi
     echo
-} >&2
+}
+
+if [[ "$MODE" == "report" ]]; then
+    emit_report
+    exit 0
+fi
+
+emit_report >&2
 
 # Try to prompt on the controlling TTY. If unavailable (agent commit, CI),
 # fail closed — the operator can rerun with --no-verify after deciding.

--- a/scripts/release-bump.sh
+++ b/scripts/release-bump.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# release-bump.sh <X.Y.Z> — deterministic release file surgery (Phases 2+4 of /release).
+#
+# Validates the version (SemVer without leading zeros, strictly greater than
+# the current Cargo.toml version, tag not already existing), then edits:
+#   Cargo.toml    version = "X.Y.Z"
+#   Cargo.lock    the urd package's version line
+#   CHANGELOG.md  [Unreleased] content becomes "## [X.Y.Z] - <today>";
+#                 comparison links at the bottom are rewritten
+# Refuses when [Unreleased] is empty — drafting the entry is judgment work
+# (Phase 3); do that first, then rerun. Ends with a consistency verdict
+# across the three files. Run on the release branch.
+#
+# Usage: scripts/release-bump.sh 0.36.0
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+NEW="${1:-}"
+if [[ -z "$NEW" ]]; then
+    echo "usage: scripts/release-bump.sh X.Y.Z" >&2
+    exit 2
+fi
+if [[ ! "$NEW" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+    echo "invalid SemVer (no leading zeros, no suffix): $NEW" >&2
+    exit 1
+fi
+
+CUR="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "([^"]+)".*/\1/')"
+IFS=. read -r ca cb cc <<< "$CUR"
+IFS=. read -r na nb nc <<< "$NEW"
+if (( na < ca || (na == ca && nb < cb) || (na == ca && nb == cb && nc <= cc) )); then
+    echo "version $NEW is not strictly greater than current $CUR" >&2
+    exit 1
+fi
+if git rev-parse -q --verify "refs/tags/v$NEW" >/dev/null; then
+    echo "tag v$NEW already exists — tags are immutable, refusing" >&2
+    exit 1
+fi
+
+UNREL="$(awk '/^## \[Unreleased\]/{f=1; next} /^## \[/{f=0} f' CHANGELOG.md | grep -v '^[[:space:]]*$' || true)"
+if [[ -z "$UNREL" ]]; then
+    echo "CHANGELOG [Unreleased] is empty — draft the entry first (Phase 3), then rerun." >&2
+    exit 1
+fi
+
+TODAY="$(date +%F)"
+
+# Cargo.toml — first version line only (the [package] one).
+sed -i "0,/^version = \"$CUR\"/s//version = \"$NEW\"/" Cargo.toml
+
+# Cargo.lock — the version line of the urd package block.
+awk -v new="$NEW" '
+    $0 == "name = \"urd\"" { in_urd = 1; print; next }
+    in_urd && /^version = / { print "version = \"" new "\""; in_urd = 0; next }
+    { print }
+' Cargo.lock > Cargo.lock.tmp && mv Cargo.lock.tmp Cargo.lock
+
+# CHANGELOG — the [Unreleased] content becomes the new version's section:
+# inserting the dated header right after the [Unreleased] header re-homes
+# everything below it, and [Unreleased] is left empty.
+sed -i "s/^## \[Unreleased\]$/## [Unreleased]\n\n## [$NEW] - $TODAY/" CHANGELOG.md
+
+# CHANGELOG links — point [Unreleased] past the new tag, add the new compare line.
+BASE="$(grep -m1 '^\[Unreleased\]: ' CHANGELOG.md | sed -E 's|^\[Unreleased\]: (.*)/compare/.*|\1|')"
+if [[ -z "$BASE" ]]; then
+    echo "could not find the [Unreleased] comparison link in CHANGELOG.md" >&2
+    exit 1
+fi
+sed -i "s|^\[Unreleased\]: .*|[Unreleased]: $BASE/compare/v$NEW...HEAD\n[$NEW]: $BASE/compare/v$CUR...v$NEW|" CHANGELOG.md
+
+# Consistency verdict — re-read everything from disk.
+FAIL=0
+verdict() { # <label> <actual> <expected>
+    if [[ "$2" == "$3" ]]; then
+        printf '  %-12s %s ✓\n' "$1" "$2"
+    else
+        printf '  %-12s %s ✗ (expected %s)\n' "$1" "$2" "$3"
+        FAIL=1
+    fi
+}
+
+echo "Release bump $CUR → $NEW:"
+verdict "Cargo.toml" "$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "([^"]+)".*/\1/')" "$NEW"
+verdict "Cargo.lock" "$(awk '$0 == "name = \"urd\"" {f=1; next} f && /^version = / {gsub(/version = |"/, ""); print; exit}' Cargo.lock)" "$NEW"
+verdict "CHANGELOG" "$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '#[] ')" "$NEW"
+verdict "compare-new" "$(grep -c "^\[$NEW\]: $BASE/compare/v$CUR...v$NEW$" CHANGELOG.md)" "1"
+verdict "compare-head" "$(grep -c "^\[Unreleased\]: $BASE/compare/v$NEW...HEAD$" CHANGELOG.md)" "1"
+
+if [[ $FAIL -eq 0 ]]; then
+    echo "Files consistent — review with git diff, then continue at Phase 5."
+else
+    echo "INCONSISTENT — inspect git diff before proceeding." >&2
+fi
+exit $FAIL

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# release-preflight.sh — read-only release preconditions (Phase 1 of /release).
+#
+# Gathers every Phase 1 fact in one pass and prints a compact verdict per
+# gate. Blocking gates: on master, clean tree, in sync with origin/master,
+# gh authenticated. Informational: current version, recent tags, commits
+# since the last tag. Exits 1 if any blocking gate fails. Touches nothing
+# (the only network call is `git fetch origin master`).
+#
+# Usage: scripts/release-preflight.sh
+
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+FAIL=0
+ok()  { printf '  %-18s %s\n' "$1" "$2"; }
+bad() { printf '  %-18s %s\n' "$1" "$2"; FAIL=1; }
+
+echo "Release preflight:"
+
+branch="$(git branch --show-current)"
+if [[ "$branch" == "master" ]]; then ok "branch" "master"
+else bad "branch" "$branch (must be master)"; fi
+
+dirty="$(git status --porcelain | wc -l)"
+if [[ "$dirty" -eq 0 ]]; then ok "tree" "clean"
+else bad "tree" "dirty ($dirty entries — commit or stash first)"; fi
+
+if git fetch origin master --quiet 2>/dev/null; then
+    read -r ahead behind <<< "$(git rev-list --left-right --count HEAD...origin/master)"
+    if [[ "$behind" -gt 0 ]]; then
+        bad "origin/master" "behind by $behind (pull first — never release a stale tree)"
+    elif [[ "$ahead" -gt 0 ]]; then
+        bad "origin/master" "ahead by $ahead (master is PR-only; unpushed commits are wrong state)"
+    else
+        ok "origin/master" "in sync"
+    fi
+else
+    bad "origin/master" "fetch failed (offline? remote auth?)"
+fi
+
+if gh auth status >/dev/null 2>&1; then ok "gh auth" "ok"
+else bad "gh auth" "not authenticated (gh auth login)"; fi
+
+version="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "([^"]+)".*/\1/')"
+ok "Cargo.toml" "$version"
+
+tags="$(git tag -l --sort=-v:refname | head -3 | paste -sd' ')"
+ok "recent tags" "${tags:-none}"
+
+last_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+if [[ -n "$last_tag" ]]; then
+    count="$(git rev-list "${last_tag}..HEAD" --count)"
+    ok "since $last_tag" "$count commit(s)"
+    git log --oneline "${last_tag}..HEAD" | head -20 | sed 's/^/    /'
+    if [[ "$count" -gt 20 ]]; then echo "    … ($((count - 20)) more)"; fi
+else
+    ok "since last tag" "no tags found"
+fi
+
+echo
+if [[ $FAIL -eq 0 ]]; then
+    echo "Preflight clean — ready for Phase 2 (version)."
+else
+    echo "Preflight BLOCKED — fix the gate(s) above before releasing."
+fi
+exit $FAIL


### PR DESCRIPTION
## Summary

Wave 1 of the skills & tooling pass: four scripts that support the deterministic parts of the dev workflow by gathering actionable state and printing compact verdicts (raw output only on failure), plus a `--report` mode for the PII scanner.

- **`scripts/check.sh`** — the full quality gate as one command: clippy, tests, release build, present-not-journey doc lint. Test count is computed from cargo's own summary lines, never hand-typed.
- **`scripts/release-preflight.sh`** — read-only release preconditions (branch, tree, origin sync, gh auth, version, tags, commits since tag), one verdict line per gate.
- **`scripts/release-bump.sh <X.Y.Z>`** — SemVer validation (strictly greater, no leading zeros, tag absent) + Cargo.toml/Cargo.lock/CHANGELOG surgery + a consistency verdict. Refuses an empty `[Unreleased]` — drafting the entry stays judgment work. The irreversible release tail (merge → tag → publish) deliberately stays un-scripted.
- **`scripts/collect-diagnostics.sh`** — one-pass, read-only, unprivileged state capture for debugging sessions: snapshot roots (name-format check), pin-file integrity, drive/UUID state vs config, heartbeat/state-db/lock freshness, systemd user units, `urd status`/`urd plan`.
- **`pre-commit-pii.sh --report`** — dry-run scan of the working tree vs HEAD including untracked text files; classified report; always exits 0. Hook behavior unchanged; the script is now the single source of truth for the PII pattern set.

`.gitignore` allowlists the four new scripts (the `scripts/*` privacy default stands).

## Testing

- `scripts/check.sh` live: clippy PASS · tests PASS 2396 passed, 0 failed, 6 ignored · build PASS · doc-lint PASS
- `release-bump.sh` in a scratch clone: all four refusal paths (empty Unreleased, not-greater, leading zero, existing tag) + success path verified against the Keep-a-Changelog structure
- `release-preflight.sh` live: correctly blocked on a dirty tree, all other gates green
- `pre-commit-pii.sh --report`: clean run + positive canary test (planted PII in an untracked file, caught and classified)
- `collect-diagnostics.sh` live on this machine: all sections accurate (pin targets verified beside their pin files)
- shellcheck clean at warning level

🤖 Generated with [Claude Code](https://claude.com/claude-code)