### PR TITLE
release: v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-09-04
+
 ### Added
 - Every persisted event variant now has a frozen historical-JSON fixture
   test, so a future wire-form change fails a test instead of silently
@@ -1892,7 +1894,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Defense-in-depth pin file protection for unsent snapshots
 - Per-subvolume error isolation in executor
 
-[Unreleased]: https://github.com/vonrobak/urd/compare/v0.36.0...HEAD
+[Unreleased]: https://github.com/vonrobak/urd/compare/v0.37.0...HEAD
+[0.37.0]: https://github.com/vonrobak/urd/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/vonrobak/urd/compare/v0.35.0...v0.36.0
 [0.35.0]: https://github.com/vonrobak/urd/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/vonrobak/urd/compare/v0.33.4...v0.34.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "urd"
-version = "0.36.0"
+version = "0.37.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "urd"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2024"
 description = "BTRFS Time Machine for Linux"
 license = "GPL-3.0-only"


### PR DESCRIPTION
## Summary

Release **v0.37.0** — the sweep-closure release. Sixteen PRs (#389–#406) closing the 2026-09-04 code-quality sweep issues #377–#388: structured `advice.issue` and doctor JSON schema 4, the doctor verdict as a pure fold, one shared emergency walk with the `min_free_bytes` ladder named, thread-panic surfacing, `urd migrate` / v2-validation / webhook fixes, `cargo test --release` in the quality gate, frozen `EventPayload` fixtures and wider voice-contract coverage, twelve ADR amendments plus ADR-119, the hygiene batch (with the `btrfs_path` fix), and the dormant sentinel active-mode machinery removed.

Breaking for `--json` consumers: `urd doctor --json` `schema_version` 3 → 4 (`data_safety[].issue` is an object); `urd status --json` `advice[].issue` is an object. No change to metrics or heartbeat.

## Testing

- scripts/check.sh: all checks passed (2516 passed, 0 failed, 6 ignored — debug and release profiles), doc-lint and voice-boundary lints pass
- pre-commit-pii.sh --report: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U75SNbnkh1ehAaCEzdXkti