### PR TITLE
refactor: hygiene batch — library unwraps, dead code, stale allows, btrfs error contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one shared walk, so they cannot drift apart (#383).
 
 ### Fixed
+- `urd` now honours the configured `btrfs_path` for its read-only `subvolume
+  show` queries too. The generation and received-UUID reads spawned a bare
+  `btrfs`, so on a host where the binary lives outside `PATH` they failed
+  while every other btrfs call succeeded — costing the unchanged-source
+  snapshot skip and the completeness check with no visible error (#387).
 - `urd doctor --thorough` no longer reports "N warnings" when the only thing
   wrong is that a drive is away. Verify's one skipped-check row per absent
   drive used to be counted as a warning, and a warning outranks the

--- a/src/advice.rs
+++ b/src/advice.rs
@@ -686,25 +686,13 @@ drives = ["primary-drive", "offsite-drive"]
         drives: Vec<DriveAssessment>,
     ) -> SubvolAssessment {
         SubvolAssessment {
-            name: name.to_string(),
-            short_name: name.to_string(),
-            status,
-            health: OperationalHealth::Healthy,
-            health_reasons: vec![],
-            local: LocalAssessment {
-                status: PromiseStatus::Protected,
-                snapshot_count: 10,
-                newest_age: Some(Duration::minutes(30)),
-                configured_interval: Interval::hours(1),
-            },
+            local: LocalAssessment::fixture(
+                PromiseStatus::Protected,
+                10,
+                Some(Duration::minutes(30)),
+            ),
             external: drives,
-            chain_health: vec![],
-            advisories: vec![],
-            redundancy_advisories: vec![],
-            errors: vec![],
-            storage_posture: None,
-            cadence_adapted: false,
-            effective_send_interval: None,
+            ..SubvolAssessment::fixture(name, status)
         }
     }
 
@@ -1564,25 +1552,13 @@ local_retention = "transient"
         health: OperationalHealth,
     ) -> SubvolAssessment {
         SubvolAssessment {
-            name: name.to_string(),
-            short_name: name.to_string(),
-            status,
             health,
-            health_reasons: vec![],
-            local: LocalAssessment {
-                status: PromiseStatus::Protected,
-                snapshot_count: 5,
-                newest_age: Some(Duration::hours(2)),
-                configured_interval: Interval::hours(1),
-            },
-            external: vec![],
-            chain_health: vec![],
-            advisories: vec![],
-            redundancy_advisories: vec![],
-            errors: vec![],
-            storage_posture: None,
-            cadence_adapted: false,
-            effective_send_interval: None,
+            local: LocalAssessment::fixture(
+                PromiseStatus::Protected,
+                5,
+                Some(Duration::hours(2)),
+            ),
+            ..SubvolAssessment::fixture(name, status)
         }
     }
 

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -327,6 +327,41 @@ pub struct SubvolAssessment {
     pub effective_send_interval: Option<Interval>,
 }
 
+#[cfg(test)]
+impl SubvolAssessment {
+    /// Test fixture: a subvolume at `status` with a healthy local history,
+    /// no drives and nothing to say. Call sites state only the axis under
+    /// test via struct-update syntax:
+    ///
+    /// ```ignore
+    /// SubvolAssessment {
+    ///     external: drives,
+    ///     ..SubvolAssessment::fixture("home", PromiseStatus::AtRisk)
+    /// }
+    /// ```
+    ///
+    /// Eleven hand-built literals across the crate used to spell all sixteen
+    /// fields out; a seventeenth field now lands here once (#387).
+    pub(crate) fn fixture(name: &str, status: PromiseStatus) -> Self {
+        Self {
+            name: name.to_string(),
+            short_name: name.to_string(),
+            status,
+            health: OperationalHealth::Healthy,
+            health_reasons: vec![],
+            local: LocalAssessment::fixture(status, 0, None),
+            external: vec![],
+            chain_health: vec![],
+            advisories: vec![],
+            redundancy_advisories: vec![],
+            errors: vec![],
+            storage_posture: None,
+            cadence_adapted: false,
+            effective_send_interval: None,
+        }
+    }
+}
+
 /// Per-subvolume raw storage signal fed into `assess()` (UPI 031-a). Resolved
 /// by the command layer (`commands/storage_signals.rs`) from `pools::pool_space`
 /// (free-ratio), `findmnt /` (host-root), and the persisted prior armed tier;
@@ -466,6 +501,25 @@ pub struct LocalAssessment {
     pub newest_age: Option<Duration>,
     #[allow(dead_code)] // consumed by verbose status display (future)
     pub configured_interval: Interval,
+}
+
+#[cfg(test)]
+impl LocalAssessment {
+    /// Test fixture. Every hand-built fixture in the crate declared the same
+    /// one-hour interval, so only the three axes tests actually vary are
+    /// parameters.
+    pub(crate) fn fixture(
+        status: PromiseStatus,
+        snapshot_count: usize,
+        newest_age: Option<Duration>,
+    ) -> Self {
+        Self {
+            status,
+            snapshot_count,
+            newest_age,
+            configured_interval: Interval::hours(1),
+        }
+    }
 }
 
 /// Per-offsite-drive rotation context, carried alongside the per-copy
