### PR TITLE
fix: ByteSize display drops spurious .0 on whole units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `ByteSize`'s display no longer pads whole values with a spurious decimal —
+  `10GB` instead of `10.0GB`, `1KB` instead of `1.0KB` — while values that
+  aren't whole at their unit still keep exactly one decimal (`1.5GB`).
+  Rounding is unchanged: `9.96GB` still rounds up and now reads `10GB`
+  instead of `10.0GB` (#332).
+
 ## [0.35.0] - 2026-07-15
 
 ### Fixed

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -3829,7 +3829,7 @@ source = "/data/beta"
         let line = format_progress_line("htpc-home", "WD-18TB", 1, 3, 1_000_000_000, 178_300_000.0, Duration::from_secs(6), None);
         assert!(line.contains("[1/3]"));
         assert!(line.contains("htpc-home → WD-18TB:"));
-        assert!(line.contains("1.0GB"));
+        assert!(line.contains("1GB"));
         assert!(line.contains("178.3MB/s"));
         assert!(!line.contains("left"));
     }
@@ -3838,7 +3838,7 @@ source = "/data/beta"
     fn format_progress_no_estimate_no_rate() {
         let line = format_progress_line("sv1", "drive1", 2, 5, 500_000, 0.0, Duration::from_secs(1), None);
         assert!(line.contains("[2/5]"));
-        assert!(line.contains("500.0KB"));
+        assert!(line.contains("500KB"));
         assert!(!line.contains("/s"));
     }
 
@@ -3863,7 +3863,7 @@ source = "/data/beta"
             Duration::from_secs(2), // < 5s
             Some(10_000_000_000),
         );
-        assert!(line.contains("/ ~10.0GB"));
+        assert!(line.contains("/ ~10GB"));
         assert!(!line.contains("left"), "ETA should be suppressed in early phase");
     }
 
@@ -3888,7 +3888,7 @@ source = "/data/beta"
             Some(10_000_000_000),
         );
         // Zero rate: falls through to no-rate branch
-        assert!(line.contains("100.0KB"));
+        assert!(line.contains("100KB"));
         assert!(!line.contains("/s"));
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1362,17 +1362,24 @@ impl FromStr for ByteSize {
 impl fmt::Display for ByteSize {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let b = self.0;
-        if b >= 1_000_000_000_000 {
-            write!(f, "{:.1}TB", b as f64 / 1_000_000_000_000.0)
+        let (value, unit) = if b >= 1_000_000_000_000 {
+            (b as f64 / 1_000_000_000_000.0, "TB")
         } else if b >= 1_000_000_000 {
-            write!(f, "{:.1}GB", b as f64 / 1_000_000_000.0)
+            (b as f64 / 1_000_000_000.0, "GB")
         } else if b >= 1_000_000 {
-            write!(f, "{:.1}MB", b as f64 / 1_000_000.0)
+            (b as f64 / 1_000_000.0, "MB")
         } else if b >= 1_000 {
-            write!(f, "{:.1}KB", b as f64 / 1_000.0)
+            (b as f64 / 1_000.0, "KB")
         } else {
-            write!(f, "{b}B")
-        }
+            return write!(f, "{b}B");
+        };
+        // Format with one decimal, then strip a trailing ".0" so whole values
+        // render without a spurious fraction. Stripping the formatted string
+        // (rather than checking `value.fract() == 0.0`) keeps rounding
+        // consistent: 9.96 GB formats to "10.0" and strips to "10GB", not "9.9GB".
+        let formatted = format!("{value:.1}");
+        let formatted = formatted.strip_suffix(".0").unwrap_or(&formatted);
+        write!(f, "{formatted}{unit}")
     }
 }
 
@@ -1722,9 +1729,31 @@ mod tests {
 
     #[test]
     fn byte_size_display() {
-        assert_eq!(ByteSize(10_000_000_000).to_string(), "10.0GB");
+        assert_eq!(ByteSize(10_000_000_000).to_string(), "10GB");
         assert_eq!(ByteSize(1_500_000_000_000).to_string(), "1.5TB");
-        assert_eq!(ByteSize(512_000_000).to_string(), "512.0MB");
+        assert_eq!(ByteSize(512_000_000).to_string(), "512MB");
+    }
+
+    #[test]
+    fn byte_size_display_whole_units_drop_decimal() {
+        // Whole values at the chosen unit render without a fraction.
+        assert_eq!(ByteSize(10_000_000_000).to_string(), "10GB");
+        assert_eq!(ByteSize(1_000).to_string(), "1KB");
+        assert_eq!(ByteSize(999).to_string(), "999B");
+        assert_eq!(ByteSize(1_000_000_000_000).to_string(), "1TB");
+    }
+
+    #[test]
+    fn byte_size_display_fractional_units_keep_one_decimal() {
+        assert_eq!(ByteSize(1_500_000_000).to_string(), "1.5GB");
+        assert_eq!(ByteSize(2_500_000).to_string(), "2.5MB");
+    }
+
+    #[test]
+    fn byte_size_display_rounds_before_stripping_decimal() {
+        // 9.96 GB rounds to "10.0" at one decimal, then strips to "10GB" —
+        // never "9.9GB" (no rounding) nor "10.0GB" (no stripping).
+        assert_eq!(ByteSize(9_960_000_000).to_string(), "10GB");
     }
 
     // ── GraduatedRetention tests ────────────────────────────────────

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -1940,7 +1940,7 @@ mod tests {
         );
         // Size annotation rendered by voice, not embedded in detail
         assert!(
-            output.contains("~53.0GB"),
+            output.contains("~53GB"),
             "should render full send size annotation: {output}"
         );
     }
@@ -2015,7 +2015,7 @@ mod tests {
         };
         let output = render_plan(&data, OutputMode::Interactive, true);
         assert!(
-            output.contains("2 sends (~53.0GB estimated for 1 of 2)"),
+            output.contains("2 sends (~53GB estimated for 1 of 2)"),
             "partial estimates should be qualified: {output}"
         );
     }
@@ -3467,7 +3467,7 @@ mod tests {
             "missing weekly window: {output}"
         );
         assert!(
-            output.contains("120.0GB"),
+            output.contains("120GB"),
             "missing disk estimate: {output}"
         );
         assert!(
@@ -3729,7 +3729,7 @@ mod tests {
             "should mention full backup: {output}"
         );
         assert!(output.contains("7 snapshots"), "should count snapshots: {output}");
-        assert!(output.contains("~53.0GB"), "should show size estimate: {output}");
+        assert!(output.contains("~53GB"), "should show size estimate: {output}");
     }
 
     #[test]
@@ -5045,11 +5045,11 @@ mod tests {
         // current=200 GB, adjusted=25 GB → recover 175 GB.
         // Not current=200 GB - suggested=50 GB = 150 GB.
         assert!(
-            out.contains("175.0GB") || out.contains("175 GB"),
+            out.contains("175GB"),
             "recovery delta must use adjusted_cost (~175 GB): {out}"
         );
         assert!(
-            !out.contains("150.0GB") && !out.contains("150 GB"),
+            !out.contains("150GB"),
             "recovery delta must not use suggested_cost (150 GB): {out}"
         );
     }

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -1593,11 +1593,11 @@ mod contract {
         let stripped = helpers::strip_ansi(&output);
         // current=200 GB, adjusted=25 GB → 175 GB recovered.
         assert!(
-            stripped.contains("175.0GB") || stripped.contains("175 GB"),
+            stripped.contains("175GB"),
             "Rule 1 violation: recovery must match rendered (tightened) shape (~175 GB): {stripped}"
         );
         assert!(
-            !stripped.contains("150.0GB") && !stripped.contains("150 GB"),
+            !stripped.contains("150GB"),
             "Rule 1 violation: recovery used suggested_cost (~150 GB) instead of adjusted_cost: {stripped}"
         );
     }


### PR DESCRIPTION
## Summary
- `ByteSize`'s `Display` impl always rendered with one decimal (`{:.1}`), so whole values like 10 GB showed as "10.0GB" instead of "10GB". Precision-as-character is part of Urd's voice; a trailing `.0` on a value that has no fraction is noise.
- Whole values now render without a fraction (`10GB`, `1KB`, `500MB`); non-whole values still keep exactly one decimal (`1.5GB`, `47.3MB`).

## Changes
- `src/types.rs`: `ByteSize`'s `Display` formats with `{:.1}` as before (so rounding is unchanged — `9.96GB` still rounds up) and then strips a trailing `.0` from the *formatted string*, rather than branching on the raw value's `fract() == 0.0` (which would leave `9.96GB` rendering as `10.0GB` instead of `10GB`). New unit tests cover whole units, fractional units, and the rounding-then-stripping edge case.
- `src/commands/backup.rs`: `format_progress_line` and `format_completion_line` render through `ByteSize` directly (not a separate formatter), so their output changes too — updated the four test assertions that pinned the old `.0` form (`"1.0GB"` → `"1GB"`, `"500.0KB"` → `"500KB"`, `"~10.0GB"` → `"~10GB"`, `"100.0KB"` → `"100KB"`).
- `src/voice/mod.rs`, `src/voice_contract.rs`: updated test assertions pinning old `.0GB` golden output (`53.0GB`→`53GB`, `120.0GB`→`120GB`, `175.0GB`/`150.0GB`→`175GB`/`150GB`) to match the new rendering. No production voice code changed — these are golden-string test fixtures.
- `CHANGELOG.md`: `### Fixed` entry under `[Unreleased]`.

### Symmetric review
Swept `rg '\{:\.1\}' src` for sibling byte-formatting helpers with the same wart. Found three other `{:.1}` call sites, all outside this fix's scope:
- `src/voice/backup.rs:56` and `:82` — elapsed-time formatting (`{:.1}s`), not bytes.
- `src/voice/mod.rs:202` — age-in-days formatting (`{:.1}d`), not bytes.

No other byte/size/speed formatter exists in the codebase (`fn format_bytes`/`format_size`/`format_speed` all absent) — the live progress line's `MB/s` rate is rendered via `ByteSize` too, so it already inherits this fix rather than needing a separate one. Recommendation: leave the three duration formatters alone; they're a different surface (time, not bytes) and out of this issue's scope.

## Test plan
```
clippy    PASS
tests     PASS  2399 passed, 0 failed, 6 ignored
build     PASS
doc-lint  PASS
All checks passed.
```

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBF4pbkC8QVBHXnBgdjmp
