### PR TITLE
feat: surface emergency reclaim in the interactive backup summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- The interactive `urd backup` summary now surfaces an emergency-preflight
+  reclaim inline as a warning — one line per snapshot root, reporting the
+  freed space (or the deletion count alone when the post-delete probe
+  failed) — instead of leaving the story to the events log, journald, and
+  the desktop notification alone. The same warning renders on the
+  empty-plan exit too, when the emergency pass freed space but the
+  re-planned run then found nothing to do. The warning line and the
+  notification body are built from the same prose function, so the two
+  surfaces can't drift (#174).
+
 ### Fixed
 - `ByteSize`'s display no longer pads whole values with a spurious decimal —
   `10GB` instead of `10.0GB`, `1KB` instead of `1.0KB` — while values that

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -134,12 +134,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // Emergency pre-flight: if any snapshot root is critically below threshold
     // (< 50% of min_free_bytes), run emergency retention before planning.
     // Runs under the lock because it performs destructive btrfs deletions.
-    let emergency_ran = run_emergency_preflight(&config, &recorder)?;
+    let emergency = run_emergency_preflight(&config, &recorder)?;
 
     // Re-plan if emergency freed space — plan may have different space_pressure
     // decisions. Reuses the SAME pre-plan `arming` (AB1: never re-resolve
     // mid-run, even though emergency just freed space).
-    if emergency_ran {
+    if emergency.any_deleted {
         backup_plan = plan::plan(&config, now, &filters, &observation, &arming)?;
         if !args.confirm_retention_change {
             filter_promise_retention(&config, &mut backup_plan);
@@ -147,6 +147,21 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     }
 
     if backup_plan.is_empty() {
+        // Emergency reclaim warnings (issue #174): the emergency pass may
+        // have deleted snapshots and then the re-plan still found nothing
+        // to do. The notification + event already carry the story in
+        // daemon/auto contexts (dispatched from `run_emergency_preflight`
+        // regardless of this branch), but an interactive TTY user landing
+        // here would otherwise see only "Nothing to do." with no hint that
+        // Urd just deleted history to make room. Same `!args.auto` gate as
+        // the explanation/"Nothing to do." choice below, and the same
+        // `WARNING:` rendering the post-run summary uses, so the two
+        // surfaces can never drift.
+        if !args.auto && !emergency.root_summaries.is_empty() {
+            let warnings = emergency_reclaim_warnings(&emergency.root_summaries);
+            print!("{}", crate::voice::render_warning_lines(&warnings));
+            println!();
+        }
         // Empty plan: no operations to execute. This includes plans where all subvolumes
         // were skipped (drives disconnected, space guard, etc.). Previously this case fell
         // through to the executor which ran zero operations and reported run_result "success".
@@ -616,7 +631,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         recorder.record(&tail.ctx, rec);
     }
 
-    let summary = build_backup_summary(
+    let mut summary = build_backup_summary(
         &backup_plan,
         &result,
         StatusAssessment::rows(&assessments, &config.resolved_subvolumes(), heartbeat_now),
@@ -624,6 +639,14 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         exec_duration,
         &preflight_warnings,
     );
+    // Emergency reclaim warnings (issue #174): same prose as the
+    // notification dispatched from `run_emergency_preflight`, one line per
+    // root that had a successful delete, so a TTY user sees inline that
+    // Urd deleted history to make room — not only in the events log,
+    // journald, or a desktop notification.
+    summary
+        .warnings
+        .extend(emergency_reclaim_warnings(&emergency.root_summaries));
     let output_mode = OutputMode::detect();
     let rendered = crate::voice::render_backup_summary(&summary, output_mode);
     println!("{rendered}");
@@ -2138,7 +2161,7 @@ fn format_elapsed(d: Duration) -> String {
 fn run_emergency_preflight(
     config: &Config,
     recorder: &Recorder<'_>,
-) -> anyhow::Result<bool> {
+) -> anyhow::Result<EmergencyPreflightResult> {
     let now = chrono::Local::now().naive_local();
     let btrfs = RealBtrfs::for_maintenance(&config.general.btrfs_path);
     let outcome = run_emergency_preflight_with(config, now, &btrfs, |p| {
@@ -2166,7 +2189,31 @@ fn run_emergency_preflight(
             dispatch: DispatchPolicy::Immediate,
         },
     );
-    Ok(outcome.any_deleted)
+    Ok(EmergencyPreflightResult {
+        any_deleted: outcome.any_deleted,
+        root_summaries: outcome.root_summaries,
+    })
+}
+
+/// Outcome of the emergency pre-flight surfaced to the run loop (issue
+/// #174): whether a re-plan is needed, and the per-root reclaim summaries
+/// the caller pushes into the interactive backup summary's warnings — the
+/// same prose the notification body uses, via
+/// [`notify::emergency_retention_prose`], so the two surfaces cannot drift.
+struct EmergencyPreflightResult {
+    any_deleted: bool,
+    root_summaries: Vec<EmergencyRootReclaim>,
+}
+
+/// Turn per-root emergency reclaim summaries into interactive backup
+/// summary warning lines (issue #174) — one line per root, built from the
+/// same [`notify::emergency_retention_prose`] the notification body uses,
+/// so the two surfaces can never drift. Pure function — no I/O.
+fn emergency_reclaim_warnings(root_summaries: &[EmergencyRootReclaim]) -> Vec<String> {
+    root_summaries
+        .iter()
+        .map(|r| notify::emergency_retention_prose(&r.root, r.freed_bytes, r.deleted_count))
+        .collect()
 }
 
 /// Structured outcome of an emergency-preflight pass. The injectable core
@@ -2983,6 +3030,45 @@ source = "/data/beta"
         assert_eq!(s.deleted_count, 2, "two older snaps deleted");
         assert_eq!(s.freed_bytes, Some(500_000_000));
         assert_eq!(s.root, dir.path().display().to_string());
+    }
+
+    #[test]
+    fn emergency_reclaim_warnings_one_line_per_root_known_and_unknown_freed() {
+        // Issue #174: the interactive summary gets one warning line per
+        // root, using the exact prose the notification body uses — a known
+        // freed delta for one root, an unknown (probe-failed) delta for
+        // the other, and the unknown case must never invent a size.
+        let root_summaries = vec![
+            EmergencyRootReclaim {
+                root: "/snap/home".to_string(),
+                freed_bytes: Some(8_200_000_000),
+                deleted_count: 39,
+            },
+            EmergencyRootReclaim {
+                root: "/snap/media".to_string(),
+                freed_bytes: None,
+                deleted_count: 3,
+            },
+        ];
+
+        let warnings = emergency_reclaim_warnings(&root_summaries);
+
+        assert_eq!(warnings.len(), 2, "one warning line per root");
+        assert_eq!(
+            warnings[0],
+            notify::emergency_retention_prose("/snap/home", Some(8_200_000_000), 39),
+            "must match the notification's prose exactly (one prose builder)"
+        );
+        assert_eq!(
+            warnings[1],
+            notify::emergency_retention_prose("/snap/media", None, 3),
+            "must match the notification's prose exactly (one prose builder)"
+        );
+        assert!(
+            !warnings[1].contains("Freed"),
+            "unknown freed-bytes must never invent a size: {}",
+            warnings[1]
+        );
     }
 
     #[test]

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -588,6 +588,24 @@ pub fn build_drive_needs_adoption_notification(label: &str) -> Notification {
     }
 }
 
+/// Prose for one snapshot root's emergency reclaim. Shared verbatim between
+/// the notification body and the interactive backup summary's warning line
+/// (issue #174) so the two surfaces can never drift. `freed_bytes` is `None`
+/// when the post-delete free-space probe failed — the prose then reports
+/// only the deletion count, never a made-up size.
+#[must_use]
+pub fn emergency_retention_prose(root: &str, freed_bytes: Option<u64>, deleted_count: usize) -> String {
+    match freed_bytes {
+        Some(bytes) => format!(
+            "Freed {} from {root} by deleting {deleted_count} snapshots before backup.",
+            crate::types::ByteSize(bytes)
+        ),
+        None => format!(
+            "Deleted {deleted_count} snapshots from {root} to recover critical space before backup."
+        ),
+    }
+}
+
 /// Build a notification for emergency retention that ran before a backup.
 /// `freed_bytes` is `None` when the post-delete free-space probe failed —
 /// the body then reports only the deletion count, never a made-up size.
@@ -597,15 +615,7 @@ pub fn build_emergency_retention_notification(
     freed_bytes: Option<u64>,
     deleted_count: usize,
 ) -> Notification {
-    let body = match freed_bytes {
-        Some(bytes) => format!(
-            "Freed {} from {root} by deleting {deleted_count} snapshots before backup.",
-            crate::types::ByteSize(bytes)
-        ),
-        None => format!(
-            "Deleted {deleted_count} snapshots from {root} to recover critical space before backup."
-        ),
-    };
+    let body = emergency_retention_prose(root, freed_bytes, deleted_count);
     Notification {
         event: NotificationEvent::EmergencyRetentionRan {
             root: root.to_string(),

--- a/src/voice/backup.rs
+++ b/src/voice/backup.rs
@@ -31,6 +31,22 @@ fn render_backup_daemon(data: &BackupSummary) -> String {
     serde_json::to_string_pretty(data).unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
 }
 
+/// Render each warning with the `WARNING:` prefix, one per line. Shared by
+/// the interactive summary's warnings block and the empty-plan exit's
+/// emergency-reclaim announcement (issue #174) — an emergency pass can
+/// delete snapshots and then find nothing left to do, and that exit has no
+/// `BackupSummary` to attach a warning to, so it renders the same lines
+/// directly. Kept here so both call sites can never drift: the voice layer
+/// owns the `WARNING:` prefix, not the caller. Empty input renders nothing.
+#[must_use]
+pub(crate) fn render_warning_lines(warnings: &[String]) -> String {
+    let mut out = String::new();
+    for warning in warnings {
+        writeln!(out, "{} {}", "WARNING:".yellow().bold(), warning).ok();
+    }
+    out
+}
+
 fn render_backup_interactive(data: &BackupSummary) -> String {
     let mut out = String::new();
 
@@ -144,9 +160,7 @@ fn render_backup_interactive(data: &BackupSummary) -> String {
     // ── Warnings ─────────────────────────────────────────────────────
     if !data.warnings.is_empty() {
         writeln!(out).ok();
-        for warning in &data.warnings {
-            writeln!(out, "{} {}", "WARNING:".yellow().bold(), warning).ok();
-        }
+        out.push_str(&render_warning_lines(&data.warnings));
     }
 
     // ── Notes (informational, not warnings) ──────────────────────────
@@ -544,6 +558,35 @@ mod tests {
         StructuredError, SubvolumeSummary,
     };
     use crate::voice::test_fixtures::color_guard;
+
+    // ── Warning lines (issue #174) ──────────────────────────────────────
+    // Shared verbatim by the interactive summary's warnings block and the
+    // empty-plan exit's emergency-reclaim announcement — pinning it here
+    // covers both call sites at once.
+
+    #[test]
+    fn render_warning_lines_prefixes_each_line() {
+        let _c = color_guard(false);
+        let warnings = vec![
+            "Freed 8.2GB from /snap/home by deleting 39 snapshots before backup.".to_string(),
+            "Deleted 3 snapshots from /snap/media to recover critical space before backup."
+                .to_string(),
+        ];
+
+        let out = render_warning_lines(&warnings);
+
+        assert_eq!(
+            out,
+            "WARNING: Freed 8.2GB from /snap/home by deleting 39 snapshots before backup.\n\
+             WARNING: Deleted 3 snapshots from /snap/media to recover critical space before backup.\n"
+        );
+    }
+
+    #[test]
+    fn render_warning_lines_empty_input_renders_nothing() {
+        let _c = color_guard(false);
+        assert_eq!(render_warning_lines(&[]), "");
+    }
 
     // ── "Safe to remove" cue (UPI 056, RD2) ────────────────────────────
 

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -45,6 +45,7 @@ mod status;
 mod verify;
 
 pub use backup::{render_backup_summary, render_pre_action};
+pub(crate) use backup::render_warning_lines;
 pub use calibrate::render_calibrate;
 pub use chooser::format_subvolume_chooser;
 pub use doctor::render_doctor;

--- a/src/voice_contract.rs
+++ b/src/voice_contract.rs
@@ -838,6 +838,54 @@ mod contract {
         );
     }
 
+    // ── Emergency reclaim warning (issue #174) ──────────────────────────
+    // The interactive summary must surface an emergency-preflight reclaim
+    // inline, using the exact prose the desktop notification body uses
+    // (`notify::emergency_retention_prose`) — one prose builder, two
+    // surfaces, so they can never drift.
+
+    #[test]
+    fn emergency_reclaim_warning_renders_with_known_freed_bytes() {
+        let _color = color_guard(false);
+        let mut s = test_backup_summary();
+        s.warnings = vec![crate::notify::emergency_retention_prose(
+            "/snap/home",
+            Some(8_200_000_000),
+            39,
+        )];
+        let output = render_backup_summary(&s, OutputMode::Interactive);
+        assert!(
+            output.contains("WARNING:"),
+            "expected a WARNING: line in:\n{output}"
+        );
+        assert!(
+            output.contains("Freed 8.2GB from /snap/home by deleting 39 snapshots before backup."),
+            "expected the exact emergency reclaim prose in:\n{output}"
+        );
+    }
+
+    #[test]
+    fn emergency_reclaim_warning_renders_without_inventing_a_size() {
+        let _color = color_guard(false);
+        let mut s = test_backup_summary();
+        s.warnings = vec![crate::notify::emergency_retention_prose(
+            "/snap/media",
+            None,
+            3,
+        )];
+        let output = render_backup_summary(&s, OutputMode::Interactive);
+        assert!(
+            output.contains(
+                "Deleted 3 snapshots from /snap/media to recover critical space before backup."
+            ),
+            "expected the count-only emergency reclaim prose in:\n{output}"
+        );
+        assert!(
+            !output.contains("Freed"),
+            "must not invent a freed size when the probe failed: {output}"
+        );
+    }
+
     // ── Rule 5 — First-line answer ─────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Summary
- The interactive `urd backup` summary now shows an emergency-preflight
  reclaim inline as a warning line, instead of leaving the story to the
  events log, journald, and the desktop notification alone.
- The same warning now also renders on the empty-plan exit — when the
  emergency pass frees space but the re-planned run then finds nothing to
  do, that exit previously said only "Nothing to do." with no hint that
  Urd had just deleted history.
- Extracted the notification body's prose into a shared
  `notify::emergency_retention_prose` function, called from both the
  notification builder and the new summary/empty-plan warnings, so those
  surfaces can never drift.
- Extracted the `WARNING:` line rendering itself into one voice helper
  (`voice::render_warning_lines`), used by both the interactive summary's
  warnings block and the empty-plan exit's announcement, so those two
  render identically too.
- `run_emergency_preflight` now returns a small `EmergencyPreflightResult`
  (the re-plan trigger plus per-root reclaim summaries) instead of a bare
  `bool`, so the run loop can push a warning line per reclaimed root into
  `BackupSummary.warnings`, or print the same lines directly on the
  empty-plan exit.

## Changes
- `src/notify.rs`: extracted `emergency_retention_prose` from
  `build_emergency_retention_notification`; notification bytes unchanged
  (existing golden tests pass unchanged).
- `src/commands/backup.rs`:
  - widened `run_emergency_preflight`'s return type to
    `EmergencyPreflightResult { any_deleted, root_summaries }`;
  - added `emergency_reclaim_warnings` (pure) turning root summaries into
    warning lines;
  - pushed those into `BackupSummary.warnings` after `build_backup_summary`
    on the executed-run exit;
  - printed the same lines via `voice::render_warning_lines` on the
    empty-plan exit, gated by the same `!args.auto` check that exit
    already uses to choose interactive vs. daemon-style output;
  - added a unit test covering two roots (one with a known freed delta,
    one with an unknown/probe-failed delta).
- `src/voice/backup.rs`: extracted `render_warning_lines` (the `WARNING:`
  prefix formatting) out of the summary's warnings block into a
  `pub(crate)` helper shared with the empty-plan exit; added two tests
  pinning its output (multi-line prefixing, and empty input renders
  nothing).
- `src/voice/mod.rs`: re-exported `render_warning_lines` at crate
  visibility so `commands::backup` can call it.
- `src/voice_contract.rs`: added two contract tests pinning the rendered
  interactive warning line end-to-end for both the known- and
  unknown-freed-bytes cases.
- `CHANGELOG.md`: `### Added` entry under `[Unreleased]`, placed above the
  `### Fixed` section from #355 (ByteSize display fix), which this branch
  rebased onto.

`BackupSummary` has no `schema_version` field, so the `--json` surface
gains `warnings` entries for free with no schema change.

## Test plan
```
clippy    PASS
tests     PASS  2404 passed, 0 failed, 6 ignored
build     PASS
doc-lint  PASS
All checks passed.
```

Rendered warning line (interactive, colors off), for reference:
```
WARNING: Freed 8.2GB from /snap/home by deleting 39 snapshots before backup.
WARNING: Deleted 3 snapshots from /snap/media to recover critical space before backup.
```

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBF4pbkC8QVBHXnBgdjmp