@@ -5356,27 +5410,7 @@ source = "/data/sv1"
     // ── diff_promise_states tests ──────────────────────────────────
 
     fn make_assess(name: &str, status: PromiseStatus) -> SubvolAssessment {
-        SubvolAssessment {
-            name: name.to_string(),
-            short_name: name.to_string(),
-            status,
-            health: OperationalHealth::Healthy,
-            health_reasons: vec![],
-            local: LocalAssessment {
-                status,
-                snapshot_count: 0,
-                newest_age: None,
-                configured_interval: Interval::hours(1),
-            },
-            external: vec![],
-            chain_health: vec![],
-            advisories: vec![],
-            redundancy_advisories: vec![],
-            errors: vec![],
-            storage_posture: None,
-            cadence_adapted: false,
-            effective_send_interval: None,
-        }
+        SubvolAssessment::fixture(name, status)
     }
 
     fn make_promise_snapshot(name: &str, status: PromiseStatus) -> PromiseSnapshot {

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -577,7 +577,7 @@ pub struct DriveAssessment {
     #[allow(dead_code)] // consumed by verbose status display (future)
     pub configured_interval: Interval,
     pub role: DriveRole,
-    /// Seconds since the drive's last `Unmount` event in `drive_connections`,
+    /// Seconds since the drive's last `Unmount` event in the `events` table,
     /// populated only when the drive is currently unmounted AND the most
     /// recent physical event is an Unmount. Rule 1 of the voice contract:
     /// stay silent when the sentinel missed the disconnect (last event is
@@ -585,7 +585,7 @@ pub struct DriveAssessment {
     pub absent_duration_secs: Option<i64>,
     /// Seconds since the most recent successful operation targeting this
     /// drive in the operations log. Populated only when the drive is
-    /// unmounted AND `drive_connections` holds *no* events for this drive
+    /// unmounted AND the `events` table holds *no* drive events for this drive
     /// at all — the drive predates sentinel observation. Never mixed with
     /// `absent_duration_secs`.
     pub last_activity_age_secs: Option<i64>,
@@ -4059,7 +4059,7 @@ send_enabled = false
 
     #[test]
     fn drive_assessment_last_activity_from_ops_log_when_no_event() {
-        // drive_connections empty for this drive → fall through to operations log.
+        // No drive events for this drive → fall through to the operations log.
         let config = test_config();
         let now = dt(2026, 3, 23, 14, 0);
         let mut fs = MockFileSystemState::new();

--- a/src/awareness.rs
+++ b/src/awareness.rs
@@ -528,14 +528,12 @@ pub struct DriveAssessment {
     /// recent physical event is an Unmount. Rule 1 of the voice contract:
     /// stay silent when the sentinel missed the disconnect (last event is
     /// Mount but drive is unmounted) — fall through to activity or silence.
-    #[allow(dead_code)] // consumed via StatusDriveAssessment by voice.rs
     pub absent_duration_secs: Option<i64>,
     /// Seconds since the most recent successful operation targeting this
     /// drive in the operations log. Populated only when the drive is
     /// unmounted AND `drive_connections` holds *no* events for this drive
     /// at all — the drive predates sentinel observation. Never mixed with
     /// `absent_duration_secs`.
-    #[allow(dead_code)] // consumed via StatusDriveAssessment by voice.rs
     pub last_activity_age_secs: Option<i64>,
     /// Rotation context for an offsite drive (UPI 056): cadence, last
     /// homecoming, and the pre-computed homecoming forecast. `None` for

--- a/src/btrfs.rs
+++ b/src/btrfs.rs
@@ -566,21 +566,30 @@ pub fn parse_subvolume_list(output: &str) -> crate::error::Result<Vec<PathBuf>> 
     Ok(paths)
 }
 
+/// The `sudo -n <btrfs_path> subvolume show <path>` invocation, built apart
+/// from running it so a test can assert the *configured* binary reaches the
+/// command line without needing sudo.
+///
+/// `-n`: never prompt. Reachable pre-grant from `urd status`/`doctor`/`plan`
+/// (via `subvolume_generation`) on a configured-but-unsealed machine —
+/// without `-n` this pops an interactive PIN+FIDO prompt from a read-only
+/// fail-open call (field visit 2026-07-06, #274). Callers already treat an
+/// Err here as "no generation info" and proceed without the optimization.
+fn show_command(btrfs_path: &str, path: &Path) -> Command {
+    let mut cmd = Command::new("sudo");
+    cmd.env("LC_ALL", "C")
+        .arg("-n")
+        .arg(btrfs_path)
+        .args(["subvolume", "show"])
+        .arg(path);
+    cmd
+}
+
 /// Run `sudo btrfs subvolume show` and return its stdout. Shared by the
 /// `BtrfsRead` field readers (`subvolume_generation`, `received_uuid`) — one
 /// invocation, one sudoers surface.
-fn subvolume_show(path: &Path) -> crate::error::Result<String> {
-    // `-n`: never prompt. Reachable pre-grant from `urd status`/`doctor`/`plan`
-    // (via `subvolume_generation`) on a configured-but-unsealed machine —
-    // without `-n` this pops an interactive PIN+FIDO prompt from a read-only
-    // fail-open call (field visit 2026-07-06, #274). Callers already treat an
-    // Err here as "no generation info" and proceed without the optimization.
-    let output = Command::new("sudo")
-        .env("LC_ALL", "C")
-        .arg("-n")
-        .arg("btrfs")
-        .args(["subvolume", "show"])
-        .arg(path)
+fn subvolume_show(btrfs_path: &str, path: &Path) -> crate::error::Result<String> {
+    let output = show_command(btrfs_path, path)
         .output()
         .map_err(|e| UrdError::btrfs_spawn(BtrfsOperation::Show, e.to_string()))?;
 
@@ -600,7 +609,7 @@ impl BtrfsRead for RealBtrfs {
     ///
     /// All btrfs subprocess calls remain in `btrfs.rs` (invariant #2).
     fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
-        let stdout = subvolume_show(path)?;
+        let stdout = subvolume_show(&self.btrfs_path, path)?;
         parse_generation(&stdout).ok_or_else(|| {
             UrdError::btrfs_spawn(
                 BtrfsOperation::Show,
@@ -610,7 +619,7 @@ impl BtrfsRead for RealBtrfs {
     }
 
     fn received_uuid(&self, path: &Path) -> crate::error::Result<Option<String>> {
-        let stdout = subvolume_show(path)?;
+        let stdout = subvolume_show(&self.btrfs_path, path)?;
         Ok(parse_received_uuid(&stdout))
     }
 
@@ -1121,6 +1130,30 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("mock: create snapshot failed")
+        );
+    }
+
+    #[test]
+    fn subvolume_show_uses_the_configured_btrfs_path() {
+        // Every other invocation in this file passes `self.btrfs_path`; the
+        // read-only `subvolume show` used to hardcode "btrfs", so a host with
+        // the binary anywhere but the default path silently lost the
+        // generation and received-UUID reads (#387).
+        let cmd = show_command("/opt/btrfs-progs/bin/btrfs", Path::new("/data/sv1"));
+        assert_eq!(cmd.get_program(), "sudo");
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(
+            args,
+            [
+                "-n",
+                "/opt/btrfs-progs/bin/btrfs",
+                "subvolume",
+                "show",
+                "/data/sv1"
+            ]
         );
     }
 

--- a/src/btrfs.rs
+++ b/src/btrfs.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 use nix::fcntl::{FcntlArg, OFlag, fcntl};
 use nix::poll::{PollFd, PollFlags, PollTimeout, poll};
 
-use crate::error::{BtrfsErrorContext, BtrfsOperation, SendReceiveErrorContext, UrdError};
+use crate::error::{BtrfsOperation, SendReceiveErrorContext, UrdError};
 use crate::guard::WATCHDOG_POLL_MS;
 
 // ── BtrfsOps trait ──────────────────────────────────────────────────────
@@ -177,25 +177,19 @@ impl BtrfsOps for RealBtrfs {
             .arg(source)
             .arg(dest)
             .output()
-            .map_err(|e| UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Snapshot,
-                    exit_code: None,
-                    stderr: format!("failed to spawn btrfs: {e}"),
-                    bytes_transferred: None,
-                },
+            .map_err(|e| {
+                UrdError::btrfs_spawn(
+                    BtrfsOperation::Snapshot,
+                    format!("failed to spawn btrfs: {e}"),
+                )
             })?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            return Err(UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Snapshot,
-                    exit_code: output.status.code(),
-                    stderr,
-                    bytes_transferred: None,
-                },
-            });
+            return Err(UrdError::btrfs_exit(
+                BtrfsOperation::Snapshot,
+                output.status.code(),
+                String::from_utf8_lossy(&output.stderr),
+            ));
         }
         Ok(())
     }
@@ -232,33 +226,27 @@ impl BtrfsOps for RealBtrfs {
             snapshot.display()
         );
 
-        let mut send_child = send_cmd.spawn().map_err(|e| UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Send,
-                exit_code: None,
-                stderr: format!("failed to spawn btrfs send: {e}"),
-                bytes_transferred: None,
-            },
+        let mut send_child = send_cmd.spawn().map_err(|e| {
+            UrdError::btrfs_spawn(
+                BtrfsOperation::Send,
+                format!("failed to spawn btrfs send: {e}"),
+            )
         })?;
 
         // Take send's stdout to pipe into receive's stdin
-        let mut send_stdout = send_child.stdout.take().ok_or_else(|| UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Send,
-                exit_code: None,
-                stderr: "failed to capture btrfs send stdout".to_string(),
-                bytes_transferred: None,
-            },
+        let mut send_stdout = send_child.stdout.take().ok_or_else(|| {
+            UrdError::btrfs_spawn(
+                BtrfsOperation::Send,
+                "failed to capture btrfs send stdout",
+            )
         })?;
 
         // Take send's stderr to drain in a thread
-        let send_stderr = send_child.stderr.take().ok_or_else(|| UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Send,
-                exit_code: None,
-                stderr: "failed to capture btrfs send stderr".to_string(),
-                bytes_transferred: None,
-            },
+        let send_stderr = send_child.stderr.take().ok_or_else(|| {
+            UrdError::btrfs_spawn(
+                BtrfsOperation::Send,
+                "failed to capture btrfs send stderr",
+            )
         })?;
 
         // Drain send stderr in a background thread to prevent deadlock
@@ -286,42 +274,34 @@ impl BtrfsOps for RealBtrfs {
             .stdout(Stdio::null())
             .stderr(Stdio::piped())
             .spawn()
-            .map_err(|e| UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Receive,
-                    exit_code: None,
-                    stderr: format!("failed to spawn btrfs receive: {e}"),
-                    bytes_transferred: None,
-                },
+            .map_err(|e| {
+                UrdError::btrfs_spawn(
+                    BtrfsOperation::Receive,
+                    format!("failed to spawn btrfs receive: {e}"),
+                )
             })?;
 
-        let mut recv_stdin = recv_child.stdin.take().ok_or_else(|| UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Receive,
-                exit_code: None,
-                stderr: "failed to capture btrfs receive stdin".to_string(),
-                bytes_transferred: None,
-            },
+        let mut recv_stdin = recv_child.stdin.take().ok_or_else(|| {
+            UrdError::btrfs_spawn(
+                BtrfsOperation::Receive,
+                "failed to capture btrfs receive stdin",
+            )
         })?;
 
         // Non-blocking writes so a full pipe (wedged receive) cannot park the
         // copy thread past the watchdog's cancel (UPI 054-b).
-        set_nonblocking(&recv_stdin).map_err(|e| UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Receive,
-                exit_code: None,
-                stderr: format!("failed to set receive stdin non-blocking: {e}"),
-                bytes_transferred: None,
-            },
+        set_nonblocking(&recv_stdin).map_err(|e| {
+            UrdError::btrfs_spawn(
+                BtrfsOperation::Receive,
+                format!("failed to set receive stdin non-blocking: {e}"),
+            )
         })?;
 
-        let recv_stderr = recv_child.stderr.take().ok_or_else(|| UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Receive,
-                exit_code: None,
-                stderr: "failed to capture btrfs receive stderr".to_string(),
-                bytes_transferred: None,
-            },
+        let recv_stderr = recv_child.stderr.take().ok_or_else(|| {
+            UrdError::btrfs_spawn(
+                BtrfsOperation::Receive,
+                "failed to capture btrfs receive stderr",
+            )
         })?;
 
         // Drain receive stderr in a background thread (mirror of send's): the
@@ -367,26 +347,22 @@ impl BtrfsOps for RealBtrfs {
         // it is already closed.
         let recv_wait =
             wait_child_cancellable(|| recv_child.try_wait(), &self.cancel, grace, poll_interval)
-                .map_err(|e| UrdError::Btrfs {
-                    context: BtrfsErrorContext {
-                        operation: BtrfsOperation::Receive,
-                        exit_code: None,
-                        stderr: format!("failed to wait for btrfs receive: {e}"),
-                        bytes_transferred: None,
-                    },
+                .map_err(|e| {
+                    UrdError::btrfs_spawn(
+                        BtrfsOperation::Receive,
+                        format!("failed to wait for btrfs receive: {e}"),
+                    )
                 })?;
         let (recv_status, recv_stderr_str) = settle_wait(recv_wait, recv_stderr_thread, "receive");
 
         // Send normally dies fast on EPIPE once its stdout pipe drops.
         let send_wait =
             wait_child_cancellable(|| send_child.try_wait(), &self.cancel, grace, poll_interval)
-                .map_err(|e| UrdError::Btrfs {
-                    context: BtrfsErrorContext {
-                        operation: BtrfsOperation::Send,
-                        exit_code: None,
-                        stderr: format!("failed to wait for btrfs send: {e}"),
-                        bytes_transferred: None,
-                    },
+                .map_err(|e| {
+                    UrdError::btrfs_spawn(
+                        BtrfsOperation::Send,
+                        format!("failed to wait for btrfs send: {e}"),
+                    )
                 })?;
         let (send_status, send_stderr_str) = settle_wait(send_wait, send_stderr_thread, "send");
 
@@ -458,25 +434,19 @@ impl BtrfsOps for RealBtrfs {
             .args(["subvolume", "delete"])
             .arg(path)
             .output()
-            .map_err(|e| UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Delete,
-                    exit_code: None,
-                    stderr: format!("failed to spawn btrfs: {e}"),
-                    bytes_transferred: None,
-                },
+            .map_err(|e| {
+                UrdError::btrfs_spawn(
+                    BtrfsOperation::Delete,
+                    format!("failed to spawn btrfs: {e}"),
+                )
             })?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            return Err(UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Delete,
-                    exit_code: output.status.code(),
-                    stderr,
-                    bytes_transferred: None,
-                },
-            });
+            return Err(UrdError::btrfs_exit(
+                BtrfsOperation::Delete,
+                output.status.code(),
+                String::from_utf8_lossy(&output.stderr),
+            ));
         }
         Ok(())
     }
@@ -515,25 +485,19 @@ impl BtrfsOps for RealBtrfs {
             .args(["subvolume", "sync"])
             .arg(path)
             .output()
-            .map_err(|e| UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Sync,
-                    exit_code: None,
-                    stderr: format!("failed to spawn btrfs: {e}"),
-                    bytes_transferred: None,
-                },
+            .map_err(|e| {
+                UrdError::btrfs_spawn(
+                    BtrfsOperation::Sync,
+                    format!("failed to spawn btrfs: {e}"),
+                )
             })?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            return Err(UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Sync,
-                    exit_code: output.status.code(),
-                    stderr,
-                    bytes_transferred: None,
-                },
-            });
+            return Err(UrdError::btrfs_exit(
+                BtrfsOperation::Sync,
+                output.status.code(),
+                String::from_utf8_lossy(&output.stderr),
+            ));
         }
         Ok(())
     }
@@ -592,14 +556,10 @@ pub fn parse_subvolume_list(output: &str) -> crate::error::Result<Vec<PathBuf>> 
         match path {
             Some(p) if !p.is_empty() => paths.push(PathBuf::from(p)),
             _ => {
-                return Err(UrdError::Btrfs {
-                    context: BtrfsErrorContext {
-                        operation: BtrfsOperation::List,
-                        exit_code: None,
-                        stderr: format!("unrecognized subvolume list line: {line}"),
-                        bytes_transferred: None,
-                    },
-                });
+                return Err(UrdError::btrfs_spawn(
+                    BtrfsOperation::List,
+                    format!("unrecognized subvolume list line: {line}"),
+                ));
             }
         }
     }
@@ -622,25 +582,14 @@ fn subvolume_show(path: &Path) -> crate::error::Result<String> {
         .args(["subvolume", "show"])
         .arg(path)
         .output()
-        .map_err(|e| UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Show,
-                exit_code: None,
-                stderr: e.to_string(),
-                bytes_transferred: None,
-            },
-        })?;
+        .map_err(|e| UrdError::btrfs_spawn(BtrfsOperation::Show, e.to_string()))?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Show,
-                exit_code: output.status.code(),
-                stderr,
-                bytes_transferred: None,
-            },
-        });
+        return Err(UrdError::btrfs_exit(
+            BtrfsOperation::Show,
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr),
+        ));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
@@ -652,13 +601,11 @@ impl BtrfsRead for RealBtrfs {
     /// All btrfs subprocess calls remain in `btrfs.rs` (invariant #2).
     fn subvolume_generation(&self, path: &Path) -> crate::error::Result<u64> {
         let stdout = subvolume_show(path)?;
-        parse_generation(&stdout).ok_or_else(|| UrdError::Btrfs {
-            context: BtrfsErrorContext {
-                operation: BtrfsOperation::Show,
-                exit_code: None,
-                stderr: "Generation field not found in btrfs subvolume show output".to_string(),
-                bytes_transferred: None,
-            },
+        parse_generation(&stdout).ok_or_else(|| {
+            UrdError::btrfs_spawn(
+                BtrfsOperation::Show,
+                "Generation field not found in btrfs subvolume show output",
+            )
         })
     }
 
@@ -681,25 +628,14 @@ impl BtrfsRead for RealBtrfs {
             .args(["subvolume", "list"])
             .arg(path)
             .output()
-            .map_err(|e| UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::List,
-                    exit_code: None,
-                    stderr: e.to_string(),
-                    bytes_transferred: None,
-                },
-            })?;
+            .map_err(|e| UrdError::btrfs_spawn(BtrfsOperation::List, e.to_string()))?;
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-            return Err(UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::List,
-                    exit_code: output.status.code(),
-                    stderr,
-                    bytes_transferred: None,
-                },
-            });
+            return Err(UrdError::btrfs_exit(
+                BtrfsOperation::List,
+                output.status.code(),
+                String::from_utf8_lossy(&output.stderr),
+            ));
         }
 
         parse_subvolume_list(&String::from_utf8_lossy(&output.stdout))
@@ -1073,14 +1009,11 @@ impl BtrfsOps for MockBtrfs {
             dest: dest.to_path_buf(),
         });
         if self.fail_creates.borrow().contains(dest) {
-            return Err(UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Snapshot,
-                    exit_code: Some(1),
-                    stderr: format!("mock: create snapshot failed for {}", dest.display()),
-                    bytes_transferred: None,
-                },
-            });
+            return Err(UrdError::btrfs_exit(
+                BtrfsOperation::Snapshot,
+                Some(1),
+                format!("mock: create snapshot failed for {}", dest.display()),
+            ));
         }
         Ok(())
     }
@@ -1119,14 +1052,11 @@ impl BtrfsOps for MockBtrfs {
                 path: path.to_path_buf(),
             });
         if self.fail_deletes.borrow().contains(path) {
-            return Err(UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Delete,
-                    exit_code: Some(1),
-                    stderr: format!("mock: delete failed for {}", path.display()),
-                    bytes_transferred: None,
-                },
-            });
+            return Err(UrdError::btrfs_exit(
+                BtrfsOperation::Delete,
+                Some(1),
+                format!("mock: delete failed for {}", path.display()),
+            ));
         }
         Ok(())
     }
@@ -1146,14 +1076,11 @@ impl BtrfsOps for MockBtrfs {
                 path: path.to_path_buf(),
             });
         if self.fail_syncs.borrow().contains(path) {
-            return Err(UrdError::Btrfs {
-                context: BtrfsErrorContext {
-                    operation: BtrfsOperation::Sync,
-                    exit_code: Some(1),
-                    stderr: format!("mock: sync failed for {}", path.display()),
-                    bytes_transferred: None,
-                },
-            });
+            return Err(UrdError::btrfs_exit(
+                BtrfsOperation::Sync,
+                Some(1),
+                format!("mock: sync failed for {}", path.display()),
+            ));
         }
         Ok(())
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,7 +47,7 @@ pub enum Commands {
     RetentionPreview(RetentionPreviewArgs),
     /// Generate shell completion scripts
     Completions(CompletionsArgs),
-    /// Migrate config from legacy schema to v1
+    /// Migrate config to the latest schema (v2)
     Migrate(MigrateArgs),
     /// View the structured event log
     Events(EventsArgs),

--- a/src/commands/events.rs
+++ b/src/commands/events.rs
@@ -30,7 +30,7 @@ pub fn run(config: Config, args: EventsArgs, output_mode: OutputMode) -> anyhow:
     let limit = args.limit.clamp(1, LIMIT_MAX);
 
     let since_dt = match args.since.as_deref() {
-        Some(s) => Some(parse_since(s)?),
+        Some(s) => Some(parse_since(chrono::Local::now().naive_local(), s)?),
         None => None,
     };
 
@@ -80,11 +80,13 @@ pub fn run(config: Config, args: EventsArgs, output_mode: OutputMode) -> anyhow:
 /// Parse a `--since` argument like "7d" / "24h" / "30m" / "5w" into the
 /// absolute cutoff `now - duration`. Same suffix vocabulary as
 /// `types::Interval::from_str`.
-fn parse_since(s: &str) -> anyhow::Result<chrono::NaiveDateTime> {
+///
+/// `now` is passed in rather than read here so the subtraction is testable
+/// exactly, instead of against a tolerance window around the wall clock.
+fn parse_since(now: chrono::NaiveDateTime, s: &str) -> anyhow::Result<chrono::NaiveDateTime> {
     let interval: crate::types::Interval = s
         .parse()
         .with_context(|| format!("invalid --since {s:?} (expected like 7d, 24h, 30m, 5w)"))?;
-    let now = chrono::Local::now().naive_local();
     Ok(now - interval.as_chrono())
 }
 
@@ -92,29 +94,44 @@ fn parse_since(s: &str) -> anyhow::Result<chrono::NaiveDateTime> {
 mod tests {
     use super::*;
 
+    fn now() -> chrono::NaiveDateTime {
+        chrono::NaiveDate::from_ymd_opt(2026, 9, 4)
+            .unwrap()
+            .and_hms_opt(14, 30, 0)
+            .unwrap()
+    }
+
     #[test]
     fn parse_since_accepts_duration_suffixes() {
-        assert!(parse_since("7d").is_ok());
-        assert!(parse_since("24h").is_ok());
-        assert!(parse_since("30m").is_ok());
-        assert!(parse_since("5w").is_ok());
+        assert!(parse_since(now(), "7d").is_ok());
+        assert!(parse_since(now(), "24h").is_ok());
+        assert!(parse_since(now(), "30m").is_ok());
+        assert!(parse_since(now(), "5w").is_ok());
     }
 
     #[test]
     fn parse_since_rejects_garbage() {
-        assert!(parse_since("garbage").is_err());
-        assert!(parse_since("").is_err());
-        assert!(parse_since("0d").is_err()); // zero is not positive
+        assert!(parse_since(now(), "garbage").is_err());
+        assert!(parse_since(now(), "").is_err());
+        assert!(parse_since(now(), "0d").is_err()); // zero is not positive
     }
 
     #[test]
     fn parse_since_subtracts_from_now() {
-        let cutoff = parse_since("1h").unwrap();
-        let now = chrono::Local::now().naive_local();
-        let delta = now.signed_duration_since(cutoff);
-        // ~1h ago ± a few seconds.
-        assert!(delta.num_seconds() >= 3590);
-        assert!(delta.num_seconds() <= 3610);
+        assert_eq!(
+            parse_since(now(), "1h").unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2026, 9, 4)
+                .unwrap()
+                .and_hms_opt(13, 30, 0)
+                .unwrap()
+        );
+        assert_eq!(
+            parse_since(now(), "7d").unwrap(),
+            chrono::NaiveDate::from_ymd_opt(2026, 8, 28)
+                .unwrap()
+                .and_hms_opt(14, 30, 0)
+                .unwrap()
+        );
     }
 
     #[test]

--- a/src/commands/retention_preview.rs
+++ b/src/commands/retention_preview.rs
@@ -15,10 +15,12 @@ pub fn run(config: Config, args: RetentionPreviewArgs, mode: OutputMode) -> anyh
     let targets: Vec<_> = if args.all {
         resolved.iter().filter(|sv| sv.enabled).collect()
     } else if let Some(ref name) = args.subvolume {
+        // `require_known_subvolume` above already rejected an unknown name;
+        // this arm is the structural restatement, not a second validation.
         let sv = resolved
             .iter()
             .find(|sv| sv.name == *name)
-            .expect("validated by require_known_subvolume");
+            .ok_or_else(|| anyhow::anyhow!("unknown subvolume: {name}"))?;
         vec![sv]
     } else if resolved.len() == 1 {
         vec![&resolved[0]]

--- a/src/commands/storage_signals.rs
+++ b/src/commands/storage_signals.rs
@@ -1444,28 +1444,11 @@ source = "/"
     }
 
     fn mk_assess(name: &str, posture: Option<StoragePosture>) -> SubvolAssessment {
-        use crate::awareness::{LocalAssessment, OperationalHealth, PromiseStatus};
-        use crate::types::Interval;
+        use crate::awareness::{LocalAssessment, PromiseStatus};
         SubvolAssessment {
-            name: name.to_string(),
-            short_name: name.to_string(),
-            status: PromiseStatus::Protected,
-            health: OperationalHealth::Healthy,
-            health_reasons: vec![],
-            local: LocalAssessment {
-                status: PromiseStatus::Protected,
-                snapshot_count: 1,
-                newest_age: None,
-                configured_interval: Interval::hours(1),
-            },
-            external: vec![],
-            chain_health: vec![],
-            advisories: vec![],
-            redundancy_advisories: vec![],
-            errors: vec![],
+            local: LocalAssessment::fixture(PromiseStatus::Protected, 1, None),
             storage_posture: posture,
-            cadence_adapted: false,
-            effective_send_interval: None,
+            ..SubvolAssessment::fixture(name, PromiseStatus::Protected)
         }
     }
 
@@ -1499,7 +1482,7 @@ source = "/"
         effective_secs: Option<i64>,
         has_external: bool,
     ) -> SubvolAssessment {
-        use crate::awareness::{DriveAssessment, LocalAssessment, OperationalHealth, PromiseStatus};
+        use crate::awareness::{DriveAssessment, LocalAssessment, PromiseStatus};
         use crate::types::{DriveRole, Interval};
         let external = if has_external {
             vec![DriveAssessment {
@@ -1519,26 +1502,12 @@ source = "/"
             vec![]
         };
         SubvolAssessment {
-            name: name.to_string(),
-            short_name: name.to_string(),
-            status,
-            health: OperationalHealth::Healthy,
-            health_reasons: vec![],
-            local: LocalAssessment {
-                status: PromiseStatus::Protected,
-                snapshot_count: 1,
-                newest_age: None,
-                configured_interval: Interval::hours(1),
-            },
+            local: LocalAssessment::fixture(PromiseStatus::Protected, 1, None),
             external,
-            chain_health: vec![],
-            advisories: vec![],
-            redundancy_advisories: vec![],
-            errors: vec![],
-            storage_posture: None,
             cadence_adapted,
             effective_send_interval: effective_secs
                 .map(|s| Interval::from_chrono(chrono::Duration::seconds(s))),
+            ..SubvolAssessment::fixture(name, status)
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,6 @@ pub struct Config {
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[allow(dead_code)]
 pub struct GeneralConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub config_version: Option<u32>,
@@ -131,7 +130,6 @@ fn group_subvolumes_by_snapshot_root<'a>(
 }
 
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
-#[allow(dead_code)]
 pub struct DriveConfig {
     pub label: String,
     #[serde(default)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -304,10 +304,6 @@ pub enum UrdError {
     #[error("Thread error: {0}")]
     Chain(String),
 
-    #[error("Retention error: {0}")]
-    #[allow(dead_code)]
-    Retention(String),
-
     #[error("btrfs command failed: {context}")]
     Btrfs { context: BtrfsErrorContext },
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -335,6 +335,43 @@ impl UrdError {
         }
     }
 
+    /// A btrfs subprocess that never ran to completion — spawn, pipe capture,
+    /// or wait failed. There is no exit code and nothing was transferred, so
+    /// only the operation and the reason vary between call sites.
+    #[must_use]
+    pub fn btrfs_spawn(operation: BtrfsOperation, stderr: impl Into<String>) -> Self {
+        Self::Btrfs {
+            context: BtrfsErrorContext {
+                operation,
+                exit_code: None,
+                stderr: stderr.into(),
+                bytes_transferred: None,
+            },
+        }
+    }
+
+    /// A btrfs subprocess that ran and exited non-zero. `exit_code` is
+    /// `Option` because a signalled child reports none.
+    ///
+    /// Both constructors mirror `executor::outcome_success` /
+    /// `outcome_failure`: the mechanical fields are stamped in one place so a
+    /// new call site states only what differs (#387).
+    #[must_use]
+    pub fn btrfs_exit(
+        operation: BtrfsOperation,
+        exit_code: Option<i32>,
+        stderr: impl Into<String>,
+    ) -> Self {
+        Self::Btrfs {
+            context: BtrfsErrorContext {
+                operation,
+                exit_code,
+                stderr: stderr.into(),
+                bytes_transferred: None,
+            },
+        }
+    }
+
     /// Extract the btrfs operation.
     #[must_use]
     pub fn btrfs_operation(&self) -> Option<BtrfsOperation> {

--- a/src/events.rs
+++ b/src/events.rs
@@ -391,13 +391,6 @@ impl Event {
     pub fn kind(&self) -> EventKind {
         self.payload.kind()
     }
-
-    /// Convenience: derive severity from the payload.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn severity(&self) -> Severity {
-        self.payload.severity()
-    }
 }
 
 // ── Run context + the emit-side stamp (UPI 088-c) ─────────────────────
@@ -723,7 +716,6 @@ mod tests {
         };
         let event = event_with(payload.clone());
         assert_eq!(event.kind(), payload.kind());
-        assert_eq!(event.severity(), payload.severity());
     }
 
     // ── Roundtrip tests (per-variant serde stability) ─────────────────

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -277,7 +277,7 @@ pub fn mark_dispatched(path: &Path) -> crate::error::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::awareness::{DriveAssessment, LocalAssessment, OperationalHealth, PromiseStatus};
+    use crate::awareness::{DriveAssessment, LocalAssessment, PromiseStatus};
     use crate::config::{
         Config, DefaultsConfig, GeneralConfig, LocalSnapshotsConfig, SnapshotRoot, SubvolumeConfig,
     };
@@ -356,17 +356,11 @@ mod tests {
     fn test_assessments() -> Vec<SubvolAssessment> {
         vec![
             SubvolAssessment {
-                name: "home".to_string(),
-                short_name: "home".to_string(),
-                status: PromiseStatus::Protected,
-                health: OperationalHealth::Healthy,
-                health_reasons: vec![],
-                local: LocalAssessment {
-                    status: PromiseStatus::Protected,
-                    snapshot_count: 24,
-                    newest_age: Some(chrono::Duration::minutes(30)),
-                    configured_interval: Interval::hours(1),
-                },
+                local: LocalAssessment::fixture(
+                    PromiseStatus::Protected,
+                    24,
+                    Some(chrono::Duration::minutes(30)),
+                ),
                 external: vec![DriveAssessment {
                     drive_label: "WD-18TB".to_string(),
                     status: PromiseStatus::Protected,
@@ -380,34 +374,15 @@ mod tests {
                     last_activity_age_secs: None,
                     rotation: None,
                 }],
-                chain_health: vec![],
-                advisories: vec![],
-                redundancy_advisories: vec![],
-                errors: vec![],
-                storage_posture: None,
-                cadence_adapted: false,
-                effective_send_interval: None,
+                ..SubvolAssessment::fixture("home", PromiseStatus::Protected)
             },
             SubvolAssessment {
-                name: "docs".to_string(),
-                short_name: "docs".to_string(),
-                status: PromiseStatus::AtRisk,
-                health: OperationalHealth::Healthy,
-                health_reasons: vec![],
-                local: LocalAssessment {
-                    status: PromiseStatus::AtRisk,
-                    snapshot_count: 5,
-                    newest_age: Some(chrono::Duration::hours(3)),
-                    configured_interval: Interval::hours(1),
-                },
-                external: vec![],
-                chain_health: vec![],
-                advisories: vec![],
-                redundancy_advisories: vec![],
-                errors: vec![],
-                storage_posture: None,
-                cadence_adapted: false,
-                effective_send_interval: None,
+                local: LocalAssessment::fixture(
+                    PromiseStatus::AtRisk,
+                    5,
+                    Some(chrono::Duration::hours(3)),
+                ),
+                ..SubvolAssessment::fixture("docs", PromiseStatus::AtRisk)
             },
         ]
     }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -81,7 +81,6 @@ pub fn acquire_lock(lock_path: &Path, trigger: &str) -> anyhow::Result<LockGuard
 ///
 /// Used by the Sentinel for auto-triggered backups — if another backup is
 /// running, the Sentinel simply skips the trigger (expected during timer overlap).
-#[allow(dead_code)] // Used by sentinel_runner (Session 2)
 pub fn try_acquire_lock(lock_path: &Path, trigger: &str) -> anyhow::Result<Option<LockGuard>> {
     if let Some(parent) = lock_path.parent() {
         std::fs::create_dir_all(parent)?;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -179,11 +179,11 @@ fn sample(out: &mut String, name: &str, labels: &[(&str, &str)], value: impl std
             if i > 0 {
                 out.push(',');
             }
-            write!(out, "{key}=\"{}\"", escape_label_value(val)).unwrap();
+            write!(out, "{key}=\"{}\"", escape_label_value(val)).ok();
         }
         out.push('}');
     }
-    writeln!(out, " {value}").unwrap();
+    writeln!(out, " {value}").ok();
 }
 
 // ── Writer ──────────────────────────────────────────────────────────────
@@ -446,8 +446,8 @@ fn format_metrics(data: &MetricsData) -> String {
         "# HELP {} Backup result: 1=success, 0=failure, 2=schedule-skipped",
         names::BACKUP_SUCCESS
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_SUCCESS).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_SUCCESS).ok();
     for sv in &data.subvolumes {
         sample(
             &mut out,
@@ -458,14 +458,14 @@ fn format_metrics(data: &MetricsData) -> String {
     }
 
     // backup_last_success_timestamp
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Unix timestamp of last successful backup",
         names::BACKUP_LAST_SUCCESS_TIMESTAMP
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_LAST_SUCCESS_TIMESTAMP).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_LAST_SUCCESS_TIMESTAMP).ok();
     for sv in &data.subvolumes {
         if let Some(ts) = sv.last_success_timestamp {
             sample(
@@ -478,14 +478,14 @@ fn format_metrics(data: &MetricsData) -> String {
     }
 
     // backup_duration_seconds
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Duration of backup operations in seconds",
         names::BACKUP_DURATION_SECONDS
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_DURATION_SECONDS).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_DURATION_SECONDS).ok();
     for sv in &data.subvolumes {
         sample(
             &mut out,
@@ -496,9 +496,9 @@ fn format_metrics(data: &MetricsData) -> String {
     }
 
     // backup_snapshot_count
-    writeln!(out).unwrap();
-    writeln!(out, "# HELP {} Number of snapshots", names::BACKUP_SNAPSHOT_COUNT).unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_SNAPSHOT_COUNT).unwrap();
+    writeln!(out).ok();
+    writeln!(out, "# HELP {} Number of snapshots", names::BACKUP_SNAPSHOT_COUNT).ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_SNAPSHOT_COUNT).ok();
     for sv in &data.subvolumes {
         sample(
             &mut out,
@@ -515,14 +515,14 @@ fn format_metrics(data: &MetricsData) -> String {
     }
 
     // backup_send_type
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Send type: 0=full, 1=incremental, 2=no send, 3=deferred",
         names::BACKUP_SEND_TYPE
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_SEND_TYPE).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_SEND_TYPE).ok();
     for sv in &data.subvolumes {
         sample(
             &mut out,
@@ -533,14 +533,14 @@ fn format_metrics(data: &MetricsData) -> String {
     }
 
     // backup_external_expected
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} 1 if the subvolume has an external destination configured (sends enabled and at least one drive in scope). Line absent otherwise.",
         names::BACKUP_EXTERNAL_EXPECTED
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_EXTERNAL_EXPECTED).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_EXTERNAL_EXPECTED).ok();
     for sv in &data.subvolumes {
         if sv.external_expected {
             sample(
@@ -553,14 +553,14 @@ fn format_metrics(data: &MetricsData) -> String {
     }
 
     // backup_external_drive_mounted
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Whether an external backup drive is mounted",
         names::BACKUP_EXTERNAL_DRIVE_MOUNTED
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_EXTERNAL_DRIVE_MOUNTED).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_EXTERNAL_DRIVE_MOUNTED).ok();
     sample(
         &mut out,
         names::BACKUP_EXTERNAL_DRIVE_MOUNTED,
@@ -569,14 +569,14 @@ fn format_metrics(data: &MetricsData) -> String {
     );
 
     // backup_external_free_bytes
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Free bytes on external backup drive",
         names::BACKUP_EXTERNAL_FREE_BYTES
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_EXTERNAL_FREE_BYTES).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_EXTERNAL_FREE_BYTES).ok();
     sample(
         &mut out,
         names::BACKUP_EXTERNAL_FREE_BYTES,
@@ -585,14 +585,14 @@ fn format_metrics(data: &MetricsData) -> String {
     );
 
     // backup_script_last_run_timestamp
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Unix timestamp of last backup run",
         names::BACKUP_SCRIPT_LAST_RUN_TIMESTAMP
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_SCRIPT_LAST_RUN_TIMESTAMP).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_SCRIPT_LAST_RUN_TIMESTAMP).ok();
     sample(
         &mut out,
         names::BACKUP_SCRIPT_LAST_RUN_TIMESTAMP,
@@ -602,19 +602,19 @@ fn format_metrics(data: &MetricsData) -> String {
 
     // ── Drift telemetry (UPI 030) ─────────────────────────────────
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Rolling time-windowed churn rate per subvolume (bytes/second). Absent for cold-start subvolumes and for subvolumes whose latest in-window send was a full send.",
         names::BACKUP_SUBVOLUME_CHURN_BYTES_PER_SECOND
     )
-    .unwrap();
+    .ok();
     writeln!(
         out,
         "# TYPE {} gauge",
         names::BACKUP_SUBVOLUME_CHURN_BYTES_PER_SECOND
     )
-    .unwrap();
+    .ok();
     for sv in &data.subvolumes {
         if let Some(churn) = sv.churn_bytes_per_second {
             sample(
@@ -626,19 +626,19 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Bytes of the most recent in-window full send for subvolumes whose latest send was a full send (e.g., transient subvolumes). Absent for incremental-only and cold-start subvolumes.",
         names::BACKUP_SUBVOLUME_LAST_FULL_SEND_BYTES
     )
-    .unwrap();
+    .ok();
     writeln!(
         out,
         "# TYPE {} gauge",
         names::BACKUP_SUBVOLUME_LAST_FULL_SEND_BYTES
     )
-    .unwrap();
+    .ok();
     for sv in &data.subvolumes {
         if let Some(bytes) = sv.last_full_send_bytes {
             sample(
@@ -652,14 +652,14 @@ fn format_metrics(data: &MetricsData) -> String {
 
     // ── Pool observability (UPI 043) ──────────────────────────────
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Free bytes on a BTRFS pool. Snapshot at backup-run cadence; not a live signal.",
         names::BACKUP_POOL_FREE_BYTES
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_POOL_FREE_BYTES).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_POOL_FREE_BYTES).ok();
     for pool in &data.pools {
         if let Some(bytes) = pool.free_bytes {
             sample(
@@ -675,14 +675,14 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Total capacity bytes of a BTRFS pool (statvfs). Snapshot at backup-run cadence; not a live signal.",
         names::BACKUP_POOL_TOTAL_BYTES
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_POOL_TOTAL_BYTES).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_POOL_TOTAL_BYTES).ok();
     for pool in &data.pools {
         if let Some(bytes) = pool.capacity_bytes {
             sample(
@@ -698,19 +698,19 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} BTRFS metadata utilization (0.0–1.0); source or destination.",
         names::BACKUP_POOL_METADATA_UTILIZATION_RATIO
     )
-    .unwrap();
+    .ok();
     writeln!(
         out,
         "# TYPE {} gauge",
         names::BACKUP_POOL_METADATA_UTILIZATION_RATIO
     )
-    .unwrap();
+    .ok();
     for pool in &data.pools {
         if let Some(ratio) = pool.metadata_utilization_ratio {
             sample(
@@ -726,14 +726,14 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Unix timestamp this pool row was last measured. Equals the run timestamp for a pool measured this run; for a destination pool whose drive is absent this run, the timestamp of the run that last measured it (carried forward from the previous .prom file). Emitted for every pool row, including carried-forward ones.",
         names::BACKUP_POOL_LAST_SEEN_TIMESTAMP
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_POOL_LAST_SEEN_TIMESTAMP).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_POOL_LAST_SEEN_TIMESTAMP).ok();
     for pool in &data.pools {
         sample(
             &mut out,
@@ -747,19 +747,19 @@ fn format_metrics(data: &MetricsData) -> String {
         );
     }
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Local snapshot count for a subvolume. Line absent when local snapshots are not configured for that subvolume.",
         names::BACKUP_SUBVOLUME_LOCAL_SNAPSHOT_COUNT
     )
-    .unwrap();
+    .ok();
     writeln!(
         out,
         "# TYPE {} gauge",
         names::BACKUP_SUBVOLUME_LOCAL_SNAPSHOT_COUNT
     )
-    .unwrap();
+    .ok();
     for sv in &data.subvolumes {
         if let Some(count) = sv.local_snapshot_count_v4 {
             sample(
@@ -771,19 +771,19 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Estimated local pinned CoW delta; wire-bytes-derived (mean over incrementals). Understates active periods of bimodal subvolumes; overstates dormancy.",
         names::BACKUP_SUBVOLUME_ESTIMATED_LOCAL_PINNED_DELTA_BYTES
     )
-    .unwrap();
+    .ok();
     writeln!(
         out,
         "# TYPE {} gauge",
         names::BACKUP_SUBVOLUME_ESTIMATED_LOCAL_PINNED_DELTA_BYTES
     )
-    .unwrap();
+    .ok();
     for sv in &data.subvolumes {
         if let Some(bytes) = sv.estimated_local_pinned_delta_bytes {
             sample(
@@ -802,14 +802,14 @@ fn format_metrics(data: &MetricsData) -> String {
     // for a disabled subvolume, which has no promise to report. Mirrors
     // heartbeat v3's own `pin_failures`/`promise_status` population exactly.
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Pin-file write failures for this subvolume in this run (sends that succeeded but whose chain marker could not be written). Emitted for every subvolume this run's awareness assessment covers; absent for disabled subvolumes.",
         names::BACKUP_PIN_FAILURES
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_PIN_FAILURES).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_PIN_FAILURES).ok();
     for sv in &data.subvolumes {
         if let Some(pin_failures) = sv.pin_failures {
             sample(
@@ -821,14 +821,14 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Post-run promise status: 0=protected, 1=at_risk, 2=unprotected. Emitted for every subvolume this run's awareness assessment covers; absent for disabled subvolumes.",
         names::BACKUP_PROMISE_STATE
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} gauge", names::BACKUP_PROMISE_STATE).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} gauge", names::BACKUP_PROMISE_STATE).ok();
     for sv in &data.subvolumes {
         if let Some(promise_state) = sv.promise_state {
             sample(
@@ -844,14 +844,14 @@ fn format_metrics(data: &MetricsData) -> String {
 
     let counters = &data.event_counters;
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Sentinel circuit-breaker open transitions.",
         names::URD_CIRCUIT_BREAKER_TRIPS_TOTAL
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} counter", names::URD_CIRCUIT_BREAKER_TRIPS_TOTAL).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} counter", names::URD_CIRCUIT_BREAKER_TRIPS_TOTAL).ok();
     sample(
         &mut out,
         names::URD_CIRCUIT_BREAKER_TRIPS_TOTAL,
@@ -859,14 +859,14 @@ fn format_metrics(data: &MetricsData) -> String {
         counters.circuit_breaker_trips,
     );
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Full-send choices, by reason.",
         names::URD_PLANNER_FULL_SENDS_TOTAL
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} counter", names::URD_PLANNER_FULL_SENDS_TOTAL).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} counter", names::URD_PLANNER_FULL_SENDS_TOTAL).ok();
     if counters.full_sends_by_reason.is_empty() {
         // Emit a zero so consumers can detect the metric exists.
         sample(
@@ -886,14 +886,14 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Planner deferrals, by scope.",
         names::URD_PLANNER_DEFERS_TOTAL
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} counter", names::URD_PLANNER_DEFERS_TOTAL).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} counter", names::URD_PLANNER_DEFERS_TOTAL).ok();
     if counters.defers_by_scope.is_empty() {
         sample(
             &mut out,
@@ -912,14 +912,14 @@ fn format_metrics(data: &MetricsData) -> String {
         }
     }
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Snapshots pruned by retention, by rule.",
         names::URD_RETENTION_PRUNES_TOTAL
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} counter", names::URD_RETENTION_PRUNES_TOTAL).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} counter", names::URD_RETENTION_PRUNES_TOTAL).ok();
     if counters.prunes_by_rule.is_empty() {
         sample(
             &mut out,
@@ -948,15 +948,15 @@ fn format_metrics(data: &MetricsData) -> String {
     // docs/20-reference/metrics.md). Consumers should use `increase()` /
     // `rate()`, which tolerate a counter reset if that ever changes.
 
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Sentinel circuit-breaker open transitions. Public mirror of {}; same value.",
         names::BACKUP_CIRCUIT_BREAKER_TRIPS_TOTAL,
         names::URD_CIRCUIT_BREAKER_TRIPS_TOTAL,
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} counter", names::BACKUP_CIRCUIT_BREAKER_TRIPS_TOTAL).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} counter", names::BACKUP_CIRCUIT_BREAKER_TRIPS_TOTAL).ok();
     sample(
         &mut out,
         names::BACKUP_CIRCUIT_BREAKER_TRIPS_TOTAL,
@@ -965,27 +965,27 @@ fn format_metrics(data: &MetricsData) -> String {
     );
 
     let emergency_prunes = counter_value(&counters.prunes_by_rule, "emergency");
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Snapshots pruned under emergency retention. Public mirror of {}{{rule=\"emergency\"}}; same value, 0 when no such events exist.",
         names::BACKUP_EMERGENCY_PRUNES_TOTAL,
         names::URD_RETENTION_PRUNES_TOTAL,
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} counter", names::BACKUP_EMERGENCY_PRUNES_TOTAL).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} counter", names::BACKUP_EMERGENCY_PRUNES_TOTAL).ok();
     sample(&mut out, names::BACKUP_EMERGENCY_PRUNES_TOTAL, &[], emergency_prunes);
 
     let chain_broken_full_sends = counter_value(&counters.full_sends_by_reason, "chain_broken");
-    writeln!(out).unwrap();
+    writeln!(out).ok();
     writeln!(
         out,
         "# HELP {} Full sends triggered by a broken incremental chain. Public mirror of {}{{reason=\"chain_broken\"}}; same value, 0 when no such events exist.",
         names::BACKUP_CHAIN_BROKEN_FULL_SENDS_TOTAL,
         names::URD_PLANNER_FULL_SENDS_TOTAL,
     )
-    .unwrap();
-    writeln!(out, "# TYPE {} counter", names::BACKUP_CHAIN_BROKEN_FULL_SENDS_TOTAL).unwrap();
+    .ok();
+    writeln!(out, "# TYPE {} counter", names::BACKUP_CHAIN_BROKEN_FULL_SENDS_TOTAL).ok();
     sample(
         &mut out,
         names::BACKUP_CHAIN_BROKEN_FULL_SENDS_TOTAL,

--- a/src/notify.rs
+++ b/src/notify.rs
@@ -49,21 +49,18 @@ pub enum NotificationEvent {
     },
     /// Heartbeat is stale — no backup completed within expected window.
     /// Evaluated by the Sentinel (5b), not by `urd backup` itself.
-    #[allow(dead_code)] // Constructed by Sentinel (5b), not backup command
     BackupOverdue {
         last_heartbeat_age_hours: u64,
         stale_after_hours: u64,
     },
     /// A subvolume's operational health worsened (e.g., Healthy -> Degraded).
     /// Separate from PromiseDegraded — health is operational readiness, not data safety.
-    #[allow(dead_code)] // Constructed by Sentinel (VFM-B), not backup command
     HealthDegraded {
         subvolume: String,
         from: String,
         to: String,
     },
     /// A subvolume's operational health improved.
-    #[allow(dead_code)] // Constructed by Sentinel (VFM-B), not backup command
     HealthRecovered {
         subvolume: String,
         from: String,
@@ -163,7 +160,9 @@ impl std::fmt::Display for Urgency {
 /// A notification ready to be dispatched.
 #[derive(Debug, Clone)]
 pub struct Notification {
-    #[allow(dead_code)] // Used in tests for pattern matching; will be used by Sentinel (5b)
+    /// Read only by this module's tests, which pattern-match the event a
+    /// notification was built from; the dispatcher renders title/body.
+    #[allow(dead_code)]
     pub event: NotificationEvent,
     pub urgency: Urgency,
     pub title: String,

--- a/src/observation.rs
+++ b/src/observation.rs
@@ -105,7 +105,8 @@ pub trait HistoryQuery {
         drive_label: &str,
     ) -> Option<NaiveDateTime>;
 
-    /// Most recent mount/unmount event for a drive from `drive_connections`.
+    /// Most recent mount/unmount event for a drive, from the `events` table
+    /// (`kind='drive'`).
     /// None if no event recorded (drive never seen by sentinel).
     fn last_drive_event(&self, drive_label: &str) -> Option<DriveEvent>;
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -2138,10 +2138,7 @@ mod tests {
 
     #[test]
     fn from_assessment_propagates_redundancy_advisories() {
-        use crate::awareness::{
-            LocalAssessment, OperationalHealth, PromiseStatus, SubvolAssessment,
-        };
-        use crate::types::Interval;
+        use crate::awareness::{LocalAssessment, PromiseStatus, SubvolAssessment};
 
         let advisory = RedundancyAdvisory {
             kind: RedundancyAdvisoryKind::NoOffsiteProtection,
@@ -2150,25 +2147,9 @@ mod tests {
             detail: "test detail".to_string(),
         };
         let assessment = SubvolAssessment {
-            name: "sv1".to_string(),
-            short_name: "sv1".to_string(),
-            status: PromiseStatus::Protected,
-            health: OperationalHealth::Healthy,
-            health_reasons: vec![],
-            local: LocalAssessment {
-                status: PromiseStatus::Protected,
-                snapshot_count: 5,
-                newest_age: None,
-                configured_interval: Interval::hours(1),
-            },
-            external: vec![],
-            chain_health: vec![],
-            advisories: vec![],
+            local: LocalAssessment::fixture(PromiseStatus::Protected, 5, None),
             redundancy_advisories: vec![advisory.clone()],
-            errors: vec![],
-            storage_posture: None,
-            cadence_adapted: false,
-            effective_send_interval: None,
+            ..SubvolAssessment::fixture("sv1", PromiseStatus::Protected)
         };
 
         let sa = StatusAssessment::incomplete_from_assessment(&assessment);

--- a/src/plan/external.rs
+++ b/src/plan/external.rs
@@ -25,7 +25,7 @@ pub(super) fn plan_external_retention(i: &ExternalRetentionInputs) -> PlanFragme
         return f;
     }
 
-    let free_bytes = obs.fs.filesystem_free_bytes(&ext_dir).unwrap_or(u64::MAX);
+    let free_bytes = super::free_bytes_fail_open(obs, &ext_dir);
     let min_free = drive.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
 
     let mut result = retention::space_governed_retention(

--- a/src/plan/local.rs
+++ b/src/plan/local.rs
@@ -61,96 +61,25 @@ pub(super) fn plan_local_snapshot(i: &LocalSnapshotInputs) -> SnapshotOutcome {
         );
     }
 
-    let should_create = if force || filters.skip_intervals {
-        true
-    } else if let Some(newest) = newest {
-        let elapsed = now.signed_duration_since(newest.datetime());
-        super::interval_elapsed(elapsed, subvol.snapshot_interval.as_chrono())
+    // `Some(mins)` exactly when the interval has *not* elapsed: the minutes
+    // until it does, computed while `newest` is in hand so the deferral below
+    // needs no second lookup. `None` means create — forced, no snapshot exists
+    // yet, or the interval has elapsed.
+    let interval_pending_mins = if force || filters.skip_intervals {
+        None
     } else {
-        true // No snapshots exist — create first one
+        newest.and_then(|newest| {
+            let elapsed = now.signed_duration_since(newest.datetime());
+            let interval = subvol.snapshot_interval.as_chrono();
+            if super::interval_elapsed(elapsed, interval) {
+                None
+            } else {
+                Some((interval - elapsed).num_minutes())
+            }
+        })
     };
 
-    if should_create {
-        // Generation comparison: skip if subvolume hasn't changed since last snapshot.
-        // Fail open — if either generation query fails, proceed with snapshot.
-        if !filters.force_snapshot
-            && !force
-            && let Some(newest) = newest
-        {
-            let snap_path = local_dir.join(newest.as_str());
-            match (
-                obs.btrfs.subvolume_generation(&subvol.source),
-                obs.btrfs.subvolume_generation(&snap_path),
-            ) {
-                (Ok(sg), Ok(ng)) if sg == ng => {
-                    let elapsed = now.signed_duration_since(newest.datetime());
-                    let mins = elapsed.num_minutes();
-                    f.defer(
-                        &subvol.name,
-                        None,
-                        format!(
-                            "unchanged \u{2014} no changes since last snapshot ({} ago)",
-                            super::format_duration_short(mins)
-                        ),
-                        None,
-                        DeferScope::Subvolume,
-                        now,
-                    );
-                    return SnapshotOutcome {
-                        planned: None,
-                        fragment: f,
-                    };
-                }
-                (Err(e1), Err(e2)) => {
-                    log::warn!("{}: failed to read source generation: {e1}", subvol.name);
-                    log::warn!("{}: failed to read snapshot generation: {e2}", subvol.name);
-                }
-                (Err(e), _) => {
-                    log::warn!(
-                        "{}: failed to read source generation, proceeding: {e}",
-                        subvol.name
-                    );
-                }
-                (_, Err(e)) => {
-                    log::warn!(
-                        "{}: failed to read snapshot generation, proceeding: {e}",
-                        subvol.name
-                    );
-                }
-                _ => {} // generations differ — proceed
-            }
-        }
-
-        let snap_name = SnapshotName::new(now, &subvol.short_name);
-        // Check if this exact snapshot already exists
-        if local_snaps.iter().any(|s| s.as_str() == snap_name.as_str()) {
-            f.defer(
-                &subvol.name,
-                None,
-                "snapshot already exists".to_string(),
-                None,
-                DeferScope::Subvolume,
-                now,
-            );
-            return SnapshotOutcome {
-                planned: None,
-                fragment: f,
-            };
-        }
-        f.push_operation(PlannedOperation::CreateSnapshot {
-            source: subvol.source.clone(),
-            dest: local_dir.join(snap_name.as_str()),
-            subvolume_name: subvol.name.clone(),
-        });
-        // Invariant: returned name matches CreateSnapshot.dest filename
-        SnapshotOutcome {
-            planned: Some(snap_name),
-            fragment: f,
-        }
-    } else {
-        let next_in = subvol.snapshot_interval.as_chrono()
-            - now.signed_duration_since(newest.unwrap().datetime());
-        let mins = next_in.num_minutes();
+    if let Some(mins) = interval_pending_mins {
         f.defer(
             &subvol.name,
             None,
@@ -162,10 +91,87 @@ pub(super) fn plan_local_snapshot(i: &LocalSnapshotInputs) -> SnapshotOutcome {
             DeferScope::Subvolume,
             now,
         );
-        SnapshotOutcome {
+        return SnapshotOutcome {
             planned: None,
             fragment: f,
+        };
+    }
+
+    // Generation comparison: skip if subvolume hasn't changed since last snapshot.
+    // Fail open — if either generation query fails, proceed with snapshot.
+    if !filters.force_snapshot
+        && !force
+        && let Some(newest) = newest
+    {
+        let snap_path = local_dir.join(newest.as_str());
+        match (
+            obs.btrfs.subvolume_generation(&subvol.source),
+            obs.btrfs.subvolume_generation(&snap_path),
+        ) {
+            (Ok(sg), Ok(ng)) if sg == ng => {
+                let elapsed = now.signed_duration_since(newest.datetime());
+                let mins = elapsed.num_minutes();
+                f.defer(
+                    &subvol.name,
+                    None,
+                    format!(
+                        "unchanged \u{2014} no changes since last snapshot ({} ago)",
+                        super::format_duration_short(mins)
+                    ),
+                    None,
+                    DeferScope::Subvolume,
+                    now,
+                );
+                return SnapshotOutcome {
+                    planned: None,
+                    fragment: f,
+                };
+            }
+            (Err(e1), Err(e2)) => {
+                log::warn!("{}: failed to read source generation: {e1}", subvol.name);
+                log::warn!("{}: failed to read snapshot generation: {e2}", subvol.name);
+            }
+            (Err(e), _) => {
+                log::warn!(
+                    "{}: failed to read source generation, proceeding: {e}",
+                    subvol.name
+                );
+            }
+            (_, Err(e)) => {
+                log::warn!(
+                    "{}: failed to read snapshot generation, proceeding: {e}",
+                    subvol.name
+                );
+            }
+            _ => {} // generations differ — proceed
         }
+    }
+
+    let snap_name = SnapshotName::new(now, &subvol.short_name);
+    // Check if this exact snapshot already exists
+    if local_snaps.iter().any(|s| s.as_str() == snap_name.as_str()) {
+        f.defer(
+            &subvol.name,
+            None,
+            "snapshot already exists".to_string(),
+            None,
+            DeferScope::Subvolume,
+            now,
+        );
+        return SnapshotOutcome {
+            planned: None,
+            fragment: f,
+        };
+    }
+    f.push_operation(PlannedOperation::CreateSnapshot {
+        source: subvol.source.clone(),
+        dest: local_dir.join(snap_name.as_str()),
+        subvolume_name: subvol.name.clone(),
+    });
+    // Invariant: returned name matches CreateSnapshot.dest filename
+    SnapshotOutcome {
+        planned: Some(snap_name),
+        fragment: f,
     }
 }
 

--- a/src/plan/local.rs
+++ b/src/plan/local.rs
@@ -23,7 +23,7 @@ pub(super) fn plan_local_snapshot(i: &LocalSnapshotInputs) -> SnapshotOutcome {
     // catastrophic. See 2026-03-24-local-space-exhaustion-postmortem.md.
     let min_free = subvol.min_free_bytes.unwrap_or(0);
     if min_free > 0 {
-        let free = obs.fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
+        let free = super::free_bytes_fail_open(obs, local_dir);
         if free < min_free {
             use crate::types::ByteSize;
             f.defer(
@@ -262,7 +262,7 @@ pub(super) fn plan_local_retention(i: &LocalRetentionInputs) -> PlanFragment {
         LocalRetentionPolicy::Graduated(retention_config) => {
             // Check space pressure
             let min_free = subvol.min_free_bytes.unwrap_or(0);
-            let free_bytes = obs.fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
+            let free_bytes = super::free_bytes_fail_open(obs, local_dir);
             let space_pressure = min_free > 0 && free_bytes < min_free;
 
             let mut result = retention::graduated_retention(
@@ -458,7 +458,7 @@ mod tests {
             ..subvol(LocalRetentionPolicy::Transient)
         };
         let e = eff(LocalRetentionPolicy::Transient, true);
-        // No free_bytes entry for local_dir() -> unwrap_or(u64::MAX), fail-open.
+        // No free_bytes entry for local_dir() -> free_bytes_fail_open, fail-open.
         let fs = MockFileSystemState::new();
         let btrfs = MockBtrfs::new();
         let obs = Observation {

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -28,6 +28,18 @@ mod tests;
 #[cfg(test)]
 pub use testkit::MockFileSystemState;
 
+/// Free bytes on the filesystem holding `path`, or `u64::MAX` when the read
+/// fails.
+///
+/// Backups fail open (ADR-107): an unreadable free count must never stand in
+/// for "full". `u64::MAX` reads as unlimited room, so every space guard above
+/// it degrades to a no-op and the snapshot or send proceeds — the opposite
+/// fallback would let one failed `statvfs` quietly stop protecting data.
+/// Deletions fail closed and do not go through here.
+pub(super) fn free_bytes_fail_open(obs: &Observation, path: &Path) -> u64 {
+    obs.fs.filesystem_free_bytes(path).unwrap_or(u64::MAX)
+}
+
 /// Send-space guard (UPI 054-a): returns the defer reason when the source
 /// pool's free space is below the host-survival floor (`min_free +
 /// cleanup_budget` — the same `guard::source_floor_bytes` the mid-op watchdog
@@ -49,7 +61,7 @@ fn send_floor_defer_reason(
 ) -> Option<String> {
     let capacity = obs.fs.filesystem_capacity_bytes(local_dir).unwrap_or(0);
     let floor = crate::guard::source_floor_bytes(subvol.min_free_bytes.unwrap_or(0), capacity);
-    let free = obs.fs.filesystem_free_bytes(local_dir).unwrap_or(u64::MAX);
+    let free = free_bytes_fail_open(obs, local_dir);
     if free < floor {
         use crate::types::ByteSize;
         Some(format!(
@@ -704,10 +716,7 @@ fn exceeds_available_space(
     obs: &Observation,
 ) -> Option<(u64, u64, u64, u64)> {
     let estimated = (raw_bytes as f64 * 1.2) as u64; // 20% safety margin
-    let free = obs
-        .fs
-        .filesystem_free_bytes(&drive.mount_path)
-        .unwrap_or(u64::MAX);
+    let free = free_bytes_fail_open(obs, &drive.mount_path);
     let min_free = drive.min_free_bytes.map(|b| b.bytes()).unwrap_or(0);
     let available = free.saturating_sub(min_free);
     if estimated > available {
@@ -928,14 +937,14 @@ fn drive_record_to_event(record: &crate::state::DriveConnectionRecord) -> Option
         "mounted" => DriveEventKind::Mount,
         "unmounted" => DriveEventKind::Unmount,
         other => {
-            log::warn!("unknown drive_connections.event_type {other:?} — ignoring");
+            log::warn!("unknown drive event_type {other:?} — ignoring");
             return None;
         }
     };
     let at = chrono::NaiveDateTime::parse_from_str(&record.timestamp, "%Y-%m-%dT%H:%M:%S")
         .inspect_err(|e| {
             log::warn!(
-                "failed to parse drive_connections.timestamp {:?}: {e}",
+                "failed to parse drive event timestamp {:?}: {e}",
                 record.timestamp
             );
         })

--- a/src/plan/send.rs
+++ b/src/plan/send.rs
@@ -48,29 +48,35 @@ pub(super) fn plan_external_send(i: &SendInputs) -> PlanFragment {
         .external_snapshots(drive, &subvol.name)
         .unwrap_or_default();
 
-    // Check send interval
+    // Check send interval. `Some(mins)` exactly when a newest external
+    // snapshot exists and its interval has *not* elapsed — the minutes until
+    // it does. `None` means send: forced, no external snapshot yet (send the
+    // first one), or the interval has elapsed.
     let newest_ext = ext_snaps.iter().max();
-    let should_send = if force || skip_intervals {
-        true
-    } else if let Some(newest) = newest_ext {
-        let elapsed = now.signed_duration_since(newest.datetime());
-        super::interval_elapsed(elapsed, eff.send_interval.as_chrono())
+    let interval_pending_mins = if force || skip_intervals {
+        None
     } else {
-        true // No external snapshots — send first one
+        newest_ext.and_then(|newest| {
+            let elapsed = now.signed_duration_since(newest.datetime());
+            let interval = eff.send_interval.as_chrono();
+            if super::interval_elapsed(elapsed, interval) {
+                None
+            } else {
+                Some((interval - elapsed).num_minutes())
+            }
+        })
     };
 
-    if !should_send {
-        let next_in = eff.send_interval.as_chrono()
-            - now.signed_duration_since(newest_ext.unwrap().datetime());
+    if let Some(mins) = interval_pending_mins {
         f.defer(
             &subvol.name,
             Some(&drive.label),
             format!(
                 "send to {} not due (next in ~{})",
                 drive.label,
-                super::format_duration_short(next_in.num_minutes())
+                super::format_duration_short(mins)
             ),
-            Some(next_in.num_minutes()),
+            Some(mins),
             DeferScope::Drive,
             now,
         );
@@ -109,16 +115,16 @@ pub(super) fn plan_external_send(i: &SendInputs) -> PlanFragment {
 
     // Resolve parent for incremental send
     let pin = obs.fs.read_pin_file(local_dir, &drive.label).unwrap_or(None);
-    let is_incremental = if let Some(ref parent_name) = pin {
-        // Parent must exist both locally and on the external drive
+    // `Some` only when the pinned parent exists both locally and on the
+    // external drive — an incremental send needs both ends of the chain.
+    let incremental_parent = pin.as_ref().filter(|parent_name| {
         let parent_exists_local = local_snaps
             .iter()
             .any(|s| s.as_str() == parent_name.as_str());
         let parent_exists_ext = ext_snaps.iter().any(|s| s.as_str() == parent_name.as_str());
         parent_exists_local && parent_exists_ext
-    } else {
-        false
-    };
+    });
+    let is_incremental = incremental_parent.is_some();
 
     // Space estimation: skip if estimated send size exceeds available space.
     // One cascade (#210/#304): same-drive history > cross-drive history >
@@ -195,8 +201,7 @@ pub(super) fn plan_external_send(i: &SendInputs) -> PlanFragment {
         ))
     };
 
-    if is_incremental {
-        let parent_name = pin.unwrap();
+    if let Some(parent_name) = incremental_parent {
         let parent_path = local_dir.join(parent_name.as_str());
         f.push_operation(PlannedOperation::SendIncremental {
             parent: parent_path,

--- a/src/recommendation.rs
+++ b/src/recommendation.rs
@@ -218,10 +218,11 @@ pub enum AdjustmentReason {
 }
 
 impl HeadroomAwareRecommendation {
-    /// Test/fixture helper: wrap a plain `ShapeRecommendation` as a
+    /// Test fixture helper: wrap a plain `ShapeRecommendation` as a
     /// Healthy `HeadroomAwareRecommendation` (no adjustment, no
-    /// tightening). Used by voice tests that pre-date UPI 044, and by
-    /// doctor.rs when no headroom signal is observed.
+    /// tightening). Sole callers are the voice and voice-contract tests
+    /// that pre-date UPI 044 — production always carries a real headroom
+    /// signal, so nothing outside `cfg(test)` builds one of these.
     #[must_use]
     #[allow(dead_code)]
     pub fn healthy_from(rec: ShapeRecommendation) -> Self {

--- a/src/recommendation.rs
+++ b/src/recommendation.rs
@@ -223,8 +223,8 @@ impl HeadroomAwareRecommendation {
     /// tightening). Sole callers are the voice and voice-contract tests
     /// that pre-date UPI 044 — production always carries a real headroom
     /// signal, so nothing outside `cfg(test)` builds one of these.
+    #[cfg(test)]
     #[must_use]
-    #[allow(dead_code)]
     pub fn healthy_from(rec: ShapeRecommendation) -> Self {
         Self {
             recommendation: rec,

--- a/src/retention.rs
+++ b/src/retention.rs
@@ -275,7 +275,7 @@ pub fn graduated_retention(
                 &mut delete,
                 &mut events,
             );
-        } else if monthly_cutoff.is_none() || dt >= monthly_cutoff.unwrap() {
+        } else if monthly_cutoff.is_none_or(|cutoff| dt >= cutoff) {
             let month_key = (dt.date().year(), dt.date().month());
             let slot_was_empty = monthly_slots.insert(month_key);
             apply_slot_thinning(
@@ -288,7 +288,7 @@ pub fn graduated_retention(
                 &mut delete,
                 &mut events,
             );
-        } else if yearly_cutoff.is_some() && dt >= yearly_cutoff.unwrap() {
+        } else if yearly_cutoff.is_some_and(|cutoff| dt >= cutoff) {
             let year_key = dt.date().year();
             let slot_was_empty = yearly_slots.insert(year_key);
             apply_slot_thinning(

--- a/src/run_tail.rs
+++ b/src/run_tail.rs
@@ -440,7 +440,7 @@ mod tests {
     use super::*;
     use crate::awareness::{
         ChainBreakReason, ChainStatus, DriveAssessment, DriveChainHealth, LocalAssessment,
-        OperationalHealth, PromiseStatus, SubvolAssessment,
+        PromiseStatus, SubvolAssessment,
     };
     use crate::heartbeat::SubvolumeHeartbeat;
     use crate::types::{DriveRole, Interval};
@@ -1005,25 +1005,10 @@ source = "/data/alpha"
         external: Vec<DriveAssessment>,
     ) -> SubvolAssessment {
         SubvolAssessment {
-            name: name.to_string(),
-            short_name: name.to_string(),
-            status,
-            health: OperationalHealth::Healthy,
-            health_reasons: vec![],
-            local: LocalAssessment {
-                status: PromiseStatus::Protected,
-                snapshot_count: 10,
-                newest_age: None,
-                configured_interval: Interval::hours(1),
-            },
+            local: LocalAssessment::fixture(PromiseStatus::Protected, 10, None),
             external,
             chain_health,
-            advisories: vec![],
-            redundancy_advisories: vec![],
-            errors: vec![],
-            storage_posture: None,
-            cadence_adapted: false,
-            effective_send_interval: None,
+            ..SubvolAssessment::fixture(name, status)
         }
     }
 

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -1076,25 +1076,8 @@ mod tests {
 
     fn make_assessment(name: &str, status: PromiseStatus) -> SubvolAssessment {
         SubvolAssessment {
-            name: name.to_string(),
-            short_name: name.to_string(),
-            status,
-            health: OperationalHealth::Healthy,
-            health_reasons: vec![],
-            local: LocalAssessment {
-                status,
-                snapshot_count: 5,
-                newest_age: None,
-                configured_interval: Interval::hours(1),
-            },
-            external: vec![],
-            chain_health: vec![],
-            advisories: vec![],
-            redundancy_advisories: vec![],
-            errors: vec![],
-            storage_posture: None,
-            cadence_adapted: false,
-            effective_send_interval: None,
+            local: LocalAssessment::fixture(status, 5, None),
+            ..SubvolAssessment::fixture(name, status)
         }
     }
 
@@ -1105,17 +1088,7 @@ mod tests {
         drive_status: PromiseStatus,
     ) -> SubvolAssessment {
         SubvolAssessment {
-            name: name.to_string(),
-            short_name: name.to_string(),
-            status,
-            health: OperationalHealth::Healthy,
-            health_reasons: vec![],
-            local: LocalAssessment {
-                status: PromiseStatus::Protected,
-                snapshot_count: 5,
-                newest_age: None,
-                configured_interval: Interval::hours(1),
-            },
+            local: LocalAssessment::fixture(PromiseStatus::Protected, 5, None),
             external: vec![DriveAssessment {
                 drive_label: drive_label.to_string(),
                 status: drive_status,
@@ -1129,13 +1102,7 @@ mod tests {
                 last_activity_age_secs: None,
                 rotation: None,
             }],
-            chain_health: vec![],
-            advisories: vec![],
-            redundancy_advisories: vec![],
-            errors: vec![],
-            storage_posture: None,
-            cadence_adapted: false,
-            effective_send_interval: None,
+            ..SubvolAssessment::fixture(name, status)
         }
     }
 

--- a/src/sentinel.rs
+++ b/src/sentinel.rs
@@ -49,8 +49,8 @@ pub enum SentinelAction {
     /// Re-assess promise states, compare with previous, dispatch notifications
     /// if changed, and write the sentinel state file. This is the primary tick.
     Assess,
-    /// Log a drive mount/unmount event. The runner logs and (in Session 3)
-    /// records the event in the drive_connections table.
+    /// Log a drive mount/unmount event. The runner logs it and records it in
+    /// the `events` table (`kind='drive'`).
     LogDriveChange {
         label: String,
         mounted: bool,

--- a/src/state.rs
+++ b/src/state.rs
@@ -537,26 +537,33 @@ impl StateDb {
             .map_err(|e| UrdError::State(format!("failed to read operations: {e}")))
     }
 
-    /// Get the bytes_transferred from the most recent successful send of a given type
-    /// for a subvolume to a specific drive. Returns None if no matching history exists.
-    pub fn last_successful_send_size(
+    /// Bytes transferred by the most recent send of `send_type` for `subvol`
+    /// that ended in `result` (`"success"` / `"failure"`), optionally narrowed
+    /// to one drive. `None` when no matching operation recorded a byte count.
+    ///
+    /// The four public readers below are this query with its two axes pinned:
+    /// success or failure, one drive or any drive. `NULL` for `drive` disables
+    /// the drive predicate rather than matching a NULL `drive_label`.
+    fn send_size(
         &self,
         subvol: &str,
-        drive: &str,
+        drive: Option<&str>,
         send_type: &str,
+        result: &str,
     ) -> crate::error::Result<Option<u64>> {
         let mut stmt = self
             .conn
             .prepare(
                 "SELECT bytes_transferred FROM operations
-                 WHERE subvolume = ?1 AND drive_label = ?2 AND operation = ?3
-                   AND result = 'success' AND bytes_transferred IS NOT NULL
+                 WHERE subvolume = ?1 AND operation = ?2 AND result = ?3
+                   AND bytes_transferred IS NOT NULL
+                   AND (?4 IS NULL OR drive_label = ?4)
                  ORDER BY id DESC LIMIT 1",
             )
             .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
 
         let mut rows = stmt
-            .query_map(rusqlite::params![subvol, drive, send_type], |row| {
+            .query_map(rusqlite::params![subvol, send_type, result, drive], |row| {
                 let bytes: i64 = row.get(0)?;
                 Ok(bytes as u64)
             })
@@ -570,6 +577,17 @@ impl StateDb {
     }
 
     /// Get the bytes_transferred from the most recent successful send of a given type
+    /// for a subvolume to a specific drive. Returns None if no matching history exists.
+    pub fn last_successful_send_size(
+        &self,
+        subvol: &str,
+        drive: &str,
+        send_type: &str,
+    ) -> crate::error::Result<Option<u64>> {
+        self.send_size(subvol, Some(drive), send_type, "success")
+    }
+
+    /// Get the bytes_transferred from the most recent successful send of a given type
     /// for a subvolume across **all** drives. Returns None if no matching history exists.
     /// Used as a cross-drive fallback when the target drive has no history (e.g., drive swap).
     pub fn last_successful_send_size_any_drive(
@@ -577,28 +595,7 @@ impl StateDb {
         subvol: &str,
         send_type: &str,
     ) -> crate::error::Result<Option<u64>> {
-        let mut stmt = self
-            .conn
-            .prepare(
-                "SELECT bytes_transferred FROM operations
-                 WHERE subvolume = ?1 AND operation = ?2
-                   AND result = 'success' AND bytes_transferred IS NOT NULL
-                 ORDER BY id DESC LIMIT 1",
-            )
-            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
-
-        let mut rows = stmt
-            .query_map(rusqlite::params![subvol, send_type], |row| {
-                let bytes: i64 = row.get(0)?;
-                Ok(bytes as u64)
-            })
-            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
-
-        match rows.next() {
-            Some(Ok(size)) => Ok(Some(size)),
-            Some(Err(e)) => Err(UrdError::State(format!("failed to read send size: {e}"))),
-            None => Ok(None),
-        }
+        self.send_size(subvol, None, send_type, "success")
     }
 
     /// Get the timestamp of the most recent successful send (full or incremental)
@@ -820,28 +817,7 @@ impl StateDb {
         drive: &str,
         send_type: &str,
     ) -> crate::error::Result<Option<u64>> {
-        let mut stmt = self
-            .conn
-            .prepare(
-                "SELECT bytes_transferred FROM operations
-                 WHERE subvolume = ?1 AND drive_label = ?2 AND operation = ?3
-                   AND result = 'failure' AND bytes_transferred IS NOT NULL
-                 ORDER BY id DESC LIMIT 1",
-            )
-            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
-
-        let mut rows = stmt
-            .query_map(rusqlite::params![subvol, drive, send_type], |row| {
-                let bytes: i64 = row.get(0)?;
-                Ok(bytes as u64)
-            })
-            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
-
-        match rows.next() {
-            Some(Ok(size)) => Ok(Some(size)),
-            Some(Err(e)) => Err(UrdError::State(format!("failed to read send size: {e}"))),
-            None => Ok(None),
-        }
+        self.send_size(subvol, Some(drive), send_type, "failure")
     }
 
     /// Get the bytes_transferred from the most recent failed send of a given type
@@ -852,28 +828,7 @@ impl StateDb {
         subvol: &str,
         send_type: &str,
     ) -> crate::error::Result<Option<u64>> {
-        let mut stmt = self
-            .conn
-            .prepare(
-                "SELECT bytes_transferred FROM operations
-                 WHERE subvolume = ?1 AND operation = ?2
-                   AND result = 'failure' AND bytes_transferred IS NOT NULL
-                 ORDER BY id DESC LIMIT 1",
-            )
-            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
-
-        let mut rows = stmt
-            .query_map(rusqlite::params![subvol, send_type], |row| {
-                let bytes: i64 = row.get(0)?;
-                Ok(bytes as u64)
-            })
-            .map_err(|e| UrdError::State(format!("query failed: {e}")))?;
-
-        match rows.next() {
-            Some(Ok(size)) => Ok(Some(size)),
-            Some(Err(e)) => Err(UrdError::State(format!("failed to read send size: {e}"))),
-            None => Ok(None),
-        }
+        self.send_size(subvol, None, send_type, "failure")
     }
 
     // ── Drive connection methods ─────────────────────────────────────
@@ -2019,6 +1974,38 @@ mod tests {
             db.last_successful_send_size_any_drive("sv1", "send_full")
                 .unwrap(),
             Some(200_000)
+        );
+    }
+
+    #[test]
+    fn drive_scoped_query_ignores_rows_without_a_drive_label() {
+        // The shared `send_size` query disables its drive predicate on NULL
+        // rather than matching a NULL `drive_label`: a drive-scoped read must
+        // never claim a driveless operation's bytes as that drive's history.
+        let db = StateDb::open_memory().unwrap();
+        let run_id = db.begin_run("full").unwrap();
+
+        db.record_operation(&OperationRecord {
+            run_id,
+            subvolume: "sv1".to_string(),
+            operation: "send_full".to_string(),
+            drive_label: None,
+            duration_secs: Some(10.0),
+            result: "success".to_string(),
+            error_message: None,
+            bytes_transferred: Some(100_000),
+        })
+        .unwrap();
+
+        assert_eq!(
+            db.last_successful_send_size("sv1", "DriveA", "send_full")
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            db.last_successful_send_size_any_drive("sv1", "send_full")
+                .unwrap(),
+            Some(100_000)
         );
     }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -77,8 +77,12 @@ pub struct DriveConnectionRecord {
 
 /// An operation record returned from database queries.
 #[derive(Debug)]
-#[allow(dead_code)]
 pub struct OperationRow {
+    /// `id` and `bytes_transferred` complete the row's 1:1 projection of the
+    /// `operations` table. Both queries that build an `OperationRow` select
+    /// all nine columns and share one positional mapper, so dropping either
+    /// field would re-index that mapper without saving the database any work.
+    #[allow(dead_code)]
     pub id: i64,
     pub run_id: i64,
     pub subvolume: String,
@@ -87,6 +91,7 @@ pub struct OperationRow {
     pub duration_secs: Option<f64>,
     pub result: String,
     pub error_message: Option<String>,
+    #[allow(dead_code)]
     pub bytes_transferred: Option<i64>,
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -639,7 +639,7 @@ impl StateDb {
 
     /// Get the timestamp of the most recent successful send (any subvolume) for a
     /// given drive. Used by the D-1 drive-absence cascade to estimate when a
-    /// drive was last actively written to, when `drive_connections` is empty.
+    /// drive was last actively written to, when the drive has no `events` rows.
     pub fn last_successful_operation_at(
         &self,
         drive_label: &str,

--- a/src/types.rs
+++ b/src/types.rs
@@ -172,7 +172,7 @@ impl SendKind {
 // ── DriveEvent ──────────────────────────────────────────────────────────
 
 /// A drive mount or unmount event recorded by the sentinel daemon.
-/// Sourced from the `drive_connections` table.
+/// Sourced from the `events` table (`kind='drive'`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DriveEvent {
     pub kind: DriveEventKind,

--- a/src/types.rs
+++ b/src/types.rs
@@ -20,8 +20,8 @@ pub struct Interval(chrono::Duration);
 impl Interval {
     /// Constructed only by the config tests; production intervals come from
     /// `FromStr` over the declared strings ("15m", "1h", ...).
+    #[cfg(test)]
     #[must_use]
-    #[allow(dead_code)]
     pub fn minutes(n: i64) -> Self {
         Self(chrono::Duration::minutes(n))
     }
@@ -280,8 +280,8 @@ impl SnapshotName {
 
     /// Called only by this module's tests; every production caller wants
     /// the full `datetime()` for ordering.
+    #[cfg(test)]
     #[must_use]
-    #[allow(dead_code)]
     pub fn date(&self) -> NaiveDate {
         self.datetime.date()
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -17,9 +17,11 @@ pub use crate::retention::DeleteKind;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Interval(chrono::Duration);
 
-#[allow(dead_code)]
 impl Interval {
+    /// Constructed only by the config tests; production intervals come from
+    /// `FromStr` over the declared strings ("15m", "1h", ...).
     #[must_use]
+    #[allow(dead_code)]
     pub fn minutes(n: i64) -> Self {
         Self(chrono::Duration::minutes(n))
     }
@@ -194,7 +196,6 @@ pub struct SnapshotName {
     short_name: String,
 }
 
-#[allow(dead_code)]
 impl SnapshotName {
     /// Create a new snapshot name from a datetime and short name.
     #[must_use]
@@ -277,7 +278,10 @@ impl SnapshotName {
         self.datetime
     }
 
+    /// Called only by this module's tests; every production caller wants
+    /// the full `datetime()` for ordering.
     #[must_use]
+    #[allow(dead_code)]
     pub fn date(&self) -> NaiveDate {
         self.datetime.date()
     }
@@ -1264,7 +1268,6 @@ pub struct PlannedLifecycle {
 /// carries the planner's per-subvolume lifecycle judgment — the executor
 /// builds its `SubvolumeContext` from this rather than re-deriving.
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct BackupPlan {
     pub operations: Vec<PlannedOperation>,
     pub timestamp: NaiveDateTime,
@@ -1273,7 +1276,6 @@ pub struct BackupPlan {
     pub lifecycles: HashMap<String, PlannedLifecycle>,
 }
 
-#[allow(dead_code)]
 impl BackupPlan {
     #[must_use]
     pub fn is_empty(&self) -> bool {


### PR DESCRIPTION
## Summary

The hygiene batch from the 2026-09-04 sweep, in nine commits meant to be read
one at a time. Eight are behaviour-preserving and carry no CHANGELOG entry; one
is a real bug the sweep turned up next to the duplication it was cataloguing,
and it has one.

Every listed item is done or accounted for below. Where clippy disagreed with
the issue — three items the issue called dead are alive, and several allows it
called stale are load-bearing for tests — the code says so now instead of the
issue.

## Changes

**`refactor: remove unwrap/expect from library code`**
- `src/plan/local.rs`, `src/plan/send.rs` — both interval checks computed a
  `should_*` bool and then re-derived the deferral from the very `Option` the
  bool had inspected, `unwrap()`ping it. They now compute
  `Option<minutes-until-due>` in one pass; the impossible case stops being
  expressible. `local.rs`'s branch becomes a guard clause, so the body
  de-indents — that is most of its diff.
- `src/plan/send.rs` — `is_incremental: bool` + `pin.unwrap()` becomes
  `incremental_parent: Option<&SnapshotName>`; the incremental arm binds the
  parent.
- `src/retention.rs` — two `is_none() || >= unwrap()` chains → `is_none_or` /
  `is_some_and`.
- `src/commands/retention_preview.rs` — `.expect("validated by ...")` →
  `ok_or_else(..)?`.
- `src/metrics.rs` — 79 × `write!(String, ..).unwrap()` → the `.ok()` idiom
  `voice/mod.rs` already uses. Mechanical; no line got longer (`.ok()` is
  shorter than `.unwrap()`), and the eleven lines still over 100 columns are
  pre-existing HELP strings, byte-identical to master.

**`refactor: delete two dead items kept alive by allow(dead_code)`**
- `UrdError::Retention` (no constructor, ever) and `Event::severity()` (only its
  own test called it; the test keeps its live `kind()` assertion).
- `voice::humanize_cadence` was listed with them but is **not** dead — since the
  voice/status split it is called from `voice/status.rs:278`. Left alone.

**`refactor: remove or narrow stale allow(dead_code) attributes`** — per-site
table below.

**`refactor: name the two btrfs error shapes instead of repeating them`**
- `UrdError::btrfs_spawn(op, stderr)` / `btrfs_exit(op, code, stderr)` in
  `error.rs`, mirroring `executor.rs`'s `outcome_success` / `outcome_failure`.
  All 24 `BtrfsErrorContext` literals in `btrfs.rs` go through them; the import
  drops. The five exit sites also lose their `let stderr = ...` temporary —
  `impl Into<String>` takes the `Cow` from `from_utf8_lossy` directly.
- The two `SendReceiveErrorContext` literals stay explicit: they carry
  `bytes_transferred` from a partial send, which is the "branches that carry
  distinct fields construct the literal directly" case `executor.rs:97` already
  documents. Hand-wrapped to rustfmt shape; no `cargo fmt` was run.

**`refactor: fold the four send-size readers onto one query`**
- One private `StateDb::send_size(subvol, drive: Option<&str>, send_type,
  result)`. The drive predicate is `?4 IS NULL OR drive_label = ?4`, so the
  absent-drive case disables the filter rather than needing a second SQL string.
  The four public readers keep their names, signatures and docs and become one
  line each.
- **Design decision:** I chose the nullable-parameter predicate over two SQL
  strings + a `Vec<&dyn ToSql>`. It keeps one query text and one params list at
  the cost of a predicate SQLite evaluates per row — irrelevant under
  `ORDER BY id DESC LIMIT 1` on this table. New test
  `drive_scoped_query_ignores_rows_without_a_drive_label` pins the corner that
  rewrite could plausibly have got wrong.

**`test: one SubvolAssessment fixture instead of eleven literals`**
- `#[cfg(test)] SubvolAssessment::fixture(name, status)` plus a companion
  `LocalAssessment::fixture(status, count, newest_age)` in `awareness.rs`. Call
  sites use struct-update syntax and state only the axis under test.
- **Scope note:** the issue named four sites (verified at `e50c43c`); master has
  since grown to **eleven**, across `awareness.rs`, `advice.rs` ×2, `output.rs`,
  `heartbeat.rs` ×2, `run_tail.rs`, `commands/storage_signals.rs` ×2 and
  `sentinel.rs` ×2. I converted all eleven — converting four and leaving seven
  would have left the duplication the item exists to remove. No test changed an
  input or an assertion; `-209/+96` lines.

**`refactor: correct comments that outlived what they described`**
- `cli.rs` — `urd migrate --help` said "from legacy schema to v1", two schema
  versions late → "to the latest schema (v2)".
- Six doc comments and two `log::warn!` strings still named `drive_connections`,
  a table UPI 036 subsumed into `events` and dropped (`observation.rs`,
  `sentinel.rs`, `types.rs`, `awareness.rs` ×3, `state.rs`, `plan/mod.rs` ×2).
  `state.rs`'s migration keeps the name — it is talking about the legacy table
  on purpose.
- Five planner sites read free space as `unwrap_or(u64::MAX)` with the ADR-107
  rationale spelled out at exactly one of them. They now go through
  `plan::free_bytes_fail_open`, which carries the reasoning in its name and doc.
  (The issue offered "one named helper **or** a pointer comment"; the helper
  also removes the repetition.)
- `commands/events.rs::parse_since(now, s)` — `now` is now injected. The test
  that asserted a ±10 s window around "about an hour ago" asserts exact cutoffs
  for two durations. This was the suite's last wall-clock-dependent test.

**`fix: honour btrfs_path for the read-only subvolume show queries`** ← the one
behaviour change
- `btrfs.rs::subvolume_show` spawned a literal `"btrfs"` while every other
  invocation in the file passes `self.btrfs_path`. On a host that configures the
  binary outside `PATH`, `subvolume_generation` and `received_uuid` failed where
  snapshot/send/delete/sync/list all succeeded. Both readers fail open, so
  nothing broke loudly: the unchanged-source snapshot skip stopped skipping and
  the received-UUID completeness check stopped confirming — silently, on exactly
  the hosts that took the trouble to declare the path.
- `subvolume_show(btrfs_path, path)` now takes it; both `BtrfsRead` impls pass
  `&self.btrfs_path`. The invocation moves into `show_command(btrfs_path, path)
  -> Command` so a test can assert the configured binary reaches the argv via
  `get_program()` / `get_args()` — no sudo, no fake binary. The `-n` rationale
  moves onto that function, since it is the command's property.
- CHANGELOG under `### Fixed`.

**`refactor: gate the three test-only helpers on cfg(test)`** (review follow-up)
- `healthy_from`, `Interval::minutes` and `SnapshotName::date` were first kept
  as narrowed allows with a "tests call it" reason. That is the shape of comment
  this issue exists to retire: it silences the compiler instead of telling it the
  truth. They are now `#[cfg(test)]`, so the bin build has nothing to warn about
  and no attribute is needed. `--all-targets -D warnings` stays clean, which is
  the proof none of the three had a production caller hiding behind the allow.
  The doc comments stay and now explain the gate.
- `Notification.event` and `OperationRow`'s two fields keep narrowed allows —
  they are fields, and `cfg(test)` on a field ripples into every constructor.

## Per-allow table

| Site (pre-change) | What it covered | Action |
| --- | --- | --- |
| `lock.rs:84` | `try_acquire_lock` | **Removed** — called at `sentinel_runner.rs:793`. |
| `notify.rs:52/59/66` | `BackupOverdue` / `HealthDegraded` / `HealthRecovered` | **Removed** — all three constructed in `sentinel_runner.rs`. |
| `notify.rs:166` | `Notification.event` | **Kept, comment corrected** — read only by `notify.rs`'s own tests (10 sites). The old note also promised a Sentinel caller that never arrived. |
| `recommendation.rs:226` | `healthy_from` | **Replaced with `#[cfg(test)]`** — called from `voice/mod.rs` and `voice_contract.rs` tests only. Its doc also claimed a `doctor.rs` caller that does not exist; corrected. |
| `config.rs:29` | whole `GeneralConfig` struct | **Removed** — every field read. |
| `config.rs:134` | whole `DriveConfig` struct | **Removed** — every field read. |
| `awareness.rs:467` | `LocalAssessment.configured_interval` | **Kept** — genuinely dead in both targets. See "still dead". |
| `awareness.rs:523` | `DriveAssessment.configured_interval` | **Kept** — genuinely dead in both targets. See "still dead". |
| `awareness.rs:531/538` | `absent_duration_secs`, `last_activity_age_secs` | **Removed** — both read via `StatusDriveAssessment`. |
| `state.rs:80` | whole `OperationRow` (8 fields, 2 dead) | **Narrowed** to `id` and `bytes_transferred`, with the reason on the struct: the row is a 1:1 projection of `operations`, and both queries share one *positional* mapper, so dropping either field re-indexes that mapper without saving the database any work. |
| `types.rs:20` | whole `impl Interval` | **Removed**; `Interval::minutes` is now `#[cfg(test)]` — constructed only by `config.rs` tests, production intervals come from `FromStr`. `hours` / `days` / `as_chrono` are live. |
| `types.rs:197` | whole `impl SnapshotName` | **Removed**; `SnapshotName::date` is now `#[cfg(test)]` — called only by its own test, every production caller wants `datetime()` for ordering. |
| `types.rs:1267` | whole `BackupPlan` struct | **Removed** — every field read. |
| `types.rs:1276` | whole `impl BackupPlan` | **Removed** — `is_empty` and `summary` both live. |

**Still dead** (allow kept, nothing — not even a test — reads them): the two
`configured_interval` fields, `awareness.rs:467` and `:523`. Their
"consumed by verbose status display (future)" note is the honest state of
things, and deleting them means deciding that verbose status will never want the
declared interval — a product call, not a hygiene one.

Note the split that made this fiddly: `Interval::minutes`, `SnapshotName::date`,
`Notification.event` and `healthy_from` are dead in the `bin` target but alive in
the `test` target, so `--all-targets -D warnings` needs *something* said about
each. Three of the four are functions and are now `#[cfg(test)]`, which states
the fact rather than suppressing the symptom. `Notification.event` is a field, so
it keeps a narrowed allow — `cfg(test)` on a field would ripple into every
constructor of the struct.

## Not done

- **Docs tree** (`ADR-relating-to-bash-script/`) — skipped; the supervisor
  archived the predecessor ADR-020 in #390.
- **`sentinel.rs`'s 16 "Session 4: active mode" allows** — out of scope, that is
  #385.
- **`plan/send.rs:225`** ("stamped by backup.rs after plan creation") — the issue
  asks it to cite an ADR-100 amendment that has not been written. Left as the
  only in-code record of that post-plan mutation.

## Out of scope / noticed

- `cargo test` hangs indefinitely in this environment when stdin is an open
  socket: a `commands::encounter` test blocks on a `unix_stream_data_wait` read.
  `cargo test < /dev/null` is the workaround. Not investigated further.

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings` — clean after **every** one of
      the nine commits, not just at the tip.
- [x] `cargo test` — **2532 → 2534 passed**, 0 failed, 5 ignored (+1 ignored
      integration). Baseline measured on `789b39f` in this worktree. The two new
      tests are `state::tests::drive_scoped_query_ignores_rows_without_a_drive_label`
      and `btrfs::tests::subvolume_show_uses_the_configured_btrfs_path`.
- [x] `scripts/check-voice-boundary.sh`, `check-present-not-journey.sh`,
      `check-docs.sh`, `check-registry.sh` — all pass.
- [x] `scripts/pre-commit-pii.sh --report` — no findings; branch diff against
      `origin/master` re-scanned for username / home paths / hostnames.
- [x] Rebased onto `789b39f`; the only conflict was the `[Unreleased]` CHANGELOG
      bullet, resolved by keeping both.
- [x] No `cargo fmt` run; every wrapped line hand-matched to the surrounding
      style, and no added line exceeds 100 columns.

Closes #387

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti

