### PR TITLE
fix: build webhook notification body with serde_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The default webhook notification body is now built with `serde_json`
+  instead of hand-escaping only double quotes, so a title or body
+  containing a backslash, newline, tab, or other control character
+  produces valid JSON instead of a silently malformed payload — the exact
+  content that shows up in watchdog and storage-pressure alerts (#379).
+
 ## [0.36.0] - 2026-09-03
 
 ### Added

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -755,14 +755,36 @@ fn dispatch_webhook(notification: &Notification, url: &str, template: Option<&st
     }
 }
 
+/// Wire shape for the default webhook payload. A plain struct (rather than
+/// `serde_json::json!`) so field order is guaranteed without depending on
+/// serde_json's `preserve_order` feature.
+#[derive(Serialize)]
+struct WebhookPayload<'a> {
+    title: &'a str,
+    body: &'a str,
+    urgency: Urgency,
+}
+
 fn default_webhook_body(notification: &Notification) -> String {
-    // Simple JSON payload compatible with most webhook receivers
-    format!(
-        r#"{{"title":"{}","body":"{}","urgency":"{}"}}"#,
-        notification.title.replace('"', "\\\""),
-        notification.body.replace('"', "\\\""),
-        notification.urgency,
-    )
+    // Simple JSON payload compatible with most webhook receivers. Built via
+    // serde_json so title/body are escaped correctly for any content
+    // (backslashes, newlines, control characters), not just double quotes.
+    let payload = WebhookPayload {
+        title: &notification.title,
+        body: &notification.body,
+        urgency: notification.urgency,
+    };
+    serde_json::to_string(&payload).unwrap_or_else(|e| {
+        // Serializing a struct of String/enum fields cannot fail in
+        // practice; this fallback exists only to avoid unwrap() in
+        // library code. It still carries the real urgency rather than a
+        // hard-coded "info", so a critical alert doesn't get silently
+        // downgraded if this branch ever fires — Urgency's Display output
+        // is plain lowercase ASCII, so it's always safe to inline
+        // unescaped. The failure itself is logged so it isn't silent.
+        log::error!("Failed to serialize webhook payload: {e}");
+        format!(r#"{{"title":"","body":"","urgency":"{}"}}"#, notification.urgency)
+    })
 }
 
 fn dispatch_command(notification: &Notification, path: &PathBuf, args: &[String]) -> bool {
@@ -1421,6 +1443,26 @@ mod tests {
         let body = default_webhook_body(&notification);
         let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(parsed["urgency"], "critical");
+    }
+
+    #[test]
+    fn webhook_body_escapes_special_characters() {
+        // Backslash, newline, tab, double quote, and a non-ASCII character —
+        // a hand-escaped format! that only handles `"` mangles all of these.
+        let title = "back\\slash \"quoted\" title";
+        let body = "line one\nline two\twith tab and caf\u{e9}";
+        let notification = Notification {
+            event: NotificationEvent::AllUnprotected,
+            urgency: Urgency::Warning,
+            title: title.to_string(),
+            body: body.to_string(),
+        };
+        let serialized = default_webhook_body(&notification);
+        let parsed: serde_json::Value = serde_json::from_str(&serialized)
+            .expect("webhook body must be valid JSON even with special characters");
+        assert_eq!(parsed["title"], title);
+        assert_eq!(parsed["body"], body);
+        assert_eq!(parsed["urgency"], "warning");
     }
 
     // ── Drive reconnection notifications ──────────────────────────────


### PR DESCRIPTION
## Summary

- `default_webhook_body()` in `src/notify.rs` hand-built its JSON with `format!`
  and only escaped double quotes, so a title or body containing a backslash,
  newline, tab, or other control character produced invalid JSON — a silent
  webhook delivery failure for exactly the alerts that matter (watchdog abort,
  storage pressure, promise transitions).

## Changes

- `src/notify.rs`: added a private `WebhookPayload<'a>` struct with
  `#[derive(Serialize)]` (fields `title`, `body`, `urgency: Urgency`) and
  rewrote `default_webhook_body()` to build it and call
  `serde_json::to_string`. `Urgency` already derives `Serialize` with
  `#[serde(rename_all = "lowercase")]`, so it serializes to the same string
  ("info"/"warning"/"critical") the old `Display` impl produced — no wire
  change there.
- Added `webhook_body_escapes_special_characters`: builds a notification whose
  title and body contain a backslash, a newline, a tab, a double quote, and a
  non-ASCII character (`é`), asserts the output parses with `serde_json` and
  that each field round-trips to the exact original string.
- `CHANGELOG.md`: one bullet under `### Fixed`.

### Design decisions

- **Struct over `serde_json::json!`:** `serde_json`'s default map (used by
  `json!({...})`) does not preserve insertion order unless the
  `preserve_order` feature is enabled (checked `Cargo.toml` — it isn't). A
  plain struct with `#[derive(Serialize)]` guarantees field order
  (`title`, `body`, `urgency`) matches the original payload shape without
  taking on that extra dependency feature. This was also the issue's
  stated preference for the "if order matters" branch.
- **Fallback on serialize error:** `serde_json::to_string` returns a
  `Result`; since library code may not `unwrap()`/`expect()`, a fallback
  literal JSON string is used on the (in practice unreachable, since all
  fields are `String`/`&str`/a C-like enum) error path, per CLAUDE.md's
  "safe fallback, not just convenient" rule.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 2444 passed, 0 failed, 6 ignored (baseline was 2443
      passed, 6 ignored; +1 for the new escaping test)
- [x] `bash scripts/check-present-not-journey.sh` — pass
- [x] `bash scripts/check-docs.sh` — pass
- [x] `bash scripts/pre-commit-pii.sh --report` — clean, no findings

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti
