### PR TITLE
refactor: make the advice issue structured data, not a rendered phrase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,4 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - run: bash scripts/check-docs.sh
       - run: bash scripts/check-present-not-journey.sh
+      - run: bash scripts/check-voice-boundary.sh

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ scripts/*
 !scripts/check-docs.sh
 !scripts/check-registry.sh
 !scripts/check-present-not-journey.sh
+!scripts/check-voice-boundary.sh
 !scripts/staging-reset.sh
 !scripts/check.sh
 !scripts/release-preflight.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   home (#388).
 
 ### Changed
+- The `issue` field that names what is wrong with a subvolume is now a
+  structured object instead of a rendered sentence, on both `urd status
+  --json` (`advice[].issue`) and `urd doctor --json`
+  (`data_safety[].issue`). It carries the promise state under its semantic
+  name ("AT RISK") together with a tagged shape — `stale`,
+  `no_external_drives`, `all_drives_disconnected`, `chain_broken`,
+  `drive_away`, `no_advice` — and an age in seconds where one applies, so a
+  consumer reads fields instead of parsing prose. The mythic labels
+  (`sealed` / `waning` / `exposed`) no longer reach any machine surface;
+  they are chosen at render time, and a new lint keeps them inside the
+  presentation layer for good. `urd status` and `urd doctor` read exactly
+  as before. The doctor JSON `schema_version` goes 3 → 4 (#384).
 - The voice contract (`voice_contract.rs`) now exercises the `urd
   emergency` renderers in full and 15 of the onboarding/earning-flow
   renderers in `voice/encounter.rs` — the incident and root-granting

--- a/scripts/check-voice-boundary.sh
+++ b/scripts/check-voice-boundary.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# check-voice-boundary.sh — Keep the mythic voice inside src/voice/.
+#
+# CLAUDE.md: "The mythic voice (the character of the norn) belongs entirely in the
+# presentation layer (`voice/`), never in config or data structures." The glossary says
+# the same from the other side: the promise states travel as semantic names
+# (PROTECTED / AT RISK / UNPROTECTED) on every machine surface, and only the interactive
+# CLI renders them as `sealed` / `waning` / `exposed`. When a voice word is built into a
+# serialized field, that contract breaks silently — the word reaches `--json`, and the
+# one-to-one mapping in `voice/mod.rs::exposure_label` acquires a second, independently
+# maintained copy. Issue #384 found exactly that in `ActionableAdvice.issue`.
+#
+# This lint fails when the three exposure labels appear as bare string literals anywhere
+# in src/ outside src/voice/. Identifiers (`sealed_count`, `waning_names`) are untouched,
+# and whole-line comments are stripped first — the glossary and several doc comments quote
+# the vocabulary legitimately. Only a literal on a line of code counts.
+#
+# src/voice_contract.rs is exempt: it is the voice's own golden-test suite, asserting on
+# rendered output, and lives outside the directory only because it spans every renderer.
+#
+# TODO(#384): the sibling guards from the same issue land once parts 2 and 3 merge —
+#   no `colored::Colorize` use in src/commands/, and no `Local::now()` / `Utc::now()`
+#   in src/voice/ non-test code.
+#
+# Usage: scripts/check-voice-boundary.sh
+#   exit 0 = clean, exit 1 = violations found.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# The frozen voice vocabulary (glossary → "Cluster: Voice labels").
+pattern='"(sealed|waning|exposed)"'
+
+# Files searched: all Rust sources outside the presentation layer, minus the exemption.
+mapfile -t targets < <(
+    find src -name '*.rs' -not -path 'src/voice/*' -not -path 'src/voice_contract.rs' | sort
+)
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    echo "FAIL: no Rust sources found outside src/voice/ — is this the repo root?"
+    exit 1
+fi
+
+# `grep -n` emits `file:line:content`; drop the hits whose content is a whole-line
+# comment, so prose that quotes the vocabulary does not trip the lint.
+hits="$(grep -nE "$pattern" "${targets[@]}" | grep -vE '^[^:]+:[0-9]+:[[:space:]]*//' || true)"
+
+if [[ -n "$hits" ]]; then
+    echo "ERROR: mythic voice labels found outside src/voice/:"
+    printf '%s\n' "$hits" | sed 's/^/       /'
+    echo
+    echo "FAIL: 'sealed' / 'waning' / 'exposed' are presentation, not data. Carry the"
+    echo "      PromiseStatus instead and let voice/mod.rs::exposure_label choose the word."
+    exit 1
+fi
+
+echo "Linted ${#targets[@]} Rust source(s) outside src/voice/ for voice-label leaks."
+echo "PASS: No mythic voice labels outside the presentation layer."

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -4,13 +4,14 @@
 # Gates, in order: clippy (--all-targets, warnings are errors), unit tests,
 # release-mode tests (also builds the release binary; debug assertions are
 # off here, closing the gap `debug_assert!`/`#[should_panic]` can hide in
-# debug-only runs), then the present-not-journey doc lint (independent of
-# compilation, always runs). Prints one verdict line per gate plus a test
+# debug-only runs), then two source-text lints — present-not-journey for the
+# governed docs and the voice-boundary guard for src/. Both are independent of
+# compilation and always run. Prints one verdict line per gate plus a test
 # count computed from cargo's own summary lines — never hand-typed.
 #
 # On the green path only the roll-up is printed. When a gate fails, its full
 # output is replayed after the roll-up (the fix needs it); cargo gates after
-# a failed cargo gate are skipped, the doc lint still runs, exit code is 1.
+# a failed cargo gate are skipped, the text lints still run, exit code is 1.
 #
 # Usage: scripts/check.sh [test-filter]
 #   With a filter, runs only `cargo test <filter>` and reports that one gate.
@@ -86,5 +87,6 @@ else
 fi
 
 run_gate "doc-lint" "$WORK/doclint.log" ./scripts/check-present-not-journey.sh || true
+run_gate "voice" "$WORK/voice.log" ./scripts/check-voice-boundary.sh || true
 
 finish

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -1,6 +1,9 @@
-//! Pure: translate `SubvolAssessment` into actionable advice — issue text,
-//! recommended command, reason. The "what should the user do?" surface.
-//! Rule-based; the volatile layer where product refinements land.
+//! Pure: translate `SubvolAssessment` into actionable advice — a structured
+//! issue, a recommended command, a reason. The "what should the user do?"
+//! surface. Rule-based; the volatile layer where product refinements land.
+//!
+//! The issue is data, not prose: `voice::render_advice_issue` picks the words,
+//! so the mythic exposure labels never enter this module or the JSON it feeds.
 //!
 //! Sibling to [`crate::awareness`], which observes promise state. This
 //! module turns observations into prescriptions.
@@ -18,13 +21,72 @@ use crate::types::{DriveRole, ProtectionLevel};
 
 // ── Actionable Advice ─────────────────────────────────────────────────
 
+/// The distinct shapes an issue takes, independent of how it reads.
+///
+/// One variant per condition [`compute_advice`] can report, plus `NoAdvice`
+/// for the unwhole promise the advice rules have no remedy for (`urd doctor`
+/// still shows that row). Every field is a machine value — a drive label, an
+/// age in seconds, a scope flag — never a rendered phrase: the prose, and the
+/// voice label that leads it, are `voice::render_advice_issue`'s to choose
+/// (glossary: daemon JSON keeps the semantic names).
+///
+/// Serializes internally tagged, so a consumer reads
+/// `{"kind": "chain_broken", "drive": "WD-18TB"}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum IssueDetail {
+    /// No `[[drives]]` section at all — nothing to send to.
+    NoExternalDrives,
+    /// Drives are configured, but every one of them is disconnected.
+    AllDrivesDisconnected,
+    /// The promise has slipped, and the newest copy's age is what to say.
+    /// `external_only` picks which copy counts: the freshest external send
+    /// for a subvolume with no local recovery, the newest local snapshot
+    /// otherwise. `age_secs` is `None` when no such copy exists yet — an
+    /// absence, never a zero (a zero age would read as "just now").
+    Stale {
+        external_only: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        age_secs: Option<i64>,
+    },
+    /// The send chain to `drive` is broken; the next send must be full.
+    ChainBroken { drive: String },
+    /// `drive`'s absence is the documented cause of the degradation.
+    DriveAway { drive: String },
+    /// The promise is not whole and the advice rules have no remedy to name
+    /// (an unearned machine, chiefly). Carries no detail by design.
+    NoAdvice,
+}
+
+/// A subvolume's issue in machine terms: the promise status plus the shape
+/// of what is wrong.
+///
+/// `status` serializes SCREAMING ("AT RISK") like every other promise-state
+/// surface; `detail` carries the specifics. `voice::render_advice_issue`
+/// turns the pair into the phrase `urd doctor` prints — this type never
+/// holds the phrase itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AdviceIssue {
+    /// Promise status (serializes SCREAMING: "PROTECTED" / "AT RISK" / "UNPROTECTED").
+    pub status: PromiseStatus,
+    pub detail: IssueDetail,
+}
+
+impl AdviceIssue {
+    /// Pair a promise status with the shape of what is wrong.
+    #[must_use]
+    pub fn new(status: PromiseStatus, detail: IssueDetail) -> Self {
+        Self { status, detail }
+    }
+}
+
 /// Actionable advice for a subvolume based on its full assessment.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ActionableAdvice {
     /// Which subvolume this advice is for.
     pub subvolume: String,
-    /// Short problem description ("waning — last external send 43h ago").
-    pub issue: String,
+    /// What is wrong, structured. The voice renders the phrase.
+    pub issue: AdviceIssue,
     /// The exact command to run, or None if no CLI action can help.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<String>,
@@ -66,7 +128,9 @@ pub fn compute_advice(
             }
             return Some(ActionableAdvice {
                 subvolume: name.clone(),
-                issue: format!("waning{}", format_age_suffix(assessment, false)),
+                // `external_only` is moot here: with sends off, the local
+                // snapshot is the only copy there is to age.
+                issue: stale_issue(assessment, false),
                 command: Some(format!("urd backup --subvolume {name}")),
                 reason: None,
             });
@@ -79,7 +143,7 @@ pub fn compute_advice(
     if assessment.status == PromiseStatus::Unprotected && assessment.external.is_empty() {
         return Some(ActionableAdvice {
             subvolume: name.clone(),
-            issue: "exposed — no external drives configured".to_string(),
+            issue: AdviceIssue::new(assessment.status, IssueDetail::NoExternalDrives),
             command: None,
             reason: Some(
                 "Add a [[drives]] section to your config to enable external backups".to_string(),
@@ -95,7 +159,7 @@ pub fn compute_advice(
         let first_label = &assessment.external[0].drive_label;
         return Some(ActionableAdvice {
             subvolume: name.clone(),
-            issue: "exposed — all drives disconnected".to_string(),
+            issue: AdviceIssue::new(assessment.status, IssueDetail::AllDrivesDisconnected),
             command: None,
             reason: Some(format!("Connect {first_label} to restore protection")),
         });
@@ -111,7 +175,7 @@ pub fn compute_advice(
         }
         return Some(ActionableAdvice {
             subvolume: name.clone(),
-            issue: format_age_issue(assessment, external_only),
+            issue: stale_issue(assessment, external_only),
             command: Some(format!("urd backup --force-full --subvolume {name}")),
             reason: Some(chain_break_reason_text(broken)),
         });
@@ -123,7 +187,7 @@ pub fn compute_advice(
     {
         return Some(ActionableAdvice {
             subvolume: name.clone(),
-            issue: format_age_issue(assessment, external_only),
+            issue: stale_issue(assessment, external_only),
             command: None,
             reason: Some(format!(
                 "Connect {} and run `urd backup`",
@@ -139,7 +203,7 @@ pub fn compute_advice(
         }
         return Some(ActionableAdvice {
             subvolume: name.clone(),
-            issue: format_age_issue(assessment, external_only),
+            issue: stale_issue(assessment, external_only),
             command: Some(format!("urd backup --subvolume {name}")),
             reason: None,
         });
@@ -159,7 +223,12 @@ pub fn compute_advice(
             }
             return Some(ActionableAdvice {
                 subvolume: name.clone(),
-                issue: format!("degraded — thread to {} broken", broken.drive_label),
+                issue: AdviceIssue::new(
+                    assessment.status,
+                    IssueDetail::ChainBroken {
+                        drive: broken.drive_label.clone(),
+                    },
+                ),
                 command: Some(format!("urd backup --force-full --subvolume {name}")),
                 reason: Some("will need full send on next backup".to_string()),
             });
@@ -178,7 +247,12 @@ pub fn compute_advice(
         }) {
             return Some(ActionableAdvice {
                 subvolume: name.clone(),
-                issue: format!("degraded — {} away", absent.drive_label),
+                issue: AdviceIssue::new(
+                    assessment.status,
+                    IssueDetail::DriveAway {
+                        drive: absent.drive_label.clone(),
+                    },
+                ),
                 command: None,
                 reason: Some(format!("Consider connecting {}", absent.drive_label)),
             });
@@ -243,8 +317,11 @@ fn chain_break_reason_text(ch: &DriveChainHealth) -> String {
     }
 }
 
-/// Format an age suffix like " — last backup 43 hours ago".
-fn format_age_suffix(assessment: &SubvolAssessment, external_only: bool) -> String {
+/// Age in seconds of the copy whose staleness the issue is about: the freshest
+/// external send when there is no local recovery, the newest local snapshot
+/// otherwise. `None` when no such copy exists — an absence the voice renders as
+/// silence, never as an age of zero.
+fn issue_age_secs(assessment: &SubvolAssessment, external_only: bool) -> Option<i64> {
     let age: Option<Duration> = if external_only {
         assessment
             .external
@@ -254,33 +331,19 @@ fn format_age_suffix(assessment: &SubvolAssessment, external_only: bool) -> Stri
     } else {
         assessment.local.newest_age
     };
-
-    match age {
-        Some(d) => {
-            let secs = d.num_seconds();
-            let label = if external_only {
-                "last external send"
-            } else {
-                "last backup"
-            };
-            if secs >= 86400 {
-                format!(" — {label} {} days ago", secs / 86400)
-            } else {
-                format!(" — {label} {} hours ago", secs / 3600)
-            }
-        }
-        None => String::new(),
-    }
+    age.map(|d| d.num_seconds())
 }
 
-/// Format the issue string with age context.
-fn format_age_issue(assessment: &SubvolAssessment, external_only: bool) -> String {
-    let status_word = match assessment.status {
-        PromiseStatus::Unprotected => "exposed",
-        PromiseStatus::AtRisk => "waning",
-        PromiseStatus::Protected => "sealed",
-    };
-    format!("{status_word}{}", format_age_suffix(assessment, external_only))
+/// The age-carrying issue: the promise status paired with how long since the
+/// newest copy that counts.
+fn stale_issue(assessment: &SubvolAssessment, external_only: bool) -> AdviceIssue {
+    AdviceIssue::new(
+        assessment.status,
+        IssueDetail::Stale {
+            external_only,
+            age_secs: issue_age_secs(assessment, external_only),
+        },
+    )
 }
 
 // ── Redundancy advisories ──────────────────────────────────────────────
@@ -1549,7 +1612,10 @@ local_retention = "transient"
     fn advice_unprotected_no_drives() {
         let a = test_assessment_for_advice("sv1", PromiseStatus::Unprotected, OperationalHealth::Healthy);
         let advice = compute_advice(&a, true, true, false).unwrap();
-        assert_eq!(advice.issue, "exposed — no external drives configured");
+        assert_eq!(
+            advice.issue,
+            AdviceIssue::new(PromiseStatus::Unprotected, IssueDetail::NoExternalDrives)
+        );
         assert!(advice.command.is_none());
         assert!(advice.reason.unwrap().contains("[[drives]]"));
     }
@@ -1559,7 +1625,10 @@ local_retention = "transient"
         let mut a = test_assessment_for_advice("sv1", PromiseStatus::Unprotected, OperationalHealth::Blocked);
         a.external = vec![drive_assessment("WD-18TB", false, None)];
         let advice = compute_advice(&a, true, true, false).unwrap();
-        assert_eq!(advice.issue, "exposed — all drives disconnected");
+        assert_eq!(
+            advice.issue,
+            AdviceIssue::new(PromiseStatus::Unprotected, IssueDetail::AllDrivesDisconnected)
+        );
         assert!(advice.command.is_none());
         assert!(advice.reason.unwrap().contains("Connect WD-18TB"));
     }
@@ -1611,7 +1680,15 @@ local_retention = "transient"
             },
         }];
         let advice = compute_advice(&a, true, true, false).unwrap();
-        assert!(advice.issue.contains("degraded"));
+        assert_eq!(
+            advice.issue,
+            AdviceIssue::new(
+                PromiseStatus::Protected,
+                IssueDetail::ChainBroken {
+                    drive: "WD-18TB".to_string()
+                }
+            )
+        );
         assert!(advice.command.as_ref().unwrap().contains("--force-full"));
         assert!(advice.reason.as_ref().unwrap().contains("full send"));
     }
@@ -1625,7 +1702,15 @@ local_retention = "transient"
         a.external = vec![drive_assessment("WD-18TB1", false, Some(48))];
         a.health_reasons = vec!["WD-18TB1 overdue for 45 days".to_string()];
         let advice = compute_advice(&a, true, true, false).unwrap();
-        assert_eq!(advice.issue, "degraded — WD-18TB1 away");
+        assert_eq!(
+            advice.issue,
+            AdviceIssue::new(
+                PromiseStatus::Protected,
+                IssueDetail::DriveAway {
+                    drive: "WD-18TB1".to_string()
+                }
+            )
+        );
         assert!(advice.reason.as_ref().unwrap().contains("Consider connecting WD-18TB1"));
     }
 
@@ -1677,15 +1762,16 @@ local_retention = "transient"
         // Local age is 2h (from test_assessment_for_advice), but external send was 48h ago
         a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
         let advice = compute_advice(&a, true, true, true).unwrap();
-        assert!(
-            advice.issue.contains("last external send"),
-            "expected 'last external send' in issue: {}",
-            advice.issue
-        );
-        assert!(
-            !advice.issue.contains("last backup"),
-            "should not say 'last backup' when external_only: {}",
-            advice.issue
+        assert_eq!(
+            advice.issue,
+            AdviceIssue::new(
+                PromiseStatus::AtRisk,
+                IssueDetail::Stale {
+                    external_only: true,
+                    age_secs: Some(48 * 3600),
+                }
+            ),
+            "external-only advice must age the external send, not the local snapshot"
         );
     }
 
@@ -1745,9 +1831,185 @@ local_retention = "transient"
         a.external = vec![drive_assessment("WD-18TB1", false, Some(48))];
         a.health_reasons = vec!["WD-18TB1 overdue for 45 days".to_string()];
         let advice = compute_advice(&a, false, true, false).unwrap();
-        assert_eq!(advice.issue, "degraded — WD-18TB1 away");
+        assert_eq!(
+            advice.issue,
+            AdviceIssue::new(
+                PromiseStatus::Protected,
+                IssueDetail::DriveAway {
+                    drive: "WD-18TB1".to_string()
+                }
+            )
+        );
         assert!(advice.command.is_none());
         assert!(advice.reason.as_ref().unwrap().contains("Consider connecting WD-18TB1"));
+    }
+
+    /// Every branch of [`compute_advice`] maps to exactly one [`IssueDetail`]
+    /// shape, and every field on it is a machine value — a status, a drive
+    /// label, an age in seconds. Nothing here reads as prose; the phrase is
+    /// `voice::render_advice_issue`'s, and its byte-for-byte golden lives
+    /// beside it in `voice/mod.rs`.
+    #[test]
+    fn compute_advice_issue_shape_per_branch() {
+        let stale = |external_only, age_secs| IssueDetail::Stale {
+            external_only,
+            age_secs,
+        };
+
+        // Branch 1: sends disabled, only local staleness matters. `external_only`
+        // is moot with no sends, so the local snapshot is what ages.
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", false, None)];
+        assert_eq!(
+            compute_advice(&a, true, false, true).unwrap().issue,
+            AdviceIssue::new(PromiseStatus::AtRisk, stale(false, Some(2 * 3600)))
+        );
+
+        // Branch 2: no drives configured at all.
+        let a = test_assessment_for_advice("sv1", PromiseStatus::Unprotected, OperationalHealth::Healthy);
+        assert_eq!(
+            compute_advice(&a, true, true, false).unwrap().issue,
+            AdviceIssue::new(PromiseStatus::Unprotected, IssueDetail::NoExternalDrives)
+        );
+
+        // Branch 3: drives configured, every one disconnected.
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::Unprotected, OperationalHealth::Blocked);
+        a.external = vec![drive_assessment("WD-18TB", false, None)];
+        assert_eq!(
+            compute_advice(&a, true, true, false).unwrap().issue,
+            AdviceIssue::new(PromiseStatus::Unprotected, IssueDetail::AllDrivesDisconnected)
+        );
+
+        // Branch 4: chain broken on a mounted drive. The issue is the age, not
+        // the break (the break is the `reason`); `external_only` picks the copy
+        // that ages, and the carried status follows the assessment.
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
+        a.chain_health = vec![DriveChainHealth {
+            drive_label: "WD-18TB".to_string(),
+            status: ChainStatus::Broken {
+                reason: ChainBreakReason::PinMissingLocally,
+                pin_parent: None,
+            },
+        }];
+        assert_eq!(
+            compute_advice(&a, true, true, false).unwrap().issue,
+            AdviceIssue::new(PromiseStatus::AtRisk, stale(false, Some(2 * 3600)))
+        );
+        assert_eq!(
+            compute_advice(&a, true, true, true).unwrap().issue,
+            AdviceIssue::new(PromiseStatus::AtRisk, stale(true, Some(48 * 3600)))
+        );
+        a.status = PromiseStatus::Unprotected;
+        assert_eq!(
+            compute_advice(&a, true, true, false).unwrap().issue,
+            AdviceIssue::new(PromiseStatus::Unprotected, stale(false, Some(2 * 3600)))
+        );
+
+        // Branch 5: at risk with a drive absent and no break on a mounted one.
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", false, Some(48))];
+        assert_eq!(
+            compute_advice(&a, true, true, false).unwrap().issue,
+            AdviceIssue::new(PromiseStatus::AtRisk, stale(false, Some(2 * 3600)))
+        );
+
+        // Branch 6: at risk, drive mounted, chain whole. A subvolume with no
+        // snapshot yet carries `None` — an absence, not an age of zero.
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::AtRisk, OperationalHealth::Healthy);
+        a.external = vec![drive_assessment("WD-18TB", true, Some(48))];
+        assert_eq!(
+            compute_advice(&a, true, true, false).unwrap().issue,
+            AdviceIssue::new(PromiseStatus::AtRisk, stale(false, Some(2 * 3600)))
+        );
+        a.local.newest_age = None;
+        assert_eq!(
+            compute_advice(&a, true, true, false).unwrap().issue,
+            AdviceIssue::new(PromiseStatus::AtRisk, stale(false, None))
+        );
+
+        // Branch 7: protected but degraded by a break on a mounted drive.
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB", true, Some(6))];
+        a.chain_health = vec![DriveChainHealth {
+            drive_label: "WD-18TB".to_string(),
+            status: ChainStatus::Broken {
+                reason: ChainBreakReason::NoPinFile,
+                pin_parent: None,
+            },
+        }];
+        assert_eq!(
+            compute_advice(&a, true, true, false).unwrap().issue,
+            AdviceIssue::new(
+                PromiseStatus::Protected,
+                IssueDetail::ChainBroken {
+                    drive: "WD-18TB".to_string()
+                }
+            )
+        );
+
+        // Branch 8: protected but degraded because a named drive is away.
+        let mut a = test_assessment_for_advice("sv1", PromiseStatus::Protected, OperationalHealth::Degraded);
+        a.external = vec![drive_assessment("WD-18TB1", false, Some(48))];
+        a.health_reasons = vec!["WD-18TB1 overdue for 45 days".to_string()];
+        assert_eq!(
+            compute_advice(&a, true, true, false).unwrap().issue,
+            AdviceIssue::new(
+                PromiseStatus::Protected,
+                IssueDetail::DriveAway {
+                    drive: "WD-18TB1".to_string()
+                }
+            )
+        );
+    }
+
+    /// The serialized shape is the contract `urd status --json` and
+    /// `urd doctor --json` publish: semantic promise names, a tagged detail,
+    /// an age in seconds. No voice label may appear in it.
+    #[test]
+    fn advice_issue_serializes_with_semantic_names() {
+        let v = serde_json::to_value(AdviceIssue::new(
+            PromiseStatus::AtRisk,
+            IssueDetail::Stale {
+                external_only: true,
+                age_secs: Some(172_800),
+            },
+        ))
+        .unwrap();
+        assert_eq!(v["status"], "AT RISK");
+        assert_eq!(v["detail"]["kind"], "stale");
+        assert_eq!(v["detail"]["external_only"], true);
+        assert_eq!(v["detail"]["age_secs"], 172_800);
+
+        let v = serde_json::to_value(AdviceIssue::new(
+            PromiseStatus::Protected,
+            IssueDetail::ChainBroken {
+                drive: "WD-18TB".to_string(),
+            },
+        ))
+        .unwrap();
+        assert_eq!(v["status"], "PROTECTED");
+        assert_eq!(v["detail"]["kind"], "chain_broken");
+        assert_eq!(v["detail"]["drive"], "WD-18TB");
+
+        // An unknown age is omitted rather than serialized as a zero.
+        let v = serde_json::to_value(AdviceIssue::new(
+            PromiseStatus::Unprotected,
+            IssueDetail::Stale {
+                external_only: false,
+                age_secs: None,
+            },
+        ))
+        .unwrap();
+        assert_eq!(v["detail"]["kind"], "stale");
+        assert!(v["detail"].get("age_secs").is_none(), "{v}");
+
+        let v = serde_json::to_value(AdviceIssue::new(
+            PromiseStatus::Unprotected,
+            IssueDetail::NoAdvice,
+        ))
+        .unwrap();
+        assert_eq!(v["detail"]["kind"], "no_advice");
     }
 
     // ── count_distinct_causes (UPI 079-a §3) ───────────────────────────
@@ -1755,7 +2017,7 @@ local_retention = "transient"
     fn adv(subvol: &str, reason: Option<&str>) -> ActionableAdvice {
         ActionableAdvice {
             subvolume: subvol.to_string(),
-            issue: "issue".to_string(),
+            issue: AdviceIssue::new(PromiseStatus::AtRisk, IssueDetail::NoAdvice),
             command: None,
             reason: reason.map(str::to_string),
         }

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use crate::advice;
+use crate::advice::{self, AdviceIssue, IssueDetail};
 use crate::awareness::{self, PromiseStatus};
 use crate::cli::{DoctorArgs, VerifyArgs};
 use crate::commands::world::World;
@@ -209,7 +209,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
                 PromiseStatus::Unprotected => {
                     advice.as_ref().map(unpack_advice).unwrap_or_else(|| {
                         (
-                            Some("exposed — data may not be recoverable".to_string()),
+                            Some(AdviceIssue::new(a.status, IssueDetail::NoAdvice)),
                             Some("Run `urd backup` or connect a drive.".to_string()),
                             None,
                         )
@@ -218,7 +218,7 @@ pub fn run(config: Config, args: DoctorArgs, output_mode: OutputMode) -> anyhow:
                 PromiseStatus::AtRisk => {
                     advice.as_ref().map(unpack_advice).unwrap_or_else(|| {
                         (
-                            Some("waning".to_string()),
+                            Some(AdviceIssue::new(a.status, IssueDetail::NoAdvice)),
                             Some("Run `urd backup` to refresh.".to_string()),
                             None,
                         )
@@ -965,7 +965,7 @@ fn build_doctor_churn_view_inner(
 /// without a "what do I do" handle.
 fn unpack_advice(
     adv: &advice::ActionableAdvice,
-) -> (Option<String>, Option<String>, Option<String>) {
+) -> (Option<AdviceIssue>, Option<String>, Option<String>) {
     match adv.command.as_ref() {
         Some(c) => (
             Some(adv.issue.clone()),
@@ -1162,12 +1162,28 @@ protection = "recorded"
     fn unpack_advice_keeps_command_as_suggestion_with_reason_context() {
         let adv = advice::ActionableAdvice {
             subvolume: "music".to_string(),
-            issue: "waning — last external send 43h ago".to_string(),
+            issue: AdviceIssue::new(
+                PromiseStatus::AtRisk,
+                IssueDetail::Stale {
+                    external_only: true,
+                    age_secs: Some(43 * 3600),
+                },
+            ),
             command: Some("urd backup --subvolume music".to_string()),
             reason: Some("Drive is mounted; a send closes the gap.".to_string()),
         };
         let (issue, suggestion, reason) = unpack_advice(&adv);
-        assert_eq!(issue.as_deref(), Some("waning — last external send 43h ago"));
+        assert_eq!(
+            issue,
+            Some(AdviceIssue::new(
+                PromiseStatus::AtRisk,
+                IssueDetail::Stale {
+                    external_only: true,
+                    age_secs: Some(43 * 3600),
+                },
+            )),
+            "the advice's structured issue passes through untouched"
+        );
         assert_eq!(
             suggestion.as_deref(),
             Some("Run `urd backup --subvolume music`.")
@@ -1181,7 +1197,13 @@ protection = "recorded"
         // reach the → suggestion slot, not render as dimmed context.
         let adv = advice::ActionableAdvice {
             subvolume: "music".to_string(),
-            issue: "waning — last external send 3d ago".to_string(),
+            issue: AdviceIssue::new(
+                PromiseStatus::AtRisk,
+                IssueDetail::Stale {
+                    external_only: true,
+                    age_secs: Some(3 * 86_400),
+                },
+            ),
             command: None,
             reason: Some("Connect WD-18TB1 and run `urd backup`".to_string()),
         };

--- a/src/output.rs
+++ b/src/output.rs
@@ -7,7 +7,7 @@ use std::io::IsTerminal;
 
 use serde::{Deserialize, Serialize};
 
-use crate::advice::{ActionableAdvice, RedundancyAdvisory, RedundancyAdvisoryKind};
+use crate::advice::{ActionableAdvice, AdviceIssue, RedundancyAdvisory, RedundancyAdvisoryKind};
 use crate::awareness::{DriveAssessment, PromiseStatus, SubvolAssessment};
 use crate::config::ResolvedSubvolume;
 use crate::rotation::WindowSource;
@@ -659,8 +659,12 @@ pub struct EmergencyResult {
 /// v2 has `local: Option<HeadroomAwareRecommendation>` (nested
 /// `.recommendation` plus headroom fields). v3 (#125) adds the optional
 /// `retention_checks` array (orphan/legacy pin advisories; absent when empty).
+/// v4 (#384) retypes each `data_safety[].issue` from a rendered sentence to a
+/// structured `AdviceIssue` object — `{"status": "AT RISK", "detail": {"kind":
+/// "stale", ...}}` — so the JSON carries the semantic promise name and a tagged
+/// issue shape instead of the interactive voice label.
 /// Bump for any future breaking JSON shape change; document in CHANGELOG.
-pub const DOCTOR_OUTPUT_SCHEMA_VERSION: u32 = 3;
+pub const DOCTOR_OUTPUT_SCHEMA_VERSION: u32 = 4;
 
 /// Full output for the `urd doctor` command.
 #[derive(Debug, Serialize)]
@@ -867,8 +871,11 @@ pub struct DoctorDataSafety {
     /// Promise status (serializes SCREAMING: "PROTECTED" / "AT RISK" / "UNPROTECTED").
     pub status: PromiseStatus,
     pub health: String,
+    /// What is wrong, structured (schema v4). `voice::render_advice_issue`
+    /// turns it into the line `urd doctor` prints; JSON consumers read
+    /// `issue.status` and `issue.detail.kind` instead of parsing prose.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issue: Option<String>,
+    pub issue: Option<AdviceIssue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub suggestion: Option<String>,
     /// Why this command is suggested, or what physical action to take.
@@ -2785,7 +2792,7 @@ source = "/data/sv2"
             verdict: DoctorVerdict::healthy(),
         };
         let value = serde_json::to_value(&output).unwrap();
-        assert_eq!(value.get("schema_version"), Some(&serde_json::Value::from(3)));
+        assert_eq!(value.get("schema_version"), Some(&serde_json::Value::from(4)));
         // Empty retention_checks is omitted from JSON (no false gravity, #125).
         assert_eq!(value.get("retention_checks"), None);
     }

--- a/src/voice/doctor.rs
+++ b/src/voice/doctor.rs
@@ -134,6 +134,7 @@ fn render_doctor_interactive(data: &DoctorOutput) -> String {
         .ok();
         for ds in &data.data_safety {
             if let Some(ref issue) = ds.issue {
+                let issue = super::render_advice_issue(issue);
                 writeln!(out, "    \u{2717} {} {}", ds.name, issue.red()).ok();
                 if let Some(ref suggestion) = ds.suggestion {
                     writeln!(out, "      \u{2192} {suggestion}").ok();

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -11,6 +11,7 @@ use std::fmt::Write;
 
 use colored::Colorize;
 
+use crate::advice::{AdviceIssue, IssueDetail};
 use crate::awareness::{OperationalHealth, PromiseStatus};
 use crate::output::{SkipCategory, VerifyCheck, VerifyOutput};
 // Test-only imports — moved-renderer types still referenced by parent tests
@@ -125,6 +126,71 @@ pub(super) fn exposure_label(status: PromiseStatus) -> String {
         PromiseStatus::Protected => "sealed".to_string(),
         PromiseStatus::AtRisk => "waning".to_string(),
         PromiseStatus::Unprotected => "exposed".to_string(),
+    }
+}
+
+/// Render an [`AdviceIssue`] as the phrase interactive surfaces print
+/// ("waning — last external send 2 days ago").
+///
+/// The one home of that phrasing. `advice.rs` builds the issue from machine
+/// values alone, so the voice label enters through [`exposure_label`] here and
+/// nowhere else — the glossary's "daemon JSON keeps the semantic names" holds
+/// by construction rather than by discipline.
+pub(super) fn render_advice_issue(issue: &AdviceIssue) -> String {
+    match &issue.detail {
+        IssueDetail::NoExternalDrives => format!(
+            "{} \u{2014} no external drives configured",
+            exposure_label(issue.status)
+        ),
+        IssueDetail::AllDrivesDisconnected => format!(
+            "{} \u{2014} all drives disconnected",
+            exposure_label(issue.status)
+        ),
+        IssueDetail::Stale {
+            external_only,
+            age_secs,
+        } => format!(
+            "{}{}",
+            exposure_label(issue.status),
+            render_age_suffix(*external_only, *age_secs)
+        ),
+        // A broken chain and a documented-absent drive describe operational
+        // health, not the promise — these rows are PROTECTED — so the phrase
+        // leads with "degraded" rather than the exposure label.
+        IssueDetail::ChainBroken { drive } => {
+            format!("degraded \u{2014} thread to {drive} broken")
+        }
+        IssueDetail::DriveAway { drive } => format!("degraded \u{2014} {drive} away"),
+        // No remedy to name. An unwhole promise still earns its label; a broken
+        // one earns the warning that comes with it.
+        IssueDetail::NoAdvice => match issue.status {
+            PromiseStatus::Unprotected => format!(
+                "{} \u{2014} data may not be recoverable",
+                exposure_label(issue.status)
+            ),
+            PromiseStatus::AtRisk | PromiseStatus::Protected => exposure_label(issue.status),
+        },
+    }
+}
+
+/// " — last backup 2 hours ago" / " — last external send 2 days ago",
+/// or empty when no copy's age is known. Days once past a day, hours below it —
+/// truncating, so "2 days ago" means at least two.
+fn render_age_suffix(external_only: bool, age_secs: Option<i64>) -> String {
+    match age_secs {
+        Some(secs) => {
+            let label = if external_only {
+                "last external send"
+            } else {
+                "last backup"
+            };
+            if secs >= 86400 {
+                format!(" \u{2014} {label} {} days ago", secs / 86400)
+            } else {
+                format!(" \u{2014} {label} {} hours ago", secs / 3600)
+            }
+        }
+        None => String::new(),
     }
 }
 
@@ -3053,6 +3119,102 @@ mod tests {
         assert_eq!(exposure_label(PromiseStatus::Unprotected), "exposed");
     }
 
+    /// Byte-for-byte goldens for every issue shape (#384). These strings are
+    /// the ones `urd doctor` printed when the issue was still a preformatted
+    /// `String` built in `advice.rs`; the refactor that moved the phrasing here
+    /// must not have moved a single character of it.
+    #[test]
+    fn render_advice_issue_goldens() {
+        let stale = |status, external_only, age_secs| {
+            AdviceIssue::new(
+                status,
+                IssueDetail::Stale {
+                    external_only,
+                    age_secs,
+                },
+            )
+        };
+
+        // Age-carrying shapes: the exposure label leads, the aged copy follows.
+        assert_eq!(
+            render_advice_issue(&stale(PromiseStatus::AtRisk, false, Some(2 * 3600))),
+            "waning \u{2014} last backup 2 hours ago"
+        );
+        assert_eq!(
+            render_advice_issue(&stale(PromiseStatus::AtRisk, true, Some(48 * 3600))),
+            "waning \u{2014} last external send 2 days ago"
+        );
+        assert_eq!(
+            render_advice_issue(&stale(PromiseStatus::Unprotected, false, Some(2 * 3600))),
+            "exposed \u{2014} last backup 2 hours ago"
+        );
+        // Exactly a day crosses from hours to days.
+        assert_eq!(
+            render_advice_issue(&stale(PromiseStatus::AtRisk, false, Some(86_400))),
+            "waning \u{2014} last backup 1 days ago"
+        );
+        assert_eq!(
+            render_advice_issue(&stale(PromiseStatus::AtRisk, false, Some(86_399))),
+            "waning \u{2014} last backup 23 hours ago"
+        );
+        // No age known: the label alone, never "0 hours ago".
+        assert_eq!(
+            render_advice_issue(&stale(PromiseStatus::AtRisk, false, None)),
+            "waning"
+        );
+
+        assert_eq!(
+            render_advice_issue(&AdviceIssue::new(
+                PromiseStatus::Unprotected,
+                IssueDetail::NoExternalDrives
+            )),
+            "exposed \u{2014} no external drives configured"
+        );
+        assert_eq!(
+            render_advice_issue(&AdviceIssue::new(
+                PromiseStatus::Unprotected,
+                IssueDetail::AllDrivesDisconnected
+            )),
+            "exposed \u{2014} all drives disconnected"
+        );
+
+        // Health-shaped issues lead with "degraded": the promise still holds.
+        assert_eq!(
+            render_advice_issue(&AdviceIssue::new(
+                PromiseStatus::Protected,
+                IssueDetail::ChainBroken {
+                    drive: "WD-18TB".to_string()
+                }
+            )),
+            "degraded \u{2014} thread to WD-18TB broken"
+        );
+        assert_eq!(
+            render_advice_issue(&AdviceIssue::new(
+                PromiseStatus::Protected,
+                IssueDetail::DriveAway {
+                    drive: "WD-18TB1".to_string()
+                }
+            )),
+            "degraded \u{2014} WD-18TB1 away"
+        );
+
+        // Doctor's no-remedy rows.
+        assert_eq!(
+            render_advice_issue(&AdviceIssue::new(
+                PromiseStatus::Unprotected,
+                IssueDetail::NoAdvice
+            )),
+            "exposed \u{2014} data may not be recoverable"
+        );
+        assert_eq!(
+            render_advice_issue(&AdviceIssue::new(
+                PromiseStatus::AtRisk,
+                IssueDetail::NoAdvice
+            )),
+            "waning"
+        );
+    }
+
     /// Pins the colored `exposure_cell` output for every `PromiseStatus`
     /// variant (#305). The old string-relay design (`exposure_label` then a
     /// re-match in `color_exposure_str`) let a future label change silently
@@ -3285,7 +3447,10 @@ mod tests {
             name: "htpc-docs".to_string(),
             status: PromiseStatus::Unprotected,
             health: "blocked".to_string(),
-            issue: Some("exposed — data may not be recoverable".to_string()),
+            issue: Some(AdviceIssue::new(
+                PromiseStatus::Unprotected,
+                IssueDetail::NoAdvice,
+            )),
             suggestion: Some("Run `urd backup` or connect a drive.".to_string()),
             reason: None,
             storage_posture: None,
@@ -3582,7 +3747,10 @@ mod tests {
         let mut data = test_doctor_output();
         data.data_safety[0].status = PromiseStatus::Unprotected;
         data.data_safety[0].health = "blocked".to_string();
-        data.data_safety[0].issue = Some("exposed".to_string());
+        data.data_safety[0].issue = Some(AdviceIssue::new(
+            PromiseStatus::Unprotected,
+            IssueDetail::NoAdvice,
+        ));
         data.verdict = DoctorVerdict::issues(1);
         let output = render_doctor(&data, OutputMode::Interactive);
         assert!(
@@ -3674,7 +3842,13 @@ mod tests {
             name: "htpc-home".to_string(),
             status: PromiseStatus::AtRisk,
             health: "degraded".to_string(),
-            issue: Some("waning — last backup 48 hours ago".to_string()),
+            issue: Some(AdviceIssue::new(
+                PromiseStatus::AtRisk,
+                IssueDetail::Stale {
+                    external_only: false,
+                    age_secs: Some(48 * 3600),
+                },
+            )),
             suggestion: Some("Run `urd backup --force-full --subvolume htpc-home`.".to_string()),
             reason: Some("thread to WD-18TB broken (pin missing locally)".to_string()),
             storage_posture: None,
@@ -3699,7 +3873,10 @@ mod tests {
             name: "htpc-home".to_string(),
             status: PromiseStatus::Unprotected,
             health: "blocked".to_string(),
-            issue: Some("exposed — all drives disconnected".to_string()),
+            issue: Some(AdviceIssue::new(
+                PromiseStatus::Unprotected,
+                IssueDetail::AllDrivesDisconnected,
+            )),
             suggestion: None,
             reason: Some("Connect WD-18TB to restore protection".to_string()),
             storage_posture: None,

--- a/src/voice/status.rs
+++ b/src/voice/status.rs
@@ -861,9 +861,22 @@ pub fn render_first_time(mode: OutputMode) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::advice::ActionableAdvice;
+    use crate::advice::{ActionableAdvice, AdviceIssue, IssueDetail};
     use crate::output::{AdaptationSummary, DriveInfo, StatusDriveAssessment};
     use crate::voice::test_fixtures::*;
+
+    /// An AT RISK staleness issue with `age_secs` since the last local backup.
+    /// Status rendering never prints the issue (it renders the subvolume name,
+    /// the command and the reason), so these fixtures only have to be valid.
+    fn at_risk_issue(age_secs: Option<i64>) -> AdviceIssue {
+        AdviceIssue::new(
+            PromiseStatus::AtRisk,
+            IssueDetail::Stale {
+                external_only: false,
+                age_secs,
+            },
+        )
+    }
 
     #[test]
     fn interactive_contains_subvolume_names() {
@@ -1571,7 +1584,7 @@ mod tests {
         let mut data = test_status_output();
         data.advice = vec![ActionableAdvice {
             subvolume: "htpc-docs".to_string(),
-            issue: "waning — last backup 3 hours ago".to_string(),
+            issue: at_risk_issue(Some(3 * 3600)),
             command: Some("urd backup --subvolume htpc-docs".to_string()),
             reason: None,
         }];
@@ -1593,13 +1606,13 @@ mod tests {
         data.advice = vec![
             ActionableAdvice {
                 subvolume: "htpc-docs".to_string(),
-                issue: "waning".to_string(),
+                issue: at_risk_issue(None),
                 command: Some("urd backup --subvolume htpc-docs".to_string()),
                 reason: None,
             },
             ActionableAdvice {
                 subvolume: "htpc-home".to_string(),
-                issue: "exposed".to_string(),
+                issue: AdviceIssue::new(PromiseStatus::Unprotected, IssueDetail::NoAdvice),
                 command: None,
                 reason: Some("Connect WD-18TB".to_string()),
             },
@@ -1628,13 +1641,13 @@ mod tests {
         data.advice = vec![
             ActionableAdvice {
                 subvolume: "htpc-home".to_string(),
-                issue: "waning".to_string(),
+                issue: at_risk_issue(None),
                 command: None,
                 reason: Some(shared.clone()),
             },
             ActionableAdvice {
                 subvolume: "htpc-docs".to_string(),
-                issue: "waning".to_string(),
+                issue: at_risk_issue(None),
                 command: None,
                 reason: Some(shared),
             },
@@ -2259,7 +2272,7 @@ mod tests {
         data.waning_names = vec!["htpc-docs".to_string()];
         data.best_advice = Some(ActionableAdvice {
             subvolume: "htpc-docs".to_string(),
-            issue: "waning — last backup 3 hours ago".to_string(),
+            issue: at_risk_issue(Some(3 * 3600)),
             command: Some("urd backup --subvolume htpc-docs".to_string()),
             reason: None,
         });
@@ -2279,7 +2292,7 @@ mod tests {
         data.exposed_names = vec!["htpc-home".to_string()];
         data.best_advice = Some(ActionableAdvice {
             subvolume: "htpc-home".to_string(),
-            issue: "exposed".to_string(),
+            issue: AdviceIssue::new(PromiseStatus::Unprotected, IssueDetail::NoAdvice),
             command: None,
             reason: Some("Connect WD-18TB".to_string()),
         });
@@ -2305,7 +2318,7 @@ mod tests {
         // Provide advice so the suggestion line renders
         data.advice = vec![ActionableAdvice {
             subvolume: "htpc-docs".to_string(),
-            issue: "waning — last backup 3 hours ago".to_string(),
+            issue: at_risk_issue(Some(3 * 3600)),
             command: Some("urd backup --subvolume htpc-docs".to_string()),
             reason: None,
         }];


### PR DESCRIPTION
## Summary

Part 1 of #384 — "Mythic vocabulary in a serialized field". Parts 2 and 3
(colored output in `commands/`, wall clock in renderers) landed separately in
#397; this PR is the remaining, and the only one with a machine-readable
contract in it.

`ActionableAdvice.issue` was a `String` that `advice.rs` composed by hand
("waning — last external send 43h ago"), and it is serialized — through
`StatusOutput.advice` in `urd status --json`, and via `DoctorDataSafety.issue`
in `urd doctor --json`. The mythic exposure labels therefore reached machine
surfaces, against the glossary's "Daemon JSON output keeps the semantic names",
and `format_age_issue` was a second, independently maintained copy of the
`PromiseStatus` → label mapping that `voice/mod.rs::exposure_label` owns.

The issue is now structured data; the voice renders the phrase.

## Changes

**`src/advice.rs`** — new `AdviceIssue { status: PromiseStatus, detail:
IssueDetail }`, with `IssueDetail` an internally tagged, snake_case enum:

| Variant (JSON `kind`) | Produced by |
|---|---|
| `no_external_drives` | branch 2 — UNPROTECTED, `external` empty |
| `all_drives_disconnected` | branch 3 — UNPROTECTED, every drive unmounted |
| `stale { external_only, age_secs }` | branch 1 (sends disabled, AT RISK), branch 4 (chain broken on a mounted drive), branch 5 (AT RISK, drive absent), branch 6 (AT RISK, drive mounted, chain whole) |
| `chain_broken { drive }` | branch 7 — PROTECTED + Degraded, break on a mounted drive |
| `drive_away { drive }` | branch 8 — PROTECTED + Degraded, a named drive's absence is the documented cause |
| `no_advice` | `commands/doctor.rs`' two fallbacks, where a promise is unwhole and `compute_advice` returned nothing (an unearned machine, chiefly) |

`format_age_suffix` / `format_age_issue` are replaced by `issue_age_secs` (an
`Option<i64>` extractor) and `stale_issue`. No string formatting remains in the
module.

**`src/voice/mod.rs`** — `render_advice_issue` is the one home of the phrasing;
the exposure word enters through `exposure_label` and nowhere else.
`render_age_suffix` carries the day/hour split unchanged.

**`src/voice/doctor.rs`** — renders the structured issue through that helper.

**`src/commands/doctor.rs`** — `unpack_advice` returns `Option<AdviceIssue>`;
the two hard-coded fallback sentences become `AdviceIssue::new(a.status,
IssueDetail::NoAdvice)`. Only the `issue` field was touched — the verdict
counters restructured in #400 are untouched.

**`src/output.rs`** — `DoctorDataSafety.issue: Option<AdviceIssue>`;
`DOCTOR_OUTPUT_SCHEMA_VERSION` 3 → 4, with the constant's doc comment saying
what v4 changed.

**`scripts/check-voice-boundary.sh`** (new, tracked; added to the `.gitignore`
`!scripts/…` allowlist) — fails when `"sealed"`, `"waning"` or `"exposed"`
appear as string literals in `src/` outside `src/voice/`. Wired into
`scripts/check.sh` as a `voice` gate beside `doc-lint`, and into CI's `docs`
job. Carries a `# TODO(#384)` for the Colorize and wall-clock guards the
supervisor adds after parts 2/3.

## Design decisions the issue left open

- **`status` is carried on every variant, including the two "degraded" ones.**
  Branches 7 and 8 render "degraded — …" while the promise is PROTECTED: the
  word comes from operational health, not from the promise. Keeping
  `status: PROTECTED` alongside `chain_broken` is the honest reading, and the
  renderer picks "degraded" for those two variants rather than an exposure
  label.
- **One `no_advice` variant, not two.** Doctor's two fallbacks share one
  condition — a non-PROTECTED row for which the advice rules produced nothing —
  and differ only in what the voice says about it. The variant names the
  condition; the renderer adds "— data may not be recoverable" for UNPROTECTED.
- **Ages as `Option<i64>` seconds**, matching `StatusOutput.last_run_age_secs`
  and avoiding a lossy cast from `Duration::num_seconds`. `None` is omitted from
  the JSON rather than serialized as a zero, which would read as "just now".
- **The lint strips whole-line comments** and exempts `src/voice_contract.rs`.
  Both exemptions are earned: doc comments quote the vocabulary legitimately
  (e.g. `config.rs`'s `rotation_interval`), and `voice_contract.rs` is the
  voice's own golden suite, outside `src/voice/` only because it spans every
  renderer.
- **No ADR-119 entry.** That registry covers `clippy.toml` disallowed-methods
  guards whose rule is "one sanctioned caller" (its point 3 excludes broader
  hygiene lints). This is a source-text lint with no sanctioned caller.

## Consumer check

The homelab stack consumes the Prometheus metrics and the heartbeat, neither of
which is touched. Nothing in the repo parses `advice[].issue` or
`data_safety[].issue`. `urd status --json` carries no `schema_version`, so its
shape change is recorded in the CHANGELOG under `### Changed`; `urd doctor
--json` does, and it is bumped per ADR-115's rule. There is no doctor-JSON
reference doc under `docs/20-reference/` — `cli.md` documents `urd doctor`'s
behaviour, not its JSON shape — so nothing there needed updating.

## Test plan

- [x] Goldens captured from the pre-refactor code first, one assertion per issue
      shape, and confirmed green against `master` before any production line
      changed; they are now `voice::tests::render_advice_issue_goldens`, so
      `urd doctor`'s human output is byte-identical.
- [x] `advice::tests::compute_advice_issue_shape_per_branch` pins the exact
      `AdviceIssue` every branch of `compute_advice` produces, including the
      external-only age source and the no-age-known case.
- [x] `advice::tests::advice_issue_serializes_with_semantic_names` pins the JSON
      contract: `"AT RISK"`, `kind: "stale"`, `age_secs` omitted when absent.
- [x] Existing `advice.rs` / `voice/status.rs` / `commands/doctor.rs` tests that
      asserted on the prose now assert on the structured value.
- [x] `output::tests::doctor_output_schema_version_emitted_at_top_level` updated
      to 4.
- [x] `bash scripts/check-voice-boundary.sh` — passes; verified against a
      deliberately planted `const _X: &str = "waning";` in `src/awareness.rs`,
      which it caught and located.
- [x] `bash scripts/check.sh` — `clippy PASS`, `tests PASS 2503 passed, 0
      failed, 6 ignored`, `release PASS 2503 passed`, `doc-lint PASS`,
      `voice PASS`. Master baseline 2500; +3 tests.
- [x] `bash scripts/check-docs.sh`, `bash scripts/check-present-not-journey.sh`
      — pass.
- [x] `bash scripts/pre-commit-pii.sh --report` — clean.

Refs #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti
