### PR TITLE
refactor: carry PromiseStatus to the exposure color decision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Rounding is unchanged: `9.96GB` still rounds up and now reads `10GB`
   instead of `10.0GB` (#332).
 
+### Changed
+- The EXPOSURE column's label-to-color plumbing now carries `PromiseStatus`
+  straight to the color decision instead of round-tripping through the
+  `"sealed"`/`"waning"`/`"exposed"` strings: `exposure_cell(status, dimmed)`
+  matches the enum exhaustively (compiler-enforced against new variants),
+  with the UPI 080 pre-dimmed adapting-row case as an explicit parameter. The
+  table formatter no longer re-matches on the EXPOSURE column at all, closing
+  the silent-uncolored-fallthrough hazard the old string relay had. No
+  behavior change — `urd status`/`urd backup` output is byte-identical (#305).
+
 ## [0.35.0] - 2026-07-15
 
 ### Fixed

--- a/src/voice/backup.rs
+++ b/src/voice/backup.rs
@@ -14,8 +14,8 @@ use crate::output::{BackupSummary, OutputMode, PreActionSummary, SkipCategory};
 use crate::types::{ByteSize, DriveRole};
 
 use super::{
-    SuggestionContext, append_suggestion, color_result, exposure_label, format_status_table,
-    pluralize, skip_tag,
+    SuggestionContext, append_suggestion, color_result, exposure_cell, exposure_label,
+    format_status_table, pluralize, skip_tag,
 };
 
 /// Render post-backup summary according to the given mode.
@@ -397,7 +397,7 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
     // Build rows
     let mut rows: Vec<Vec<String>> = Vec::new();
     for assessment in &data.assessments {
-        let mut row = vec![exposure_label(assessment.status)];
+        let mut row = vec![exposure_cell(assessment.status, false)];
         if show_protection {
             row.push(
                 assessment
@@ -425,7 +425,7 @@ fn render_assessment_table(data: &BackupSummary, out: &mut String) {
         rows.push(row);
     }
 
-    format_status_table(&headers, &rows, Some(0), None, out);
+    format_status_table(&headers, &rows, None, out);
 }
 
 /// Render advisories and errors from awareness assessments.

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -124,6 +124,34 @@ pub(super) fn exposure_label(status: PromiseStatus) -> String {
     }
 }
 
+/// Render a promise status as its colored EXPOSURE cell string, in one step.
+///
+/// The type is carried all the way to the color decision instead of round-
+/// tripping through the label string (#305): callers pass the `PromiseStatus`
+/// enum here directly, so an exhaustive `match` — compiler-enforced against
+/// new variants — replaces the former string re-match on `"sealed"` /
+/// `"waning"` / `"exposed"` that silently left an unmatched label uncolored.
+///
+/// `dimmed` is the explicit pre-dimmed case (UPI 080, `status::exposure_cell`):
+/// an adapting row is "waning by design", not a failure, so its cell renders
+/// dim instead of the earned color. Dimming always wins over the earned
+/// color — it only ever de-emphasizes a row, never brightens one.
+///
+/// The returned string already carries its ANSI color; table rendering must
+/// not re-match on it (that was the bug) — it passes cells through unchanged
+/// unless a column asks for further coloring (see `format_status_table`).
+pub(super) fn exposure_cell(status: PromiseStatus, dimmed: bool) -> String {
+    let label = exposure_label(status);
+    if dimmed {
+        return label.dimmed().to_string();
+    }
+    match status {
+        PromiseStatus::Protected => label.green().to_string(),
+        PromiseStatus::AtRisk => label.yellow().to_string(),
+        PromiseStatus::Unprotected => label.red().to_string(),
+    }
+}
+
 /// Group per-subvolume advisory NOTE strings for display (UPI 079-a §4).
 ///
 /// Collects, for each distinct advisory string (exact equality), the subvolume
@@ -250,26 +278,22 @@ fn format_table(
     }
 }
 
-/// Format status table with optional colored SAFETY and HEALTH columns.
+/// Format status table with an optional colored HEALTH column.
+///
+/// The EXPOSURE column is no longer colored here — callers build already-
+/// colored cells via `exposure_cell` before the row is handed to this
+/// formatter (#305), so the EXPOSURE cell simply passes through unchanged
+/// like any other pre-rendered cell.
 fn format_status_table(
     headers: &[String],
     rows: &[Vec<String>],
-    safety_col: Option<usize>,
     health_col: Option<usize>,
     out: &mut String,
 ) {
     format_table(
         headers,
         rows,
-        |i, cell| {
-            if safety_col == Some(i) {
-                Some(color_exposure_str(cell))
-            } else if health_col == Some(i) {
-                Some(color_health_str(cell))
-            } else {
-                None
-            }
-        },
+        |i, cell| (health_col == Some(i)).then(|| color_health_str(cell)),
         out,
     );
 }
@@ -295,17 +319,6 @@ fn strip_ansi_len(s: &str) -> usize {
 }
 
 // ── Color helpers ───────────────────────────────────────────────────────
-
-fn color_exposure_str(exposure: &str) -> String {
-    match exposure {
-        "sealed" => "sealed".green().to_string(),
-        "waning" => "waning".yellow().to_string(),
-        "exposed" => "exposed".red().to_string(),
-        // An adapting row's cell arrives already dimmed (UPI 080, `status::exposure_cell`)
-        // and falls here — passed through unchanged so the de-emphasis survives.
-        other => other.to_string(),
-    }
-}
 
 fn color_health_str(health: &str) -> String {
     match health {
@@ -2863,6 +2876,73 @@ mod tests {
         assert_eq!(exposure_label(PromiseStatus::Protected), "sealed");
         assert_eq!(exposure_label(PromiseStatus::AtRisk), "waning");
         assert_eq!(exposure_label(PromiseStatus::Unprotected), "exposed");
+    }
+
+    /// Pins the colored `exposure_cell` output for every `PromiseStatus`
+    /// variant (#305). The old string-relay design (`exposure_label` then a
+    /// re-match in `color_exposure_str`) let a future label change silently
+    /// ship uncolored output because the fall-through arm passed any
+    /// unmatched string through unchanged. Now the color decision matches on
+    /// the enum directly and exhaustively — a new `PromiseStatus` variant
+    /// fails to compile here rather than rendering uncolored at runtime.
+    #[test]
+    fn exposure_cell_colors_every_promise_status() {
+        let _color = color_guard(true);
+        assert_eq!(
+            exposure_cell(PromiseStatus::Protected, false),
+            "sealed".green().to_string()
+        );
+        assert_eq!(
+            exposure_cell(PromiseStatus::AtRisk, false),
+            "waning".yellow().to_string()
+        );
+        assert_eq!(
+            exposure_cell(PromiseStatus::Unprotected, false),
+            "exposed".red().to_string()
+        );
+    }
+
+    /// The UPI 080 pre-dimmed adapting-row cell must render byte-identical
+    /// regardless of which `PromiseStatus` it dims — `dimmed: true` always
+    /// wins over the earned color (#305).
+    #[test]
+    fn exposure_cell_dimmed_overrides_earned_color_for_every_status() {
+        let _color = color_guard(true);
+        assert_eq!(
+            exposure_cell(PromiseStatus::Protected, true),
+            "sealed".dimmed().to_string()
+        );
+        assert_eq!(
+            exposure_cell(PromiseStatus::AtRisk, true),
+            "waning".dimmed().to_string()
+        );
+        assert_eq!(
+            exposure_cell(PromiseStatus::Unprotected, true),
+            "exposed".dimmed().to_string()
+        );
+    }
+
+    /// End-to-end pass-through pin: a pre-colored EXPOSURE cell (the UPI 080
+    /// dimmed adapting-row case, built by `exposure_cell`) must survive
+    /// `format_status_table` byte-identical. Before #305, the EXPOSURE column
+    /// was re-matched by `color_exposure_str` inside this formatter — any
+    /// already-colored string that didn't match `"sealed"`/`"waning"`/
+    /// `"exposed"` fell through unchanged only because of an explicit (and
+    /// easy to lose) fallback arm. Now the formatter never touches the
+    /// EXPOSURE column at all, so pass-through is structural, not a matched
+    /// case.
+    #[test]
+    fn format_status_table_passes_through_precolored_exposure_cell_unchanged() {
+        let _color = color_guard(true);
+        let headers = vec!["EXPOSURE".to_string(), "SUBVOLUME".to_string()];
+        let precolored = exposure_cell(PromiseStatus::AtRisk, true);
+        let rows = vec![vec![precolored.clone(), "htpc-home".to_string()]];
+        let mut out = String::new();
+        format_status_table(&headers, &rows, None, &mut out);
+        assert!(
+            out.contains(&precolored),
+            "pre-colored EXPOSURE cell must pass through byte-identical: {out:?}"
+        );
     }
 
     #[test]

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -20,7 +20,7 @@ use crate::types::{ByteSize, DriveRole};
 
 use super::drive_row::{aggregate_drive_info, offsite_drive_label, unmounted_drive_label};
 use super::{
-    SuggestionContext, append_suggestion, color_result, exposure_label, format_status_table,
+    SuggestionContext, append_suggestion, color_result, exposure_cell, format_status_table,
     humanize_cadence, humanize_duration, pluralize,
 };
 
@@ -335,24 +335,20 @@ fn storage_posture_line(p: &PoolPostureSummary) -> colored::ColoredString {
 
 /// The EXPOSURE cell string for one row (UPI 080, adapting de-emphasis).
 ///
-/// Normally the plain voice label (`sealed`/`waning`/`exposed`), coloured
-/// downstream by `color_exposure_str` on the safety column. The one exception:
-/// an *adapting* row — AT RISK purely because the Critical-pool cadence cap
-/// slowed it (`cadence_adapted`), with a healthy chain — is "waning by design",
-/// not a failure, so its cell is pre-dimmed here. De-emphasis only: it is never
-/// brighter than `status`, and the `health == "healthy"` clause is ruling (i) —
-/// a broken-chain (degraded) capped row keeps the alarming yellow, because a
-/// broken chain *is* something to act on. The pre-coloured string passes through
-/// `color_exposure_str`'s fall-through branch untouched.
-fn exposure_cell(a: &StatusAssessment) -> String {
-    let label = exposure_label(a.status);
+/// Normally the earned color for `a.status` (`sealed`/`waning`/`exposed`),
+/// via the shared `exposure_cell(status, dimmed)` (#305) — the enum drives
+/// the color decision directly, no string re-match involved. The one
+/// exception: an *adapting* row — AT RISK purely because the Critical-pool
+/// cadence cap slowed it (`cadence_adapted`), with a healthy chain — is
+/// "waning by design", not a failure, so its cell is pre-dimmed instead.
+/// De-emphasis only: it is never brighter than `status`, and the
+/// `health == "healthy"` clause is ruling (i) — a broken-chain (degraded)
+/// capped row keeps the alarming yellow, because a broken chain *is*
+/// something to act on.
+fn assessment_exposure_cell(a: &StatusAssessment) -> String {
     let adapting =
         a.status == PromiseStatus::AtRisk && a.cadence_adapted && a.health == "healthy";
-    if adapting {
-        label.dimmed().to_string()
-    } else {
-        label
-    }
+    exposure_cell(a.status, adapting)
 }
 
 pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
@@ -409,9 +405,11 @@ pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
     }
     headers.push("THREAD".to_string());
 
-    // Track which columns need coloring. Indices shift when EXPOSURE is hidden:
-    // HEALTH then leads at index 0 instead of following EXPOSURE at index 1.
-    let safety_col = if show_exposure { Some(0usize) } else { None };
+    // Track which column needs HEALTH coloring. Its index shifts when
+    // EXPOSURE is hidden: HEALTH then leads at index 0 instead of following
+    // EXPOSURE at index 1. EXPOSURE cells arrive already colored (built via
+    // `assessment_exposure_cell`/`exposure_cell`, #305) so they need no
+    // column-index bookkeeping here.
     let health_col = if show_health {
         Some(if show_exposure { 1 } else { 0 })
     } else {
@@ -424,7 +422,7 @@ pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
         // Safety column — omitted entirely when every subvolume is sealed.
         let mut row: Vec<String> = Vec::new();
         if show_exposure {
-            row.push(exposure_cell(assessment));
+            row.push(assessment_exposure_cell(assessment));
         }
 
         if show_health {
@@ -488,7 +486,7 @@ pub(super) fn render_subvolume_table(data: &StatusOutput, out: &mut String) {
         rows.push(row);
     }
 
-    format_status_table(&headers, &rows, safety_col, health_col, out);
+    format_status_table(&headers, &rows, health_col, out);
 }
 
 /// Render chain health for interactive display.


### PR DESCRIPTION
## Summary
- The EXPOSURE label→color pipeline was a stringly-typed relay: `exposure_label` mapped `PromiseStatus` to `"sealed"`/`"waning"`/`"exposed"`, then `color_exposure_str` re-matched those strings to pick a color, with a fall-through arm that rendered any unmatched string uncolored.
- Replaced it with `exposure_cell(status: PromiseStatus, dimmed: bool) -> String`, which owns label + color + the UPI 080 pre-dimmed adapting-row case as an explicit parameter — the color decision is now an exhaustive `match` on the enum (compiler-enforced against new variants), not a string re-match with a silent fallback.

## Changes
- `src/voice/mod.rs`: added `exposure_cell(status, dimmed)` next to `exposure_label`; removed `color_exposure_str` entirely; `format_status_table` dropped its `safety_col` parameter — it no longer touches the EXPOSURE column, since callers now hand it an already-colored cell.
- `src/voice/status.rs`: renamed the local per-row helper to `assessment_exposure_cell`, which computes the UPI 080 `dimmed` condition and calls the shared `exposure_cell`; dropped the now-unused `safety_col` local.
- `src/voice/backup.rs`: its EXPOSURE row cell is now built via `exposure_cell(status, false)` instead of the bare label; `exposure_label` is still used (unchanged) for the plain-text transition arrow line (`"exposed → sealed"`), which is never colored.
- `CHANGELOG.md`: `### Changed` entry, explicitly no behavior change.

Alternative rejected: carrying `(PromiseStatus, String)` pairs through the row (`Vec<Vec<String>>`) and matching on the enum at table-render time. This would have required changing the table formatter's row/column model (`Vec<String>` cells, a generic `Fn(usize, &str) -> Option<String>` colorizer shared with the unrelated HEALTH column) to carry a typed payload for one column only, for materially more churn than the single-function approach that already appears as the suggested primary direction in the issue.

## Test plan
- [x] Every existing `src/voice/*` and `voice_contract.rs` test passes unmodified (no assertions edited).
- [x] Added `exposure_cell_colors_every_promise_status` — pins the colored output for each `PromiseStatus`.
- [x] Added `exposure_cell_dimmed_overrides_earned_color_for_every_status` — pins the dimmed override for each status.
- [x] Added `format_status_table_passes_through_precolored_exposure_cell_unchanged` — end-to-end pin that a pre-colored (UPI 080 dimmed) EXPOSURE cell survives the table formatter byte-identical.
- [x] `scripts/check.sh`:
```
clippy    PASS
tests     PASS  2399 passed, 0 failed, 6 ignored
build     PASS
doc-lint  PASS
All checks passed.
```

Closes #305

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBF4pbkC8QVBHXnBgdjmp
