### PR TITLE
refactor: move colored output out of commands/, wall clock out of voice/

### DIFF
--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -5,8 +5,6 @@ use std::sync::{Arc, Mutex};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
-use colored::Colorize;
-
 use crate::awareness::{PromiseStatus, SubvolAssessment};
 use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::cli::BackupArgs;
@@ -171,7 +169,7 @@ pub fn run(config: Config, args: BackupArgs) -> anyhow::Result<()> {
             let explanation = build_empty_plan_explanation(&backup_plan, &filters);
             print!("{}", crate::voice::render_empty_plan(&explanation));
         } else {
-            println!("{}", "Nothing to do.".dimmed());
+            print!("{}", crate::voice::render_nothing_to_do());
         }
         // ── The run tail, empty-plan exit (UPI 088-b) ──────────────────
         // Gather → decide (pure) → execute, same contract order as the

--- a/src/commands/drives.rs
+++ b/src/commands/drives.rs
@@ -112,7 +112,8 @@ pub fn run_drives_list(config: &Config, output_mode: OutputMode) -> anyhow::Resu
     }
 
     let output = DrivesListOutput { drives: entries };
-    print!("{}", voice::render_drives_list(&output, output_mode));
+    let now = chrono::Local::now().naive_local();
+    print!("{}", voice::render_drives_list(&output, output_mode, now));
     Ok(())
 }
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -513,18 +513,21 @@ fn handle_incomplete_deletions(
         std::io::stdin().read_line(&mut input)?;
         if input.trim().eq_ignore_ascii_case("y") {
             let path = std::path::Path::new(&inc.path);
-            let result = btrfs.delete_subvolume(path);
-            let ok = result.is_ok();
-            let error_detail = result.as_ref().err().map(std::string::ToString::to_string);
-            println!(
-                "{}",
-                crate::voice::render_incomplete_deletion_result(
-                    &inc.path,
-                    error_detail.as_deref().map_or(Ok(()), Err),
-                )
-            );
-            if ok {
-                deleted.push(inc.path.clone());
+            match btrfs.delete_subvolume(path) {
+                Ok(()) => {
+                    println!(
+                        "{}",
+                        crate::voice::render_incomplete_deletion_result(&inc.path, Ok(()))
+                    );
+                    deleted.push(inc.path.clone());
+                }
+                Err(e) => println!(
+                    "{}",
+                    crate::voice::render_incomplete_deletion_result(
+                        &inc.path,
+                        Err(&e.to_string())
+                    )
+                ),
             }
         }
     }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -484,8 +484,6 @@ fn handle_incomplete_deletions(
     config: &Config,
     incompletes: &[InitIncomplete],
 ) -> anyhow::Result<Vec<String>> {
-    use colored::Colorize;
-
     let mut deleted = Vec::new();
 
     if incompletes.is_empty() {
@@ -493,10 +491,7 @@ fn handle_incomplete_deletions(
     }
 
     println!();
-    println!(
-        "{}",
-        "Potentially incomplete snapshots on external drives:".bold()
-    );
+    println!("{}", crate::voice::render_incomplete_deletion_header());
 
     let sys = crate::btrfs::SystemBtrfs::probe(&config.general.btrfs_path);
     let btrfs = RealBtrfs::new(
@@ -507,10 +502,8 @@ fn handle_incomplete_deletions(
 
     for inc in incompletes {
         println!(
-            "  {} {} on {} (not pinned, may be from interrupted transfer)",
-            "WARNING".yellow(),
-            inc.snapshot,
-            inc.drive,
+            "{}",
+            crate::voice::render_incomplete_deletion_warning(&inc.snapshot, &inc.drive)
         );
 
         print!("  Delete {}? [y/N] ", inc.path);
@@ -520,14 +513,18 @@ fn handle_incomplete_deletions(
         std::io::stdin().read_line(&mut input)?;
         if input.trim().eq_ignore_ascii_case("y") {
             let path = std::path::Path::new(&inc.path);
-            match btrfs.delete_subvolume(path) {
-                Ok(()) => {
-                    println!("  {} Deleted {}", "OK".green(), inc.path);
-                    deleted.push(inc.path.clone());
-                }
-                Err(e) => {
-                    println!("  {} Failed to delete {}: {e}", "ERROR".red(), inc.path);
-                }
+            let result = btrfs.delete_subvolume(path);
+            let ok = result.is_ok();
+            let error_detail = result.as_ref().err().map(std::string::ToString::to_string);
+            println!(
+                "{}",
+                crate::voice::render_incomplete_deletion_result(
+                    &inc.path,
+                    error_detail.as_deref().map_or(Ok(()), Err),
+                )
+            );
+            if ok {
+                deleted.push(inc.path.clone());
             }
         }
     }

--- a/src/commands/sentinel.rs
+++ b/src/commands/sentinel.rs
@@ -31,7 +31,8 @@ pub fn status(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         None => SentinelStatusOutput::NotRunning { last_seen: None },
     };
 
-    let rendered = voice::render_sentinel_status(&status_output, output_mode);
+    let now = chrono::Local::now().naive_local();
+    let rendered = voice::render_sentinel_status(&status_output, output_mode, now);
     print!("{rendered}");
 
     Ok(())

--- a/src/voice/drives.rs
+++ b/src/voice/drives.rs
@@ -14,11 +14,17 @@ use crate::output::{
 };
 use crate::plan::format_duration_short;
 
-/// Render the drives list output.
+/// Render the drives list output. `now` is the caller's wall-clock reading,
+/// threaded through to compute "absent NNm" ages — the renderer itself
+/// stays a pure function of its input (no `Local::now()` inside `voice/`).
 #[must_use]
-pub fn render_drives_list(data: &DrivesListOutput, mode: OutputMode) -> String {
+pub fn render_drives_list(
+    data: &DrivesListOutput,
+    mode: OutputMode,
+    now: chrono::NaiveDateTime,
+) -> String {
     match mode {
-        OutputMode::Interactive => render_drives_list_interactive(data),
+        OutputMode::Interactive => render_drives_list_interactive(data, now),
         OutputMode::Daemon => {
             serde_json::to_string_pretty(data)
                 .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
@@ -26,7 +32,7 @@ pub fn render_drives_list(data: &DrivesListOutput, mode: OutputMode) -> String {
     }
 }
 
-fn render_drives_list_interactive(data: &DrivesListOutput) -> String {
+fn render_drives_list_interactive(data: &DrivesListOutput, now: chrono::NaiveDateTime) -> String {
     let mut out = String::new();
 
     if data.drives.is_empty() {
@@ -38,7 +44,7 @@ fn render_drives_list_interactive(data: &DrivesListOutput) -> String {
     let status_strs: Vec<String> = data
         .drives
         .iter()
-        .map(|d| format_drive_status(&d.status))
+        .map(|d| format_drive_status(&d.status, now))
         .collect();
 
     let label_w = data
@@ -79,14 +85,14 @@ fn render_drives_list_interactive(data: &DrivesListOutput) -> String {
     out
 }
 
-fn format_drive_status(status: &DriveStatus) -> String {
+fn format_drive_status(status: &DriveStatus, now: chrono::NaiveDateTime) -> String {
     match status {
         DriveStatus::Connected => "connected".to_string(),
         DriveStatus::UuidMismatch => "uuid mismatch".to_string(),
         DriveStatus::UuidCheckFailed => "uuid unverified".to_string(),
         DriveStatus::Absent { last_seen } => {
             if let Some(ts) = last_seen {
-                if let Some(duration) = format_absent_duration(ts) {
+                if let Some(duration) = format_absent_duration(ts, now) {
                     format!("absent {duration}")
                 } else {
                     "absent".to_string()
@@ -127,14 +133,12 @@ fn color_token_state(state: &TokenState, text: &str) -> String {
     }
 }
 
-/// Format an ISO timestamp as a human-readable absent duration from now.
-/// Reuses `format_duration_short` from plan.rs for consistent formatting.
-fn format_absent_duration(timestamp: &str) -> Option<String> {
+/// Format an ISO timestamp as a human-readable absent duration relative to
+/// `now`. Reuses `format_duration_short` from plan.rs for consistent
+/// formatting.
+fn format_absent_duration(timestamp: &str, now: chrono::NaiveDateTime) -> Option<String> {
     let ts = chrono::NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%dT%H:%M:%S").ok()?;
-    let mins = chrono::Local::now()
-        .naive_local()
-        .signed_duration_since(ts)
-        .num_minutes();
+    let mins = now.signed_duration_since(ts).num_minutes();
     if mins < 1 {
         None
     } else {

--- a/src/voice/init.rs
+++ b/src/voice/init.rs
@@ -208,3 +208,82 @@ fn format_init_status(status: InitStatus) -> String {
         InitStatus::Error => "ERROR".red().to_string(),
     }
 }
+
+// ── Interactive incomplete-snapshot deletion prompt ────────────────────
+//
+// `urd init` offers to delete unpinned, possibly-interrupted snapshots on
+// external drives one at a time (an interactive TTY loop, so it cannot be
+// folded into `render_init`'s single-shot report). These three renderers
+// carry only the colored text; the command handler still owns the blank
+// line, the `Delete ...? [y/N]` prompt, stdin, and the btrfs call.
+
+/// Header printed once above the per-snapshot warnings.
+#[must_use]
+pub fn render_incomplete_deletion_header() -> String {
+    "Potentially incomplete snapshots on external drives:"
+        .bold()
+        .to_string()
+}
+
+/// Per-snapshot warning line offering deletion.
+#[must_use]
+pub fn render_incomplete_deletion_warning(snapshot: &str, drive: &str) -> String {
+    format!(
+        "  {} {} on {} (not pinned, may be from interrupted transfer)",
+        "WARNING".yellow(),
+        snapshot,
+        drive,
+    )
+}
+
+/// Outcome line after attempting to delete an incomplete snapshot.
+/// `error` carries the formatted failure detail on `Err`.
+#[must_use]
+pub fn render_incomplete_deletion_result(path: &str, result: Result<(), &str>) -> String {
+    match result {
+        Ok(()) => format!("  {} Deleted {path}", "OK".green()),
+        Err(e) => format!("  {} Failed to delete {path}: {e}", "ERROR".red()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::voice::test_fixtures::color_guard;
+
+    #[test]
+    fn incomplete_deletion_header_matches_pinned_text() {
+        let _c = color_guard(false);
+        assert_eq!(
+            render_incomplete_deletion_header(),
+            "Potentially incomplete snapshots on external drives:"
+        );
+    }
+
+    #[test]
+    fn incomplete_deletion_warning_names_snapshot_and_drive() {
+        let _c = color_guard(false);
+        assert_eq!(
+            render_incomplete_deletion_warning("20260904-0100-home", "WD-18TB"),
+            "  WARNING 20260904-0100-home on WD-18TB (not pinned, may be from interrupted transfer)"
+        );
+    }
+
+    #[test]
+    fn incomplete_deletion_result_ok() {
+        let _c = color_guard(false);
+        assert_eq!(
+            render_incomplete_deletion_result("/mnt/snap/home", Ok(())),
+            "  OK Deleted /mnt/snap/home"
+        );
+    }
+
+    #[test]
+    fn incomplete_deletion_result_err() {
+        let _c = color_guard(false);
+        assert_eq!(
+            render_incomplete_deletion_result("/mnt/snap/home", Err("permission denied")),
+            "  ERROR Failed to delete /mnt/snap/home: permission denied"
+        );
+    }
+}

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -68,8 +68,11 @@ pub use encounter::{
 };
 pub use get::render_get;
 pub use history::{render_events, render_history, render_subvolume_history};
-pub use init::{render_init, render_init_first_time};
-pub use plan::{render_empty_plan, render_plan};
+pub use init::{
+    render_incomplete_deletion_header, render_incomplete_deletion_result,
+    render_incomplete_deletion_warning, render_init, render_init_first_time,
+};
+pub use plan::{render_empty_plan, render_nothing_to_do, render_plan};
 pub use retention::render_retention_preview;
 pub use sentinel::render_sentinel_status;
 pub use status::{render_default_status, render_first_time, render_status};
@@ -817,6 +820,15 @@ mod tests {
         TransitionEvent, VerifyCheck, VerifyDrive,
         VerifyOutput, VerifySubvolume,
     };
+
+    /// Fixed "now" for renderer tests that used to read the wall clock
+    /// internally (drives absence / sentinel assessment age). Parsing a
+    /// literal keeps these golden tests deterministic instead of drifting
+    /// with the real calendar.
+    fn fixed_now(iso: &str) -> chrono::NaiveDateTime {
+        chrono::NaiveDateTime::parse_from_str(iso, "%Y-%m-%dT%H:%M:%S")
+            .unwrap_or_else(|e| panic!("bad fixed_now literal {iso:?}: {e}"))
+    }
 
     // ── Table primitive tests ───────────────────────────────────────
 
@@ -2821,21 +2833,21 @@ mod tests {
     #[test]
     fn sentinel_running_contains_watching() {
         let _color = color_guard(false);
-        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
+        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
         assert!(output.contains("watching"), "missing 'watching'");
     }
 
     #[test]
     fn sentinel_running_contains_pid() {
         let _color = color_guard(false);
-        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
+        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
         assert!(output.contains("12345"), "missing PID");
     }
 
     #[test]
     fn sentinel_running_contains_tick() {
         let _color = color_guard(false);
-        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
+        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
         assert!(output.contains("15m"), "missing tick interval");
         assert!(output.contains("all promises held"), "missing promise summary");
     }
@@ -2843,7 +2855,7 @@ mod tests {
     #[test]
     fn sentinel_running_contains_drive() {
         let _color = color_guard(false);
-        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive);
+        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
         assert!(output.contains("WD-18TB"), "missing drive label");
     }
 
@@ -2851,7 +2863,7 @@ mod tests {
     fn sentinel_not_running_shows_message() {
         let _color = color_guard(false);
         let data = SentinelStatusOutput::NotRunning { last_seen: None };
-        let output = render_sentinel_status(&data, OutputMode::Interactive);
+        let output = render_sentinel_status(&data, OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
         assert!(output.contains("not running"), "missing 'not running'");
         assert!(output.contains("urd sentinel run"), "missing start hint");
     }
@@ -2862,7 +2874,7 @@ mod tests {
         let data = SentinelStatusOutput::NotRunning {
             last_seen: Some("2026-03-27T10:00:00".to_string()),
         };
-        let output = render_sentinel_status(&data, OutputMode::Interactive);
+        let output = render_sentinel_status(&data, OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
         assert!(output.contains("not running"), "missing 'not running'");
         assert!(output.contains("2026-03-27T10:00:00"), "missing last seen timestamp");
     }
@@ -2927,16 +2939,14 @@ mod tests {
     #[test]
     fn sentinel_assessment_age_is_relative() {
         let _color = color_guard(false);
-        let five_min_ago = (chrono::Local::now().naive_local()
-            - chrono::Duration::minutes(5))
-        .format("%Y-%m-%dT%H:%M:%S")
-        .to_string();
+        let five_min_ago = "2026-03-27T13:15:00".to_string();
+        let now = fixed_now("2026-03-27T13:20:00");
         let mut data = test_sentinel_running();
         let SentinelStatusOutput::Running { ref mut state, .. } = data else {
             unreachable!()
         };
         state.last_assessment = Some(five_min_ago.clone());
-        let output = render_sentinel_status(&data, OutputMode::Interactive);
+        let output = render_sentinel_status(&data, OutputMode::Interactive, now);
         assert!(
             output.contains("5m ago"),
             "assessment age must be relative: {output}"
@@ -2944,6 +2954,31 @@ mod tests {
         assert!(
             !output.contains(&five_min_ago),
             "the raw ISO stamp belongs to JSON mode only: {output}"
+        );
+    }
+
+    /// Golden test (issue #384 part 3): `render_sentinel_status` used to
+    /// call `chrono::Local::now()` internally, which made the assessment
+    /// age line untestable without racing the real clock. With `now`
+    /// threaded through as a parameter, a fixed instant in produces a
+    /// fixed line out.
+    #[test]
+    fn sentinel_assessment_age_golden_line() {
+        let _color = color_guard(false);
+        let now = fixed_now("2026-03-27T13:20:00");
+        let mut data = test_sentinel_running();
+        let SentinelStatusOutput::Running { ref mut state, .. } = data else {
+            unreachable!()
+        };
+        state.last_assessment = Some("2026-03-27T13:15:00".to_string());
+        let output = render_sentinel_status(&data, OutputMode::Interactive, now);
+        assert_eq!(
+            output,
+            "SENTINEL — watching\n\
+             \n\
+             \x20\x20Running       since 3h 12m (PID 12345)\n\
+             \x20\x20Assessment    5m ago (tick: 15m — all promises held)\n\
+             \x20\x20Connected     WD-18TB\n"
         );
     }
 
@@ -2955,7 +2990,11 @@ mod tests {
             unreachable!()
         };
         state.last_assessment = Some("not-a-timestamp".to_string());
-        let output = render_sentinel_status(&data, OutputMode::Interactive);
+        let output = render_sentinel_status(
+            &data,
+            OutputMode::Interactive,
+            fixed_now("2026-03-27T13:20:00"),
+        );
         assert!(
             output.contains("not-a-timestamp"),
             "unparseable stamp renders raw, never panics: {output}"
@@ -2964,7 +3003,11 @@ mod tests {
 
     #[test]
     fn sentinel_daemon_produces_valid_json() {
-        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Daemon);
+        let output = render_sentinel_status(
+            &test_sentinel_running(),
+            OutputMode::Daemon,
+            fixed_now("2026-03-27T13:20:00"),
+        );
         let parsed: serde_json::Value =
             serde_json::from_str(&output).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{output}"));
         assert_eq!(parsed["status"], "running");
@@ -4220,6 +4263,12 @@ mod tests {
     }
 
     #[test]
+    fn nothing_to_do_renders_dimmed_line() {
+        let _c = test_fixtures::color_guard(false);
+        assert_eq!(render_nothing_to_do(), "Nothing to do.\n");
+    }
+
+    #[test]
     fn pre_action_no_estimates() {
         let summary = PreActionSummary {
             snapshot_count: 3,
@@ -4286,7 +4335,7 @@ mod tests {
     #[test]
     fn drives_list_interactive_columns() {
         let _color = color_guard(false);
-        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive);
+        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, fixed_now("2026-03-29T10:00:00"));
         assert!(output.contains("DRIVE"), "should have header: {output}");
         assert!(output.contains("STATUS"), "should have header: {output}");
         assert!(output.contains("TOKEN"), "should have header: {output}");
@@ -4305,7 +4354,7 @@ mod tests {
     #[test]
     fn drives_list_absent_shows_duration() {
         let _color = color_guard(false);
-        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive);
+        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, fixed_now("2026-03-29T10:00:00"));
         // The absent drive's last_seen is 2026-03-24, so "absent Nd" should appear
         assert!(
             output.contains("absent") && output.contains("d"),
@@ -4316,7 +4365,7 @@ mod tests {
     #[test]
     fn drives_list_uuid_mismatch_shows_status() {
         let _color = color_guard(false);
-        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive);
+        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, fixed_now("2026-03-29T10:00:00"));
         assert!(
             output.contains("uuid mismatch"),
             "uuid mismatch drive should show status: {output}"
@@ -4326,7 +4375,7 @@ mod tests {
     #[test]
     fn drives_list_token_column_uses_ascii() {
         let _color = color_guard(false);
-        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive);
+        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, fixed_now("2026-03-29T10:00:00"));
         assert!(output.contains("ok"), "Verified token should show 'ok': {output}");
         // Token column should not contain Unicode check/cross marks
         assert!(
@@ -4335,9 +4384,29 @@ mod tests {
         );
     }
 
+    /// Golden test (issue #384 part 3): `render_drives_list` used to call
+    /// `chrono::Local::now()` internally to compute the "absent NNd" age,
+    /// which made this line untestable without racing the real clock. With
+    /// `now` threaded through as a parameter, a fixed instant in produces a
+    /// fixed line out.
+    #[test]
+    fn drives_list_absent_duration_golden_line() {
+        let _color = color_guard(false);
+        let now = fixed_now("2026-03-29T10:00:00");
+        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, now);
+        assert_eq!(
+            output,
+            "DRIVE        STATUS          TOKEN            FREE   ROLE\n\
+             WD-18TB      connected       ok              4.2TB   primary\n\
+             WD-18TB1     absent 5d       recorded            —   offsite\n\
+             2TB-backup   connected       new             1.1TB   primary\n\
+             BAD-UUID     uuid mismatch   -               500GB   primary\n"
+        );
+    }
+
     #[test]
     fn drives_list_daemon_valid_json() {
-        let output = render_drives_list(&test_drives_list(), OutputMode::Daemon);
+        let output = render_drives_list(&test_drives_list(), OutputMode::Daemon, fixed_now("2026-03-29T10:00:00"));
         let parsed: serde_json::Value =
             serde_json::from_str(&output).expect("should be valid JSON");
         assert!(parsed["drives"].is_array());

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -830,6 +830,18 @@ mod tests {
             .unwrap_or_else(|e| panic!("bad fixed_now literal {iso:?}: {e}"))
     }
 
+    /// Fixed "now" for the sentinel status tests (10 minutes after
+    /// `test_sentinel_running`'s `last_assessment`).
+    fn sentinel_now() -> chrono::NaiveDateTime {
+        fixed_now("2026-03-27T13:20:00")
+    }
+
+    /// Fixed "now" for the drives list tests (5 days after
+    /// `test_drives_list`'s absent drive's `last_seen`).
+    fn drives_now() -> chrono::NaiveDateTime {
+        fixed_now("2026-03-29T10:00:00")
+    }
+
     // ── Table primitive tests ───────────────────────────────────────
 
     /// Regression: pre-colored cells (ANSI codes already embedded) must not
@@ -2833,21 +2845,33 @@ mod tests {
     #[test]
     fn sentinel_running_contains_watching() {
         let _color = color_guard(false);
-        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
+        let output = render_sentinel_status(
+            &test_sentinel_running(),
+            OutputMode::Interactive,
+            sentinel_now(),
+        );
         assert!(output.contains("watching"), "missing 'watching'");
     }
 
     #[test]
     fn sentinel_running_contains_pid() {
         let _color = color_guard(false);
-        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
+        let output = render_sentinel_status(
+            &test_sentinel_running(),
+            OutputMode::Interactive,
+            sentinel_now(),
+        );
         assert!(output.contains("12345"), "missing PID");
     }
 
     #[test]
     fn sentinel_running_contains_tick() {
         let _color = color_guard(false);
-        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
+        let output = render_sentinel_status(
+            &test_sentinel_running(),
+            OutputMode::Interactive,
+            sentinel_now(),
+        );
         assert!(output.contains("15m"), "missing tick interval");
         assert!(output.contains("all promises held"), "missing promise summary");
     }
@@ -2855,7 +2879,11 @@ mod tests {
     #[test]
     fn sentinel_running_contains_drive() {
         let _color = color_guard(false);
-        let output = render_sentinel_status(&test_sentinel_running(), OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
+        let output = render_sentinel_status(
+            &test_sentinel_running(),
+            OutputMode::Interactive,
+            sentinel_now(),
+        );
         assert!(output.contains("WD-18TB"), "missing drive label");
     }
 
@@ -2863,7 +2891,7 @@ mod tests {
     fn sentinel_not_running_shows_message() {
         let _color = color_guard(false);
         let data = SentinelStatusOutput::NotRunning { last_seen: None };
-        let output = render_sentinel_status(&data, OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
+        let output = render_sentinel_status(&data, OutputMode::Interactive, sentinel_now());
         assert!(output.contains("not running"), "missing 'not running'");
         assert!(output.contains("urd sentinel run"), "missing start hint");
     }
@@ -2874,7 +2902,7 @@ mod tests {
         let data = SentinelStatusOutput::NotRunning {
             last_seen: Some("2026-03-27T10:00:00".to_string()),
         };
-        let output = render_sentinel_status(&data, OutputMode::Interactive, fixed_now("2026-03-27T13:20:00"));
+        let output = render_sentinel_status(&data, OutputMode::Interactive, sentinel_now());
         assert!(output.contains("not running"), "missing 'not running'");
         assert!(output.contains("2026-03-27T10:00:00"), "missing last seen timestamp");
     }
@@ -2940,7 +2968,7 @@ mod tests {
     fn sentinel_assessment_age_is_relative() {
         let _color = color_guard(false);
         let five_min_ago = "2026-03-27T13:15:00".to_string();
-        let now = fixed_now("2026-03-27T13:20:00");
+        let now = sentinel_now();
         let mut data = test_sentinel_running();
         let SentinelStatusOutput::Running { ref mut state, .. } = data else {
             unreachable!()
@@ -2965,7 +2993,7 @@ mod tests {
     #[test]
     fn sentinel_assessment_age_golden_line() {
         let _color = color_guard(false);
-        let now = fixed_now("2026-03-27T13:20:00");
+        let now = sentinel_now();
         let mut data = test_sentinel_running();
         let SentinelStatusOutput::Running { ref mut state, .. } = data else {
             unreachable!()
@@ -2993,7 +3021,7 @@ mod tests {
         let output = render_sentinel_status(
             &data,
             OutputMode::Interactive,
-            fixed_now("2026-03-27T13:20:00"),
+            sentinel_now(),
         );
         assert!(
             output.contains("not-a-timestamp"),
@@ -3006,7 +3034,7 @@ mod tests {
         let output = render_sentinel_status(
             &test_sentinel_running(),
             OutputMode::Daemon,
-            fixed_now("2026-03-27T13:20:00"),
+            sentinel_now(),
         );
         let parsed: serde_json::Value =
             serde_json::from_str(&output).unwrap_or_else(|e| panic!("invalid JSON: {e}\n{output}"));
@@ -4335,7 +4363,11 @@ mod tests {
     #[test]
     fn drives_list_interactive_columns() {
         let _color = color_guard(false);
-        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, fixed_now("2026-03-29T10:00:00"));
+        let output = render_drives_list(
+            &test_drives_list(),
+            OutputMode::Interactive,
+            drives_now(),
+        );
         assert!(output.contains("DRIVE"), "should have header: {output}");
         assert!(output.contains("STATUS"), "should have header: {output}");
         assert!(output.contains("TOKEN"), "should have header: {output}");
@@ -4354,7 +4386,11 @@ mod tests {
     #[test]
     fn drives_list_absent_shows_duration() {
         let _color = color_guard(false);
-        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, fixed_now("2026-03-29T10:00:00"));
+        let output = render_drives_list(
+            &test_drives_list(),
+            OutputMode::Interactive,
+            drives_now(),
+        );
         // The absent drive's last_seen is 2026-03-24, so "absent Nd" should appear
         assert!(
             output.contains("absent") && output.contains("d"),
@@ -4365,7 +4401,11 @@ mod tests {
     #[test]
     fn drives_list_uuid_mismatch_shows_status() {
         let _color = color_guard(false);
-        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, fixed_now("2026-03-29T10:00:00"));
+        let output = render_drives_list(
+            &test_drives_list(),
+            OutputMode::Interactive,
+            drives_now(),
+        );
         assert!(
             output.contains("uuid mismatch"),
             "uuid mismatch drive should show status: {output}"
@@ -4375,7 +4415,11 @@ mod tests {
     #[test]
     fn drives_list_token_column_uses_ascii() {
         let _color = color_guard(false);
-        let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, fixed_now("2026-03-29T10:00:00"));
+        let output = render_drives_list(
+            &test_drives_list(),
+            OutputMode::Interactive,
+            drives_now(),
+        );
         assert!(output.contains("ok"), "Verified token should show 'ok': {output}");
         // Token column should not contain Unicode check/cross marks
         assert!(
@@ -4392,7 +4436,7 @@ mod tests {
     #[test]
     fn drives_list_absent_duration_golden_line() {
         let _color = color_guard(false);
-        let now = fixed_now("2026-03-29T10:00:00");
+        let now = drives_now();
         let output = render_drives_list(&test_drives_list(), OutputMode::Interactive, now);
         assert_eq!(
             output,
@@ -4406,7 +4450,7 @@ mod tests {
 
     #[test]
     fn drives_list_daemon_valid_json() {
-        let output = render_drives_list(&test_drives_list(), OutputMode::Daemon, fixed_now("2026-03-29T10:00:00"));
+        let output = render_drives_list(&test_drives_list(), OutputMode::Daemon, drives_now());
         let parsed: serde_json::Value =
             serde_json::from_str(&output).expect("should be valid JSON");
         assert!(parsed["drives"].is_array());

--- a/src/voice/plan.rs
+++ b/src/voice/plan.rs
@@ -29,6 +29,14 @@ pub fn render_empty_plan(explanation: &crate::output::EmptyPlanExplanation) -> S
     out
 }
 
+/// Render the terse "nothing to do" line for a manual backup whose plan
+/// came up empty with no skipped subvolumes to explain (see
+/// `render_empty_plan` for the richer case).
+#[must_use]
+pub fn render_nothing_to_do() -> String {
+    format!("{}\n", "Nothing to do.".dimmed())
+}
+
 /// Render plan output according to the given mode.
 ///
 /// `verbose` gates the per-operation wall (UPI 028): the default output is

--- a/src/voice/sentinel.rs
+++ b/src/voice/sentinel.rs
@@ -9,11 +9,18 @@ use colored::Colorize;
 use crate::awareness::PromiseStatus;
 use crate::output::{OutputMode, SentinelStatusOutput};
 
-/// Render sentinel status output according to the given mode.
+/// Render sentinel status output according to the given mode. `now` is the
+/// caller's wall-clock reading, threaded through to compute the relative
+/// assessment age — the renderer itself stays a pure function of its input
+/// (no `Local::now()` inside `voice/`).
 #[must_use]
-pub fn render_sentinel_status(data: &SentinelStatusOutput, mode: OutputMode) -> String {
+pub fn render_sentinel_status(
+    data: &SentinelStatusOutput,
+    mode: OutputMode,
+    now: chrono::NaiveDateTime,
+) -> String {
     match mode {
-        OutputMode::Interactive => render_sentinel_status_interactive(data),
+        OutputMode::Interactive => render_sentinel_status_interactive(data, now),
         OutputMode::Daemon => {
             serde_json::to_string_pretty(data)
                 .unwrap_or_else(|e| format!("{{\"error\": \"{e}\"}}"))
@@ -21,7 +28,10 @@ pub fn render_sentinel_status(data: &SentinelStatusOutput, mode: OutputMode) -> 
     }
 }
 
-fn render_sentinel_status_interactive(data: &SentinelStatusOutput) -> String {
+fn render_sentinel_status_interactive(
+    data: &SentinelStatusOutput,
+    now: chrono::NaiveDateTime,
+) -> String {
     let mut out = String::new();
 
     match data {
@@ -44,7 +54,7 @@ fn render_sentinel_status_interactive(data: &SentinelStatusOutput) -> String {
                     out,
                     "  {:<14}{} (tick: {})",
                     "Assessment",
-                    humanize_assessment_age(last),
+                    humanize_assessment_age(last, now),
                     tick_desc
                 )
                 .ok();
@@ -78,16 +88,13 @@ fn render_sentinel_status_interactive(data: &SentinelStatusOutput) -> String {
 }
 
 /// Format the sentinel state file's ISO `last_assessment` stamp as a
-/// relative age ("5m ago"). Falls back to the raw string when it doesn't
-/// parse (hand-edited state file) — degraded, never wrong.
-fn humanize_assessment_age(timestamp: &str) -> String {
+/// relative age ("5m ago") from `now`. Falls back to the raw string when it
+/// doesn't parse (hand-edited state file) — degraded, never wrong.
+fn humanize_assessment_age(timestamp: &str, now: chrono::NaiveDateTime) -> String {
     let Ok(ts) = chrono::NaiveDateTime::parse_from_str(timestamp, "%Y-%m-%dT%H:%M:%S") else {
         return timestamp.to_string();
     };
-    let mins = chrono::Local::now()
-        .naive_local()
-        .signed_duration_since(ts)
-        .num_minutes();
+    let mins = now.signed_duration_since(ts).num_minutes();
     if mins < 1 {
         "just now".to_string()
     } else {


### PR DESCRIPTION
## Summary
- Part 2 (colored output outside `voice/`): moved the incomplete-snapshot
  deletion prompt (`commands/init.rs`) and the "Nothing to do." line
  (`commands/backup.rs`) into new voice render functions. Command handlers
  now only `println!`/`print!` what voice returns.
- Part 3 (wall clock inside renderers): `voice/drives.rs` and
  `voice/sentinel.rs` no longer call `chrono::Local::now()`. Both take an
  explicit `now: chrono::NaiveDateTime` parameter, computed once by the
  command handler and threaded through — matching the existing
  `age_secs(&self, now: chrono::NaiveDateTime)` idiom in `output.rs`.
- Part 1 (mythic vocabulary in `ActionableAdvice.issue`) is out of scope —
  handled in a separate PR; `src/advice.rs` untouched.

No user-visible change: every renderer produces byte-identical output for
the same input as before (verified with golden tests).

## Changes
- `src/voice/init.rs`: added `render_incomplete_deletion_header`,
  `render_incomplete_deletion_warning`, `render_incomplete_deletion_result`
  — the three colored fragments of the interactive incomplete-snapshot
  deletion prompt. The command handler still owns the blank line, the
  `Delete ...? [y/N]` prompt, stdin, and the btrfs call (none of that is
  colored). Added 4 unit tests pinning the rendered text.
- `src/commands/init.rs`: `handle_incomplete_deletions` now calls the three
  voice functions instead of `colored::Colorize` directly; removed the
  local `use colored::Colorize;`.
- `src/voice/plan.rs`: added `render_nothing_to_do()` next to its sibling
  `render_empty_plan` (both handle a manual backup's empty-plan exit).
  Added a unit test.
- `src/commands/backup.rs`: the empty-plan `else` branch now calls
  `voice::render_nothing_to_do()`; removed the now-unused
  `use colored::Colorize;`.
- `src/voice/drives.rs`: `render_drives_list` and its private helpers
  (`render_drives_list_interactive`, `format_drive_status`,
  `format_absent_duration`) take `now: chrono::NaiveDateTime` instead of
  reading `chrono::Local::now()`.
- `src/voice/sentinel.rs`: `render_sentinel_status` and its private helpers
  (`render_sentinel_status_interactive`, `humanize_assessment_age`) take
  `now: chrono::NaiveDateTime` the same way.
- `src/commands/drives.rs` / `src/commands/sentinel.rs`: compute
  `chrono::Local::now().naive_local()` once and pass it to the renderer.
- `src/voice/mod.rs`: re-exports for the three new `init` functions and
  `render_nothing_to_do`; updated every existing test call site for the
  new `now` parameter; added a shared `fixed_now(iso)` test helper; added
  one golden test per previously-untestable renderer
  (`sentinel_assessment_age_golden_line`,
  `drives_list_absent_duration_golden_line`); rewrote
  `sentinel_assessment_age_is_relative`, which previously built its
  "5 minutes ago" fixture from the *real* wall clock at test time (a
  latent, inadvertent flakiness source), onto fixed timestamps.

## Design decisions
- **Why `now` as a parameter, not a precomputed `*_age_secs` field on the
  output struct** (the pattern the issue points at,
  `output.rs`'s `last_run_age_secs`): both existing timestamp fields are
  serialized. `DriveStatus::Absent { last_seen }` reaches `drives list`'s
  daemon-mode JSON, and `SentinelStateFile` (behind
  `SentinelStatusOutput::Running { state, .. }`) is *also* the on-disk
  Sentinel state file with its own `schema_version` — CLAUDE.md treats
  on-disk contract changes as ADR-gated. Adding a new field to either
  would be a JSON/on-disk surface change for a Patch-tier issue. Passing
  `now` in as an explicit parameter keeps the renderer pure and fully
  golden-testable with **zero** JSON/on-disk surface change — nothing
  for the supervisor to review on that front. Flagging per the issue's
  ask to report this if it came up.
- The `handle_incomplete_deletions` outcome line needed a small type
  massage: `btrfs.delete_subvolume` returns `crate::error::Result<()>`
  (a `thiserror` type), and the voice layer shouldn't depend on
  `error.rs`. The handler converts the error to a `String` once
  (`result.as_ref().err().map(ToString::to_string)`) before handing a
  `Result<(), &str>` to the renderer.

## Acceptance grep guards (not wired into `scripts/check.sh` per the
supervisor's note — listed here for that decision)
```
grep -rn "Colorize\|\.bold()\|\.red()\|\.green()\|\.yellow()\|\.dimmed()" src/commands/
grep -rn "Local::now\|Utc::now" src/voice/
```
(No `"sealed"|"waning"|"exposed"` guard — that's part 1's scope, not touched here.)

## Out of scope / noticed
- Nothing else matching the colored-output-in-commands/ or
  wall-clock-in-voice/ patterns turned up on a full-repo grep.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 2450 passed, 5 ignored (lib) + 1 ignored (integration,
      unchanged from baseline: 2443 passed, 6 ignored total before this PR)
- [x] `bash scripts/check-present-not-journey.sh` — pass
- [x] `bash scripts/check-docs.sh` — pass
- [x] `bash scripts/pre-commit-pii.sh --report` — clean, no findings

Refs #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti
