### PR TITLE
refactor: one emergency walk, one name for the min_free_bytes ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surfaces where a miscalibrated line matters most — under the
   no-falsehood, first-line, and gravity-calibration rules. Test-only;
   no renderer prose changed (#386).
+- `urd emergency` now deletes exactly the snapshots it listed before asking
+  for confirmation, instead of re-reading the snapshot directories after the
+  prompt and deleting whatever it found the second time. What you confirm is
+  what is removed. The set itself is unchanged, and both the interactive
+  command and the automatic pre-backup emergency pass now select it through
+  one shared walk, so they cannot drift apart (#383).
 
 ### Fixed
 - `urd doctor --thorough` no longer reports "N warnings" when the only thing

--- a/src/commands/backup.rs
+++ b/src/commands/backup.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 use crate::awareness::{PromiseStatus, SubvolAssessment};
 use crate::btrfs::{BtrfsOps, RealBtrfs};
 use crate::cli::BackupArgs;
+use crate::commands::emergency;
 use crate::commands::storage_signals;
 use crate::commands::world::{self, World};
 use crate::config::Config;
@@ -2277,9 +2278,10 @@ fn format_elapsed(d: Duration) -> String {
 
 /// Emergency pre-flight: check each snapshot root for critical space conditions.
 ///
-/// If any root has `free_bytes < min_free_bytes / 2` (critical threshold), run
-/// `emergency_retention()` on that root's subvolumes and delete the results.
-/// Returns `true` if any deletions were performed (caller should re-plan).
+/// If any root is below `guard::emergency_automatic_threshold` (half
+/// `min_free_bytes` — the unattended rung of the ladder), walk that root with
+/// the shared `emergency::emergency_walk` and delete what it offers. Returns
+/// `true` if any deletions were performed (caller should re-plan).
 ///
 /// Runs under the advisory lock. Skips roots without `min_free_bytes`.
 /// Skips transient subvolumes. Isolates per-subvolume failures (ADR-109).
@@ -2370,9 +2372,10 @@ struct EmergencyRootReclaim {
 
 /// Testable core of [`run_emergency_preflight`]: the free-space probe and the
 /// btrfs handle are injected and the clock is passed in, so the ADR-107
-/// deletion path is unit-testable without a live filesystem. Reads snapshot
-/// dirs / pin files and issues deletes via `btrfs`, returning the prune events
-/// (the wrapper records them best-effort).
+/// deletion path is unit-testable without a live filesystem. Selects candidates
+/// through `emergency::emergency_walk` — the same walk `urd emergency` renders
+/// — and issues the deletes via `btrfs`, returning the prune events (the
+/// wrapper records them best-effort).
 ///
 /// `now` is read once per pass — not per subvolume as the inline version did —
 /// so every prune event in one pass shares an `occurred_at`. Benign: the events
@@ -2399,8 +2402,9 @@ fn run_emergency_preflight_with(
 
         let free = free_bytes(&root.path).unwrap_or(u64::MAX);
 
-        // Critical threshold: below 50% of min_free_bytes
-        if free >= min_free / 2 {
+        // Critical threshold: the narrowest rung of the min_free_bytes ladder
+        // (`guard`), because this is the only rung that deletes unattended.
+        if free >= guard::emergency_automatic_threshold(min_free) {
             continue;
         }
 
@@ -2413,39 +2417,15 @@ fn run_emergency_preflight_with(
 
         let mut root_deleted: usize = 0;
 
-        for subvol_name in &root.subvolumes {
-            // Skip transient subvolumes — already delete aggressively
-            let subvol = resolved.iter().find(|s| &s.name == subvol_name);
-            if subvol.is_some_and(|s| s.local_retention.is_transient()) {
-                continue;
-            }
-
-            let local_dir = root.path.join(subvol_name);
-            let snaps = match plan::read_snapshot_dir(&local_dir) {
-                Ok(s) => s,
-                Err(e) => {
-                    log::warn!(
-                        "Emergency: cannot read {}: {e} — skipping",
-                        local_dir.display()
-                    );
-                    continue;
-                }
-            };
-
-            if snaps.is_empty() {
-                continue;
-            }
-
-            let latest = snaps.iter().max().unwrap().clone();
-            let pinned =
-                crate::chain::find_pinned_snapshots(&local_dir, &drive_labels);
-
-            let mut result = crate::retention::emergency_retention(
-                &snaps,
-                &latest,
-                &pinned,
-                now,
-            );
+        // The shared per-root walk (issue #383): transient skip, snapshot
+        // enumeration, pin read, and `emergency_retention` — one
+        // implementation, also driving `urd emergency`'s assessment.
+        for subvol in emergency::emergency_walk(root, &resolved, &drive_labels, now) {
+            let emergency::EmergencySubvolPlan {
+                inputs, mut result, ..
+            } = subvol;
+            let subvol_name = &inputs.name;
+            let local_dir = &inputs.local_dir;
 
             // Map snap → its emitted event (by snapshot name) so we can
             // persist only events whose underlying delete succeeded.
@@ -2656,6 +2636,7 @@ mod tests {
     };
     use crate::types::Interval;
     use crate::types::{DeleteKind, FullSendReason, PlannedOperation};
+    use std::collections::BTreeSet;
     use std::path::PathBuf;
 
     // ── Mid-op watchdog arming + reserve-create (UPI 033) ──────────────
@@ -3366,6 +3347,60 @@ source = "/data/beta"
             "the only snapshot is the latest — never deleted"
         );
         assert!(!out.any_deleted);
+    }
+
+    #[test]
+    fn emergency_command_and_preflight_offer_the_same_candidates() {
+        // Issue #383: `urd emergency` and this preflight share one walk, so
+        // for the same root they must select the same snapshots. If they
+        // could drift, the interactive surface would confirm one set and the
+        // unattended one delete another.
+        let dir = tempfile::TempDir::new().unwrap();
+        let alpha = dir.path().join("alpha");
+        make_snap_dirs(&alpha, &THREE_SNAPS);
+        let mut config = emergency_config(dir.path());
+        config.drives.push(crate::config::DriveConfig {
+            label: "D1".to_string(),
+            uuid: None,
+            mount_path: std::path::PathBuf::from("/mnt/d1"),
+            snapshot_root: ".snapshots".to_string(),
+            role: crate::types::DriveRole::Offsite,
+            max_usage_percent: None,
+            min_free_bytes: None,
+            rotation_interval: None,
+        });
+        std::fs::write(
+            alpha.join(".last-external-parent-D1"),
+            "20260101-1200-alpha\n",
+        )
+        .unwrap();
+
+        // The unattended surface: what the preflight actually deleted.
+        let mock = crate::btrfs::MockBtrfs::new();
+        run_emergency_preflight_with(&config, pass_now(), &mock, below()).unwrap();
+        let executed: BTreeSet<PathBuf> = deleted_paths(&mock).into_iter().collect();
+
+        // The interactive surface: what `urd emergency` renders and asks the
+        // user to confirm. 400 MB is below both rungs of the ladder.
+        let rendered: BTreeSet<PathBuf> =
+            emergency::assess_roots(&config, pass_now(), below())
+                .iter()
+                .filter(|a| a.assessment.is_critical)
+                .flat_map(|a| a.plans.iter())
+                .flat_map(|p| {
+                    p.result
+                        .delete
+                        .iter()
+                        .map(|d| p.inputs.local_dir.join(d.snapshot.as_str()))
+                })
+                .collect();
+
+        assert_eq!(
+            rendered,
+            BTreeSet::from([alpha.join("20260102-1200-alpha")]),
+            "the pinned oldest and the latest survive on both surfaces"
+        );
+        assert_eq!(rendered, executed, "one walk, one candidate set");
     }
 
     fn make_outcome(

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -162,7 +162,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
         };
         let min_free = min_free_bs.bytes();
         if let Ok(free) = drives::filesystem_free_bytes(&root.path)
-            && free < min_free * 2
+            && free < crate::guard::doctor_warn_threshold(min_free)
         {
             let free_display = crate::types::ByteSize(free);
             let threshold_display = crate::types::ByteSize(min_free);

--- a/src/commands/emergency.rs
+++ b/src/commands/emergency.rs
@@ -1,86 +1,219 @@
+use std::collections::HashSet;
 use std::io::IsTerminal;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use crate::btrfs::{BtrfsOps, RealBtrfs, SystemBtrfs};
 use crate::chain;
-use crate::config::Config;
+use crate::config::{Config, ResolvedSubvolume, SnapshotRoot};
 use crate::drives;
+use crate::guard;
 use crate::output::{
     EmergencyOutput, EmergencyResult, EmergencyRootAssessment, EmergencySubvolDetail, OutputMode,
 };
 use crate::plan;
-use crate::retention;
+use crate::retention::{self, RetentionResult};
+use crate::types::SnapshotName;
 use crate::voice;
 
-pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
+/// One subvolume's already-read emergency inputs: the snapshots present in
+/// its local dir and the pin set guarding them (issue #383).
+///
+/// The I/O half of the emergency walk, split from the decision half so the
+/// decision stays pure (ADR-108) and testable without a filesystem.
+#[derive(Debug, Clone)]
+pub(crate) struct EmergencySubvolInputs {
+    pub(crate) name: String,
+    pub(crate) local_dir: PathBuf,
+    pub(crate) snapshots: Vec<SnapshotName>,
+    pub(crate) pinned: HashSet<SnapshotName>,
+}
+
+/// What the emergency walk decided for one subvolume: the inputs it read, the
+/// newest snapshot, and the `retention::emergency_retention` verdict.
+///
+/// The two surfaces differ only in what they do with this: `urd emergency`
+/// renders it and asks, the pre-backup preflight deletes.
+#[derive(Debug, Clone)]
+pub(crate) struct EmergencySubvolPlan {
+    pub(crate) inputs: EmergencySubvolInputs,
+    pub(crate) latest: SnapshotName,
+    pub(crate) result: RetentionResult,
+}
+
+/// One root's assessment plus the plans behind it. The plans travel with the
+/// assessment so the walk happens once per invocation: `urd emergency` deletes
+/// exactly the set the user confirmed, never a freshly re-read one.
+#[derive(Debug)]
+pub(crate) struct AssessedRoot {
+    pub(crate) assessment: EmergencyRootAssessment,
+    pub(crate) plans: Vec<EmergencySubvolPlan>,
+}
+
+/// Decide which snapshots emergency retention may reclaim, per subvolume.
+/// Pure (ADR-108) — no I/O and no clock; `now` only stamps the prune events.
+///
+/// A subvolume with no snapshots yields no plan at all: there is no `latest`
+/// to anchor the keep set on, and nothing to delete. Everything else is
+/// delegated to [`retention::emergency_retention`], which keeps the newest
+/// snapshot and every pin (ADR-106 layers 1–2) and offers up the middle.
+#[must_use]
+pub(crate) fn emergency_candidates(
+    inputs: &[EmergencySubvolInputs],
+    now: chrono::NaiveDateTime,
+) -> Vec<EmergencySubvolPlan> {
+    inputs
+        .iter()
+        .filter_map(|sv| {
+            let latest = sv.snapshots.iter().max()?.clone();
+            let result =
+                retention::emergency_retention(&sv.snapshots, &latest, &sv.pinned, now);
+            Some(EmergencySubvolPlan {
+                inputs: sv.clone(),
+                latest,
+                result,
+            })
+        })
+        .collect()
+}
+
+/// Read the emergency inputs for one snapshot root: each non-transient
+/// subvolume's snapshot list and pin set.
+///
+/// Two skips, both in the safe direction for a walk whose only product is
+/// deletions:
+/// - **Transient subvolumes** are skipped outright — their own retention
+///   already deletes down to the working set, so there is nothing for an
+///   emergency to reclaim.
+/// - **An unreadable snapshot dir** is logged and skipped (ADR-109 error
+///   isolation). Fail-open for the *assessment* is fail-closed for the
+///   *deletion*: a subvolume Urd cannot enumerate contributes no candidates,
+///   so an I/O failure can never widen the delete set.
+fn gather_emergency_inputs(
+    root: &SnapshotRoot,
+    resolved: &[ResolvedSubvolume],
+    drive_labels: &[String],
+) -> Vec<EmergencySubvolInputs> {
+    let mut inputs = Vec::new();
+
+    for subvol_name in &root.subvolumes {
+        // Skip transient subvolumes — already delete aggressively
+        let subvol = resolved.iter().find(|s| &s.name == subvol_name);
+        if subvol.is_some_and(|s| s.local_retention.is_transient()) {
+            continue;
+        }
+
+        let local_dir = root.path.join(subvol_name);
+        let snapshots = match plan::read_snapshot_dir(&local_dir) {
+            Ok(s) => s,
+            Err(e) => {
+                log::warn!(
+                    "Emergency: cannot read snapshot dir {}: {e} — skipping",
+                    local_dir.display()
+                );
+                continue;
+            }
+        };
+
+        if snapshots.is_empty() {
+            continue;
+        }
+
+        let pinned = chain::find_pinned_snapshots(&local_dir, drive_labels);
+
+        inputs.push(EmergencySubvolInputs {
+            name: subvol_name.clone(),
+            local_dir,
+            snapshots,
+            pinned,
+        });
+    }
+
+    inputs
+}
+
+/// The per-root emergency walk — the one implementation both surfaces share
+/// (issue #383). Gathers the I/O-bound inputs, then applies the pure decision.
+///
+/// Callers still owe the ADR-106 layer-3 re-check
+/// ([`chain::is_pinned_at_delete_time`]) immediately before each delete: this
+/// walk reads pins once, at planning time, and cannot see a pin written
+/// between here and the delete.
+#[must_use]
+pub(crate) fn emergency_walk(
+    root: &SnapshotRoot,
+    resolved: &[ResolvedSubvolume],
+    drive_labels: &[String],
+    now: chrono::NaiveDateTime,
+) -> Vec<EmergencySubvolPlan> {
+    let inputs = gather_emergency_inputs(root, resolved, drive_labels);
+    emergency_candidates(&inputs, now)
+}
+
+/// Snapshots this plan would delete that have never reached a drive: those
+/// newer than the oldest pin which are neither pinned nor the latest. With no
+/// pins at all nothing was ever sent, so everything but the latest counts.
+/// Pure — drives the "chain will break" warning in the assessment.
+#[must_use]
+fn unsent_count(subvol: &EmergencySubvolPlan) -> usize {
+    let snaps = &subvol.inputs.snapshots;
+    let pinned = &subvol.inputs.pinned;
+    match pinned.iter().min() {
+        Some(oldest) => snaps
+            .iter()
+            .filter(|s| *s > oldest && !pinned.contains(*s) && **s != subvol.latest)
+            .count(),
+        // No pins = nothing ever sent. All except latest are "unsent"
+        None => snaps.iter().filter(|s| **s != subvol.latest).count(),
+    }
+}
+
+/// Assess every snapshot root: how much space is free, whether that is a
+/// crisis, and what emergency retention would reclaim if it were.
+///
+/// The injectable core of [`run`] — the free-space probe is passed in and the
+/// clock is passed in, so the assessment `urd emergency` renders is testable
+/// without a live filesystem (mirroring `backup::run_emergency_preflight_with`
+/// on the automatic side).
+///
+/// A root whose probe fails reads as `u64::MAX` free — never critical, never
+/// a candidate for deletion (ADR-107: never delete what cannot be confirmed
+/// unsafe to keep).
+#[must_use]
+pub(crate) fn assess_roots(
+    config: &Config,
+    now: chrono::NaiveDateTime,
+    free_bytes: impl Fn(&Path) -> Option<u64>,
+) -> Vec<AssessedRoot> {
     let resolved = config.resolved_subvolumes();
     let drive_labels = config.drive_labels();
 
     let mut roots = Vec::new();
 
     for root in &config.local_snapshots.roots {
-        let free_bytes = drives::filesystem_free_bytes(&root.path).unwrap_or(u64::MAX);
+        let free = free_bytes(&root.path).unwrap_or(u64::MAX);
         let min_free = root.min_free_bytes.map(|b| b.bytes());
-        let is_critical = min_free.is_some_and(|threshold| free_bytes < threshold);
+        let is_critical = min_free
+            .is_some_and(|threshold| free < guard::emergency_interactive_threshold(threshold));
 
+        let mut plans = Vec::new();
         let mut subvol_details = Vec::new();
         let mut total_unsent: usize = 0;
         let mut drives_needing_full = Vec::new();
 
         if is_critical {
-            for subvol_name in &root.subvolumes {
-                // Skip transient subvolumes — already delete aggressively
-                let subvol = resolved.iter().find(|s| &s.name == subvol_name);
-                if subvol.is_some_and(|s| s.local_retention.is_transient()) {
-                    continue;
-                }
+            plans = emergency_walk(root, &resolved, &drive_labels, now);
 
-                // Enumerate snapshots (skip on failure — ADR-109)
-                let local_dir = root.path.join(subvol_name);
-                let snaps = match plan::read_snapshot_dir(&local_dir) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        log::warn!("Cannot read snapshot dir {}: {e}", local_dir.display());
-                        continue;
-                    }
-                };
-
-                if snaps.is_empty() {
-                    continue;
-                }
-
-                let latest = snaps.iter().max().unwrap().clone();
-
-                let pinned = chain::find_pinned_snapshots(&local_dir, &drive_labels);
-
-                // Snapshots newer than oldest pin that aren't pinned — will need full send
-                let oldest_pin = pinned.iter().min();
-                let unsent: Vec<_> = if let Some(oldest) = oldest_pin {
-                    snaps
-                        .iter()
-                        .filter(|s| *s > oldest && !pinned.contains(s) && *s != &latest)
-                        .collect()
-                } else {
-                    // No pins = nothing ever sent. All except latest are "unsent"
-                    snaps.iter().filter(|s| *s != &latest).collect()
-                };
-                total_unsent += unsent.len();
-
-                let result = retention::emergency_retention(
-                    &snaps,
-                    &latest,
-                    &pinned,
-                    chrono::Local::now().naive_local(),
-                );
-
+            for subvol in &plans {
+                total_unsent += unsent_count(subvol);
                 subvol_details.push(EmergencySubvolDetail {
-                    name: subvol_name.clone(),
-                    snapshot_count: snaps.len(),
-                    keep_count: result.keep.len(),
-                    delete_count: result.delete.len(),
-                    latest: latest.as_str().to_string(),
-                    pinned_count: pinned.len(),
+                    name: subvol.inputs.name.clone(),
+                    snapshot_count: subvol.inputs.snapshots.len(),
+                    keep_count: subvol.result.keep.len(),
+                    delete_count: subvol.result.delete.len(),
+                    latest: subvol.latest.as_str().to_string(),
+                    pinned_count: subvol.inputs.pinned.len(),
                 });
             }
 
@@ -100,18 +233,31 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
             }
         }
 
-        roots.push(EmergencyRootAssessment {
-            root: root.path.clone(),
-            free_bytes,
-            min_free_bytes: min_free,
-            is_critical,
-            subvolumes: subvol_details,
-            unsent_count: total_unsent,
-            drives_needing_full_send: drives_needing_full,
+        roots.push(AssessedRoot {
+            assessment: EmergencyRootAssessment {
+                root: root.path.clone(),
+                free_bytes: free,
+                min_free_bytes: min_free,
+                is_critical,
+                subvolumes: subvol_details,
+                unsent_count: total_unsent,
+                drives_needing_full_send: drives_needing_full,
+            },
+            plans,
         });
     }
 
-    let output = EmergencyOutput { roots };
+    roots
+}
+
+pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
+    let assessed = assess_roots(&config, chrono::Local::now().naive_local(), |p| {
+        drives::filesystem_free_bytes(p).ok()
+    });
+
+    let output = EmergencyOutput {
+        roots: assessed.iter().map(|a| a.assessment.clone()).collect(),
+    };
     print!("{}", voice::render_emergency(&output, output_mode));
 
     if !output.has_crisis() {
@@ -144,40 +290,24 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         sys.supports_compressed_data,
     );
 
-    for root_assessment in &output.roots {
-        if !root_assessment.is_critical {
+    for root_assessment in &assessed {
+        if !root_assessment.assessment.is_critical {
             continue;
         }
 
-        let free_before = drives::filesystem_free_bytes(&root_assessment.root).unwrap_or(0);
+        let root_path = &root_assessment.assessment.root;
+        let free_before = drives::filesystem_free_bytes(root_path).unwrap_or(0);
         let mut deleted: usize = 0;
         let mut failed: usize = 0;
 
-        for detail in &root_assessment.subvolumes {
-            let local_dir = root_assessment.root.join(&detail.name);
-            let snaps = match plan::read_snapshot_dir(&local_dir) {
-                Ok(s) => s,
-                Err(_) => continue,
-            };
-
-            if snaps.is_empty() {
-                continue;
-            }
-
-            let latest = snaps.iter().max().unwrap().clone();
-            let pinned = chain::find_pinned_snapshots(&local_dir, &drive_labels);
-            let result = retention::emergency_retention(
-                &snaps,
-                &latest,
-                &pinned,
-                chrono::Local::now().naive_local(),
-            );
-
-            for rd in &result.delete {
-                let snap_path = local_dir.join(rd.snapshot.as_str());
+        // The plans the user just confirmed — deleting a freshly re-read set
+        // would delete snapshots that were never shown to them.
+        for subvol in &root_assessment.plans {
+            for rd in &subvol.result.delete {
+                let snap_path = subvol.inputs.local_dir.join(rd.snapshot.as_str());
 
                 // Defense-in-depth (ADR-106 layer 3): shared re-check
-                if chain::is_pinned_at_delete_time(&snap_path, &detail.name, &config) {
+                if chain::is_pinned_at_delete_time(&snap_path, &subvol.inputs.name, &config) {
                     log::warn!(
                         "Defense-in-depth: refusing to delete pinned snapshot {}",
                         snap_path.display()
@@ -198,31 +328,30 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
         }
 
         // Sync so freed space is visible to subsequent checks
-        if let Err(e) = btrfs.sync_subvolumes(&root_assessment.root) {
+        if let Err(e) = btrfs.sync_subvolumes(root_path) {
             log::warn!(
                 "btrfs subvolume sync failed for {}: {e}",
-                root_assessment.root.display()
+                root_path.display()
             );
         }
 
-        let free_after = drives::filesystem_free_bytes(&root_assessment.root).unwrap_or(0);
+        let free_after = drives::filesystem_free_bytes(root_path).unwrap_or(0);
         let freed_bytes = free_after.saturating_sub(free_before);
-        let min_free = root_assessment.min_free_bytes.unwrap_or(0);
+        let min_free = root_assessment.assessment.min_free_bytes.unwrap_or(0);
 
         // Count remaining snapshots
         let remaining: usize = root_assessment
-            .subvolumes
+            .plans
             .iter()
-            .map(|d| {
-                let local_dir = root_assessment.root.join(&d.name);
-                plan::read_snapshot_dir(&local_dir)
+            .map(|subvol| {
+                plan::read_snapshot_dir(&subvol.inputs.local_dir)
                     .map(|s| s.len())
                     .unwrap_or(0)
             })
             .sum();
 
         let result = EmergencyResult {
-            root: root_assessment.root.clone(),
+            root: root_path.clone(),
             deleted,
             failed,
             freed_bytes,
@@ -235,4 +364,373 @@ pub fn run(config: Config, output_mode: OutputMode) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A config with one snapshot root under `root`, one subvolume `alpha`,
+    /// one drive `D1`, and a 1 GB `min_free_bytes` — so the interactive crisis
+    /// line sits at 1 GB and the automatic one at 500 MB.
+    fn emergency_config(root: &Path) -> Config {
+        let toml_str = r#"
+drives = [
+  { label = "D1", mount_path = "/mnt/d1", snapshot_root = ".snapshots", role = "offsite" }
+]
+
+[general]
+state_db = "/tmp/urd-emergency/urd.db"
+metrics_file = "/tmp/urd-emergency/m.prom"
+log_dir = "/tmp/urd-emergency"
+heartbeat_file = "/tmp/urd-emergency/hb.json"
+
+[local_snapshots]
+roots = [
+  { path = "/snap", subvolumes = ["alpha"] }
+]
+
+[defaults]
+snapshot_interval = "1h"
+send_interval = "4h"
+[defaults.local_retention]
+hourly = 24
+[defaults.external_retention]
+daily = 30
+
+[[subvolumes]]
+name = "alpha"
+short_name = "alpha"
+source = "/data/alpha"
+"#;
+        let mut config: Config = toml::from_str(toml_str).unwrap();
+        config.local_snapshots.roots[0].path = root.to_path_buf();
+        config.local_snapshots.roots[0].min_free_bytes =
+            Some(crate::types::ByteSize(1_000_000_000));
+        config
+    }
+
+    /// A fixed clock newer than every test snapshot. Its value never changes
+    /// which snapshots `emergency_retention` keeps (latest + pinned).
+    fn pass_now() -> chrono::NaiveDateTime {
+        chrono::NaiveDate::from_ymd_opt(2026, 1, 4)
+            .unwrap()
+            .and_hms_opt(4, 0, 0)
+            .unwrap()
+    }
+
+    const THREE_SNAPS: [&str; 3] = [
+        "20260101-1200-alpha",
+        "20260102-1200-alpha",
+        "20260103-1200-alpha",
+    ];
+
+    fn snap(name: &str) -> SnapshotName {
+        SnapshotName::parse(name).unwrap()
+    }
+
+    fn subvol_inputs(name: &str, snapshots: &[&str], pins: &[&str]) -> EmergencySubvolInputs {
+        EmergencySubvolInputs {
+            name: name.to_string(),
+            local_dir: PathBuf::from("/snap").join(name),
+            snapshots: snapshots.iter().map(|s| snap(s)).collect(),
+            pinned: pins.iter().map(|s| snap(s)).collect(),
+        }
+    }
+
+    /// The snapshot names one plan offers for deletion, sorted.
+    fn offered(subvol: &EmergencySubvolPlan) -> Vec<String> {
+        let mut names: Vec<String> = subvol
+            .result
+            .delete
+            .iter()
+            .map(|d| d.snapshot.as_str().to_string())
+            .collect();
+        names.sort();
+        names
+    }
+
+    /// Create the subvol dir and one child dir per snapshot name.
+    fn make_snap_dirs(subvol_dir: &Path, names: &[&str]) {
+        std::fs::create_dir_all(subvol_dir).unwrap();
+        for n in names {
+            std::fs::create_dir(subvol_dir.join(n)).unwrap();
+        }
+    }
+
+    // ── The pure decision: emergency_candidates ────────────────────────
+
+    #[test]
+    fn candidates_never_offer_the_latest_snapshot() {
+        let plans = emergency_candidates(&[subvol_inputs("alpha", &THREE_SNAPS, &[])], pass_now());
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].latest, snap("20260103-1200-alpha"));
+        assert_eq!(
+            offered(&plans[0]),
+            vec!["20260101-1200-alpha", "20260102-1200-alpha"],
+            "the newest snapshot is the one thing an emergency always keeps"
+        );
+    }
+
+    #[test]
+    fn candidates_never_offer_a_pinned_snapshot() {
+        // Oldest is a drive's chain parent (ADR-106 layers 1-2).
+        let plans = emergency_candidates(
+            &[subvol_inputs("alpha", &THREE_SNAPS, &["20260101-1200-alpha"])],
+            pass_now(),
+        );
+        assert_eq!(
+            offered(&plans[0]),
+            vec!["20260102-1200-alpha"],
+            "only the unpinned middle is offered"
+        );
+        assert_eq!(plans[0].result.keep.len(), 2, "pin and latest both kept");
+    }
+
+    #[test]
+    fn candidates_offer_nothing_when_every_snapshot_is_pinned() {
+        let plans =
+            emergency_candidates(&[subvol_inputs("alpha", &THREE_SNAPS, &THREE_SNAPS)], pass_now());
+        assert!(
+            plans[0].result.delete.is_empty(),
+            "an all-pinned subvolume yields no candidates, even in a crisis"
+        );
+    }
+
+    #[test]
+    fn candidates_leave_a_lone_snapshot_alone() {
+        let plans = emergency_candidates(
+            &[subvol_inputs("alpha", &["20260101-1200-alpha"], &[])],
+            pass_now(),
+        );
+        assert!(
+            plans[0].result.delete.is_empty(),
+            "the only snapshot is the latest — an emergency never empties a subvolume"
+        );
+    }
+
+    #[test]
+    fn candidates_skip_a_subvolume_with_no_snapshots() {
+        let plans = emergency_candidates(
+            &[
+                subvol_inputs("alpha", &[], &[]),
+                subvol_inputs("beta", &THREE_SNAPS, &[]),
+            ],
+            pass_now(),
+        );
+        assert_eq!(plans.len(), 1, "an empty subvolume yields no plan at all");
+        assert_eq!(plans[0].inputs.name, "beta");
+    }
+
+    #[test]
+    fn candidates_decide_each_subvolume_independently() {
+        let plans = emergency_candidates(
+            &[
+                subvol_inputs("alpha", &THREE_SNAPS, &["20260102-1200-alpha"]),
+                subvol_inputs("beta", &["20260101-1200-beta", "20260102-1200-beta"], &[]),
+            ],
+            pass_now(),
+        );
+        assert_eq!(offered(&plans[0]), vec!["20260101-1200-alpha"]);
+        assert_eq!(offered(&plans[1]), vec!["20260101-1200-beta"]);
+    }
+
+    // ── The I/O gather ────────────────────────────────────────────────
+
+    #[test]
+    fn gather_reads_snapshots_and_pins_from_disk() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let alpha = dir.path().join("alpha");
+        make_snap_dirs(&alpha, &THREE_SNAPS);
+        std::fs::write(
+            alpha.join(".last-external-parent-D1"),
+            "20260101-1200-alpha\n",
+        )
+        .unwrap();
+        let config = emergency_config(dir.path());
+
+        let inputs = gather_emergency_inputs(
+            &config.local_snapshots.roots[0],
+            &config.resolved_subvolumes(),
+            &config.drive_labels(),
+        );
+
+        assert_eq!(inputs.len(), 1);
+        assert_eq!(inputs[0].local_dir, alpha);
+        assert_eq!(inputs[0].snapshots.len(), 3, "pin file is not a snapshot");
+        assert_eq!(
+            inputs[0].pinned,
+            HashSet::from([snap("20260101-1200-alpha")]),
+            "the drive's chain parent is carried into the decision"
+        );
+    }
+
+    #[test]
+    fn gather_skips_a_transient_subvolume() {
+        let dir = tempfile::TempDir::new().unwrap();
+        make_snap_dirs(&dir.path().join("alpha"), &THREE_SNAPS);
+        let mut config = emergency_config(dir.path());
+        config.subvolumes[0].local_retention =
+            Some(crate::types::LocalRetentionConfig::Transient);
+
+        let inputs = gather_emergency_inputs(
+            &config.local_snapshots.roots[0],
+            &config.resolved_subvolumes(),
+            &config.drive_labels(),
+        );
+
+        assert!(
+            inputs.is_empty(),
+            "transient retention already deletes aggressively — nothing to reclaim"
+        );
+    }
+
+    #[test]
+    fn gather_skips_an_unreadable_snapshot_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        // A regular file where the snapshot dir should be: read_dir fails.
+        std::fs::write(dir.path().join("alpha"), b"not a directory").unwrap();
+        let config = emergency_config(dir.path());
+
+        let inputs = gather_emergency_inputs(
+            &config.local_snapshots.roots[0],
+            &config.resolved_subvolumes(),
+            &config.drive_labels(),
+        );
+
+        assert!(
+            inputs.is_empty(),
+            "a subvolume Urd cannot enumerate contributes no deletion candidates"
+        );
+    }
+
+    #[test]
+    fn gather_skips_a_missing_snapshot_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config = emergency_config(dir.path());
+
+        let inputs = gather_emergency_inputs(
+            &config.local_snapshots.roots[0],
+            &config.resolved_subvolumes(),
+            &config.drive_labels(),
+        );
+
+        assert!(inputs.is_empty(), "no snapshots, no plan");
+    }
+
+    // ── unsent accounting ─────────────────────────────────────────────
+
+    #[test]
+    fn unsent_counts_everything_but_latest_when_nothing_was_ever_sent() {
+        let plans = emergency_candidates(&[subvol_inputs("alpha", &THREE_SNAPS, &[])], pass_now());
+        assert_eq!(unsent_count(&plans[0]), 2);
+    }
+
+    #[test]
+    fn unsent_counts_only_snapshots_newer_than_the_oldest_pin() {
+        let plans = emergency_candidates(
+            &[subvol_inputs("alpha", &THREE_SNAPS, &["20260102-1200-alpha"])],
+            pass_now(),
+        );
+        assert_eq!(
+            unsent_count(&plans[0]),
+            0,
+            "the only snapshot newer than the pin is the latest, which survives"
+        );
+    }
+
+    // ── The assessment `urd emergency` renders ─────────────────────────
+
+    #[test]
+    fn assessment_below_the_crisis_line_offers_candidates() {
+        let dir = tempfile::TempDir::new().unwrap();
+        make_snap_dirs(&dir.path().join("alpha"), &THREE_SNAPS);
+        let config = emergency_config(dir.path());
+
+        let assessed = assess_roots(&config, pass_now(), |_| Some(900_000_000));
+
+        assert_eq!(assessed.len(), 1);
+        assert!(assessed[0].assessment.is_critical, "900 MB < the 1 GB rung");
+        assert_eq!(assessed[0].plans.len(), 1);
+        assert_eq!(offered(&assessed[0].plans[0]), THREE_SNAPS[..2].to_vec());
+        let detail = &assessed[0].assessment.subvolumes[0];
+        assert_eq!(detail.snapshot_count, 3);
+        assert_eq!(detail.delete_count, 2);
+        assert_eq!(detail.keep_count, 1);
+        assert_eq!(assessed[0].assessment.unsent_count, 2);
+    }
+
+    #[test]
+    fn assessment_above_the_crisis_line_yields_no_candidates() {
+        let dir = tempfile::TempDir::new().unwrap();
+        make_snap_dirs(&dir.path().join("alpha"), &THREE_SNAPS);
+        let config = emergency_config(dir.path());
+
+        // Exactly at the rung: `min_free_bytes` itself is not yet a crisis.
+        let assessed = assess_roots(&config, pass_now(), |_| Some(1_000_000_000));
+
+        assert!(!assessed[0].assessment.is_critical);
+        assert!(
+            assessed[0].plans.is_empty(),
+            "a healthy root is never walked — no snapshot is ever a candidate"
+        );
+        assert!(assessed[0].assessment.subvolumes.is_empty());
+    }
+
+    #[test]
+    fn assessment_of_an_unmeasurable_root_is_never_a_crisis() {
+        let dir = tempfile::TempDir::new().unwrap();
+        make_snap_dirs(&dir.path().join("alpha"), &THREE_SNAPS);
+        let config = emergency_config(dir.path());
+
+        let assessed = assess_roots(&config, pass_now(), |_| None);
+
+        assert!(
+            !assessed[0].assessment.is_critical,
+            "a failed probe must never license deletions (ADR-107)"
+        );
+        assert!(assessed[0].plans.is_empty());
+    }
+
+    #[test]
+    fn assessment_of_a_root_without_min_free_bytes_is_never_a_crisis() {
+        let dir = tempfile::TempDir::new().unwrap();
+        make_snap_dirs(&dir.path().join("alpha"), &THREE_SNAPS);
+        let mut config = emergency_config(dir.path());
+        config.local_snapshots.roots[0].min_free_bytes = None;
+
+        let assessed = assess_roots(&config, pass_now(), |_| Some(0));
+
+        assert!(!assessed[0].assessment.is_critical);
+        assert!(assessed[0].plans.is_empty());
+        assert!(assessed[0].assessment.min_free_bytes.is_none());
+    }
+
+    #[test]
+    fn assessment_names_drives_whose_chain_breaks() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let alpha = dir.path().join("alpha");
+        make_snap_dirs(&alpha, &THREE_SNAPS);
+        // D1's pin is the oldest, so the two snapshots after it are unsent.
+        std::fs::write(
+            alpha.join(".last-external-parent-D1"),
+            "20260101-1200-alpha\n",
+        )
+        .unwrap();
+        let config = emergency_config(dir.path());
+
+        let assessed = assess_roots(&config, pass_now(), |_| Some(900_000_000));
+
+        assert_eq!(
+            offered(&assessed[0].plans[0]),
+            vec!["20260102-1200-alpha"],
+            "the pin survives; only the unpinned middle is offered"
+        );
+        assert_eq!(assessed[0].assessment.unsent_count, 1);
+        assert_eq!(
+            assessed[0].assessment.drives_needing_full_send,
+            vec!["D1".to_string()],
+            "deleting an unsent intermediate forces D1's next send to be full"
+        );
+    }
 }

--- a/src/guard.rs
+++ b/src/guard.rs
@@ -94,6 +94,49 @@ pub fn source_floor_bytes(min_free: u64, capacity_bytes: u64) -> u64 {
     min_free + budget
 }
 
+// ── The min_free_bytes criticality ladder (UPI 016) ────────────────────
+
+// Three surfaces ask the same question — "is this root close enough to
+// `min_free_bytes` to act?" — and answer it differently, because each acts
+// differently: `urd doctor` only warns, `urd emergency` asks a human first,
+// and the pre-backup preflight deletes unattended. The rungs were designed
+// together in UPI 016 (April 2026,
+// `docs/97-plans/2026-04-05-plan-016-emergency-space-response.md`, lines
+// 194/324/382) but lived as three bare multipliers in three files; they are
+// named here, next to `source_floor_bytes`, because this module already owns
+// the thresholds derived from `min_free_bytes`.
+//
+// The ladder predates the tiered storage model
+// (`storage_critical::TightnessTier`, UPI 031-a), which now answers a related
+// question per pool with hysteresis. Whether the ladder survives alongside the
+// tiers, or folds into them, belongs to the ADR-113 do-no-harm re-grill —
+// naming the rungs is the prerequisite for that conversation, not its answer.
+
+/// Widest rung — `urd doctor`'s space-trend warning: twice `min_free_bytes`.
+/// Doctor only prints, so it may speak long before anything is at stake.
+#[must_use]
+pub fn doctor_warn_threshold(min_free: u64) -> u64 {
+    min_free.saturating_mul(2)
+}
+
+/// Middle rung — the crisis line for the invoked `urd emergency`:
+/// `min_free_bytes` itself. The command deletes only after a human confirms,
+/// so it may act at the configured floor rather than below it. Identity by
+/// design: the rung is named so the whole ladder reads in one place.
+#[must_use]
+pub fn emergency_interactive_threshold(min_free: u64) -> u64 {
+    min_free
+}
+
+/// Narrowest rung — the automatic pre-backup preflight: half
+/// `min_free_bytes`. The only rung that deletes with no human present, so it
+/// waits until the root is unambiguously in trouble; a backup that merely
+/// dips below `min_free_bytes` is left for the human-facing surfaces.
+#[must_use]
+pub fn emergency_automatic_threshold(min_free: u64) -> u64 {
+    min_free / 2
+}
+
 // ── Presence-aware pin shedding (ADR-116, UPI 058) ─────────────────────
 
 /// One drive's scope for a subvolume: whether it is **usable for a send right
@@ -376,5 +419,38 @@ mod tests {
     #[test]
     fn away_sheddable_empty_scopes_is_empty() {
         assert!(away_sheddable_pins(&[]).is_empty());
+    }
+
+    // ── The min_free_bytes criticality ladder (UPI 016) ────────────────
+
+    #[test]
+    fn ladder_rungs_widen_with_how_gently_the_surface_acts() {
+        // The ordering is the whole point: doctor (warns) speaks first, the
+        // invoked emergency (asks) next, the unattended preflight (deletes)
+        // last. A change that reorders these is a behavior change, not a
+        // refactor.
+        let min_free = 1_000_000_000u64;
+        assert!(
+            emergency_automatic_threshold(min_free)
+                < emergency_interactive_threshold(min_free)
+        );
+        assert!(
+            emergency_interactive_threshold(min_free) < doctor_warn_threshold(min_free)
+        );
+    }
+
+    #[test]
+    fn ladder_rungs_keep_their_designed_values() {
+        let min_free = 1_000_000_000u64;
+        assert_eq!(doctor_warn_threshold(min_free), 2_000_000_000);
+        assert_eq!(emergency_interactive_threshold(min_free), 1_000_000_000);
+        assert_eq!(emergency_automatic_threshold(min_free), 500_000_000);
+    }
+
+    #[test]
+    fn doctor_warn_saturates_instead_of_wrapping() {
+        // An absurd min_free must not wrap to a tiny threshold and silence
+        // the warning entirely.
+        assert_eq!(doctor_warn_threshold(u64::MAX), u64::MAX);
     }
 }


### PR DESCRIPTION
## Summary

Two of the three items in #383. `urd emergency` and the pre-backup emergency
preflight each carried their own copy of the same per-root walk, so a fix to
either had to be mirrored into the other by hand — and the interactive command,
which deletes snapshots, had no tests at all. Both now go through one walk, and
the `min_free_bytes` criticality ladder gets a name in one module.

Item 3 (whether the ladder survives alongside `TightnessTier`) is deliberately
**not** answered here: it is a human re-grill question. The constants say so and
point at the ADR-113 do-no-harm re-grill; nothing is folded into the tiers.

## Changes

**`src/commands/emergency.rs`** — now owns the shared walk.
- `EmergencySubvolInputs` — one subvolume's already-read snapshots and pin set.
- `gather_emergency_inputs` (I/O) — per root: transient skip, `read_snapshot_dir`,
  `find_pinned_snapshots`.
- `emergency_candidates` (pure, ADR-108) — over already-read data: newest snapshot,
  then `retention::emergency_retention`. No I/O, no clock; `now` only stamps events.
- `emergency_walk` — the one function both surfaces call (gather, then decide).
- `assess_roots` — the injectable core of `urd emergency` (free-space probe and clock
  passed in), mirroring `backup::run_emergency_preflight_with` on the automatic side.
  This is what gives the command its first tests.
- `unsent_count` — the chain-break accounting, lifted out as a pure function.

**`src/commands/backup.rs`** — `run_emergency_preflight_with` drops its ~35-line
inline copy of the walk and iterates `emergency::emergency_walk` instead. Its two
doc comments are updated to match.

**`src/guard.rs`** — the ladder, named: `doctor_warn_threshold` (× 2),
`emergency_interactive_threshold` (identity), `emergency_automatic_threshold` (÷ 2),
with the UPI 016 provenance and the re-grill pointer in the section comment.
`guard` rather than `storage_critical` because `guard` already owns the thresholds
*derived from `min_free_bytes`* (`source_floor_bytes` sits directly above them);
`storage_critical` owns free-*ratio* tiers, a different currency.

**`src/commands/doctor.rs`** — one line: `free < min_free * 2` becomes
`free < crate::guard::doctor_warn_threshold(min_free)`. Nothing moved or reformatted
(#382 is restructuring `doctor::run` concurrently).

### Design decisions

**Fail direction at every skip in the shared walk.** All three skips shrink the
delete set, never widen it:
- *Transient subvolume* → skipped: its own retention already prunes to the working set.
- *Unreadable snapshot dir* → logged and skipped (ADR-109). Fail-open for the
  *assessment* is fail-closed for the *deletion*: a subvolume Urd cannot enumerate
  contributes no candidates.
- *Empty snapshot list* → no plan at all: there is no `latest` to anchor the keep set on.
- Above the threshold, or an unmeasurable root (`unwrap_or(u64::MAX)`), or a root with
  no `min_free_bytes` → never critical, never walked. A failed probe can never license
  a deletion (ADR-107).

**ADR-106 layer 3 stays at both delete sites.** `is_pinned_at_delete_time` is
deliberately *not* moved into the shared candidate selection — the walk reads pins once,
at planning time, and the TOCTOU window is between there and the delete. Both delete
loops still call it immediately before each `delete_subvolume`.

**`urd emergency` no longer re-walks after the prompt.** It used to assess, render,
confirm, and then re-read every snapshot directory and recompute from scratch. It now
carries the plans forward and deletes the set the user was shown. Same set in practice,
but no longer by coincidence — and strictly more conservative, since a snapshot created
between the prompt and the deletes can no longer displace the `latest` that was protected
at assessment time. This is the only user-visible change, and the CHANGELOG bullet.

**Two `.unwrap()` calls left library code.** Both copies did `snaps.iter().max().unwrap()`;
the pure function uses `?` in a `filter_map` and simply yields no plan for a subvolume
with no snapshots.

## Out of scope / noticed

- `chain::is_pinned_at_delete_time`'s doc claims it fails closed "if ... pin files can't
  be read", but it delegates to `chain::find_pinned_snapshots`, which logs an unreadable
  pin file and returns the set *without* that pin — so an unreadable pin file reads as
  "not pinned" at layer 3, not as "keep". `retention::emergency_retention`'s own doc
  warns the caller about exactly this ("caller must not pass empty when pin files are
  unreadable"). Pre-existing on both delete paths and untouched here; it is an ADR-106
  layer-3 semantics question, not a refactor.
- The interactive `EmergencySubvolDetail.pinned_count` and the preflight's event stamping
  remain surface-specific; only candidate *selection* is shared, which is what #383 asked for.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo test` — **2521 passed, 0 failed, 5 ignored** (2500 on `origin/master` at
      `c97f99e`; +21 new).
- [x] 17 new tests in `commands::emergency` — the command's first: latest never a
      candidate; pinned never a candidate; all-pinned yields nothing; a lone snapshot is
      never deleted; empty subvolume yields no plan; per-subvolume independence; gather
      reads snapshots and pins from a `TempDir`; gather skips a transient subvolume, an
      unreadable snapshot dir (a file where the dir should be), and a missing one;
      unsent accounting with and without pins; assessment below / at / above the crisis
      line, an unmeasurable root, a root with no `min_free_bytes`, and the
      drives-needing-full-send warning.
- [x] 3 new tests in `guard` — the rungs' ordering (widest for the surface that only
      warns, narrowest for the one that deletes unattended), their UPI 016 values, and
      `doctor_warn_threshold` saturating instead of wrapping.
- [x] 1 new cross-surface test in `commands::backup` —
      `emergency_command_and_preflight_offer_the_same_candidates`: the paths the preflight
      actually deleted (`MockBtrfs`) equal the paths `urd emergency`'s assessment would
      render, on the same `TempDir` root with a pinned oldest snapshot.
- [x] `scripts/check-present-not-journey.sh`, `scripts/check-docs.sh` — pass.
- [x] `scripts/pre-commit-pii.sh` — clean (hook ran at commit; branch diff re-scanned
      manually for username / home paths / hostname).
- [ ] `cargo build --release` — not run (supervisor runs it once). Note `scripts/check.sh`
      on master now runs `cargo test --release` in place of the release build; not run here.

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti
