### PR TITLE
feat: promote alert-worthy signals into the backup_* metrics contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   case the progress line can't show a total or an ETA for. Incremental
   sends without an estimate don't trigger it (calibration can't help
   those), and the suggestion only appears in interactive output (#254).
+- Five alert-worthy signals are now reachable under the public `backup_*`
+  Prometheus contract, since downstream alerting only binds to that
+  namespace: `backup_circuit_breaker_trips_total`,
+  `backup_emergency_prunes_total`, and
+  `backup_chain_broken_full_sends_total` mirror their existing `urd_*`
+  counters byte-for-byte; `backup_pin_failures` and `backup_promise_state`
+  are new per-subvolume gauges sourced from the same post-run awareness
+  assessment that already feeds the heartbeat. Every existing `urd_*` series
+  is unchanged (#337, #338).
 
 ### Changed
 - The EXPOSURE column's label-to-color plumbing now carries `PromiseStatus`

--- a/docs/20-reference/metrics.md
+++ b/docs/20-reference/metrics.md
@@ -6,7 +6,7 @@ project: ['[[urd]]']
 sensitivity: public
 status: active
 created: '2026-05-02'
-timestamp: '2026-09-03T12:45:40+02:00'
+timestamp: '2026-09-03T13:15:00+02:00'
 ---
 # Prometheus Metrics Reference
 
@@ -37,9 +37,11 @@ These properties are guaranteed and load-bearing for downstream consumers
    change with coordinated downstream updates. The `urd_*` namespace is
    reserved for Urd internals and may evolve freely.
 2. **Encoding stability.** `backup_send_type`'s value mapping
-   (`0=full / 1=incremental / 2=no-send / 3=deferred`) and
-   `backup_success`'s mapping (`0=failure / 1=success / 2=schedule-skipped`)
-   are part of the contract. A consumer that filters on `backup_send_type == 2`
+   (`0=full / 1=incremental / 2=no-send / 3=deferred`),
+   `backup_success`'s mapping (`0=failure / 1=success / 2=schedule-skipped`),
+   and `backup_promise_state`'s mapping (`0=protected / 1=at_risk /
+   2=unprotected`, `PromiseStatus::metric_value` in `src/awareness.rs`) are
+   part of the contract. A consumer that filters on `backup_send_type == 2`
    to suppress alerts on cold subvolumes will silently break if the encoding shifts.
 3. **`backup_script_last_run_timestamp` is the heartbeat.** Updated on every
    run regardless of outcome. A monitor can detect "Urd itself stopped" by
@@ -84,6 +86,18 @@ These properties are guaranteed and load-bearing for downstream consumers
    metrics are written by external tooling. Urd must never emit those names.
 10. **Reserved namespace.** Urd writes only `backup_*` (public contract) and
     `urd_*` (internal). Other prefixes are out of scope.
+11. **The `_total` counters are all-time cumulative, not per-run.** Every
+    `_total` series (`backup_circuit_breaker_trips_total`,
+    `backup_emergency_prunes_total`, `backup_chain_broken_full_sends_total`,
+    and their `urd_*` siblings) is a `COUNT(*)` over the structured event log
+    ([ADR-114](../00-foundation/decisions/2026-04-30-ADR-114-structured-event-log.md)),
+    not a delta since the last run. They are monotonic for as long as the
+    events table is never pruned — true today (`src/state.rs` has no
+    events-table delete path). If a future retention policy starts pruning
+    old events, these counters would drop rather than only ever climb;
+    consumers should query them with `increase()` or `rate()`, both of which
+    already tolerate a counter reset, rather than assuming monotonicity by
+    reading the raw value.
 
 ---
 
@@ -185,6 +199,29 @@ Gauge. Bytes of the most recent in-window full send (UPI 030).
 subvolumes. Emitted for transient/storage-critical subvolumes whose latest
 send was a full send (so the previous incremental rate doesn't apply).
 
+### `backup_pin_failures`
+
+Gauge. Number of sends that succeeded but whose pin-file (chain marker)
+write failed, for this subvolume in this run. Same source as heartbeat v3's
+per-subvolume `pin_failures` field.
+
+**Conditional.** Emitted (including `0`, per contract point 4) for every
+subvolume this run's awareness assessment covers — every *enabled*
+subvolume, whether executed, skipped (interval, drive absent), or deferred.
+**Absent for a disabled subvolume**: awareness computes no assessment for a
+disabled subvolume, so there is no promise for it to report pin failures
+against. This is the same population as `backup_promise_state` below.
+
+### `backup_promise_state`
+
+Gauge. This subvolume's post-run promise status: `0=protected`, `1=at_risk`,
+`2=unprotected` (see Contract point 2). Sourced from the same post-run
+awareness assessment that feeds the heartbeat's `promise_status` field.
+
+**Conditional.** Same population and absence rule as `backup_pin_failures`
+above: present for every enabled subvolume assessed this run, absent for a
+disabled subvolume.
+
 ---
 
 ## Global gauges
@@ -284,6 +321,34 @@ Same `scope="none"` zero sentinel as above.
 Counter, label `rule`. Snapshot prunes by retention rule
 (`graduated_hourly`, `graduated_daily`, `emergency`, ...). Same `rule="none"`
 zero sentinel as above.
+
+---
+
+## Public mirrors of alert-worthy counters (`backup_*`)
+
+Three signals above were alert-worthy but reachable only under `urd_*`,
+which downstream alerting does not bind to (issues #337/#338). Each mirror
+below has **the exact same value** as a specific `urd_*` series or label
+slice — same events-table derivation, same all-time-cumulative semantics
+(Contract point 11) — projected onto a no-label `backup_*` name so an alert
+rule can reach it directly.
+
+### `backup_circuit_breaker_trips_total`
+
+Counter, no labels. Same value as `urd_circuit_breaker_trips_total`.
+
+### `backup_emergency_prunes_total`
+
+Counter, no labels. Same value as
+`urd_retention_prunes_total{rule="emergency"}`; `0` when no emergency-rule
+prune events exist (including when the events table is empty).
+
+### `backup_chain_broken_full_sends_total`
+
+Counter, no labels. Same value as
+`urd_planner_full_sends_total{reason="chain_broken"}`; `0` when no
+chain-broken full sends have occurred (including when the events table is
+empty).
 
 ---
 

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -215,6 +215,18 @@ impl PromiseStatus {
     pub fn worsened_from(self, prev: Self) -> bool {
         self < prev
     }
+
+    /// Prometheus metric value for `backup_promise_state`: 0=protected,
+    /// 1=at_risk, 2=unprotected. The encoding is part of the `backup_*`
+    /// contract (`docs/20-reference/metrics.md`) — do not renumber.
+    #[must_use]
+    pub fn metric_value(self) -> u8 {
+        match self {
+            Self::Protected => 0,
+            Self::AtRisk => 1,
+            Self::Unprotected => 2,
+        }
+    }
 }
 
 impl std::fmt::Display for PromiseStatus {
@@ -1568,6 +1580,15 @@ mod tests {
         assert!(PromiseStatus::Unprotected.worsened_from(PromiseStatus::AtRisk));
         assert!(!PromiseStatus::Protected.worsened_from(PromiseStatus::AtRisk));
         assert!(!PromiseStatus::Protected.worsened_from(PromiseStatus::Protected));
+    }
+
+    // ── PromiseStatus::metric_value (backup_promise_state, issue #337) ──
+
+    #[test]
+    fn metric_value_matches_contract_encoding() {
+        assert_eq!(PromiseStatus::Protected.metric_value(), 0);
+        assert_eq!(PromiseStatus::AtRisk.metric_value(), 1);
+        assert_eq!(PromiseStatus::Unprotected.metric_value(), 2);
     }
 
     /// Test config with one drive and min_free_bytes set.

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, Instant};
 
 use colored::Colorize;
 
+use crate::awareness::{PromiseStatus, SubvolAssessment};
 use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::cli::BackupArgs;
 use crate::commands::storage_signals;
@@ -213,6 +214,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
             &fs_state,
             &churn_views,
             &observability,
+            &assessments,
         )?;
         if let Err(e) = heartbeat::write(&config.general.heartbeat_file, &tail.heartbeat) {
             log::warn!("Failed to write heartbeat: {e}");
@@ -578,6 +580,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         &fs_state,
         &churn_views,
         &observability,
+        &assessments,
     )?;
 
     // Write heartbeat (fresh timestamp — `now` is from before execution).
@@ -1336,6 +1339,19 @@ fn externally_expected_subvolumes(config: &Config) -> HashSet<String> {
         .collect()
 }
 
+/// Look up each assessed subvolume's promise status by name (issues
+/// #337/#338: `backup_pin_failures` / `backup_promise_state`). The
+/// population is exactly the awareness assessments for this run — enabled
+/// subvolumes only; disabled subvolumes never appear here, matching
+/// heartbeat v3's own `pin_failures`/`promise_status` population.
+fn promise_status_lookup(assessments: &[SubvolAssessment]) -> HashMap<&str, PromiseStatus> {
+    assessments
+        .iter()
+        .map(|a| (a.name.as_str(), a.status))
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
 fn write_metrics_after_execution(
     config: &Config,
     result: &crate::executor::ExecutionResult,
@@ -1344,9 +1360,11 @@ fn write_metrics_after_execution(
     fs_state: &dyn FilesystemQuery,
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
     observability: &PoolObservability,
+    assessments: &[SubvolAssessment],
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
     let external_expected = externally_expected_subvolumes(config);
+    let promise_by_name = promise_status_lookup(assessments);
     let mut subvolume_metrics = Vec::new();
 
     // Metrics for executed subvolumes
@@ -1362,6 +1380,11 @@ fn write_metrics_after_execution(
         let external_count = count_external_snapshots(config, &sv_result.name, fs_state);
         let churn = churn_views.get(&sv_result.name).copied().unwrap_or_default();
         let extras = observability.subvol_extras.get(&sv_result.name);
+        // `Some` iff this subvolume has an assessment this run (always true for
+        // an executed subvolume in practice — the executor only runs enabled
+        // subvolumes, and assess() covers every enabled one). Ties pin_failures'
+        // presence to promise_state's rather than assuming it independently.
+        let assessed_status = promise_by_name.get(sv_result.name.as_str()).copied();
 
         subvolume_metrics.push(SubvolumeMetrics {
             name: sv_result.name.clone(),
@@ -1377,6 +1400,8 @@ fn write_metrics_after_execution(
             local_snapshot_count_v4: extras.and_then(|e| e.local_snapshot_count),
             estimated_local_pinned_delta_bytes: extras
                 .and_then(|e| e.estimated_local_pinned_delta_bytes),
+            pin_failures: assessed_status.map(|_| sv_result.pin_failures),
+            promise_state: assessed_status.map(|s| s.metric_value()),
         });
     }
 
@@ -1394,6 +1419,7 @@ fn write_metrics_after_execution(
         &already_emitted,
         churn_views,
         observability,
+        &promise_by_name,
     );
 
     // Carry forward last_success_timestamp from previous .prom file
@@ -1406,6 +1432,7 @@ fn write_metrics_after_execution(
 /// Execute the tail's metrics decision (UPI 088-b): one total match over
 /// [`MetricsSpec`], shared by both exits — the variant carries the execution
 /// result its writer needs, so neither call site has an impossible arm.
+#[allow(clippy::too_many_arguments)]
 fn write_metrics_per_spec(
     config: &Config,
     spec: &MetricsSpec<'_>,
@@ -1414,11 +1441,18 @@ fn write_metrics_per_spec(
     fs_state: &dyn FilesystemQuery,
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
     observability: &PoolObservability,
+    assessments: &[SubvolAssessment],
 ) -> anyhow::Result<()> {
     match spec {
-        MetricsSpec::Skipped => {
-            write_metrics_for_skipped(config, plan, now, fs_state, churn_views, observability)
-        }
+        MetricsSpec::Skipped => write_metrics_for_skipped(
+            config,
+            plan,
+            now,
+            fs_state,
+            churn_views,
+            observability,
+            assessments,
+        ),
         MetricsSpec::AfterExecution(result) => write_metrics_after_execution(
             config,
             result,
@@ -1427,6 +1461,7 @@ fn write_metrics_per_spec(
             fs_state,
             churn_views,
             observability,
+            assessments,
         ),
     }
 }
@@ -1438,8 +1473,10 @@ fn write_metrics_for_skipped(
     fs_state: &dyn FilesystemQuery,
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
     observability: &PoolObservability,
+    assessments: &[SubvolAssessment],
 ) -> anyhow::Result<()> {
     let now_ts = now.and_utc().timestamp();
+    let promise_by_name = promise_status_lookup(assessments);
     let mut subvolume_metrics = Vec::new();
 
     append_skipped_metrics(
@@ -1450,6 +1487,7 @@ fn write_metrics_for_skipped(
         &HashSet::new(),
         churn_views,
         observability,
+        &promise_by_name,
     );
 
     // Carry forward last_success_timestamp from previous .prom file
@@ -1731,6 +1769,7 @@ fn build_empty_plan_explanation(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn append_skipped_metrics(
     config: &Config,
     plan: &crate::types::BackupPlan,
@@ -1739,6 +1778,7 @@ fn append_skipped_metrics(
     already_emitted: &HashSet<String>,
     churn_views: &HashMap<String, ChurnHeartbeatFields>,
     observability: &PoolObservability,
+    promise_by_name: &HashMap<&str, PromiseStatus>,
 ) {
     let external_expected = externally_expected_subvolumes(config);
     let mut seen = already_emitted.clone();
@@ -1753,6 +1793,11 @@ fn append_skipped_metrics(
         let external_count = count_external_snapshots(config, name, fs_state);
         let churn = churn_views.get(name).copied().unwrap_or_default();
         let extras = observability.subvol_extras.get(name);
+        // A skipped subvolume was never executed, so any pin failure is
+        // impossible — 0 whenever it was assessed (mirrors heartbeat's
+        // `sv_result.map(...).unwrap_or(0)`, where `sv_result` is always
+        // `None` for a name absent from `result.subvolume_results`).
+        let assessed_status = promise_by_name.get(name.as_str()).copied();
 
         subvolume_metrics.push(SubvolumeMetrics {
             name: name.clone(),
@@ -1768,6 +1813,8 @@ fn append_skipped_metrics(
             local_snapshot_count_v4: extras.and_then(|e| e.local_snapshot_count),
             estimated_local_pinned_delta_bytes: extras
                 .and_then(|e| e.estimated_local_pinned_delta_bytes),
+            pin_failures: assessed_status.map(|_| 0),
+            promise_state: assessed_status.map(|s| s.metric_value()),
         });
     }
 }
@@ -2543,9 +2590,7 @@ fn filter_promise_retention(config: &Config, plan: &mut BackupPlan) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::awareness::{
-        LocalAssessment, OperationalHealth, PromiseStatus, SubvolAssessment,
-    };
+    use crate::awareness::{LocalAssessment, OperationalHealth};
     use crate::types::SendKind;
     use crate::executor::{
         ExecutionResult, OpResult, OperationOutcome, RunResult, SendType, SubvolumeResult,
@@ -3329,6 +3374,32 @@ source = "/data/beta"
             cadence_adapted: false,
             effective_send_interval: None,
         }]
+    }
+
+    // ── promise_status_lookup (backup_pin_failures / backup_promise_state,
+    //    issues #337/#338) ────────────────────────────────────────────
+
+    #[test]
+    fn promise_status_lookup_finds_assessed_subvolume() {
+        let assessments = sample_assessments();
+        let lookup = promise_status_lookup(&assessments);
+        assert_eq!(lookup.get("htpc-home"), Some(&PromiseStatus::Protected));
+    }
+
+    #[test]
+    fn promise_status_lookup_misses_unassessed_subvolume() {
+        // Models a disabled subvolume: assess() never produced an entry for
+        // it, so the lookup must not synthesize one.
+        let assessments = sample_assessments();
+        let lookup = promise_status_lookup(&assessments);
+        assert_eq!(lookup.get("some-disabled-subvol"), None);
+    }
+
+    #[test]
+    fn promise_status_lookup_empty_for_no_assessments() {
+        let assessments = empty_assessments();
+        let lookup = promise_status_lookup(&assessments);
+        assert!(lookup.is_empty());
     }
 
     fn empty_plan() -> BackupPlan {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -37,6 +37,15 @@ pub(crate) mod names {
     pub const URD_PLANNER_FULL_SENDS_TOTAL: &str = "urd_planner_full_sends_total";
     pub const URD_PLANNER_DEFERS_TOTAL: &str = "urd_planner_defers_total";
     pub const URD_RETENTION_PRUNES_TOTAL: &str = "urd_retention_prunes_total";
+    // Alert-worthy signals promoted into the public contract (issues #337/#338):
+    // same events-table derivation as their urd_* siblings, or the same
+    // per-run population as heartbeat v3, just under a `backup_*` name so
+    // downstream alerting (which only binds to `backup_*`) can reach them.
+    pub const BACKUP_CIRCUIT_BREAKER_TRIPS_TOTAL: &str = "backup_circuit_breaker_trips_total";
+    pub const BACKUP_EMERGENCY_PRUNES_TOTAL: &str = "backup_emergency_prunes_total";
+    pub const BACKUP_CHAIN_BROKEN_FULL_SENDS_TOTAL: &str = "backup_chain_broken_full_sends_total";
+    pub const BACKUP_PIN_FAILURES: &str = "backup_pin_failures";
+    pub const BACKUP_PROMISE_STATE: &str = "backup_promise_state";
 }
 
 // ── Types ───────────────────────────────────────────────────────────────
@@ -127,6 +136,19 @@ pub struct SubvolumeMetrics {
     /// Emit policy: line absent when `None` (cold-start);
     /// `Some(0)` is emitted (distinguishes "known zero" from "unknown").
     pub estimated_local_pinned_delta_bytes: Option<u64>,
+    /// Pin-file write failures for this subvolume in this run. `Some(_)` for
+    /// the same population as `promise_state` below (every subvolume the
+    /// post-run awareness assessment covers — enabled subvolumes only);
+    /// `None` for a subvolume with no assessment this run (disabled). Feeds
+    /// `backup_pin_failures`. Mirrors heartbeat v3's per-subvolume
+    /// `pin_failures` population and source exactly.
+    pub pin_failures: Option<u32>,
+    /// Post-run promise status: `Some(0)`=protected, `Some(1)`=at_risk,
+    /// `Some(2)`=unprotected (`PromiseStatus::metric_value`). `None` when no
+    /// awareness assessment exists for this subvolume this run (disabled
+    /// subvolumes — Urd holds no promise for them). Feeds
+    /// `backup_promise_state`.
+    pub promise_state: Option<u8>,
 }
 
 /// Escape `\`, `"`, and newline in a Prometheus label value per the
@@ -773,6 +795,51 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
+    // ── Pin failures / promise state (alert-worthy `backup_*` promotions) ──
+    //
+    // Both share the awareness-assessment population: `Some` only for a
+    // subvolume this run's `assess()` covered (enabled subvolumes); `None`
+    // for a disabled subvolume, which has no promise to report. Mirrors
+    // heartbeat v3's own `pin_failures`/`promise_status` population exactly.
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP {} Pin-file write failures for this subvolume in this run (sends that succeeded but whose chain marker could not be written). Emitted for every subvolume this run's awareness assessment covers; absent for disabled subvolumes.",
+        names::BACKUP_PIN_FAILURES
+    )
+    .unwrap();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_PIN_FAILURES).unwrap();
+    for sv in &data.subvolumes {
+        if let Some(pin_failures) = sv.pin_failures {
+            sample(
+                &mut out,
+                names::BACKUP_PIN_FAILURES,
+                &[("subvolume", sv.name.as_str())],
+                pin_failures,
+            );
+        }
+    }
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP {} Post-run promise status: 0=protected, 1=at_risk, 2=unprotected. Emitted for every subvolume this run's awareness assessment covers; absent for disabled subvolumes.",
+        names::BACKUP_PROMISE_STATE
+    )
+    .unwrap();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_PROMISE_STATE).unwrap();
+    for sv in &data.subvolumes {
+        if let Some(promise_state) = sv.promise_state {
+            sample(
+                &mut out,
+                names::BACKUP_PROMISE_STATE,
+                &[("subvolume", sv.name.as_str())],
+                promise_state,
+            );
+        }
+    }
+
     // ── Structured event counters ─────────────────────────────────
 
     let counters = &data.event_counters;
@@ -871,7 +938,74 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
+    // ── Public mirrors of alert-worthy internal counters (backup_*) ────
+    //
+    // Same events-table derivation as their urd_* siblings above — the
+    // downstream alerting consumer only binds to `backup_*` names, so these
+    // exist purely to make the value reachable under the public contract.
+    // Both are all-time cumulative over the events log (ADR-114): monotonic
+    // for as long as the log is not pruned (it currently never is — see
+    // docs/20-reference/metrics.md). Consumers should use `increase()` /
+    // `rate()`, which tolerate a counter reset if that ever changes.
+
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP {} Sentinel circuit-breaker open transitions. Public mirror of {}; same value.",
+        names::BACKUP_CIRCUIT_BREAKER_TRIPS_TOTAL,
+        names::URD_CIRCUIT_BREAKER_TRIPS_TOTAL,
+    )
+    .unwrap();
+    writeln!(out, "# TYPE {} counter", names::BACKUP_CIRCUIT_BREAKER_TRIPS_TOTAL).unwrap();
+    sample(
+        &mut out,
+        names::BACKUP_CIRCUIT_BREAKER_TRIPS_TOTAL,
+        &[],
+        counters.circuit_breaker_trips,
+    );
+
+    let emergency_prunes = counter_value(&counters.prunes_by_rule, "emergency");
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP {} Snapshots pruned under emergency retention. Public mirror of {}{{rule=\"emergency\"}}; same value, 0 when no such events exist.",
+        names::BACKUP_EMERGENCY_PRUNES_TOTAL,
+        names::URD_RETENTION_PRUNES_TOTAL,
+    )
+    .unwrap();
+    writeln!(out, "# TYPE {} counter", names::BACKUP_EMERGENCY_PRUNES_TOTAL).unwrap();
+    sample(&mut out, names::BACKUP_EMERGENCY_PRUNES_TOTAL, &[], emergency_prunes);
+
+    let chain_broken_full_sends = counter_value(&counters.full_sends_by_reason, "chain_broken");
+    writeln!(out).unwrap();
+    writeln!(
+        out,
+        "# HELP {} Full sends triggered by a broken incremental chain. Public mirror of {}{{reason=\"chain_broken\"}}; same value, 0 when no such events exist.",
+        names::BACKUP_CHAIN_BROKEN_FULL_SENDS_TOTAL,
+        names::URD_PLANNER_FULL_SENDS_TOTAL,
+    )
+    .unwrap();
+    writeln!(out, "# TYPE {} counter", names::BACKUP_CHAIN_BROKEN_FULL_SENDS_TOTAL).unwrap();
+    sample(
+        &mut out,
+        names::BACKUP_CHAIN_BROKEN_FULL_SENDS_TOTAL,
+        &[],
+        chain_broken_full_sends,
+    );
+
     out
+}
+
+/// Look up a labeled counter's value by key, defaulting to 0 when the key is
+/// absent (no such events this run — the events-table queries never emit a
+/// zero row for an untriggered label, unlike the `reason="none"` /
+/// `rule="none"` family sentinels above).
+#[must_use]
+fn counter_value(pairs: &[(String, u64)], key: &str) -> u64 {
+    pairs
+        .iter()
+        .find(|(label, _)| label == key)
+        .map_or(0, |(_, count)| *count)
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────
@@ -896,6 +1030,8 @@ mod tests {
                     last_full_send_bytes: None,
                     local_snapshot_count_v4: None,
                     estimated_local_pinned_delta_bytes: None,
+                    pin_failures: None,
+                    promise_state: None,
                 },
                 SubvolumeMetrics {
                     name: "htpc-home".to_string(),
@@ -910,6 +1046,8 @@ mod tests {
                     last_full_send_bytes: None,
                     local_snapshot_count_v4: None,
                     estimated_local_pinned_delta_bytes: None,
+                    pin_failures: None,
+                    promise_state: None,
                 },
             ],
             external_drive_mounted: true,
@@ -1062,6 +1200,8 @@ mod tests {
                 last_full_send_bytes: None,
                 local_snapshot_count_v4: None,
                 estimated_local_pinned_delta_bytes: None,
+                pin_failures: None,
+                promise_state: None,
             },
             SubvolumeMetrics {
                 name: "sv-b".to_string(),
@@ -1076,6 +1216,8 @@ mod tests {
                 last_full_send_bytes: None,
                 local_snapshot_count_v4: None,
                 estimated_local_pinned_delta_bytes: None,
+                pin_failures: None,
+                promise_state: None,
             },
             SubvolumeMetrics {
                 name: "sv-c".to_string(),
@@ -1090,6 +1232,8 @@ mod tests {
                 last_full_send_bytes: None,
                 local_snapshot_count_v4: None,
                 estimated_local_pinned_delta_bytes: None,
+                pin_failures: None,
+                promise_state: None,
             },
         ];
 
@@ -1124,6 +1268,8 @@ mod tests {
                 last_full_send_bytes: None,
                 local_snapshot_count_v4: None,
                 estimated_local_pinned_delta_bytes: None,
+                pin_failures: None,
+                promise_state: None,
             }],
             external_drive_mounted: true,
             external_free_bytes: 1_000_000,
@@ -1148,6 +1294,8 @@ mod tests {
             last_full_send_bytes: None,
             local_snapshot_count_v4: None,
             estimated_local_pinned_delta_bytes: None,
+            pin_failures: None,
+            promise_state: None,
         }];
         apply_carried_forward_timestamps(&mut svs, &carried);
 
@@ -1373,6 +1521,8 @@ mod tests {
             last_full_send_bytes: None,
             local_snapshot_count_v4: None,
             estimated_local_pinned_delta_bytes: None,
+            pin_failures: None,
+            promise_state: None,
         }
     }
 
@@ -1764,6 +1914,147 @@ mod tests {
         assert!(!output.contains("backup_pool_total_bytes{"));
     }
 
+    // ── backup_pin_failures / backup_promise_state (issues #337/#338) ──
+
+    #[test]
+    fn format_metrics_emits_pin_failures_and_promise_state_help_and_type() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_pin_failures"));
+        assert!(output.contains("# TYPE backup_pin_failures gauge"));
+        assert!(output.contains("# HELP backup_promise_state"));
+        assert!(output.contains("# TYPE backup_promise_state gauge"));
+    }
+
+    #[test]
+    fn format_metrics_emits_pin_failures_zero_for_assessed_subvolume() {
+        let mut data = sample_data();
+        data.subvolumes[0].pin_failures = Some(0);
+        let output = format_metrics(&data);
+        assert!(
+            output.contains("backup_pin_failures{subvolume=\"subvol3-opptak\"} 0"),
+            "series presence beats value: a zero pin-failure count must still be emitted"
+        );
+    }
+
+    #[test]
+    fn format_metrics_emits_pin_failures_nonzero_value() {
+        let mut data = sample_data();
+        data.subvolumes[0].pin_failures = Some(3);
+        let output = format_metrics(&data);
+        assert!(output.contains("backup_pin_failures{subvolume=\"subvol3-opptak\"} 3"));
+    }
+
+    #[test]
+    fn format_metrics_omits_pin_failures_and_promise_state_for_unassessed_subvolume() {
+        // `None` models a disabled subvolume: no awareness assessment this
+        // run, so neither series is emitted for it — HELP/TYPE stay present
+        // unconditionally (both fields already default to None in sample_data()).
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(!output.contains("backup_pin_failures{"));
+        assert!(!output.contains("backup_promise_state{"));
+    }
+
+    #[test]
+    fn format_metrics_emits_promise_state_for_all_three_encodings() {
+        let mut data = sample_data();
+        data.subvolumes[0].promise_state = Some(0); // protected
+        data.subvolumes[1].promise_state = Some(2); // unprotected
+        data.subvolumes.push(SubvolumeMetrics {
+            promise_state: Some(1), // at_risk
+            ..ts_subvol("sv-third", None)
+        });
+        let output = format_metrics(&data);
+        assert!(output.contains("backup_promise_state{subvolume=\"subvol3-opptak\"} 0"));
+        assert!(output.contains("backup_promise_state{subvolume=\"htpc-home\"} 2"));
+        assert!(output.contains("backup_promise_state{subvolume=\"sv-third\"} 1"));
+    }
+
+    #[test]
+    fn format_metrics_emits_pin_failures_for_skipped_subvolume() {
+        // A skipped subvolume (success == 2) still gets an assessed
+        // pin_failures/promise_state pair — the population is the awareness
+        // assessment, not the execution outcome.
+        let mut data = sample_data();
+        data.subvolumes[1].pin_failures = Some(0); // htpc-home is success == 2 (skipped)
+        data.subvolumes[1].promise_state = Some(1);
+        let output = format_metrics(&data);
+        assert!(output.contains("backup_pin_failures{subvolume=\"htpc-home\"} 0"));
+        assert!(output.contains("backup_promise_state{subvolume=\"htpc-home\"} 1"));
+    }
+
+    // ── backup_circuit_breaker_trips_total / backup_emergency_prunes_total /
+    //    backup_chain_broken_full_sends_total (issues #337/#338) ──────
+    //
+    // Public `backup_*` mirrors of the `urd_*` event counters — same
+    // events-table derivation, same values, reachable under the name the
+    // downstream alerting consumer actually binds to.
+
+    #[test]
+    fn format_metrics_emits_backup_counter_mirrors_help_and_type() {
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(output.contains("# HELP backup_circuit_breaker_trips_total"));
+        assert!(output.contains("# TYPE backup_circuit_breaker_trips_total counter"));
+        assert!(output.contains("# HELP backup_emergency_prunes_total"));
+        assert!(output.contains("# TYPE backup_emergency_prunes_total counter"));
+        assert!(output.contains("# HELP backup_chain_broken_full_sends_total"));
+        assert!(output.contains("# TYPE backup_chain_broken_full_sends_total counter"));
+    }
+
+    #[test]
+    fn format_metrics_emits_zero_backup_counter_mirrors_when_no_events() {
+        // sample_data()'s EventCounters::default() has no trips, no
+        // "emergency" prune, no "chain_broken" full send.
+        let data = sample_data();
+        let output = format_metrics(&data);
+        assert!(output.contains("backup_circuit_breaker_trips_total 0"));
+        assert!(output.contains("backup_emergency_prunes_total 0"));
+        assert!(output.contains("backup_chain_broken_full_sends_total 0"));
+    }
+
+    #[test]
+    fn format_metrics_mirrors_circuit_breaker_trips_value() {
+        let mut data = sample_data();
+        data.event_counters.circuit_breaker_trips = 7;
+        let output = format_metrics(&data);
+        assert!(output.contains("urd_circuit_breaker_trips_total 7"));
+        assert!(output.contains("backup_circuit_breaker_trips_total 7"));
+    }
+
+    #[test]
+    fn format_metrics_mirrors_emergency_prunes_ignoring_other_rules() {
+        let mut data = sample_data();
+        data.event_counters.prunes_by_rule = vec![
+            ("graduated_daily".to_string(), 14),
+            ("emergency".to_string(), 2),
+        ];
+        let output = format_metrics(&data);
+        assert!(output.contains("backup_emergency_prunes_total 2"));
+        // The non-emergency rule count must not leak into the mirror.
+        assert!(!output.contains("backup_emergency_prunes_total 14"));
+    }
+
+    #[test]
+    fn format_metrics_mirrors_chain_broken_full_sends_ignoring_other_reasons() {
+        let mut data = sample_data();
+        data.event_counters.full_sends_by_reason = vec![
+            ("first_send".to_string(), 3),
+            ("chain_broken".to_string(), 1),
+        ];
+        let output = format_metrics(&data);
+        assert!(output.contains("backup_chain_broken_full_sends_total 1"));
+        assert!(!output.contains("backup_chain_broken_full_sends_total 3"));
+    }
+
+    #[test]
+    fn counter_value_defaults_to_zero_for_missing_key() {
+        let pairs = vec![("first_send".to_string(), 3)];
+        assert_eq!(counter_value(&pairs, "chain_broken"), 0);
+        assert_eq!(counter_value(&pairs, "first_send"), 3);
+    }
+
     // ── sample() helper (UPI 061) ─────────────────────────────────
 
     #[test]
@@ -1809,20 +2100,23 @@ mod tests {
     // ── Golden file (UPI 061) ─────────────────────────────────────
     //
     // The golden fixture exercises every emission branch reachable in one
-    // MetricsData: all 21 metrics present, Some/None splits across
+    // MetricsData: all 26 metrics present, Some/None splits across
     // subvolumes, both pool roles, non-empty event counters. Branches a
     // single fixture cannot reach (zero-sentinel counter lines, unmounted
     // drive, per-metric absence) are pinned by the `contains` tests above.
     //
-    // src/testdata/golden_metrics.prom is WRITE-ONCE for refactors: it was
-    // generated from the pre-UPI-061 formatter and is the byte-level proof
-    // that the contract-surface refactor changed nothing for realistic
-    // configs (ADR-105 / homelab ADR-021). Never regenerate it to make this
-    // test pass after a refactor — a mismatch is a bug in the formatter, not
-    // the file. A deliberate new metric (e.g. `backup_pool_last_seen_timestamp`,
-    // issue #339) is the one case that legitimately amends the fixture —
-    // done by hand, with the diff reviewed as part of the change, not by
-    // regenerating from formatter output.
+    // src/testdata/golden_metrics.prom was generated from the pre-UPI-061
+    // formatter and is the byte-level proof that the contract-surface
+    // refactor changed nothing for realistic configs (ADR-105 / homelab
+    // ADR-021). It is WRITE-ONCE except for a deliberate, documented
+    // contract addition: a mismatch from touching unrelated formatter code
+    // is a bug in the formatter, not in the file — never regenerate to paper
+    // over that. Two such additions have landed by hand, each reviewed as a
+    // diff against the prior fixture rather than regenerated wholesale: issue
+    // #339 added the backup_pool_last_seen_timestamp block, and issues
+    // #337/#338 added the backup_pin_failures/backup_promise_state/
+    // backup_circuit_breaker_trips_total/backup_emergency_prunes_total/
+    // backup_chain_broken_full_sends_total blocks.
 
     fn golden_data() -> MetricsData {
         MetricsData {
@@ -1840,6 +2134,8 @@ mod tests {
                     last_full_send_bytes: None,
                     local_snapshot_count_v4: Some(7),
                     estimated_local_pinned_delta_bytes: Some(0),
+                    pin_failures: Some(0),
+                    promise_state: Some(0),
                 },
                 SubvolumeMetrics {
                     name: "htpc-home".to_string(),
@@ -1854,6 +2150,8 @@ mod tests {
                     last_full_send_bytes: Some(12_000_000_000),
                     local_snapshot_count_v4: None,
                     estimated_local_pinned_delta_bytes: Some(5_000_000),
+                    pin_failures: Some(0),
+                    promise_state: Some(1),
                 },
                 SubvolumeMetrics {
                     name: "sv-media".to_string(),
@@ -1868,6 +2166,8 @@ mod tests {
                     last_full_send_bytes: None,
                     local_snapshot_count_v4: Some(0),
                     estimated_local_pinned_delta_bytes: None,
+                    pin_failures: Some(2),
+                    promise_state: Some(2),
                 },
             ],
             external_drive_mounted: true,
@@ -1931,7 +2231,7 @@ mod tests {
 
     #[test]
     fn guard_metric_names_live_only_in_names_module() {
-        const ALL: [&str; 21] = [
+        const ALL: [&str; 26] = [
             names::BACKUP_SUCCESS,
             names::BACKUP_LAST_SUCCESS_TIMESTAMP,
             names::BACKUP_DURATION_SECONDS,
@@ -1953,6 +2253,11 @@ mod tests {
             names::URD_PLANNER_FULL_SENDS_TOTAL,
             names::URD_PLANNER_DEFERS_TOTAL,
             names::URD_RETENTION_PRUNES_TOTAL,
+            names::BACKUP_CIRCUIT_BREAKER_TRIPS_TOTAL,
+            names::BACKUP_EMERGENCY_PRUNES_TOTAL,
+            names::BACKUP_CHAIN_BROKEN_FULL_SENDS_TOTAL,
+            names::BACKUP_PIN_FAILURES,
+            names::BACKUP_PROMISE_STATE,
         ];
 
         let source = include_str!("metrics.rs");

--- a/src/testdata/golden_metrics.prom
+++ b/src/testdata/golden_metrics.prom
@@ -84,6 +84,18 @@ backup_subvolume_local_snapshot_count{subvolume="sv-media"} 0
 backup_subvolume_estimated_local_pinned_delta_bytes{subvolume="subvol3-opptak"} 0
 backup_subvolume_estimated_local_pinned_delta_bytes{subvolume="htpc-home"} 5000000
 
+# HELP backup_pin_failures Pin-file write failures for this subvolume in this run (sends that succeeded but whose chain marker could not be written). Emitted for every subvolume this run's awareness assessment covers; absent for disabled subvolumes.
+# TYPE backup_pin_failures gauge
+backup_pin_failures{subvolume="subvol3-opptak"} 0
+backup_pin_failures{subvolume="htpc-home"} 0
+backup_pin_failures{subvolume="sv-media"} 2
+
+# HELP backup_promise_state Post-run promise status: 0=protected, 1=at_risk, 2=unprotected. Emitted for every subvolume this run's awareness assessment covers; absent for disabled subvolumes.
+# TYPE backup_promise_state gauge
+backup_promise_state{subvolume="subvol3-opptak"} 0
+backup_promise_state{subvolume="htpc-home"} 1
+backup_promise_state{subvolume="sv-media"} 2
+
 # HELP urd_circuit_breaker_trips_total Sentinel circuit-breaker open transitions.
 # TYPE urd_circuit_breaker_trips_total counter
 urd_circuit_breaker_trips_total 5
@@ -102,3 +114,15 @@ urd_planner_defers_total{scope="drive"} 3
 # TYPE urd_retention_prunes_total counter
 urd_retention_prunes_total{rule="graduated_daily"} 14
 urd_retention_prunes_total{rule="emergency"} 2
+
+# HELP backup_circuit_breaker_trips_total Sentinel circuit-breaker open transitions. Public mirror of urd_circuit_breaker_trips_total; same value.
+# TYPE backup_circuit_breaker_trips_total counter
+backup_circuit_breaker_trips_total 5
+
+# HELP backup_emergency_prunes_total Snapshots pruned under emergency retention. Public mirror of urd_retention_prunes_total{rule="emergency"}; same value, 0 when no such events exist.
+# TYPE backup_emergency_prunes_total counter
+backup_emergency_prunes_total 2
+
+# HELP backup_chain_broken_full_sends_total Full sends triggered by a broken incremental chain. Public mirror of urd_planner_full_sends_total{reason="chain_broken"}; same value, 0 when no such events exist.
+# TYPE backup_chain_broken_full_sends_total counter
+backup_chain_broken_full_sends_total 1


### PR DESCRIPTION
## Summary
- Promotes five alert-worthy signals into the public `backup_*` Prometheus contract, since the downstream monitoring stack only binds alerts to that namespace, without renaming or removing any existing `urd_*` series or touching the heartbeat schema.
- `backup_circuit_breaker_trips_total`, `backup_emergency_prunes_total`, and `backup_chain_broken_full_sends_total` are byte-identical mirrors of their `urd_*` siblings (same events-table derivation, same value).
- `backup_pin_failures` and `backup_promise_state` are new per-subvolume gauges sourced from the same post-run awareness assessment that already feeds heartbeat v3's `pin_failures`/`promise_status` fields.

## Changes
- `src/metrics.rs`: five new `names::` constants; two new `SubvolumeMetrics` fields (`pin_failures: Option<u32>`, `promise_state: Option<u8>`); five new emission blocks with HELP/TYPE lines; new `counter_value()` helper for label-keyed lookups with a 0 default; guard test's `ALL` array now 26 (20 original + 1 from #359's `backup_pool_last_seen_timestamp`, already on master, + 5 from this PR); golden fixture (`src/testdata/golden_metrics.prom`) and `golden_data()` updated with a pure append (verified via diff — no existing line changed).
- `src/awareness.rs`: `PromiseStatus::metric_value()` — `0=protected, 1=at_risk, 2=unprotected`, following the same pattern as `SendType::metric_value()` in `executor.rs`.
- `src/commands/backup.rs`: new `promise_status_lookup()` helper builds a `HashMap<&str, PromiseStatus>` from the run's awareness assessments; threaded through `write_metrics_per_spec` → `write_metrics_after_execution` / `write_metrics_for_skipped` → `append_skipped_metrics` so both new gauges are populated for executed *and* skipped subvolumes (issue #181's count-query duplication was deliberately left untouched, per the task).
- `docs/20-reference/metrics.md`: new entries for both gauges and the three counter mirrors, `backup_promise_state`'s encoding added to Contract point 2 (mirroring how `backup_send_type`'s is stated), a new Contract point 11 documenting that the `_total` counters are all-time cumulative (`COUNT(*)` over the events table, confirmed no pruning path exists in `state.rs` today) and that consumers should use `increase()`/`rate()`, plus a bumped frontmatter `timestamp`.
- `CHANGELOG.md`: `### Added` entry under `[Unreleased]`.

### Design choices / rejected alternatives
- **Population for the two new gauges is the awareness-assessment population (enabled subvolumes only), not literally every config entry.** A disabled subvolume has no assessment and thus no promise to report pin failures or promise state against — the task's own source pointer ("whatever feeds heartbeat v3's per-subvolume `pin_failures`") pins this population, and it exactly matches heartbeat's existing behavior. Existing metrics like `backup_success`/`backup_send_type` *do* cover disabled subvolumes (via `plan.skipped`), so this is a deliberate scope difference from those — documented explicitly in `metrics.md` as "absent for a disabled subvolume." Flagging this for reviewer attention below.
- **The three counter mirrors are computed inline in `format_metrics` from `data.event_counters`**, not threaded as new `MetricsData` fields — they're pure re-projections of data already present, so no new plumbing through `commands/backup.rs` was needed for those three.
- **Golden fixture updated in place** rather than left failing: the file's own comment marks it "WRITE-ONCE... a mismatch is a bug in the formatter, not in the file," which was written to guard against *accidental* format drift during the original UPI-061 refactor. This change is a deliberate, coordinated contract addition, verified via `diff` to be a pure append with zero changes to any existing line; the comment now names both this PR's addition and #359's as the two deliberate exceptions.

### Rebase note
This branch was rebased twice onto `master` after #359 (pool-metric carry-forward: `backup_pool_last_seen_timestamp`, `CarriedPoolRow`, `read_existing_pool_rows`, `apply_carried_forward_pools`, a `PoolMetric.last_seen_timestamp` field) and #362 (calibrate nudge) merged. Conflicts were in `src/metrics.rs` (the golden-fixture guard comment and the `ALL` array's declared length — the array *contents* auto-merged cleanly since the two features touched non-overlapping struct fields/lines), `docs/20-reference/metrics.md` (frontmatter `timestamp` only — Contract point 7 vs. point 11 and both new gauge sections auto-merged cleanly), and `CHANGELOG.md` (`### Added` bullet ordering, twice). `src/commands/backup.rs`, `src/pools.rs`, and `src/testdata/golden_metrics.prom` merged with zero conflicts; both features' functionality is present and tested together (see `pool_carry_forward_roundtrip_reemits_absent_destination_row` and `promise_status_lookup_finds_assessed_subvolume` both passing in the same run).

## Test plan
```
clippy    PASS
tests     PASS  2440 passed, 0 failed, 6 ignored
build     PASS
doc-lint  PASS
All checks passed.
```
(2440 vs. this branch's original 2412 reflects #359's and #362's own test additions landing on `master` in the interim — 0 failed throughout.)

New/updated tests from this PR: `src/metrics.rs` (12 new format tests covering HELP/TYPE presence, zero-emission, per-subvolume presence for skipped subvolumes, all three promise-state encodings, counter-mirror correctness, and the `counter_value()` helper), `src/awareness.rs` (`metric_value_matches_contract_encoding`), `src/commands/backup.rs` (3 new tests for `promise_status_lookup`).

Closes #337
Closes #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBF4pbkC8QVBHXnBgdjmp
