### PR TITLE
fix: make headroom_aware_pointer_only's Pressure invariant unrepresentable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --all-targets --locked -- -D warnings
       - run: cargo test --locked
+      - run: cargo test --release --locked
 
   docs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its lock no longer loses that firing either — the teardown recovers the
   poisoned slot, so the tripped pool still gets its emergency reclaim, its
   event, and its notification (#381).
+- The pointer-only recommendation `urd doctor --thorough` emits for a
+  subvolume under source-pool pressure is now Pressure-only by
+  construction, rather than by a debug-only assertion that release builds
+  skipped. The quality gate (`scripts/check.sh` and CI) now also runs the
+  test suite under the release profile, so a debug/release behaviour gap
+  cannot reopen unnoticed (#380).
 
 ## [0.36.0] - 2026-09-03
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -2,7 +2,9 @@
 # check.sh — the /check quality gate as one command with a compact roll-up.
 #
 # Gates, in order: clippy (--all-targets, warnings are errors), unit tests,
-# release build, then the present-not-journey doc lint (independent of
+# release-mode tests (also builds the release binary; debug assertions are
+# off here, closing the gap `debug_assert!`/`#[should_panic]` can hide in
+# debug-only runs), then the present-not-journey doc lint (independent of
 # compilation, always runs). Prints one verdict line per gate plus a test
 # count computed from cargo's own summary lines — never hand-typed.
 #
@@ -72,13 +74,15 @@ fi
 if run_gate "clippy" "$WORK/clippy.log" cargo clippy --all-targets -- -D warnings; then
     if run_gate "tests" "$WORK/tests.log" cargo test; then
         LINES[1]="$(printf '%-9s PASS  %s' "tests" "$(test_counts "$WORK/tests.log")")"
-        run_gate "build" "$WORK/build.log" cargo build --release || true
+        if run_gate "release" "$WORK/release.log" cargo test --release; then
+            LINES[2]="$(printf '%-9s PASS  %s' "release" "$(test_counts "$WORK/release.log")")"
+        fi
     else
-        LINES+=("$(printf '%-9s SKIP  (tests failed)' "build")")
+        LINES+=("$(printf '%-9s SKIP  (tests failed)' "release")")
     fi
 else
     LINES+=("$(printf '%-9s SKIP  (clippy failed)' "tests")")
-    LINES+=("$(printf '%-9s SKIP  (clippy failed)' "build")")
+    LINES+=("$(printf '%-9s SKIP  (clippy failed)' "release")")
 fi
 
 run_gate "doc-lint" "$WORK/doclint.log" ./scripts/check-present-not-journey.sh || true

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -894,7 +894,6 @@ fn build_doctor_recommendation_view_inner(
                 Some(recommendation::headroom_aware_pointer_only(
                     &cur,
                     ShapeRole::Local,
-                    severity_local,
                     reason,
                 ))
             }
@@ -914,7 +913,6 @@ fn build_doctor_recommendation_view_inner(
                 Some(recommendation::headroom_aware_pointer_only(
                     &cur,
                     ShapeRole::External,
-                    severity_external,
                     reason,
                 ))
             }

--- a/src/recommendation.rs
+++ b/src/recommendation.rs
@@ -460,19 +460,17 @@ fn tighten(
 /// `suggested == current && both costs zero` and emits only the reason
 /// line — no shape, no recovery tail.
 ///
-/// Severity is restricted to `Pressure`; Healthy/Caution synth is meaningless
-/// and would represent a doctor.rs bug.
+/// Pressure-only by construction: the function sets `severity` to
+/// `HeadroomSeverity::Pressure` itself, so Healthy/Caution synth (which
+/// would represent a doctor.rs bug) is unrepresentable rather than merely
+/// asserted against.
 #[must_use]
 pub fn headroom_aware_pointer_only(
     current: &ResolvedGraduatedRetention,
     role: ShapeRole,
-    severity: HeadroomSeverity,
     reason: AdjustmentReason,
 ) -> HeadroomAwareRecommendation {
-    debug_assert!(
-        matches!(severity, HeadroomSeverity::Pressure),
-        "headroom_aware_pointer_only is only valid for Pressure severity, got {severity:?}",
-    );
+    let severity = HeadroomSeverity::Pressure;
     let zero_cost = CostProjection {
         data_bytes: 0,
         snapshot_count: 0,
@@ -1393,7 +1391,6 @@ mod tests {
         let h = headroom_aware_pointer_only(
             &cur,
             ShapeRole::Local,
-            HeadroomSeverity::Pressure,
             AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
         );
         assert_eq!(h.recommendation.suggested, h.recommendation.current);
@@ -1409,26 +1406,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn headroom_aware_pointer_only_panics_on_healthy() {
+    fn headroom_aware_pointer_only_severity_is_always_pressure() {
+        // Pressure-only by construction: the function no longer takes a
+        // severity parameter, so Healthy/Caution synth is unrepresentable.
         let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
-        let _ = headroom_aware_pointer_only(
+        let h = headroom_aware_pointer_only(
             &cur,
             ShapeRole::Local,
-            HeadroomSeverity::Healthy,
             AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
         );
-    }
-
-    #[test]
-    #[should_panic]
-    fn headroom_aware_pointer_only_panics_on_caution() {
-        let cur = shape(24, 60, 52, crate::types::MonthlyCount::Count(24), 0);
-        let _ = headroom_aware_pointer_only(
-            &cur,
-            ShapeRole::Local,
-            HeadroomSeverity::Caution,
-            AdjustmentReason::SourcePoolLow { free_ratio: 0.1 },
-        );
+        assert_eq!(h.severity, HeadroomSeverity::Pressure);
     }
 }

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -5454,7 +5454,6 @@ mod tests {
         let h = crate::recommendation::headroom_aware_pointer_only(
             &cur,
             crate::recommendation::ShapeRole::Local,
-            crate::recommendation::HeadroomSeverity::Pressure,
             crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.10 },
         );
         let view = crate::output::DoctorRecommendationView {
@@ -5530,7 +5529,6 @@ mod tests {
         let h = crate::recommendation::headroom_aware_pointer_only(
             &cur,
             crate::recommendation::ShapeRole::Local,
-            crate::recommendation::HeadroomSeverity::Pressure,
             crate::recommendation::AdjustmentReason::SourcePoolLow { free_ratio: 0.10 },
         );
         let view = crate::output::DoctorRecommendationView {


### PR DESCRIPTION
## Summary
- `recommendation::headroom_aware_pointer_only`'s "only valid for Pressure
  severity" invariant was guarded by a `debug_assert!`, which release builds
  compile out — `cargo test --release` silently passed 2 of 2443 tests.
- Fixed by making the invariant unrepresentable: the function no longer
  takes a `severity` parameter and always synthesizes
  `HeadroomSeverity::Pressure` itself.
- Closed the debug/release test gap structurally: `scripts/check.sh` and CI
  now both run `cargo test --release`.

## Changes
- `src/recommendation.rs` — `headroom_aware_pointer_only` drops the
  `severity: HeadroomSeverity` parameter; sets `Pressure` internally; doc
  comment updated to describe "Pressure-only by construction." Deleted the
  `debug_assert!` and the two `#[should_panic]` tests
  (`..._panics_on_healthy`, `..._panics_on_caution`); replaced with one test
  (`..._severity_is_always_pressure`) asserting the returned severity.
- `src/commands/doctor.rs` — both call sites (already inside
  `HeadroomSeverity::Pressure` match arms) stop passing `severity_local` /
  `severity_external`.
- `src/voice/mod.rs` — both test call sites stop passing
  `HeadroomSeverity::Pressure` explicitly.
- `scripts/check.sh` — the `build` gate (`cargo build --release`, output
  never exercised) is replaced with a `release` gate running
  `cargo test --release`, decorated with its own pass/fail/ignored count
  via the existing `test_counts` helper (mirrors the `tests` gate). Header
  comment updated to describe the new gate order and why it exists.
- `.github/workflows/ci.yml` — added `cargo test --release --locked` after
  the debug `cargo test --locked` step in the `quality` job.
- `CHANGELOG.md` — one bullet under `### Fixed`.

## Design decisions
- Chose "make invalid states unrepresentable" over swapping the
  `debug_assert!` for a runtime `assert!`/typed refusal returning
  `Option`/`Result`, per the supervisor's pinned decision: both production
  call sites already only reach this function from a `Pressure` match arm,
  so a runtime check would just be dead code paths with no caller that
  could ever hit them — dropping the parameter is strictly simpler and the
  compiler now proves the invariant instead of a test.
- Measured `cargo test --release` locally before adding it anywhere:
  **3m48.84s wall time** (well under the 6-minute caution threshold from
  the brief, and under the job's 30-minute timeout), so it was added to
  both `check.sh` and CI rather than `check.sh` only.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test` — 2442 passed, 0 failed, 6 ignored (master baseline:
      2443 passed, 6 ignored; net -1 from removing two `#[should_panic]`
      tests and adding one new test).
- [x] `cargo test --release` — 2442 passed, 0 failed, 6 ignored, green.
      Wall time: 3m48.84s.
- [x] `bash scripts/check-present-not-journey.sh` — pass.
- [x] `bash scripts/check-docs.sh` — pass.
- [x] `bash scripts/pre-commit-pii.sh --report` — clean, no findings.
- [x] `bash scripts/check.sh` end-to-end — all four gates (clippy, tests,
      release, doc-lint) pass with the new roll-up format.

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti
