### PR TITLE
release: v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-09-03
+
 ### Added
 - The interactive `urd backup` summary now surfaces an emergency-preflight
   reclaim inline as a warning — one line per snapshot root, reporting the
@@ -1795,7 +1797,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.35.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.36.0...HEAD
+[0.36.0]: https://github.com/vonrobak/urd/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/vonrobak/urd/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/vonrobak/urd/compare/v0.33.4...v0.34.0
 [0.33.4]: https://github.com/vonrobak/urd/compare/v0.33.3...v0.33.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.35.0"
+version = "0.36.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.35.0"
+version = "0.36.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.36.0** — the 2026-09-03 polish sprint. Contains #355 (#332), #356 (#174), #357 (#305), #358 (#333), #359 (#339), #360 (#337, #338), #362 (#254), #364 (#361). Full entry in `CHANGELOG.md`.

Headlines: the interactive backup summary now tells a TTY user when the emergency pre-flight deleted history; the offsite rotation drive keeps capacity telemetry while away (`backup_pool_last_seen_timestamp` makes staleness honest); five alert-worthy signals joined the `backup_*` Prometheus contract; `urd plan` nudges toward `urd calibrate` when a first send has no size estimate; the two voice color relays are enum-typed; `10GB` not `10.0GB`; TOML syntax errors are no longer blamed on `config_version`.

## Testing

- scripts/check.sh: all checks passed (2443 passed, 0 failed, 6 ignored)
- scripts/pre-commit-pii.sh --report: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxBF4pbkC8QVBHXnBgdjmp
