### PR TITLE
refactor: derive the doctor verdict from the assembled output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no renderer prose changed (#386).
 
 ### Fixed
+- `urd doctor --thorough` no longer reports "N warnings" when the only thing
+  wrong is that a drive is away. Verify's one skipped-check row per absent
+  drive used to be counted as a warning, and a warning outranks the
+  "subvolumes degraded — data is safe, drives are absent" verdict, so the
+  reassuring answer was hidden behind an alarming count. The verdict is now
+  derived once from the assembled report rather than from a tally kept by
+  hand alongside it, so a row that the report itself calls an expected
+  condition can no longer masquerade as a finding (#382).
 - The default webhook notification body is now built with `serde_json`
   instead of hand-escaping only double quotes, so a title or body
   containing a backslash, newline, tab, or other control character

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -26,9 +26,6 @@ use crate::voice;
 use crate::commands::{init, verify};
 
 pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow::Result<()> {
-    let mut warn_count: usize = 0;
-    let mut error_count: usize = 0;
-
     // ── 1. Config checks (preflight — pure, instant) ──────────────
     let preflight_results = preflight::preflight_checks(&config);
     let config_checks: Vec<DoctorCheck> = if preflight_results.is_empty() {
@@ -42,7 +39,6 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         // nothing to protect. Surface as a config warning so the verdict
         // becomes Warnings rather than the misleading Healthy.
         if subvol_count == 0 {
-            warn_count += 1;
             vec![DoctorCheck {
                 name: "No subvolumes configured.".to_string(),
                 status: DoctorCheckStatus::Warn,
@@ -64,7 +60,6 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         preflight_results
             .iter()
             .map(|c| {
-                warn_count += 1;
                 let suggestion = match c.name {
                     "weakening-override" => {
                         Some("Reduce the interval to match, or change protection to custom".to_string())
@@ -89,14 +84,8 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         .map(|c| {
             let status = match c.status {
                 InitStatus::Ok => DoctorCheckStatus::Ok,
-                InitStatus::Warn => {
-                    warn_count += 1;
-                    DoctorCheckStatus::Warn
-                }
-                InitStatus::Error => {
-                    error_count += 1;
-                    DoctorCheckStatus::Error
-                }
+                InitStatus::Warn => DoctorCheckStatus::Warn,
+                InitStatus::Error => DoctorCheckStatus::Error,
             };
             DoctorCheck {
                 name: c.name,
@@ -130,13 +119,6 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
             build_sudoers_drift_checks(&config, listing.as_deref())
         }
     };
-    for check in &drift_checks {
-        match check.status {
-            DoctorCheckStatus::Warn => warn_count += 1,
-            DoctorCheckStatus::Error => error_count += 1,
-            DoctorCheckStatus::Ok => {}
-        }
-    }
     infra_checks.extend(drift_checks);
 
     // ── Units drift + linger (UPI 075) ───────────────────────────
@@ -161,18 +143,10 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     {
         units_checks.extend(linger_check());
     }
-    for check in &units_checks {
-        match check.status {
-            DoctorCheckStatus::Warn => warn_count += 1,
-            DoctorCheckStatus::Error => error_count += 1,
-            DoctorCheckStatus::Ok => {}
-        }
-    }
     infra_checks.extend(units_checks);
 
     // UUID fingerprinting checks for mounted drives
     for (label, _uuid, snippet) in drives::check_missing_uuids(&config.drives) {
-        warn_count += 1;
         infra_checks.push(DoctorCheck {
             name: format!("{label}: no UUID configured"),
             status: DoctorCheckStatus::Warn,
@@ -190,7 +164,6 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         if let Ok(free) = drives::filesystem_free_bytes(&root.path)
             && free < min_free * 2
         {
-            warn_count += 1;
             let free_display = crate::types::ByteSize(free);
             let threshold_display = crate::types::ByteSize(min_free);
             infra_checks.push(DoctorCheck {
@@ -234,7 +207,6 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
                 }
                 PromiseStatus::Protected => advice.as_ref().map(unpack_advice).unwrap_or_default(),
                 PromiseStatus::Unprotected => {
-                    error_count += 1;
                     advice.as_ref().map(unpack_advice).unwrap_or_else(|| {
                         (
                             Some("exposed — data may not be recoverable".to_string()),
@@ -244,7 +216,6 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
                     })
                 }
                 PromiseStatus::AtRisk => {
-                    warn_count += 1;
                     advice.as_ref().map(unpack_advice).unwrap_or_else(|| {
                         (
                             Some("waning".to_string()),
@@ -298,7 +269,6 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
                 }
             }
             _ => {
-                warn_count += 1;
                 DoctorSentinelStatus {
                     running: false,
                     pid: None,
@@ -322,11 +292,6 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         None
     };
 
-    if let Some(ref v) = verify_output {
-        warn_count += v.warn_count as usize;
-        error_count += v.fail_count as usize;
-    }
-
     // ── 5.5 Churn (UPI 030 — only with --thorough) ────────────────
     let churn_view = if args.thorough {
         Some(build_doctor_churn_view(&config, world.db()))
@@ -347,27 +312,6 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
     } else {
         Vec::new()
     };
-    warn_count += retention_checks.len();
-
-    // ── 6. Verdict ────────────────────────────────────────────────
-    let degraded_count = data_safety
-        .iter()
-        .filter(|d| d.status == PromiseStatus::Protected && d.health != "healthy")
-        .count();
-
-    // NOTE: When --thorough is used, verify's drive-mounted warnings inflate warn_count.
-    // This can mask the Degraded verdict when absent drives are the only issue.
-    // Accepted trade-off: plain `urd doctor` (where status directs users) works correctly.
-    // The --thorough path may show Warnings instead of Degraded in this scenario.
-    let verdict = if error_count > 0 {
-        DoctorVerdict::issues(error_count)
-    } else if warn_count > 0 {
-        DoctorVerdict::warnings(warn_count)
-    } else if degraded_count > 0 {
-        DoctorVerdict::degraded(degraded_count)
-    } else {
-        DoctorVerdict::healthy()
-    };
 
     // UPI 042 Branch G: surface a soft notice when loaded config is older
     // than the current schema. Build SchemaStatus only when there's
@@ -381,7 +325,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         }),
     };
 
-    let output = DoctorOutput {
+    let mut output = DoctorOutput {
         schema_version: crate::output::DOCTOR_OUTPUT_SCHEMA_VERSION,
         config_checks,
         infra_checks,
@@ -392,8 +336,16 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         churn: churn_view,
         recommendations: recommendation_view,
         retention_checks,
-        verdict,
+        // Placeholder — overwritten on the next line, before anything reads it.
+        verdict: DoctorVerdict::healthy(),
     };
+
+    // ── 6. Verdict ─────────────────────────────────────────────────
+    // Derived once, as a pure fold over the assembled output (#382): every
+    // finding this run reports is already a row somewhere above, so the
+    // verdict reads those rows instead of a parallel tally that has to be
+    // kept honest by hand.
+    output.verdict = crate::output::verdict(&output);
 
     print!("{}", voice::render_doctor(&output, output_mode));
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -936,6 +936,89 @@ impl DoctorVerdict {
     }
 }
 
+/// Derive the doctor verdict from the assembled output — a pure fold, no
+/// side counters (#382).
+///
+/// Precedence is unchanged from UPI 045: any error wins (`Issues`), then
+/// any warning (`Warnings`), then any protected-but-unhealthy subvolume
+/// (`Degraded`), else `Healthy`. The count is a sum across every
+/// contributing section, which is why it is not filterable from a single
+/// field on `DoctorOutput`.
+///
+/// What counts:
+/// - `config_checks` / `infra_checks` / `retention_checks`: `Warn` and `Error`.
+/// - `data_safety`: `Unprotected` is an error, `AtRisk` a warning.
+/// - `sentinel`: a stopped daemon is a warning (absent section says nothing).
+/// - `verify` (`--thorough`): every `warn` / `fail` check, plus its
+///   preflight warnings — **except** absent-drive rows
+///   ([`VerifyCheck::is_expected_condition`]). An unmounted drive is not a
+///   finding: data safety already reports it as the cause of `Degraded`,
+///   and counting it as a warning masked that verdict.
+#[must_use]
+pub fn verdict(output: &DoctorOutput) -> DoctorVerdict {
+    let mut warnings: usize = 0;
+    let mut errors: usize = 0;
+
+    let groups = [
+        &output.config_checks,
+        &output.infra_checks,
+        &output.retention_checks,
+    ];
+    for check in groups.into_iter().flatten() {
+        match check.status {
+            DoctorCheckStatus::Warn => warnings += 1,
+            DoctorCheckStatus::Error => errors += 1,
+            DoctorCheckStatus::Ok => {}
+        }
+    }
+
+    for row in &output.data_safety {
+        match row.status {
+            PromiseStatus::Unprotected => errors += 1,
+            PromiseStatus::AtRisk => warnings += 1,
+            PromiseStatus::Protected => {}
+        }
+    }
+
+    if output.sentinel.as_ref().is_some_and(|s| !s.running) {
+        warnings += 1;
+    }
+
+    if let Some(verify) = &output.verify {
+        warnings += verify.preflight_warnings.len();
+        for check in verify
+            .subvolumes
+            .iter()
+            .flat_map(|sv| &sv.drives)
+            .flat_map(|d| &d.checks)
+        {
+            if check.is_warning_finding() {
+                warnings += 1;
+            } else if check.is_failure() {
+                errors += 1;
+            }
+        }
+    }
+
+    // "Protected but not healthy" — the drive-absent posture. `health` is
+    // `OperationalHealth`'s Display form; "healthy" is the only clean value.
+    let degraded = output
+        .data_safety
+        .iter()
+        .filter(|d| d.status == PromiseStatus::Protected && d.health != "healthy")
+        .count();
+
+    if errors > 0 {
+        DoctorVerdict::issues(errors)
+    } else if warnings > 0 {
+        DoctorVerdict::warnings(warnings)
+    } else if degraded > 0 {
+        DoctorVerdict::degraded(degraded)
+    } else {
+        DoctorVerdict::healthy()
+    }
+}
+
 // ── GetOutput ──────────────────────────────────────────────────────────
 
 /// Structured output for the `urd get` command (metadata, not file content).
@@ -1465,6 +1548,20 @@ impl VerifyCheck {
     pub fn is_expected_condition(&self) -> bool {
         self.name == Self::DRIVE_MOUNTED && self.status == "warn"
     }
+
+    /// Returns true if this check is a warning that names a real finding —
+    /// a `warn` that is not an expected condition. The doctor verdict counts
+    /// these; absent-drive rows are reported by data safety instead (#382).
+    #[must_use]
+    pub fn is_warning_finding(&self) -> bool {
+        self.status == "warn" && !self.is_expected_condition()
+    }
+
+    /// Returns true if this check failed.
+    #[must_use]
+    pub fn is_failure(&self) -> bool {
+        self.status == "fail"
+    }
 }
 
 // ── Init output ─────────────────────────────────────────────────────────
@@ -1843,6 +1940,191 @@ mod tests {
             assert_eq!(verdict.status, status);
             assert_eq!(verdict.count, count);
         }
+    }
+
+    // ── verdict() — the verdict as a pure fold over the output (#382) ──
+    //
+    // Doctor no longer keeps a parallel tally: every finding it reports is
+    // a row in `DoctorOutput`, and the verdict counts those rows. These
+    // tests pin the precedence (Issues > Warnings > Degraded > Healthy) and
+    // the one classification that matters — an absent drive under
+    // `--thorough` is an expected condition, not a warning.
+
+    fn blank_doctor_output() -> DoctorOutput {
+        DoctorOutput {
+            schema_version: DOCTOR_OUTPUT_SCHEMA_VERSION,
+            config_checks: Vec::new(),
+            infra_checks: Vec::new(),
+            data_safety: Vec::new(),
+            sentinel: None,
+            schema_status: None,
+            verify: None,
+            churn: None,
+            recommendations: None,
+            retention_checks: Vec::new(),
+            verdict: DoctorVerdict::healthy(),
+        }
+    }
+
+    fn doctor_check(status: DoctorCheckStatus) -> DoctorCheck {
+        DoctorCheck {
+            name: "check".to_string(),
+            status,
+            detail: None,
+            suggestion: None,
+        }
+    }
+
+    fn safety_row(status: PromiseStatus, health: &str) -> DoctorDataSafety {
+        DoctorDataSafety {
+            name: "opptak".to_string(),
+            status,
+            health: health.to_string(),
+            issue: None,
+            suggestion: None,
+            reason: None,
+            storage_posture: None,
+        }
+    }
+
+    fn verify_check(name: &str, status: &str) -> VerifyCheck {
+        VerifyCheck {
+            name: name.to_string(),
+            status: status.to_string(),
+            detail: None,
+            suggestion: None,
+        }
+    }
+
+    /// A `--thorough` verify section carrying these checks on one
+    /// subvolume/drive pair. Its own `warn_count` / `fail_count` are set to
+    /// values the verdict must ignore: it folds the rows, not the tallies.
+    fn verify_section(checks: Vec<VerifyCheck>, preflight: Vec<String>) -> VerifyOutput {
+        VerifyOutput {
+            subvolumes: vec![VerifySubvolume {
+                name: "opptak".to_string(),
+                drives: vec![VerifyDrive {
+                    label: "WD-EXT".to_string(),
+                    checks,
+                }],
+            }],
+            preflight_warnings: preflight,
+            ok_count: 0,
+            warn_count: 99,
+            fail_count: 99,
+        }
+    }
+
+    #[test]
+    fn verdict_healthy_when_no_section_speaks() {
+        let output = blank_doctor_output();
+        assert_eq!(verdict(&output), DoctorVerdict::healthy());
+    }
+
+    #[test]
+    fn verdict_healthy_ignores_ok_rows_and_a_running_sentinel() {
+        let mut output = blank_doctor_output();
+        output.config_checks = vec![doctor_check(DoctorCheckStatus::Ok)];
+        output.infra_checks = vec![doctor_check(DoctorCheckStatus::Ok)];
+        output.data_safety = vec![safety_row(PromiseStatus::Protected, "healthy")];
+        output.sentinel = Some(DoctorSentinelStatus {
+            running: true,
+            pid: Some(1),
+            uptime: None,
+        });
+        assert_eq!(verdict(&output), DoctorVerdict::healthy());
+    }
+
+    #[test]
+    fn verdict_counts_warnings_from_every_contributing_section() {
+        let mut output = blank_doctor_output();
+        output.config_checks = vec![doctor_check(DoctorCheckStatus::Warn)];
+        output.infra_checks = vec![doctor_check(DoctorCheckStatus::Warn)];
+        output.retention_checks = vec![doctor_check(DoctorCheckStatus::Warn)];
+        output.data_safety = vec![safety_row(PromiseStatus::AtRisk, "degraded")];
+        output.sentinel = Some(DoctorSentinelStatus {
+            running: false,
+            pid: None,
+            uptime: None,
+        });
+        output.verify = Some(verify_section(
+            vec![verify_check("stale-pin", "warn")],
+            vec!["interval weakens the named level".to_string()],
+        ));
+        // config + infra + retention + at-risk + sentinel + verify + verify
+        // preflight = 7.
+        assert_eq!(verdict(&output), DoctorVerdict::warnings(7));
+    }
+
+    #[test]
+    fn verdict_errors_win_and_count_only_errors() {
+        let mut output = blank_doctor_output();
+        output.infra_checks = vec![
+            doctor_check(DoctorCheckStatus::Error),
+            doctor_check(DoctorCheckStatus::Warn),
+        ];
+        output.data_safety = vec![
+            safety_row(PromiseStatus::Unprotected, "blocked"),
+            safety_row(PromiseStatus::AtRisk, "degraded"),
+        ];
+        output.verify = Some(verify_section(
+            vec![verify_check("pin-exists-drive", "fail")],
+            Vec::new(),
+        ));
+        assert_eq!(verdict(&output), DoctorVerdict::issues(3));
+    }
+
+    #[test]
+    fn verdict_degraded_when_protected_subvolumes_are_unhealthy_and_nothing_warns() {
+        let mut output = blank_doctor_output();
+        output.data_safety = vec![
+            safety_row(PromiseStatus::Protected, "degraded"),
+            safety_row(PromiseStatus::Protected, "degraded"),
+            safety_row(PromiseStatus::Protected, "healthy"),
+        ];
+        assert_eq!(verdict(&output), DoctorVerdict::degraded(2));
+    }
+
+    #[test]
+    fn verdict_warnings_outrank_degraded() {
+        let mut output = blank_doctor_output();
+        output.data_safety = vec![safety_row(PromiseStatus::Protected, "degraded")];
+        output.infra_checks = vec![doctor_check(DoctorCheckStatus::Warn)];
+        assert_eq!(verdict(&output), DoctorVerdict::warnings(1));
+    }
+
+    /// Regression (#382): under `--thorough`, verify emits one
+    /// `drive-mounted` warn per absent drive. Those used to be counted as
+    /// verdict warnings, which outranked and hid the Degraded verdict that
+    /// data safety had already earned for exactly the same absent drive.
+    #[test]
+    fn verdict_absent_drive_under_thorough_does_not_mask_degraded() {
+        let mut output = blank_doctor_output();
+        output.data_safety = vec![
+            safety_row(PromiseStatus::Protected, "degraded"),
+            safety_row(PromiseStatus::Protected, "degraded"),
+        ];
+        output.verify = Some(verify_section(
+            vec![
+                verify_check(VerifyCheck::DRIVE_MOUNTED, "warn"),
+                verify_check("pin-file", "ok"),
+            ],
+            Vec::new(),
+        ));
+        assert_eq!(verdict(&output), DoctorVerdict::degraded(2));
+    }
+
+    #[test]
+    fn verdict_absent_drive_does_not_inflate_a_real_warning_count() {
+        let mut output = blank_doctor_output();
+        output.verify = Some(verify_section(
+            vec![
+                verify_check(VerifyCheck::DRIVE_MOUNTED, "warn"),
+                verify_check("orphans", "warn"),
+            ],
+            Vec::new(),
+        ));
+        assert_eq!(verdict(&output), DoctorVerdict::warnings(1));
     }
 
     // ── RedundancyAdvisory tests ────────────────────────────────────────


### PR DESCRIPTION
## Summary

`doctor::run` maintained a tally alongside the report it was summarizing:
16 hand-written `warn_count` / `error_count` increments spread across six
independent check groups, folded into the verdict 300 lines later. The
function's own NOTE admitted what that cost: under `--thorough`, verify's
one skipped-check row per absent drive was counted as a warning, and a
warning outranks Degraded — so the reassuring "N subvolumes degraded. Data
is safe — drives are absent." verdict was hidden behind an alarming
warning count, in exactly the situation Urd should be calm about.

The verdict is now `output::verdict(&DoctorOutput)`: a pure function of
the assembled output (ADR-108), no I/O, no arguments but the report.
All 16 increments are gone.

### The audit: every increment → the output row that already carried it

Done before writing any code. No increment turned out to be orphaned —
there was no warning counted but never emitted — so nothing had to be
added to the output to make the fold complete. Every increment was a
duplicate of a fact the report was already telling.

| # | Increment site (pre-change line) | Output field carrying the same fact |
|---|---|---|
| 1 | `:45` zero-subvolume config warning | `config_checks[].status == Warn` |
| 2 | `:67` per preflight result | `config_checks[].status == Warn` |
| 3 | `:93` `InitStatus::Warn` | `infra_checks[].status == Warn` |
| 4 | `:97` `InitStatus::Error` | `infra_checks[].status == Error` |
| 5 | `:135` sudoers drift Warn | `infra_checks[].status == Warn` |
| 6 | `:136` sudoers drift Error | `infra_checks[].status == Error` |
| 7 | `:166` units/linger drift Warn | `infra_checks[].status == Warn` |
| 8 | `:167` units/linger drift Error | `infra_checks[].status == Error` |
| 9 | `:175` drive without a UUID | `infra_checks[].status == Warn` |
| 10 | `:193` space-trend threshold | `infra_checks[].status == Warn` |
| 11 | `:237` `PromiseStatus::Unprotected` | `data_safety[].status == UNPROTECTED` |
| 12 | `:247` `PromiseStatus::AtRisk` | `data_safety[].status == AT RISK` |
| 13 | `:301` sentinel not running | `sentinel.running == false` |
| 14 | `:326` `verify.warn_count` | `verify.subvolumes[].drives[].checks[].status == "warn"` + `verify.preflight_warnings[]` |
| 15 | `:327` `verify.fail_count` | `verify.subvolumes[].drives[].checks[].status == "fail"` |
| 16 | `:350` `retention_checks.len()` | `retention_checks[].status == Warn` |

Rows 14/15 fold verify's own structure rather than reading its aggregate
`warn_count` / `fail_count` fields — the aggregates are themselves
hand-maintained counters inside `verify.rs`, and folding the rows makes
doctor's verdict independent of them. The two agree today (verified: every
`total_warn` / `total_fail` increment in `collect_verify_output` accompanies
a check pushed into the structure, and preflight warnings land in
`preflight_warnings`), and the tests set verify's aggregates to garbage
values to prove the verdict ignores them.

### The masking fix: classification, not reordering

Precedence is untouched: Issues > Warnings > Degraded > Healthy.

`VerifyCheck` already carried the right distinction —
`is_expected_condition()` (`name == "drive-mounted" && status == "warn"`),
the predicate `voice::classify_verify_checks` uses to render absent drives
as "not mounted — skipped" instead of as a finding. The verdict now honours
the same predicate, so the verdict line and the section body can no longer
disagree about what counts as a problem. An absent drive is already
reported by `data_safety` as the cause of Degraded; counting it a second
time as a warning was double-reporting one fact under two severities.

No new `DoctorCheckStatus::Info` variant was needed, so **no JSON enum
change and no `schema_version` bump**. `verdict.status` / `verdict.count`
keep their shape; the count changes only in the case the deleted NOTE
described. `docs/20-reference/cli.md` documents `urd doctor`'s contract but
not its JSON verdict fields, so no reference update was required.

## Changes

**`src/output.rs`**
- New `pub fn verdict(output: &DoctorOutput) -> DoctorVerdict` next to
  `DoctorVerdict` — the single source of truth for the verdict, folding
  config/infra/retention check statuses, data-safety promise states, the
  sentinel row, and (under `--thorough`) verify's checks and preflight
  warnings. Doc comment enumerates exactly what counts and why absent
  drives don't.
- `VerifyCheck::is_warning_finding()` and `is_failure()` beside the existing
  `is_expected_condition()`, so verify's stringly `status: String` is matched
  in one impl block rather than at each call site.
- Eight table-ish tests for `verdict()` (see Test plan).

**`src/commands/doctor.rs`**
- Deleted all 16 increments, both counter declarations, the `degraded_count`
  local, and the "Accepted trade-off" NOTE (no longer true).
- `DoctorOutput` is built with a placeholder verdict and sealed on the next
  line by `output.verdict = crate::output::verdict(&output);`. The
  placeholder is overwritten before anything reads it — the alternative
  (passing every section to a many-argument builder) would reintroduce by
  hand the coupling the fold exists to remove.
- The storage-pressure block (`free < min_free * 2`) is left in place per
  the concurrent #383 work: only the `warn_count += 1;` line inside it is
  gone; the literal, the condition, and the block's position are untouched.

**`CHANGELOG.md`** — one bullet under `### Fixed` (the masking is
user-visible).

## Out of scope / noticed

- **Preflight warnings are double-counted under `--thorough`.** Both
  `doctor`'s `config_checks` and `verify`'s `preflight_warnings` come from
  `preflight::preflight_checks(&config)`, so a config preflight warning adds
  2 to the count under `--thorough`. This predates the PR; the fold
  reproduces it deliberately so counts stay byte-identical outside the
  masking case. Worth a follow-up.
- **`urd doctor` always exits 0.** `docs/20-reference/cli.md` says exit `1`
  "if any check is `Error`", but `run()` returns `Ok(())` unconditionally
  and `main.rs` does nothing further. Now that the verdict is a value
  derived in one place, wiring the exit code to it is a small, separate
  change.
- **`VerifyCheck::status` is a `String`, and `DoctorDataSafety::health` is a
  `String`** (`"healthy"` compared by literal, as before). Typing either
  would touch verify's JSON shape and several renderers — not this PR.

## Test plan

- [x] `output::verdict` — healthy on an empty report; healthy with `Ok` rows
      and a running sentinel; warnings summed across all seven contributing
      sources (7); errors win and count only errors (3, with warnings
      present); degraded counted from protected-but-unhealthy rows only;
      warnings outrank degraded.
- [x] **Regression for the documented masking case**: two degraded protected
      subvolumes + a `--thorough` verify section whose only warn is
      `drive-mounted` → `Degraded(2)`, not `Warnings`.
- [x] Absent-drive rows don't inflate a real warning count either (a
      `drive-mounted` warn alongside an `orphans` warn → `Warnings(1)`).
- [x] Existing doctor JSON / voice-contract tests pass unchanged (nothing
      edited in `voice/`, `voice_contract.rs`, or the doctor JSON tests).
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test` — **2494 passed, 0 failed, 5 ignored** (branch baseline
      2486; +8 new tests). Ran with `touch src/main.rs` first to avoid a
      stale shared-target binary.
- [x] `scripts/check-present-not-journey.sh`, `scripts/check-docs.sh` — pass.
- [x] `scripts/pre-commit-pii.sh --report` — clean.

Branch fast-forwarded onto `origin/master` (`737c646`) before committing, so
the CHANGELOG bullet sits on top of the four PRs that landed meanwhile.

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti
