### PR TITLE
fix: refuse conflicting min_free_bytes on a shared snapshot_root in v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   containing a backslash, newline, tab, or other control character
   produces valid JSON instead of a silently malformed payload — the exact
   content that shows up in watchdog and storage-pressure alerts (#379).
+- A v2 config in which two subvolumes share a `snapshot_root` but declare
+  different `min_free_bytes` is now refused at load, with the same message v1
+  has always given. Before, the first-listed value silently governed the whole
+  root, so one subvolume's space guard quietly ran at the other's threshold.
+  Both schemas now build their snapshot roots through the same grouping
+  function, so the rule cannot hold in one and lapse in the other; the refusal
+  also names the two subvolumes that actually disagree rather than whichever
+  was listed first. Legacy configs declare `min_free_bytes` once per root and
+  cannot express the conflict (#378).
 
 ## [0.36.0] - 2026-09-03
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,9 +68,67 @@ pub struct SnapshotRoot {
     pub min_free_bytes: Option<ByteSize>,
 }
 
-/// Per-root grouping accumulator for the v1/v2 parsers: `(subvolume names,
-/// first-non-None min_free_bytes)`.
-type RootGrouping = (Vec<String>, Option<ByteSize>);
+/// Per-root grouping accumulator for the shared v1/v2 root construction:
+/// `(subvolume names, the declared min_free_bytes and the subvolume that
+/// declared it)`. The threshold slot is filled by the first subvolume under
+/// the root that declares one; a later disagreement is refused rather than
+/// resolved, so the value that survives is the only one declared for the root.
+type RootGrouping<'a> = (Vec<String>, Option<(ByteSize, &'a str)>);
+
+/// Group v1/v2 subvolumes into the `[local_snapshots]` roots the internal
+/// `Config` carries, refusing a config in which two subvolumes share a
+/// `snapshot_root` but declare different `min_free_bytes`.
+///
+/// Grouping and refusal are one operation on purpose: the space check is per
+/// *root*, so two disagreeing thresholds have no honest resolution — whichever
+/// won would silently govern the other subvolume's snapshots. Both
+/// `V1Config::into_config` and `V2Config::into_config` build their roots here,
+/// so the rule cannot hold in one schema and quietly lapse in the other
+/// (ADR-111: three parsers, one shared construction surface).
+///
+/// Roots come back ordered by path, each carrying the single `min_free_bytes`
+/// declared for it — unique or absent, never a first-wins pick among rivals.
+///
+/// # Errors
+///
+/// Returns the structural-error message (ADR-109: the config is *wrong*, so
+/// Urd refuses to start) naming both subvolumes, their shared root, and the
+/// two conflicting values.
+fn group_subvolumes_by_snapshot_root<'a>(
+    subvolumes: impl IntoIterator<Item = (&'a str, &'a Path, Option<ByteSize>)>,
+) -> Result<Vec<SnapshotRoot>, String> {
+    // BTreeMap gives deterministic root ordering.
+    let mut root_map: std::collections::BTreeMap<&Path, RootGrouping<'a>> =
+        std::collections::BTreeMap::new();
+    for (name, snapshot_root, min_free_bytes) in subvolumes {
+        let entry = root_map
+            .entry(snapshot_root)
+            .or_insert_with(|| (Vec::new(), None));
+        entry.0.push(name.to_string());
+        match (entry.1, min_free_bytes) {
+            (Some((declared, declared_by)), Some(new)) if declared != new => {
+                return Err(format!(
+                    "subvolumes {declared_by:?} and {name:?} share snapshot_root {:?} but \
+                     declare different min_free_bytes ({declared} vs {new}). \
+                     Use the same value or move them to separate roots.",
+                    snapshot_root.display()
+                ));
+            }
+            // The first declaration for the root wins; agreeing repeats are
+            // no-ops, and disagreement never reaches here.
+            (None, Some(new)) => entry.1 = Some((new, name)),
+            _ => {}
+        }
+    }
+    Ok(root_map
+        .into_iter()
+        .map(|(path, (subvolumes, declared))| SnapshotRoot {
+            path: path.to_path_buf(),
+            subvolumes,
+            min_free_bytes: declared.map(|(bytes, _)| bytes),
+        })
+        .collect())
+}
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 #[allow(dead_code)]
@@ -680,29 +738,20 @@ impl V1Config {
     ///
     /// Synthesizes `LocalSnapshotsConfig` and `DefaultsConfig` so all downstream
     /// code (executor, chain, commands) continues working without changes.
-    fn into_config(self) -> Config {
+    ///
+    /// # Errors
+    ///
+    /// Returns the shared root-grouping refusal when two subvolumes share a
+    /// `snapshot_root` but declare different `min_free_bytes`.
+    fn into_config(self) -> Result<Config, String> {
         // Build LocalSnapshotsConfig by grouping subvolumes by snapshot_root.
-        // BTreeMap gives deterministic root ordering. The tuple carries the
-        // first-non-None min_free_bytes for the root.
-        let mut root_map: std::collections::BTreeMap<PathBuf, RootGrouping> =
-            std::collections::BTreeMap::new();
-        for sv in &self.subvolumes {
-            let entry = root_map
-                .entry(sv.snapshot_root.clone())
-                .or_insert_with(|| (Vec::new(), None));
-            entry.0.push(sv.name.clone());
-            if entry.1.is_none() {
-                entry.1 = sv.min_free_bytes;
-            }
-        }
-        let roots: Vec<SnapshotRoot> = root_map
-            .into_iter()
-            .map(|(path, (subvolumes, min_free_bytes))| SnapshotRoot {
-                path,
-                subvolumes,
-                min_free_bytes,
-            })
-            .collect();
+        let roots = group_subvolumes_by_snapshot_root(self.subvolumes.iter().map(|sv| {
+            (
+                sv.name.as_str(),
+                sv.snapshot_root.as_path(),
+                sv.min_free_bytes,
+            )
+        }))?;
 
         let defaults = parser_fallback_defaults();
 
@@ -734,7 +783,7 @@ impl V1Config {
             })
             .collect();
 
-        Config {
+        Ok(Config {
             general: GeneralConfig {
                 config_version: Some(self.general.config_version),
                 state_db: self.general.state_db,
@@ -749,7 +798,7 @@ impl V1Config {
             drives: self.drives,
             subvolumes,
             notifications: self.notifications,
-        }
+        })
     }
 }
 
@@ -809,30 +858,9 @@ impl V1Config {
             }
         }
 
-        // Reject conflicting min_free_bytes on subvolumes sharing a snapshot_root
-        let mut root_thresholds: std::collections::HashMap<&Path, (Option<ByteSize>, &str)> =
-            std::collections::HashMap::new();
-        for sv in &self.subvolumes {
-            let entry = root_thresholds
-                .entry(&sv.snapshot_root)
-                .or_insert((sv.min_free_bytes, &sv.name));
-            if let (Some(existing), Some(new)) = (entry.0, sv.min_free_bytes)
-                && existing != new
-            {
-                return Err(format!(
-                    "subvolumes {:?} and {:?} share snapshot_root {:?} but declare \
-                     different min_free_bytes ({existing} vs {new}). \
-                     Use the same value or move them to separate roots.",
-                    entry.1,
-                    sv.name,
-                    sv.snapshot_root.display()
-                ));
-            }
-            // Promote None → Some if a later subvolume specifies a value
-            if entry.0.is_none() && sv.min_free_bytes.is_some() {
-                entry.0 = sv.min_free_bytes;
-            }
-        }
+        // Conflicting min_free_bytes on subvolumes sharing a snapshot_root is
+        // refused where the roots are built — group_subvolumes_by_snapshot_root(),
+        // called from into_config() — so v1 and v2 enforce it from one site.
 
         Ok(())
     }
@@ -926,7 +954,7 @@ fn parse_legacy(raw: &str) -> Result<Config, String> {
 fn parse_v1(raw: &str) -> Result<Config, String> {
     let v1: V1Config = toml::from_str(raw).map_err(|e| e.to_string())?;
     v1.validate_v1()?;
-    Ok(v1.into_config())
+    v1.into_config()
 }
 
 // ── V2 wire types (UPI 042) ─────────────────────────────────────────────
@@ -1101,27 +1129,20 @@ struct V2SubvolumeConfig {
 impl V2Config {
     /// Convert v2 config into the internal Config representation. Mirrors
     /// `V1Config::into_config()` shape.
-    fn into_config(self) -> Config {
-        // Mirrors V1::into_config: first-non-None min_free_bytes per root.
-        let mut root_map: std::collections::BTreeMap<PathBuf, RootGrouping> =
-            std::collections::BTreeMap::new();
-        for sv in &self.subvolumes {
-            let entry = root_map
-                .entry(sv.snapshot_root.clone())
-                .or_insert_with(|| (Vec::new(), None));
-            entry.0.push(sv.name.clone());
-            if entry.1.is_none() {
-                entry.1 = sv.min_free_bytes;
-            }
-        }
-        let roots: Vec<SnapshotRoot> = root_map
-            .into_iter()
-            .map(|(path, (subvolumes, min_free_bytes))| SnapshotRoot {
-                path,
-                subvolumes,
-                min_free_bytes,
-            })
-            .collect();
+    ///
+    /// # Errors
+    ///
+    /// Returns the shared root-grouping refusal when two subvolumes share a
+    /// `snapshot_root` but declare different `min_free_bytes`.
+    fn into_config(self) -> Result<Config, String> {
+        // Same shared grouping as v1: one declared min_free_bytes per root.
+        let roots = group_subvolumes_by_snapshot_root(self.subvolumes.iter().map(|sv| {
+            (
+                sv.name.as_str(),
+                sv.snapshot_root.as_path(),
+                sv.min_free_bytes,
+            )
+        }))?;
 
         let defaults = parser_fallback_defaults();
 
@@ -1153,7 +1174,7 @@ impl V2Config {
             })
             .collect();
 
-        Config {
+        Ok(Config {
             general: GeneralConfig {
                 config_version: Some(self.general.config_version),
                 state_db: self.general.state_db,
@@ -1168,7 +1189,7 @@ impl V2Config {
             drives: self.drives,
             subvolumes,
             notifications: self.notifications,
-        }
+        })
     }
 
     /// Validate v2-specific rules. Same shape as V1::validate_v1.
@@ -1208,7 +1229,7 @@ impl V2Config {
 fn parse_v2(raw: &str) -> Result<Config, String> {
     let v2: V2Config = toml::from_str(raw).map_err(|e| e.to_string())?;
     v2.validate_v2()?;
-    Ok(v2.into_config())
+    v2.into_config()
 }
 
 // ── Utilities ───────────────────────────────────────────────────────────
@@ -3870,6 +3891,104 @@ source = "/docs"
 snapshot_root = "/snap"
 "#;
         parse_v1(config_str).unwrap();
+    }
+
+    // The min_free_bytes conflict rule reached v2 through the shared root
+    // construction (issue #378). Both schemas group roots with the same
+    // function, so they must refuse — and accept — the same configs.
+
+    #[test]
+    fn v2_rejects_conflicting_min_free_bytes_in_same_root() {
+        let body = r#"
+[[subvolumes]]
+name = "home"
+source = "/home"
+snapshot_root = "/snap"
+min_free_bytes = "10GB"
+
+[[subvolumes]]
+name = "docs"
+source = "/docs"
+snapshot_root = "/snap"
+min_free_bytes = "50GB"
+"#;
+        let v2_err = parse_v2(&format!("[general]\nconfig_version = 2\n{body}")).unwrap_err();
+        let v1_err = parse_v1(&format!("[general]\nconfig_version = 1\n{body}")).unwrap_err();
+        assert!(v2_err.contains("different min_free_bytes"), "{v2_err}");
+        // Same rule, same words — the refusal cannot drift between schemas.
+        assert_eq!(v2_err, v1_err);
+    }
+
+    #[test]
+    fn v2_allows_same_min_free_bytes_in_same_root() {
+        let config = parse_v2(r#"
+[general]
+config_version = 2
+
+[[subvolumes]]
+name = "home"
+source = "/home"
+snapshot_root = "/snap"
+min_free_bytes = "10GB"
+
+[[subvolumes]]
+name = "docs"
+source = "/docs"
+snapshot_root = "/snap"
+min_free_bytes = "10GB"
+"#).unwrap();
+        assert_eq!(config.root_min_free_bytes("docs"), Some(10_000_000_000));
+    }
+
+    #[test]
+    fn v2_allows_mixed_none_and_some_min_free_bytes() {
+        let config = parse_v2(r#"
+[general]
+config_version = 2
+
+[[subvolumes]]
+name = "home"
+source = "/home"
+snapshot_root = "/snap"
+min_free_bytes = "10GB"
+
+[[subvolumes]]
+name = "docs"
+source = "/docs"
+snapshot_root = "/snap"
+"#).unwrap();
+        // The one declared threshold governs the whole root.
+        assert_eq!(config.root_min_free_bytes("home"), Some(10_000_000_000));
+        assert_eq!(config.root_min_free_bytes("docs"), Some(10_000_000_000));
+    }
+
+    #[test]
+    fn min_free_bytes_conflict_names_the_declaring_subvolumes() {
+        // The first subvolume under the root declares nothing, so the message
+        // must name the two that actually disagree — not the first listed.
+        let err = parse_v2(r#"
+[general]
+config_version = 2
+
+[[subvolumes]]
+name = "quiet"
+source = "/quiet"
+snapshot_root = "/snap"
+
+[[subvolumes]]
+name = "home"
+source = "/home"
+snapshot_root = "/snap"
+min_free_bytes = "10GB"
+
+[[subvolumes]]
+name = "docs"
+source = "/docs"
+snapshot_root = "/snap"
+min_free_bytes = "50GB"
+"#).unwrap_err();
+        assert!(err.contains("subvolumes \"home\" and \"docs\""), "{err}");
+        assert!(!err.contains("quiet"), "{err}");
     }
 
     // ── cleanup_budget residual-key tolerance (UPI 068, ADR-111 amendment


### PR DESCRIPTION
## Summary

`validate_v1` refused two subvolumes that share a `snapshot_root` but declare
different `min_free_bytes`; `validate_v2` never got the rule, so a v2 config with
the same conflict loaded silently and the first-listed value governed the whole
root — one subvolume's space guard quietly running at the other's threshold. That
is a structural error (ADR-109: the config is *wrong*, not the world unready), and
nothing marked it as a deliberate v2 omission the way the v1-only fortified/offsite
rule right above it is marked.

The rule diverged because it lived in a validation loop while the roots it governs
were built by a near-verbatim copy in each `into_config()`. This PR makes grouping
and refusal one operation in one place, called from both schemas' construction
paths, so it cannot diverge again (ADR-111 keeps the three parsers by design but
allows depth at the shared construction surface).

## Changes

**`src/config.rs`**

- New `group_subvolumes_by_snapshot_root()` — a pure function over the
  per-subvolume `(name, snapshot_root, min_free_bytes)` triples that returns the
  `[local_snapshots]` roots, or the conflict refusal. It replaces the two copied
  grouping loops and the v1-only validation loop.
- `V1Config::into_config()` and `V2Config::into_config()` build their roots through
  it and become `Result<Config, String>`; `parse_v1`/`parse_v2` propagate. Their
  doc comments gain `# Errors`.
- `validate_v1` loses its copy of the check, replaced by a comment pointing at the
  single site. Ordering is unchanged: the protection-contract rules still run
  before the root construction, so a config that violates both reports the contract
  error first, exactly as before.
- The `RootGrouping` accumulator now carries `(ByteSize, &str)` — the declared
  threshold *and* who declared it.

**Decisions made where the issue left them open**

- *Where the rule lives.* In construction, not in `validate_*`. A root carries one
  threshold; a config declaring two for the same root cannot be turned into roots
  honestly, so the refusal belongs to the act of building them. This gives exactly
  one call site for both schemas rather than a check in two validators plus an
  infallible grouping that would have to swallow the impossible error. Both
  schemas still refuse at `Config::load()`, so ADR-109's load-time contract holds.
- *Legacy is deliberately excluded, not overlooked.* The legacy schema declares
  `min_free_bytes` once per `[local_snapshots]` root, so the conflict is not
  expressible there — there is nothing to refuse. `urd migrate` inlines that single
  per-root value onto every subvolume under the root, so migrated configs are
  conflict-free by construction. Noted in the commit message too.
- *Message.* v1's wording is kept verbatim (a test asserts the v1 and v2 errors are
  byte-identical). One behavioral improvement inside that shape: the message now
  names the two subvolumes that actually disagree. Before, it named the first
  subvolume listed under the root, which was wrong whenever that one declared no
  threshold at all.
- *`into_config`'s "first-non-None min_free_bytes per root" comment* (issue item 4)
  is gone rather than reworded: the shared function's doc now states that a root
  carries the single declared threshold — unique or absent, never a first-wins pick
  among rivals — which is guaranteed now that disagreement is refused.

**`CHANGELOG.md`** — one bullet under `### Fixed`.

## Out of scope / noticed

- **The `ProtectionFields` trait (issue item 2) was not built,** per instruction, and
  I do not think it earns its keep as a follow-up either. The three
  `ProtectionContractView` constructions differ in real ways — v1 and v2 read
  distinct wire types (`LocalRetentionConfig` vs `V2LocalRetentionConfig`), and the
  legacy one deliberately passes `local_snapshots: None` because the field does not
  exist in that schema and computes `has_any_drives` against `Config` rather than the
  wire struct. A trait would abstract three call sites into one generic `build_view`
  plus three impls of nine accessors each — the same knowledge, spread wider, and it
  would not have prevented this bug (the drift was in a rule that lives *outside*
  the view). The divergence risk that is real here was the construction of the
  roots, which this PR closes directly.
- The v1-only fortified/offsite rule remains v1-only. It carries an explicit comment
  explaining why (preflight owns the all-schema advisory), so it is a documented
  asymmetry, not a gap — left alone.

## Test plan

- [x] `v2_rejects_conflicting_min_free_bytes_in_same_root` — the v2 fixture is
      refused, and its error is asserted `assert_eq!`-equal to the v1 error for the
      same fixture (only `config_version` differs), so the two can never drift.
- [x] `v2_allows_same_min_free_bytes_in_same_root` — agreeing declarations still
      load, and the root resolves to the shared value.
- [x] `v2_allows_mixed_none_and_some_min_free_bytes` — one declared, one absent
      still loads, and both subvolumes resolve to the one declared threshold.
- [x] `min_free_bytes_conflict_names_the_declaring_subvolumes` — with a
      non-declaring subvolume listed first, the message names the two that
      disagree and does not name the quiet one.
- [x] The existing `v1_rejects_conflicting_min_free_bytes_in_same_root`,
      `v1_allows_same_...` and `v1_allows_mixed_...` tests pass unchanged through
      the shared function.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test` — 2447 passed, 5 ignored (+1 in the integration target);
      master baseline was 2443, plus the 4 tests above.
- [x] `scripts/check-present-not-journey.sh`, `scripts/check-docs.sh` — pass.
- [x] `scripts/pre-commit-pii.sh --report` — clean.

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti
