### PR TITLE
fix: surface progress and watchdog thread panics on join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   do-no-harm storage guard — additionally earns a warning line in the
   interactive backup summary and a critical notification in the same batch as
   any watchdog firing, so an unattended nightly run is never silent about an
-  unguarded tail (#381).
+  unguarded tail. A watchdog that stashed a firing and then died while holding
+  its lock no longer loses that firing either — the teardown recovers the
+  poisoned slot, so the tripped pool still gets its emergency reclaim, its
+  event, and its notification (#381).
 
 ## [0.36.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `urd migrate` no longer silently drops a drive's `rotation_interval`
   (ADR-116) when migrating a legacy or v1 config to v2 — an offsite drive's
   declared rotation cadence now survives the hop intact (#377).
+- A panic in `urd backup`'s progress-display or storage-watchdog thread is no
+  longer swallowed when the run joins it. Both now log the panic and name the
+  thread; a dead watchdog — which means every send after it ran without the
+  do-no-harm storage guard — additionally earns a warning line in the
+  interactive backup summary and a critical notification in the same batch as
+  any watchdog firing, so an unattended nightly run is never silent about an
+  unguarded tail (#381).
 
 ## [0.36.0] - 2026-09-03
 

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -435,15 +435,13 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     //     watchdog thread (M1 — no DB connection there); the teardown only records
     //     the stashed outcome on the single main connection.
     // An operator Ctrl-C produces no firing and never reclaims.
-    let watchdog_firings: Vec<WatchdogFiring> = firing
-        .lock()
-        .map(|mut f| std::mem::take(&mut *f))
-        .unwrap_or_default();
+    let watchdog_firings: Vec<WatchdogFiring> = take_firings(&firing);
     let mut watchdog_notifications = Vec::new();
     // The panic rides the same batch as the firings (dispatched once after the
     // loop), so an unattended 04:00 run is not silent about an unguarded tail.
     // A watchdog that stashed a firing and *then* panicked still gets that
-    // firing handled below — the slot is read after the join, not before.
+    // firing handled below — the slot is read after the join, not before, and
+    // `take_firings` recovers it even if the panic poisoned the mutex.
     if let Some(message) = &watchdog_panic {
         watchdog_notifications.push(notify::build_watchdog_panic_notification(message));
     }
@@ -1126,6 +1124,21 @@ fn join_logged(handle: std::thread::JoinHandle<()>, thread_name: &str) -> Option
             Some(message)
         }
     }
+}
+
+/// Drain the watchdog's thread→main firing slot, recovering the stash even
+/// when the mutex is **poisoned** (issue #381). A watchdog that dies while
+/// holding this guard poisons it, and the former `.map(…).unwrap_or_default()`
+/// then discarded exactly the record the panic made most urgent: the pool the
+/// thread had just tripped, whose abort-reclaim, event, and notification all
+/// hang off it. The recovery is the same one [`progress_display_loop`] uses for
+/// its context mutex — a `Vec<WatchdogFiring>` is a plain owned value that a
+/// `push` either completed or did not, so a panic cannot leave it half-written
+/// in a way that makes reading it unsound. Only the thread that held the lock
+/// died; the data behind it is intact.
+fn take_firings(slot: &Mutex<Vec<WatchdogFiring>>) -> Vec<WatchdogFiring> {
+    let mut guard = slot.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    std::mem::take(&mut *guard)
 }
 
 /// On-disk name of the retired emergency reserve file (UPI 033, retired by UPI
@@ -4944,6 +4957,52 @@ source = "/data/beta"
             join_logged(h, "storage watchdog"),
             Some("watchdog lost /data".to_string()),
         );
+    }
+
+    #[test]
+    fn take_firings_recovers_a_stash_from_a_poisoned_slot() {
+        // The exact ordering this fix exists for: the watchdog stashes a
+        // firing and then dies while still holding the guard. The old
+        // `.unwrap_or_default()` dropped the stash on the floor — the abort
+        // reclaim, the WatchdogAbort event, and the notification with it.
+        let slot: Arc<Mutex<Vec<WatchdogFiring>>> = Arc::new(Mutex::new(Vec::new()));
+        let writer = slot.clone();
+        let h = std::thread::spawn(move || {
+            let mut stash = writer.lock().unwrap();
+            stash.push(poisoning_firing());
+            panic!("watchdog died holding the firing slot");
+        });
+        assert!(h.join().is_err(), "the writer must have panicked");
+        assert!(slot.is_poisoned(), "a panic under the guard poisons the mutex");
+
+        let taken = take_firings(&slot);
+
+        assert_eq!(taken.len(), 1, "the stashed firing survives the poisoning");
+        assert_eq!(taken[0].pool_label, "/data");
+        assert!(
+            take_firings(&slot).is_empty(),
+            "the slot is drained, not copied"
+        );
+    }
+
+    #[test]
+    fn take_firings_drains_a_healthy_slot() {
+        let slot: Mutex<Vec<WatchdogFiring>> = Mutex::new(vec![poisoning_firing()]);
+        assert_eq!(take_firings(&slot).len(), 1);
+        assert!(take_firings(&slot).is_empty(), "one drain only");
+    }
+
+    /// A minimal cross-filesystem firing with nothing stashed — enough to
+    /// prove identity through a poisoned slot.
+    fn poisoning_firing() -> WatchdogFiring {
+        WatchdogFiring {
+            pool_label: "/data".to_string(),
+            subvol_names: vec!["home".to_string()],
+            mountpoint: PathBuf::from("/data"),
+            floor_bytes: 4_000_000_000,
+            send_aborted: false,
+            reclaim: None,
+        }
     }
 
     #[test]

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -410,17 +410,22 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     let result = executor.execute(&backup_plan, mode);
     let exec_duration = exec_start.elapsed();
 
-    // Stop progress display
+    // Stop progress display. A panic here costs the progress line and nothing
+    // else, so it is logged (issue #381) and carried no further.
     progress_shutdown.store(true, Ordering::SeqCst);
     if let Some(h) = progress_handle {
-        h.join().ok();
+        let _ = join_logged(h, "progress display");
     }
 
     // ── Mid-op watchdog teardown (UPI 033, pool-scoped by UPI 065-b) ────
     watchdog_shutdown.store(true, Ordering::SeqCst);
-    if let Some(h) = watchdog_handle {
-        h.join().ok(); // may briefly block on an in-progress cross-fs reclaim
-    }
+    // A watchdog that panicked left every send after it running with no
+    // host-survival guard behind it — the one thread whose death the run must
+    // not keep quiet about (issue #381, ADR-113 Layer 2). Told three ways: the
+    // `error!` from `join_logged`, a Critical notification in the firing batch
+    // below, and a warning line in the interactive summary.
+    // The join itself may briefly block on an in-progress cross-fs reclaim.
+    let watchdog_panic = watchdog_handle.and_then(|h| join_logged(h, "storage watchdog"));
     // One firing per tripped pool. Two shapes (UPI 065-b):
     //   • same-filesystem (`send_aborted`): the watchdog cancelled the in-flight
     //     send, which freed no source space — do the post-abort two-tier reclaim
@@ -435,6 +440,13 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
         .map(|mut f| std::mem::take(&mut *f))
         .unwrap_or_default();
     let mut watchdog_notifications = Vec::new();
+    // The panic rides the same batch as the firings (dispatched once after the
+    // loop), so an unattended 04:00 run is not silent about an unguarded tail.
+    // A watchdog that stashed a firing and *then* panicked still gets that
+    // firing handled below — the slot is read after the join, not before.
+    if let Some(message) = &watchdog_panic {
+        watchdog_notifications.push(notify::build_watchdog_panic_notification(message));
+    }
     for fire in &watchdog_firings {
         // Route the response (pure, `run_tail::decide_reclaim`); the act-time
         // I/O — presence re-confirmation and the reclaim itself — threads
@@ -660,6 +672,12 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
     summary
         .warnings
         .extend(emergency_reclaim_warnings(&emergency.root_summaries));
+    // A watchdog that died mid-run (issue #381): the same prose the
+    // notification carries, so a TTY user sees inline that the run's later
+    // sends had no storage guard behind them.
+    if let Some(message) = &watchdog_panic {
+        summary.warnings.push(notify::watchdog_panic_prose(message));
+    }
     let output_mode = OutputMode::detect();
     let rendered = crate::voice::render_backup_summary(&summary, output_mode);
     println!("{rendered}");
@@ -1077,6 +1095,35 @@ fn handle_watchdog_trip(
             floor_bytes: pool.floor_bytes,
             send_aborted: false,
             reclaim: Some((outcome, ts)),
+        }
+    }
+}
+
+// ── Worker-thread teardown ──────────────────────────────────────────────
+
+/// Join a worker thread without swallowing a panic (issue #381). `join().ok()`
+/// discarded the payload, so a dead progress or watchdog thread left no trace
+/// anywhere — no log line, no summary line, no notification. This logs an
+/// `error!` naming the thread and hands the panic message back so the caller
+/// can carry it further; the watchdog does (its death means the run continued
+/// without ADR-113's in-flight guard), the cosmetic progress display does not.
+///
+/// Returns `None` when the thread returned normally. The message is the panic
+/// payload's own text — `panic!("literal")` yields a `&str`, a formatted
+/// `panic!` yields a `String`; anything else (`panic_any`) has no printable
+/// form, so the message says that rather than inventing one.
+#[must_use]
+fn join_logged(handle: std::thread::JoinHandle<()>, thread_name: &str) -> Option<String> {
+    match handle.join() {
+        Ok(()) => None,
+        Err(payload) => {
+            let message = payload
+                .downcast_ref::<&str>()
+                .map(|s| (*s).to_string())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "non-string panic payload".to_string());
+            log::error!("The {thread_name} thread panicked: {message}");
+            Some(message)
         }
     }
 }
@@ -4868,5 +4915,45 @@ source = "/data/beta"
         apply_token_gating(&mut plan, &TokenGating::default());
         // Empty gating touches nothing — no drops, no stamps.
         assert_eq!(plan.operations, before);
+    }
+
+    // ── Worker-thread teardown (issue #381) ────────────────────────────
+
+    #[test]
+    fn join_logged_returns_none_when_the_thread_returns_normally() {
+        let h = std::thread::spawn(|| {});
+        assert_eq!(join_logged(h, "progress display"), None);
+    }
+
+    #[test]
+    fn join_logged_reports_a_literal_panic_payload() {
+        // `panic!("literal")` hands back a `&str` payload.
+        let h = std::thread::spawn(|| panic!("poll loop exploded"));
+        assert_eq!(
+            join_logged(h, "storage watchdog"),
+            Some("poll loop exploded".to_string()),
+        );
+    }
+
+    #[test]
+    fn join_logged_reports_a_formatted_panic_payload() {
+        // A formatted `panic!` hands back a `String` payload instead.
+        let pool = "/data";
+        let h = std::thread::spawn(move || panic!("watchdog lost {pool}"));
+        assert_eq!(
+            join_logged(h, "storage watchdog"),
+            Some("watchdog lost /data".to_string()),
+        );
+    }
+
+    #[test]
+    fn join_logged_names_an_unprintable_panic_payload() {
+        // `panic_any` with a non-string payload has no printable form — say
+        // so rather than invent a message.
+        let h = std::thread::spawn(|| std::panic::panic_any(7u8));
+        assert_eq!(
+            join_logged(h, "storage watchdog"),
+            Some("non-string panic payload".to_string()),
+        );
     }
 }

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -110,6 +110,13 @@ pub enum NotificationEvent {
         pool_label: String,
         snapshots_reclaimed: u32,
     },
+    /// The mid-op watchdog thread died mid-run (issue #381, ADR-113 Layer 2):
+    /// every send after the panic ran with no in-flight host-survival guard.
+    /// Dispatched best-effort by `urd backup` in the same batch as any firing
+    /// the thread stashed before it died. `message` is the panic payload's text.
+    WatchdogStopped {
+        message: String,
+    },
     /// The always-on sentinel shed Urd-owned local snapshots while idle to keep a
     /// source pool above the host-survival floor (UPI 034, ADR-113 Layer 3).
     /// Dispatched best-effort by the sentinel only when at least one snapshot was
@@ -502,6 +509,36 @@ pub fn build_watchdog_abort_notification(
         urgency: Urgency::Critical,
         title,
         body,
+    }
+}
+
+/// The single prose for a mid-op watchdog that died mid-run (issue #381),
+/// shared verbatim by the notification body and the interactive backup
+/// summary's warning line so the two surfaces cannot drift — the same pairing
+/// [`emergency_retention_prose`] gives the emergency pre-flight. States the
+/// consequence, not the mechanism: whatever the run sent after the panic ran
+/// without the in-flight guard.
+#[must_use]
+pub fn watchdog_panic_prose(message: &str) -> String {
+    format!("Storage watchdog stopped mid-run ({message}); the remaining sends ran unguarded.")
+}
+
+/// Build the notification for a mid-op watchdog thread that panicked (issue
+/// #381). `Critical`, the same urgency as a watchdog abort: the guard ADR-113
+/// leans on for host survival was absent for part of the run, and an
+/// unattended run must say so before the next one starts.
+#[must_use]
+pub fn build_watchdog_panic_notification(message: &str) -> Notification {
+    Notification {
+        event: NotificationEvent::WatchdogStopped {
+            message: message.to_string(),
+        },
+        urgency: Urgency::Critical,
+        title: "Storage watchdog stopped".to_string(),
+        body: format!(
+            "{} Please check free space on the source drives before the next backup.",
+            watchdog_panic_prose(message)
+        ),
     }
 }
 
@@ -909,6 +946,45 @@ mod tests {
         let n = build_watchdog_abort_notification("/home", 0, false);
         assert!(n.body.contains("couldn't fully reclaim"));
         assert!(n.body.contains("left untouched"));
+    }
+
+    // ── Watchdog panic notification (issue #381) ───────────────────
+
+    #[test]
+    fn watchdog_panic_notification_is_critical_and_names_the_consequence() {
+        let n = build_watchdog_panic_notification("poll thread exploded");
+        assert_eq!(
+            n.urgency,
+            Urgency::Critical,
+            "an unguarded run is a host-survival event, like an abort"
+        );
+        assert!(n.title.contains("Storage watchdog stopped"));
+        assert!(
+            n.body.starts_with(&watchdog_panic_prose("poll thread exploded")),
+            "body must open with the shared prose: {}",
+            n.body
+        );
+        assert!(n.body.contains("poll thread exploded"), "carries the panic message");
+        assert!(
+            n.body.contains("check free space"),
+            "says what the operator should do: {}",
+            n.body
+        );
+        assert!(matches!(
+            n.event,
+            NotificationEvent::WatchdogStopped { ref message } if message == "poll thread exploded"
+        ));
+    }
+
+    #[test]
+    fn watchdog_panic_prose_states_the_sends_ran_unguarded() {
+        let prose = watchdog_panic_prose("lock poisoned");
+        assert!(prose.contains("lock poisoned"));
+        assert!(prose.contains("ran unguarded"));
+        assert!(
+            !prose.contains("aborted"),
+            "a panic stopped the guard, not a send: {prose}"
+        );
     }
 
     // ── Emergency eject notification (UPI 034) ─────────────────────


### PR DESCRIPTION
## Summary

`backup::run` joined both worker threads with `h.join().ok()`, discarding any
panic payload. A dead progress thread costs only the progress line, but a dead
watchdog thread means every send after the panic ran with **no ADR-113 in-flight
storage guard** — and nothing said so: no log line, no summary line, no
notification. The thread whose death matters most was the one the run was
quietest about.

Both joins now go through a small `join_logged` helper. The progress display
stops at the log line (cosmetic). The watchdog is told three ways, all through
machinery that already exists: the `error!`, a warning line in the interactive
backup summary, and a `Critical` notification in the same batch as any watchdog
firing — so an unattended 04:00 run is not silent about an unguarded tail.

## Changes

**`src/commands/backup.rs`**
- New private `join_logged(handle: JoinHandle<()>, thread_name: &str) ->
  Option<String>`: joins; on `Err(payload)` downcasts `&str`, then `String`, else
  `"non-string panic payload"`, logs `error!` naming the thread, and returns the
  message. `Ok` returns `None`. Placed in a new "Worker-thread teardown" section
  beside the watchdog wiring it serves.
- Progress teardown: `let _ = join_logged(h, "progress display")` — log only.
- Watchdog teardown: `let watchdog_panic = watchdog_handle.and_then(|h|
  join_logged(h, "storage watchdog"))`.
- On a panic, a `Critical` notification is pushed into `watchdog_notifications`
  ahead of the firing loop, so it rides the existing single post-loop
  `recorder.record` dispatch (which fires with empty events — `DispatchPolicy::
  Immediate` only checks the notification vec).
- On a panic, `summary.warnings` gets the shared prose line, right after the
  emergency-reclaim warnings (#174's mechanism, same file, same shape).
- New private `take_firings(&Mutex<Vec<WatchdogFiring>>) -> Vec<WatchdogFiring>`
  replaces the teardown's `firing.lock().map(…).unwrap_or_default()`: it recovers
  a **poisoned** guard (`unwrap_or_else(|poisoned| poisoned.into_inner())`) and
  then takes the `Vec`. A watchdog that stashes a firing and then panics while
  holding that guard poisons the mutex, and the old expression dropped exactly
  the record the panic made most urgent — the tripped pool's abort-reclaim, its
  `WatchdogAbort` event, and its notification all hang off that firing. The
  recovery is the same one `progress_display_loop` already uses for its context
  mutex, and it is sound rather than merely convenient: a `push` either completed
  or it did not, so a panic cannot leave a `Vec<WatchdogFiring>` half-written in a
  way that makes reading it unsafe. Only the thread died; the data is intact.

**`src/notify.rs`**
- `watchdog_panic_prose(message)` — the single prose, shared verbatim by the
  summary warning line and the notification body, exactly the pairing
  `emergency_retention_prose` gives the emergency pre-flight (#174), so the two
  surfaces cannot drift: *"Storage watchdog stopped mid-run (`<message>`); the
  remaining sends ran unguarded."*
- `build_watchdog_panic_notification(message)` — `Urgency::Critical`, the same
  urgency as a watchdog abort (the absence of the host-survival guard is a
  host-survival event), body = prose + "Please check free space on the source
  drives before the next backup."
- New `NotificationEvent::WatchdogStopped { message }`.

## Decisions the issue left open

- **Does a watchdog panic escalate to a notification?** Yes — `Critical`, on the
  watchdog firing path. A panic that only reached journald would be invisible on
  exactly the unattended runs the watchdog exists for.
- **No new `EventPayload` variant.** The events table is an on-disk contract
  (ADR-105) and this fix does not need to change it. `NotificationEvent` is
  in-memory only (not `Serialize`, never persisted), so the new variant costs
  nothing on disk.
- **Ordering is unchanged where it matters.** The firing slot (`firing.lock()`)
  is read *after* the join, as before — a watchdog that stashed a firing and then
  panicked still gets that firing reclaimed, evented, and notified exactly as
  before. The panic notification is simply pushed into the same batch first.
- **Poisoned-lock handling untouched**, per the file's existing graceful-degrade
  convention.

## Out of scope / noticed

- Nothing outstanding. The poisoned-firing-slot gap this fix made reachable is
  addressed here (second commit) rather than deferred; no other poisoned-lock
  site in the file was touched.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test` — **2451 passed, 0 failed, 6 ignored** (master baseline 2443
      passed / 6 ignored; +8 new). `cargo test backup` — 159 passed.
- [x] `join_logged` tested in isolation, four cases: clean return → `None`;
      `panic!("literal")` (`&str` payload); formatted `panic!` (`String`
      payload); `panic_any(7u8)` → `"non-string panic payload"`.
- [x] `take_firings` tested against a genuinely poisoned slot: a spawned thread
      pushes a firing and panics while holding the guard; the slot is asserted
      poisoned, the stashed firing still comes back, and a second take yields
      empty (drained, not copied). Healthy-path drain covered too.
- [x] `notify`: the panic notification is `Critical`, opens with the shared
      prose, carries the message, and names the action; the prose says "ran
      unguarded" and never claims a send was "aborted".
- [x] `bash scripts/check-present-not-journey.sh` — PASS.
- [x] `bash scripts/check-docs.sh` — PASS (66 links).
- [x] `bash scripts/pre-commit-pii.sh --report` — clean.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti
