### PR TITLE
feat: nudge toward calibrate when a full send has no size estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pool row — the run timestamp for a pool measured this run, the
   carried-forward timestamp otherwise — so staleness stays honest. A drive
   removed from config stops being carried forward (#339).
+- `urd plan` (and `urd backup`'s dry-run preview) now nudges toward
+  `urd calibrate` when a planned full send has no size estimate — the one
+  case the progress line can't show a total or an ETA for. Incremental
+  sends without an estimate don't trigger it (calibration can't help
+  those), and the suggestion only appears in interactive output (#254).
 
 ### Changed
 - The EXPOSURE column's label-to-color plumbing now carries `PromiseStatus`

--- a/docs/20-reference/cli.md
+++ b/docs/20-reference/cli.md
@@ -285,7 +285,9 @@ verified.
 
 **Contract.** Measures snapshot sizes (via `du`) to improve send-time
 estimates. Reads the filesystem; may take significant wall-clock time on
-large subvolumes. Writes calibration data to the state DB.
+large subvolumes. Writes calibration data to the state DB. Calibrating
+before a subvolume's first-ever full send gives that send's progress line
+a total and an ETA it would otherwise lack.
 
 **Notable flags.**
 

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -402,7 +402,13 @@ enum SuggestionContext {
     /// Bare `urd` (default command).
     Default { has_issues: bool },
     /// `urd plan`.
-    Plan { has_operations: bool, has_space_skip: bool },
+    Plan {
+        has_operations: bool,
+        has_space_skip: bool,
+        /// At least one full send has no size estimate — `urd calibrate`
+        /// would give it a total and an ETA on the progress line (UPI 254).
+        has_unsized_full_send: bool,
+    },
     /// `urd backup`.
     Backup { has_failures: bool },
     /// `urd verify`.
@@ -420,12 +426,15 @@ fn suggest_next_action(context: &SuggestionContext) -> Option<&'static str> {
         SuggestionContext::Default { has_issues: true } => {
             Some("Run `urd status` for details.")
         }
-        SuggestionContext::Plan { has_space_skip: true, has_operations: true } => {
+        SuggestionContext::Plan { has_space_skip: true, has_operations: true, .. } => {
             Some("Run `urd calibrate` to review retention, then `urd backup`.")
         }
         SuggestionContext::Plan { has_space_skip: true, .. } => {
             Some("Run `urd calibrate` to review retention.")
         }
+        SuggestionContext::Plan { has_unsized_full_send: true, .. } => Some(
+            "Run `urd calibrate` to size first sends \u{2014} the progress line then shows a total and an ETA.",
+        ),
         SuggestionContext::Plan { has_operations: true, .. } => {
             Some("Run `urd backup` to execute this plan.")
         }
@@ -2071,6 +2080,105 @@ mod tests {
     }
 
     #[test]
+    fn plan_unsized_full_send_suggests_calibrate() {
+        let _color = color_guard(false);
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![PlanOperationEntry {
+                subvolume: "htpc-docs".to_string(),
+                operation: "send".to_string(),
+                detail: "snap -> WD-18TB (full \u{2014} first send)".to_string(),
+                drive_label: Some("WD-18TB".to_string()),
+                estimated_bytes: None,
+                is_full_send: Some(true),
+                full_send_reason: Some("first send".to_string()),
+            }],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 1,
+                sends: 1,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: None,
+                configured_subvolumes: 1,
+            },
+            warnings: vec![],
+        };
+        let output = render_plan(&data, OutputMode::Interactive, true);
+        assert!(
+            output.contains("urd calibrate"),
+            "unsized full send should nudge toward calibrate: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_sized_full_send_no_calibrate_suggestion() {
+        let _color = color_guard(false);
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![PlanOperationEntry {
+                subvolume: "htpc-home".to_string(),
+                operation: "send".to_string(),
+                detail: "snap -> WD-18TB (full \u{2014} first send)".to_string(),
+                drive_label: Some("WD-18TB".to_string()),
+                estimated_bytes: Some(53_000_000_000),
+                is_full_send: Some(true),
+                full_send_reason: Some("first send".to_string()),
+            }],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 1,
+                sends: 1,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: Some(53_000_000_000),
+                configured_subvolumes: 1,
+            },
+            warnings: vec![],
+        };
+        let output = render_plan(&data, OutputMode::Interactive, true);
+        assert!(
+            !output.contains("urd calibrate"),
+            "a full send that already has an estimate should not nudge toward calibrate: {output}"
+        );
+    }
+
+    #[test]
+    fn plan_unsized_incremental_no_calibrate_suggestion() {
+        let _color = color_guard(false);
+        // Calibration cannot help an incremental send (it sizes whole
+        // subvolumes, not diffs), so a missing estimate here must not
+        // trigger the nudge.
+        let data = PlanOutput {
+            timestamp: "2026-03-29 13:57".to_string(),
+            operations: vec![PlanOperationEntry {
+                subvolume: "htpc-home".to_string(),
+                operation: "send".to_string(),
+                detail: "snap -> WD-18TB (incremental, parent: prev)".to_string(),
+                drive_label: Some("WD-18TB".to_string()),
+                estimated_bytes: None,
+                is_full_send: Some(false),
+                full_send_reason: None,
+            }],
+            skipped: vec![],
+            summary: PlanSummaryOutput {
+                snapshots: 1,
+                sends: 1,
+                deletions: 0,
+                skipped: 0,
+                estimated_total_bytes: None,
+                configured_subvolumes: 1,
+            },
+            warnings: vec![],
+        };
+        let output = render_plan(&data, OutputMode::Interactive, true);
+        assert!(
+            !output.contains("urd calibrate"),
+            "an unsized incremental send should not nudge toward calibrate: {output}"
+        );
+    }
+
+    #[test]
     fn plan_daemon_json_includes_estimated_bytes() {
         let data = PlanOutput {
             timestamp: "2026-03-29 13:57".to_string(),
@@ -3657,6 +3765,7 @@ mod tests {
         assert!(suggest_next_action(&SuggestionContext::Plan {
             has_operations: false,
             has_space_skip: false,
+            has_unsized_full_send: false,
         })
         .is_none());
     }
@@ -3666,6 +3775,7 @@ mod tests {
         let s = suggest_next_action(&SuggestionContext::Plan {
             has_operations: true,
             has_space_skip: false,
+            has_unsized_full_send: false,
         })
         .unwrap();
         assert!(s.contains("urd backup"), "should suggest backup: {s}");
@@ -3676,10 +3786,38 @@ mod tests {
         let s = suggest_next_action(&SuggestionContext::Plan {
             has_operations: true,
             has_space_skip: true,
+            has_unsized_full_send: false,
         })
         .unwrap();
         assert!(s.contains("urd calibrate"), "should suggest calibrate: {s}");
         assert!(s.contains("urd backup"), "should also suggest backup: {s}");
+    }
+
+    #[test]
+    fn suggestion_plan_unsized_full_send_suggests_calibrate() {
+        let s = suggest_next_action(&SuggestionContext::Plan {
+            has_operations: true,
+            has_space_skip: false,
+            has_unsized_full_send: true,
+        })
+        .unwrap();
+        assert!(s.contains("urd calibrate"), "should suggest calibrate: {s}");
+        assert!(s.contains("total"), "should mention the progress-line total: {s}");
+        assert!(s.contains("ETA"), "should mention the ETA: {s}");
+    }
+
+    #[test]
+    fn suggestion_plan_space_skip_wins_over_unsized_full_send() {
+        // Only one suggestion line is ever shown — space-skip's calibrate
+        // nudge already points at `urd calibrate`, so it takes priority
+        // over the unsized-full-send nudge when both conditions hold.
+        let s = suggest_next_action(&SuggestionContext::Plan {
+            has_operations: true,
+            has_space_skip: true,
+            has_unsized_full_send: true,
+        })
+        .unwrap();
+        assert!(s.contains("review retention"), "space-skip wording should win: {s}");
     }
 
     #[test]

--- a/src/voice/plan.rs
+++ b/src/voice/plan.rs
@@ -193,10 +193,18 @@ fn render_plan_interactive(data: &PlanOutput, verbose: bool) -> String {
         .skipped
         .iter()
         .any(|s| s.category == SkipCategory::SpaceExceeded);
+    // A first-ever full send has nothing to estimate from (no same-drive or
+    // any-drive history, no calibrated size) — `urd calibrate` is the honest
+    // fix, since auto-calibrating with a `du -sb` walk before every send
+    // would be a do-no-harm concern (UPI 254).
+    let has_unsized_full_send = data.operations.iter().any(|op| {
+        op.operation == "send" && op.is_full_send == Some(true) && op.estimated_bytes.is_none()
+    });
     append_suggestion(
         &SuggestionContext::Plan {
             has_operations: !data.operations.is_empty(),
             has_space_skip,
+            has_unsized_full_send,
         },
         &mut out,
     );


### PR DESCRIPTION
## Summary
- `urd plan` (and `urd backup`'s `--dry-run` preview) now nudges the user toward `urd calibrate` when at least one **full** send in the plan has no size estimate — the one case where the live progress line can show sent bytes but no total and no ETA.
- Incrementals without an estimate never trigger it: calibration sizes whole subvolumes, not diffs, so it wouldn't help.

## Changes
- `src/voice/mod.rs`: added `has_unsized_full_send: bool` to `SuggestionContext::Plan`, with a new `suggest_next_action` arm that fires only when no space-exceeded skip is already present (that arm already recommends `urd calibrate` for a different reason, and only one suggestion line is ever shown).
- `src/voice/plan.rs`: `render_plan_interactive` now derives `has_unsized_full_send` from `data.operations` (`operation == "send" && is_full_send == Some(true) && estimated_bytes.is_none()`) and threads it into the suggestion context.
- `docs/20-reference/cli.md`: one added sentence on `urd calibrate` noting it also gives a first send's progress line a total and an ETA.
- `CHANGELOG.md`: `### Added` entry under `[Unreleased]`.
- Tests: new unit tests in `src/voice/mod.rs` covering the `suggest_next_action` gating (present / absent / space-skip-wins) and the full `render_plan` integration (unsized full send → suggestion present; sized full send → absent; unsized incremental → absent). No `voice_contract.rs` change — that file doesn't currently pin next-action suggestion wording at all (checked; no hits for "calibrate" or "Suggestion" there).

No change to the JSON/daemon output surface — `SuggestionContext` and `suggest_next_action` are only reached from `render_plan_interactive`; `render_plan`'s `OutputMode::Daemon` branch is untouched and still serializes `PlanOutput` directly.

## Rendered suggestion line
```
Run `urd calibrate` to size first sends — the progress line then shows a total and an ETA.
```

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — all passing (see roll-up below)
- [x] `scripts/check.sh` roll-up:
```
clippy    PASS
tests     PASS  2407 passed, 0 failed, 6 ignored
build     PASS
doc-lint  PASS
All checks passed.
```

Refs #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBF4pbkC8QVBHXnBgdjmp
