### PR TITLE
feat: carry forward pool capacity gauges for absent destination drives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-planned run then found nothing to do. The warning line and the
   notification body are built from the same prose function, so the two
   surfaces can't drift (#174).
+- Destination pool capacity gauges (`backup_pool_free_bytes`,
+  `backup_pool_total_bytes`, `backup_pool_metadata_utilization_ratio`) now
+  survive a configured drive's absence: when the drive isn't mounted for a
+  run, its last-seen values are carried forward from the previous `.prom`
+  file, all labels verbatim, so the offsite rotation drive still has
+  telemetry to alert on while it's away. A new gauge,
+  `backup_pool_last_seen_timestamp{uuid,role,label}`, is emitted for every
+  pool row — the run timestamp for a pool measured this run, the
+  carried-forward timestamp otherwise — so staleness stays honest. A drive
+  removed from config stops being carried forward (#339).
 
 ### Changed
 - The EXPOSURE column's label-to-color plumbing now carries `PromiseStatus`

--- a/docs/20-reference/metrics.md
+++ b/docs/20-reference/metrics.md
@@ -6,7 +6,7 @@ project: ['[[urd]]']
 sensitivity: public
 status: active
 created: '2026-05-02'
-timestamp: '2026-06-10T08:44:18+02:00'
+timestamp: '2026-09-03T12:45:40+02:00'
 ---
 # Prometheus Metrics Reference
 
@@ -57,10 +57,23 @@ These properties are guaranteed and load-bearing for downstream consumers
    subvolumes and for subvolumes whose latest in-window send was the wrong kind
    (full / incremental respectively). The `# HELP` text states this explicitly;
    alerts must not assume the series exists.
-7. **Carry-forward of `backup_last_success_timestamp`.** When a subvolume is
-   not attempted in a run (interval gating, skip), its previous timestamp is
-   read from the existing `.prom` file and re-emitted unchanged. The series
-   does not disappear during quiet periods.
+7. **Carry-forward of `backup_last_success_timestamp` and the pool gauges.**
+   When a subvolume is not attempted in a run (interval gating, skip), its
+   previous timestamp is read from the existing `.prom` file and re-emitted
+   unchanged. The series does not disappear during quiet periods.
+
+   The same mechanism covers a configured destination drive that isn't
+   mounted this run (the offsite rotation drive being the motivating case,
+   issue #339): `backup_pool_free_bytes`, `backup_pool_total_bytes`, and
+   `backup_pool_metadata_utilization_ratio` are re-read from the previous
+   `.prom` file, keyed by `label`, and re-emitted with all labels (`uuid`,
+   `role`, `label`) verbatim. Only labels still present in config are
+   eligible — removing a drive from config stops the carry-forward and its
+   series goes absent, same as any other conditional series here. Source
+   pools (`role="source"`) are always measured and never carried. A
+   configured drive that has never been mounted while Urd ran has no prior
+   row to carry, so its series simply doesn't exist yet — it appears after
+   the drive's first mounted run.
 8. **Label cardinality is stable.** `subvolume`, `location` (`local|external`),
    `reason`, `scope`, `rule`, and the pool-gauge labels `uuid`, `role`
    (`source|destination`), `label` are the only labels. No host labels, no
@@ -221,6 +234,20 @@ within a run; line absent under the same conditions.
 
 Gauge. BTRFS metadata utilization, `0.0`–`1.0`. Line absent when metadata
 info couldn't be read.
+
+### `backup_pool_last_seen_timestamp`
+
+Gauge. Unix epoch seconds. Emitted for **every** pool row, including
+carried-forward ones (UPI issue #339) — unlike the three gauges above, this
+one is never conditional on a syscall succeeding.
+
+For a pool measured in this run, it equals `backup_script_last_run_timestamp`.
+For a destination row carried forward because its drive wasn't mounted this
+run, it is the timestamp of the run that last measured it. This is what
+makes carry-forward staleness-honest: a consumer can alert on
+`time() - backup_pool_last_seen_timestamp{role="destination"} > threshold`
+without being fooled by a flat-lined `backup_pool_free_bytes` value that
+just hasn't been refreshed.
 
 ---
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -180,7 +180,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         // judged before the metrics write (the writer only touches `.prom`).
         let heartbeat_now = chrono::Local::now().naive_local();
         let churn_views = build_churn_views(&config, world.db(), heartbeat_now);
-        let observability = gather_pool_observability(&config, &churn_views, &fs_state);
+        let observability = gather_pool_observability(
+            &config,
+            now.and_utc().timestamp(),
+            &churn_views,
+            &fs_state,
+        );
         let previous_hb = heartbeat::read(&config.general.heartbeat_file);
         // Posture parity (UPI 063): the empty-plan heartbeat embeds promise
         // verdicts, and verdicts are posture-sensitive — S4's "the projection
@@ -537,7 +542,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     // the same projection into both metrics and heartbeat (UPI 030).
     let heartbeat_now = chrono::Local::now().naive_local();
     let churn_views = build_churn_views(&config, world.db(), heartbeat_now);
-    let observability = gather_pool_observability(&config, &churn_views, &fs_state);
+    let observability = gather_pool_observability(
+        &config,
+        now.and_utc().timestamp(),
+        &churn_views,
+        &fs_state,
+    );
 
     // Assess under the SINGLE pre-plan `signals` (the AB1/S2 invariant
     // above) — do NOT re-gather. The post-execution assess reflects the
@@ -1509,6 +1519,7 @@ fn build_churn_views(
 /// heartbeat for the same run.
 fn gather_pool_observability(
     config: &Config,
+    now_ts: i64,
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
     fs_state: &dyn FilesystemQuery,
 ) -> PoolObservability {
@@ -1537,6 +1548,7 @@ fn gather_pool_observability(
     let pool_metrics = pools::compute_pool_metrics_from(
         &source_pools,
         &drive_resolutions,
+        now_ts,
         |mp| pools::pool_space(mp).ok(),
         pools::metadata_utilization_ratio,
     );
@@ -1764,9 +1776,22 @@ fn write_global_metrics(
     config: &Config,
     now_ts: i64,
     subvolume_metrics: Vec<SubvolumeMetrics>,
-    pool_metrics: Vec<PoolMetric>,
+    mut pool_metrics: Vec<PoolMetric>,
 ) -> anyhow::Result<()> {
     let (drive_mounted, free_bytes) = drives::first_mounted_drive_status(config);
+
+    // Carry forward destination-pool rows for configured drives absent this
+    // run (issue #339) — same best-effort posture and reader mechanism as
+    // the subvolume timestamp carry-forward above. A drive removed from
+    // config is never carried; `apply_carried_forward_pools` checks that.
+    let configured_destination_labels: HashSet<String> =
+        config.drives.iter().map(|d| d.label.clone()).collect();
+    let carried_pools = metrics::read_existing_pool_rows(&config.general.metrics_file);
+    metrics::apply_carried_forward_pools(
+        &mut pool_metrics,
+        &carried_pools,
+        &configured_destination_labels,
+    );
 
     // Aggregate counter families from the events table.
     // Best-effort: a missing or unreadable DB yields zeros, never an error.

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 use std::path::Path;
 
@@ -28,6 +28,7 @@ pub(crate) mod names {
     pub const BACKUP_POOL_TOTAL_BYTES: &str = "backup_pool_total_bytes";
     pub const BACKUP_POOL_METADATA_UTILIZATION_RATIO: &str =
         "backup_pool_metadata_utilization_ratio";
+    pub const BACKUP_POOL_LAST_SEEN_TIMESTAMP: &str = "backup_pool_last_seen_timestamp";
     pub const BACKUP_SUBVOLUME_LOCAL_SNAPSHOT_COUNT: &str =
         "backup_subvolume_local_snapshot_count";
     pub const BACKUP_SUBVOLUME_ESTIMATED_LOCAL_PINNED_DELTA_BYTES: &str =
@@ -70,6 +71,14 @@ pub struct PoolMetric {
     /// never skew within a run.
     pub capacity_bytes: Option<u64>,
     pub metadata_utilization_ratio: Option<f64>,
+    /// Unix seconds this row was last measured (issue #339). For a pool
+    /// measured in this run it equals `script_last_run_timestamp`; for a
+    /// carried-forward destination row (configured drive absent this run)
+    /// it is the timestamp of the run that last measured it. Always
+    /// present — unlike the three gauges above, this feeds
+    /// `backup_pool_last_seen_timestamp`, emitted unconditionally for every
+    /// row so staleness stays honest even when a pool row itself is thin.
+    pub last_seen_timestamp: i64,
 }
 
 /// Prometheus counter family derived from the events table by
@@ -239,6 +248,156 @@ fn parse_escaped_label(s: &str) -> Option<(String, &str)> {
         }
     }
     None
+}
+
+/// A destination pool row reconstructed from a previous `.prom` file
+/// (issue #339): everything `apply_carried_forward_pools` needs to re-emit
+/// `backup_pool_free_bytes` / `backup_pool_total_bytes` /
+/// `backup_pool_metadata_utilization_ratio` / `backup_pool_last_seen_timestamp`
+/// for a configured drive that is absent this run.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CarriedPoolRow {
+    pub uuid: String,
+    pub free_bytes: Option<u64>,
+    pub capacity_bytes: Option<u64>,
+    pub metadata_utilization_ratio: Option<f64>,
+    pub last_seen_timestamp: i64,
+}
+
+/// The pool-gauge names `read_existing_pool_rows` scans for — every metric
+/// carrying the `{uuid,role,label}` label set.
+const POOL_GAUGE_NAMES: [&str; 4] = [
+    names::BACKUP_POOL_FREE_BYTES,
+    names::BACKUP_POOL_TOTAL_BYTES,
+    names::BACKUP_POOL_METADATA_UTILIZATION_RATIO,
+    names::BACKUP_POOL_LAST_SEEN_TIMESTAMP,
+];
+
+/// Parse one pool-gauge sample line (`<metric>{uuid="...",role="...",label="..."} value`)
+/// against the known pool-gauge names. Reuses `parse_escaped_label` — the
+/// same unescaping logic `read_existing_timestamps` uses — rather than a
+/// second hand-rolled parser. Returns the matched metric name, the three
+/// labels (unescaped), and the raw value string; `None` for anything that
+/// isn't a pool-gauge line or is malformed.
+fn parse_pool_sample_line(line: &str) -> Option<(&'static str, String, String, String, &str)> {
+    for &metric_name in &POOL_GAUGE_NAMES {
+        let prefix = format!("{metric_name}{{uuid=\"");
+        let Some(rest) = line.strip_prefix(prefix.as_str()) else {
+            continue;
+        };
+        let (uuid, rest) = parse_escaped_label(rest)?;
+        let rest = rest.strip_prefix(",role=\"")?;
+        let (role, rest) = parse_escaped_label(rest)?;
+        let rest = rest.strip_prefix(",label=\"")?;
+        let (label, rest) = parse_escaped_label(rest)?;
+        let rest = rest.strip_prefix('}')?;
+        return Some((metric_name, uuid, role, label, rest.trim()));
+    }
+    None
+}
+
+/// Read destination-pool rows (`role="destination"`) from an existing
+/// `.prom` file, keyed by `label` — the drive's config identity (issue
+/// #339). Only labels with a carried `backup_pool_last_seen_timestamp`
+/// entry are returned: a `.prom` written before this gauge existed has no
+/// honest "last seen" value to carry, so that row is simply not carried
+/// forward until the drive is next mounted and measured under this code.
+/// Missing or unparseable files return an empty map — never fails the run
+/// (metrics are best-effort, mirroring `read_existing_timestamps`).
+#[must_use]
+pub fn read_existing_pool_rows(path: &Path) -> HashMap<String, CarriedPoolRow> {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return HashMap::new();
+    };
+
+    let mut uuid_by_label: HashMap<String, String> = HashMap::new();
+    let mut free_bytes: HashMap<String, u64> = HashMap::new();
+    let mut capacity_bytes: HashMap<String, u64> = HashMap::new();
+    let mut metadata_ratio: HashMap<String, f64> = HashMap::new();
+    let mut last_seen: HashMap<String, i64> = HashMap::new();
+
+    for line in content.lines() {
+        let Some((metric_name, uuid, role, label, value)) =
+            parse_pool_sample_line(line.trim())
+        else {
+            continue;
+        };
+        if role != "destination" {
+            continue;
+        }
+        uuid_by_label.insert(label.clone(), uuid);
+        if metric_name == names::BACKUP_POOL_FREE_BYTES
+            && let Ok(v) = value.parse()
+        {
+            free_bytes.insert(label, v);
+        } else if metric_name == names::BACKUP_POOL_TOTAL_BYTES
+            && let Ok(v) = value.parse()
+        {
+            capacity_bytes.insert(label, v);
+        } else if metric_name == names::BACKUP_POOL_METADATA_UTILIZATION_RATIO
+            && let Ok(v) = value.parse()
+        {
+            metadata_ratio.insert(label, v);
+        } else if metric_name == names::BACKUP_POOL_LAST_SEEN_TIMESTAMP
+            && let Ok(v) = value.parse()
+        {
+            last_seen.insert(label, v);
+        }
+    }
+
+    last_seen
+        .into_iter()
+        .filter_map(|(label, ts)| {
+            let uuid = uuid_by_label.get(&label)?.clone();
+            Some((
+                label.clone(),
+                CarriedPoolRow {
+                    uuid,
+                    free_bytes: free_bytes.get(&label).copied(),
+                    capacity_bytes: capacity_bytes.get(&label).copied(),
+                    metadata_utilization_ratio: metadata_ratio.get(&label).copied(),
+                    last_seen_timestamp: ts,
+                },
+            ))
+        })
+        .collect()
+}
+
+/// Re-emit destination-pool rows for configured drives that weren't
+/// measured this run (issue #339, option 1: carried-forward last-seen
+/// values). A row is eligible only when its `label` is still in
+/// `configured_destination_labels` — remove a drive from config and its
+/// series goes absent, same posture as every other conditional series in
+/// this file. Rows already present this run (measured, with a fresh
+/// `last_seen_timestamp`) are left untouched and never duplicated.
+pub fn apply_carried_forward_pools(
+    pools: &mut Vec<PoolMetric>,
+    carried: &HashMap<String, CarriedPoolRow>,
+    configured_destination_labels: &HashSet<String>,
+) {
+    let measured_destination_labels: HashSet<String> = pools
+        .iter()
+        .filter(|p| p.role == "destination")
+        .map(|p| p.label.clone())
+        .collect();
+
+    for label in configured_destination_labels {
+        if measured_destination_labels.contains(label) {
+            continue;
+        }
+        let Some(row) = carried.get(label) else {
+            continue;
+        };
+        pools.push(PoolMetric {
+            uuid: row.uuid.clone(),
+            role: "destination".to_string(),
+            label: label.clone(),
+            free_bytes: row.free_bytes,
+            capacity_bytes: row.capacity_bytes,
+            metadata_utilization_ratio: row.metadata_utilization_ratio,
+            last_seen_timestamp: row.last_seen_timestamp,
+        });
+    }
 }
 
 /// Fill in `last_success_timestamp` from carried-forward values for subvolumes
@@ -543,6 +702,27 @@ fn format_metrics(data: &MetricsData) -> String {
                 ratio,
             );
         }
+    }
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP {} Unix timestamp this pool row was last measured. Equals the run timestamp for a pool measured this run; for a destination pool whose drive is absent this run, the timestamp of the run that last measured it (carried forward from the previous .prom file). Emitted for every pool row, including carried-forward ones.",
+        names::BACKUP_POOL_LAST_SEEN_TIMESTAMP
+    )
+    .unwrap();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_POOL_LAST_SEEN_TIMESTAMP).unwrap();
+    for pool in &data.pools {
+        sample(
+            &mut out,
+            names::BACKUP_POOL_LAST_SEEN_TIMESTAMP,
+            &[
+                ("uuid", pool.uuid.as_str()),
+                ("role", pool.role.as_str()),
+                ("label", pool.label.as_str()),
+            ],
+            pool.last_seen_timestamp,
+        );
     }
 
     writeln!(out).unwrap();
@@ -974,6 +1154,204 @@ mod tests {
         assert_eq!(svs[0].last_success_timestamp, Some(12345));
     }
 
+    // ── Pool carry-forward (issue #339) ────────────────────────────
+    //
+    // Mirrors the subvolume-timestamp carry-forward tests above: read the
+    // previous `.prom` file, merge with what this run measured, and prove
+    // labels no longer in config stop being carried.
+
+    fn dest_pool(uuid: &str, label: &str, last_seen: i64) -> PoolMetric {
+        PoolMetric {
+            uuid: uuid.to_string(),
+            role: "destination".to_string(),
+            label: label.to_string(),
+            free_bytes: Some(1_000_000_000),
+            capacity_bytes: Some(2_000_000_000),
+            metadata_utilization_ratio: Some(0.1),
+            last_seen_timestamp: last_seen,
+        }
+    }
+
+    #[test]
+    fn read_existing_pool_rows_missing_file_is_empty() {
+        let rows = read_existing_pool_rows(Path::new("/nonexistent/backup.prom"));
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn read_existing_pool_rows_only_carries_destination_role() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("backup.prom");
+        let mut data = sample_data();
+        data.pools.push(PoolMetric {
+            uuid: "uuid-src".to_string(),
+            role: "source".to_string(),
+            label: "/home".to_string(),
+            free_bytes: Some(1),
+            capacity_bytes: Some(2),
+            metadata_utilization_ratio: Some(0.1),
+            last_seen_timestamp: 1_000_000,
+        });
+        write_metrics(&path, &data).unwrap();
+
+        let rows = read_existing_pool_rows(&path);
+        assert!(rows.is_empty(), "source-role rows must never be carried forward");
+    }
+
+    #[test]
+    fn read_existing_pool_rows_skips_row_without_last_seen_line() {
+        // A .prom written before backup_pool_last_seen_timestamp existed:
+        // free/total present, no last_seen line. There is no honest "last
+        // seen" value to carry, so the row is not carried — it reappears
+        // once the drive is next mounted and measured under this code.
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("backup.prom");
+        std::fs::write(
+            &path,
+            concat!(
+                "backup_pool_free_bytes{uuid=\"uuid-old\",role=\"destination\",label=\"OLD\"} 111\n",
+                "backup_pool_total_bytes{uuid=\"uuid-old\",role=\"destination\",label=\"OLD\"} 222\n",
+            ),
+        )
+        .unwrap();
+
+        let rows = read_existing_pool_rows(&path);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn pool_carry_forward_roundtrip_reemits_absent_destination_row() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("backup.prom");
+
+        // First run: OFFSITE mounted and measured.
+        let mut data = sample_data();
+        data.pools.push(dest_pool("uuid-offsite", "OFFSITE", 1_000_000));
+        write_metrics(&path, &data).unwrap();
+
+        // Second run: OFFSITE absent (drive away), but still configured.
+        let carried = read_existing_pool_rows(&path);
+        let mut configured = HashSet::new();
+        configured.insert("OFFSITE".to_string());
+        let mut pools: Vec<PoolMetric> = Vec::new(); // nothing measured this run
+        apply_carried_forward_pools(&mut pools, &carried, &configured);
+
+        assert_eq!(pools.len(), 1);
+        let row = &pools[0];
+        assert_eq!(row.uuid, "uuid-offsite");
+        assert_eq!(row.role, "destination");
+        assert_eq!(row.label, "OFFSITE");
+        assert_eq!(row.free_bytes, Some(1_000_000_000));
+        assert_eq!(row.capacity_bytes, Some(2_000_000_000));
+        assert_eq!(row.metadata_utilization_ratio, Some(0.1));
+        assert_eq!(row.last_seen_timestamp, 1_000_000);
+
+        // The rendered output carries all three gauges plus last_seen,
+        // labels verbatim.
+        let mut data2 = sample_data();
+        data2.pools = pools;
+        let output = format_metrics(&data2);
+        assert!(output.contains(
+            "backup_pool_free_bytes{uuid=\"uuid-offsite\",role=\"destination\",label=\"OFFSITE\"} 1000000000"
+        ));
+        assert!(output.contains(
+            "backup_pool_total_bytes{uuid=\"uuid-offsite\",role=\"destination\",label=\"OFFSITE\"} 2000000000"
+        ));
+        assert!(output.contains(
+            "backup_pool_metadata_utilization_ratio{uuid=\"uuid-offsite\",role=\"destination\",label=\"OFFSITE\"} 0.1"
+        ));
+        assert!(output.contains(
+            "backup_pool_last_seen_timestamp{uuid=\"uuid-offsite\",role=\"destination\",label=\"OFFSITE\"} 1000000"
+        ));
+    }
+
+    #[test]
+    fn pool_carry_forward_does_not_duplicate_when_drive_present() {
+        let mut carried = HashMap::new();
+        carried.insert(
+            "OFFSITE".to_string(),
+            CarriedPoolRow {
+                uuid: "uuid-offsite".to_string(),
+                free_bytes: Some(1),
+                capacity_bytes: Some(2),
+                metadata_utilization_ratio: Some(0.5),
+                last_seen_timestamp: 1_000_000,
+            },
+        );
+        let mut configured = HashSet::new();
+        configured.insert("OFFSITE".to_string());
+
+        // This run measured OFFSITE fresh — the run timestamp, not the
+        // carried one, must win.
+        let mut pools = vec![dest_pool("uuid-offsite", "OFFSITE", 2_000_000)];
+        pools[0].free_bytes = Some(999);
+        apply_carried_forward_pools(&mut pools, &carried, &configured);
+
+        assert_eq!(pools.len(), 1, "measured row must not be duplicated by carry-forward");
+        assert_eq!(pools[0].free_bytes, Some(999));
+        assert_eq!(pools[0].last_seen_timestamp, 2_000_000);
+    }
+
+    #[test]
+    fn pool_carry_forward_drops_label_not_in_config() {
+        let mut carried = HashMap::new();
+        carried.insert(
+            "RETIRED-DRIVE".to_string(),
+            CarriedPoolRow {
+                uuid: "uuid-retired".to_string(),
+                free_bytes: Some(1),
+                capacity_bytes: Some(2),
+                metadata_utilization_ratio: Some(0.5),
+                last_seen_timestamp: 1_000_000,
+            },
+        );
+        let configured = HashSet::new(); // RETIRED-DRIVE no longer configured
+
+        let mut pools: Vec<PoolMetric> = Vec::new();
+        apply_carried_forward_pools(&mut pools, &carried, &configured);
+
+        assert!(
+            pools.is_empty(),
+            "a label removed from config must not be carried forward"
+        );
+    }
+
+    #[test]
+    fn pool_carry_forward_noop_when_nothing_carried() {
+        // No prior .prom file: read_existing_pool_rows returns an empty map
+        // (see read_existing_pool_rows_missing_file_is_empty), so a run's
+        // freshly measured rows pass through unchanged — identical to
+        // today's behavior, plus the last_seen_timestamp each row already
+        // carries from compute_pool_metrics_from.
+        let mut pools = vec![dest_pool("uuid-a", "OFFSITE", 500)];
+        let before = pools.clone();
+        let carried = HashMap::new();
+        let mut configured = HashSet::new();
+        configured.insert("OFFSITE".to_string());
+
+        apply_carried_forward_pools(&mut pools, &carried, &configured);
+
+        assert_eq!(pools, before);
+    }
+
+    #[test]
+    fn format_metrics_emits_pool_last_seen_timestamp_help_and_type() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_pool_last_seen_timestamp"));
+        assert!(output.contains("# TYPE backup_pool_last_seen_timestamp gauge"));
+    }
+
+    #[test]
+    fn format_metrics_emits_pool_last_seen_timestamp_unconditionally_per_row() {
+        let mut data = sample_data();
+        data.pools.push(dest_pool("uuid-a", "OFFSITE", 42));
+        let output = format_metrics(&data);
+        assert!(output.contains(
+            "backup_pool_last_seen_timestamp{uuid=\"uuid-a\",role=\"destination\",label=\"OFFSITE\"} 42"
+        ));
+    }
+
     // ── Escaped-label round-trip (UPI 061) ────────────────────────
     //
     // The writer escapes the subvolume label (via sample()); the reader
@@ -1186,6 +1564,7 @@ mod tests {
             free_bytes: None,
             capacity_bytes: None,
             metadata_utilization_ratio: None,
+            last_seen_timestamp: 0,
         }
     }
 
@@ -1430,16 +1809,20 @@ mod tests {
     // ── Golden file (UPI 061) ─────────────────────────────────────
     //
     // The golden fixture exercises every emission branch reachable in one
-    // MetricsData: all 20 metrics present, Some/None splits across
+    // MetricsData: all 21 metrics present, Some/None splits across
     // subvolumes, both pool roles, non-empty event counters. Branches a
     // single fixture cannot reach (zero-sentinel counter lines, unmounted
     // drive, per-metric absence) are pinned by the `contains` tests above.
     //
-    // src/testdata/golden_metrics.prom is WRITE-ONCE: it was generated from
-    // the pre-UPI-061 formatter and is the byte-level proof that the
-    // contract-surface refactor changed nothing for realistic configs
-    // (ADR-105 / homelab ADR-021). Never regenerate it to make this test
-    // pass — a mismatch is a bug in the formatter, not in the file.
+    // src/testdata/golden_metrics.prom is WRITE-ONCE for refactors: it was
+    // generated from the pre-UPI-061 formatter and is the byte-level proof
+    // that the contract-surface refactor changed nothing for realistic
+    // configs (ADR-105 / homelab ADR-021). Never regenerate it to make this
+    // test pass after a refactor — a mismatch is a bug in the formatter, not
+    // the file. A deliberate new metric (e.g. `backup_pool_last_seen_timestamp`,
+    // issue #339) is the one case that legitimately amends the fixture —
+    // done by hand, with the diff reviewed as part of the change, not by
+    // regenerating from formatter output.
 
     fn golden_data() -> MetricsData {
         MetricsData {
@@ -1513,6 +1896,7 @@ mod tests {
                     free_bytes: Some(123_456_789),
                     capacity_bytes: Some(500_000_000_000),
                     metadata_utilization_ratio: Some(0.25),
+                    last_seen_timestamp: 1_711_100_120,
                 },
                 PoolMetric {
                     uuid: "uuid-dst".to_string(),
@@ -1521,6 +1905,10 @@ mod tests {
                     free_bytes: Some(4_400_000_000_000),
                     capacity_bytes: None,
                     metadata_utilization_ratio: Some(0.5),
+                    // Deliberately distinct from script_last_run_timestamp —
+                    // exercises the carried-forward case (a destination row
+                    // whose last_seen predates this run) in the golden fixture.
+                    last_seen_timestamp: 1_700_000_000,
                 },
             ],
         }
@@ -1543,7 +1931,7 @@ mod tests {
 
     #[test]
     fn guard_metric_names_live_only_in_names_module() {
-        const ALL: [&str; 20] = [
+        const ALL: [&str; 21] = [
             names::BACKUP_SUCCESS,
             names::BACKUP_LAST_SUCCESS_TIMESTAMP,
             names::BACKUP_DURATION_SECONDS,
@@ -1558,6 +1946,7 @@ mod tests {
             names::BACKUP_POOL_FREE_BYTES,
             names::BACKUP_POOL_TOTAL_BYTES,
             names::BACKUP_POOL_METADATA_UTILIZATION_RATIO,
+            names::BACKUP_POOL_LAST_SEEN_TIMESTAMP,
             names::BACKUP_SUBVOLUME_LOCAL_SNAPSHOT_COUNT,
             names::BACKUP_SUBVOLUME_ESTIMATED_LOCAL_PINNED_DELTA_BYTES,
             names::URD_CIRCUIT_BREAKER_TRIPS_TOTAL,

--- a/src/pools.rs
+++ b/src/pools.rs
@@ -287,11 +287,16 @@ pub(crate) fn metadata_utilization_ratio_from(sysfs_root: &Path, uuid: &str) -> 
 /// `space_resolver` and `metadata_resolver` are accepted as closures so tests
 /// can substitute pure stand-ins; production callers pass `pool_space` /
 /// `metadata_utilization_ratio`. `space_resolver` returns free + capacity from
-/// a single statvfs so the two never skew within a run.
+/// a single statvfs so the two never skew within a run. `now_ts` is the run's
+/// canonical timestamp — the same value written to
+/// `backup_script_last_run_timestamp` — stamped onto every row's
+/// `last_seen_timestamp` (issue #339); a row measured this run is never
+/// ambiguous about when "this run" was.
 #[must_use]
 pub fn compute_pool_metrics_from(
     detected_pools: &[SourcePool],
     drives: &[DriveResolution],
+    now_ts: i64,
     mut space_resolver: impl FnMut(&Path) -> Option<PoolSpace>,
     mut metadata_resolver: impl FnMut(&str) -> Option<f64>,
 ) -> Vec<PoolMetric> {
@@ -309,6 +314,7 @@ pub fn compute_pool_metrics_from(
             free_bytes: space.map(|s| s.free_bytes),
             capacity_bytes: space.map(|s| s.capacity_bytes),
             metadata_utilization_ratio: meta,
+            last_seen_timestamp: now_ts,
         });
     }
 
@@ -329,6 +335,7 @@ pub fn compute_pool_metrics_from(
             free_bytes: space.map(|s| s.free_bytes),
             capacity_bytes: space.map(|s| s.capacity_bytes),
             metadata_utilization_ratio: meta,
+            last_seen_timestamp: now_ts,
         });
     }
 
@@ -564,7 +571,7 @@ mod tests {
         }];
 
         let meta = |_: &str| Some(0.25_f64);
-        let metrics = compute_pool_metrics_from(&pools, &drives, fixed_space(42, 100), meta);
+        let metrics = compute_pool_metrics_from(&pools, &drives, 1_711_100_120, fixed_space(42, 100), meta);
 
         assert_eq!(metrics.len(), 2);
         assert_eq!(metrics[0].uuid, "uuid-src");
@@ -586,7 +593,7 @@ mod tests {
             mounted: false,
             mountpoint: None,
         }];
-        let metrics = compute_pool_metrics_from(&[], &drives, fixed_space(0, 0), |_| None);
+        let metrics = compute_pool_metrics_from(&[], &drives, 1_711_100_120, fixed_space(0, 0), |_| None);
         assert!(metrics.is_empty());
     }
 
@@ -644,7 +651,7 @@ mod tests {
             mounted: true,
             mountpoint: Some(PathBuf::from("/mnt/wd")),
         }];
-        let metrics = compute_pool_metrics_from(&[], &drives, fixed_space(0, 0), |_| None);
+        let metrics = compute_pool_metrics_from(&[], &drives, 1_711_100_120, fixed_space(0, 0), |_| None);
         assert!(metrics.is_empty());
     }
 }

--- a/src/testdata/golden_metrics.prom
+++ b/src/testdata/golden_metrics.prom
@@ -69,6 +69,11 @@ backup_pool_total_bytes{uuid="uuid-src",role="source",label="/home"} 50000000000
 backup_pool_metadata_utilization_ratio{uuid="uuid-src",role="source",label="/home"} 0.25
 backup_pool_metadata_utilization_ratio{uuid="uuid-dst",role="destination",label="WD-18TB"} 0.5
 
+# HELP backup_pool_last_seen_timestamp Unix timestamp this pool row was last measured. Equals the run timestamp for a pool measured this run; for a destination pool whose drive is absent this run, the timestamp of the run that last measured it (carried forward from the previous .prom file). Emitted for every pool row, including carried-forward ones.
+# TYPE backup_pool_last_seen_timestamp gauge
+backup_pool_last_seen_timestamp{uuid="uuid-src",role="source",label="/home"} 1711100120
+backup_pool_last_seen_timestamp{uuid="uuid-dst",role="destination",label="WD-18TB"} 1700000000
+
 # HELP backup_subvolume_local_snapshot_count Local snapshot count for a subvolume. Line absent when local snapshots are not configured for that subvolume.
 # TYPE backup_subvolume_local_snapshot_count gauge
 backup_subvolume_local_snapshot_count{subvolume="subvol3-opptak"} 7


### PR DESCRIPTION
## Summary
- The offsite rotation drive is unmounted most of the time, so `backup_pool_free_bytes` / `backup_pool_total_bytes` / `backup_pool_metadata_utilization_ratio` went absent exactly for the drive that leaves the house — the consumer had nothing to alert on.
- Reuses the same carry-forward mechanism contract point 7 already documents for `backup_last_success_timestamp`: a configured destination drive absent this run has its last-seen pool gauges re-read from the previous `.prom` file and re-emitted with identical labels (`uuid`, `role`, `label`).
- Adds `backup_pool_last_seen_timestamp{uuid,role,label}`, emitted for every pool row (the run timestamp for a row measured this run, the carried-forward timestamp otherwise), so staleness stays honest instead of a flat-lined capacity value looking fresh.

## Changes
- `src/metrics.rs`: new `PoolMetric.last_seen_timestamp` field; new gauge `backup_pool_last_seen_timestamp`; `CarriedPoolRow`, `read_existing_pool_rows` (reuses the existing `parse_escaped_label` reader, no second parser), and `apply_carried_forward_pools` — only labels still present in config are eligible, so removing a drive from config stops its carry-forward.
- `src/pools.rs`: `compute_pool_metrics_from` takes the run's `now_ts` and stamps it onto every freshly measured row.
- `src/commands/backup.rs`: `gather_pool_observability` threads `now_ts` through (the same `now` already used for `backup_script_last_run_timestamp`); `write_global_metrics` merges in carried-forward destination rows before writing.
- `docs/20-reference/metrics.md`: contract point 7 extended to cover the pool gauges; new gauge documented with HELP text and absence semantics; frontmatter timestamp bumped.
- `src/testdata/golden_metrics.prom`: golden fixture amended by hand (not regenerated) to include the new gauge line, one measured + one carried-forward-style value, per its own write-once-for-refactors convention.
- `CHANGELOG.md`: `### Added` entry under `[Unreleased]`.

Sample output (one measured source pool, one destination pool with a distinct carried `last_seen`):
```
backup_pool_free_bytes{uuid="uuid-src",role="source",label="/home"} 123456789
backup_pool_free_bytes{uuid="uuid-dst",role="destination",label="WD-18TB"} 4400000000000

backup_pool_last_seen_timestamp{uuid="uuid-src",role="source",label="/home"} 1711100120
backup_pool_last_seen_timestamp{uuid="uuid-dst",role="destination",label="WD-18TB"} 1700000000
```

## Test plan
- `scripts/check.sh`:
```
clippy    PASS
tests     PASS  2404 passed, 0 failed, 6 ignored
build     PASS
doc-lint  PASS
All checks passed.
```
- New tests mirror the existing subvolume carry-forward tests: prior-row-with-drive-absent re-emits all three gauges + `last_seen` (`pool_carry_forward_roundtrip_reemits_absent_destination_row`), drive-present-this-run uses fresh values and doesn't duplicate (`pool_carry_forward_does_not_duplicate_when_drive_present`), a label no longer in config is dropped (`pool_carry_forward_drops_label_not_in_config`), no prior file behaves as a no-op (`pool_carry_forward_noop_when_nothing_carried`), source-role rows are never carried (`read_existing_pool_rows_only_carries_destination_role`), a pre-feature `.prom` with no `last_seen` line isn't carried (`read_existing_pool_rows_skips_row_without_last_seen_line`), and the `names` guard test's `ALL` array is updated to 21.
- `golden_file_byte_identical` still passes with the fixture amended for the new gauge — proves the rest of the formatter's byte output is unchanged.

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBF4pbkC8QVBHXnBgdjmp
